### PR TITLE
fix: scope token usage to authenticated API key

### DIFF
--- a/src/routes/token-usage.ts
+++ b/src/routes/token-usage.ts
@@ -1,15 +1,16 @@
 // GET /api/token-usage — query per-key token usage records
 //
-// IMPORTANT DESIGN DECISION: Usage data is intentionally readable by ALL authenticated
-// users (both admin and API key users), without scoping. Any authenticated user can view
-// usage records for all keys. API keys themselves are only readable by their owner.
+// Admin users can view all keys or filter by key_id.
+// API key users are scoped to their own key only.
 
 import type { Context } from "hono";
 import { queryUsage } from "../lib/usage-tracker.ts";
 import { listApiKeys } from "../lib/api-keys.ts";
 
 export const tokenUsage = async (c: Context) => {
-  const keyId = c.req.query("key_id") || undefined;
+  const isAdmin: boolean = c.get("isAdmin") ?? false;
+  const apiKeyId: string | undefined = c.get("apiKeyId");
+  const keyId = isAdmin ? (c.req.query("key_id") || undefined) : apiKeyId;
   const start = c.req.query("start") ?? "";
   const end = c.req.query("end") ?? "";
 

--- a/src/ui/dashboard/client.tsx
+++ b/src/ui/dashboard/client.tsx
@@ -103,6 +103,7 @@ export function dashboardAssets() {
     return {
       authKey: '',
       isAdmin,
+      loginKeyId: localStorage.getItem('login_key_id') || '',
       tab: initTab,
       meLoaded: false,
       githubAccounts: [],
@@ -676,7 +677,9 @@ export function dashboardAssets() {
               }
               const start = rangeStart.toISOString().slice(0, 13);
               const end = new Date(now.getTime() + 3600000).toISOString().slice(0, 13);
-              const resp = await fetch('/api/token-usage?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end), { headers: this.authHeaders() });
+              let tokenUrl = '/api/token-usage?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end);
+              if (!this.isAdmin && this.loginKeyId) tokenUrl += '&key_id=' + encodeURIComponent(this.loginKeyId);
+              const resp = await fetch(tokenUrl, { headers: this.authHeaders() });
               if (resp.status === 401) {
                 this.logout();
                 return;


### PR DESCRIPTION
## Problem

When a non-admin user logs into the dashboard with an API key, the Usage tab shows token consumption for **all** keys in the system. This leaks usage information across tenants — a user with key "Desktop" can see exactly how much "WorkStation", "Hermes", etc. are consuming.

The original design comment in `token-usage.ts` stated this was intentional, but in practice it breaks the multi-tenant isolation that the API key system provides. Admin users should see everything; API key users should only see their own data.

## Changes

**Server-side (`src/routes/token-usage.ts`):**
- Non-admin requests now ignore the `key_id` query parameter and are forced to their own `apiKeyId` (set by auth middleware)
- Admin requests retain the existing behavior (optional `key_id` filter, or all keys if omitted)

**Client-side (`src/ui/dashboard/client.tsx`):**
- Non-admin sessions pass `key_id` in the fetch URL as defense-in-depth
- Reads `login_key_id` from localStorage (already stored by the login flow but previously unused)

## Test plan
- [ ] Login with admin key → usage page shows all keys
- [ ] Login with API key → usage page shows only that key's data
- [ ] `curl /api/token-usage` with API key in `x-api-key` header → response scoped to that key only
- [ ] `curl /api/token-usage?key_id=other` with API key → `key_id` param ignored, still returns own data only

🤖 Generated with [Claude Code](https://claude.com/claude-code)