### PR TITLE
feat(responses): add stored item metadata

### DIFF
--- a/apps/api/migrations/0025_responses_item_metadata.sql
+++ b/apps/api/migrations/0025_responses_item_metadata.sql
@@ -13,5 +13,4 @@ END;
 UPDATE responses_items SET origin = CASE WHEN upstream_id IS NULL THEN 'synthetic' ELSE 'upstream' END;
 UPDATE responses_items SET refreshed_at = created_at;
 
-DROP INDEX idx_responses_items_created_at;
 CREATE INDEX idx_responses_items_refreshed_at ON responses_items (refreshed_at);

--- a/apps/api/migrations/0025_responses_item_metadata.sql
+++ b/apps/api/migrations/0025_responses_item_metadata.sql
@@ -1,0 +1,17 @@
+ALTER TABLE responses_items ADD COLUMN origin TEXT NOT NULL DEFAULT 'upstream' CHECK (origin IN ('input', 'upstream', 'synthetic'));
+ALTER TABLE responses_items ADD COLUMN refreshed_at INTEGER NOT NULL DEFAULT 0;
+
+CREATE TRIGGER trg_responses_items_refreshed_at_default
+AFTER INSERT ON responses_items
+WHEN NEW.refreshed_at = 0
+BEGIN
+  UPDATE responses_items
+  SET refreshed_at = NEW.created_at
+  WHERE rowid = NEW.rowid;
+END;
+
+UPDATE responses_items SET origin = CASE WHEN upstream_id IS NULL THEN 'synthetic' ELSE 'upstream' END;
+UPDATE responses_items SET refreshed_at = created_at;
+
+DROP INDEX idx_responses_items_created_at;
+CREATE INDEX idx_responses_items_refreshed_at ON responses_items (refreshed_at);

