### PR TITLE
fix(data-plane): strip unsupported tool fields before forwarding to Copilot API

### DIFF
--- a/src/data-plane/llm/sources/messages/normalize/strip-unsupported-tools.ts
+++ b/src/data-plane/llm/sources/messages/normalize/strip-unsupported-tools.ts
@@ -1,23 +1,52 @@
 import type { MessagesPayload } from "../../../../../lib/messages-types.ts";
 
 /**
- * Messages exposes a built-in `web_search` tool, but Copilot's native
- * `/v1/messages` surface does not accept it today. We drop it at source
- * normalize so native and translated Messages routing start from the same
- * cleaned request.
+ * Copilot's native `/v1/messages` surface only accepts the fields defined in
+ * `MessagesClientTool` for client-provided (custom) tools.  Any extra
+ * top-level properties — such as `eager_input_streaming` sent by the
+ * Anthropic SDK — cause a 400 "Extra inputs are not permitted" rejection.
+ *
+ * We also filter out `web_search` tools which Copilot does not support.
  *
  * References:
  * - https://github.com/caozhiyuan/copilot-api/commit/3c12f580bf4d269ab18838bcc259a89719f8a2cd
  * - https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool
  */
+
+/** Fields that Copilot accepts on a client (custom) tool definition. */
+const ALLOWED_CLIENT_TOOL_KEYS = new Set([
+  "type",
+  "name",
+  "description",
+  "input_schema",
+  "strict",
+  "cache_control",
+]);
+
 export const stripUnsupportedMessagesTools = (
   payload: MessagesPayload,
 ): void => {
   if (!payload.tools) return;
 
+  // Remove unsupported tool types (e.g. web_search)
   payload.tools = payload.tools.filter((tool) =>
     (tool as unknown as Record<string, unknown>).type !== "web_search"
   );
+
+  // Strip unknown top-level keys from client tools so Copilot doesn't reject
+  // them.  Properties like `eager_input_streaming` are valid in the Anthropic
+  // API but not accepted by Copilot's stricter schema.
+  for (const tool of payload.tools) {
+    const record = tool as unknown as Record<string, unknown>;
+    // Only sanitize client (custom) tools, not server/native tool types
+    if (record.type === undefined || record.type === "custom") {
+      for (const key of Object.keys(record)) {
+        if (!ALLOWED_CLIENT_TOOL_KEYS.has(key)) {
+          delete record[key];
+        }
+      }
+    }
+  }
 
   if (payload.tools.length === 0) delete payload.tools;
 };


### PR DESCRIPTION
## Problem

When clients (e.g. OpenClaw, Claude Code via pi-ai) send tool definitions with extra top-level fields like `eager_input_streaming`, Copilot's native `/v1/messages` endpoint rejects the request with:

```
400 {"type":"error","error":{"type":"invalid_request_error",
"message":"tools.0.custom.eager_input_streaming: Extra inputs are not permitted"}}
```

This field is valid in the Anthropic Messages API but not accepted by Copilot's stricter schema validation. The issue causes intermittent failures for any client that uses the Anthropic SDK's eager input streaming feature (enabled by default in newer versions).

## Root Cause

The existing `stripUnsupportedMessagesTools` function filters out unsupported tool **types** (e.g. `web_search`) but does not sanitize individual tool **fields**. Extra top-level properties on client tool definitions pass through to the upstream Copilot API unchanged.

## Fix

Added an allowlist-based sanitizer in `strip-unsupported-tools.ts` that removes unknown top-level keys from client (custom) tool definitions during request normalization. Only the fields defined in `MessagesClientTool` (`type`, `name`, `description`, `input_schema`, `strict`, `cache_control`) are preserved.

This approach is forward-compatible: server/native tool types are left untouched, and adding new supported fields only requires updating the allowlist.

## Testing

Reproduced locally by sending a request with `eager_input_streaming: true` on a tool definition through copilot-gateway — confirmed the 400 error before the fix and successful pass-through after.

---

*This PR was submitted by [Kagura](https://github.com/kagura-agent), an AI agent running on [OpenClaw](https://github.com/openclaw/openclaw).*
*Disclosure: This contribution was generated with AI assistance.*