### PR TITLE
fix: strip Claude Code billing attribution header to restore prompt cache

### DIFF
--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -113,17 +113,18 @@ const BILLING_HEADER_LINE_RE =
 const CCH_HASH_RE = /cch=[0-9a-f]{5,};?/gi;
 
 function stripBillingAttribution(text: string): string {
-  let result = text
+  return text
     .replace(BILLING_HEADER_LINE_RE, "")
     .replace(CCH_HASH_RE, "")
     .trim();
-  // Never return empty — Anthropic API rejects empty text content blocks
-  return result || " ";
 }
 
 function stripReservedKeywords(payload: AnthropicMessagesPayload): void {
   if (typeof payload.system === "string") {
     payload.system = stripBillingAttribution(payload.system);
+    if (!payload.system) {
+      delete (payload as Record<string, unknown>).system;
+    }
   } else if (Array.isArray(payload.system)) {
     for (const block of payload.system) {
       block.text = stripBillingAttribution(block.text);

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -93,26 +93,61 @@ function isContextWindowError(text: string): boolean {
     text.includes("context_length_exceeded");
 }
 
-/** Copilot rejects requests containing this string in system prompts */
-const RESERVED_KEYWORD = "x-anthropic-billing-header";
+/**
+ * Strip the entire billing attribution line from Claude Code.
+ *
+ * Claude Code's native binary injects a billing header into the system prompt:
+ *   x-anthropic-billing-header: cc_version=2.1.114; cc_entrypoint=cli; cch=<hash>
+ *
+ * The `cch=` hash changes with EVERY request (it's a hash of the request body),
+ * which means the system prompt content changes every turn, completely invalidating
+ * the prompt cache. The previous code only stripped the keyword itself, leaving
+ * the varying hash in the text.
+ *
+ * This regex removes the entire line (keyword + all parameters including the hash).
+ * We also strip any orphaned `cch=<hex>` patterns that the native binary's memmem
+ * might have injected into message content instead of the billing header.
+ */
+const BILLING_HEADER_LINE_RE =
+  /x-anthropic-billing-header[^\n]*/g;
+const CCH_HASH_RE = /cch=[0-9a-f]{5,};?/gi;
+
+function stripBillingAttribution(text: string): string {
+  let result = text
+    .replace(BILLING_HEADER_LINE_RE, "")
+    .replace(CCH_HASH_RE, "")
+    .trim();
+  // Never return empty — Anthropic API rejects empty text content blocks
+  return result || " ";
+}
 
 function stripReservedKeywords(payload: AnthropicMessagesPayload): void {
   if (typeof payload.system === "string") {
-    payload.system = payload.system.replaceAll(RESERVED_KEYWORD, "");
+    payload.system = stripBillingAttribution(payload.system);
   } else if (Array.isArray(payload.system)) {
     for (const block of payload.system) {
-      block.text = block.text.replaceAll(RESERVED_KEYWORD, "");
+      block.text = stripBillingAttribution(block.text);
+    }
+    // Remove blocks that are now effectively empty (only whitespace)
+    payload.system = payload.system.filter((b) => b.text.trim().length > 0);
+    // If all system blocks were removed, drop system entirely
+    if (payload.system.length === 0) {
+      delete (payload as Record<string, unknown>).system;
     }
   }
   for (const msg of payload.messages) {
     if (typeof msg.content === "string") {
-      msg.content = msg.content.replaceAll(RESERVED_KEYWORD, "");
+      msg.content = stripBillingAttribution(msg.content);
     } else if (Array.isArray(msg.content)) {
       for (const block of msg.content) {
         if ("text" in block && typeof block.text === "string") {
-          block.text = block.text.replaceAll(RESERVED_KEYWORD, "");
+          block.text = stripBillingAttribution(block.text);
         }
       }
+      // Remove empty text blocks from message content
+      msg.content = msg.content.filter(
+        (b) => !("text" in b && typeof (b as { text: string }).text === "string" && (b as { text: string }).text.trim().length === 0),
+      );
     }
   }
 }

--- a/src/routes/messages_test.ts
+++ b/src/routes/messages_test.ts
@@ -992,3 +992,206 @@ Deno.test("/v1/messages drops reasoning config when the responses endpoint suppo
   assertFalse("reasoning" in upstreamBody!);
   assertFalse("include" in upstreamBody!);
 });
+
+// ── Billing attribution stripping tests ──
+
+Deno.test("stripReservedKeywords removes entire billing header line from string system", async () => {
+  const { apiKey } = await setupAppTest();
+
+  let upstreamBody: Record<string, unknown> | undefined;
+
+  await withMockedFetch(async (request) => {
+    const url = new URL(request.url);
+    if (url.hostname === "update.code.visualstudio.com") return jsonResponse(["1.110.1"]);
+    if (url.pathname === "/copilot_internal/v2/token") {
+      return jsonResponse({ token: "tok", expires_at: 4102444800, refresh_in: 3600 });
+    }
+    if (url.pathname === "/models") {
+      return jsonResponse(copilotModels([{ id: "claude-native", supported_endpoints: ["/v1/messages"] }]));
+    }
+    if (url.pathname === "/v1/messages") {
+      upstreamBody = JSON.parse(await request.text());
+      return sseResponse([
+        { event: "message_start", data: { type: "message_start", message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "claude-native", stop_reason: null, stop_sequence: null, usage: { input_tokens: 10, output_tokens: 0 } } } },
+        { event: "content_block_start", data: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } },
+        { event: "content_block_delta", data: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } } },
+        { event: "content_block_stop", data: { type: "content_block_stop", index: 0 } },
+        { event: "message_delta", data: { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 1 } } },
+        { event: "message_stop", data: { type: "message_stop" } },
+      ]);
+    }
+    throw new Error(`Unhandled fetch ${request.url}`);
+  }, async () => {
+    const response = await requestApp("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": apiKey.key },
+      body: JSON.stringify({
+        model: "claude-native",
+        max_tokens: 10,
+        stream: false,
+        system: "You are helpful.\nx-anthropic-billing-header: cc_version=2.1.114; cc_entrypoint=cli; cch=abcde12345;\nBe concise.",
+        messages: [{ role: "user", content: "Hi" }],
+      }),
+    });
+    assertEquals(response.status, 200);
+  });
+
+  assertExists(upstreamBody);
+  const sys = upstreamBody!.system as string;
+  // Billing header line is fully removed
+  assertFalse(sys.includes("x-anthropic-billing-header"));
+  assertFalse(sys.includes("cch="));
+  // Real content is preserved
+  assertEquals(sys.includes("You are helpful."), true);
+  assertEquals(sys.includes("Be concise."), true);
+});
+
+Deno.test("stripReservedKeywords removes billing-only system block without 400 error", async () => {
+  const { apiKey } = await setupAppTest();
+
+  let upstreamBody: Record<string, unknown> | undefined;
+
+  await withMockedFetch(async (request) => {
+    const url = new URL(request.url);
+    if (url.hostname === "update.code.visualstudio.com") return jsonResponse(["1.110.1"]);
+    if (url.pathname === "/copilot_internal/v2/token") {
+      return jsonResponse({ token: "tok", expires_at: 4102444800, refresh_in: 3600 });
+    }
+    if (url.pathname === "/models") {
+      return jsonResponse(copilotModels([{ id: "claude-native", supported_endpoints: ["/v1/messages"] }]));
+    }
+    if (url.pathname === "/v1/messages") {
+      upstreamBody = JSON.parse(await request.text());
+      return sseResponse([
+        { event: "message_start", data: { type: "message_start", message: { id: "msg_2", type: "message", role: "assistant", content: [], model: "claude-native", stop_reason: null, stop_sequence: null, usage: { input_tokens: 5, output_tokens: 0 } } } },
+        { event: "content_block_start", data: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } },
+        { event: "content_block_delta", data: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } } },
+        { event: "content_block_stop", data: { type: "content_block_stop", index: 0 } },
+        { event: "message_delta", data: { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 1 } } },
+        { event: "message_stop", data: { type: "message_stop" } },
+      ]);
+    }
+    throw new Error(`Unhandled fetch ${request.url}`);
+  }, async () => {
+    // System has two blocks: one with only billing header, one with real content
+    const response = await requestApp("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": apiKey.key },
+      body: JSON.stringify({
+        model: "claude-native",
+        max_tokens: 10,
+        stream: false,
+        system: [
+          { type: "text", text: "x-anthropic-billing-header: cc_version=2.1.114; cc_entrypoint=cli; cch=ff00ff00ff;" },
+          { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+        ],
+        messages: [{ role: "user", content: "Hi" }],
+      }),
+    });
+    assertEquals(response.status, 200);
+  });
+
+  assertExists(upstreamBody);
+  // Empty billing block should be removed, only the real block remains
+  const sys = upstreamBody!.system as Array<Record<string, unknown>>;
+  assertEquals(sys.length, 1);
+  assertEquals(sys[0].text, "You are a helpful assistant.");
+  assertExists(sys[0].cache_control);
+});
+
+Deno.test("stripReservedKeywords handles all-billing system blocks by removing system entirely", async () => {
+  const { apiKey } = await setupAppTest();
+
+  let upstreamBody: Record<string, unknown> | undefined;
+
+  await withMockedFetch(async (request) => {
+    const url = new URL(request.url);
+    if (url.hostname === "update.code.visualstudio.com") return jsonResponse(["1.110.1"]);
+    if (url.pathname === "/copilot_internal/v2/token") {
+      return jsonResponse({ token: "tok", expires_at: 4102444800, refresh_in: 3600 });
+    }
+    if (url.pathname === "/models") {
+      return jsonResponse(copilotModels([{ id: "claude-native", supported_endpoints: ["/v1/messages"] }]));
+    }
+    if (url.pathname === "/v1/messages") {
+      upstreamBody = JSON.parse(await request.text());
+      return sseResponse([
+        { event: "message_start", data: { type: "message_start", message: { id: "msg_3", type: "message", role: "assistant", content: [], model: "claude-native", stop_reason: null, stop_sequence: null, usage: { input_tokens: 5, output_tokens: 0 } } } },
+        { event: "content_block_start", data: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } },
+        { event: "content_block_delta", data: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } } },
+        { event: "content_block_stop", data: { type: "content_block_stop", index: 0 } },
+        { event: "message_delta", data: { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 1 } } },
+        { event: "message_stop", data: { type: "message_stop" } },
+      ]);
+    }
+    throw new Error(`Unhandled fetch ${request.url}`);
+  }, async () => {
+    // System has only billing header blocks — should be removed entirely
+    const response = await requestApp("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": apiKey.key },
+      body: JSON.stringify({
+        model: "claude-native",
+        max_tokens: 10,
+        stream: false,
+        system: [
+          { type: "text", text: "x-anthropic-billing-header: cc_version=2.1.114; cc_entrypoint=cli; cch=aabbccdd;" },
+        ],
+        messages: [{ role: "user", content: "Hi" }],
+      }),
+    });
+    assertEquals(response.status, 200);
+  });
+
+  assertExists(upstreamBody);
+  // system should be removed entirely (not present or undefined)
+  assertFalse("system" in upstreamBody!);
+});
+
+Deno.test("stripReservedKeywords strips cch= hash from message content", async () => {
+  const { apiKey } = await setupAppTest();
+
+  let upstreamBody: Record<string, unknown> | undefined;
+
+  await withMockedFetch(async (request) => {
+    const url = new URL(request.url);
+    if (url.hostname === "update.code.visualstudio.com") return jsonResponse(["1.110.1"]);
+    if (url.pathname === "/copilot_internal/v2/token") {
+      return jsonResponse({ token: "tok", expires_at: 4102444800, refresh_in: 3600 });
+    }
+    if (url.pathname === "/models") {
+      return jsonResponse(copilotModels([{ id: "claude-native", supported_endpoints: ["/v1/messages"] }]));
+    }
+    if (url.pathname === "/v1/messages") {
+      upstreamBody = JSON.parse(await request.text());
+      return sseResponse([
+        { event: "message_start", data: { type: "message_start", message: { id: "msg_4", type: "message", role: "assistant", content: [], model: "claude-native", stop_reason: null, stop_sequence: null, usage: { input_tokens: 5, output_tokens: 0 } } } },
+        { event: "content_block_start", data: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } },
+        { event: "content_block_delta", data: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } } },
+        { event: "content_block_stop", data: { type: "content_block_stop", index: 0 } },
+        { event: "message_delta", data: { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 1 } } },
+        { event: "message_stop", data: { type: "message_stop" } },
+      ]);
+    }
+    throw new Error(`Unhandled fetch ${request.url}`);
+  }, async () => {
+    const response = await requestApp("/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-api-key": apiKey.key },
+      body: JSON.stringify({
+        model: "claude-native",
+        max_tokens: 10,
+        stream: false,
+        messages: [{ role: "user", content: "Hello cch=abcdef12345; world" }],
+      }),
+    });
+    assertEquals(response.status, 200);
+  });
+
+  assertExists(upstreamBody);
+  const msgs = upstreamBody!.messages as Array<Record<string, unknown>>;
+  const content = msgs[0].content as string;
+  assertFalse(content.includes("cch="));
+  assertEquals(content.includes("Hello"), true);
+  assertEquals(content.includes("world"), true);
+});


### PR DESCRIPTION
## Problem

Claude Code's native binary injects a billing attribution header into the system prompt:

```
x-anthropic-billing-header: cc_version=2.1.114; cc_entrypoint=cli; cch=<hash>
```

The `cch=` hash is computed from the request body and changes with **every request**. Since the Copilot API uses prefix-based prompt caching, the changing hash causes the system prompt prefix to differ on every turn, completely invalidating prompt cache.

**Impact**: `cache_read_input_tokens` is always 0 for all Claude Code sessions, while `cache_creation_input_tokens` shows tokens being cached but never reused.

## Solution

- Upgrade `stripReservedKeywords` to remove the entire billing header line (not just the keyword)
- Strip orphaned `cch=<hex>` hashes from message content
- Filter empty text blocks after stripping to prevent Anthropic API 400 errors ("text content blocks must be non-empty")
- Remove system entirely when all blocks are stripped (billing-only system prompts)

## Verification

- Confirmed cache hit restoration: after fix, `cache_read_input_tokens` goes from 0 to matching `cache_creation_input_tokens` on subsequent turns
- Added 4 unit tests covering: string system, array system with mixed blocks, all-billing system blocks, and message content stripping