--- a/apps/api/src/control-plane/data-transfer/routes_test.ts
+++ b/apps/api/src/control-plane/data-transfer/routes_test.ts
@@ -143,9 +143,11 @@ const STORED_RESPONSES_ITEM: StoredResponsesItem = {
   upstreamId: null,
   upstreamItemId: null,
   itemType: 'message',
+  origin: 'synthetic',
   encryptedContentHash: null,
   payload: { item: { type: 'message', id: 'msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA', role: 'assistant', content: [] } },
   createdAt: 1_000,
+  refreshedAt: 1_000,
 };
 
 const PERFORMANCE_1: PerformanceTelemetryRecord = {

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -36,8 +36,8 @@ export interface StatefulResponsesContext {
  * Anything that varies per provider-binding attempt belongs on `Invocation`,
  * not here. `statefulResponsesContext` is the one exception: the serve loop
  * reassigns it per attempt so cross-layer readers outside `Invocation`
- * plumbing (output.ts:buildRow, source-interceptor `transformItems`) reach
- * it via the only handle they have. Read it through
+ * plumbing (output persistence, source-interceptor `transformItems`) reach it
+ * via the only handle they have. Read it through
  * `request.statefulResponsesContext` at access time; never capture the
  * inner object in a closure or background task — that snapshot belongs to
  * one attempt only.

--- a/apps/api/src/data-plane/llm/sources/chat-completions/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/chat-completions/serve_test.ts
@@ -80,9 +80,11 @@ test('/v1/chat/completions rewrites stored Responses reasoning_items before the 
       upstreamId: 'up_chat_origin',
       upstreamItemId: 'raw_rs_chat',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 

--- a/apps/api/src/data-plane/llm/sources/messages/count-tokens_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/count-tokens_test.ts
@@ -237,9 +237,11 @@ test('/v1/messages/count_tokens rewrites stored Responses reasoning signatures b
       upstreamId: 'up_count_origin',
       upstreamItemId: 'raw_rs_count',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 

--- a/apps/api/src/data-plane/llm/sources/messages/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/serve_test.ts
@@ -348,9 +348,11 @@ test('/v1/messages rewrites stored Responses reasoning signatures before the ups
       upstreamId: 'up_messages_origin',
       upstreamItemId: 'raw_rs_messages',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 

--- a/apps/api/src/data-plane/llm/sources/responses/items/image-generation-replay_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/image-generation-replay_test.ts
@@ -43,9 +43,11 @@ test('a stored image_generation_call referenced by id is inline-expanded with it
     upstreamId: null, // synthetic / portable — no upstream owns it
     upstreamItemId: null,
     itemType: 'image_generation_call',
+    origin: 'synthetic',
     payload: { item: { type: 'image_generation_call', id: storedId, status: 'completed', result: PNG_B64, revised_prompt: 'a cat', output_format: 'png' } },
     encryptedContentHash: null,
     createdAt: Date.now(),
+    refreshedAt: Date.now(),
   };
   const repo = new InMemoryRepo();
   initRepo(repo);

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -96,8 +96,41 @@ export const storeResponsesOutputItems = <TFrame>(
   };
 
   const buffer: StoredResponsesItem[] = [];
+
+  const buildRow = async (newId: string, originalItem: ResponsesInputItem): Promise<StoredResponsesItem> => {
+    const upstreamId = responsesItemId(originalItem);
+    if (upstreamId === null) {
+      throw new Error(`Cannot persist Responses item without an upstream id (newId=${newId}, type=${originalItem.type})`);
+    }
+    // A native Responses upstream owns its items — except those a source
+    // interceptor synthesized this request, whose gateway-minted ids the
+    // upstream never issued. Those persist with no upstream identity so they
+    // stay non_affinity.
+    const upstreamOwned = context.targetApi === 'responses' && !request.statefulResponsesContext.newSyntheticIds.has(upstreamId);
+    const encryptedContent = responsesItemEncryptedContent(originalItem);
+    // Source interceptors register the per-item server-only payload under the
+    // wire id transformItems sees; the same id is `upstreamId` here. Attaching
+    // it lets a later turn restore the real success/failure state even when the
+    // client stripped fields from the echoed wire item.
+    const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
+    const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
+    const now = Date.now();
+    return {
+      id: newId,
+      apiKeyId: request.apiKeyId ?? null,
+      upstreamId: upstreamOwned ? context.upstream : null,
+      upstreamItemId: upstreamOwned ? upstreamId : null,
+      itemType: originalItem.type,
+      origin: upstreamOwned ? 'upstream' : 'synthetic',
+      payload: context.store === false ? null : persistedPayload,
+      encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
+      createdAt: now,
+      refreshedAt: now,
+    };
+  };
+
   const onItemFinalized: ResponsesItemFinalizedHandler = async (originalItem, newId) => {
-    const row = await buildRow(newId, originalItem, context, request);
+    const row = await buildRow(newId, originalItem);
     if (wantsStream) await insertStoredItems([row]);
     else buffer.push(row);
   };
@@ -107,41 +140,4 @@ export const storeResponsesOutputItems = <TFrame>(
   const commitForNonStreaming = wantsStream ? undefined : (): Promise<void> => insertStoredItems(buffer);
 
   return { events: view.streamMapIdAsResponsesItems(frames, idMapper, onItemFinalized), commitForNonStreaming };
-};
-
-const buildRow = async (
-  newId: string,
-  originalItem: ResponsesInputItem,
-  context: StoreResponsesContext,
-  request: RequestContext,
-): Promise<StoredResponsesItem> => {
-  const upstreamId = responsesItemId(originalItem);
-  if (upstreamId === null) {
-    throw new Error(`Cannot persist Responses item without an upstream id (newId=${newId}, type=${originalItem.type})`);
-  }
-  // A native Responses upstream owns its items — except those a source
-  // interceptor synthesized this request, whose gateway-minted ids the
-  // upstream never issued. Those persist with no upstream identity so they
-  // stay non_affinity.
-  const upstreamOwned = context.targetApi === 'responses' && !request.statefulResponsesContext.newSyntheticIds.has(upstreamId);
-  const encryptedContent = responsesItemEncryptedContent(originalItem);
-  // Source interceptors register the per-item server-only payload under the
-  // wire id transformItems sees; the same id is `upstreamId` here. Attaching
-  // it lets a later turn restore the real success/failure state even when the
-  // client stripped fields from the echoed wire item.
-  const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
-  const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
-  const now = Date.now();
-  return {
-    id: newId,
-    apiKeyId: request.apiKeyId ?? null,
-    upstreamId: upstreamOwned ? context.upstream : null,
-    upstreamItemId: upstreamOwned ? upstreamId : null,
-    itemType: originalItem.type,
-    origin: upstreamOwned ? 'upstream' : 'synthetic',
-    payload: context.store === false ? null : persistedPayload,
-    encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
-    createdAt: now,
-    refreshedAt: now,
-  };
 };

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -131,14 +131,17 @@ const buildRow = async (
   // client stripped fields from the echoed wire item.
   const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
   const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
+  const now = Date.now();
   return {
     id: newId,
     apiKeyId: request.apiKeyId ?? null,
     upstreamId: upstreamOwned ? context.upstream : null,
     upstreamItemId: upstreamOwned ? upstreamId : null,
     itemType: originalItem.type,
+    origin: upstreamOwned ? 'upstream' : 'synthetic',
     payload: context.store === false ? null : persistedPayload,
     encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
-    createdAt: Date.now(),
+    createdAt: now,
+    refreshedAt: now,
   };
 };

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -118,6 +118,10 @@ class ControlledResponsesItemsRepo implements ResponsesItemsRepo {
     });
   }
 
+  refreshMany(): Promise<number> {
+    return Promise.resolve(0);
+  }
+
   clearPayloadOlderThan(): Promise<number> {
     return Promise.resolve(0);
   }

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
@@ -67,9 +67,15 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
     getRepo().responsesItems.lookupManyByEncryptedContentHash(apiKeyId, [...new Set(hashByContent.values())]),
   ]);
   const rowById = new Map(byId.map(row => [row.id, row]));
-  const rowByHash = new Map(byHash.flatMap(row => row.encryptedContentHash !== null ? [[row.encryptedContentHash, row] as const] : []));
+  const rowByHash = new Map<string, StoredResponsesItem>();
+  for (const row of byHash) {
+    if (row.encryptedContentHash !== null && !rowByHash.has(row.encryptedContentHash)) {
+      rowByHash.set(row.encryptedContentHash, row);
+    }
+  }
 
   const failures: StoredResponsesItemsFailure[] = [];
+  const touchedIds = new Set<string>();
   for (const ref of references) {
     const row = (ref.id !== undefined ? rowById.get(ref.id) : undefined)
       ?? (ref.encryptedContent !== undefined ? rowByHash.get(hashByContent.get(ref.encryptedContent)!) : undefined);
@@ -84,6 +90,7 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
     }
 
     ref.row = row;
+    touchedIds.add(row.id);
     if (ref.type === 'item_reference' && row.payload === null && row.upstreamItemId === null) {
       failures.push({ kind: 'item-not-found', itemId: row.id });
       continue;
@@ -100,6 +107,7 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
       failures.push({ kind: 'item-not-found', itemId: row.id });
     }
   }
