### PR TITLE
fix(shim): collapse multi-`search_query` into one wsc with multi-query action

### DIFF
--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
@@ -754,10 +754,11 @@ test('iteration cap returns the iteration-cap notice without backend call on cap
 
 // ── Ambiguous multi-op function_call rejection ─────────────────────────────
 
-// One private payload ⇄ one wsc ⇄ one op. Any shim call that carries more
-// than one logical operation — multi-kind mix or multi-instance same-kind
-// — is rejected before backend dispatch with a single ambiguous-error wsc
-// so the model knows to split the request into independent calls.
+// `web_search_call.action` carries exactly one action type; a shim call
+// that mixes kinds (search + open) or stacks multiple non-search ops
+// (multi `open`/`find`) cannot reduce to a single wsc and is rejected
+// before backend dispatch. Multi-`search_query` collapses into one wsc
+// with a multi-query search action — see the collapse tests below.
 
 const assertAmbiguousShimRejection = async (args: string, backend: { calls: unknown[] }): Promise<void> => {
   const shim = withResponsesWebSearchShim;
@@ -783,7 +784,7 @@ const assertAmbiguousShimRejection = async (args: string, backend: { calls: unkn
   assertEquals(item.action?.type, 'search');
   assert(Array.isArray(item.results));
   assert(item.results![0].snippet.includes('ambiguous'));
-  assert(item.results![0].snippet.includes('one operation'));
+  assert(item.results![0].snippet.includes('one web_search_call'));
 };
 
 test('multi-kind shim call (search_query + open) is rejected as ambiguous before any backend dispatch', async () => {
@@ -794,18 +795,77 @@ test('multi-kind shim call (search_query + open) is rejected as ambiguous before
   );
 });
 
-test('multi-instance same-kind shim call (two search_query entries) is rejected as ambiguous', async () => {
-  const { backend } = makeStubDeps();
-  await assertAmbiguousShimRejection(
-    JSON.stringify({ search_query: [{ q: 'q1' }, { q: 'q2' }] }),
-    backend,
-  );
-});
-
 test('multi-instance same-kind shim call (two open entries) is rejected as ambiguous', async () => {
   const { backend } = makeStubDeps();
   await assertAmbiguousShimRejection(
     JSON.stringify({ open: [{ ref_id: 'https://example.com/a' }, { ref_id: 'https://example.com/b' }] }),
+    backend,
+  );
+});
+
+test('multi-instance same-kind shim call (two find entries) is rejected as ambiguous', async () => {
+  const { backend } = makeStubDeps();
+  await assertAmbiguousShimRejection(
+    JSON.stringify({ find: [{ ref_id: 'https://example.com/', pattern: 'a' }, { ref_id: 'https://example.com/', pattern: 'b' }] }),
+    backend,
+  );
+});
+
+// ── Multi-`search_query` collapse ─────────────────────────────────────
+//
+// `search_query: [...]` natively maps to `web_search_call.action.queries`
+// (a string[]), so multi-entry batches stay 1:1 with one wsc carrying
+// every query and the merged result set.
+
+test('multi-`search_query` entries collapse into one web_search_call with a multi-query action and merged results', async () => {
+  const calls: string[] = [];
+  const { backend } = makeStubDeps({
+    providerOverrides: {
+      async search({ query }) {
+        calls.push(query);
+        return { type: 'ok', results: [{ source: `https://r/${query}`, title: query, content: [{ type: 'text', text: `result for ${query}` }] }] };
+      },
+    },
+  });
+  const shim = withResponsesWebSearchShim;
+  const inv = makeInvocation();
+  const args = JSON.stringify({ search_query: [{ q: 'q1' }, { q: 'q2' }, { q: 'q3' }] });
+  const turn: ScriptedTurn = [
+    mkResponseCreated(),
+    mkResponseInProgress(),
+    mkFunctionCallAdded(0, 'call_multi', SHIM_TOOL_NAME),
+    mkFunctionCallArgsDone(0, args),
+    mkFunctionCallDone(0, 'call_multi', SHIM_TOOL_NAME, args),
+    mkResponseCompleted(),
+  ];
+  const script = scriptedRun([turn, messageTurn('done', 0)]);
+  const result = await shim(inv, makeRequest(), script.run);
+  assert(result.type === 'events');
+  const events = eventPayloads(await collectFrames(result.events));
+
+  // Exactly one wsc on the wire.
+  const wsCallDone = events.filter((e): e is Extract<ResponsesStreamEvent, { type: 'response.output_item.done' }> =>
+    e.type === 'response.output_item.done'
+    && (e as { item?: { type?: string } }).item?.type === 'web_search_call');
+  assertEquals(wsCallDone.length, 1);
+  const item = wsCallDone[0].item as ResponsesOutputWebSearchCall;
+  assertEquals(item.action?.type, 'search');
+  const action = item.action as Extract<ResponsesWebSearchAction, { type: 'search' }>;
+  assertEquals(action.queries, ['q1', 'q2', 'q3']);
+
+  // Three backend search calls (one per query, parallel).
+  const searchCalls = backend.calls.filter(c => c.kind === 'search');
+  assertEquals(searchCalls.length, 3);
+  assertEquals(calls.sort(), ['q1', 'q2', 'q3']);
+
+  // Merged results in entry order.
+  assertEquals(item.results?.map(r => r.url), ['https://r/q1', 'https://r/q2', 'https://r/q3']);
+});
+
+test('multi-`search_query` with one malformed entry (missing q) is rejected as ambiguous', async () => {
+  const { backend } = makeStubDeps();
+  await assertAmbiguousShimRejection(
+    JSON.stringify({ search_query: [{ q: 'q1' }, {}] }),
     backend,
   );
 });

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
@@ -502,12 +502,21 @@ const searchIr = (
   query: string,
   results: ResponsesWebSearchResult[],
   sources?: { type: 'url'; url: string }[],
+): WebSearchCallIR => searchIrFromQueries([query], results, sources);
+
+// Builds a single wsc for one or more search queries. Multi-query actions
+// are protocol-native (`{type:'search', queries:[...]}`); the singular
+// `query` field is emitted alongside for SDKs that only know the legacy
+// single-string shape — see `actionSearchQueries`.
+const searchIrFromQueries = (
+  queries: string[],
+  results: ResponsesWebSearchResult[],
+  sources?: { type: 'url'; url: string }[],
 ): WebSearchCallIR => ({
-  // Emit both `query` and `queries`; see `actionSearchQueries`.
   action: {
     type: 'search',
-    query,
-    queries: [query],
+    query: queries.join(' | '),
+    queries,
     // Native gates `sources` on `include:
     // ["web_search_call.action.sources"]`; only include when the
     // client opted in. The producer (dispatch.ts) decides whether to
@@ -883,18 +892,49 @@ const runBackendSearch = async (
   op: Extract<ShimLogicalOperation, { kind: 'search' }>,
   state: ShimState,
 ): Promise<WebSearchCallIR> => {
-  const query = op.query;
-
   if (op.error !== undefined) {
     const title = op.errorKind === 'missing-arg' ? 'Missing argument' : 'Invalid ref_id';
-    return searchIr(query, [errorSnippet(title, op.error)]);
+    return searchIr(op.query, [errorSnippet(title, op.error)]);
   }
-
   const active = await resolveActiveProvider(state);
   if ('unavailable' in active) {
-    return searchIr(query, [errorSnippet('Search error', searchFailedText(active.unavailable))]);
+    return searchIr(op.query, [errorSnippet('Search error', searchFailedText(active.unavailable))]);
   }
+  const { results, sources } = await runOneSearchQuery(op.query, state, active);
+  return searchIr(op.query, results, sources);
+};
 
+// Collapses N `search_query` entries into one wsc: same-action protocol
+// shape (`{type:'search', queries:[...]}`) with the merged result set
+// (concatenated in entry order). Per-query failures interleave as error
+// snippets so the model sees which queries succeeded.
+const runBackendSearchMulti = async (
+  ops: Array<Extract<ShimLogicalOperation, { kind: 'search' }>>,
+  state: ShimState,
+): Promise<WebSearchCallIR> => {
+  const queries = ops.map(op => op.query);
+  const active = await resolveActiveProvider(state);
+  if ('unavailable' in active) {
+    return searchIrFromQueries(queries, [errorSnippet('Search error', searchFailedText(active.unavailable))]);
+  }
+  const perQuery = await Promise.all(ops.map(op => runOneSearchQuery(op.query, state, active)));
+  const mergedResults = perQuery.flatMap(r => r.results);
+  const mergedSources = state.includeSearchActionSources
+    ? perQuery.flatMap(r => r.sources ?? [])
+    : undefined;
+  return searchIrFromQueries(queries, mergedResults, mergedSources);
+};
+
+interface SearchQueryOutcome {
+  results: ResponsesWebSearchResult[];
+  sources?: { type: 'url'; url: string }[];
+}
+
+const runOneSearchQuery = async (
+  query: string,
+  state: ShimState,
+  active: { provider: WebSearchProvider; providerName: WebSearchProviderName },
+): Promise<SearchQueryOutcome> => {
   try {
     const searchRequest = {
       query,
@@ -918,7 +958,7 @@ const runBackendSearch = async (
 
     if (result.type === 'error') {
       const msg = result.message ?? result.errorCode;
-      return searchIr(query, [errorSnippet('Search error', searchFailedText(msg))]);
+      return { results: [errorSnippet('Search error', searchFailedText(msg))] };
     }
 
     // Per-snippet char cap on web_search_call.results[].snippet. Providers
@@ -938,10 +978,10 @@ const runBackendSearch = async (
     const sources = state.includeSearchActionSources
       ? result.results.map(r => ({ type: 'url' as const, url: r.source }))
       : undefined;
-    return searchIr(query, results, sources);
+    return sources !== undefined ? { results, sources } : { results };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    return searchIr(query, [errorSnippet('Search error', searchFailedText(msg))]);
+    return { results: [errorSnippet('Search error', searchFailedText(msg))] };
   }
 };
 
@@ -1219,19 +1259,32 @@ const planShimSlots = (
     };
   }
 
-  // One private payload ⇄ one wsc ⇄ one op. A shim call that bundles
-  // more than one logical op (multi-kind mix, or multi-instance of any
-  // sub-property array) cannot be reduced to a single wsc action shape,
-  // so surface it as an ambiguous error and let the model split the
-  // request into independent calls.
+  // Multi-`search_query` entries collapse into one wsc with a multi-query
+  // action (`{type:'search', queries:[...]}`) — protocol-native and the
+  // only same-kind shape that fits in one wsc. Require every entry to
+  // parse cleanly; one malformed entry forces the model to fix all of
+  // them rather than silently dropping a search.
+  if (parsed.ops.length > 1 && parsed.ops.every(op => op.kind === 'search' && op.error === undefined)) {
+    const searchOps = parsed.ops as Array<Extract<ShimLogicalOperation, { kind: 'search' }>>;
+    return {
+      id: synthesizeWebSearchCallId(),
+      promise: runBackendSearchMulti(searchOps, state),
+    };
+  }
+
+  // Any other multi-op shape cannot reduce to a single wsc action: `open`
+  // and `find` actions each carry one url/pattern, and mixed kinds have
+  // incompatible action types. Surface as ambiguous and let the model
+  // split into independent calls.
   if (parsed.ops.length > 1) {
     return {
       id: synthesizeWebSearchCallId(),
       promise: Promise.resolve(schemaErrorIr(
         'ambiguous shim call',
         'Ambiguous tool call',
-        `Error: ambiguous \`${toolName}\` tool call — each function_call may carry only one operation. `
-        + 'Split into multiple independent calls (one search_query[] entry, OR one open[] entry, OR one find[] entry per call).',
+        `Error: ambiguous \`${toolName}\` tool call — each function_call maps to one web_search_call. `
+        + 'Multiple `search_query` entries are fine (they collapse into one search). '
+        + 'For `open`/`find`, or any mix of kinds, split into one call per `open[]` entry, `find[]` entry, or `search_query[]` batch.',
       )),
     };
   }
@@ -1307,7 +1360,7 @@ export const webSearchServerTool: ServerToolRegistration = (ctx, request) => {
                   { type: 'response.web_search_call.in_progress' },
                   { type: 'response.web_search_call.searching' },
                 ],
-                async *run() {
+                run: async function* run() {
                   const ir = await slot.promise;
                   // `results` is gated on the client's `include`
                   // opt-in to match native Responses' default wire


### PR DESCRIPTION
`web.run`'s schema lets the model batch N parallel searches in one
function_call (`search_query: [{q:A},{q:B},...]`). The prior
multi-op-ambiguous guard treated each entry as a separate op and
rejected the call as ambiguous, forcing the model to retry N times
serially.

The native `web_search_call.action` for search natively carries
`queries: string[]`, so multi-entry batches stay 1:1 with one wsc:
- All entries clean → run the N searches in parallel, build one wsc
  with `action: {type:'search', queries:[...], query:'A | B | ...'}`
  and concatenate the per-query result sets in entry order. The
  singular `query` field is retained for SDKs that only know the
  legacy single-string shape (`actionSearchQueries` accepts either).
- Any entry malformed (missing `q`) → still ambiguous; force the
  model to fix all entries rather than silently dropping a search.

The ambiguous branch now only fires for shapes that genuinely cannot
reduce to one wsc action: multi-kind (search + open / find), multi
`open[]`, or multi `find[]`. The error message reflects the new
contract (one function_call ↔ one web_search_call, multi-search is
fine, split open/find/mixed kinds).

Extracted `runOneSearchQuery` as the shared per-query backend call so
single-search (`runBackendSearch`) and multi-search (`runBackendSearchMulti`)
share the request/parse/error-wrap path.

Tests: dropped the obsolete "two search_query → ambiguous" assertion;
added a positive collapse test (3 queries → 1 wsc, 3 backend calls,
merged results in entry order) and a malformed-entry test (one
missing-q forces ambiguous). The remaining ambiguous tests (multi-kind,
multi-open, multi-find) and the updated assertion text are unchanged in
spirit.