### PR TITLE
fix: include cache tokens in Anthropic usage tracking

### DIFF
--- a/src/lib/anthropic-types.ts
+++ b/src/lib/anthropic-types.ts
@@ -213,4 +213,6 @@ export interface AnthropicStreamState {
   thinkingSignatureSent?: boolean;
   /** Accumulated reasoning_opaque when no thinking block was open to receive it */
   pendingReasoningOpaque?: string;
+  /** Whether usage has already been sent in a message_delta event */
+  usageSent?: boolean;
 }

--- a/src/lib/openai-types.ts
+++ b/src/lib/openai-types.ts
@@ -16,6 +16,8 @@ export interface ChatCompletionsPayload {
     | "required"
     | { type: "function"; function: { name: string } }
     | null;
+  /** Request usage stats in streaming responses */
+  stream_options?: { include_usage: boolean } | null;
   /** Thinking budget for reasoning models */
   thinking_budget?: number;
 }

--- a/src/lib/translate/openai-stream.ts
+++ b/src/lib/translate/openai-stream.ts
@@ -190,6 +190,9 @@ function handleFinishReason(
   }
 
   closeCurrentBlock(state, events);
+
+  if (chunk.usage) state.usageSent = true;
+
   events.push(
     {
       type: "message_delta",
@@ -206,7 +209,20 @@ export function translateChunkToAnthropicEvents(
 ): AnthropicStreamEventData[] {
   const events: AnthropicStreamEventData[] = [];
 
-  if (chunk.choices.length === 0 || state.aborted) return events;
+  // Handle usage-only chunk (choices=[], usage present) — OpenAI sends this
+  // as the final chunk when stream_options.include_usage is true
+  if (chunk.choices.length === 0) {
+    if (!state.aborted && chunk.usage && !state.usageSent) {
+      state.usageSent = true;
+      events.push({
+        type: "message_delta",
+        delta: { stop_reason: null, stop_sequence: null },
+        usage: mapOpenAIUsage(chunk.usage),
+      });
+    }
+    return events;
+  }
+  if (state.aborted) return events;
 
   const choice = chunk.choices[0];
   const { delta } = choice;

--- a/src/lib/translate/openai.ts
+++ b/src/lib/translate/openai.ts
@@ -75,6 +75,7 @@ export function translateToOpenAI(
     max_tokens: payload.max_tokens,
     stop: payload.stop_sequences,
     stream: payload.stream,
+    ...(payload.stream ? { stream_options: { include_usage: true } } : {}),
     temperature: payload.temperature,
     top_p: payload.top_p,
     user: payload.metadata?.user_id,

--- a/src/middleware/usage.ts
+++ b/src/middleware/usage.ts
@@ -71,6 +71,7 @@ function interceptStreaming(c: Context, keyId: string, model: string): void {
 
   let inputTokens = 0;
   let outputTokens = 0;
+  let gotInputFromStart = false;
   let buffer = "";
 
   const transform = new TransformStream<Uint8Array, Uint8Array>({
@@ -89,9 +90,10 @@ function interceptStreaming(c: Context, keyId: string, model: string): void {
 
         try {
           const parsed = JSON.parse(data);
-          extractUsageFromStreamEvent(parsed, (i, o) => {
+          extractUsageFromStreamEvent(parsed, gotInputFromStart, (i, o, fromStart) => {
             inputTokens += i;
             outputTokens += o;
+            if (fromStart) gotInputFromStart = true;
           });
         } catch { /* ignore non-JSON lines */ }
       }
@@ -103,9 +105,10 @@ function interceptStreaming(c: Context, keyId: string, model: string): void {
         if (data && data !== "[DONE]") {
           try {
             const parsed = JSON.parse(data);
-            extractUsageFromStreamEvent(parsed, (i, o) => {
+            extractUsageFromStreamEvent(parsed, gotInputFromStart, (i, o, fromStart) => {
               inputTokens += i;
               outputTokens += o;
+              if (fromStart) gotInputFromStart = true;
             });
           } catch { /* ignore */ }
         }
@@ -149,7 +152,7 @@ interface UsageInfo {
 function extractUsageFromJson(json: any): UsageInfo | null {
   // Anthropic Messages: { usage: { input_tokens, output_tokens } }
   if (json?.usage?.input_tokens != null) {
-    return { input: json.usage.input_tokens, output: json.usage.output_tokens ?? 0 };
+    return { input: json.usage.input_tokens + (json.usage.cache_read_input_tokens ?? 0) + (json.usage.cache_creation_input_tokens ?? 0), output: json.usage.output_tokens ?? 0 };
   }
   // OpenAI Chat Completions: { usage: { prompt_tokens, completion_tokens } }
   if (json?.usage?.prompt_tokens != null) {
@@ -159,22 +162,35 @@ function extractUsageFromJson(json: any): UsageInfo | null {
 }
 
 // deno-lint-ignore no-explicit-any
-function extractUsageFromStreamEvent(parsed: any, add: (input: number, output: number) => void): void {
+function extractUsageFromStreamEvent(parsed: any, gotInputFromStart: boolean, add: (input: number, output: number, fromStart: boolean) => void): void {
   // Anthropic message_start: { message: { usage: { input_tokens } } }
-  if (parsed.type === "message_start" && parsed.message?.usage?.input_tokens != null) {
-    add(parsed.message.usage.input_tokens, 0);
+  if (parsed.type === "message_start" && parsed.message?.usage) {
+    const u = parsed.message.usage;
+    const inputFromStart = (u.input_tokens ?? 0) + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0);
+    if (inputFromStart > 0) {
+      add(inputFromStart, 0, true);
+    }
   }
-  // Anthropic message_delta: { usage: { output_tokens } }
+  // Anthropic message_delta: { usage: { output_tokens, input_tokens? } }
+  // In translated streams (OpenAI→Anthropic), the message_start may have
+  // input_tokens=0 because the upstream usage-only chunk arrives after the
+  // first chunk. The usage-only chunk generates a supplemental message_delta
+  // carrying both input_tokens and output_tokens. We only extract input_tokens
+  // from message_delta when message_start didn't already provide them.
   if (parsed.type === "message_delta" && parsed.usage?.output_tokens != null) {
-    add(0, parsed.usage.output_tokens);
+    let deltaInput = 0;
+    if (!gotInputFromStart && parsed.usage.input_tokens != null) {
+      deltaInput = (parsed.usage.input_tokens ?? 0) + (parsed.usage.cache_read_input_tokens ?? 0) + (parsed.usage.cache_creation_input_tokens ?? 0);
+    }
+    add(deltaInput, parsed.usage.output_tokens, false);
   }
   // Responses response.completed: { response: { usage: { input_tokens, output_tokens } } }
   if (parsed.type === "response.completed" && parsed.response?.usage) {
     const u = parsed.response.usage;
-    add(u.input_tokens ?? 0, u.output_tokens ?? 0);
+    add(u.input_tokens ?? 0, u.output_tokens ?? 0, false);
   }
   // OpenAI Chat Completions chunk with usage
   if (parsed.usage?.prompt_tokens != null) {
-    add(parsed.usage.prompt_tokens, parsed.usage.completion_tokens ?? 0);
+    add(parsed.usage.prompt_tokens, parsed.usage.completion_tokens ?? 0, false);
   }
 }

--- a/src/routes/chat-completions.ts
+++ b/src/routes/chat-completions.ts
@@ -383,6 +383,9 @@ async function handleViaCompletionsApi(
 
   // Always stream upstream to avoid blocking on large responses
   body.stream = true;
+  if (!body.stream_options) {
+    body.stream_options = { include_usage: true };
+  }
 
   const resp = await copilotFetch(
     "/chat/completions",

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -354,6 +354,7 @@ async function handleTranslated(
 
   // Always stream upstream to avoid blocking on large responses
   openAIPayload.stream = true;
+  openAIPayload.stream_options = { include_usage: true };
 
   const resp = await copilotFetch(
     "/chat/completions",


### PR DESCRIPTION
## Problem

When using Anthropic models with prompt caching (e.g. Claude Code with long conversations), the usage tracking middleware severely underreports input token counts.

Anthropic Messages API returns three separate token counts in usage:
- `input_tokens` — non-cached input tokens
- `cache_read_input_tokens` — tokens served from cache
- `cache_creation_input_tokens` — tokens written to cache

The usage middleware only counted `input_tokens`, completely missing the cache components. In practice, with heavy caching, reported input tokens could be ~10% of actual usage.

## Fix

### 1. Include cache tokens in usage extraction (`src/middleware/usage.ts`)
- Non-streaming: sum all three token fields in `extractUsageFromJson`
- Streaming: sum all three fields in both `message_start` and `message_delta` events
- Track whether input tokens were already reported in `message_start` to avoid double-counting from translated streams where a supplemental `message_delta` may also carry input counts

### 2. Add `stream_options.include_usage` for Chat Completions translation paths
- When translating Anthropic Messages → OpenAI Chat Completions (for upstream Copilot API), the upstream may not include usage in streaming responses unless explicitly requested
- Added `stream_options: { include_usage: true }` to:
  - `src/lib/translate/openai.ts` (Messages→OpenAI translation)
  - `src/routes/messages.ts` (translated Messages handler)
  - `src/routes/chat-completions.ts` (Chat Completions passthrough)

### 3. Handle usage-only stream chunks (`src/lib/translate/openai-stream.ts`)
- OpenAI sends a final chunk with `choices=[]` and `usage` present when `stream_options.include_usage` is true
- Previously this was silently dropped; now it generates a `message_delta` event with the usage data
- Track `usageSent` state to avoid duplicate usage reporting

## Testing

Tested with Claude Code (heavy prompt caching) via copilot-gateway. Before fix, input tokens showed ~500 for requests actually consuming ~15,000 tokens. After fix, counts match Anthropic dashboard.