+  if (touchedIds.size > 0) await getRepo().responsesItems.refreshMany(apiKeyId, [...touchedIds], Date.now());
 
   return {
     references,

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
@@ -43,6 +43,7 @@ const insertRows = async (rows: readonly StoredResponsesItem[]) => {
   const repo = new InMemoryRepo();
   initRepo(repo);
   await repo.responsesItems.insertMany(rows);
+  return repo;
 };
 
 const prepareResponsesItems = async (sourceItems: string | readonly ResponsesInputItem[]) =>
@@ -493,6 +494,35 @@ test('id-less reasoning is matched by encrypted_content hash and prefers its own
   // Routed elsewhere (owner unavailable): the blob would not verify, so the
   // reasoning item is dropped rather than carried.
   assertEquals(await rewriteResponsesItems(items, prepared, provider('up_b')), []);
+});
+
+test('matched stored items are refreshed during preparation', async () => {
+  const id = storedReasoningId('refresh');
+  const repo = await insertRows([
+    storedRow({ id, itemType: 'reasoning', upstreamId: 'up_a', upstreamItemId: 'raw_rs_a', payload: null, createdAt: 1_000, refreshedAt: 1_000 }),
+  ]);
+
+  await prepareResponsesItems([{ type: 'item_reference', id }]);
+
+  const [row] = await repo.responsesItems.lookupMany(API_KEY_ID, [id]);
+  assert(row.refreshedAt > 1_000);
+});
+
+test('id-less encrypted_content duplicate hash keeps the freshest stored row', async () => {
+  const enc = 'duplicate-enc';
+  const hash = await hashResponsesItemEncryptedContent(enc);
+  await insertRows([
+    storedRow({ id: storedReasoningId('old'), itemType: 'reasoning', upstreamId: 'up_old', upstreamItemId: 'raw_old', encryptedContentHash: hash, payload: null, createdAt: 1_000, refreshedAt: 1_000 }),
+    storedRow({ id: storedReasoningId('new'), itemType: 'reasoning', upstreamId: 'up_new', upstreamItemId: 'raw_new', encryptedContentHash: hash, payload: null, createdAt: 2_000, refreshedAt: 2_000 }),
+  ]);
+
+  const items = [{ type: 'reasoning', summary: [], encrypted_content: enc }] as unknown as ResponsesInputItem[];
+  const prepared = await prepareResponsesItems(items);
+  const plan = planResponsesItemProviders([provider('up_old'), provider('up_new')], prepared);
+
+  assertEquals(plan.type, 'providers');
+  if (plan.type === 'providers') assertEquals(plan.providers.map(item => item.upstream), ['up_new', 'up_old']);
+  assertEquals(await rewriteResponsesItems(items, prepared, provider('up_new')), [{ type: 'reasoning', summary: [], encrypted_content: enc, id: 'raw_new' }]);
 });
 
 test('id-less compaction is matched by encrypted_content hash and forces its owning upstream', async () => {

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
@@ -80,6 +80,7 @@ const storedRow = (
     apiKeyId: API_KEY_ID,
     upstreamId: null,
     upstreamItemId: null,
+    origin: overrides.origin ?? (overrides.upstreamId === undefined || overrides.upstreamId === null ? 'synthetic' : 'upstream'),
     encryptedContentHash: null,
     payload: payload === undefined || payload === null
       ? null
@@ -87,6 +88,7 @@ const storedRow = (
         ? payload as StoredResponsesItem['payload']
         : { item: payload },
     createdAt: 1_000,
+    refreshedAt: 1_000,
     ...rest,
   };
 };

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -138,11 +138,13 @@ test('/v1/responses expands stored synthetic item_reference before the upstream 
       upstreamId: null,
       upstreamItemId: null,
       itemType: 'message',
+      origin: 'synthetic',
       encryptedContentHash: null,
       // payload.item.id is the original wire id, distinct from the stored row
       // id; the rewriter preserves it verbatim on the wire for synthetic rows.
       payload: { item: storedItem },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -225,9 +227,11 @@ test('/v1/responses expands same-origin item_reference for Copilot because Copil
       upstreamId: copilotUpstream.id,
       upstreamItemId: 'raw_msg_copilot',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -307,9 +311,11 @@ test('/v1/responses rejects metadata-only item_reference for Copilot before upst
       upstreamId: copilotUpstream.id,
       upstreamItemId: 'raw_msg_copilot_metadata',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: null,
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
   let generationFetchCalls = 0;
@@ -397,9 +403,11 @@ test('/v1/responses prefers latest portable stored-item origin and rewrites only
       upstreamId: 'up_a',
       upstreamItemId: 'raw_rs_a',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
     {
       id: secondId,
@@ -407,9 +415,11 @@ test('/v1/responses prefers latest portable stored-item origin and rewrites only
       upstreamId: 'up_b',
       upstreamItemId: 'raw_rs_b',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -498,9 +508,11 @@ test('/v1/responses falls back with portable non-origin message items using temp
       upstreamId: 'up_a',
       upstreamItemId: 'raw_msg_a',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
     {
       id: secondId,
@@ -508,9 +520,11 @@ test('/v1/responses falls back with portable non-origin message items using temp
       upstreamId: 'up_b',
       upstreamItemId: 'raw_msg_b',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -584,9 +598,11 @@ test('/v1/responses rejects multiple forcing stored-item origins before generati
       upstreamId: 'up_a',
       upstreamItemId: 'raw_cmp_a',
       itemType: 'compaction',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
     {
       id: secondId,
@@ -594,9 +610,11 @@ test('/v1/responses rejects multiple forcing stored-item origins before generati
       upstreamId: 'up_b',
       upstreamItemId: 'raw_cmp_b',
       itemType: 'compaction',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
   let generationFetchCalls = 0;

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -691,7 +691,18 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
         .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
-      return await Promise.all(results.map(toStoredResponsesItem));
+      return await Promise.all(results.map(async row => ({
+        id: row.id,
+        apiKeyId: row.api_key_id,
+        upstreamId: row.upstream_id,
+        upstreamItemId: row.upstream_item_id,
+        itemType: row.item_type,
+        origin: row.origin,
+        payload: await parseStoredResponsesPayload(row.id, row.payload_json),
+        encryptedContentHash: row.encrypted_content_hash,
+        createdAt: row.created_at,
+        refreshedAt: row.refreshed_at,
+      })));
     }));
     return perChunk.flat();
   }
@@ -769,19 +780,6 @@ interface ResponsesItemRow {
   created_at: number;
   refreshed_at: number;
 }
-
-const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredResponsesItem> => ({
-  id: row.id,
-  apiKeyId: row.api_key_id,
-  upstreamId: row.upstream_id,
-  upstreamItemId: row.upstream_item_id,
-  itemType: row.item_type,
-  origin: row.origin,
-  payload: await parseStoredResponsesPayload(row.id, row.payload_json),
-  encryptedContentHash: row.encrypted_content_hash,
-  createdAt: row.created_at,
-  refreshedAt: row.refreshed_at,
-});
 
 class D1SearchConfigRepo implements SearchConfigRepo {
   constructor(private db: D1Database) {}

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -655,6 +655,7 @@ class D1CacheRepo implements CacheRepo {
 }
 
 const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, encrypted_content_hash, created_at, refreshed_at';
+const RESPONSES_ITEM_ID_SCOPE_SQL = "COALESCE(api_key_id, '') = COALESCE(?, '')";
 
 class D1ResponsesItemsRepo implements ResponsesItemsRepo {
   constructor(private db: D1Database) {}
@@ -685,8 +686,9 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     const perChunk = await Promise.all(chunks.map(async chunk => {
       const placeholders = chunk.map(() => '?').join(', ');
       const orderSql = column === 'id' ? '' : ' ORDER BY refreshed_at DESC, created_at DESC, id ASC';
+      const scopeSql = column === 'id' ? RESPONSES_ITEM_ID_SCOPE_SQL : 'api_key_id IS ?';
       const { results } = await this.db
-        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE api_key_id IS ? AND ${column} IN (${placeholders})${orderSql}`)
+        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
       return await Promise.all(results.map(toStoredResponsesItem));
@@ -723,7 +725,7 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     const results = await Promise.all(chunks.map(async chunk => {
       const placeholders = chunk.map(() => '?').join(', ');
       return await this.db
-        .prepare(`UPDATE responses_items SET refreshed_at = ? WHERE api_key_id IS ? AND id IN (${placeholders}) AND refreshed_at < ?`)
+        .prepare(`UPDATE responses_items SET refreshed_at = ? WHERE ${RESPONSES_ITEM_ID_SCOPE_SQL} AND id IN (${placeholders}) AND refreshed_at < ?`)
         .bind(refreshedAt, apiKeyId, ...chunk, refreshedAt)
         .run();
     }));

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -654,7 +654,7 @@ class D1CacheRepo implements CacheRepo {
   }
 }
 
-const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, payload_json, encrypted_content_hash, created_at';
+const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, encrypted_content_hash, created_at, refreshed_at';
 
 class D1ResponsesItemsRepo implements ResponsesItemsRepo {
   constructor(private db: D1Database) {}
@@ -684,8 +684,9 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
 
     const perChunk = await Promise.all(chunks.map(async chunk => {
       const placeholders = chunk.map(() => '?').join(', ');
+      const orderSql = column === 'id' ? '' : ' ORDER BY refreshed_at DESC, created_at DESC, id ASC';
       const { results } = await this.db
-        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE api_key_id IS ? AND ${column} IN (${placeholders})`)
+        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE api_key_id IS ? AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
       return await Promise.all(results.map(toStoredResponsesItem));
@@ -704,21 +705,38 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
       // happen.
       return this.db
         .prepare(
-          `INSERT INTO responses_items (${RESPONSES_ITEM_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO responses_items (${RESPONSES_ITEM_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT (id, COALESCE(api_key_id, '')) DO NOTHING`,
         )
-        .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, payload, item.encryptedContentHash, item.createdAt);
+        .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, item.origin, payload, item.encryptedContentHash, item.createdAt, item.refreshedAt);
     }));
     await this.runStatements(statements);
   }
 
-  async clearPayloadOlderThan(createdBefore: number): Promise<number> {
-    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND created_at < ?').bind(createdBefore).run();
+  async refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number> {
+    const unique = [...new Set(ids)];
+    if (unique.length === 0) return 0;
+
+    const CHUNK = 88;
+    const chunks: string[][] = [];
+    for (let i = 0; i < unique.length; i += CHUNK) chunks.push(unique.slice(i, i + CHUNK));
+    const results = await Promise.all(chunks.map(async chunk => {
+      const placeholders = chunk.map(() => '?').join(', ');
+      return await this.db
+        .prepare(`UPDATE responses_items SET refreshed_at = ? WHERE api_key_id IS ? AND id IN (${placeholders}) AND refreshed_at < ?`)
+        .bind(refreshedAt, apiKeyId, ...chunk, refreshedAt)
+        .run();
+    }));
+    return results.reduce((sum, result) => sum + ((result.meta.changes as number | undefined) ?? 0), 0);
+  }
+
+  async clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
+    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND refreshed_at < ?').bind(refreshedBefore).run();
     return (result.meta.changes as number | undefined) ?? 0;
   }
 
-  async deleteOlderThan(createdBefore: number): Promise<number> {
-    const result = await this.db.prepare('DELETE FROM responses_items WHERE created_at < ?').bind(createdBefore).run();
+  async deleteOlderThan(refreshedBefore: number): Promise<number> {
+    const result = await this.db.prepare('DELETE FROM responses_items WHERE refreshed_at < ?').bind(refreshedBefore).run();
     return (result.meta.changes as number | undefined) ?? 0;
   }
 
@@ -743,9 +761,11 @@ interface ResponsesItemRow {
   upstream_id: string | null;
   upstream_item_id: string | null;
   item_type: string;
+  origin: StoredResponsesItem['origin'];
   payload_json: string | null;
   encrypted_content_hash: string | null;
   created_at: number;
+  refreshed_at: number;
 }
 
 const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredResponsesItem> => ({
@@ -754,9 +774,11 @@ const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredRespo
   upstreamId: row.upstream_id,
   upstreamItemId: row.upstream_item_id,
   itemType: row.item_type,
+  origin: row.origin,
   payload: await parseStoredResponsesPayload(row.id, row.payload_json),
   encryptedContentHash: row.encrypted_content_hash,
   createdAt: row.created_at,
+  refreshedAt: row.refreshed_at,
 });
 
 class D1SearchConfigRepo implements SearchConfigRepo {

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -743,8 +743,8 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     return results.reduce((sum, result) => sum + ((result.meta.changes as number | undefined) ?? 0), 0);
   }
 
-  async clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
-    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND refreshed_at < ?').bind(refreshedBefore).run();
+  async clearPayloadOlderThan(createdBefore: number): Promise<number> {
+    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND created_at < ?').bind(createdBefore).run();
     return (result.meta.changes as number | undefined) ?? 0;
   }
 

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -676,6 +676,19 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
   // well under the cap (the `api_key_id` bind shares the budget) and union
   // the results.
   private async lookupByColumn(apiKeyId: string | null, column: 'id' | 'encrypted_content_hash', values: readonly string[]): Promise<StoredResponsesItem[]> {
+    interface ResponsesItemRow {
+      id: string;
+      api_key_id: string | null;
+      upstream_id: string | null;
+      upstream_item_id: string | null;
+      item_type: string;
+      origin: StoredResponsesItem['origin'];
+      payload_json: string | null;
+      encrypted_content_hash: string | null;
+      created_at: number;
+      refreshed_at: number;
+    }
+
     const unique = [...new Set(values)];
     if (unique.length === 0) return [];
 
@@ -766,19 +779,6 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     }
     for (const statement of statements) await statement.run();
   }
-}
-
-interface ResponsesItemRow {
-  id: string;
-  api_key_id: string | null;
-  upstream_id: string | null;
-  upstream_item_id: string | null;
-  item_type: string;
-  origin: StoredResponsesItem['origin'];
-  payload_json: string | null;
-  encrypted_content_hash: string | null;
-  created_at: number;
-  refreshed_at: number;
 }
 
 class D1SearchConfigRepo implements SearchConfigRepo {

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -449,10 +449,10 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     return Promise.resolve(changes);
   }
 
-  clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
+  clearPayloadOlderThan(createdBefore: number): Promise<number> {
     let changes = 0;
     for (const row of this.store.values()) {
-      if (row.refreshedAt < refreshedBefore && row.payload !== null) {
+      if (row.createdAt < createdBefore && row.payload !== null) {
         row.payload = null;
         changes += 1;
       }

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -425,7 +425,7 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
         rows.push(cloneStoredResponsesItem(row));
       }
     }
-    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
+    return Promise.resolve(rows.toSorted((a, b) => b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id)));
   }
 
   insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
@@ -481,9 +481,6 @@ const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesIte
   ...item,
   payload: item.payload === null ? null : structuredClone(item.payload),
 });
-
-const compareResponsesItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
-  b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);
 
 const responsesItemStoreKey = (apiKeyId: string | null, id: string): string => `${apiKeyId ?? ''}\0${id}`;
 

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -425,7 +425,7 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
         rows.push(cloneStoredResponsesItem(row));
       }
     }
-    return Promise.resolve(rows);
+    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
   }
 
   insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
