### PR TITLE
fix(web): drop duplicate api-key card on keys page

### DIFF
--- a/apps/web/src/pages/dashboard/keys.vue
+++ b/apps/web/src/pages/dashboard/keys.vue
@@ -180,10 +180,6 @@ const modelsForSnippets = computed(() => modelsStore.models.value ?? []);
       <div class="mt-5">
         <CliSnippet :api-key="configurationKey" :models="modelsForSnippets" />
       </div>
-
-      <div v-if="!auth.isAdmin && keys[0] && !selectedKey" class="mt-5">
-        <Code :code="keys[0].key" :copyable="true" />
-      </div>
     </div>
 
     <EditKeyDialog


### PR DESCRIPTION
The extra <Code> block at the bottom of the keys page re-rendered the api-key's raw key for non-admin users — it duplicated the CliSnippet above and surprised users logged in with their own api key.