### PR TITLE
fix(responses): avoid spilled payload overwrites

### DIFF
--- a/apps/api/src/repo/responses-payload.ts
+++ b/apps/api/src/repo/responses-payload.ts
@@ -39,8 +39,8 @@ export const serializeStoredResponsesPayload = async (
   // `payload_json` column carries version, storage discriminator, key,
   // sha256, and byteLength; the body itself does not repeat them.
   const fileBody = encoder.encode(JSON.stringify(payload));
-  const key = await storedResponsesPayloadFileKey(id, apiKeyId, createdAt);
   const sha256 = await sha256Hex(fileBody);
+  const key = await storedResponsesPayloadFileKey(id, apiKeyId, createdAt, sha256);
   await getFileProvider().put(key, fileBody);
   return JSON.stringify({
     version: 1,
@@ -120,10 +120,11 @@ const storedResponsesPayloadFileKey = async (
   id: string,
   apiKeyId: string | null,
   createdAt: number,
+  sha256: string,
 ): Promise<string> => {
   const expires = new Date(createdAt + RESPONSES_ITEM_PAYLOAD_TTL_MS);
   const scope = (await sha256Hex(encoder.encode(apiKeyId ?? ''))).slice(0, 16);
-  return `${responsesItemsHourPrefix(expires.getTime())}${scope}/${id}.json`;
+  return `${responsesItemsHourPrefix(expires.getTime())}${scope}/${id}/${sha256}.json`;
 };
 
 // Files live under their expiry hour. A bucket whose hour is strictly before

--- a/apps/api/src/repo/responses-payload_test.ts
+++ b/apps/api/src/repo/responses-payload_test.ts
@@ -26,6 +26,23 @@ test('the reserved private payload field round-trips through both inline and fil
   assertEquals(parsed?.private, { results: 'preserved' });
 });
 
+test('spilled payload file keys include the content hash to avoid overwrites', async () => {
+  const files = new MemoryFileProvider();
+  initFileProvider(files);
+  const createdAt = Date.UTC(2026, 4, 28, 12);
+
+  const first = await serializeStoredResponsesPayload('msg_same_id', 'key_a', createdAt, {
+    item: { type: 'message', id: 'msg_big', content: `a${'x'.repeat(600 * 1024)}` },
+  });
+  const second = await serializeStoredResponsesPayload('msg_same_id', 'key_a', createdAt, {
+    item: { type: 'message', id: 'msg_big', content: `b${'x'.repeat(600 * 1024)}` },
+  });
+
+  assertEquals((await files.listKeys('responses-items/v1/expires/')).length, 2);
+  assertEquals((await parseStoredResponsesPayload('msg_same_id', first))?.item, { type: 'message', id: 'msg_big', content: `a${'x'.repeat(600 * 1024)}` });
+  assertEquals((await parseStoredResponsesPayload('msg_same_id', second))?.item, { type: 'message', id: 'msg_big', content: `b${'x'.repeat(600 * 1024)}` });
+});
+
 test('sweepExpiredResponsesItemPayloadFiles deletes every elapsed hour bucket and leaves the current and future buckets intact', async () => {
   const files = new MemoryFileProvider();
   initFileProvider(files);


### PR DESCRIPTION
## Summary
- Include the spilled Responses item payload sha256 in R2 file keys.
- Prevent same id/scope/timestamp large payloads from overwriting each other.
- Add regression coverage that both spilled descriptors remain readable.

## Test Plan
- `pnpm exec vitest run apps/api/src/repo/responses-payload_test.ts apps/api/src/repo/responses-items_test.ts --reporter=verbose`
- `pnpm --filter @floway-dev/api run typecheck`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