@@ -437,10 +437,22 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     return Promise.resolve();
   }
 
-  clearPayloadOlderThan(createdBefore: number): Promise<number> {
+  refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number> {
+    let changes = 0;
+    for (const id of new Set(ids)) {
+      const row = this.store.get(responsesItemStoreKey(apiKeyId, id));
+      if (row && row.refreshedAt < refreshedAt) {
+        row.refreshedAt = refreshedAt;
+        changes += 1;
+      }
+    }
+    return Promise.resolve(changes);
+  }
+
+  clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
     let changes = 0;
     for (const row of this.store.values()) {
-      if (row.createdAt < createdBefore && row.payload !== null) {
+      if (row.refreshedAt < refreshedBefore && row.payload !== null) {
         row.payload = null;
         changes += 1;
       }
@@ -448,10 +460,10 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     return Promise.resolve(changes);
   }
 
-  deleteOlderThan(createdBefore: number): Promise<number> {
+  deleteOlderThan(refreshedBefore: number): Promise<number> {
     let changes = 0;
     for (const [id, row] of this.store) {
-      if (row.createdAt < createdBefore) {
+      if (row.refreshedAt < refreshedBefore) {
         this.store.delete(id);
         changes += 1;
       }
@@ -469,6 +481,9 @@ const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesIte
   ...item,
   payload: item.payload === null ? null : structuredClone(item.payload),
 });
+
+const compareResponsesItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
+  b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);
 
 const responsesItemStoreKey = (apiKeyId: string | null, id: string): string => `${apiKeyId ?? ''}\0${id}`;
 

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -11,8 +11,10 @@ const storedItem = (overrides: Partial<StoredResponsesItem> & Pick<StoredRespons
   upstreamId: null,
   upstreamItemId: null,
   itemType: 'message',
+  origin: 'upstream',
   encryptedContentHash: null,
   payload: { item: { id: overrides.id, type: 'message', content: [{ type: 'output_text', text: overrides.id }] } },
+  refreshedAt: overrides.createdAt,
   ...overrides,
 });
 
@@ -50,19 +52,33 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
   assertEquals(await repo.lookupMany('key_b', [first.id, second.id, adminScoped.id]), []);
   assertEquals(await repo.lookupMany('key_a', []), []);
 
-  assertEquals(await repo.clearPayloadOlderThan(2_500), 2);
+  assertEquals(await repo.refreshMany('key_a', [first.id, first.id, second.id, adminScoped.id, 'missing'], 4_000), 2);
   assertEquals(
     await repo.lookupMany('key_a', [first.id, second.id]),
     [
-      { ...first, payload: null },
-      { ...second, payload: null },
+      { ...first, refreshedAt: 4_000 },
+      { ...second, refreshedAt: 4_000 },
     ],
   );
-  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [adminScoped]);
+  assertEquals(await repo.refreshMany('key_a', [first.id], 3_500), 0);
+  assertEquals(await repo.refreshMany(null, [adminScoped.id], 5_000), 1);
+  const refreshedAdminScoped = { ...adminScoped, refreshedAt: 5_000 };
 
-  assertEquals(await repo.deleteOlderThan(3_000), 2);
+  assertEquals(await repo.clearPayloadOlderThan(2_500), 0);
+  assertEquals(await repo.clearPayloadOlderThan(4_500), 2);
+  assertEquals(
+    await repo.lookupMany('key_a', [first.id, second.id]),
+    [
+      { ...first, payload: null, refreshedAt: 4_000 },
+      { ...second, payload: null, refreshedAt: 4_000 },
+    ],
+  );
+  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [refreshedAdminScoped]);
+
+  assertEquals(await repo.deleteOlderThan(3_000), 0);
+  assertEquals(await repo.deleteOlderThan(4_500), 2);
   assertEquals(await repo.lookupMany('key_a', [first.id, second.id]), []);
