### PR TITLE
fix(scripts): target remote D1 in db:migrate

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "db:migrate": "wrangler d1 migrations apply $(node -p \"require('jsonc-parser').parse(require('fs').readFileSync('wrangler.jsonc','utf8')).d1_databases[0].database_name\")",
+    "db:migrate": "wrangler d1 migrations apply $(node -p \"require('jsonc-parser').parse(require('fs').readFileSync('wrangler.jsonc','utf8')).d1_databases[0].database_name\") --remote",
     "lint": "eslint --cache .",
     "lint:fix": "eslint --cache . --fix",
     "test": "vitest run",


### PR DESCRIPTION
The production deploy workflow in AGENTS.md is documented as:

    pnpm run db:migrate && pnpm run deploy

so db:migrate must target the same environment as the deploy: the remote D1 instance. Without --remote, wrangler defaults to a local sqlite, which silently no-ops against production. This produced a dangerous middle state during deploy: the new Worker code was published while the remote D1 still ran the pre-migration schema.

Local development can still migrate the local D1 directly with:

    pnpm exec wrangler d1 migrations apply copilot-db
