### PR TITLE
feat(shim): persist web_search_call as private payload; reject multi-op shim calls

### DIFF
--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -19,8 +19,8 @@ export type LlmTargetApi = 'messages' | 'responses' | 'chat-completions';
  *
  * - `privatePayload`: wire item id → shim-defined opaque blob, round-tripped
  *   verbatim by persistence as `payload.private`. The shape is shim-specific.
- * - `newSyntheticIds`: gateway-minted item ids no upstream issued (e.g. a
- *   server-tool shim's `web_search_call`), persisted as non_affinity.
+ * - `newSyntheticIds`: gateway-minted item ids no upstream issued, persisted
+ *   as non_affinity.
  */
 export interface StatefulResponsesContext {
   readonly privatePayload: Map<string, unknown>;

--- a/apps/api/src/data-plane/llm/sources/gemini/interceptors/strip-unsupported-tools.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/interceptors/strip-unsupported-tools.ts
@@ -5,9 +5,6 @@ import type { GeminiPayload, GeminiToolGroup } from '@floway-dev/protocols/gemin
  * Only function declarations are currently translatable from Gemini tool
  * groups. Strip the rest after target planning so target emitters never see
  * unsupported tool capabilities.
- *
- * TODO: Support Gemini googleSearch through the existing web-search shim
- * instead of dropping it here.
  */
 const stripToolCapabilities = (tool: GeminiToolGroup): void => {
   delete tool.googleSearch;

--- a/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
@@ -51,7 +51,8 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
 
 const requestContext = (apiKeyId?: string): RequestContext => ({
   requestStartedAt: 0,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
+  runtimeLocation: 'test',
   clientStream: false,
   ...(apiKeyId !== undefined ? { apiKeyId } : {}),
 });
@@ -176,7 +177,7 @@ const collect = async <T>(events: AsyncIterable<T>): Promise<T[]> => {
 // event sequence used by the replay-only wiring tests below. Only handles text
 // blocks (with optional citations) because that is the shape these fixtures
 // exercise; extend if a future test needs other block kinds.
-const messagesResultToUpstreamFrames = (response: MessagesResult): ProtocolFrame<MessagesStreamEvent>[] => {
+const messagesResponseToUpstreamFrames = (response: MessagesResult): ProtocolFrame<MessagesStreamEvent>[] => {
   const frames: ProtocolFrame<MessagesStreamEvent>[] = [
     eventFrame({
       type: 'message_start',
@@ -195,7 +196,7 @@ const messagesResultToUpstreamFrames = (response: MessagesResult): ProtocolFrame
 
   response.content.forEach((block, index) => {
     if (block.type !== 'text') {
-      throw new Error(`messagesResultToUpstreamFrames only handles text blocks; got ${block.type}`);
+      throw new Error(`messagesResponseToUpstreamFrames only handles text blocks; got ${block.type}`);
     }
     frames.push(eventFrame({
       type: 'content_block_start',
@@ -561,7 +562,7 @@ test('withMessagesWebSearchShim allows replay-only history when the search provi
     Promise.resolve({
       type: 'events',
       events: toAsyncIterable(
-        messagesResultToUpstreamFrames({
+        messagesResponseToUpstreamFrames({
           id: 'msg_replay_only',
           type: 'message',
           role: 'assistant',
@@ -610,7 +611,7 @@ test('withMessagesWebSearchShim emits native-like citation deltas for replay-onl
     Promise.resolve({
       type: 'events',
       events: toAsyncIterable(
-        messagesResultToUpstreamFrames({
+        messagesResponseToUpstreamFrames({
           id: 'msg_replay_only_stream',
           type: 'message',
           role: 'assistant',

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
@@ -1,7 +1,7 @@
 import { jsonrepair } from 'jsonrepair';
 
 import type { InterceptorRun, RequestContext, ResponsesInterceptor, ResponsesInvocation, StatefulResponsesContext } from '../../../interceptors.ts';
-import type { EventResult, EventResultMetadata, ExecuteResult } from '../../../shared/errors/result.ts';
+import type { EventResultMetadata, ExecuteResult } from '../../../shared/errors/result.ts';
 import { truncatePreservingCodePoints } from '../../../shared/text.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
@@ -36,7 +36,14 @@ export interface MergeState {
 export interface InterceptedFunctionCall {
   callId: string;
   name: string;
-  argumentsJson: string;
+  /**
+   * Parsed and jsonrepair-cleaned `arguments` object. `null` when the
+   * raw upstream string is not a JSON object even after jsonrepair —
+   * dispatchers handle that case via their own error path. Dispatchers
+   * that persist function-call inputs across turns should serialize
+   * this rather than the raw upstream string; replaying the raw form
+   * would re-break the next turn the same way it broke this one.
+   */
   arguments: Record<string, unknown> | null;
 }
 
@@ -51,7 +58,7 @@ export interface ServerToolResultSlot {
      * Optional server-only blob registered on `request.statefulResponsesContext.privatePayload`
      * under `slot.id` before the slot's wire item leaves materialize. The
      * persistence layer stores it in `payload.private`; the replay-side
-     * `transformItems` reads it back to reconstruct full state across turns.
+     * `transformItems` reads it back to reconstruct the full IR.
      */
     privatePayload?: unknown;
   }>;
@@ -96,7 +103,7 @@ export type ServerToolPrepareResult =
     type: 'active';
     baseToolName: string;
     // History rewrite, applied whether or not the tool is hosted this
-    // turn so replayed items (e.g. an echoed `web_search_call`) become
+    // turn so items echoed from a previous turn's output become
     // upstream-readable even on a request that no longer declares the
     // hosted tool.
     transformItems?: (items: ResponsesInputItem[], toolName: string) => ResponsesInputItem[];
@@ -131,10 +138,7 @@ export interface TurnSummary {
   terminalStatus: UpstreamTerminal;
 }
 
-interface LatestMetadata {
-  modelIdentity: EventResultMetadata['modelIdentity'];
-  performance: EventResultMetadata['performance'];
-}
+type LatestUpstreamMetadata = Pick<EventResultMetadata, 'modelIdentity' | 'performance'>;
 
 const synthesizeShimResponseId = (): string =>
   `resp_shim_${crypto.randomUUID().replace(/-/g, '')}`;
@@ -217,16 +221,11 @@ export const usageOf = (usage: ResponsesResult['usage']): Partial<MergeUsage> =>
   return out;
 };
 
-const serverToolChoiceType = (toolChoice: ResponsesToolChoice | undefined): string | undefined =>
-  typeof toolChoice === 'object' && toolChoice !== null && typeof toolChoice.type === 'string'
-    ? toolChoice.type
-    : undefined;
-
 const rewriteHostedToolChoice = (
   toolChoice: ResponsesToolChoice | undefined,
   active: readonly ActiveServerTool[],
 ): ResponsesToolChoice | undefined => {
-  const choiceType = serverToolChoiceType(toolChoice);
+  const choiceType = typeof toolChoice === 'object' && toolChoice !== null && typeof toolChoice.type === 'string' ? toolChoice.type : undefined;
   if (choiceType === undefined) return toolChoice;
   for (const entry of active) {
     if (!entry.hasHostedTool) continue;
@@ -240,15 +239,12 @@ const rewriteHostedToolChoice = (
   return toolChoice;
 };
 
-// Bound on the suffix search; defends against a pathological tools list
-// that somehow occupies every `<baseName>_<n>` candidate.
+// Cap on the suffix search; resolveServerToolName throws if exhausted.
 const MAX_NAME_RESOLUTION_ATTEMPTS = 1000;
 
 export const resolveServerToolName = (baseName: string, tools: readonly ResponsesTool[]): string => {
   const taken = new Set(tools.flatMap(tool => (tool.type === 'function' || tool.type === 'custom') ? [tool.name] : []));
   if (!taken.has(baseName)) return baseName;
-  // `baseName` was attempt 1; suffixes `_2`…`_MAX` make up the rest, so
-  // the bound is inclusive and the total names tried equals MAX.
   for (let i = 2; i <= MAX_NAME_RESOLUTION_ATTEMPTS; i++) {
     const candidate = `${baseName}_${i}`;
     if (!taken.has(candidate)) return candidate;
@@ -284,9 +280,10 @@ export const parseServerToolArguments = (argumentsJson: string): Record<string, 
   } catch {
     return null;
   }
-  return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
-    ? parsed as Record<string, unknown>
-    : null;
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
 };
 
 const syntheticInProgressResponse = (state: MergeState, id: string, model: string): ResponsesResult => {
@@ -367,6 +364,7 @@ export const serverToolResultSlot = (args: {
   result: Promise<{
     item: ServerToolOutputItem;
     endEvents: readonly ServerToolLifecycleEvent[];
+    privatePayload?: unknown;
   }>;
 }): ServerToolResultSlot => ({
   id: args.id,
@@ -375,8 +373,11 @@ export const serverToolResultSlot = (args: {
   result: args.result.then(result => ({
     item: result.item,
     endEvents: [...result.endEvents],
+    ...(result.privatePayload !== undefined ? { privatePayload: result.privatePayload } : {}),
   })),
 });
+
+const attachServerToolItemId = (item: ServerToolOutputItem, id: string): ResponsesOutputItem => ({ ...item, id } as ResponsesOutputItem);
 
 const serverToolStartFrames = (
   merge: MergeState,
@@ -411,9 +412,7 @@ const serverToolEndFrames = (
   return frames;
 };
 
-const attachServerToolItemId = (item: ServerToolOutputItem, id: string): ResponsesOutputItem => ({ ...item, id } as ResponsesOutputItem);
-
-const responsesInputItemsOf = (input: ResponsesPayload['input']): ResponsesInputItem[] =>
+const responseInputItemsOf = (input: ResponsesPayload['input']): ResponsesInputItem[] =>
   Array.isArray(input) ? input : [{ type: 'message', role: 'user', content: input }];
 
 const transformServerToolItems = (
@@ -425,6 +424,13 @@ const transformServerToolItems = (
     if (entry.transformItems !== undefined) next = entry.transformItems(next, entry.toolName);
   }
   return next;
+};
+
+const UPSTREAM_TERMINAL_LABEL: Record<UpstreamTerminal['kind'], string> = {
+  completed: 'response.completed',
+  failed: 'response.failed',
+  incomplete: 'response.incomplete',
+  'bare-error-pre-shell': 'a pre-shell bare error',
 };
 
 export const consumeTurnStreaming = async function* (
@@ -441,7 +447,11 @@ export const consumeTurnStreaming = async function* (
 
   const openItems = new Map<number, number>();
   const openItemIds = new Map<number, string>();
-  const interceptedByUpstreamIndex = new Map<number, { intercepted: InterceptedFunctionCall; dispatcher: ServerToolDispatcher; reservedOutputIndex: number }>();
+  // `argumentsJson` accumulates `function_call_arguments.delta` chunks
+  // until the closing `.done` parses them into `intercepted.arguments`.
+  // Kept on the entry (not on `InterceptedFunctionCall`) because it's
+  // streaming state, not part of the dispatcher's input.
+  const interceptedByUpstreamIndex = new Map<number, { intercepted: InterceptedFunctionCall; dispatcher: ServerToolDispatcher; reservedOutputIndex: number; argumentsJson: string }>();
 
   const ensureModel = (): string => {
     if (merge.lastSeenModel === null) {
@@ -523,7 +533,7 @@ export const consumeTurnStreaming = async function* (
       if (item.type === 'function_call') {
         const dispatcher = dispatchers.get(item.name);
         if (dispatcher !== undefined) {
-          // Reserve the downstream index the umbrella occupies now, at
+          // Reserve the downstream index the shim call occupies now, at
           // `.added`; the actual slot count is only known at `.done`,
           // where slot 0 takes this reserved index and any further slots
           // take fresh ones. Those stay contiguous because Responses
@@ -534,10 +544,10 @@ export const consumeTurnStreaming = async function* (
           interceptedByUpstreamIndex.set(upstreamIndex, {
             dispatcher,
             reservedOutputIndex: merge.outputIndex++,
+            argumentsJson: '',
             intercepted: {
               callId: item.call_id,
               name: item.name,
-              argumentsJson: '',
               arguments: {},
             },
           });
@@ -568,8 +578,8 @@ export const consumeTurnStreaming = async function* (
       const upstreamIndex = event.output_index;
       const intercepted = interceptedByUpstreamIndex.get(upstreamIndex);
       if (intercepted !== undefined) {
-        if (event.item.type === 'function_call') intercepted.intercepted.argumentsJson = event.item.arguments;
-        intercepted.intercepted.arguments = parseServerToolArguments(intercepted.intercepted.argumentsJson);
+        if (event.item.type === 'function_call') intercepted.argumentsJson = event.item.arguments;
+        intercepted.intercepted.arguments = parseServerToolArguments(intercepted.argumentsJson);
         const slots = intercepted.dispatcher({ intercepted: intercepted.intercepted, loopState });
         if (loopState.remainingToolCalls !== undefined) loopState.remainingToolCalls -= 1;
         const dispatchedSlots: DispatchedServerToolSlot[] = [];
@@ -597,7 +607,7 @@ export const consumeTurnStreaming = async function* (
     if (event.type === 'response.function_call_arguments.delta') {
       const intercepted = interceptedByUpstreamIndex.get(event.output_index);
       if (intercepted !== undefined) {
-        intercepted.intercepted.argumentsJson += event.delta;
+        intercepted.argumentsJson += event.delta;
         continue;
       }
       const rewritten = rewriteOutputIndex(event, openItems, openItemIds, merge);
@@ -608,7 +618,7 @@ export const consumeTurnStreaming = async function* (
     if (event.type === 'response.function_call_arguments.done') {
       const intercepted = interceptedByUpstreamIndex.get(event.output_index);
       if (intercepted !== undefined) {
-        intercepted.intercepted.argumentsJson = event.arguments;
+        intercepted.argumentsJson = event.arguments;
         continue;
       }
       const rewritten = rewriteOutputIndex(event, openItems, openItemIds, merge);
@@ -668,7 +678,7 @@ export const consumeTurnStreaming = async function* (
         output: [],
         status: 'failed',
         error: {
-          message: `Upstream emitted ${UPSTREAM_TERMINAL_LABEL[terminalStatus.kind]} without closing umbrella function_call items at upstream output_index ${unmatched.join(', ')}.`,
+          message: `Upstream emitted ${UPSTREAM_TERMINAL_LABEL[terminalStatus.kind]} without closing shim call items at upstream output_index ${unmatched.join(', ')}.`,
           code: 'server_error',
         },
         incomplete_details: null,
@@ -677,13 +687,6 @@ export const consumeTurnStreaming = async function* (
   }
 
   return { dispatched, sawClientToolCall, turnUsage, terminalStatus };
-};
-
-const UPSTREAM_TERMINAL_LABEL: Record<UpstreamTerminal['kind'], string> = {
-  completed: 'response.completed',
-  failed: 'response.failed',
-  incomplete: 'response.incomplete',
-  'bare-error-pre-shell': 'a pre-shell bare error',
 };
 
 const MAX_BODY_EXCERPT_CHARS = 512;
@@ -822,7 +825,7 @@ async function* runMultiTurnLoop(args: {
   statefulResponsesContext: StatefulResponsesContext;
   canonicalInput: ResponsesInputItem[];
   active: readonly ActiveServerTool[];
-  metadata: LatestMetadata;
+  metadata: LatestUpstreamMetadata;
   resolveFinalMetadata: (m: EventResultMetadata) => void;
 }): AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>> {
   const { ctx, run, merge, loopState, demoteForcedServerToolChoiceAfterFirstTurn, turn1Iter, dispatchers, statefulResponsesContext, active, metadata, resolveFinalMetadata } = args;
@@ -941,7 +944,7 @@ export const withResponsesServerToolShim = (
       : { ...ctx.payload, tool_choice: rewrittenToolChoice };
   }
 
-  const canonicalInput = responsesInputItemsOf(ctx.payload.input);
+  const canonicalInput = responseInputItemsOf(ctx.payload.input);
   const inputArray = Array.isArray(ctx.payload.input) ? ctx.payload.input : undefined;
   if (inputArray !== undefined) {
     const nextInput = transformServerToolItems(inputArray, active);
@@ -965,16 +968,15 @@ export const withResponsesServerToolShim = (
       && dispatchers.has(finalToolChoice.name));
 
   const merge = createMergeState();
-  const firstResultRaw = await run();
-  if (firstResultRaw.type !== 'events') return firstResultRaw;
-  const firstResult: EventResult<ProtocolFrame<RawResponsesStreamEvent>> = firstResultRaw;
+  const firstResult = await run();
+  if (firstResult.type !== 'events') return firstResult;
   const turn1Iter = consumeTurnStreaming(firstResult.events, merge, true, dispatchers, loopState);
 
   let resolveFinalMetadata!: (m: EventResultMetadata) => void;
   const shimFinalMetadata = new Promise<EventResultMetadata>(resolve => {
     resolveFinalMetadata = resolve;
   });
-  const metadata: LatestMetadata = {
+  const metadata: LatestUpstreamMetadata = {
     modelIdentity: firstResult.modelIdentity,
     performance: firstResult.performance,
   };

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
@@ -296,19 +296,6 @@ const makeStubDeps = (overrides: DepsOverrides = {}): {
   return { backend };
 };
 
-// Read every search-usage row recorded into the in-memory repo. Tests
-// that previously asserted on a captured `usageRecorded` array now
-// drain the repo aggregator.
-const drainUsageRows = async (): Promise<Array<{ provider: string; keyId: string; action: string; requests: number }>> => {
-  const repo = (await import('../../../../../repo/index.ts')).getRepo();
-  return (await repo.searchUsage.listAll()).map(r => ({
-    provider: r.provider,
-    keyId: r.keyId,
-    action: r.action,
-    requests: r.requests,
-  }));
-};
-
 interface InvocationOverrides {
   targetApi?: ResponsesInvocation['targetApi'];
   enabledFlags?: ResponsesInvocation['enabledFlags'];
@@ -331,13 +318,18 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
     model: 'claude-x',
     input: [{ type: 'message', role: 'user', content: 'hi' }],
     tools: [{ type: 'web_search' }],
+    // Opt the wire item into `results` so most tests can inspect them
+    // directly; the new include-gating tests explicitly omit this and
+    // assert the wire-item shape without `results`.
+    include: ['web_search_call.results'],
     ...overrides.payload,
   } as ResponsesPayload,
 });
 
 const makeRequest = (apiKeyId: string | undefined = 'k1'): RequestContext => ({
   requestStartedAt: 0,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
+  runtimeLocation: 'test',
   clientStream: true,
   ...(apiKeyId !== undefined ? { apiKeyId } : {}),
 });
@@ -517,7 +509,7 @@ test('shim no-ops when no hosted web_search tool is present', async () => {
 
 const hostedAliasTypes = ['web_search', 'web_search_2025_08_26', 'web_search_preview', 'web_search_preview_2025_03_11'] as const;
 for (const type of hostedAliasTypes) {
-  test(`shim rewrites hosted ${type} alias into the umbrella function tool`, async () => {
+  test(`shim rewrites hosted ${type} alias into the shim function tool`, async () => {
     makeStubDeps();
     const shim = withResponsesWebSearchShim;
     const inv = makeInvocation({
@@ -535,7 +527,7 @@ for (const type of hostedAliasTypes) {
 // ── tool_choice rewrite × 4 hosted-type values ─────────────────────────
 
 for (const type of hostedAliasTypes) {
-  test(`shim rewrites tool_choice {type: ${type}} to forced umbrella function`, async () => {
+  test(`shim rewrites tool_choice {type: ${type}} to forced shim's function tool`, async () => {
     makeStubDeps();
     const shim = withResponsesWebSearchShim;
     const inv = makeInvocation({
@@ -629,8 +621,10 @@ test('shim drives one search then a final message in two upstream turns', async 
   assertEquals(tail[0].type, 'function_call');
   assertEquals(tail[1].type, 'function_call_output');
   assert(tail[0].type === 'function_call');
-  assertFalse(tail[0].call_id === 'call_1');
-  assert(tail[0].call_id.startsWith('cc_from_ws_gw_'));
+  // Shim replay preserves the upstream's original shim call
+  // verbatim (call_id, name, jsonrepair-canonical args) so the upstream
+  // model on turn 2 sees its prior assistant turn unchanged.
+  assertEquals(tail[0].call_id, 'call_1');
   const events = eventPayloads(frames);
   const wsCallTypes = events.filter(e => e.type.startsWith('response.web_search_call'));
   assertEquals(wsCallTypes.length, 3);
@@ -663,33 +657,6 @@ test('synthesized web_search_call ids are registered as gateway-synthetic on the
   for (const e of doneEvents.filter(e => e.item.type === 'message')) {
     assertFalse(request.statefulResponsesContext.newSyntheticIds.has(e.item.id!));
   }
-});
-
-// ── Multi-action umbrella call = 1 iteration ──────────────────────────
-
-test('shim dispatches multiple logical operations from one umbrella call (one iteration)', async () => {
-  const { backend } = makeStubDeps();
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  const argsJson = JSON.stringify({
-    search_query: [{ q: 'q1' }, { q: 'q2' }, { q: 'q3' }],
-  });
-  const parallelTurn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_1', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, argsJson),
-    mkFunctionCallDone(0, 'call_1', SHIM_TOOL_NAME, argsJson),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([parallelTurn, messageTurn('done', 0)]);
-
-  await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  assertEquals(script.callCount(), 2);
-  // Three backend searches from ONE upstream call.
-  assertEquals(backend.calls.length, 3);
-  assertEquals(backend.calls.every(c => c.kind === 'search'), true);
 });
 
 // ── find_in_page cache hit ────────────────────────────────────────────
@@ -746,7 +713,7 @@ test('find_in_page triggers implicit fetchPage when URL not cached', async () =>
 
 // ── Iteration cap exhausted ───────────────────────────────────────────
 
-test('iteration cap returns iterationCapText without backend call on cap+1', async () => {
+test('iteration cap returns the iteration-cap notice without backend call on cap+1', async () => {
   const { backend } = makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation();
@@ -772,8 +739,9 @@ test('iteration cap returns iterationCapText without backend call on cap+1', asy
 
   // The cap-exceeded turn still synthesizes a full web_search_call
   // lifecycle: 31 done events = 30 successful + 1 capped. The capped
-  // call's done item carries its action with the original query so the
-  // downstream item is recognizable.
+  // call surfaces as the schema-error shape (action.type='search' with
+  // the cap diagnostic in queries[0]) rather than the original query —
+  // the shim call is rejected before backend dispatch.
   const wsCallDone = events.filter((e): e is Extract<ResponsesStreamEvent, { type: 'response.output_item.done' }> =>
     e.type === 'response.output_item.done'
     && (e as { item?: { type?: string } }).item?.type === 'web_search_call');
@@ -781,7 +749,64 @@ test('iteration cap returns iterationCapText without backend call on cap+1', asy
   const capItem = wsCallDone[30].item as ResponsesOutputWebSearchCall;
   assert(capItem.action !== undefined);
   assertEquals(capItem.action.type, 'search');
-  assertEquals((capItem.action as { queries: string[] }).queries, ['qcap']);
+});
+
+// ── Ambiguous multi-op function_call rejection ─────────────────────────────
+
+// One private payload ⇄ one wsc ⇄ one op. Any shim call that carries more
+// than one logical operation — multi-kind mix or multi-instance same-kind
+// — is rejected before backend dispatch with a single ambiguous-error wsc
+// so the model knows to split the request into independent calls.
+
+const assertAmbiguousShimRejection = async (args: string, backend: { calls: unknown[] }): Promise<void> => {
+  const shim = withResponsesWebSearchShim;
+  const inv = makeInvocation();
+  const turn: ScriptedTurn = [
+    mkResponseCreated(),
+    mkResponseInProgress(),
+    mkFunctionCallAdded(0, 'call_ambig', SHIM_TOOL_NAME),
+    mkFunctionCallArgsDone(0, args),
+    mkFunctionCallDone(0, 'call_ambig', SHIM_TOOL_NAME, args),
+    mkResponseCompleted(),
+  ];
+  const script = scriptedRun([turn, messageTurn('done', 0)]);
+  const result = await shim(inv, makeRequest(), script.run);
+  assert(result.type === 'events');
+  const events = eventPayloads(await collectFrames(result.events));
+  assertEquals(backend.calls.length, 0);
+  const wsCallDone = events.filter((e): e is Extract<ResponsesStreamEvent, { type: 'response.output_item.done' }> =>
+    e.type === 'response.output_item.done'
+    && (e as { item?: { type?: string } }).item?.type === 'web_search_call');
+  assertEquals(wsCallDone.length, 1);
+  const item = wsCallDone[0].item as ResponsesOutputWebSearchCall;
+  assertEquals(item.action?.type, 'search');
+  assert(Array.isArray(item.results));
+  assert(item.results![0].snippet.includes('ambiguous'));
+  assert(item.results![0].snippet.includes('one operation'));
+};
+
+test('multi-kind shim call (search_query + open) is rejected as ambiguous before any backend dispatch', async () => {
+  const { backend } = makeStubDeps();
+  await assertAmbiguousShimRejection(
+    JSON.stringify({ search_query: [{ q: 'q' }], open: [{ ref_id: 'https://example.com/' }] }),
+    backend,
+  );
+});
+
+test('multi-instance same-kind shim call (two search_query entries) is rejected as ambiguous', async () => {
+  const { backend } = makeStubDeps();
+  await assertAmbiguousShimRejection(
+    JSON.stringify({ search_query: [{ q: 'q1' }, { q: 'q2' }] }),
+    backend,
+  );
+});
+
+test('multi-instance same-kind shim call (two open entries) is rejected as ambiguous', async () => {
+  const { backend } = makeStubDeps();
+  await assertAmbiguousShimRejection(
+    JSON.stringify({ open: [{ ref_id: 'https://example.com/a' }, { ref_id: 'https://example.com/b' }] }),
+    backend,
+  );
 });
 
 // ── Backend search zero-results case ─────────────────────────────────
@@ -810,242 +835,6 @@ test('search returning zero results surfaces the "(no results)" template', async
     (lastOutput as { output: string }).output,
     'Search results for "empty-query":\n\n(no results)',
   );
-});
-
-// ── fetchPage per-URL failure in multi-URL batch ─────────────────────
-
-test('fetchPage with mixed success/failure across parallel opens surfaces distinct outputs', async () => {
-  // ONE umbrella call whose `open[]` array carries both URLs. The shim
-  // batches into one fetchPage({urls: [success, failure]}); the provider
-  // returns a page for one and a per-URL failure for the other.
-  const successUrl = 'https://example.com/success';
-  const failureUrl = 'https://example.com/missing';
-  const { backend } = makeStubDeps({
-    providerOverrides: {
-      async fetchPage(req): Promise<WebSearchFetchPageResult> {
-        // Tavily shape: pages + failures in one 200.
-        const out: WebSearchFetchPageResult = { type: 'ok', pages: [], failures: [] };
-        for (const url of req.urls) {
-          if (url === successUrl) {
-            out.pages.push({
-              url,
-              title: 'Hello',
-              content: 'body of success page',
-              truncated: false,
-              fullContentBytes: 20,
-            });
-          } else {
-            out.failures.push({
-              url,
-              errorCode: 'unavailable',
-              message: '404',
-            });
-          }
-        }
-        return out;
-      },
-    },
-  });
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  const argsJson = JSON.stringify({ open: [{ ref_id: successUrl }, { ref_id: failureUrl }] });
-  const parallelOpensTurn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_umbrella', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, argsJson),
-    mkFunctionCallDone(0, 'call_umbrella', SHIM_TOOL_NAME, argsJson),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([parallelOpensTurn, messageTurn('done', 0)]);
-
-  await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  // ONE fetchPage call carrying BOTH URLs.
-  const fetchCalls = backend.calls.filter(c => c.kind === 'fetchPage');
-  assertEquals(fetchCalls.length, 1);
-  const batched = fetchCalls[0].request as WebSearchFetchPageRequest;
-  assertEquals(batched.urls.length, 2);
-  assert(batched.urls.includes(successUrl));
-  assert(batched.urls.includes(failureUrl));
-
-  const input = inv.payload.input as ResponsesInputItem[];
-  // One function_call_output per logical op (umbrella unrolled into N pairs
-  // by the shared `irToUpstreamPair` renderer).
-  const outputs = input.filter(i => i.type === 'function_call_output') as Array<{
-    type: 'function_call_output';
-    call_id: string;
-    output: string;
-  }>;
-  assertEquals(outputs.length, 2);
-  const combined = outputs.map(o => o.output).join('\n\n');
-  assert(combined.includes('body of success page'));
-  assert(combined.includes(`Error fetching URL \`${failureUrl}\``));
-  assert(combined.includes('404'));
-});
-
-// ── Parallel opens batched into one fetchPage call ──────────────────
-
-test('two parallel open[] entries issue ONE fetchPage with both URLs', async () => {
-  // ≥2 `open[]` entries with distinct URLs (no cache hit, no in-flight)
-  // must batch into one provider.fetchPage call (one usage row).
-  const url1 = 'https://example.com/a';
-  const url2 = 'https://example.com/b';
-  const { backend } = makeStubDeps();
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  const parallelOpensArgs = JSON.stringify({ open: [{ ref_id: url1 }, { ref_id: url2 }] });
-  const parallelOpensTurn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_umbrella', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, parallelOpensArgs),
-    mkFunctionCallDone(0, 'call_umbrella', SHIM_TOOL_NAME, parallelOpensArgs),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([parallelOpensTurn, messageTurn('done', 0)]);
-
-  await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  const fetchCalls = backend.calls.filter(c => c.kind === 'fetchPage');
-  assertEquals(fetchCalls.length, 1);
-  const req = fetchCalls[0].request as WebSearchFetchPageRequest;
-  assertEquals([...req.urls].sort(), [url1, url2]);
-  // ONE usage record for the single batched provider call.
-  const usageRows = await drainUsageRows();
-  assertEquals(usageRows.filter(u => u.action === 'fetch_page').length, 1);
-
-  const input = inv.payload.input as ResponsesInputItem[];
-  const outputs = input.filter(i => i.type === 'function_call_output') as Array<{
-    type: 'function_call_output';
-    call_id: string;
-    output: string;
-  }>;
-  assertEquals(outputs.length, 2);
-  const combined = outputs.map(o => o.output).join('\n\n');
-  assert(combined.includes(`body of ${url1}`));
-  assert(combined.includes(`body of ${url2}`));
-});
-
-// ── Mixed cache-hit + fresh open in one turn ─────────────────────────
-
-test('mixed cache-hit + fresh open in one turn issues ONE fetchPage with only the fresh URL', async () => {
-  const cachedUrl = 'https://example.com/cached';
-  const freshUrl = 'https://example.com/fresh';
-  const { backend } = makeStubDeps();
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  // Turn 1: warm pageCache with cachedUrl.
-  // Turn 2: open both URLs; only freshUrl should hit fetchPage.
-  const turn1 = openCallTurn(0, 'call_warm', cachedUrl);
-  const turn2Args = JSON.stringify({ open: [{ ref_id: cachedUrl }, { ref_id: freshUrl }] });
-  const turn2: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_umbrella', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, turn2Args),
-    mkFunctionCallDone(0, 'call_umbrella', SHIM_TOOL_NAME, turn2Args),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([turn1, turn2, messageTurn('done', 0)]);
-
-  await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  const fetchCalls = backend.calls.filter(c => c.kind === 'fetchPage');
-  // Turn 1: cachedUrl. Turn 2: freshUrl only (cachedUrl served from cache). Total = 2.
-  assertEquals(fetchCalls.length, 2);
-  const turn2Req = fetchCalls[1].request as WebSearchFetchPageRequest;
-  assertEquals(turn2Req.urls, [freshUrl]);
-});
-
-// ── find joins concurrent open's in-flight batch ─────────────────────
-
-test('parallel open + find on the same URL share ONE fetchPage call', async () => {
-  // open kicks off a fetch; find joins the in-flight slot installed by
-  // the batch instead of starting a second fetchPage.
-  const url = 'https://example.com/shared';
-  const { backend } = makeStubDeps({
-    providerOverrides: {
-      async fetchPage(req) {
-        return {
-          type: 'ok',
-          pages: req.urls.map(u => ({
-            url: u,
-            title: 'p',
-            content: 'this body has the needle in it',
-            truncated: false,
-            fullContentBytes: 30,
-          })),
-          failures: [],
-        };
-      },
-    },
-  });
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  const parallelArgs = JSON.stringify({
-    open: [{ ref_id: url }],
-    find: [{ ref_id: url, pattern: 'needle' }],
-  });
-  const parallelTurn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_umbrella', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, parallelArgs),
-    mkFunctionCallDone(0, 'call_umbrella', SHIM_TOOL_NAME, parallelArgs),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([parallelTurn, messageTurn('done', 0)]);
-
-  await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  // ONE fetchPage call serves both ops — the pre-batch bundles every
-  // open AND find URL from the umbrella call into one provider call.
-  const fetchCalls = backend.calls.filter(c => c.kind === 'fetchPage');
-  assertEquals(fetchCalls.length, 1);
-
-  const input = inv.payload.input as ResponsesInputItem[];
-  const outputs = input.filter(i => i.type === 'function_call_output') as Array<{
-    type: 'function_call_output';
-    call_id: string;
-    output: string;
-  }>;
-  // One pair per logical op: the open and the find each get their own.
-  assertEquals(outputs.length, 2);
-  const combined = outputs.map(o => o.output).join('\n\n');
-  assert(combined.includes('this body has the needle in it'));
-  assert(combined.includes('[needle]'));
-});
-
-// ── Mixed search + open + open is one fetchPage + one search ────────
-
-test('mixed search + two opens dispatches one search and ONE batched fetchPage', async () => {
-  const url1 = 'https://example.com/x';
-  const url2 = 'https://example.com/y';
-  const { backend } = makeStubDeps();
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  const mixedArgs = JSON.stringify({
-    search_query: [{ q: 'q' }],
-    open: [{ ref_id: url1 }, { ref_id: url2 }],
-  });
-  const mixedTurn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_umbrella', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, mixedArgs),
-    mkFunctionCallDone(0, 'call_umbrella', SHIM_TOOL_NAME, mixedArgs),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([mixedTurn, messageTurn('done', 0)]);
-
-  await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  assertEquals(backend.calls.filter(c => c.kind === 'search').length, 1);
-  const fetchCalls = backend.calls.filter(c => c.kind === 'fetchPage');
-  assertEquals(fetchCalls.length, 1);
-  const req = fetchCalls[0].request as WebSearchFetchPageRequest;
-  assertEquals([...req.urls].sort(), [url1, url2]);
 });
 
 // ── Backend search failure ────────────────────────────────────────────
@@ -1077,7 +866,7 @@ test('backend search failure surfaces "Search failed: <message>"', async () => {
 
 // ── Backend fetchPage whole-batch failure ─────────────────────────────
 
-test('fetchPage whole-batch failure surfaces openFailedText', async () => {
+test('fetchPage whole-batch failure surfaces the open-page error text', async () => {
   makeStubDeps({
     providerOverrides: {
       async fetchPage() {
@@ -1497,8 +1286,8 @@ test('invalid search_context_size value rejects with 400 (no silent fall-through
 });
 
 for (const field of ['external_web_access', 'search_content_types', 'return_token_budget'] as const) {
-  test(`explicitly-set hosted ${field} is silently stripped (the umbrella tool the shim forwards never carries it)`, async () => {
-    // The shim replaces the hosted entry with its umbrella function
+  test(`explicitly-set hosted ${field} is silently stripped (the shim's function tool the shim forwards never carries it)`, async () => {
+    // The shim replaces the hosted entry with its shim's function tool
     // tool; any hosted-only field — including ones the shim has no
     // opinion on — drops out with the entry. Mirrors native: silently
     // stripped. Tests the request completes normally instead of being
@@ -2172,7 +1961,7 @@ test('usage cached_tokens never reported on any turn is omitted from wire (no fa
   assertEquals(completed.response.usage?.output_tokens_details, undefined);
 });
 
-test('next-turn function_call echo always carries the canonical re-stringified umbrella args (single shape unified with client-roundtrip)', async () => {
+test('next-turn function_call echo always carries the canonical re-stringified shim call args (single shape unified with client-roundtrip)', async () => {
   // The dispatcher always overwrites the intercepted call's
   // arguments with the canonical re-stringified form, regardless of
   // whether the upstream string was already valid JSON. This
@@ -2282,7 +2071,7 @@ test('upstream sends bare `error` frame AFTER response.created: shim emits respo
   assertEquals(failed.response.error?.message, 'mid-stream upstream blew up');
   // Upstream-supplied code carries through verbatim.
   assertEquals(failed.response.error?.code, 'server_error');
-  // No synthetic `type` field — the OpenAPI ResponseError schema
+  // No synthetic `type` field — the OpenAPI ResponsesError schema
   // defines only `{code, message}` and the bare `error` upstream frame
   // doesn't carry a `type` to forward.
   assertFalse('type' in (failed.response.error as object));
@@ -2388,7 +2177,7 @@ test('turn-1 iterator throws AFTER response.created: synthesizes response.failed
   assertEquals(failed.response.error?.code, 'server_error');
   assert(failed.response.error?.message.includes('connection reset by peer'));
   assert(failed.response.error?.message.includes('Upstream stream failed mid-response'));
-  // No synthetic `type` per the spec ResponseError schema (only
+  // No synthetic `type` per the spec ResponsesError schema (only
   // `{code, message}`).
   assertFalse('type' in (failed.response.error as object));
 });
@@ -3162,10 +2951,10 @@ test('without include: ["web_search_call.action.sources"], action.sources is abs
   assertEquals(action.sources, undefined);
 });
 
-test('web_search_call results field is always populated (always-include divergence from native)', async () => {
+test('web_search_call results field is populated on the wire when the client opted in via include: ["web_search_call.results"]', async () => {
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
+  const inv = makeInvocation(); // Default already opts in.
   const script = scriptedRun([
     searchCallTurn(0, 'call_1', 'q1'),
     messageTurn('done', 0),
@@ -3181,13 +2970,14 @@ test('web_search_call results field is always populated (always-include divergen
   assert(item.results!.length > 0);
 });
 
-test('web_search_call results stays populated even when client omits include: ["web_search_call.results"]', async () => {
-  // Native makes results opt-in via the include field; the shim ignores
-  // that opt-in because results must travel through both internal-loop
-  // and client-roundtrip directions (see server-tools/web-search.ts file header).
+test('web_search_call results field is omitted from the wire when the client did not include it (matches native default)', async () => {
+  // When the client omits `include: ["web_search_call.results"]`, the
+  // wire item carries only id/action — same as native. The IR (and
+  // therefore the persisted `payload.private`) still holds the full
+  // results so a later-turn echo can be hydrated.
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
+  const inv = makeInvocation({ payload: { include: [] } });
   const script = scriptedRun([
     searchCallTurn(0, 'call_1', 'q1'),
     messageTurn('done', 0),
@@ -3199,15 +2989,14 @@ test('web_search_call results stays populated even when client omits include: ["
   const wsCallDone = doneEvents.find(e => e.item.type === 'web_search_call');
   assert(wsCallDone !== undefined);
   const item = wsCallDone.item as ResponsesOutputWebSearchCall;
-  assert(Array.isArray(item.results));
-  assert(item.results!.length > 0);
+  assertEquals(item.results, undefined);
 });
 
-// ── Mixed-tool turn (umbrella + client tool present) ─────────────────
+// ── Mixed-tool turn (shim call + client tool present) ─────────────────
 
-test('mixed-tool: umbrella + client function_call exits to client after one turn, with both sets of items downstream', async () => {
+test('mixed-tool: shim call + client function_call exits to client after one turn, with both sets of items downstream', async () => {
   // GPT-5.x emits both kinds of tool calls in one turn. The shim executes
-  // the umbrella's searches server-side (so the client sees completed
+  // the shim's searches server-side (so the client sees completed
   // web_search_call lifecycles) and lets the client round-trip its own
   // function_call. No internal rerun, no rejection injection.
   const { backend } = makeStubDeps();
@@ -3244,7 +3033,7 @@ test('mixed-tool: umbrella + client function_call exits to client after one turn
   assertEquals(wsLifecycleCount, 3);
 });
 
-test('mixed-tool: umbrella + custom_tool_call exits to client; custom_tool_call frames flush downstream', async () => {
+test('mixed-tool: shim call + custom_tool_call exits to client; custom_tool_call frames flush downstream', async () => {
   const { backend } = makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation();
@@ -3305,13 +3094,18 @@ test('client-only tool turn (no shim call): pass-through function_call frames fl
 
 // ── Pass-through of replayed web_search_call from input ────────────────
 
-// ── Input preprocessor: web_search_call items → umbrella pair ─────────
+// ── Input preprocessor: web_search_call items → shim call pair ─────────
 
-test('input preprocessor: each web_search_call item becomes one umbrella function_call + function_call_output pair', async () => {
-  // Upstream knows the umbrella only as a function tool; a hosted
+test('input preprocessor: each web_search_call item becomes one shim call + function_call_output pair', async () => {
+  // Upstream knows the shim call only as a function tool; a hosted
   // `web_search_call` item type in its input would be unrecognized. We
   // translate each echoed item into a function_call + function_call_output
-  // pair that the upstream model can reason over.
+  // pair that the upstream model can reason over. With no per-item
+  // private payload (this test runs raw through the shim), the
+  // function_call mirrors the wire action shape and the
+  // function_call_output is the placeholder — the shim deliberately
+  // ignores the wire `results` field because gateway-side state is the
+  // only source of truth.
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const replayedSearch: ResponsesInputWebSearchCall = {
@@ -3351,16 +3145,18 @@ test('input preprocessor: each web_search_call item becomes one umbrella functio
   ]);
   // No web_search_call items remain after preprocessing.
   assertFalse(input.some(i => i.type === 'web_search_call'));
-  // The pair from the search reflects its action; the body carries the snippet.
+  // The pair from the search reflects its action.
   const searchFc = input[1] as { name: string; arguments: string };
   assertEquals(searchFc.name, SHIM_TOOL_NAME);
   assert(searchFc.arguments.includes('hello world'));
+  // No payload → output is the not-preserved placeholder, not the
+  // wire snippet. The model is told to re-search if it needs the data.
   const searchOut = input[2] as { output: string };
-  assert(searchOut.output.includes('Search results for "hello world"'));
-  assert(searchOut.output.includes('snippet body'));
+  assert(searchOut.output.includes('not preserved'));
+  assertFalse(searchOut.output.includes('snippet body'));
   const openOut = input[5] as { output: string };
-  // open_page IR's output text is the page body (its sole result snippet) verbatim.
-  assertEquals(openOut.output, 'page body');
+  assert(openOut.output.includes('not preserved'));
+  assertFalse(openOut.output.includes('page body'));
 });
 
 test('input preprocessor: replay-only activation leaves hosted tool_choice unchanged when no hosted tool is declared', async () => {
@@ -3396,10 +3192,10 @@ test('input preprocessor: web_search_call without an action is replaced by a pla
   // item entirely silently shortens conversation history, which can
   // mislead the model (e.g. its reasoning about "your last 3 tool
   // calls" no longer matches reality). Replace with a placeholder
-  // umbrella function_call (empty args, no logical ops) + a
+  // shim call (empty args, no logical ops) + a
   // function_call_output telling the model the prior contents
-  // weren't preserved. Same idea as the `resultsStripped` path for
-  // partial echoes.
+  // weren't preserved. Same idea as the no-payload-with-action path
+  // for partial echoes.
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation({
@@ -3463,11 +3259,11 @@ test('input preprocessor: web_search_call with empty id has its id synthesized a
   assertEquals(input[2].type, 'function_call_output');
 });
 
-test('input preprocessor: web_search_call without results emits the stripped-notice function_call_output (not a "(no results)" zero-hit message)', async () => {
+test('input preprocessor: web_search_call without results emits the not-preserved placeholder function_call_output (not a "(no results)" zero-hit message)', async () => {
   // Clients like codex CLI 0.133 drop the results field when persisting
-  // sessions. We backfill an empty array AND set resultsStripped, so the
-  // model sees an explicit "not preserved" notice instead of being misled
-  // into thinking the prior search returned zero hits.
+  // sessions. We emit an explicit "not preserved" notice instead of
+  // synthesizing a phantom zero-hit response that would mislead the
+  // model into thinking the prior search returned nothing.
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation({
@@ -3491,7 +3287,7 @@ test('input preprocessor: web_search_call without results emits the stripped-not
   assertEquals(fco.output, 'Prior search results were not preserved in the conversation history. Call web_search again if you need them.');
 });
 
-// ── Umbrella tool name resolution / collision fallback ────────────────
+// ── Shim tool name resolution / collision fallback ────────────────
 
 test('client declaring web_search + hosted web_search: shim falls back to web_search_2', async () => {
   makeStubDeps();
@@ -3789,7 +3585,7 @@ test('mid-stream upstream error yields response.failed and closes the SSE stream
 
 test('mid-stream 429 pass-through: code reflects upstream HTTP status (no spec-enum normalization)', async () => {
   // The shim no longer normalizes upstream error codes to the
-  // OpenAPI `ResponseErrorCode` enum. A 429 with no OpenAI-shaped
+  // OpenAPI `ResponsesErrorCode` enum. A 429 with no OpenAI-shaped
   // body falls back to `upstream_429` — the HTTP status is the most
   // honest signal, and downstream clients pattern-matching on
   // upstream's actual code see it directly.
@@ -4073,7 +3869,7 @@ test('tool_choice "required" demotes to "auto" after first intercepted turn', as
   assertEquals(seenToolChoices[1], 'auto');
 });
 
-test('tool_choice {type:"function", name:<umbrella>} demotes to "auto" after first intercepted turn', async () => {
+test('tool_choice {type:"function", name:<shim tool name>} demotes to "auto" after first intercepted turn', async () => {
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation({
@@ -4396,154 +4192,6 @@ test('two consecutive tool-call turns each with a thinking-out-loud message pres
   assertEquals(wsCallAdded.length, 2);
 });
 
-// ── Umbrella-specific behaviors ──────────────────────────────────────────
-
-test('umbrella web_search with batched multi-action args dispatches all logical ops in one iteration', async () => {
-  // ONE upstream function_call populates search_query, open, and find
-  // simultaneously — one lifecycle per op + ONE combined
-  // function_call_output.
-  const url1 = 'https://example.com/a';
-  const url2 = 'https://example.com/b';
-  const { backend } = makeStubDeps();
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  const argsJson = JSON.stringify({
-    search_query: [{ q: 'first' }, { q: 'second' }],
-    open: [{ ref_id: url1 }],
-    find: [{ ref_id: url2, pattern: 'needle' }],
-  });
-  const turn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_umbrella', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, argsJson),
-    mkFunctionCallDone(0, 'call_umbrella', SHIM_TOOL_NAME, argsJson),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([turn, messageTurn('done', 0)]);
-
-  const result = await shim(inv, makeRequest(), script.run);
-  assert(result.type === 'events');
-  const events = eventPayloads(await collectFrames(result.events));
-
-  // Two searches + one fetchPage (batching url1 + url2).
-  assertEquals(backend.calls.filter(c => c.kind === 'search').length, 2);
-  assertEquals(backend.calls.filter(c => c.kind === 'fetchPage').length, 1);
-  // Cap budget consumed twice (once per turn), not 4x for the 4 ops.
-  assertEquals(script.callCount(), 2);
-
-  // Four lifecycles (one per logical op).
-  const wsCallAdded = events.filter(e =>
-    e.type === 'response.output_item.added'
-    && (e as { item?: { type?: string } }).item?.type === 'web_search_call');
-  assertEquals(wsCallAdded.length, 4);
-
-  // One function_call_output per logical op, in source order.
-  const input = inv.payload.input as ResponsesInputItem[];
-  const outputs = input.filter(i => i.type === 'function_call_output') as Array<{
-    type: 'function_call_output';
-    call_id: string;
-    output: string;
-  }>;
-  assertEquals(outputs.length, 4);
-  const combined = outputs.map(o => o.output).join('\n\n');
-  // Each section is the per-action formatted body (search results / page
-  // body / find matches) joined in source order. The exact text formats
-  // are unit-tested in ir_test.ts and format-search-results_test.ts.
-  assert(combined.includes('Search results for "first"'));
-  assert(combined.includes('Search results for "second"'));
-  assert(combined.includes(`body of ${url1}`));
-  assert(combined.includes('needle'));
-});
-
-test('non-URL ref_id produces error sentinel; supported call in same batch still works', async () => {
-  const { backend } = makeStubDeps();
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  // One umbrella call mixing a valid URL with a bogus opaque ref_id. The
-  // bogus one produces an error sentinel without hitting the backend.
-  const argsJson = JSON.stringify({
-    open: [
-      { ref_id: 'https://example.com/good' },
-      { ref_id: 'opaque-prior-id-not-a-url' },
-    ],
-  });
-  const turn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_umbrella', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, argsJson),
-    mkFunctionCallDone(0, 'call_umbrella', SHIM_TOOL_NAME, argsJson),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([turn, messageTurn('done', 0)]);
-
-  await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  // Only the valid URL hit fetchPage; the bogus ref short-circuited.
-  const fetchCalls = backend.calls.filter(c => c.kind === 'fetchPage');
-  assertEquals(fetchCalls.length, 1);
-  const req = fetchCalls[0].request as WebSearchFetchPageRequest;
-  assertEquals(req.urls, ['https://example.com/good']);
-
-  const input = inv.payload.input as ResponsesInputItem[];
-  const outputs = input.filter(i => i.type === 'function_call_output') as Array<{
-    type: 'function_call_output';
-    call_id: string;
-    output: string;
-  }>;
-  // One pair per op: the valid open and the bogus ref each get their own.
-  assertEquals(outputs.length, 2);
-  const combined = outputs.map(o => o.output).join('\n\n');
-  assert(combined.includes('body of https://example.com/good'));
-  assert(combined.includes('ref_id must be a fully-qualified URL'));
-  assert(combined.includes('opaque-prior-id-not-a-url'));
-});
-
-test('umbrella call with only unsupported sub-properties surfaces per-entry errors as web_search_call IR items', async () => {
-  // Each unsupported entry becomes one web_search_call IR with
-  // action.type='search' (neutral carrier) + a snippet explaining what
-  // sub-property the gateway does not support. The model sees them via
-  // both the downstream wire items (always-include results) and the
-  // upstream function_call_output text.
-  const { backend } = makeStubDeps();
-  const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation();
-  const argsJson = JSON.stringify({
-    click: [{ ref_id: 'https://x', id: 1 }],
-    screenshot: [{ ref_id: 'https://x', pageno: 1 }],
-  });
-  const turn: ScriptedTurn = [
-    mkResponseCreated(),
-    mkResponseInProgress(),
-    mkFunctionCallAdded(0, 'call_bogus', SHIM_TOOL_NAME),
-    mkFunctionCallArgsDone(0, argsJson),
-    mkFunctionCallDone(0, 'call_bogus', SHIM_TOOL_NAME, argsJson),
-    mkResponseCompleted(),
-  ];
-  const script = scriptedRun([turn, messageTurn('done', 0)]);
-
-  const { frames } = await runShimAndDrain(shim, inv, makeRequest(), script.run);
-
-  assertEquals(backend.calls.length, 0);
-  // Two web_search_call lifecycle items downstream (one per unsupported entry).
-  const events = eventPayloads(frames);
-  const wsAdded = events.filter(e =>
-    e.type === 'response.output_item.added'
-    && (e as { item?: { type?: string } }).item?.type === 'web_search_call');
-  assertEquals(wsAdded.length, 2);
-
-  const input = inv.payload.input as ResponsesInputItem[];
-  const outputs = input.filter(i => i.type === 'function_call_output') as Array<{
-    type: 'function_call_output';
-    call_id: string;
-    output: string;
-  }>;
-  assertEquals(outputs.length, 2);
-  assert(outputs[0].output.includes('`click` sub-property is not supported'));
-  assert(outputs[1].output.includes('`screenshot` sub-property is not supported'));
-});
-
 test('lifecycle start frames yield BEFORE backend resolves, giving searching real wall-clock duration', async () => {
   // Gate provider.search() so the test can observe ordering: lifecycle
   // start frames must be drainable WHILE the backend is pending. If the
@@ -4611,13 +4259,13 @@ test('lifecycle start frames yield BEFORE backend resolves, giving searching rea
   assert(types.includes('response.output_item.done'));
 });
 
-test('terminal response.completed.output is in output_index order, not completion order (umbrella backend resolves AFTER a later live item)', async () => {
-  // The umbrella reserves downstream index 0 at output_item.added time;
+test('terminal response.completed.output is in output_index order, not completion order (shim backend resolves AFTER a later live item)', async () => {
+  // The shim call reserves downstream index 0 at output_item.added time;
   // the mixed-tool client function_call gets downstream index 1.
-  // We gate the backend so the umbrella's output_item.done fires AFTER
+  // We gate the backend so the shim's output_item.done fires AFTER
   // the client function_call has already finalized into accumulatedOutput.
   // The sparse-index materialization at terminal time must still place
-  // the umbrella at output[0] and the client tool at output[1].
+  // the shim call at output[0] and the client tool at output[1].
   let releaseSearch: (() => void) | null = null;
   const searchGate = new Promise<void>(resolve => { releaseSearch = resolve; });
   makeStubDeps({
@@ -4638,7 +4286,7 @@ test('terminal response.completed.output is in output_index order, not completio
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation();
   const wsArgs = JSON.stringify({ search_query: [{ q: 'q' }] });
-  // Umbrella at upstream index 0, client tool at upstream index 1. The
+  // Shim call at upstream index 0, client tool at upstream index 1. The
   // upstream's response.completed arrives BEFORE the gated backend
   // resolves; the shim will release end frames lazily as the consumer
   // pulls (so we must release the gate to finish the stream).
@@ -4656,25 +4304,25 @@ test('terminal response.completed.output is in output_index order, not completio
   const script = scriptedRun([mixedTurn]);
   const result = await shim(inv, makeRequest(), script.run);
   assert(result.type === 'events');
-  // Release the gate so the umbrella end frames + terminal can resolve.
+  // Release the gate so the shim call end frames + terminal can resolve.
   releaseSearch!();
   const events = eventPayloads(await collectFrames(result.events));
   const terminal = events[events.length - 1];
   assertEquals(terminal.type, 'response.completed');
   const output = (terminal as { response: { output: Array<{ type: string }> } }).response.output;
-  // Two items: umbrella web_search_call at slot 0, client function_call at slot 1.
+  // Two items: shim web_search_call at slot 0, client function_call at slot 1.
   // Reserved-slot ordering wins even though the client tool finalized
-  // first (no await on the .done path) and the umbrella finalized last.
+  // first (no await on the .done path) and the shim call finalized last.
   assertEquals(output.map(o => o.type), ['web_search_call', 'function_call']);
 });
 
 // ── End-to-end protocol-violation paths ──────────────────────────────
 
-test('umbrella function_call without output_item.done synthesizes response.failed (no backend dispatch)', async () => {
-  // Protocol violation: upstream emits the umbrella's added +
-  // arguments deltas but no `.done`. The unmatched-umbrella detector
+test('shim call without output_item.done synthesizes response.failed (no backend dispatch)', async () => {
+  // Protocol violation: upstream emits the shim's added +
+  // arguments deltas but no `.done`. The unmatched-shim-call detector
   // in consume-turn must promote the turn to `response.failed`; no
-  // backend search / fetchPage should fire (the umbrella never
+  // backend search / fetchPage should fire (the shim call never
   // dispatched).
   const { backend } = makeStubDeps();
   const shim = withResponsesWebSearchShim;
@@ -4695,7 +4343,7 @@ test('umbrella function_call without output_item.done synthesizes response.faile
   const terminal = events[events.length - 1] as Extract<ResponsesStreamEvent, { type: 'response.failed' }>;
   assertEquals(terminal.type, 'response.failed');
   assertEquals(terminal.response.error?.code, 'server_error');
-  assert(terminal.response.error?.message.includes('without closing umbrella function_call items'));
+  assert(terminal.response.error?.message.includes('without closing shim call items'));
   // Backend never invoked — dispatch only fires from output_item.done.
   assertEquals(backend.calls.length, 0);
 });
@@ -4761,7 +4409,8 @@ test('downstream AbortSignal threads through to provider search / fetchPage and 
   const inv = makeInvocation();
   const request: RequestContext = {
     requestStartedAt: 0,
-    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },    runtimeLocation: 'test',
+    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
+    runtimeLocation: 'test',
     clientStream: true,
     apiKeyId: 'k1',
     downstreamAbortSignal: controller.signal,
@@ -4823,7 +4472,7 @@ interface DispatchRecord {
   intercepted: InterceptedFunctionCall;
 }
 
-// Records every umbrella call without producing IRs or start frames.
+// Records every shim call call without producing IRs or start frames.
 // Tests that care about dispatcher behavior pass a custom dispatcher.
 const recordingDispatcher = (records: DispatchRecord[]) => ({ intercepted }: { intercepted: InterceptedFunctionCall }) => {
   records.push({ intercepted });
@@ -5053,7 +4702,7 @@ test('consumeTurn second turn swallows upstream response.created and in_progress
   assertEquals(eventTypesOf(result.downstreamFrames), []);
 });
 
-test('consumeTurn intercepts the umbrella shim tool and does NOT forward its 4 events', async () => {
+test('consumeTurn intercepts the shim call shim tool and does NOT forward its 4 events', async () => {
   const state = createMergeState();
   const result = await consumeTurn(
     framesOf(
@@ -5074,7 +4723,6 @@ test('consumeTurn intercepts the umbrella shim tool and does NOT forward its 4 e
   assertEquals(result.records[0].intercepted, {
     callId: 'cc_1',
     name: SHIM_TOOL_NAME,
-    argumentsJson: '{"search_query":[{"q":"hello"}]}',
     arguments: { search_query: [{ q: 'hello' }] },
   });
   assertEquals(result.summary.dispatched.length, 1);
@@ -5090,7 +4738,7 @@ test('consumeTurn intercepts the umbrella shim tool and does NOT forward its 4 e
   assertFalse(result.summary.sawClientToolCall);
 });
 
-test('consumeTurn intercepts two umbrella calls within one turn', async () => {
+test('consumeTurn intercepts two shim call calls within one turn', async () => {
   const state = createMergeState();
   const result = await consumeTurn(
     framesOf(
@@ -5105,12 +4753,12 @@ test('consumeTurn intercepts two umbrella calls within one turn', async () => {
     true,
   );
   assertEquals(result.records.length, 2);
-  assertEquals(result.records[0].intercepted.argumentsJson, '{"open":[{"ref_id":"https://x"}]}');
-  assertEquals(result.records[1].intercepted.argumentsJson, '{"find":[{"ref_id":"https://x","pattern":"p"}]}');
+  assertEquals(result.records[0].intercepted.arguments, { open: [{ ref_id: 'https://x' }] });
+  assertEquals(result.records[1].intercepted.arguments, { find: [{ ref_id: 'https://x', pattern: 'p' }] });
 });
 
-test('consumeTurn synthesizes response.failed when upstream terminates without closing an umbrella function_call', async () => {
-  // An umbrella reservation that never receives `output_item.done` is
+test('consumeTurn synthesizes response.failed when upstream terminates without closing a shim call', async () => {
+  // A shim call reservation that never receives `output_item.done` is
   // an upstream protocol violation: the model intended a tool call,
   // the gateway accepted the reservation, but the close frame never
   // arrived. Without explicit detection here the reservation is
@@ -5140,7 +4788,7 @@ test('consumeTurn synthesizes response.failed when upstream terminates without c
   assertEquals(result.summary.dispatched.length, 0);
   assertEquals(result.summary.terminalStatus.kind, 'failed');
   const ts = result.summary.terminalStatus as Extract<UpstreamTerminal, { kind: 'failed' }>;
-  assert((ts.response.error?.message ?? '').includes('without closing umbrella function_call items'));
+  assert((ts.response.error?.message ?? '').includes('without closing shim call items'));
   assert((ts.response.error?.message ?? '').includes('response.completed'));
 });
 
@@ -5159,7 +4807,7 @@ test('consumeTurn dispatches at function_call.done with .done args canonical ove
     state,
     true,
   );
-  assertEquals(result.records[0].intercepted.argumentsJson, '{"search_query":[{"q":"x"}]}');
+  assertEquals(result.records[0].intercepted.arguments, { search_query: [{ q: 'x' }] });
 });
 
 test('consumeTurn live-forwards non-shim function_calls and sets sawClientToolCall', async () => {
@@ -5284,7 +4932,7 @@ test('consumeTurn single iteration ending in message: forwards full message life
   ]);
 });
 
-test('consumeTurn one umbrella call then message in same turn: FORWARDS the message live (umbrella is consumed)', async () => {
+test('consumeTurn one shim call call then message in same turn: FORWARDS the message live (shim call is consumed)', async () => {
   const state = createMergeState();
   const result = await consumeTurn(
     framesOf(
@@ -5302,7 +4950,7 @@ test('consumeTurn one umbrella call then message in same turn: FORWARDS the mess
 
   assertEquals(result.records.length, 1);
   assertEquals(state.accumulatedOutput.size, 1);
-  // Recording dispatcher doesn't emit lifecycle frames so the umbrella's
+  // Recording dispatcher doesn't emit lifecycle frames so the shim's
   // reserved slot stays empty in accumulatedOutput, but outputIndex was
   // still bumped. The message therefore lands at index 1.
   assertEquals(state.accumulatedOutput.get(1)?.type, 'message');
@@ -5702,11 +5350,11 @@ test('consumeTurn surfaces bare `error` event as terminalStatus.failed with a sy
 
 test('consumeTurn defaults missing `error.code` to spec-defined `server_error` (no synthetic `unknown_upstream_error` literal)', async () => {
   // A bare upstream `{type: 'error'}` frame without a `code` field
-  // falls back to the OpenAPI `ResponseErrorCode` enum value
+  // falls back to the OpenAPI `ResponsesErrorCode` enum value
   // `'server_error'`. The previous `'unknown_upstream_error'`
   // synthetic literal is not in the enum and typed SDKs (openai-python
   // `Literal[...]` with strict Pydantic validation, openai-node
-  // literal union, openai-go `ResponseErrorCode string` named type)
+  // literal union, openai-go `ResponsesErrorCode string` named type)
   // reject unknown values at parse time. Reference:
   // https://github.com/openai/openai-openapi/blob/master/openapi.yaml
   const state = createMergeState();
@@ -5723,7 +5371,7 @@ test('consumeTurn defaults missing `error.code` to spec-defined `server_error` (
   );
   const ts = result.summary.terminalStatus as Extract<UpstreamTerminal, { kind: 'failed' }>;
   assertEquals(ts.response.error?.code, 'server_error');
-  // No synthetic `type` — the spec's ResponseError schema defines
+  // No synthetic `type` — the spec's ResponsesError schema defines
   // only `{code, message}` and the upstream `error` frame doesn't
   // carry a `type` field on the wire either.
   assertFalse('type' in (ts.response.error as object));
@@ -5780,7 +5428,7 @@ test('consumeTurn surfaces bare `error` event arriving BEFORE response.created a
   assertEquals(ts.error.message, 'upstream dropped before response shell');
   // Spec-defined fallback (no `code` on upstream's error frame). See
   // the matching test above for the in-shell path; both default to
-  // `server_error` from the `ResponseErrorCode` enum.
+  // `server_error` from the `ResponsesErrorCode` enum.
   assertEquals(ts.error.code, 'server_error');
 });
 
@@ -5819,7 +5467,7 @@ test('consumeTurnStreaming yields forwarded frames before upstream completes', a
   while (!(await iter.next()).done) { /* drain */ }
 });
 
-test('dispatcher start frames yield IN-LINE at function_call.done (umbrella slot precedes later items)', async () => {
+test('dispatcher start frames yield IN-LINE at function_call.done (shim call slot precedes later items)', async () => {
   const state = createMergeState();
   let dispatchOrder = 0;
   const records: DispatchRecord[] = [];
@@ -5866,9 +5514,9 @@ test('dispatcher start frames yield IN-LINE at function_call.done (umbrella slot
   assert(syntheticIdx < messageAddedIdx, `expected dispatcher start frame BEFORE later live items (synth=${syntheticIdx}, msgAdded=${messageAddedIdx})`);
 });
 
-test('umbrella output_index is reserved at output_item.added so interleaved items get later indices', async () => {
-  // Reserving at `.added` (rather than `.done`) keeps a non-umbrella
-  // item arriving between added and done from stealing the umbrella's
+test('shim call output_index is reserved at output_item.added so interleaved items get later indices', async () => {
+  // Reserving at `.added` (rather than `.done`) keeps a non-shim call
+  // item arriving between added and done from stealing the shim's
   // would-be downstream index. See spec § Output-index allocation.
   const state = createMergeState();
   const dispatcher = () => [] as ServerToolResultSlot[];

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
@@ -5,9 +5,8 @@ import { loadSearchConfig } from '../../../../../tools/web-search/search-config.
 import { searchWebAndRecordUsage, searchWebWithoutRecordingUsage } from '../../../../../tools/web-search/search.ts';
 import type { ConfiguredWebSearchProvider, WebSearchProvider, WebSearchProviderName } from '../../../../../tools/web-search/types.ts';
 import { truncatePreservingCodePoints } from '../../../../shared/text.ts';
-import { serverToolResultSlot } from '../server-tool-shim.ts';
-import type { ServerToolLoopState, ServerToolOutputItem, ServerToolRegistration } from '../server-tool-shim.ts';
-import type { ResponsesFunctionCallOutputItem, ResponsesFunctionTool, ResponsesFunctionToolCallItem, ResponsesHostedTool, ResponsesInputItem, ResponsesInputWebSearchCall, ResponsesOutputWebSearchCall, ResponsesTool, ResponsesWebSearchAction, ResponsesWebSearchResult } from '@floway-dev/protocols/responses';
+import { serverToolResultSlot, type ServerToolLoopState, type ServerToolOutputItem, type ServerToolRegistration } from '../server-tool-shim.ts';
+import type { ResponsesFunctionTool, ResponsesFunctionToolCallItem, ResponsesHostedTool, ResponsesInputItem, ResponsesOutputWebSearchCall, ResponsesTool, ResponsesWebSearchAction, ResponsesWebSearchResult } from '@floway-dev/protocols/responses';
 import { WEB_SEARCH_HOSTED_TYPE_NAMES } from '@floway-dev/protocols/responses';
 
 // Runtime set derived from the canonical tuple declared next to
@@ -16,7 +15,7 @@ import { WEB_SEARCH_HOSTED_TYPE_NAMES } from '@floway-dev/protocols/responses';
 //   https://github.com/openai/openai-python/blob/e75766769547601a25ed83b666c4d0fd046881f0/src/openai/types/responses/web_search_preview_tool.py
 export const WEB_SEARCH_HOSTED_TYPES: ReadonlySet<string> = new Set<string>(WEB_SEARCH_HOSTED_TYPE_NAMES);
 
-// Function-name regex `^[a-zA-Z0-9_-]+$` forbids dots, so the umbrella
+// Function-name regex `^[a-zA-Z0-9_-]+$` forbids dots, so the shim call
 // uses the underscored form of the model's training-time `web.run`.
 export const SHIM_TOOL_NAME = 'web_search';
 
@@ -46,11 +45,6 @@ const DEFAULT_SEARCH_CONTEXT_SIZE: keyof typeof CONTEXT_SIZE_TO_MAX_RESULTS = 'm
 export const isValidSearchContextSize = (v: unknown): v is keyof typeof CONTEXT_SIZE_TO_MAX_RESULTS =>
   typeof v === 'string' && v in CONTEXT_SIZE_TO_MAX_RESULTS;
 
-// Both `function` and `custom` client tools share the upstream callable
-// namespace (responses-via-* translators wrap `custom` as `function`
-// for non-Responses upstreams), so a client tool of either kind named
-// `web_search` collides with the umbrella. Returning a resolved name
-// (rather than throwing) lets such a client coexist.
 // The hosted tool's `user_location` must surface to the model, not just
 // to the backend provider — without this hint the model asks "Which
 // city should I check?" even when the client supplied one.
@@ -64,12 +58,12 @@ const formatUserLocation = (loc: NonNullable<ShimToolFilters['userLocation']>): 
   return joined.length === 0 ? `(timezone: ${loc.timezone})` : `${joined} (timezone: ${loc.timezone})`;
 };
 
-// `web.run` umbrella shape: 13 sub-properties on a single tool. The
+// `web.run` shim call shape: 13 sub-properties on a single tool. The
 // shim implements 3 (`search_query`, `open`, `find`); the other 10
 // surface as per-entry error IRs at dispatch time. The description
 // deliberately omits the unsupported ones.
 //   https://github.com/openai/harmony/blob/abd677f7ac962629c808197caa1feb9e3e95d2b0/src/chat.rs#L259-L313
-const buildUmbrellaTool = (
+const buildShimFunctionTool = (
   name: string,
   userLocation?: ShimToolFilters['userLocation'],
 ): ResponsesFunctionTool => {
@@ -157,10 +151,6 @@ const extractFilters = (tool: ResponsesHostedTool): ShimToolFilters => {
   return out;
 };
 
-export interface PreparedTools {
-  filters: ShimToolFilters;
-}
-
 export interface PrepareToolsError {
   /** Human-readable error message; goes into the 400 envelope's `error.message`. */
   message: string;
@@ -169,7 +159,7 @@ export interface PrepareToolsError {
 }
 
 export type PrepareToolsResult =
-  | { ok: true; prepared: PreparedTools }
+  | { ok: true; filters: ShimToolFilters }
   | { ok: false; error: PrepareToolsError };
 
 // Per-list cap matches the OpenAI documented "up to 100 allowed_domains
@@ -198,7 +188,7 @@ const validateDomainListEntry = (
 // Validate the parts of a hosted-web-search entry the shim acts on.
 // Anything else (`external_web_access`, `return_token_budget`, etc.)
 // is silently dropped along with the hosted tool itself — the shim
-// replaces the hosted entry with its umbrella function tool, so any
+// replaces the hosted entry with its shim function tool, so any
 // hosted-only field the shim doesn't process never reaches upstream
 // regardless.
 const validateHostedEntry = (tool: ResponsesHostedTool): PrepareToolsError | null => {
@@ -248,7 +238,7 @@ const validateHostedEntry = (tool: ResponsesHostedTool): PrepareToolsError | nul
 // shim will act on. When a request carries multiple hosted blocks the
 // LAST one's filters win (most-recent declaration), so callers don't
 // have to define a tie-break. Name-collision resolution and the
-// hosted-tool → umbrella-function replacement are the shim's
+// hosted-tool → shim's function-tool replacement are the shim's
 // responsibility (`resolveServerToolName` /
 // `replaceHostedToolsWithFunctionTool`); this function only reads the
 // hosted entries.
@@ -268,23 +258,25 @@ export const prepareToolsForShim = (
   }
 
   if (!hostedSeen) {
-    return { ok: true, prepared: { filters: {} } };
+    return { ok: true, filters: {} };
   }
 
-  return { ok: true, prepared: { filters: lastHostedFilters } };
+  return { ok: true, filters: lastHostedFilters };
 };
 
-// Parses one umbrella function_call's arguments into a flat list of
-// logical operations. 13 documented sub-properties total; shim
-// implements 3 (search/open/find), the other 10 surface as
-// `unsupported` ops.
+// ── Shim call parsing ──
+// Types describe one logical operation parsed out of a shim call
+// function_call. 13 documented sub-properties total in the gpt-5.x
+// `web.run` shape; the shim implements 3 (search/open/find) and surfaces
+// the other 10 as `unsupported` ops. `parseShimOperations` below
+// produces a flat list in source order.
 
 export type ShimOperationErrorKind = 'invalid-ref' | 'missing-arg';
 
 export type ShimLogicalOperation =
   | {
     kind: 'search';
-    /** Original index inside the umbrella's `search_query` array. */
+    /** Original index inside the shim's `search_query` array. */
     arrayIndex: number;
     query: string;
     /** When set, dispatch returns this verbatim instead of hitting the backend. */
@@ -308,7 +300,7 @@ export type ShimLogicalOperation =
   }
   | {
     kind: 'unsupported';
-    /** The umbrella sub-property name the model populated (e.g. `click`). */
+    /** The shim call sub-property name the model populated (e.g. `click`). */
     subProperty: string;
     /** Original index inside that sub-property's array. */
     arrayIndex: number;
@@ -319,7 +311,7 @@ export type ShimLogicalOperation =
     actualType: string;
   };
 
-export type ParsedUmbrella = { kind: 'ops'; ops: ShimLogicalOperation[] } | { kind: 'malformed' };
+export type ParsedShimCall = { kind: 'ops'; ops: ShimLogicalOperation[] } | { kind: 'malformed' };
 
 // Stricter than `/^https?:\/\//i`: that regex accepts `https://` (empty
 // host). Reject malformed refs at parse time so dispatch always sees a
@@ -344,23 +336,31 @@ const missingArgError = (field: string): string =>
 
 const SUPPORTED_KEYS: ReadonlySet<string> = new Set(['search_query', 'open', 'find']);
 
-export const parseUmbrellaOperations = (args: Record<string, unknown> | null): ParsedUmbrella => {
+// Cap on the wire-item dump inlined into the malformed-input branch's
+// `function_call_output` placeholder. A pathological prior wsc echo
+// (deeply nested, multi-kilobyte) shouldn't get to blow the upstream
+// context window through the diagnostic that explains it.
+const MAX_MALFORMED_WIRE_DUMP_CHARS = 1024;
+
+const stringField = (entry: unknown, key: string): string => {
+  if (entry === null || typeof entry !== 'object') return '';
+  const value = (entry as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : '';
+};
+
+const describeJsonType = (v: unknown): string => v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v;
+
+export const parseShimOperations = (args: Record<string, unknown> | null): ParsedShimCall => {
   if (args === null) return { kind: 'malformed' };
   const ops: ShimLogicalOperation[] = [];
-
-  // Surface wrong-typed keys as visible IRs.
-  const describeType = (v: unknown): string => v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v;
 
   const searchQuery = args.search_query;
   if (searchQuery !== undefined) {
     if (!Array.isArray(searchQuery)) {
-      ops.push({ kind: 'wrong-type', subProperty: 'search_query', actualType: describeType(searchQuery) });
+      ops.push({ kind: 'wrong-type', subProperty: 'search_query', actualType: describeJsonType(searchQuery) });
     } else {
       for (let i = 0; i < searchQuery.length; i++) {
-        const entry = searchQuery[i];
-        const q = entry !== null && typeof entry === 'object' && 'q' in entry && typeof entry.q === 'string'
-          ? entry.q
-          : '';
+        const q = stringField(searchQuery[i], 'q');
         if (q === '') {
           ops.push({ kind: 'search', arrayIndex: i, query: '', error: missingArgError('q'), errorKind: 'missing-arg' });
           continue;
@@ -373,13 +373,10 @@ export const parseUmbrellaOperations = (args: Record<string, unknown> | null): P
   const open = args.open;
   if (open !== undefined) {
     if (!Array.isArray(open)) {
-      ops.push({ kind: 'wrong-type', subProperty: 'open', actualType: describeType(open) });
+      ops.push({ kind: 'wrong-type', subProperty: 'open', actualType: describeJsonType(open) });
     } else {
       for (let i = 0; i < open.length; i++) {
-        const entry = open[i];
-        const refId = entry !== null && typeof entry === 'object' && 'ref_id' in entry && typeof entry.ref_id === 'string'
-          ? entry.ref_id
-          : '';
+        const refId = stringField(open[i], 'ref_id');
         if (refId === '') {
           ops.push({ kind: 'open', arrayIndex: i, url: '', error: missingArgError('ref_id'), errorKind: 'missing-arg' });
           continue;
@@ -396,16 +393,11 @@ export const parseUmbrellaOperations = (args: Record<string, unknown> | null): P
   const find = args.find;
   if (find !== undefined) {
     if (!Array.isArray(find)) {
-      ops.push({ kind: 'wrong-type', subProperty: 'find', actualType: describeType(find) });
+      ops.push({ kind: 'wrong-type', subProperty: 'find', actualType: describeJsonType(find) });
     } else {
       for (let i = 0; i < find.length; i++) {
-        const entry = find[i];
-        const refId = entry !== null && typeof entry === 'object' && 'ref_id' in entry && typeof entry.ref_id === 'string'
-          ? entry.ref_id
-          : '';
-        const pattern = entry !== null && typeof entry === 'object' && 'pattern' in entry && typeof entry.pattern === 'string'
-          ? entry.pattern
-          : '';
+        const refId = stringField(find[i], 'ref_id');
+        const pattern = stringField(find[i], 'pattern');
         if (refId === '') {
           ops.push({ kind: 'find', arrayIndex: i, url: '', pattern, error: missingArgError('ref_id'), errorKind: 'missing-arg' });
           continue;
@@ -423,8 +415,7 @@ export const parseUmbrellaOperations = (args: Record<string, unknown> | null): P
     }
   }
 
-  // Top-level keys outside `search_query` / `open` / `find` surface as
-  // one `unsupported` op per array entry (or a single op for a scalar).
+  // Top-level keys outside the shim call surface as unsupported ops.
   for (const key of Object.keys(args)) {
     if (SUPPORTED_KEYS.has(key)) continue;
     const value = args[key];
@@ -443,98 +434,75 @@ export const parseUmbrellaOperations = (args: Record<string, unknown> | null): P
   };
 };
 
-export const unsupportedSubPropertyText = (subProperty: string): string =>
-  `Error: the \`${subProperty}\` sub-property is not supported by this gateway. `
-  + 'Only `search_query`, `open`, and `find` are available.';
-
-export const wrongTypeSubPropertyText = (subProperty: string, actualType: string): string =>
-  `Error: the \`${subProperty}\` sub-property must be an array of objects; got ${actualType}.`;
-
-// Web_search_call IR — canonical representation of one search action,
-// the model-visible error strings that feed into IR results, and the
-// downstream lifecycle frames the IR materializes into. `id` is both the
-// value the client sees on the synthesized `web_search_call` item and
-// the seed for the upstream call_id when the reverse path replays the
-// item.
-//
-// Error-text phrasings closely follow OpenAI's gpt-oss reference
-// simple_browser tool so gpt-oss-family models (trained on those exact
-// phrasings) recognize the structure; non-OpenAI models read them as
-// plain natural-language tool output.
-//
-// References (pinned to commit 285b05d for stable line numbers):
-// - gpt-oss simple_browser_tool.py `find` no-match phrase, line 246:
-//   https://github.com/openai/gpt-oss/blob/285b05d96dea9ce7da52ecbbe86791f18239c510/gpt_oss/tools/simple_browser/simple_browser_tool.py#L246
-// - gpt-oss simple_browser_tool.py `BackendError` fetching phrase, lines 444-445:
-//   https://github.com/openai/gpt-oss/blob/285b05d96dea9ce7da52ecbbe86791f18239c510/gpt_oss/tools/simple_browser/simple_browser_tool.py#L444-L445
-// - litellm `Search failed: <e>` idiom:
-//   https://github.com/BerriAI/litellm/blob/main/litellm/integrations/websearch_interception/transformation.py
-
-// Sole safety valve — do not introduce additional safety caps in
-// this server tool. Past iteration 30 the dispatcher swaps backend
-// dispatch for the cap snippet so the model sees the bypass and
-// steers itself toward a terminal message.
+// Safety cap; see usage in `planShimSlots`.
 export const ITERATION_CAP = 30;
 
+// One web_search backend op's result data: the action shape downstream
+// references and the result list the renderer formats. Thin DTO — the
+// wsc id and `status: 'completed'` live on the dispatcher's slot, not
+// in here.
 export interface WebSearchCallIR {
-  id: string;
-  status: 'completed';
   action: ResponsesWebSearchAction;
-  /** Always populated; see file-header divergence note in server-tools/web-search.ts. */
   results: ResponsesWebSearchResult[];
-  /**
-   * Set when this IR was built from a replayed input item that lacked
-   * a `results` field — e.g. codex CLI strips the field before
-   * persisting to its session rollout. `irToOutputText` swaps the
-   * usual formatted snippet for a one-line notice so the model knows
-   * the prior content was not preserved (rather than confusing it
-   * with a genuine zero-hit search).
-   */
-  resultsStripped?: boolean;
 }
+
+/**
+ * Persistent `payload.private` shape for one `web_search_call`. One shim call
+ * function_call corresponds to exactly one wsc and one op — multi-op
+ * shim calls (multi-kind mix or multi-instance same-kind) are rejected at
+ * dispatch with an `ambiguous` error, so there is never an array to
+ * denormalize. The row id IS the wsc id, so we don't repeat it inside.
+ *
+ * - `functionCallItem` is the upstream's literal function_call from the
+ *   originating turn, with `arguments` replaced by the
+ *   jsonrepair-canonical strict-JSON form (every other field — type,
+ *   call_id, name, status — passes through untouched). Replayed verbatim
+ *   so the upstream model's prior assistant turn looks bit-exact.
+ *
+ * - `ir` is the in-flight `(action, results)` tuple straight from
+ *   `planShimSlots`. Stored as data so the rendering format can
+ *   evolve without re-persisting; reused by the renderer at replay time.
+ *   Composition (rather than inlining `action` / `results` here) keeps
+ *   any future IR field automatically reaching the persisted shape.
+ *
+ * Version-tagged: an unknown `v` falls through the no-payload branch in
+ * `transformInputItemsForWebSearch` (action re-serialized into the
+ * shim call shape, output replaced with the not-preserved notice). Starts
+ * at 1; bump only on a wire-incompatible change after release.
+ */
+export interface WebSearchCallPrivatePayload {
+  v: 1;
+  functionCallItem: ResponsesFunctionToolCallItem;
+  ir: WebSearchCallIR;
+}
+
+const isWebSearchCallPrivatePayload = (value: unknown): value is WebSearchCallPrivatePayload => {
+  if (value === null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  if (obj.v !== 1) return false;
+  const fc = obj.functionCallItem;
+  if (fc === null || typeof fc !== 'object') return false;
+  const fcObj = fc as Record<string, unknown>;
+  if (fcObj.type !== 'function_call' || typeof fcObj.call_id !== 'string' || typeof fcObj.name !== 'string' || typeof fcObj.arguments !== 'string') return false;
+  const ir = obj.ir;
+  if (ir === null || typeof ir !== 'object') return false;
+  const irObj = ir as Record<string, unknown>;
+  return irObj.action !== undefined && Array.isArray(irObj.results);
+};
 
 export const synthesizeWebSearchCallId = (): string =>
   `ws_gw_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
 
-export const searchFailedText = (providerMessage: string): string =>
-  `Search failed: ${providerMessage}`;
+// Distinct id namespace (cc_replay_*) from synthesized wsc ids (ws_gw_*)
+// so a replay call_id never reads as a wsc id in logs.
+const synthesizeReplayCallId = (): string =>
+  `cc_replay_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
 
-export const openFailedText = (url: string, providerMessage: string): string =>
-  `Error fetching URL \`${url}\`: ${providerMessage}`;
-
-export const findNoMatchesText = (pattern: string, url: string): string =>
-  `No matching \`${pattern}\` found on ${url}.`;
-
-export const iterationCapText
-  = `Web search iteration limit (${ITERATION_CAP}) reached. Further web_search calls in this response will return this same error. Summarize what you have already learned, and continue the task using other available tools (shell, file inspection, prior knowledge) or directly answer based on what you've gathered.`;
-
-export const truncationSentinel = (fullBytes: number): string =>
-  `[Content truncated; full page is ${fullBytes} bytes. Use web_search's \`find\` sub-property with a pattern to locate specific content.]`;
-
-// Returned as the function_call_output when a replayed `web_search_call`
-// item arrived without `results` (the client did not preserve them
-// across the round trip). The model still sees the action via the
-// paired function_call's arguments, so this only has to communicate
-// that re-searching is the way to recover the contents.
-export const resultsStrippedText
-  = 'Prior search results were not preserved in the conversation history. Call web_search again if you need them.';
-
-// Returned as the function_call_output (and as the snippet of the
-// synthesized lifecycle item on the malformed-args path) when an umbrella
-// call has no logical ops the shim can attribute — empty args object,
-// malformed JSON, or a non-object top-level shape. The hint names the
-// supported sub-properties so the model knows what shape to retry with.
-export const emptyUmbrellaArgsText
-  = 'Error: arguments must be a JSON object with sub-property arrays (search_query[], open[], find[]).';
-
-export const searchIr = (
-  id: string,
+const searchIr = (
   query: string,
   results: ResponsesWebSearchResult[],
   sources?: { type: 'url'; url: string }[],
 ): WebSearchCallIR => ({
-  id,
-  status: 'completed',
   // Emit both `query` and `queries`; see `actionSearchQueries`.
   action: {
     type: 'search',
@@ -549,13 +517,10 @@ export const searchIr = (
   results,
 });
 
-export const openPageIr = (
-  id: string,
+const openPageIr = (
   url: string | undefined,
   results: ResponsesWebSearchResult[],
 ): WebSearchCallIR => ({
-  id,
-  status: 'completed',
   // Omit `url` when undefined to match native's soft-failure shape;
   // never emit `url: ''`.
   action: url !== undefined && url.length > 0
@@ -564,14 +529,11 @@ export const openPageIr = (
   results,
 });
 
-export const findInPageIr = (
-  id: string,
+const findInPageIr = (
   url: string,
   pattern: string,
   results: ResponsesWebSearchResult[],
 ): WebSearchCallIR => ({
-  id,
-  status: 'completed',
   action: { type: 'find_in_page', url, pattern },
   results,
 });
@@ -580,14 +542,11 @@ export const findInPageIr = (
 // sub-property, malformed args); encode them via action.type:'search'
 // with the diagnostic in queries[0] so wire-typed SDKs still parse the
 // item.
-export const schemaErrorIr = (
-  id: string,
+const schemaErrorIr = (
   queryLabel: string,
   title: string,
   snippet: string,
 ): WebSearchCallIR => ({
-  id,
-  status: 'completed',
   // Emit both `query` and `queries`; see `actionSearchQueries`.
   action: { type: 'search', query: queryLabel, queries: [queryLabel] },
   results: [{
@@ -598,6 +557,24 @@ export const schemaErrorIr = (
   }],
 });
 
+// Error-text phrasings closely follow OpenAI's gpt-oss reference
+// simple_browser tool so gpt-oss-family models (trained on those exact
+// phrasings) recognize the structure; non-OpenAI models read them as
+// plain natural-language tool output.
+//
+// References (pinned to commit 285b05d for stable line numbers):
+// - gpt-oss simple_browser_tool.py `find` no-match phrase, line 246:
+//   https://github.com/openai/gpt-oss/blob/285b05d96dea9ce7da52ecbbe86791f18239c510/gpt_oss/tools/simple_browser/simple_browser_tool.py#L246
+// - gpt-oss simple_browser_tool.py `BackendError` fetching phrase, lines 444-445:
+//   https://github.com/openai/gpt-oss/blob/285b05d96dea9ce7da52ecbbe86791f18239c510/gpt_oss/tools/simple_browser/simple_browser_tool.py#L444-L445
+// - litellm `Search failed: <e>` idiom:
+//   https://github.com/BerriAI/litellm/blob/main/litellm/integrations/websearch_interception/transformation.py
+const searchFailedText = (providerMessage: string): string =>
+  `Search failed: ${providerMessage}`;
+
+const openFailedText = (url: string, providerMessage: string): string =>
+  `Error fetching URL \`${url}\`: ${providerMessage}`;
+
 // openai-python `ActionSearch.query` is a single string; some clients
 // send only `queries[]`. Accept both: the shim emits both fields on
 // every search action so typed SDKs reading either one keep working.
@@ -607,84 +584,12 @@ const actionSearchQueries = (action: Extract<ResponsesWebSearchAction, { type: '
   return [];
 };
 
-/**
- * Wire input item → IR. Returns null only when `action` is missing —
- * without it we can't even tell upstream what was previously searched.
- * `id` is synthesized when missing (it's an internal ref the model
- * never sees); `results` missing toggles `resultsStripped` so the
- * function_call_output reads as "not preserved" instead of "no hits".
- *
- * Replay today is reconstructed solely from the public wire item, so a
- * client that drops `results` from the echoed `web_search_call` (e.g.
- * codex CLI strips it before persisting to its rollout) forces the
- * `resultsStripped` degradation. A separate effort persists synthetic
- * Responses items server-side together with a private payload (the
- * `responses_items` store; `StoredResponsesItemPayload.private`,
- * reached via `getRepo().responsesItems`). Once the shim populates that
- * private payload at synthesis time and the replay seam
- * (`transformInputItemsForWebSearch`) gains access to a lookup, this
- * function should first restore the real results from the persisted
- * private payload keyed by the item's `id`, and fall back to the public
- * item (and `resultsStripped`) only when no persisted payload exists.
- */
-export const inputItemToIr = (item: ResponsesInputWebSearchCall): WebSearchCallIR | null => {
-  if (item.action === undefined) return null;
-  let action: ResponsesWebSearchAction;
-  if (item.action.type === 'search') {
-    const queries = actionSearchQueries(item.action);
-    // Emit both `query` and `queries`; see `actionSearchQueries`.
-    action = {
-      type: 'search',
-      ...(queries.length > 0 ? { query: queries[0] } : {}),
-      queries,
-    };
-  } else {
-    action = item.action;
-  }
-  const id = item.id !== undefined && item.id.length > 0
-    ? item.id
-    : synthesizeWebSearchCallId();
-  const hasResults = Array.isArray(item.results);
-  return {
-    id,
-    status: 'completed',
-    action,
-    results: hasResults ? item.results! : [],
-    ...(hasResults ? {} : { resultsStripped: true }),
-  };
-};
-
-/**
- * IR → umbrella function_call + function_call_output pair sharing a
- * synthetic call_id derived from the IR id. Every replay path goes
- * through this helper so echoed history and internally produced
- * web_search_call items cannot diverge.
- */
-export const irToUpstreamPair = (
-  ir: WebSearchCallIR,
-  umbrellaToolName: string,
-): {
-  functionCall: ResponsesFunctionToolCallItem;
-  functionCallOutput: ResponsesFunctionCallOutputItem;
-} => {
-  const callId = `cc_from_${ir.id}`;
-  return {
-    functionCall: {
-      type: 'function_call',
-      call_id: callId,
-      name: umbrellaToolName,
-      arguments: actionToUmbrellaArgsJson(ir.action),
-      status: 'completed',
-    },
-    functionCallOutput: {
-      type: 'function_call_output',
-      call_id: callId,
-      output: irToOutputText(ir),
-    },
-  };
-};
-
-const actionToUmbrellaArgsJson = (action: ResponsesWebSearchAction): string => {
+// Re-serializes a wire `action` back into the shim's JSON arguments
+// shape (`{search_query:[{q}]}` / `{open:[{ref_id}]}` /
+// `{find:[{ref_id,pattern}]}`). Used only on the replay-fallback path to
+// fill the paired function_call's `arguments` when no private payload
+// exists; the happy path replays the upstream's original args verbatim.
+const actionToShimCallArgsJson = (action: ResponsesWebSearchAction): string => {
   switch (action.type) {
   case 'search':
     return JSON.stringify({
@@ -712,69 +617,117 @@ const formatSearchResultsText = (query: string, results: readonly ResponsesWebSe
   return `${header}\n\n${sections.join('\n\n')}`;
 };
 
-/**
- * IR rendered as a labeled text section the upstream model reads from
- * function_call_output. Format matches what model variants have seen
- * historically so model behaviour doesn't drift on the rewrite.
- */
-export const irToOutputText = (ir: WebSearchCallIR): string => {
-  if (ir.resultsStripped) return resultsStrippedText;
-  switch (ir.action.type) {
+const renderOpOutputText = (action: ResponsesWebSearchAction, results: ResponsesWebSearchResult[]): string => {
+  switch (action.type) {
   case 'search': {
-    const queryLabel = actionSearchQueries(ir.action).join(' | ');
-    return formatSearchResultsText(queryLabel, ir.results);
+    const queryLabel = actionSearchQueries(action).join(' | ');
+    return formatSearchResultsText(queryLabel, results);
   }
   case 'open_page': {
-    if (ir.results.length === 0) {
-      const url = ir.action.url ?? '(no url)';
+    if (results.length === 0) {
+      const url = action.url ?? '(no url)';
       return `Open ${url}: (no body returned)`;
     }
-    return ir.results[0].snippet;
+    return results[0].snippet;
   }
   case 'find_in_page':
-    return ir.results.length > 0 ? ir.results[0].snippet : '';
+    return results.length > 0 ? results[0].snippet : '';
   }
 };
 
-// Echoed items without `action` become placeholder function_call /
-// function_call_output pairs with the original wire item inlined so the
-// model can inspect them; positional indices stay stable.
+// Replay preprocessor: turns echoed `web_search_call` items back into the
+// (function_call, function_call_output) pair the upstream model originally
+// saw on turn 1.
+//
+// Two paths:
+//
+// 1. Private payload hit (the request resolved the wsc id to a persisted
+//    `payload.private`): emit the upstream's literal `functionCallItem`
+//    (jsonrepair-canonical args, original call_id) plus a
+//    `function_call_output` whose body is rendered from the persisted
+//    `output.action / output.results` via `renderOpOutputText`. This is
+//    the bit-exact round-trip.
+//
+// 2. No payload (`store: false`, expired, foreign id, cross-account, or
+//    schema-version mismatch): degrade to a synthesized pair whose
+//    `function_call.arguments` is the wire action re-serialized into
+//    the shim call shape (so the model still sees what it asked for) and
+//    whose `function_call_output` text is the not-preserved placeholder.
+//    The shim deliberately does not read `item.results` from the
+//    wire — turn 1's wire results may or may not exist depending on the
+//    client's `include` opt-in, and trusting them across the wire would
+//    couple state correctness to client storage discipline.
+//
+// Echoed items with no `action` at all surface as a placeholder
+// `function_call + function_call_output` pair that inlines the raw wire
+// item so the model can see what the client actually sent.
 export const transformInputItemsForWebSearch = (
   input: ResponsesInputItem[],
-  umbrellaToolName: string,
+  toolName: string,
+  privatePayloads?: ReadonlyMap<string, unknown>,
 ): ResponsesInputItem[] => {
   const out: ResponsesInputItem[] = [];
+
   for (const item of input) {
-    if (item.type === 'web_search_call') {
-      const ir = inputItemToIr(item);
-      if (ir === null) {
-        const id = synthesizeWebSearchCallId();
-        const callId = `cc_from_${id}_malformed`;
-        out.push(
-          {
-            type: 'function_call',
-            call_id: callId,
-            name: umbrellaToolName,
-            arguments: '{}',
-            status: 'completed',
-          },
-          {
-            type: 'function_call_output',
-            call_id: callId,
-            // Include the original wire item verbatim so the model
-            // can see what was there — the placeholder shape stays
-            // stable while the malformed payload reaches the LLM
-            // for inspection.
-            output: `A prior web_search_call item in the conversation history was malformed (no \`action\` field). Original wire item: ${JSON.stringify(item)}`,
-          },
-        );
-        continue;
-      }
-      const { functionCall, functionCallOutput } = irToUpstreamPair(ir, umbrellaToolName);
-      out.push(functionCall, functionCallOutput);
+    if (item.type !== 'web_search_call') {
+      out.push(item);
       continue;
     }
-    out.push(item);
+
+    const candidatePayload = item.id !== undefined ? privatePayloads?.get(item.id) : undefined;
+    if (isWebSearchCallPrivatePayload(candidatePayload)) {
+      out.push(
+        candidatePayload.functionCallItem,
+        {
+          type: 'function_call_output',
+          call_id: candidatePayload.functionCallItem.call_id,
+          output: renderOpOutputText(candidatePayload.ir.action, candidatePayload.ir.results),
+        },
+      );
+      continue;
+    }
+
+    if (item.action === undefined) {
+      const callId = synthesizeReplayCallId();
+      // Truncate the wire dump so a deeply-nested or large prior item
+      // doesn't blow the upstream context window via a multi-kilobyte
+      // function_call_output. The model still sees enough to recognize
+      // the malformed shape.
+      const wireDump = truncatePreservingCodePoints(JSON.stringify(item), MAX_MALFORMED_WIRE_DUMP_CHARS);
+      out.push(
+        {
+          type: 'function_call',
+          call_id: callId,
+          name: toolName,
+          arguments: '{}',
+          status: 'completed',
+        },
+        {
+          type: 'function_call_output',
+          call_id: callId,
+          output: `A prior web_search_call item in the conversation history was malformed (no \`action\` field). Original wire item: ${wireDump}`,
+        },
+      );
+      continue;
+    }
+
+    const callId = synthesizeReplayCallId();
+    out.push(
+      {
+        type: 'function_call',
+        call_id: callId,
+        name: toolName,
+        arguments: actionToShimCallArgsJson(item.action),
+        status: 'completed',
+      },
+      {
+        type: 'function_call_output',
+        call_id: callId,
+        // See path 2 in the function docstring above for why the wire
+        // `item.results` is ignored.
+        output: 'Prior search results were not preserved in the conversation history. Call web_search again if you need them.',
+      },
+    );
   }
   return out;
 };
@@ -800,6 +753,12 @@ export interface ShimState {
   // `undefined` for keyless requests (admin playground); usage
   // recording is skipped in that case.
   apiKeyId: string | undefined;
+  // Set when the client passed `include: ["web_search_call.results"]` on
+  // the request. Native Responses gates the `results` field on this
+  // include token; the shim follows suit on the wire item — but the IR
+  // (and therefore `payload.private`) always carries the real results
+  // so a subsequent turn echoing the item id can be hydrated regardless.
+  includeSearchResults: boolean;
   // Set when the client passed
   // `include: ["web_search_call.action.sources"]` on the request,
   // mirroring native Responses' opt-in shape for the search-action
@@ -881,7 +840,7 @@ export const findMatches = (
 };
 
 export const formatMatches = (pattern: string, url: string, matches: readonly FindMatch[]): string => {
-  if (matches.length === 0) return findNoMatchesText(pattern, url);
+  if (matches.length === 0) return `No matching \`${pattern}\` found on ${url}.`;
   const noun = matches.length === 1 ? 'match' : 'matches';
   const lines: string[] = [`${matches.length} ${noun} for pattern: \`${pattern}\``, ''];
   for (let i = 0; i < matches.length; i++) {
@@ -921,7 +880,6 @@ const resolveActiveProvider = async (
 };
 
 const runBackendSearch = async (
-  id: string,
   op: Extract<ShimLogicalOperation, { kind: 'search' }>,
   state: ShimState,
 ): Promise<WebSearchCallIR> => {
@@ -929,12 +887,12 @@ const runBackendSearch = async (
 
   if (op.error !== undefined) {
     const title = op.errorKind === 'missing-arg' ? 'Missing argument' : 'Invalid ref_id';
-    return searchIr(id, query, [errorSnippet(title, op.error)]);
+    return searchIr(query, [errorSnippet(title, op.error)]);
   }
 
   const active = await resolveActiveProvider(state);
   if ('unavailable' in active) {
-    return searchIr(id, query, [errorSnippet('Search error', searchFailedText(active.unavailable))]);
+    return searchIr(query, [errorSnippet('Search error', searchFailedText(active.unavailable))]);
   }
 
   try {
@@ -960,7 +918,7 @@ const runBackendSearch = async (
 
     if (result.type === 'error') {
       const msg = result.message ?? result.errorCode;
-      return searchIr(id, query, [errorSnippet('Search error', searchFailedText(msg))]);
+      return searchIr(query, [errorSnippet('Search error', searchFailedText(msg))]);
     }
 
     // Per-snippet char cap on web_search_call.results[].snippet. Providers
@@ -980,10 +938,10 @@ const runBackendSearch = async (
     const sources = state.includeSearchActionSources
       ? result.results.map(r => ({ type: 'url' as const, url: r.source }))
       : undefined;
-    return searchIr(id, query, results, sources);
+    return searchIr(query, results, sources);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    return searchIr(id, query, [errorSnippet('Search error', searchFailedText(msg))]);
+    return searchIr(query, [errorSnippet('Search error', searchFailedText(msg))]);
   }
 };
 
@@ -1058,11 +1016,11 @@ const runBatchFetch = async (
   }
 };
 
-// Intra-umbrella batching: collect every URL the umbrella's
+// Intra-call batching: collect every URL the shim's
 // open[]/find[] sub-arrays reference, dedup, hit cache, and issue
-// one batched provider.fetchPage for the remainder. Cross-umbrella
+// one batched provider.fetchPage for the remainder. Cross-call
 // joining is deliberately NOT done — same-turn serial execution
-// means later umbrellas can simply read the populated cache.
+// means later shim calls can simply read the populated cache.
 const fetchAndCacheManyPages = async (
   urls: string[],
   state: ShimState,
@@ -1091,12 +1049,14 @@ const fetchAndCacheManyPages = async (
   return results;
 };
 
-const openPageSuccessIr = (id: string, url: string, cached: PageCacheEntry): WebSearchCallIR => {
+const openPageSuccessIr = (url: string, cached: PageCacheEntry): WebSearchCallIR => {
   // Provider truncates to its 10 KiB per-page cap. Truncated bodies get
   // a sentinel so the model can choose to `find` for specific content.
   const body = cached.content
-    + (cached.truncated ? `\n\n${truncationSentinel(cached.fullContentBytes)}` : '');
-  return openPageIr(id, url, [{
+    + (cached.truncated
+      ? `\n\n[Content truncated; full page is ${cached.fullContentBytes} bytes. Use web_search's \`find\` sub-property with a pattern to locate specific content.]`
+      : '');
+  return openPageIr(url, [{
     type: 'text_result',
     url,
     title: cached.title ?? '',
@@ -1105,7 +1065,6 @@ const openPageSuccessIr = (id: string, url: string, cached: PageCacheEntry): Web
 };
 
 const runBackendOpenPage = async (
-  id: string,
   op: Extract<ShimLogicalOperation, { kind: 'open' }>,
   batchPromise: Promise<Map<string, FetchAndCacheResult>>,
 ): Promise<WebSearchCallIR> => {
@@ -1116,20 +1075,19 @@ const runBackendOpenPage = async (
   // open_page action would be meaningless.
   if (op.error !== undefined) {
     const title = op.errorKind === 'missing-arg' ? 'Missing argument' : 'Invalid ref_id';
-    return searchIr(id, op.url, [errorSnippet(title, op.error)]);
+    return searchIr(op.url, [errorSnippet(title, op.error)]);
   }
 
   // Batch fetch pre-populates entries for every URL the parser produced
   // (blocked URLs get an explicit failure entry), so the lookup is total.
   const fetched = (await batchPromise).get(url)!;
   if (!fetched.ok) {
-    return openPageIr(id, url, [errorSnippet('Open page error', fetched.output)]);
+    return openPageIr(url, [errorSnippet('Open page error', fetched.output)]);
   }
-  return openPageSuccessIr(id, url, fetched.cached);
+  return openPageSuccessIr(url, fetched.cached);
 };
 
 const runBackendFind = async (
-  id: string,
   op: Extract<ShimLogicalOperation, { kind: 'find' }>,
   batchPromise: Promise<Map<string, FetchAndCacheResult>>,
 ): Promise<WebSearchCallIR> => {
@@ -1138,7 +1096,7 @@ const runBackendFind = async (
 
   if (op.error !== undefined) {
     const title = op.errorKind === 'missing-arg' ? 'Missing argument' : 'Invalid ref_id';
-    return findInPageIr(id, url, pattern, [errorSnippet(title, op.error)]);
+    return findInPageIr(url, pattern, [errorSnippet(title, op.error)]);
   }
 
   // Pre-fetch failures keep the `find_in_page` action carrying the
@@ -1146,7 +1104,7 @@ const runBackendFind = async (
   // change `action.type` mid-result.
   const fetched = (await batchPromise).get(url)!;
   if (!fetched.ok) {
-    return findInPageIr(id, url, pattern, [errorSnippet('Find error', fetched.output)]);
+    return findInPageIr(url, pattern, [errorSnippet('Find error', fetched.output)]);
   }
 
   // Mirror gpt-oss `find` defaults.
@@ -1157,7 +1115,7 @@ const runBackendFind = async (
   // Native find_in_page returns one result whose snippet either lists
   // the matches or says "No matching ...".
   const title = matches.length === 0 ? 'No match' : 'Matches';
-  return findInPageIr(id, url, pattern, [{
+  return findInPageIr(url, pattern, [{
     type: 'text_result',
     url,
     title,
@@ -1166,71 +1124,35 @@ const runBackendFind = async (
 };
 
 const executeOperation = (
-  id: string,
   op: ShimLogicalOperation,
   state: ShimState,
   batchPromise: Promise<Map<string, FetchAndCacheResult>>,
 ): Promise<WebSearchCallIR> => {
   switch (op.kind) {
   case 'search':
-    return runBackendSearch(id, op, state);
+    return runBackendSearch(op, state);
   case 'open':
-    return runBackendOpenPage(id, op, batchPromise);
+    return runBackendOpenPage(op, batchPromise);
   case 'find':
-    return runBackendFind(id, op, batchPromise);
+    return runBackendFind(op, batchPromise);
   case 'unsupported':
     return Promise.resolve(schemaErrorIr(
-      id,
       `unsupported action: ${op.subProperty}[${op.arrayIndex}]`,
       'Unsupported action',
-      unsupportedSubPropertyText(op.subProperty),
+      `Error: the \`${op.subProperty}\` sub-property is not supported by this gateway. Only \`search_query\`, \`open\`, and \`find\` are available.`,
     ));
   case 'wrong-type':
     return Promise.resolve(schemaErrorIr(
-      id,
       `wrong-type sub-property: ${op.subProperty}`,
       'Malformed sub-property',
-      wrongTypeSubPropertyText(op.subProperty, op.actualType),
+      `Error: the \`${op.subProperty}\` sub-property must be an array of objects; got ${op.actualType}.`,
     ));
   }
 };
 
-// Per-umbrella bypass: each parsed op resolves to a snippet IR
-// carrying `snippetText` in the action shape closest to what the
-// model asked for. Used for both the iteration-cap exhaustion and
-// the `max_tool_calls` budget exhaustion.
-//   https://github.com/tinfoilsh/confidential-model-router/blob/4ad5a7229fdd37f5d270b56a92dfb23a3fb2b562/toolruntime/chat_stream.go#L1014-L1019
-const irForBypassedOp = (id: string, op: ShimLogicalOperation, snippetText: string): WebSearchCallIR => {
-  switch (op.kind) {
-  case 'search':
-    return searchIr(id, op.query, [errorSnippet('Search error', snippetText)]);
-  case 'open':
-    if (op.error !== undefined) {
-      return searchIr(id, op.url, [errorSnippet('Open page error', snippetText)]);
-    }
-    return openPageIr(id, op.url, [errorSnippet('Open page error', snippetText)]);
-  case 'find':
-    return findInPageIr(id, op.url, op.pattern, [errorSnippet('Find error', snippetText)]);
-  case 'unsupported':
-    return schemaErrorIr(
-      id,
-      `unsupported action: ${op.subProperty}[${op.arrayIndex}]`,
-      'Unsupported action',
-      snippetText,
-    );
-  case 'wrong-type':
-    return schemaErrorIr(
-      id,
-      `wrong-type sub-property: ${op.subProperty}`,
-      'Malformed sub-property',
-      snippetText,
-    );
-  }
-};
-
-// Collect the open/find URL set for THIS umbrella and kick off one
+// Collect the open/find URL set for THIS shim call and kick off one
 // provider.fetchPage covering all of them. `fetchAndCacheManyPages`
-// installs per-URL inflight slots synchronously so later umbrellas in
+// installs per-URL inflight slots synchronously so later shim calls in
 // the same turn dedup against this batch.
 //
 // Blocked URLs (failing `isUrlAllowed`) are filtered OUT of the batch
@@ -1241,10 +1163,8 @@ const irForBypassedOp = (id: string, op: ShimLogicalOperation, snippetText: stri
 // That way the per-op handlers (`runBackendOpenPage` /
 // `runBackendFind`) can trust the gate's verdict by reading the map
 // directly instead of re-running `isUrlAllowed` themselves.
-const BLOCKED_BY_FILTER_OUTPUT = 'Blocked by tool filters';
-
-const startBatchFetchForUmbrella = async (
-  parsed: ParsedUmbrella,
+const startBatchFetchForShimCall = async (
+  parsed: ParsedShimCall,
   state: ShimState,
 ): Promise<Map<string, FetchAndCacheResult>> => {
   if (parsed.kind !== 'ops') return new Map();
@@ -1266,44 +1186,61 @@ const startBatchFetchForUmbrella = async (
   }
   const fetched = await fetchAndCacheManyPages(batchUrls, state);
   for (const url of blockedUrls) {
-    fetched.set(url, { ok: false, output: openFailedText(url, BLOCKED_BY_FILTER_OUTPUT) });
+    fetched.set(url, { ok: false, output: openFailedText(url, 'Blocked by tool filters') });
   }
   return fetched;
 };
 
-const planUmbrellaSlots = (
-  parsed: ParsedUmbrella,
+const planShimSlots = (
+  parsed: ParsedShimCall,
+  toolName: string,
   state: ShimState,
   loopState: ServerToolLoopState,
-): { id: string; promise: Promise<WebSearchCallIR> }[] => {
+): { id: string; promise: Promise<WebSearchCallIR> } => {
   if (loopState.iterationCount > ITERATION_CAP) {
-    if (parsed.kind === 'malformed' || parsed.ops.length === 0) {
-      const id = synthesizeWebSearchCallId();
-      return [{
-        id,
-        promise: Promise.resolve(schemaErrorIr(id, 'malformed umbrella arguments', 'Tool call budget exhausted', iterationCapText)),
-      }];
-    }
-    return parsed.ops.map(op => {
-      const id = synthesizeWebSearchCallId();
-      return { id, promise: Promise.resolve(irForBypassedOp(id, op, iterationCapText)) };
-    });
+    return {
+      id: synthesizeWebSearchCallId(),
+      promise: Promise.resolve(schemaErrorIr(
+        'tool budget exhausted',
+        'Tool call budget exhausted',
+        `Web search iteration limit (${ITERATION_CAP}) reached. Further web_search calls in this response will return this same error. Summarize what you have already learned, and continue the task using other available tools (shell, file inspection, prior knowledge) or directly answer based on what you've gathered.`,
+      )),
+    };
   }
 
   if (parsed.kind === 'malformed' || parsed.ops.length === 0) {
-    const id = synthesizeWebSearchCallId();
-    return [{
-      id,
-      promise: Promise.resolve(schemaErrorIr(id, 'malformed umbrella arguments', 'Malformed arguments', emptyUmbrellaArgsText)),
-    }];
+    return {
+      id: synthesizeWebSearchCallId(),
+      promise: Promise.resolve(schemaErrorIr(
+        'malformed shim call arguments',
+        'Malformed arguments',
+        'Error: arguments must be a JSON object with sub-property arrays (search_query[], open[], find[]).',
+      )),
+    };
   }
 
-  const batchPromise = startBatchFetchForUmbrella(parsed, state);
+  // One private payload ⇄ one wsc ⇄ one op. A shim call that bundles
+  // more than one logical op (multi-kind mix, or multi-instance of any
+  // sub-property array) cannot be reduced to a single wsc action shape,
+  // so surface it as an ambiguous error and let the model split the
+  // request into independent calls.
+  if (parsed.ops.length > 1) {
+    return {
+      id: synthesizeWebSearchCallId(),
+      promise: Promise.resolve(schemaErrorIr(
+        'ambiguous shim call',
+        'Ambiguous tool call',
+        `Error: ambiguous \`${toolName}\` tool call — each function_call may carry only one operation. `
+        + 'Split into multiple independent calls (one search_query[] entry, OR one open[] entry, OR one find[] entry per call).',
+      )),
+    };
+  }
 
-  return parsed.ops.map(op => {
-    const id = synthesizeWebSearchCallId();
-    return { id, promise: executeOperation(id, op, state, batchPromise) };
-  });
+  const batchPromise = startBatchFetchForShimCall(parsed, state);
+  return {
+    id: synthesizeWebSearchCallId(),
+    promise: executeOperation(parsed.ops[0], state, batchPromise),
+  };
 };
 
 export const webSearchServerTool: ServerToolRegistration = (ctx, request) => {
@@ -1325,17 +1262,18 @@ export const webSearchServerTool: ServerToolRegistration = (ctx, request) => {
     };
   }
 
-  const rewritten = prepared.prepared;
+  const { filters } = prepared;
   const includeArray = Array.isArray(ctx.payload.include) ? ctx.payload.include : [];
   let configuredProvider: Promise<ConfiguredWebSearchProvider> | undefined;
   const state: ShimState = {
-    filters: rewritten.filters,
+    filters,
     pageCache: new Map(),
     getProvider: () => {
       configuredProvider ??= loadSearchConfig().then(cfg => resolveConfiguredWebSearchProvider(cfg));
       return configuredProvider;
     },
     apiKeyId: request.apiKeyId,
+    includeSearchResults: includeArray.includes('web_search_call.results'),
     includeSearchActionSources: includeArray.includes('web_search_call.action.sources'),
     ...(request.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: request.downstreamAbortSignal } : {}),
   };
@@ -1343,29 +1281,52 @@ export const webSearchServerTool: ServerToolRegistration = (ctx, request) => {
   return {
     type: 'active',
     baseToolName: SHIM_TOOL_NAME,
-    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName),
+    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName, request.statefulResponsesContext.privatePayload),
     ...(hasHostedWebSearch
       ? {
           hosted: {
             isHostedTool: isHostedWebSearchTool,
-            buildFunctionTool: toolName => buildUmbrellaTool(toolName, rewritten.filters.userLocation),
+            buildFunctionTool: toolName => buildShimFunctionTool(toolName, filters.userLocation),
             dispatcher: ({ intercepted, loopState }) => {
-              const planned = planUmbrellaSlots(parseUmbrellaOperations(intercepted.arguments), state, loopState);
-              return planned.map(({ id, promise }) => serverToolResultSlot({
-                id,
+              const slot = planShimSlots(parseShimOperations(intercepted.arguments), intercepted.name, state, loopState);
+              const functionCallItem: ResponsesFunctionToolCallItem = {
+                type: 'function_call',
+                call_id: intercepted.callId,
+                name: intercepted.name,
+                // Serialize the post-jsonrepair parsed object rather than
+                // re-using the upstream's raw `arguments` string (which
+                // might be malformed); `{}` is the safe fallback when
+                // jsonrepair couldn't even produce an object.
+                arguments: JSON.stringify(intercepted.arguments ?? {}),
+                status: 'completed',
+              };
+              return [serverToolResultSlot({
+                id: slot.id,
                 startItem: { type: 'web_search_call', status: 'in_progress' },
                 startEvents: [
                   { type: 'response.web_search_call.in_progress' },
                   { type: 'response.web_search_call.searching' },
                 ],
-                result: promise.then(ir => {
-                  const item: ServerToolOutputItem & Omit<ResponsesOutputWebSearchCall, 'id'> = { type: 'web_search_call', status: 'completed', action: ir.action, results: ir.results };
+                result: slot.promise.then(ir => {
+                  // `results` is gated on the client's `include`
+                  // opt-in to match native Responses' default wire
+                  // shape; the IR keeps them either way for the
+                  // private-payload round-trip.
+                  const item: ServerToolOutputItem & Omit<ResponsesOutputWebSearchCall, 'id'> = state.includeSearchResults
+                    ? { type: 'web_search_call', status: 'completed', action: ir.action, results: ir.results }
+                    : { type: 'web_search_call', status: 'completed', action: ir.action };
+                  const privatePayload: WebSearchCallPrivatePayload = {
+                    v: 1,
+                    functionCallItem,
+                    ir,
+                  };
                   return {
                     item,
                     endEvents: [{ type: 'response.web_search_call.completed' }],
+                    privatePayload,
                   };
                 }),
-              }));
+              })];
             },
           },
         }

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search_test.ts
@@ -2,54 +2,43 @@ import { test } from 'vitest';
 
 import { resolveServerToolName } from '../server-tool-shim.ts';
 import {
-  findInPageIr,
   findMatches,
-  findNoMatchesText,
   formatMatches,
-  inputItemToIr,
-  irToOutputText,
-  irToUpstreamPair,
   isHostedWebSearchTool,
   isUrlAllowed,
-  iterationCapText,
-  openFailedText,
-  openPageIr,
-  parseUmbrellaOperations,
+  parseShimOperations,
   prepareToolsForShim,
-  schemaErrorIr,
-  searchFailedText,
-  searchIr,
   SHIM_TOOL_NAME,
   synthesizeWebSearchCallId,
-  truncationSentinel,
+  transformInputItemsForWebSearch,
   WEB_SEARCH_HOSTED_TYPES,
   type ShimLogicalOperation,
-  type WebSearchCallIR,
+  type WebSearchCallPrivatePayload,
 } from './web-search.ts';
 import { assert, assertEquals, assertFalse } from '../../../../../../test-assert.ts';
 import { truncatePreservingCodePoints } from '../../../../shared/text.ts';
-import type { ResponsesTool } from '@floway-dev/protocols/responses';
+import type { ResponsesTool, ResponsesWebSearchAction, ResponsesWebSearchResult } from '@floway-dev/protocols/responses';
 
-// ── Umbrella argument parsing (parseUmbrellaOperations) ──
+// ── Shim call argument parsing (parseShimOperations) ──
 
 const opsOf = (args: Record<string, unknown> | null): ShimLogicalOperation[] => {
-  const parsed = parseUmbrellaOperations(args);
+  const parsed = parseShimOperations(args);
   assert(parsed.kind === 'ops');
   return parsed.ops;
 };
 
-test('parseUmbrellaOperations returns ops:[] for empty object', () => {
-  assertEquals(parseUmbrellaOperations({}), { kind: 'ops', ops: [] });
+test('parseShimOperations returns ops:[] for empty object', () => {
+  assertEquals(parseShimOperations({}), { kind: 'ops', ops: [] });
 });
 
-test('parseUmbrellaOperations parses one search_query entry', () => {
+test('parseShimOperations parses one search_query entry', () => {
   assertEquals(
     opsOf({ search_query: [{ q: 'hello' }] }),
     [{ kind: 'search', arrayIndex: 0, query: 'hello' }],
   );
 });
 
-test('parseUmbrellaOperations parses multiple search_query entries with stable arrayIndex', () => {
+test('parseShimOperations parses multiple search_query entries with stable arrayIndex', () => {
   assertEquals(
     opsOf({ search_query: [{ q: 'a' }, { q: 'b' }, { q: 'c' }] }),
     [
@@ -60,21 +49,21 @@ test('parseUmbrellaOperations parses multiple search_query entries with stable a
   );
 });
 
-test('parseUmbrellaOperations parses open entry with URL ref_id', () => {
+test('parseShimOperations parses open entry with URL ref_id', () => {
   assertEquals(
     opsOf({ open: [{ ref_id: 'https://example.com' }] }),
     [{ kind: 'open', arrayIndex: 0, url: 'https://example.com' }],
   );
 });
 
-test('parseUmbrellaOperations parses find entry with URL ref_id and pattern', () => {
+test('parseShimOperations parses find entry with URL ref_id and pattern', () => {
   assertEquals(
     opsOf({ find: [{ ref_id: 'https://example.com', pattern: 'needle' }] }),
     [{ kind: 'find', arrayIndex: 0, url: 'https://example.com', pattern: 'needle' }],
   );
 });
 
-test('parseUmbrellaOperations: non-URL open ref_id produces an error sentinel', () => {
+test('parseShimOperations: non-URL open ref_id produces an error sentinel', () => {
   const ops = opsOf({ open: [{ ref_id: 'opaque-prior-id' }] });
   assertEquals(ops.length, 1);
   const op = ops[0];
@@ -86,7 +75,7 @@ test('parseUmbrellaOperations: non-URL open ref_id produces an error sentinel', 
   assertEquals(err!.includes('opaque-prior-id'), true);
 });
 
-test('parseUmbrellaOperations: non-URL find ref_id produces an error sentinel', () => {
+test('parseShimOperations: non-URL find ref_id produces an error sentinel', () => {
   const ops = opsOf({ find: [{ ref_id: 'cursor-123', pattern: 'p' }] });
   assertEquals(ops.length, 1);
   const op = ops[0];
@@ -98,7 +87,7 @@ test('parseUmbrellaOperations: non-URL find ref_id produces an error sentinel', 
   assertEquals(err!.includes('cursor-123'), true);
 });
 
-test('parseUmbrellaOperations: multi-action batched call returns all ops in order search→open→find', () => {
+test('parseShimOperations: multi-action batched call returns all ops in order search→open→find', () => {
   const ops = opsOf({
     search_query: [{ q: 'a' }],
     open: [{ ref_id: 'https://x' }],
@@ -107,7 +96,7 @@ test('parseUmbrellaOperations: multi-action batched call returns all ops in orde
   assertEquals(ops.map(o => o.kind), ['search', 'open', 'find']);
 });
 
-test('parseUmbrellaOperations: unsupported sub-properties surface one unsupported op per entry', () => {
+test('parseShimOperations: unsupported sub-properties surface one unsupported op per entry', () => {
   const ops = opsOf({
     click: [{ ref_id: 'https://x', id: 1 }],
     screenshot: [{ ref_id: 'https://x', pageno: 1 }, { ref_id: 'https://y', pageno: 2 }],
@@ -124,7 +113,7 @@ test('parseUmbrellaOperations: unsupported sub-properties surface one unsupporte
   assertEquals(ops[5], { kind: 'unsupported', subProperty: 'response_length', arrayIndex: 0 });
 });
 
-test('parseUmbrellaOperations: missing q on search_query entry surfaces a missing-argument error sentinel', () => {
+test('parseShimOperations: missing q on search_query entry surfaces a missing-argument error sentinel', () => {
   const ops = opsOf({ search_query: [{}] });
   assertEquals(ops.length, 1);
   const op = ops[0];
@@ -134,7 +123,7 @@ test('parseUmbrellaOperations: missing q on search_query entry surfaces a missin
   assert((op as { error: string }).error.includes('"q"'));
 });
 
-test('parseUmbrellaOperations: missing ref_id on open entry surfaces a missing-argument error sentinel', () => {
+test('parseShimOperations: missing ref_id on open entry surfaces a missing-argument error sentinel', () => {
   const ops = opsOf({ open: [{}] });
   assertEquals(ops.length, 1);
   const op = ops[0];
@@ -143,7 +132,7 @@ test('parseUmbrellaOperations: missing ref_id on open entry surfaces a missing-a
   assert((op as { error: string }).error.includes('"ref_id"'));
 });
 
-test('parseUmbrellaOperations: missing pattern on find entry surfaces a missing-argument error sentinel', () => {
+test('parseShimOperations: missing pattern on find entry surfaces a missing-argument error sentinel', () => {
   const ops = opsOf({ find: [{ ref_id: 'https://x' }] });
   assertEquals(ops.length, 1);
   const op = ops[0];
@@ -152,13 +141,13 @@ test('parseUmbrellaOperations: missing pattern on find entry surfaces a missing-
   assert((op as { error: string }).error.includes('"pattern"'));
 });
 
-test('parseUmbrellaOperations: array values for non-array shape are skipped', () => {
+test('parseShimOperations: array values for non-array shape are skipped', () => {
   assertEquals(opsOf({ search_query: 'oops' }), [
     { kind: 'wrong-type', subProperty: 'search_query', actualType: 'string' },
   ]);
 });
 
-test('parseUmbrellaOperations: supported key with non-array value surfaces a wrong-type op (search_query)', () => {
+test('parseShimOperations: supported key with non-array value surfaces a wrong-type op (search_query)', () => {
   // A model that populates `search_query: {"q":"x"}` (or any
   // non-array) used to be silently dropped because the array guard
   // skipped it. Surface as a model-visible `wrong-type` op so the
@@ -169,14 +158,14 @@ test('parseUmbrellaOperations: supported key with non-array value surfaces a wro
   ]);
 });
 
-test('parseUmbrellaOperations: wrong-typed supported key does not block other supported keys from executing', () => {
+test('parseShimOperations: wrong-typed supported key does not block other supported keys from executing', () => {
   const ops = opsOf({ search_query: { q: 'x' }, open: [{ ref_id: 'https://y' }] });
   assertEquals(ops.length, 2);
   assertEquals(ops[0], { kind: 'wrong-type', subProperty: 'search_query', actualType: 'object' });
   assertEquals(ops[1], { kind: 'open', arrayIndex: 0, url: 'https://y' });
 });
 
-test('parseUmbrellaOperations: wrong-typed open / find surface as wrong-type ops', () => {
+test('parseShimOperations: wrong-typed open / find surface as wrong-type ops', () => {
   assertEquals(opsOf({ open: 'https://x' }), [
     { kind: 'wrong-type', subProperty: 'open', actualType: 'string' },
   ]);
@@ -185,17 +174,7 @@ test('parseUmbrellaOperations: wrong-typed open / find surface as wrong-type ops
   ]);
 });
 
-// ── IR builders and replay (searchIr / inputItemToIr / irToUpstreamPair …) ──
-
-const FIXED_ID = 'ws_test_fixed_0123456789abcdef';
-
-const fixedIr = (overrides: Partial<WebSearchCallIR> = {}): WebSearchCallIR => ({
-  id: FIXED_ID,
-  status: 'completed',
-  action: { type: 'search', queries: ['hello'] },
-  results: [{ type: 'text_result', url: 'https://x', title: 'X', snippet: 'snip' }],
-  ...overrides,
-});
+// ── IR builders (private to web-search.ts; exercised end-to-end below) ──
 
 test('synthesizeWebSearchCallId produces unique ws_gw_ prefixed ids', () => {
   const a = synthesizeWebSearchCallId();
@@ -203,199 +182,6 @@ test('synthesizeWebSearchCallId produces unique ws_gw_ prefixed ids', () => {
   assert(a.startsWith('ws_gw_'));
   assert(b.startsWith('ws_gw_'));
   assert(a !== b);
-});
-
-test('searchIr places query in action.queries and uses status=completed', () => {
-  const ir = searchIr(FIXED_ID, 'hello world', []);
-  assertEquals(ir.status, 'completed');
-  assertEquals(ir.id, FIXED_ID);
-  // Both `query` (singular, required by openai-python ActionSearch)
-  // and `queries` (plural, newer codex) are populated so every typed
-  // SDK reads the value regardless of which field its model declares.
-  assertEquals(ir.action, { type: 'search', query: 'hello world', queries: ['hello world'] });
-  assertEquals(ir.results, []);
-});
-
-test('openPageIr with url preserves it on the action', () => {
-  const ir = openPageIr(FIXED_ID, 'https://example.com', []);
-  assertEquals(ir.action, { type: 'open_page', url: 'https://example.com' });
-});
-
-test('openPageIr with undefined url omits the field from the action (matches native soft-failure shape)', () => {
-  const ir = openPageIr(FIXED_ID, undefined, [{ type: 'text_result', url: '', title: 'Error', snippet: 'fetch failed' }]);
-  assertEquals(ir.action, { type: 'open_page' });
-  assertEquals(ir.results.length, 1);
-});
-
-test('findInPageIr keeps url and pattern on the action', () => {
-  const ir = findInPageIr(FIXED_ID, 'https://x', 'p', []);
-  assertEquals(ir.action, { type: 'find_in_page', url: 'https://x', pattern: 'p' });
-});
-
-test('schemaErrorIr uses action.type=search with descriptive queries entry', () => {
-  const ir = schemaErrorIr(FIXED_ID, 'unsupported action: click[0]', 'Unsupported action', 'Error: this gateway does not support `click`.');
-  // Both `query` and `queries` set so openai-python-style SDKs reading
-  // the singular `query` field don't see undefined for the diagnostic.
-  assertEquals(ir.action, { type: 'search', query: 'unsupported action: click[0]', queries: ['unsupported action: click[0]'] });
-  assertEquals(ir.results.length, 1);
-  assertEquals(ir.results[0].snippet, 'Error: this gateway does not support `click`.');
-  assertEquals(ir.results[0].title, 'Unsupported action');
-});
-
-test('schemaErrorIr accepts a custom title (Case 5 malformed args uses "Malformed arguments")', () => {
-  const ir = schemaErrorIr(FIXED_ID, 'malformed umbrella arguments', 'Malformed arguments', 'Error: arguments must be a JSON object.');
-  assertEquals(ir.results[0].title, 'Malformed arguments');
-  assertEquals(ir.results[0].snippet, 'Error: arguments must be a JSON object.');
-});
-
-test('inputItemToIr passes through a well-formed input item verbatim', () => {
-  const ir = inputItemToIr({
-    type: 'web_search_call',
-    id: 'ws_input_abc',
-    status: 'completed',
-    action: { type: 'open_page', url: 'https://y' },
-    results: [{ type: 'text_result', url: 'https://y', title: 'Y', snippet: 'body' }],
-  });
-  assert(ir !== null);
-  assertEquals(ir.id, 'ws_input_abc');
-  assertEquals(ir.action, { type: 'open_page', url: 'https://y' });
-  assertEquals(ir.results.length, 1);
-});
-
-test('inputItemToIr returns null for items lacking an action (no neutral fabrication)', () => {
-  const ir = inputItemToIr({ type: 'web_search_call' });
-  assertEquals(ir, null);
-});
-
-test('inputItemToIr synthesizes a fresh id when the echoed item dropped it (clients like codex CLI strip ws_gw_ ids on session persist)', () => {
-  const irMissing = inputItemToIr({
-    type: 'web_search_call',
-    action: { type: 'search', queries: ['q'] },
-  });
-  assert(irMissing !== null);
-  assertEquals(irMissing.id.startsWith('ws_gw_'), true);
-  const irEmpty = inputItemToIr({
-    type: 'web_search_call',
-    id: '',
-    action: { type: 'search', queries: ['q'] },
-  });
-  assert(irEmpty !== null);
-  assertEquals(irEmpty.id.startsWith('ws_gw_'), true);
-});
-
-test('inputItemToIr marks resultsStripped when the echoed item has no results field', () => {
-  const ir = inputItemToIr({
-    type: 'web_search_call',
-    id: 'ws_kept',
-    action: { type: 'search', queries: ['q'] },
-  });
-  assert(ir !== null);
-  assertEquals(ir.resultsStripped, true);
-  assertEquals(ir.results, []);
-});
-
-test('inputItemToIr leaves resultsStripped unset when results is an empty array (zero-hit search, not stripped)', () => {
-  const ir = inputItemToIr({
-    type: 'web_search_call',
-    id: 'ws_kept',
-    action: { type: 'search', queries: ['q'] },
-    results: [],
-  });
-  assert(ir !== null);
-  assertEquals(ir.resultsStripped, undefined);
-});
-
-test('inputItemToIr clamps status to completed regardless of source value', () => {
-  const ir = inputItemToIr({
-    type: 'web_search_call',
-    id: 'ws_abc',
-    status: 'failed',
-    action: { type: 'search', queries: ['q'] },
-  });
-  assert(ir !== null);
-  assertEquals(ir.status, 'completed');
-});
-
-test('irToUpstreamPair derives a stable call_id from the IR id and shares it on both items', () => {
-  const ir = fixedIr({ id: 'ws_x' });
-  const pair = irToUpstreamPair(ir, 'web_search');
-  assertEquals(pair.functionCall.call_id, pair.functionCallOutput.call_id);
-  assertEquals(pair.functionCall.call_id, 'cc_from_ws_x');
-  assertEquals(pair.functionCall.name, 'web_search');
-  assertEquals(pair.functionCall.arguments, JSON.stringify({ search_query: [{ q: 'hello' }] }));
-});
-
-test('irToUpstreamPair uses the umbrella tool name passed in (collision-fallback aware)', () => {
-  const ir = fixedIr();
-  const pair = irToUpstreamPair(ir, 'web_search_2');
-  assertEquals(pair.functionCall.name, 'web_search_2');
-});
-
-test('irToOutputText for search action uses formatSearchResults shape (Search results for X then numbered hits)', () => {
-  const ir = searchIr(FIXED_ID, 'hello', [{ type: 'text_result', url: 'https://x', title: 'X', snippet: 'body' }]);
-  const text = irToOutputText(ir);
-  assert(text.startsWith('Search results for "hello":'));
-  assert(text.includes('[1] X'));
-  assert(text.includes('https://x'));
-  assert(text.includes('body'));
-});
-
-test('irToOutputText for open_page action uses the result snippet (page body) as the text', () => {
-  const ir = openPageIr(FIXED_ID, 'https://y', [{ type: 'text_result', url: 'https://y', title: 'Y', snippet: 'page body here' }]);
-  const text = irToOutputText(ir);
-  assertEquals(text, 'page body here');
-});
-
-test('irToOutputText for find_in_page action uses the result snippet (formatMatches output) verbatim', () => {
-  const ir = findInPageIr(FIXED_ID, 'https://x', 'needle', [{ type: 'text_result', url: '', title: 'No match', snippet: 'No matching `needle` found on https://x.' }]);
-  const text = irToOutputText(ir);
-  assertEquals(text, 'No matching `needle` found on https://x.');
-});
-
-test('irToOutputText for an open_page failure (no results) emits a "(no body returned)" sentinel', () => {
-  const ir = openPageIr(FIXED_ID, undefined, []);
-  const text = irToOutputText(ir);
-  assertEquals(text, 'Open (no url): (no body returned)');
-});
-
-test('searchFailedText formats provider message', () => {
-  assertEquals(searchFailedText('rate limited'), 'Search failed: rate limited');
-});
-
-test('openFailedText formats URL and provider message', () => {
-  assertEquals(openFailedText('https://x.com', '404'), 'Error fetching URL `https://x.com`: 404');
-});
-
-test('openFailedText handles the blocked-by-filter sentinel uniformly', () => {
-  assertEquals(
-    openFailedText('https://x.com', 'Blocked by tool filters'),
-    'Error fetching URL `https://x.com`: Blocked by tool filters',
-  );
-});
-
-test('findNoMatchesText includes URL and uses "No matching ..." wording (mirrors native find_in_page no-match snippet)', () => {
-  assertEquals(findNoMatchesText('foo bar', 'https://x.com'), 'No matching `foo bar` found on https://x.com.');
-});
-
-test('iterationCapText is the exact text fed back to the model on cap-exceeded turns', () => {
-  assertEquals(
-    iterationCapText,
-    'Web search iteration limit (30) reached. Further web_search calls in this response will return this same error. Summarize what you have already learned, and continue the task using other available tools (shell, file inspection, prior knowledge) or directly answer based on what you\'ve gathered.',
-  );
-});
-
-test('truncationSentinel formats full-page byte count', () => {
-  assertEquals(
-    truncationSentinel(50_000),
-    '[Content truncated; full page is 50000 bytes. Use web_search\'s `find` sub-property with a pattern to locate specific content.]',
-  );
-});
-
-test('truncationSentinel handles zero bytes', () => {
-  assertEquals(
-    truncationSentinel(0),
-    '[Content truncated; full page is 0 bytes. Use web_search\'s `find` sub-property with a pattern to locate specific content.]',
-  );
 });
 
 // ── truncatePreservingCodePoints boundary cases ───────────────────────
@@ -427,44 +213,6 @@ test('truncatePreservingCodePoints: high surrogate at position max-1 walks back 
     const code = out.charCodeAt(i);
     assertFalse(code >= 0xD800 && code <= 0xDBFF);
   }
-});
-
-// Search-result text rendering is exercised through `irToOutputText`
-// because the formatter is a private helper inside ir.ts. These tests
-// verify the wire shape clients depend on.
-
-test('irToOutputText (search) empty results renders header + (no results)', () => {
-  assertEquals(
-    irToOutputText(searchIr(FIXED_ID, 'deepseek', [])),
-    'Search results for "deepseek":\n\n(no results)',
-  );
-});
-
-test('irToOutputText (search) single result rendered with index 1', () => {
-  const out = irToOutputText(searchIr(FIXED_ID, 'deepseek', [
-    { type: 'text_result', url: 'https://deepseek.ai', title: 'DeepSeek', snippet: 'AI company.' },
-  ]));
-  assertEquals(
-    out,
-    'Search results for "deepseek":\n\n[1] DeepSeek\nhttps://deepseek.ai\nAI company.',
-  );
-});
-
-test('irToOutputText (search) three results separated by blank lines', () => {
-  const out = irToOutputText(searchIr(FIXED_ID, 'llms', [
-    { type: 'text_result', url: 'https://a.com', title: 'A', snippet: 'sa' },
-    { type: 'text_result', url: 'https://b.com', title: 'B', snippet: 'sb' },
-    { type: 'text_result', url: 'https://c.com', title: 'C', snippet: 'sc' },
-  ]));
-  assertEquals(
-    out,
-    'Search results for "llms":\n\n[1] A\nhttps://a.com\nsa\n\n[2] B\nhttps://b.com\nsb\n\n[3] C\nhttps://c.com\nsc',
-  );
-});
-
-test('irToOutputText (search) query is interpolated verbatim into the header', () => {
-  const out = irToOutputText(searchIr(FIXED_ID, 'quotes "inside" the query', []));
-  assertEquals(out.startsWith('Search results for "quotes "inside" the query":'), true);
 });
 
 // ── Backend dispatch helpers (isUrlAllowed / findMatches / formatMatches) ──
@@ -582,13 +330,13 @@ test('formatMatches: multi-match output uses Match N: headers', () => {
 
 // ── Tool detection, filter prep, and name resolution ──
 
-const UMBRELLA = SHIM_TOOL_NAME;
+const SHIM_TOOL = SHIM_TOOL_NAME;
 const hostedVariants = ['web_search', 'web_search_2025_08_26', 'web_search_preview', 'web_search_preview_2025_03_11'] as const;
 
 const prepare = (tools: ResponsesTool[]) => {
   const result = prepareToolsForShim(tools);
   assert(result.ok);
-  return result.prepared;
+  return { filters: result.filters };
 };
 
 test('isHostedWebSearchTool recognizes every hosted variant', () => {
@@ -623,15 +371,128 @@ test('prepareToolsForShim passes through with empty filters when no hosted web_s
 });
 
 test('resolveServerToolName returns the first free sequential name', () => {
-  assertEquals(resolveServerToolName(UMBRELLA, []), UMBRELLA);
-  assertEquals(resolveServerToolName(UMBRELLA, [{ type: 'function', name: UMBRELLA, parameters: {}, strict: false }]), `${UMBRELLA}_2`);
-  assertEquals(resolveServerToolName(UMBRELLA, [
-    { type: 'function', name: UMBRELLA, parameters: {}, strict: false },
-    { type: 'custom', name: `${UMBRELLA}_2` },
-  ]), `${UMBRELLA}_3`);
+  assertEquals(resolveServerToolName(SHIM_TOOL, []), SHIM_TOOL);
+  assertEquals(resolveServerToolName(SHIM_TOOL, [{ type: 'function', name: SHIM_TOOL, parameters: {}, strict: false }]), `${SHIM_TOOL}_2`);
+  assertEquals(resolveServerToolName(SHIM_TOOL, [
+    { type: 'function', name: SHIM_TOOL, parameters: {}, strict: false },
+    { type: 'custom', name: `${SHIM_TOOL}_2` },
+  ]), `${SHIM_TOOL}_3`);
 });
 
 test('prepareToolsForShim rejects invalid hosted fields', () => {
   const result = prepareToolsForShim([{ type: 'web_search', search_context_size: 'huge' } as unknown as ResponsesTool]);
   assertEquals(result.ok, false);
+});
+
+// ── Private-payload restoration (transformInputItemsForWebSearch) ──
+
+const makePrivatePayload = (
+  upstreamCallId: string,
+  upstreamArgs: string,
+  action: ResponsesWebSearchAction,
+  results: ResponsesWebSearchResult[],
+): WebSearchCallPrivatePayload => ({
+  v: 1,
+  functionCallItem: {
+    type: 'function_call',
+    call_id: upstreamCallId,
+    name: 'web_search',
+    arguments: upstreamArgs,
+    status: 'completed',
+  },
+  ir: { action, results },
+});
+
+test('transformInputItemsForWebSearch replays the upstream function_call verbatim when a private payload exists', () => {
+  // One wsc maps 1:1 to one shim call. The shim's
+  // jsonrepair-canonical args and the per-op output are persisted on
+  // this single row.
+  const payload = makePrivatePayload(
+    'call_orig_xyz',
+    '{"search_query":[{"q":"caffeine","topn":5}]}',
+    { type: 'search', query: 'caffeine', queries: ['caffeine'] },
+    [{ type: 'text_result', url: 'u', title: 't', snippet: 'cached body' }],
+  );
+  const map = new Map<string, unknown>([['ws_xxx_abc', payload]]);
+  const out = transformInputItemsForWebSearch(
+    [{ type: 'web_search_call', id: 'ws_xxx_abc' }],
+    'web_search',
+    map,
+  );
+  assertEquals(out.length, 2);
+  const [fc, fco] = out as [{ type: string; name: string; arguments: string; call_id: string }, { type: string; output: string; call_id: string }];
+  assertEquals(fc.type, 'function_call');
+  assertEquals(fc.call_id, 'call_orig_xyz');
+  assertEquals(fc.name, 'web_search');
+  // The upstream's call_id and canonical args are preserved bit-exact —
+  // `topn` survives even though the IR drops it.
+  assertEquals(fc.arguments, '{"search_query":[{"q":"caffeine","topn":5}]}');
+  assertEquals(fco.call_id, 'call_orig_xyz');
+  assert(fco.output.includes('cached body'));
+});
+
+test('transformInputItemsForWebSearch replays each echoed wsc independently (one pair per wsc)', () => {
+  // Two distinct shim calls (different upstream call_ids) → two replay
+  // pairs, one per wsc.
+  const p1 = makePrivatePayload('call_u1', '{"search_query":[{"q":"q1"}]}',
+    { type: 'search', queries: ['q1'] }, [{ type: 'text_result', url: 'u1', title: 't1', snippet: 'body1' }]);
+  const p2 = makePrivatePayload('call_u2', '{"search_query":[{"q":"q2"}]}',
+    { type: 'search', queries: ['q2'] }, [{ type: 'text_result', url: 'u2', title: 't2', snippet: 'body2' }]);
+  const map = new Map<string, unknown>([['ws_one', p1], ['ws_two', p2]]);
+  const out = transformInputItemsForWebSearch(
+    [
+      { type: 'web_search_call', id: 'ws_one' },
+      { type: 'web_search_call', id: 'ws_two' },
+    ],
+    'web_search',
+    map,
+  );
+  assertEquals(out.length, 4);
+  const callIds = out.map(it => (it as { call_id?: unknown }).call_id).filter((id): id is string => typeof id === 'string');
+  assertEquals(callIds, ['call_u1', 'call_u1', 'call_u2', 'call_u2']);
+  const outputs = out.filter(it => (it as { type: string }).type === 'function_call_output') as Array<{ output: string }>;
+  assert(outputs[0].output.includes('body1'));
+  assert(outputs[1].output.includes('body2'));
+});
+
+test('transformInputItemsForWebSearch emits the not-preserved placeholder even when the wire item still carries results (no payload → we do not trust client-supplied results)', () => {
+  const out = transformInputItemsForWebSearch(
+    [{
+      type: 'web_search_call', id: 'ws_xxx_abc',
+      action: { type: 'search', queries: ['caffeine'] },
+      results: [{ type: 'text_result', url: 'u', title: 't', snippet: 'public-wire body' }],
+    }],
+    'web_search',
+  );
+  assertEquals(out.length, 2);
+  const fc = out[0] as { type: string; arguments: string };
+  const fco = out[1] as { type: string; output: string };
+  // The synthesized function_call mirrors the wire action shape so the
+  // model still sees what it had asked for.
+  assertEquals(fc.arguments, '{"search_query":[{"q":"caffeine"}]}');
+  // ... but the function_call_output is the placeholder — we deliberately
+  // ignore the wire `results` field, since we have no way to verify it
+  // matches what the gateway actually returned on turn 1.
+  assertEquals(fco.output, 'Prior search results were not preserved in the conversation history. Call web_search again if you need them.');
+});
+
+test('transformInputItemsForWebSearch emits the not-preserved placeholder when results are missing and no private payload exists', () => {
+  const out = transformInputItemsForWebSearch(
+    [{ type: 'web_search_call', id: 'ws_xxx_abc', action: { type: 'search', queries: ['q'] } }],
+    'web_search',
+  );
+  const fco = out[1] as { type: string; output: string };
+  assertEquals(fco.output, 'Prior search results were not preserved in the conversation history. Call web_search again if you need them.');
+});
+
+test('transformInputItemsForWebSearch ignores a stashed value with the wrong schema version (forward-compat)', () => {
+  const map = new Map<string, unknown>([['ws_xxx_abc', { v: 99, anything: 'goes' }]]);
+  // Falls back to public-wire reconstruction; no crash, no false hydration.
+  const out = transformInputItemsForWebSearch(
+    [{ type: 'web_search_call', id: 'ws_xxx_abc', action: { type: 'search', queries: ['q'] } }],
+    'web_search',
+    map,
+  );
+  const fco = out[1] as { type: string; output: string };
+  assertEquals(fco.output, 'Prior search results were not preserved in the conversation history. Call web_search again if you need them.');
 });

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -120,9 +120,9 @@ const buildRow = async (
     throw new Error(`Cannot persist Responses item without an upstream id (newId=${newId}, type=${originalItem.type})`);
   }
   // A native Responses upstream owns its items — except those a source
-  // interceptor synthesized this request (e.g. the web-search shim's
-  // web_search_call), whose gateway-minted ids the upstream never issued.
-  // Those persist with no upstream identity so they stay non_affinity.
+  // interceptor synthesized this request, whose gateway-minted ids the
+  // upstream never issued. Those persist with no upstream identity so they
+  // stay non_affinity.
   const upstreamOwned = context.targetApi === 'responses' && !request.statefulResponsesContext.newSyntheticIds.has(upstreamId);
   const encryptedContent = responsesItemEncryptedContent(originalItem);
   // Source interceptors register the per-item server-only payload under the

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -23,12 +23,15 @@ const makeContext = (overrides: Partial<StoreResponsesContext> = {}): StoreRespo
   store: overrides.store,
 });
 
-const makeRequest = (syntheticItemIds: Iterable<string> = []): RequestContext => ({
+const makeRequest = (
+  syntheticItemIds: Iterable<string> = [],
+  privatePayloads: Iterable<readonly [string, unknown]> = [],
+): RequestContext => ({
   requestStartedAt: 0,
   apiKeyId,
   runtimeLocation: 'test',
   clientStream: true,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set(syntheticItemIds) },
+  statefulResponsesContext: { privatePayload: new Map(privatePayloads), newSyntheticIds: new Set(syntheticItemIds) },
 });
 
 const messageItem = (id: string, text: string): Extract<ResponsesOutputItem, { type: 'message' }> => ({
@@ -354,6 +357,57 @@ test('gateway-synthesized items registered this request do not claim upstream ow
   assertEquals(row.upstreamId, null);
   assertEquals(row.upstreamItemId, null);
   assertEquals(row.itemType, 'web_search_call');
+});
+
+test('private payload registered on the request is attached to the persisted row by upstream id', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  // The shim registers `statefulResponsesContext.privatePayload[slot.id] = {...}` before
+  // yielding the wire item. The persistence layer keys off the wire item's id
+  // (which equals slot.id here), so the row picks up `payload.private` even
+  // though the wire item itself never carries it.
+  const synthetic: Extract<ResponsesOutputItem, { type: 'web_search_call' }> = {
+    type: 'web_search_call',
+    id: 'ws_gw_priv00000000000000000',
+    status: 'completed',
+    action: { type: 'search', query: 'q', queries: ['q'] },
+    results: [{ type: 'text_result', url: 'u', title: 't', snippet: 'public-wire' }],
+  };
+  const privateBlob = { v: 1, functionCallItem: { type: 'function_call', call_id: 'call_orig_xyz', name: 'web_search', arguments: '{"search_query":[{"q":"q"}]}', status: 'completed' }, ir: { action: synthetic.action, results: [{ type: 'text_result', url: 'u', title: 't', snippet: 'server-only body' }] } };
+
+  const events = await collectEvents(storeStreaming(framesFrom([
+    { type: 'response.output_item.done', output_index: 0, item: synthetic },
+    { type: 'response.completed', response: response([synthetic]) },
+  ]), makeContext(), makeRequest([synthetic.id], [[synthetic.id, privateBlob]])));
+
+  const storedId = eventAt(events, 'response.output_item.done').item.id!;
+  const [row] = await repo.responsesItems.lookupMany(apiKeyId, [storedId]);
+  assertEquals(row.payload?.private, privateBlob);
+});
+
+test('store: false skips persisting private payload even when one was registered', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const synthetic: Extract<ResponsesOutputItem, { type: 'web_search_call' }> = {
+    type: 'web_search_call',
+    id: 'ws_gw_priv00000000000000001',
+    status: 'completed',
+    action: { type: 'search', query: 'q', queries: ['q'] },
+    results: [],
+  };
+  const privateBlob = { v: 1, functionCallItem: { type: 'function_call', call_id: 'call_orig_xyz', name: 'web_search', arguments: '{}', status: 'completed' }, ir: { action: synthetic.action, results: [] } };
+
+  const events = await collectEvents(storeStreaming(framesFrom([
+    { type: 'response.output_item.done', output_index: 0, item: synthetic },
+    { type: 'response.completed', response: response([synthetic]) },
+  ]), makeContext({ store: false }), makeRequest([synthetic.id], [[synthetic.id, privateBlob]])));
+
+  const storedId = eventAt(events, 'response.output_item.done').item.id!;
+  const [row] = await repo.responsesItems.lookupMany(apiKeyId, [storedId]);
+  // store:false retains the metadata-only row but drops both `item` and
+  // `private` so the gateway behaves like OpenAI's own "stored item disappears"
+  // semantics on the next-turn lookup.
+  assertEquals(row.payload, null);
 });
 
 test('non-streaming buffers item rows and persists nothing until commit', async () => {

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy.ts
@@ -169,8 +169,7 @@ const retryCyberPolicyEvents = async function* (
  * - https://deploymentsafety.openai.com/gpt-5-3-codex/cybersecurity
  *
  * TODO: Add gateway-side recent cyber-policy retry/error-log storage so
- * operators can inspect detailed upstream failures, matching the web-search shim
- * error-log TODO pattern.
+ * operators can inspect detailed upstream failures.
  */
 export const withCyberPolicyRetried: ResponsesInterceptor = async (ctx, request, run) => {
   if (!ctx.enabledFlags.has('retry-cyber-policy')) return await run();

--- a/packages/protocols/src/responses/web-search-lifecycle.ts
+++ b/packages/protocols/src/responses/web-search-lifecycle.ts
@@ -18,7 +18,7 @@ import type { ResponsesOutputWebSearchCall, ResponsesStreamEvent } from './index
 // `Optional`) parse the start frame the same way they parse the
 // end frame. Native upstreams omit `action` on `.added` and only
 // populate it on `.done`; the shim diverges here because it always
-// knows the action at start time (the umbrella's parsed arguments
+// knows the action at start time (the shim's parsed arguments
 // produce the action shape before any backend work).
 //   https://github.com/openai/openai-python/blob/HEAD/src/openai/types/responses/response_function_web_search.py
 

--- a/packages/translate/src/responses-via-chat-completions/request.ts
+++ b/packages/translate/src/responses-via-chat-completions/request.ts
@@ -49,7 +49,7 @@ const translateResponsesTools = (tools: ResponsesTool[] | null | undefined, cust
   // names). Native Responses targets receive those entries unchanged; this
   // translator narrows to function and Freeform `custom` tools, recording
   // the latter in `customToolNames` so the events translator can recover
-  // the freeform shape on the way back. The umbrella shim's web_search
+  // the freeform shape on the way back. The shim's web_search
   // function tool is in `payload.tools` under its resolved name (the shim
   // injects it on every request that uses hosted web_search) and reaches
   // here as an ordinary function tool — no special carve-out needed.

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -231,7 +231,7 @@ const translateTools = (tools: ResponsesTool[] | null | undefined, customToolNam
   // Responses targets receive those entries unchanged; this translator
   // narrows to function and Freeform `custom` tools, recording the latter
   // in `customToolNames` so the events translator can reverse the wrap.
-  // The umbrella shim's web_search function tool reaches this code under
+  // The shim's web_search function tool reaches this code under
   // its resolved name as an ordinary function tool — no special carve-out
   // needed.
   const out: MessagesTool[] = [];


### PR DESCRIPTION
## Why

Until now the Responses web_search shim relied on the client to faithfully echo each `web_search_call` item back (including the `results` field) for context to survive across turns. That bet only paid off when the client ran a generous round-trip; codex CLI strips `results` from its session rollout, and any client that follows the spec literally is free to drop the field on the wire because OpenAI marks it opt-in via `include: ["web_search_call.results"]`. When the data didn't come back, the shim either rebuilt from whatever the wire still carried (lossy) or emitted a placeholder; the model's view of its prior assistant turn drifted from what actually happened.

## What

Move the source of truth to the gateway. Per-item private payload (`StoredResponsesItemPayload.private`, populated for the first time) holds the upstream's original function_call (with `arguments` replaced by the jsonrepair-canonical strict-JSON form) plus the per-op IR (action + results). On replay the shim looks up the echoed wsc id in the gateway-side store, splices the persisted function_call back verbatim, and re-renders the function_call_output from the persisted IR. The wire item becomes a lossy projection for the client; gateway-side state is the only thing the shim trusts on round-trip.

## Shape decisions that fall out

- **One shim call ⇄ one web_search_call ⇄ one logical op.** The old multi-op shim call (`{search_query:[...], open:[...], find:[...]}`) is rejected at dispatch as `Ambiguous tool call`; the model is asked to split into independent calls. Removes the N-to-1 wsc explosion and the multi-URL fetchPage batching that only existed to serve it.
- **`web_search_call.results` follows native opt-in.** Emitted on the wire only when the client included `"web_search_call.results"` in `include`. Wire shape matches native; IR (and therefore `payload.private`) always carries the full results regardless.
- **Replay's no-payload branch is conservative.** `store: false`, expired payload, foreign id, cross-account — all ignore wire `item.results` and emit the not-preserved placeholder. The shim never trusts client-supplied results state again.
- **Replay's malformed-input branch dumps the wire image.** An echoed wsc with no `action` field and no matching private payload gets a truncated wire image inside a synthetic `function_call_output` so the model sees the failure mode rather than nothing at all.

## Naming

The old "umbrella" terminology — meant to evoke "one function tool covers N operation shapes" — was retired now that we enforce a single op per call. The function tool the shim presents to the upstream is now called the **shim's function tool**; one invocation is a **shim call**. Identifier renames mirror the prose: `parseShimOperations` (was `parseUmbrellaOperations`), `planShimSlots` (was `planUmbrellaSlots`), `ParsedShimCall` (was `ParsedUmbrella`), `buildShimFunctionTool` (was `buildUmbrellaTool`), etc.

## Plumbing

- `parseServerToolArguments` returns the parsed-and-jsonrepaired arguments (`null` only when the raw string isn't a JSON object even after repair); the dispatcher persists `JSON.stringify(arguments)` on the function_call item so trailing-comma JSON that survived jsonrepair on turn N replays bit-exact on turn N+1.
- `ServerToolResultSlot.result` gains an optional `privatePayload` forwarded by `serverToolResultSlot` and consumed by `materializeServerToolItems`, which registers it on `request.statefulResponsesContext.privatePayload` under `slot.id`. The per-attempt seed (from #27) hydrates the same map from `prepared.references` so the replay-side `transformItems` finds the payload by whatever id ends up on the wire.
- The private-payload envelope shape is `{ v: 1, functionCallItem, ir: { action, results } }`. `v: 1` reserves room for migrations; the full envelope round-trips through `payload.private` verbatim.

## Test impact

Six obsolete multi-op dispatch tests went away; three ambiguity-rejection and several private-payload hydrate/fallback tests took their place. The web-search registration's `transformItems` closure reads `request.statefulResponsesContext.privatePayload` at invocation time so each attempt sees its own fresh map.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` (1488 / 1488 pass)
- [x] Azure gpt-5.4 native-vs-shim replay-fidelity re-run with 6 echo strategies × `store={true,false}` × `{A,B}` — shim mirrors native on the common path, degrades gracefully (200 + placeholder) where native 400s