-  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [adminScoped]);
+  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [refreshedAdminScoped]);
 
   await repo.deleteAll();
   assertEquals(await repo.lookupMany(null, [adminScoped.id]), []);
@@ -120,9 +136,11 @@ test('D1 responses items repo rejects malformed stored payload_json', async () =
     upstream_id: null,
     upstream_item_id: null,
     item_type: 'message',
+    origin: 'synthetic',
     payload_json: '{bad json',
     encrypted_content_hash: null,
     created_at: 1_000,
+    refreshed_at: 1_000,
   });
 
   await assertRejects(() => new D1Repo(db).responsesItems.lookupMany('key_a', ['msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA']), Error, 'Malformed responses_items.payload_json JSON');
@@ -234,15 +252,59 @@ test('migration 0023 creates the responses_items table and cleanup indexes', asy
   }
 });
 
+test('migration 0025 adds responses item metadata and refresh index', async () => {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  try {
+    applySqlJsFile(db, '0023_responses_items.sql');
+    db.run(`
+      INSERT INTO responses_items (id, upstream_id, upstream_item_id, item_type, created_at)
+      VALUES
+        ('msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA', NULL, NULL, 'message', 1),
+        ('rs_mFBDiA_Lh1uXb7nD_bQb4I1CUYH2w', 'up_a', 'raw_rs_a', 'reasoning', 2)
+    `);
+    applySqlJsFile(db, '0025_responses_item_metadata.sql');
+
+    assertEquals(
+      sqlJsRows<{ name: string }>(db, 'PRAGMA table_info(responses_items)').map(row => row.name).filter(name => name === 'origin' || name === 'refreshed_at'),
+      ['origin', 'refreshed_at'],
+    );
+    assertEquals(
+      sqlJsRows<{ id: string; origin: string; refreshed_at: number }>(db, 'SELECT id, origin, refreshed_at FROM responses_items ORDER BY created_at'),
+      [
+        { id: 'msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA', origin: 'synthetic', refreshed_at: 1 },
+        { id: 'rs_mFBDiA_Lh1uXb7nD_bQb4I1CUYH2w', origin: 'upstream', refreshed_at: 2 },
+      ],
+    );
+    assertEquals(
+      sqlJsRows<{ name: string }>(db, "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'responses_items' ORDER BY name").map(row => row.name),
+      ['idx_responses_items_api_key_id', 'idx_responses_items_enc_hash', 'idx_responses_items_id_scope', 'idx_responses_items_refreshed_at'],
+    );
+    db.run("INSERT INTO responses_items (id, item_type, created_at) VALUES ('ws_WGRXTA_sVlhxg6BAV0BUzj0KkWSqA', 'web_search_call', 3)");
+    assertEquals(
+      sqlJsRows<{ origin: string; refreshed_at: number }>(db, "SELECT origin, refreshed_at FROM responses_items WHERE id = 'ws_WGRXTA_sVlhxg6BAV0BUzj0KkWSqA'")[0],
+      { origin: 'upstream', refreshed_at: 3 },
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN DELETE FROM responses_items WHERE refreshed_at < 10')
+        .some(row => row.detail.includes('idx_responses_items_refreshed_at')),
+    );
+  } finally {
+    db.close();
+  }
+});
+
 type FakeResponsesItemRow = {
   id: string;
   api_key_id: string | null;
   upstream_id: string | null;
   upstream_item_id: string | null;
   item_type: string;
+  origin: StoredResponsesItem['origin'];
   payload_json: string | null;
   encrypted_content_hash: string | null;
   created_at: number;
+  refreshed_at: number;
 };
 
 class FakeResponsesItemsD1PreparedStatement {
@@ -276,11 +338,15 @@ class FakeResponsesItemsD1PreparedStatement {
       this.db.insert(this.binds);
       return Promise.resolve({ results: [], success: true, meta: { changes: 1 } });
     }
+    if (this.query.startsWith('UPDATE responses_items SET refreshed_at = ?')) {
+      const changes = this.db.refresh(this.binds);
+      return Promise.resolve({ results: [], success: true, meta: { changes } });
+    }
     if (this.query.startsWith('UPDATE responses_items SET payload_json = NULL')) {
       const changes = this.db.clearPayloadOlderThan(this.binds[0] as number);
       return Promise.resolve({ results: [], success: true, meta: { changes } });
     }
-    if (this.query.startsWith('DELETE FROM responses_items WHERE created_at < ?')) {
+    if (this.query.startsWith('DELETE FROM responses_items WHERE refreshed_at < ?')) {
       const changes = this.db.deleteOlderThan(this.binds[0] as number);
       return Promise.resolve({ results: [], success: true, meta: { changes } });
     }
@@ -308,7 +374,18 @@ class FakeResponsesItemsD1Database implements D1Database {
   }
 
   insert(binds: unknown[]): void {
-    const [id, apiKeyId, upstreamId, upstreamItemId, itemType, payload, encryptedContentHash, createdAt] = binds as [string, string | null, string | null, string | null, string, string | null, string | null, number];
+    const [id, apiKeyId, upstreamId, upstreamItemId, itemType, origin, payload, encryptedContentHash, createdAt, refreshedAt] = binds as [
+      string,
+      string | null,
+      string | null,
+      string | null,
+      string,
+      StoredResponsesItem['origin'],
+      string | null,
+      string | null,
+      number,
+      number,
+    ];
     const existing = this.rows.find(row => row.id === id && row.api_key_id === apiKeyId);
     if (existing) return;  // mirrors d1.ts `ON CONFLICT DO NOTHING`
     this.rows.push({
@@ -317,10 +394,26 @@ class FakeResponsesItemsD1Database implements D1Database {
       upstream_id: upstreamId,
       upstream_item_id: upstreamItemId,
       item_type: itemType,
+      origin,
       payload_json: payload,
       encrypted_content_hash: encryptedContentHash,
       created_at: createdAt,
+      refreshed_at: refreshedAt,
     });
+  }
+
+  refresh(binds: unknown[]): number {
+    const [refreshedAt, apiKeyId, ...rest] = binds as [number, string | null, ...Array<string | number>];
+    const ids = new Set(rest.slice(0, -1) as string[]);
+    const maxExisting = rest.at(-1) as number;
+    let changes = 0;
+    for (const row of this.rows) {
+      if (row.api_key_id === apiKeyId && ids.has(row.id) && row.refreshed_at < maxExisting) {
+        row.refreshed_at = refreshedAt;
+        changes += 1;
+      }
+    }
+    return changes;
   }
 
   lookup(query: string, binds: unknown[]): FakeResponsesItemRow[] {
@@ -329,7 +422,8 @@ class FakeResponsesItemsD1Database implements D1Database {
     if (query.includes('encrypted_content_hash IN')) {
       return this.rows
         .filter(row => row.api_key_id === apiKeyId && row.encrypted_content_hash !== null && wanted.has(row.encrypted_content_hash))
-        .map(row => ({ ...row }));
+        .map(row => ({ ...row }))
+        .toSorted(compareFakeResponsesItemsByFreshness);
     }
     const matches = this.rows.filter(row => wanted.has(row.id) && row.api_key_id === apiKeyId);
     const order = new Map(keys.map((id, index) => [id, index]));
@@ -339,7 +433,7 @@ class FakeResponsesItemsD1Database implements D1Database {
   clearPayloadOlderThan(createdBefore: number): number {
     let changes = 0;
     for (const row of this.rows) {
-      if (row.created_at < createdBefore && row.payload_json !== null) {
+      if (row.refreshed_at < createdBefore && row.payload_json !== null) {
         row.payload_json = null;
         changes += 1;
       }
@@ -349,10 +443,13 @@ class FakeResponsesItemsD1Database implements D1Database {
 
   deleteOlderThan(createdBefore: number): number {
     const previousLength = this.rows.length;
-    this.rows = this.rows.filter(row => row.created_at >= createdBefore);
+    this.rows = this.rows.filter(row => row.refreshed_at >= createdBefore);
     return previousLength - this.rows.length;
   }
 }
+
+const compareFakeResponsesItemsByFreshness = (a: FakeResponsesItemRow, b: FakeResponsesItemRow): number =>
+  b.refreshed_at - a.refreshed_at || b.created_at - a.created_at || a.id.localeCompare(b.id);
 
 type SqlJsDatabase = {
   run(sql: string): void;

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -289,6 +289,18 @@ test('migration 0025 adds responses item metadata and refresh index', async () =
       sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN DELETE FROM responses_items WHERE refreshed_at < 10')
         .some(row => row.detail.includes('idx_responses_items_refreshed_at')),
     );
+    assert(
+      sqlJsRows<{ detail: string }>(
+        db,
+        "EXPLAIN QUERY PLAN SELECT id FROM responses_items WHERE COALESCE(api_key_id, '') = COALESCE('key_a', '') AND id IN ('msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA')",
+      ).some(row => row.detail.includes('idx_responses_items_id_scope')),
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(
+        db,
+        "EXPLAIN QUERY PLAN UPDATE responses_items SET refreshed_at = 10 WHERE COALESCE(api_key_id, '') = COALESCE('key_a', '') AND id IN ('msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA') AND refreshed_at < 10",
+      ).some(row => row.detail.includes('idx_responses_items_id_scope')),
+    );
   } finally {
     db.close();
   }

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -64,8 +64,8 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
   assertEquals(await repo.refreshMany(null, [adminScoped.id], 5_000), 1);
   const refreshedAdminScoped = { ...adminScoped, refreshedAt: 5_000 };
 
-  assertEquals(await repo.clearPayloadOlderThan(2_500), 0);
-  assertEquals(await repo.clearPayloadOlderThan(4_500), 2);
+  assertEquals(await repo.clearPayloadOlderThan(500), 0);
+  assertEquals(await repo.clearPayloadOlderThan(2_500), 2);
   assertEquals(
     await repo.lookupMany('key_a', [first.id, second.id]),
     [
@@ -278,7 +278,7 @@ test('migration 0025 adds responses item metadata and refresh index', async () =
     );
     assertEquals(
       sqlJsRows<{ name: string }>(db, "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'responses_items' ORDER BY name").map(row => row.name),
-      ['idx_responses_items_api_key_id', 'idx_responses_items_enc_hash', 'idx_responses_items_id_scope', 'idx_responses_items_refreshed_at'],
+      ['idx_responses_items_api_key_id', 'idx_responses_items_created_at', 'idx_responses_items_enc_hash', 'idx_responses_items_id_scope', 'idx_responses_items_refreshed_at'],
     );
     db.run("INSERT INTO responses_items (id, item_type, created_at) VALUES ('ws_WGRXTA_sVlhxg6BAV0BUzj0KkWSqA', 'web_search_call', 3)");
     assertEquals(
@@ -288,6 +288,10 @@ test('migration 0025 adds responses item metadata and refresh index', async () =
     assert(
       sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN DELETE FROM responses_items WHERE refreshed_at < 10')
         .some(row => row.detail.includes('idx_responses_items_refreshed_at')),
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND created_at < 10')
+        .some(row => row.detail.includes('idx_responses_items_created_at')),
     );
     assert(
       sqlJsRows<{ detail: string }>(
@@ -445,7 +449,7 @@ class FakeResponsesItemsD1Database implements D1Database {
   clearPayloadOlderThan(createdBefore: number): number {
     let changes = 0;
     for (const row of this.rows) {
-      if (row.refreshed_at < createdBefore && row.payload_json !== null) {
+      if (row.created_at < createdBefore && row.payload_json !== null) {
         row.payload_json = null;
         changes += 1;
       }

--- a/apps/api/src/repo/types.ts
+++ b/apps/api/src/repo/types.ts
@@ -166,12 +166,14 @@ export interface StoredResponsesItem {
   upstreamId: string | null;
   upstreamItemId: string | null;
   itemType: string;
+  origin: 'input' | 'upstream' | 'synthetic';
   payload: StoredResponsesItemPayload | null;
   // sha256 of the item's `encrypted_content`, when it carries one (reasoning /
   // compaction). Lets a later turn that echoes the blob without a gateway id
   // recover this row's owning upstream for affinity routing.
   encryptedContentHash: string | null;
   createdAt: number;
+  refreshedAt: number;
 }
 
 export interface StoredResponsesItemPayload {
@@ -188,8 +190,9 @@ export interface ResponsesItemsRepo {
   lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItem[]>;
   lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   insertMany(items: readonly StoredResponsesItem[]): Promise<void>;
-  clearPayloadOlderThan(createdBefore: number): Promise<number>;
-  deleteOlderThan(createdBefore: number): Promise<number>;
+  refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number>;
+  clearPayloadOlderThan(refreshedBefore: number): Promise<number>;
+  deleteOlderThan(refreshedBefore: number): Promise<number>;
   deleteAll(): Promise<void>;
 }
 

--- a/apps/api/src/repo/types.ts
+++ b/apps/api/src/repo/types.ts
@@ -191,7 +191,7 @@ export interface ResponsesItemsRepo {
   lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   insertMany(items: readonly StoredResponsesItem[]): Promise<void>;
   refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number>;
-  clearPayloadOlderThan(refreshedBefore: number): Promise<number>;
+  clearPayloadOlderThan(createdBefore: number): Promise<number>;
   deleteOlderThan(refreshedBefore: number): Promise<number>;
   deleteAll(): Promise<void>;
 }


### PR DESCRIPTION
Add responses_items origin and refreshed_at metadata with D1/memory repo support, refreshMany, refreshed_at cleanup, and deterministic hash lookup ordering.

Backfill existing rows and add a refreshed_at trigger/index so cleanup can use the indexed column directly.

Use scoped (id, COALESCE(api_key_id, '')) lookups and refreshes so D1 avoids API-key scans. Refresh referenced rows after request planning, preserve freshest encrypted-content matches, and keep payload cleanup tied to created_at so spilled files and DB descriptors expire together.