### PR TITLE
fix(data-plane): include usageModel metadata in embeddings serve

### DIFF
--- a/src/data-plane/embeddings/serve.ts
+++ b/src/data-plane/embeddings/serve.ts
@@ -8,11 +8,12 @@ import {
   getErrorMessage,
   proxyJsonResponse,
 } from "../shared/http/proxy-response.ts";
+import { withUsageResponseMetadata } from "../../middleware/usage-response-metadata.ts";
 
 export const embeddings = async (c: Context) => {
   try {
     const body = await c.req.text();
-    let model = "unknown";
+    let model: string | null = null;
     try {
       const parsed = JSON.parse(body) as { model?: unknown };
       if (typeof parsed.model === "string") model = parsed.model;
@@ -20,7 +21,7 @@ export const embeddings = async (c: Context) => {
       // Let upstream preserve the request-shape error; fallback simply has no model signal.
     }
 
-    const resp = await withAccountFallback(model, ({ account }) =>
+    const resp = await withAccountFallback(model ?? "unknown", ({ account }) =>
       copilotFetch(
         "/embeddings",
         { method: "POST", body },
@@ -28,7 +29,13 @@ export const embeddings = async (c: Context) => {
         account.accountType,
       ));
 
-    return proxyJsonResponse(resp);
+    // GitHub Copilot's embeddings response does not include a `model` field, so
+    // the usage middleware cannot recover one from the JSON body. Carry the
+    // requested model through usage metadata to satisfy requireUsageModel().
+    // This mirrors the usageModel writeback added in d8dd086 for chat
+    // completions / messages / responses serves.
+    const proxied = proxyJsonResponse(resp);
+    return model ? withUsageResponseMetadata(proxied, { usageModel: model }) : proxied;
   } catch (e: unknown) {
     if (isCopilotTokenFetchError(e)) {
       return new Response(e.body, {

--- a/src/middleware/usage_test.ts
+++ b/src/middleware/usage_test.ts
@@ -1303,3 +1303,69 @@ Deno.test("usage middleware records Responses via Messages usage once", async ()
   assertEquals(usage[0].inputTokens, 7);
   assertEquals(usage[0].outputTokens, 9);
 });
+
+Deno.test("usage middleware records embeddings usage when upstream omits model field", async () => {
+  // Regression: GitHub Copilot's /embeddings response does NOT include a
+  // `model` field. After d8dd086 added requireUsageModel(), the chat-class
+  // serves were updated to write usageModel metadata, but the embeddings
+  // serve was missed, so /v1/embeddings returned 500. The embeddings serve
+  // now mirrors the chat-class pattern by carrying the requested model
+  // through usage metadata.
+  const { repo, apiKey } = await setupAppTest();
+
+  await withMockedFetch((request) => {
+    const url = new URL(request.url);
+
+    if (url.hostname === "update.code.visualstudio.com") {
+      return jsonResponse(["1.110.1"]);
+    }
+    if (url.pathname === "/copilot_internal/v2/token") {
+      return jsonResponse({
+        token: "copilot-access-token",
+        expires_at: 4102444800,
+        refresh_in: 3600,
+      });
+    }
+    if (url.pathname === "/models") {
+      return jsonResponse(copilotModels([
+        {
+          id: "text-embedding-3-small",
+          supported_endpoints: ["/embeddings"],
+        },
+      ]));
+    }
+    if (url.pathname === "/embeddings") {
+      // Real GitHub Copilot embeddings response: usage present, model absent.
+      return jsonResponse({
+        object: "list",
+        data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2] }],
+        usage: { prompt_tokens: 4, total_tokens: 4 },
+      });
+    }
+
+    throw new Error(`Unhandled fetch ${request.url}`);
+  }, async () => {
+    const response = await requestApp("/v1/embeddings", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey.key,
+      },
+      body: JSON.stringify({
+        model: "text-embedding-3-small",
+        input: ["hello"],
+      }),
+    });
+
+    assertEquals(response.status, 200);
+    await response.json();
+  });
+
+  await flushAsyncWork();
+
+  const usage = await repo.usage.listAll();
+  assertEquals(usage.length, 1);
+  // Falls back to the requested model carried via usage metadata.
+  assertEquals(usage[0].model, "text-embedding-3-small");
+  assertEquals(usage[0].inputTokens, 4);
+});


### PR DESCRIPTION
## Summary

`POST /v1/embeddings` returns HTTP 500 for every authenticated request after d8dd086 (`fix(data-plane): account usage under resolved model`). All embeddings traffic going through the gateway is broken; chat-class endpoints are unaffected.

```
Error: Usage response has token usage but no model
    at requireUsageModel (src/middleware/usage.ts:155:9)
```

## Root cause

d8dd086 added `requireUsageModel()` in the usage middleware and updated the chat-completions, messages, and responses serves to write `usageModel` metadata via `withUsageResponseMetadata()`. `src/data-plane/embeddings/serve.ts` was not updated.

GitHub Copilot's `/embeddings` upstream response carries `usage` but no `model` field, so when the usage middleware extracts tokens from the JSON body it has no model signal in either the metadata header or the response payload, and `requireUsageModel()` throws.

## Reproduction

```bash
curl -X POST https://<gateway>/v1/embeddings \
  -H "Authorization: Bearer <user-api-key>" \
  -H "Content-Type: application/json" \
  -d '{"model":"text-embedding-3-small","input":["test"]}'
# HTTP 500 — Internal Server Error
```

## Fix

Mirror the chat-class pattern in `embeddings/serve.ts`: after proxying the upstream response, wrap it with `withUsageResponseMetadata({ usageModel })` using the model from the parsed request body. Embeddings have no alias-resolution layer, so the requested model **is** the resolved model.

```ts
const proxied = proxyJsonResponse(resp);
return model ? withUsageResponseMetadata(proxied, { usageModel: model }) : proxied;
```

If the request body has no parseable `model` field we leave the proxied response untouched and let `requireUsageModel()` continue to surface the malformed-input case (existing behavior).

## Tests

Added a regression test in `src/middleware/usage_test.ts` that mocks an upstream `/embeddings` response **without** a `model` field (matching real Copilot behavior) and asserts the request succeeds with usage recorded under the requested model.

- The new test fails on the parent of this commit (HTTP 500).
- All 522 existing tests still pass.

```
ok | 522 passed | 0 failed
```

## Scope

Single-file fix + single-test addition. No other behavior changes.
