### PR TITLE
refactor(llm): introduce per-attempt statefulResponsesContext

### DIFF
--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -19,8 +19,8 @@ export type LlmTargetApi = 'messages' | 'responses' | 'chat-completions';
  *
  * - `privatePayload`: wire item id → shim-defined opaque blob, round-tripped
  *   verbatim by persistence as `payload.private`. The shape is shim-specific.
- * - `newSyntheticIds`: gateway-minted item ids no upstream issued (a
- *   server-tool shim's `web_search_call`, ...), persisted as non_affinity.
+ * - `newSyntheticIds`: gateway-minted item ids no upstream issued (e.g. a
+ *   server-tool shim's `web_search_call`), persisted as non_affinity.
  */
 export interface StatefulResponsesContext {
   readonly privatePayload: Map<string, unknown>;
@@ -37,7 +37,10 @@ export interface StatefulResponsesContext {
  * not here. `statefulResponsesContext` is the one exception: the serve loop
  * reassigns it per attempt so cross-layer readers outside `Invocation`
  * plumbing (output.ts:buildRow, source-interceptor `transformItems`) reach
- * it via the only handle they have.
+ * it via the only handle they have. Read it through
+ * `request.statefulResponsesContext` at access time; never capture the
+ * inner object in a closure or background task — that snapshot belongs to
+ * one attempt only.
  *
  * Telemetry recording is done via global helpers that accept `apiKeyId` (and
  * `scheduleBackground` for performance) explicitly so call sites stay visible

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -12,24 +12,45 @@ export type LlmSourceApi = 'messages' | 'responses' | 'chat-completions' | 'gemi
 export type LlmTargetApi = 'messages' | 'responses' | 'chat-completions';
 
 /**
- * Per-HTTP-request invariants. Constructed once when the source serve handler
+ * Stateful per-attempt bag the Responses pipeline uses to thread server-tool
+ * shim state across layers within a single provider-binding attempt.
+ * `privatePayload` maps wire item id → opaque blob: seeded at the start of
+ * each attempt from `prepared.references` (synthetic rows' `payload.item.id`
+ * is preserved verbatim on the wire by `rewriteStoredResponsesItemsForProvider`,
+ * so the lookup key matches), mutated in flight by `materializeServerToolItems`
+ * as a shim synthesizes new items, and read at finalize by
+ * `storeResponsesOutputItems` so the persisted row captures `payload.private`.
+ * The shape is shim-specific; persistence round-trips it verbatim and never
+ * inspects it. `newSyntheticIds` collects gateway-minted ids that no upstream
+ * issued (e.g. a server-tool shim's `web_search_call`) so persistence stores
+ * those rows with no upstream identity — non_affinity — even on a native
+ * Responses upstream. Both are empty when no source interceptor opts in. The
+ * whole bag is reassigned (not mutated in place) at the top of every attempt
+ * so a failed attempt's shim writes don't leak into the next attempt's fresh
+ * state.
+ */
+export interface StatefulResponsesContext {
+  readonly privatePayload: Map<string, unknown>;
+  readonly newSyntheticIds: Set<string>;
+}
+
+/**
+ * Per-HTTP-request scope. Constructed once when the source serve handler
  * receives `c: Context` (in `createRequestContext`) and threaded through every
  * layer (source interceptors, target emits, target interceptors, telemetry).
  *
- * Fields that never change across provider-binding attempts or interceptor
- * passes belong here. Fields that depend on which binding the planner is
- * trying belong on `Invocation`.
+ * Holds both immutable per-request identities/adapters (apiKeyId,
+ * runtimeLocation, scheduleBackground, downstreamAbortSignal, ...) and
+ * mutable per-request bags that cross-layer producers and consumers share
+ * (e.g. `statefulResponsesContext`). Anything that varies per provider-binding
+ * attempt belongs on `Invocation`, not here — except `statefulResponsesContext`,
+ * which is reassigned per attempt because the shim's downstream readers
+ * (output.ts:buildRow, source-interceptor `transformItems` callbacks) sit
+ * outside any `Invocation` plumbing and only have `RequestContext` to look at.
  *
- * Pure data: identities and runtime adapters only. No method-like fields,
- * no closures captured over identities. Telemetry recording is done via
- * global helpers that accept `apiKeyId` (and `scheduleBackground` for
- * performance) explicitly so call sites stay visible about the no-op when
- * the request has no API key (ADMIN_KEY playground path).
- *
- * Mutable per-request state (last performance row, downstream abort
- * controller) is intentionally NOT here. It lives as local variables in the
- * source serve function. `RequestContext` is plain read-only data and is safe
- * to share with closures and background tasks.
+ * Telemetry recording is done via global helpers that accept `apiKeyId` (and
+ * `scheduleBackground` for performance) explicitly so call sites stay visible
+ * about the no-op when the request has no API key (ADMIN_KEY playground path).
  */
 export interface RequestContext {
   readonly requestStartedAt: number;
@@ -40,11 +61,7 @@ export interface RequestContext {
   readonly scheduleBackground?: BackgroundScheduler;
   readonly downstreamAbortSignal?: AbortSignal;
   readonly clientStream: boolean;
-  // Ids of Responses output items the gateway itself synthesized this request
-  // (e.g. a server-tool shim's web_search_call), which carry a gateway-minted
-  // id no upstream issued. Persistence stores these with no upstream identity —
-  // non_affinity — even on a native Responses upstream.
-  readonly responsesSyntheticItemIds: Set<string>;
+  statefulResponsesContext: StatefulResponsesContext;
 }
 
 /**

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -12,22 +12,15 @@ export type LlmSourceApi = 'messages' | 'responses' | 'chat-completions' | 'gemi
 export type LlmTargetApi = 'messages' | 'responses' | 'chat-completions';
 
 /**
- * Stateful per-attempt bag the Responses pipeline uses to thread server-tool
- * shim state across layers within a single provider-binding attempt.
- * `privatePayload` maps wire item id → opaque blob: seeded at the start of
- * each attempt from `prepared.references` (synthetic rows' `payload.item.id`
- * is preserved verbatim on the wire by `rewriteStoredResponsesItemsForProvider`,
- * so the lookup key matches), mutated in flight by `materializeServerToolItems`
- * as a shim synthesizes new items, and read at finalize by
- * `storeResponsesOutputItems` so the persisted row captures `payload.private`.
- * The shape is shim-specific; persistence round-trips it verbatim and never
- * inspects it. `newSyntheticIds` collects gateway-minted ids that no upstream
- * issued (e.g. a server-tool shim's `web_search_call`) so persistence stores
- * those rows with no upstream identity — non_affinity — even on a native
- * Responses upstream. Both are empty when no source interceptor opts in. The
- * whole bag is reassigned (not mutated in place) at the top of every attempt
- * so a failed attempt's shim writes don't leak into the next attempt's fresh
- * state.
+ * Per-attempt bag the Responses pipeline uses to thread server-tool shim
+ * state across layers (source serve → source interceptors → persistence)
+ * within a single provider-binding attempt. The whole bag is reassigned at
+ * the top of every attempt, so a failed attempt's writes don't leak forward.
+ *
+ * - `privatePayload`: wire item id → shim-defined opaque blob, round-tripped
+ *   verbatim by persistence as `payload.private`. The shape is shim-specific.
+ * - `newSyntheticIds`: gateway-minted item ids no upstream issued (a
+ *   server-tool shim's `web_search_call`, ...), persisted as non_affinity.
  */
 export interface StatefulResponsesContext {
   readonly privatePayload: Map<string, unknown>;
@@ -35,18 +28,16 @@ export interface StatefulResponsesContext {
 }
 
 /**
- * Per-HTTP-request scope. Constructed once when the source serve handler
- * receives `c: Context` (in `createRequestContext`) and threaded through every
- * layer (source interceptors, target emits, target interceptors, telemetry).
+ * Per-HTTP-request scope. Constructed once in `createRequestContext` and
+ * threaded through every layer (source interceptors, target emits, target
+ * interceptors, telemetry). Holds both immutable identities/adapters and
+ * mutable per-request bags that cross-layer producers and consumers share.
  *
- * Holds both immutable per-request identities/adapters (apiKeyId,
- * runtimeLocation, scheduleBackground, downstreamAbortSignal, ...) and
- * mutable per-request bags that cross-layer producers and consumers share
- * (e.g. `statefulResponsesContext`). Anything that varies per provider-binding
- * attempt belongs on `Invocation`, not here — except `statefulResponsesContext`,
- * which is reassigned per attempt because the shim's downstream readers
- * (output.ts:buildRow, source-interceptor `transformItems` callbacks) sit
- * outside any `Invocation` plumbing and only have `RequestContext` to look at.
+ * Anything that varies per provider-binding attempt belongs on `Invocation`,
+ * not here. `statefulResponsesContext` is the one exception: the serve loop
+ * reassigns it per attempt so cross-layer readers outside `Invocation`
+ * plumbing (output.ts:buildRow, source-interceptor `transformItems`) reach
+ * it via the only handle they have.
  *
  * Telemetry recording is done via global helpers that accept `apiKeyId` (and
  * `scheduleBackground` for performance) explicitly so call sites stay visible

--- a/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
@@ -28,7 +28,7 @@ const invocation = (payload: GeminiPayload): GeminiInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
@@ -20,7 +20,7 @@ const testTelemetryModelIdentity = {
 };
 const request = (): RequestContext => ({
   requestStartedAt: performance.now(),
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 });
 

--- a/apps/api/src/data-plane/llm/sources/messages/count-tokens/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/count-tokens/serve.ts
@@ -5,6 +5,7 @@ import { listModelProviders, resolveModelForProvider } from '../../../../provide
 import { type MessagesInvocation, runInterceptors } from '../../../interceptors.ts';
 import { toInternalDebugError } from '../../../shared/errors/internal-debug-error.ts';
 import { createRequestContext } from '../../request-context.ts';
+import { responsesItemId } from '../../responses/items/format.ts';
 import { planResponsesItemProviders, prepareStoredResponsesItemsForSource, rewriteStoredResponsesItemsForProvider } from '../../responses/items/request-plan.ts';
 import { bodyAnthropicBetaResponse, bodyBetaParam, messagesFailureEnvelope, parseAnthropicBeta } from '../traits.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
@@ -48,6 +49,17 @@ export const countTokens = async (c: Context) => {
 
       const attemptPayload = structuredClone(payload);
       attemptPayload.model = resolvedModelId;
+      // Fresh stateful bag per attempt — matches the chat path's per-attempt
+      // semantics. count_tokens never reaches a shim that mutates this bag,
+      // but the seed still needs to be present so any future stateful
+      // interceptor reads consistent state.
+      request.statefulResponsesContext = {
+        privatePayload: new Map(preparedStoredItems.references.flatMap(ref => {
+          const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });
+          return wireId && ref.row?.payload?.private !== undefined ? [[wireId, ref.row.payload.private] as const] : [];
+        })),
+        newSyntheticIds: new Set(),
+      };
       attemptPayload.messages = await rewriteStoredResponsesItemsForProvider(attemptPayload.messages, preparedStoredItems, binding, messagesViaResponsesItemsView);
       // Build a MessagesInvocation matching the chat-planning shape so
       // provider-registered count_tokens interceptors (Copilot's vision,

--- a/apps/api/src/data-plane/llm/sources/messages/count-tokens/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/count-tokens/serve.ts
@@ -50,9 +50,7 @@ export const countTokens = async (c: Context) => {
       const attemptPayload = structuredClone(payload);
       attemptPayload.model = resolvedModelId;
       // Fresh stateful bag per attempt — matches the chat path's per-attempt
-      // semantics. count_tokens never reaches a shim that mutates this bag,
-      // but the seed still needs to be present so any future stateful
-      // interceptor reads consistent state.
+      // semantics.
       request.statefulResponsesContext = {
         privatePayload: new Map(preparedStoredItems.references.flatMap(ref => {
           const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });

--- a/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
@@ -51,7 +51,7 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
 
 const requestContext = (apiKeyId?: string): RequestContext => ({
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
   ...(apiKeyId !== undefined ? { apiKeyId } : {}),
 });

--- a/apps/api/src/data-plane/llm/sources/request-context.ts
+++ b/apps/api/src/data-plane/llm/sources/request-context.ts
@@ -16,7 +16,7 @@ export const createRequestContext = (c: Context, downstreamAbortSignal: AbortSig
     runtimeLocation: runtimeLocationFromRequest(c.req.raw),
     scheduleBackground,
     clientStream,
-    responsesSyntheticItemIds: new Set(),
+    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
     ...(downstreamAbortSignal !== undefined ? { downstreamAbortSignal } : {}),
   };
 };

--- a/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
+++ b/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
@@ -121,7 +121,7 @@ const testTelemetryModelIdentity = {
 const requestStartedAt = performance.now();
 const request = (): RequestContext => ({
   requestStartedAt,
-  responsesSyntheticItemIds: new Set(),
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: true,
 });

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
@@ -1,6 +1,6 @@
 import { jsonrepair } from 'jsonrepair';
 
-import type { InterceptorRun, RequestContext, ResponsesInterceptor, ResponsesInvocation } from '../../../interceptors.ts';
+import type { InterceptorRun, RequestContext, ResponsesInterceptor, ResponsesInvocation, StatefulResponsesContext } from '../../../interceptors.ts';
 import type { EventResult, EventResultMetadata, ExecuteResult } from '../../../shared/errors/result.ts';
 import { truncatePreservingCodePoints } from '../../../shared/text.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
@@ -47,6 +47,13 @@ export interface ServerToolResultSlot {
   result: Promise<{
     item: ServerToolOutputItem;
     endEvents: ServerToolLifecycleEvent[];
+    /**
+     * Optional server-only blob registered on `request.statefulResponsesContext.privatePayload`
+     * under `slot.id` before the slot's wire item leaves materialize. The
+     * persistence layer stores it in `payload.private`; the replay-side
+     * `transformItems` reads it back to reconstruct full state across turns.
+     */
+    privatePayload?: unknown;
   }>;
 }
 
@@ -786,15 +793,19 @@ export const synthesizeTerminalEnvelope = (
 async function* materializeServerToolItems(
   dispatched: ReadonlyArray<{ slots: DispatchedServerToolSlot[] }>,
   merge: MergeState,
-  syntheticItemIds: Set<string>,
+  statefulResponsesContext: StatefulResponsesContext,
 ): AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>, void> {
   for (const d of dispatched) {
     for (const { slot, outputIndex } of d.slots) {
       const result = await slot.result;
       // The slot item is gateway-synthesized, not upstream-emitted; register
       // its id so persistence stores it with no upstream identity even on a
-      // native Responses stream.
-      syntheticItemIds.add(slot.id);
+      // native Responses stream. The private payload (when the dispatcher
+      // produced one) registers under the same id so persistence captures it
+      // and the next loop turn's replay-side `transformItems` finds it by the
+      // accumulated output item's id.
+      statefulResponsesContext.newSyntheticIds.add(slot.id);
+      if (result.privatePayload !== undefined) statefulResponsesContext.privatePayload.set(slot.id, result.privatePayload);
       yield* serverToolEndFrames(merge, outputIndex, slot, result);
     }
   }
@@ -808,13 +819,13 @@ async function* runMultiTurnLoop(args: {
   demoteForcedServerToolChoiceAfterFirstTurn: boolean;
   turn1Iter: AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>, TurnSummary>;
   dispatchers: ReadonlyMap<string, ServerToolDispatcher>;
-  syntheticItemIds: Set<string>;
+  statefulResponsesContext: StatefulResponsesContext;
   canonicalInput: ResponsesInputItem[];
   active: readonly ActiveServerTool[];
   metadata: LatestMetadata;
   resolveFinalMetadata: (m: EventResultMetadata) => void;
 }): AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>> {
-  const { ctx, run, merge, loopState, demoteForcedServerToolChoiceAfterFirstTurn, turn1Iter, dispatchers, syntheticItemIds, active, metadata, resolveFinalMetadata } = args;
+  const { ctx, run, merge, loopState, demoteForcedServerToolChoiceAfterFirstTurn, turn1Iter, dispatchers, statefulResponsesContext, active, metadata, resolveFinalMetadata } = args;
   const baseInput = args.canonicalInput;
   let midStreamError: unknown = undefined;
   try {
@@ -825,12 +836,12 @@ async function* runMultiTurnLoop(args: {
       const executedShim = turn.dispatched.length > 0;
 
       if (turn.terminalStatus.kind === 'failed') {
-        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, syntheticItemIds);
+        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesContext);
         yield synthesizeTerminalEnvelope(merge, { kind: 'failed', error: turn.terminalStatus.response.error });
         return;
       }
       if (turn.terminalStatus.kind === 'incomplete') {
-        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, syntheticItemIds);
+        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesContext);
         yield synthesizeTerminalEnvelope(merge, { kind: 'incomplete', incompleteDetails: turn.terminalStatus.response.incomplete_details });
         return;
       }
@@ -846,7 +857,7 @@ async function* runMultiTurnLoop(args: {
         return;
       }
 
-      yield* materializeServerToolItems(turn.dispatched, merge, syntheticItemIds);
+      yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesContext);
       if (turn.sawClientToolCall) {
         yield synthesizeTerminalEnvelope(merge, { kind: 'completed' });
         return;
@@ -978,7 +989,7 @@ export const withResponsesServerToolShim = (
       demoteForcedServerToolChoiceAfterFirstTurn,
       turn1Iter,
       dispatchers,
-      syntheticItemIds: request.responsesSyntheticItemIds,
+      statefulResponsesContext: request.statefulResponsesContext,
       canonicalInput,
       active,
       metadata,

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
@@ -337,7 +337,7 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
 
 const makeRequest = (apiKeyId: string | undefined = 'k1'): RequestContext => ({
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: true,
   ...(apiKeyId !== undefined ? { apiKeyId } : {}),
 });
@@ -657,11 +657,11 @@ test('synthesized web_search_call ids are registered as gateway-synthetic on the
   assert(wsCallDoneIds.length > 0, 'expected a synthesized web_search_call');
   for (const id of wsCallDoneIds) {
     assert(id.startsWith('ws_gw_'));
-    assert(request.responsesSyntheticItemIds.has(id), `expected ${id} registered as synthetic`);
+    assert(request.statefulResponsesContext.newSyntheticIds.has(id), `expected ${id} registered as synthetic`);
   }
   // A genuine upstream item (the final message) is not registered.
   for (const e of doneEvents.filter(e => e.item.type === 'message')) {
-    assertFalse(request.responsesSyntheticItemIds.has(e.item.id!));
+    assertFalse(request.statefulResponsesContext.newSyntheticIds.has(e.item.id!));
   }
 });
 
@@ -4761,7 +4761,7 @@ test('downstream AbortSignal threads through to provider search / fetchPage and 
   const inv = makeInvocation();
   const request: RequestContext = {
     requestStartedAt: 0,
-    responsesSyntheticItemIds: new Set(),    runtimeLocation: 'test',
+    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },    runtimeLocation: 'test',
     clientStream: true,
     apiKeyId: 'k1',
     downstreamAbortSignal: controller.signal,

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -123,15 +123,24 @@ const buildRow = async (
   // interceptor synthesized this request (e.g. the web-search shim's
   // web_search_call), whose gateway-minted ids the upstream never issued.
   // Those persist with no upstream identity so they stay non_affinity.
-  const upstreamOwned = context.targetApi === 'responses' && !request.responsesSyntheticItemIds.has(upstreamId);
+  const upstreamOwned = context.targetApi === 'responses' && !request.statefulResponsesContext.newSyntheticIds.has(upstreamId);
   const encryptedContent = responsesItemEncryptedContent(originalItem);
+  // Source interceptors register the per-item server-only payload under the
+  // wire id transformItems sees; the same id is `upstreamId` here. Attaching
+  // it lets a later turn restore the real success/failure state even when the
+  // client stripped fields from the echoed wire item.
+  const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
   return {
     id: newId,
     apiKeyId: request.apiKeyId ?? null,
     upstreamId: upstreamOwned ? context.upstream : null,
     upstreamItemId: upstreamOwned ? upstreamId : null,
     itemType: originalItem.type,
-    payload: context.store === false ? null : { item: originalItem },
+    payload: context.store === false
+      ? null
+      : privatePayload !== undefined
+        ? { item: originalItem, private: privatePayload }
+        : { item: originalItem },
     encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
     createdAt: Date.now(),
   };

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -130,17 +130,14 @@ const buildRow = async (
   // it lets a later turn restore the real success/failure state even when the
   // client stripped fields from the echoed wire item.
   const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
+  const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
   return {
     id: newId,
     apiKeyId: request.apiKeyId ?? null,
     upstreamId: upstreamOwned ? context.upstream : null,
     upstreamItemId: upstreamOwned ? upstreamId : null,
     itemType: originalItem.type,
-    payload: context.store === false
-      ? null
-      : privatePayload !== undefined
-        ? { item: originalItem, private: privatePayload }
-        : { item: originalItem },
+    payload: context.store === false ? null : persistedPayload,
     encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
     createdAt: Date.now(),
   };

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -28,7 +28,7 @@ const makeRequest = (syntheticItemIds: Iterable<string> = []): RequestContext =>
   apiKeyId,
   runtimeLocation: 'test',
   clientStream: true,
-  responsesSyntheticItemIds: new Set(syntheticItemIds),
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set(syntheticItemIds) },
 });
 
 const messageItem = (id: string, text: string): Extract<ResponsesOutputItem, { type: 'message' }> => ({

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
@@ -265,27 +265,39 @@ const rewriteStoredResponsesItemForProvider = (
     ?? (encryptedContent !== null ? rowByEncryptedContent.get(encryptedContent) : undefined);
   if (row === undefined) return item;
 
+  // An `item_reference` whose stored row has no inline payload can only
+  // travel as a reference on the wire; a provider that doesn't support
+  // `item_reference` input has no way to expand it.
   if (item.type === 'item_reference' && row.payload === null && !provider.supportsResponsesItemReference) {
     throwLlmServeFailure({ kind: 'item-not-found', itemId: row.id });
   }
 
-  // Only upstream-owned reasoning is bound to the upstream that produced it and
-  // must be dropped when routing elsewhere. Synthetic rows have no owner, carry
-  // their full payload, and stay portable to any upstream regardless of type —
-  // they fall through to inline expansion below.
-  if (isUpstreamOwned(row) && row.itemType === 'reasoning' && row.upstreamId !== provider.upstream) return null;
-  if (item.type === 'item_reference' && row.upstreamId === provider.upstream && row.upstreamItemId && provider.supportsResponsesItemReference) return itemWithId(item, row.upstreamItemId);
+  if (!isUpstreamOwned(row)) {
+    // Synthetic rows have no owning upstream and stay portable to any
+    // provider. Inline-expand from the stored payload and preserve
+    // `payload.item.id` verbatim so the wire id matches what the per-attempt
+    // `privatePayload` seed reads — source interceptors look the payload up
+    // by whatever id the rewriter puts on the wire, no rewriter-side stash.
+    return storedItemReplacementBase(item, row);
+  }
 
+  // Owned reasoning is bound to the upstream that produced it; drop it when
+  // routing elsewhere.
+  if (row.itemType === 'reasoning' && row.upstreamId !== provider.upstream) return null;
+
+  if (row.upstreamId === provider.upstream && row.upstreamItemId) {
+    // Same upstream: substitute the original upstream-issued id. A
+    // reference-capable provider keeps the wire item as `item_reference`;
+    // others inline-expand against the stored payload.
+    return item.type === 'item_reference' && provider.supportsResponsesItemReference
+      ? itemWithId(item, row.upstreamItemId)
+      : itemWithId(storedItemReplacementBase(item, row), row.upstreamItemId);
+  }
+
+  // Cross-upstream owned: mint a tmp id so the foreign upstream's id
+  // namespace can't bleed into the new upstream's view.
   const replacement = storedItemReplacementBase(item, row);
-  if (row.upstreamId === provider.upstream && row.upstreamItemId) return itemWithId(replacement, row.upstreamItemId);
-  // Cross-upstream owned items mint a tmp id so the foreign upstream's id
-  // namespace can't bleed into the new upstream's view. Synthetic (no
-  // upstream-id) rows keep `payload.item`'s gateway-namespaced id verbatim,
-  // so the wire id matches what the per-attempt `privatePayload` seed reads
-  // — source interceptors look the payload up by whatever id the rewriter
-  // puts on the wire, and that's the same id without any rewriter-side
-  // stashing.
-  if (isUpstreamOwned(row) && responsesItemId(replacement) !== null) return itemWithId(replacement, createTemporaryResponsesItemId(row.itemType));
+  if (responsesItemId(replacement) !== null) return itemWithId(replacement, createTemporaryResponsesItemId(row.itemType));
   return replacement;
 };
 

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
@@ -278,7 +278,14 @@ const rewriteStoredResponsesItemForProvider = (
 
   const replacement = storedItemReplacementBase(item, row);
   if (row.upstreamId === provider.upstream && row.upstreamItemId) return itemWithId(replacement, row.upstreamItemId);
-  if (responsesItemId(replacement) !== null) return itemWithId(replacement, createTemporaryResponsesItemId(row.itemType));
+  // Cross-upstream owned items mint a tmp id so the foreign upstream's id
+  // namespace can't bleed into the new upstream's view. Synthetic (no
+  // upstream-id) rows keep `payload.item`'s gateway-namespaced id verbatim,
+  // so the wire id matches what the per-attempt `privatePayload` seed reads
+  // — source interceptors look the payload up by whatever id the rewriter
+  // puts on the wire, and that's the same id without any rewriter-side
+  // stashing.
+  if (isUpstreamOwned(row) && responsesItemId(replacement) !== null) return itemWithId(replacement, createTemporaryResponsesItemId(row.itemType));
   return replacement;
 };
 

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -139,7 +139,9 @@ test('/v1/responses expands stored synthetic item_reference before the upstream 
       upstreamItemId: null,
       itemType: 'message',
       encryptedContentHash: null,
-      payload: { item: { ...storedItem, id } },
+      // payload.item.id is the original wire id, distinct from the stored row
+      // id; the rewriter preserves it verbatim on the wire for synthetic rows.
+      payload: { item: storedItem },
       createdAt: Date.now(),
     },
   ]);
@@ -203,7 +205,7 @@ test('/v1/responses expands stored synthetic item_reference before the upstream 
   assertExists(upstreamBody);
   const input = upstreamBody.input as Array<Record<string, unknown>>;
   assertEquals(input[0].type, 'message');
-  assertStringIncludes(input[0].id as string, 'msg_tmp_');
+  assertEquals(input[0].id, storedItem.id);
   assertEquals(input[0].content, [{ type: 'output_text', text: 'expanded synthetic context' }]);
 });
 

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono';
 
 import { createRequestContext } from './request-context.ts';
 import type { RequestContext } from '../interceptors.ts';
+import { responsesItemId } from './responses/items/format.ts';
 import { type ResponsesItemsCommit, storeResponsesOutputItems } from './responses/items/output.ts';
 import { planResponsesItemProviders, type PreparedStoredResponsesItems, prepareStoredResponsesItemsForSource, rewriteStoredResponsesItemsForProvider, type StoredResponsesProviderPlan } from './responses/items/request-plan.ts';
 import { type LlmServeFailure, LlmServeFailureError, type LlmSourcePlan, type LlmSourceTraits, type Result } from './traits.ts';
@@ -85,6 +86,21 @@ const attemptProviders = async <TItems, TEvent>(
     const { binding } = resolved;
     const target = plan.pickTarget(binding.upstreamModel.upstreamEndpoints);
     if (!target) continue;
+
+    // Fresh stateful bag per attempt so a failed earlier attempt's shim
+    // writes — private payloads stashed under tmp ids that won't be minted
+    // again, new synthetic ids that no output stream will reference — don't
+    // leak into the next attempt. Seed key is the wire id the rewriter will
+    // produce: only synthetic rows carry `payload.private`, and the rewriter
+    // preserves their `payload.item.id` verbatim, so the lookup reads that
+    // id directly.
+    request.statefulResponsesContext = {
+      privatePayload: new Map(prepared.references.flatMap(ref => {
+        const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });
+        return wireId && ref.row?.payload?.private !== undefined ? [[wireId, ref.row.payload.private] as const] : [];
+      })),
+      newSyntheticIds: new Set(),
+    };
 
     const rawResult = await plan.attempt({
       binding,

--- a/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
+++ b/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
@@ -18,6 +18,6 @@ export const chatCompletionsInvocation = (payload: ChatCompletionsPayload, enabl
 
 export const stubRequestContext: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/emit_test.ts
+++ b/apps/api/src/data-plane/llm/targets/emit_test.ts
@@ -19,7 +19,7 @@ const baseInvocation = (): Invocation<{ model: string; stream?: boolean }> => ({
 
 const baseRequest = (): RequestContext => ({
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  apiKeyId: 'key_a',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  apiKeyId: 'key_a',
   clientStream: true,
   runtimeLocation: 'SJC',
 });

--- a/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -25,7 +25,7 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
@@ -37,7 +37,7 @@ const makeInvocation = (payload: ResponsesPayload): ResponsesInvocation => ({
 
 const stubRequest = (overrides: { downstreamAbortSignal?: AbortSignal } = {}): RequestContext => ({
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: true,
   ...(overrides.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: overrides.downstreamAbortSignal } : {}),
 });

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/telemetry_test.ts
+++ b/apps/api/src/data-plane/llm/targets/telemetry_test.ts
@@ -51,7 +51,7 @@ const baseRequest = (
   overrides: { downstreamAbortSignal?: AbortSignal; stream?: boolean; apiKeyId?: string | undefined } = {},
 ): RequestContext => ({
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  apiKeyId: 'apiKeyId' in overrides ? overrides.apiKeyId : 'key_a',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  apiKeyId: 'apiKeyId' in overrides ? overrides.apiKeyId : 'key_a',
   clientStream: overrides.stream ?? true,
   runtimeLocation: 'SJC',
   scheduleBackground: (promise: Promise<unknown>) => {
@@ -317,7 +317,7 @@ test('withUpstreamTelemetry skips recording when apiKeyId is absent', async () =
     },
     {
       requestStartedAt: 0,
-      responsesSyntheticItemIds: new Set(),      clientStream: true,
+      statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },      clientStream: true,
       runtimeLocation: 'SJC',
       scheduleBackground: promise => background.push(promise),
     },

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
@@ -23,7 +23,7 @@ const invocation = (): ChatCompletionsInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
@@ -10,7 +10,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
@@ -12,7 +12,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
@@ -10,7 +10,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
@@ -10,7 +10,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
@@ -12,7 +12,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
@@ -10,7 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
@@ -39,7 +39,7 @@ const makeCtx = (
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
@@ -10,7 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
@@ -10,7 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
@@ -10,7 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
@@ -10,7 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
@@ -10,7 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
@@ -10,7 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
@@ -36,7 +36,7 @@ const invocation = (): ResponsesInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
@@ -12,7 +12,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
@@ -10,7 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
-  responsesSyntheticItemIds: new Set(),  runtimeLocation: 'test',
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/provider_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider_test.ts
@@ -369,7 +369,7 @@ test('Copilot provider sets copilot-vision-request when an image is nested insid
 
   const stubRequest: RequestContext = {
     requestStartedAt: 0,
-    responsesSyntheticItemIds: new Set(),    runtimeLocation: 'test',
+    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },    runtimeLocation: 'test',
     clientStream: false,
   };
 


### PR DESCRIPTION
Replaces the single readonly `responsesSyntheticItemIds: Set<string>` field on `RequestContext` with a `statefulResponsesContext` (`{privatePayload, newSyntheticIds}`) umbrella that the source serve reassigns at the top of every provider-binding attempt. A failed earlier attempt's shim writes — synthetic ids whose response stream never reached the client, private payloads stashed under tmp ids that won't be re-minted — no longer leak into the next attempt.

`privatePayload` is the new generic plumbing for source-tool shims to round-trip per-item server-only state across turns:

- Source serve seeds it inline (`new Map(prepared.references.flatMap(...))`) at the start of each attempt; the seed key is `payload.item.id` of each stored row that carries `payload.private`.
- `materializeServerToolItems` registers freshly-synthesized payloads via the new optional `ServerToolResultSlot.privatePayload` so the next loop turn finds them in memory.
- `output.ts:buildRow` reads the same map at finalize time so the persisted row captures `payload.private` alongside `payload.item`.

For the seed key to match the wire id the rewriter produces, `rewriteStoredResponsesItemsForProvider` now treats synthetic rows (no owning upstream) as its first branch and returns the stored payload's item verbatim — `payload.item.id` reaches the wire and the source interceptor finds the private payload under that same id, with no rewriter-side stashing. Cross-upstream owned rows still mint a tmp id; same-upstream owned rows still substitute `upstreamItemId`.

Forty test fixtures that hand-build `RequestContext` literals gained the new field. One serve_test that asserted the old `msg_tmp_` minting for synthetic rows was updated to the new contract (wire id == `payload.item.id`); its fixture now sets `payload.item.id` distinct from the stored row id to make the preservation explicit.