### PR TITLE
fix: strip client-side headers before forwarding to Copilot API to prevent 403

### DIFF
--- a/src/lib/copilot.ts
+++ b/src/lib/copilot.ts
@@ -173,7 +173,10 @@ export async function copilotFetch(
   const baseUrl = copilotBaseUrl(accountType);
   const editorVer = await getEditorVersion();
 
-  const headers = new Headers(init.headers);
+  // Build headers from scratch (whitelist-only) to avoid forwarding
+  // client-side headers (e.g. x-stainless-*, openai-organization, User-Agent: OpenAI/JS)
+  // that cause Copilot API to return 403.
+  const headers = new Headers();
   headers.set("Authorization", `Bearer ${token}`);
   headers.set("Content-Type", "application/json");
   headers.set("editor-version", editorVer);


### PR DESCRIPTION
## Problem

When clients such as OpenClaw or tools using the OpenAI JS SDK send requests to copilot-gateway, they include headers added by the OpenAI SDK internals:

- `x-stainless-arch`, `x-stainless-os`, `x-stainless-runtime`, `x-stainless-runtime-version`, `x-stainless-lang`, `x-stainless-package-version`
- `User-Agent: OpenAI/JS <version>`
- `openai-organization`

These headers are currently forwarded as-is to the GitHub Copilot API via `new Headers(init.headers)`, which causes the Copilot API to respond with **403 (request blocked)**.

## Fix

Build the outgoing headers from scratch (`new Headers()`) instead of inheriting from the inbound request. Only the headers required by the Copilot API are included — all client-side headers are discarded before the upstream request is made.

## Testing

Verified by removing the offending headers at the client side and confirming requests succeed. With this fix, clients using the OpenAI JS SDK no longer need to manually suppress their SDK headers.