### PR TITLE
refactor(llm): split source execution from HTTP serving

### DIFF
--- a/apps/api/migrations/0025_responses_item_metadata.sql
+++ b/apps/api/migrations/0025_responses_item_metadata.sql
@@ -13,5 +13,4 @@ END;
 UPDATE responses_items SET origin = CASE WHEN upstream_id IS NULL THEN 'synthetic' ELSE 'upstream' END;
 UPDATE responses_items SET refreshed_at = created_at;
 
-DROP INDEX idx_responses_items_created_at;
 CREATE INDEX idx_responses_items_refreshed_at ON responses_items (refreshed_at);

--- a/apps/api/migrations/0025_responses_item_metadata.sql
+++ b/apps/api/migrations/0025_responses_item_metadata.sql
@@ -1,0 +1,17 @@
+ALTER TABLE responses_items ADD COLUMN origin TEXT NOT NULL DEFAULT 'upstream' CHECK (origin IN ('input', 'upstream', 'synthetic'));
+ALTER TABLE responses_items ADD COLUMN refreshed_at INTEGER NOT NULL DEFAULT 0;
+
+CREATE TRIGGER trg_responses_items_refreshed_at_default
+AFTER INSERT ON responses_items
+WHEN NEW.refreshed_at = 0
+BEGIN
+  UPDATE responses_items
+  SET refreshed_at = NEW.created_at
+  WHERE rowid = NEW.rowid;
+END;
+
+UPDATE responses_items SET origin = CASE WHEN upstream_id IS NULL THEN 'synthetic' ELSE 'upstream' END;
+UPDATE responses_items SET refreshed_at = created_at;
+
+DROP INDEX idx_responses_items_created_at;
+CREATE INDEX idx_responses_items_refreshed_at ON responses_items (refreshed_at);

--- a/apps/api/src/control-plane/data-transfer/routes_test.ts
+++ b/apps/api/src/control-plane/data-transfer/routes_test.ts
@@ -143,9 +143,11 @@ const STORED_RESPONSES_ITEM: StoredResponsesItem = {
   upstreamId: null,
   upstreamItemId: null,
   itemType: 'message',
+  origin: 'synthetic',
   encryptedContentHash: null,
   payload: { item: { type: 'message', id: 'msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA', role: 'assistant', content: [] } },
   createdAt: 1_000,
+  refreshedAt: 1_000,
 };
 
 const PERFORMANCE_1: PerformanceTelemetryRecord = {

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -28,7 +28,7 @@ export interface StatefulResponsesContext {
 }
 
 /**
- * Per client request scope. Constructed once in `createRequestContext` and
+ * Per client request scope. Constructed once in `createHttpRequestContext` and
  * threaded through every layer (source interceptors, target emits, target
  * interceptors, telemetry). Holds both immutable identities/adapters and
  * mutable per-request bags that cross-layer producers and consumers share.
@@ -50,7 +50,7 @@ export interface RequestContext {
   readonly requestStartedAt: number;
   readonly apiKeyId?: string;
   // null = Default mode (inherit global upstream order).
-  readonly apiKeyUpstreamIds?: readonly string[] | null;
+  readonly apiKeyUpstreamIds: readonly string[] | null;
   readonly runtimeLocation: string;
   readonly scheduleBackground?: BackgroundScheduler;
   readonly downstreamAbortSignal?: AbortSignal;

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -28,7 +28,7 @@ export interface StatefulResponsesContext {
 }
 
 /**
- * Per-HTTP-request scope. Constructed once in `createRequestContext` and
+ * Per client request scope. Constructed once in `createRequestContext` and
  * threaded through every layer (source interceptors, target emits, target
  * interceptors, telemetry). Holds both immutable identities/adapters and
  * mutable per-request bags that cross-layer producers and consumers share.
@@ -60,7 +60,7 @@ export interface RequestContext {
 
 /**
  * Per-provider-binding-attempt request-side description. Rebuilt for every
- * binding the planner tries inside one HTTP request.
+ * binding the planner tries inside one client request.
  *
  * - sourceApi / targetApi: the protocol the client spoke and the protocol
  *   the planner picked for this binding.

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -36,8 +36,8 @@ export interface StatefulResponsesContext {
  * Anything that varies per provider-binding attempt belongs on `Invocation`,
  * not here. `statefulResponsesContext` is the one exception: the serve loop
  * reassigns it per attempt so cross-layer readers outside `Invocation`
- * plumbing (output.ts:buildRow, source-interceptor `transformItems`) reach
- * it via the only handle they have. Read it through
+ * plumbing (output persistence, source-interceptor `transformItems`) reach it
+ * via the only handle they have. Read it through
  * `request.statefulResponsesContext` at access time; never capture the
  * inner object in a closure or background task — that snapshot belongs to
  * one attempt only.

--- a/apps/api/src/data-plane/llm/sources/chat-completions/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/chat-completions/serve_test.ts
@@ -80,9 +80,11 @@ test('/v1/chat/completions rewrites stored Responses reasoning_items before the 
       upstreamId: 'up_chat_origin',
       upstreamItemId: 'raw_rs_chat',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 

--- a/apps/api/src/data-plane/llm/sources/chat-completions/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/chat-completions/traits.ts
@@ -6,8 +6,8 @@ import type { ExecuteResult } from '../../shared/errors/result.ts';
 import { emitToChatCompletions } from '../../targets/chat-completions/emit.ts';
 import { emitToMessages } from '../../targets/messages/emit.ts';
 import { emitToResponses } from '../../targets/responses/emit.ts';
-import { createRequestContext } from '../request-context.ts';
-import { type LlmEndpoint, jsonUpstreamErrorResult, sourceErrorResult, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
+import { createHttpRequestContext } from '../request-context.ts';
+import { type LlmHttpEndpoint, jsonUpstreamErrorResult, sourceErrorResult, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload, ChatCompletionsMessage } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
@@ -55,20 +55,20 @@ const renderChatCompletionsFailure = (failure: LlmServeFailure): ExecuteResult<P
 
 // Target interceptors may force upstream usage for gateway accounting, but
 // Chat SSE exposes usage only when the caller requested `include_usage`.
-// `setup` parses that intent off the body; `respond` reads it back from the
+// `prepare` parses that intent off the body; `respond` reads it back from the
 // per-request Hono context, since the shared traits object holds no per-call
 // state.
 const INCLUDE_USAGE_CHUNK_KEY = 'chatCompletionsIncludeUsageChunk';
 
-const chatCompletionsGenerate: LlmEndpoint<readonly ChatCompletionsMessage[], ChatCompletionsStreamEvent> = {
-  respond: async ({ c, result, request, wantsStream, downstreamAbortController }) =>
-    await respondChatCompletions(c, result, wantsStream, c.get(INCLUDE_USAGE_CHUNK_KEY) === true, request, downstreamAbortController),
-  setup: async c => {
+const chatCompletionsGenerate: LlmHttpEndpoint<readonly ChatCompletionsMessage[], ChatCompletionsStreamEvent> = {
+  respond: async ({ c, result, runtime }) =>
+    await respondChatCompletions(c, result, runtime.wantsStream, c.get(INCLUDE_USAGE_CHUNK_KEY) === true, runtime.request, runtime.downstreamAbortController),
+  prepare: async c => {
     const payload = await c.req.json<ChatCompletionsPayload>();
     c.set(INCLUDE_USAGE_CHUNK_KEY, payload.stream_options?.include_usage === true);
     const wantsStream = payload.stream === true;
     const downstreamAbortController = wantsStream ? new AbortController() : undefined;
-    const request = createRequestContext(c, downstreamAbortController?.signal, wantsStream);
+    const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream);
     return {
       request,
       items: payload.messages,

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -1,5 +1,4 @@
 import { listModelProviders, resolveModelForProvider } from '../../providers/registry.ts';
-import type { RequestContext } from '../interceptors.ts';
 import { responsesItemId } from './responses/items/format.ts';
 import { type ResponsesItemsCommit, storeResponsesOutputItems } from './responses/items/output.ts';
 import {
@@ -29,12 +28,6 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
   return await attemptProviders(providerPlan, plan, prepared, renderFailure);
 };
 
-// Walk the planned providers in order: resolve the model, pick a target, run
-// the attempt; the first provider yielding an upstream result wins, with its
-// output items wrapped for persistence. A provider whose model or target does
-// not resolve is skipped. An exhausted walk renders the model diagnostic —
-// missing when no provider had the model, unsupported when one did but offered
-// no usable target.
 const attemptProviders = async <TItems, TEvent>(
   providerPlan: StoredResponsesProviderPlan,
   plan: LlmEndpointPlan<TItems, TEvent>,
@@ -53,7 +46,13 @@ const attemptProviders = async <TItems, TEvent>(
     const target = plan.pickTarget(binding.upstreamModel.endpoints);
     if (!target) continue;
 
-    resetAttemptStatefulResponsesContext(plan.request, prepared);
+    plan.request.statefulResponsesContext = {
+      privatePayload: new Map(prepared.references.flatMap(ref => {
+        const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });
+        return wireId && ref.row?.payload?.private !== undefined ? [[wireId, ref.row.payload.private] as const] : [];
+      })),
+      newSyntheticIds: new Set(),
+    };
 
     const rawResult = await plan.attempt({
       binding,
@@ -70,16 +69,4 @@ const attemptProviders = async <TItems, TEvent>(
   // The diagnostic names the model the client requested, not whichever upstream
   // id a provider resolved it to.
   return { result: renderFailure(sawModel ? { kind: 'model-unsupported', model: plan.model } : { kind: 'model-missing', model: plan.model }) };
-};
-
-const resetAttemptStatefulResponsesContext = (request: RequestContext, prepared: PreparedStoredResponsesItems): void => {
-  // Fresh stateful bag per attempt so a failed earlier attempt's shim writes do
-  // not leak into the next provider attempt.
-  request.statefulResponsesContext = {
-    privatePayload: new Map(prepared.references.flatMap(ref => {
-      const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });
-      return wireId && ref.row?.payload?.private !== undefined ? [[wireId, ref.row.payload.private] as const] : [];
-    })),
-    newSyntheticIds: new Set(),
-  };
 };

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -3,10 +3,8 @@ import { responsesItemId } from './responses/items/format.ts';
 import { type ResponsesItemsCommit, storeResponsesOutputItems } from './responses/items/output.ts';
 import {
   planResponsesItemProviders,
-  type PreparedStoredResponsesItems,
   prepareStoredResponsesItemsForSource,
   rewriteStoredResponsesItemsForProvider,
-  type StoredResponsesProviderPlan,
 } from './responses/items/request-plan.ts';
 import type { LlmEndpointPlan, LlmServeFailure, Result } from './traits.ts';
 
@@ -25,15 +23,6 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
   if (prepared.failures[0]) return { result: renderFailure(prepared.failures[0]) };
 
   const providerPlan = planResponsesItemProviders(await listModelProviders(plan.request.apiKeyUpstreamIds), prepared);
-  return await attemptProviders(providerPlan, plan, prepared, renderFailure);
-};
-
-const attemptProviders = async <TItems, TEvent>(
-  providerPlan: StoredResponsesProviderPlan,
-  plan: LlmEndpointPlan<TItems, TEvent>,
-  prepared: PreparedStoredResponsesItems,
-  renderFailure: RenderLlmFailure<TEvent>,
-): Promise<LlmSourceExecution<TEvent>> => {
   if (providerPlan.type === 'failure') return { result: renderFailure(providerPlan.failure) };
 
   let sawModel = false;

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -8,17 +8,10 @@ import {
 } from './responses/items/request-plan.ts';
 import type { LlmEndpointPlan, LlmServeFailure, Result } from './traits.ts';
 
-export interface LlmSourceExecution<TEvent> {
-  result: Result<TEvent>;
-  commitForNonStreaming?: ResponsesItemsCommit;
-}
-
-export type RenderLlmFailure<TEvent> = (failure: LlmServeFailure) => Result<TEvent>;
-
 export const executeLlmSourcePlan = async <TItems, TEvent>(
   plan: LlmEndpointPlan<TItems, TEvent>,
-  renderFailure: RenderLlmFailure<TEvent>,
-): Promise<LlmSourceExecution<TEvent>> => {
+  renderFailure: (failure: LlmServeFailure) => Result<TEvent>,
+): Promise<{ result: Result<TEvent>; commitForNonStreaming?: ResponsesItemsCommit }> => {
   const prepared = await prepareStoredResponsesItemsForSource(plan.items, plan.request.apiKeyId ?? null, plan.responsesItemsView);
   if (prepared.failures[0]) return { result: renderFailure(prepared.failures[0]) };
 

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -1,0 +1,85 @@
+import { listModelProviders, resolveModelForProvider } from '../../providers/registry.ts';
+import type { RequestContext } from '../interceptors.ts';
+import { responsesItemId } from './responses/items/format.ts';
+import { type ResponsesItemsCommit, storeResponsesOutputItems } from './responses/items/output.ts';
+import {
+  planResponsesItemProviders,
+  type PreparedStoredResponsesItems,
+  prepareStoredResponsesItemsForSource,
+  rewriteStoredResponsesItemsForProvider,
+  type StoredResponsesProviderPlan,
+} from './responses/items/request-plan.ts';
+import type { LlmEndpointPlan, LlmServeFailure, Result } from './traits.ts';
+
+export interface LlmSourceExecution<TEvent> {
+  result: Result<TEvent>;
+  commitForNonStreaming?: ResponsesItemsCommit;
+}
+
+export type RenderLlmFailure<TEvent> = (failure: LlmServeFailure) => Result<TEvent>;
+
+export const executeLlmSourcePlan = async <TItems, TEvent>(
+  plan: LlmEndpointPlan<TItems, TEvent>,
+  renderFailure: RenderLlmFailure<TEvent>,
+): Promise<LlmSourceExecution<TEvent>> => {
+  const prepared = await prepareStoredResponsesItemsForSource(plan.items, plan.request.apiKeyId ?? null, plan.responsesItemsView);
+  if (prepared.failures[0]) return { result: renderFailure(prepared.failures[0]) };
+
+  const providerPlan = planResponsesItemProviders(await listModelProviders(plan.request.apiKeyUpstreamIds), prepared);
+  return await attemptProviders(providerPlan, plan, prepared, renderFailure);
+};
+
+// Walk the planned providers in order: resolve the model, pick a target, run
+// the attempt; the first provider yielding an upstream result wins, with its
+// output items wrapped for persistence. A provider whose model or target does
+// not resolve is skipped. An exhausted walk renders the model diagnostic —
+// missing when no provider had the model, unsupported when one did but offered
+// no usable target.
+const attemptProviders = async <TItems, TEvent>(
+  providerPlan: StoredResponsesProviderPlan,
+  plan: LlmEndpointPlan<TItems, TEvent>,
+  prepared: PreparedStoredResponsesItems,
+  renderFailure: RenderLlmFailure<TEvent>,
+): Promise<LlmSourceExecution<TEvent>> => {
+  if (providerPlan.type === 'failure') return { result: renderFailure(providerPlan.failure) };
+
+  let sawModel = false;
+  for (const provider of providerPlan.providers) {
+    const resolved = await resolveModelForProvider(provider, plan.model);
+    if (!resolved) continue;
+    sawModel = true;
+
+    const { binding } = resolved;
+    const target = plan.pickTarget(binding.upstreamModel.endpoints);
+    if (!target) continue;
+
+    resetAttemptStatefulResponsesContext(plan.request, prepared);
+
+    const rawResult = await plan.attempt({
+      binding,
+      target,
+      model: resolved.id,
+      rewriteItems: items => rewriteStoredResponsesItemsForProvider(items, prepared, binding, plan.responsesItemsView),
+    });
+    if (rawResult.type !== 'events') return { result: rawResult };
+
+    const stored = storeResponsesOutputItems(rawResult.events, plan.responsesItemsView, { targetApi: target, upstream: binding.upstream, store: plan.store }, plan.request, plan.wantsStream);
+    return { result: { ...rawResult, events: stored.events }, commitForNonStreaming: stored.commitForNonStreaming };
+  }
+
+  // The diagnostic names the model the client requested, not whichever upstream
+  // id a provider resolved it to.
+  return { result: renderFailure(sawModel ? { kind: 'model-unsupported', model: plan.model } : { kind: 'model-missing', model: plan.model }) };
+};
+
+const resetAttemptStatefulResponsesContext = (request: RequestContext, prepared: PreparedStoredResponsesItems): void => {
+  // Fresh stateful bag per attempt so a failed earlier attempt's shim writes do
+  // not leak into the next provider attempt.
+  request.statefulResponsesContext = {
+    privatePayload: new Map(prepared.references.flatMap(ref => {
+      const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });
+      return wireId && ref.row?.payload?.private !== undefined ? [[wireId, ref.row.payload.private] as const] : [];
+    })),
+    newSyntheticIds: new Set(),
+  };
+};

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -55,7 +55,6 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
     return { result: { ...rawResult, events: stored.events }, commitForNonStreaming: stored.commitForNonStreaming };
   }
 
-  // The diagnostic names the model the client requested, not whichever upstream
-  // id a provider resolved it to.
+  // The diagnostic names the model the client requested, not whichever upstream id a provider resolved it to.
   return { result: renderFailure(sawModel ? { kind: 'model-unsupported', model: plan.model } : { kind: 'model-missing', model: plan.model }) };
 };

--- a/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
@@ -28,6 +28,7 @@ const invocation = (payload: GeminiPayload): GeminiInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
@@ -20,6 +20,7 @@ const testTelemetryModelIdentity = {
 };
 const request = (): RequestContext => ({
   requestStartedAt: performance.now(),
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 });

--- a/apps/api/src/data-plane/llm/sources/gemini/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/traits.ts
@@ -147,7 +147,7 @@ const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamE
         const invocation: MessagesInvocation = geminiInvocation(binding, 'messages', resolvedModelId, countPayload);
         const response = await runInterceptors(invocation, request, invocation.targetInterceptors?.messagesCountTokens ?? [], async () => {
           const { model: _model, ...callBody } = invocation.payload;
-          const result = await binding.provider.callMessagesCountTokens(invocation.upstreamModel, callBody, undefined, invocation.headers);
+          const result = await invocation.provider.callMessagesCountTokens(invocation.upstreamModel, callBody, undefined, invocation.headers);
           return result.response;
         });
         if (!response.ok) {

--- a/apps/api/src/data-plane/llm/sources/gemini/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/traits.ts
@@ -8,9 +8,9 @@ import { type ExecuteResult, plainResult } from '../../shared/errors/result.ts';
 import { emitToChatCompletions } from '../../targets/chat-completions/emit.ts';
 import { emitToMessages } from '../../targets/messages/emit.ts';
 import { emitToResponses } from '../../targets/responses/emit.ts';
-import { createRequestContext } from '../request-context.ts';
+import { createHttpRequestContext } from '../request-context.ts';
 import { plainResultFromResponse } from '../respond.ts';
-import { jsonUpstreamErrorResult, sourceErrorResult, type LlmEndpoint, type LlmEndpointName, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
+import { jsonUpstreamErrorResult, sourceErrorResult, type LlmEndpointName, type LlmHttpEndpoint, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiContent, GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
@@ -66,10 +66,10 @@ const parseGeminiModelAction = (modelAction: string | undefined): { model: strin
   return { model: modelAction.slice(0, separator).replace(/^models\//, ''), action: modelAction.slice(separator + 1) };
 };
 
-const geminiGenerate: LlmEndpoint<readonly GeminiContent[], GeminiStreamEvent> = {
-  respond: async ({ c, result, request, wantsStream, downstreamAbortController }) =>
-    await respondGemini(c, result, wantsStream, request, downstreamAbortController),
-  setup: async c => {
+const geminiGenerate: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamEvent> = {
+  respond: async ({ c, result, runtime }) =>
+    await respondGemini(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
+  prepare: async c => {
     const parsed = parseGeminiModelAction(c.req.param('modelAction'));
     if (parsed instanceof Response) return parsed;
     const { model, action } = parsed;
@@ -79,7 +79,7 @@ const geminiGenerate: LlmEndpoint<readonly GeminiContent[], GeminiStreamEvent> =
     const wantsStream = action === 'streamGenerateContent';
 
     const downstreamAbortController = wantsStream ? new AbortController() : undefined;
-    const request = createRequestContext(c, downstreamAbortController?.signal, wantsStream);
+    const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream);
     const payload = await c.req.json<GeminiPayload>();
     return {
       request,
@@ -132,13 +132,13 @@ const totalTokensFromUpstream = (value: unknown): number | null => {
   return null;
 };
 
-const geminiCountTokens: LlmEndpoint<readonly GeminiContent[], GeminiStreamEvent> = {
-  respond: async ({ c, result, request, wantsStream, downstreamAbortController }) =>
-    await respondGemini(c, result, wantsStream, request, downstreamAbortController),
-  setup: async c => {
+const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamEvent> = {
+  respond: async ({ c, result, runtime }) =>
+    await respondGemini(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
+  prepare: async c => {
     const parsed = parseGeminiModelAction(c.req.param('modelAction'));
     if (parsed instanceof Response) return parsed;
-    const request = createRequestContext(c, undefined, false);
+    const request = createHttpRequestContext(c, undefined, false);
     const body = await c.req.json<GeminiCountTokensRequest>();
     const generateContentRequest = body.generateContentRequest ?? { contents: body.contents };
     return {

--- a/apps/api/src/data-plane/llm/sources/gemini/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/traits.ts
@@ -114,24 +114,6 @@ const geminiGenerate: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamEven
   },
 };
 
-// count_tokens accepts either a bare `{ contents }` or the full
-// `{ generateContentRequest }` form. It cannot run the streaming
-// source-interceptor pipeline, so the few normalizations that path applies via
-// interceptors are done inline below, then it translates to Messages and counts
-// via `messages_count_tokens`.
-interface GeminiCountTokensRequest {
-  contents?: GeminiContent[];
-  generateContentRequest?: GeminiPayload;
-}
-
-const totalTokensFromUpstream = (value: unknown): number | null => {
-  if (!value || typeof value !== 'object') return null;
-  const payload = value as { input_tokens?: unknown; total_tokens?: unknown };
-  if (typeof payload.input_tokens === 'number') return payload.input_tokens;
-  if (typeof payload.total_tokens === 'number') return payload.total_tokens;
-  return null;
-};
-
 const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamEvent> = {
   respond: async ({ c, result, runtime }) =>
     await respondGemini(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
@@ -139,7 +121,7 @@ const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamE
     const parsed = parseGeminiModelAction(c.req.param('modelAction'));
     if (parsed instanceof Response) return parsed;
     const request = createHttpRequestContext(c, undefined, false);
-    const body = await c.req.json<GeminiCountTokensRequest>();
+    const body = await c.req.json<{ contents?: GeminiContent[]; generateContentRequest?: GeminiPayload }>();
     const generateContentRequest = body.generateContentRequest ?? { contents: body.contents };
     return {
       request,
@@ -162,18 +144,7 @@ const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamE
         // so strip it before sending. The events translator never runs.
         const { target } = await translateGeminiViaMessages(countRequest, { model: resolvedModelId, fallbackMaxOutputTokens: binding.upstreamModel.limits.max_output_tokens });
         const { stream: _stream, ...countPayload } = target;
-        const invocation: MessagesInvocation = {
-          sourceApi: 'gemini',
-          targetApi: 'messages',
-          model: resolvedModelId,
-          upstream: binding.upstream,
-          upstreamModel: binding.upstreamModel,
-          provider: binding.provider,
-          enabledFlags: binding.enabledFlags,
-          ...(binding.targetInterceptors !== undefined ? { targetInterceptors: binding.targetInterceptors } : {}),
-          payload: countPayload,
-          headers: {},
-        };
+        const invocation: MessagesInvocation = geminiInvocation(binding, 'messages', resolvedModelId, countPayload);
         const response = await runInterceptors(invocation, request, invocation.targetInterceptors?.messagesCountTokens ?? [], async () => {
           const { model: _model, ...callBody } = invocation.payload;
           const result = await binding.provider.callMessagesCountTokens(invocation.upstreamModel, callBody, undefined, invocation.headers);
@@ -183,7 +154,15 @@ const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamE
           const text = await response.text();
           return await plainResultFromResponse(geminiRpcErrorResponse(response.status, text || 'Upstream token counting request failed.'));
         }
-        const totalTokens = totalTokensFromUpstream(await response.json());
+        const upstreamCount = await response.json();
+        const upstreamTokenCounts = upstreamCount && typeof upstreamCount === 'object'
+          ? upstreamCount as { input_tokens?: unknown; total_tokens?: unknown }
+          : {};
+        const totalTokens = typeof upstreamTokenCounts.input_tokens === 'number'
+          ? upstreamTokenCounts.input_tokens
+          : typeof upstreamTokenCounts.total_tokens === 'number'
+            ? upstreamTokenCounts.total_tokens
+            : null;
         if (totalTokens === null) return await plainResultFromResponse(geminiInternalRpcErrorResponse(502, new Error('Invalid upstream token counting response.')));
         return plainResult(200, new Headers({ 'content-type': 'application/json' }), new TextEncoder().encode(JSON.stringify({ totalTokens })));
       },

--- a/apps/api/src/data-plane/llm/sources/gemini/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/traits.ts
@@ -147,7 +147,7 @@ const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamE
         const invocation: MessagesInvocation = geminiInvocation(binding, 'messages', resolvedModelId, countPayload);
         const response = await runInterceptors(invocation, request, invocation.targetInterceptors?.messagesCountTokens ?? [], async () => {
           const { model: _model, ...callBody } = invocation.payload;
-          const result = await invocation.provider.callMessagesCountTokens(invocation.upstreamModel, callBody, undefined, invocation.headers);
+          const result = await invocation.provider.callMessagesCountTokens(invocation.upstreamModel, callBody, undefined, invocation.headers, invocation.anthropicBeta);
           return result.response;
         });
         if (!response.ok) {

--- a/apps/api/src/data-plane/llm/sources/messages/count-tokens_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/count-tokens_test.ts
@@ -237,9 +237,11 @@ test('/v1/messages/count_tokens rewrites stored Responses reasoning signatures b
       upstreamId: 'up_count_origin',
       upstreamItemId: 'raw_rs_count',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 

--- a/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
@@ -51,6 +51,7 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
 
 const requestContext = (apiKeyId?: string): RequestContext => ({
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: false,

--- a/apps/api/src/data-plane/llm/sources/messages/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/serve_test.ts
@@ -348,9 +348,11 @@ test('/v1/messages rewrites stored Responses reasoning signatures before the ups
       upstreamId: 'up_messages_origin',
       upstreamItemId: 'raw_rs_messages',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 

--- a/apps/api/src/data-plane/llm/sources/messages/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/traits.ts
@@ -6,9 +6,9 @@ import type { ExecuteResult } from '../../shared/errors/result.ts';
 import { emitToChatCompletions } from '../../targets/chat-completions/emit.ts';
 import { emitToMessages } from '../../targets/messages/emit.ts';
 import { emitToResponses } from '../../targets/responses/emit.ts';
-import { createRequestContext } from '../request-context.ts';
+import { createHttpRequestContext } from '../request-context.ts';
 import { plainResultFromResponse } from '../respond.ts';
-import { type LlmEndpoint, type LlmEndpointName, jsonUpstreamErrorResult, sourceErrorResult, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
+import { type LlmEndpointName, type LlmHttpEndpoint, jsonUpstreamErrorResult, sourceErrorResult, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesMessage, MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -105,16 +105,16 @@ const renderMessagesFailure = (failure: LlmServeFailure, endpoint: LlmEndpointNa
   return jsonUpstreamErrorResult(status, body);
 };
 
-const messagesGenerate: LlmEndpoint<readonly MessagesMessage[], MessagesStreamEvent> = {
-  respond: async ({ c, result, request, wantsStream, downstreamAbortController }) =>
-    await respondMessages(c, result, wantsStream, request, downstreamAbortController),
-  setup: async c => {
+const messagesGenerate: LlmHttpEndpoint<readonly MessagesMessage[], MessagesStreamEvent> = {
+  respond: async ({ c, result, runtime }) =>
+    await respondMessages(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
+  prepare: async c => {
     const payload = await c.req.json<MessagesPayload>();
     const rejectedBetaParam = bodyBetaParam(payload);
     if (rejectedBetaParam) return bodyAnthropicBetaResponse(rejectedBetaParam);
     const wantsStream = payload.stream === true;
     const downstreamAbortController = wantsStream ? new AbortController() : undefined;
-    const request = createRequestContext(c, downstreamAbortController?.signal, wantsStream);
+    const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream);
     const anthropicBeta = parseAnthropicBeta(c.req.header('anthropic-beta'));
     return {
       request,
@@ -150,14 +150,14 @@ const messagesGenerate: LlmEndpoint<readonly MessagesMessage[], MessagesStreamEv
 // measurement, not a stream: it gates on the `messages.countTokens` upstream
 // capability, calls that endpoint through the same count_tokens interceptors,
 // and proxies the upstream body back as a plain result.
-const messagesCountTokens: LlmEndpoint<readonly MessagesMessage[], MessagesStreamEvent> = {
-  respond: async ({ c, result, request, wantsStream, downstreamAbortController }) =>
-    await respondMessages(c, result, wantsStream, request, downstreamAbortController),
-  setup: async c => {
+const messagesCountTokens: LlmHttpEndpoint<readonly MessagesMessage[], MessagesStreamEvent> = {
+  respond: async ({ c, result, runtime }) =>
+    await respondMessages(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
+  prepare: async c => {
     const payload = await c.req.json<MessagesPayload>();
     const rejectedBetaParam = bodyBetaParam(payload);
     if (rejectedBetaParam) return bodyAnthropicBetaResponse(rejectedBetaParam);
-    const request = createRequestContext(c, undefined, false);
+    const request = createHttpRequestContext(c, undefined, false);
     const anthropicBeta = parseAnthropicBeta(c.req.header('anthropic-beta'));
     return {
       request,

--- a/apps/api/src/data-plane/llm/sources/messages/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/traits.ts
@@ -16,7 +16,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { type SourceEmit, translateMessagesViaChatCompletions, translateMessagesViaResponses, viaTranslation } from '@floway-dev/translate';
 import { messagesViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
-export const parseAnthropicBeta = (raw: string | undefined): string[] | undefined => {
+const parseAnthropicBeta = (raw: string | undefined): string[] | undefined => {
   if (!raw) return undefined;
   const values = raw
     .split(',')
@@ -25,14 +25,14 @@ export const parseAnthropicBeta = (raw: string | undefined): string[] | undefine
   return values.length > 0 ? values : undefined;
 };
 
-export const bodyBetaParam = (payload: MessagesPayload): string | undefined => {
+const bodyBetaParam = (payload: MessagesPayload): string | undefined => {
   const record = payload as unknown as Record<string, unknown>;
   if (Object.hasOwn(record, 'anthropic_beta')) return 'anthropic_beta';
   if (Object.hasOwn(record, 'betas')) return 'betas';
   return undefined;
 };
 
-export const bodyAnthropicBetaResponse = (param: string): Response =>
+const bodyAnthropicBetaResponse = (param: string): Response =>
   Response.json(
     {
       error: {
@@ -80,28 +80,18 @@ const messagesInvocation = <TPayload extends { model: string }>(
   ...(anthropicBeta !== undefined ? { anthropicBeta } : {}),
 });
 
-// Maps a serve failure to the Messages (Anthropic) error envelope, shared with
-// the count_tokens path which answers in the same shape under a different
-// endpoint label. `internal` is excluded — it is rendered with a stack trace by
-// the caller, not as a flat envelope.
-export const messagesFailureEnvelope = (
-  failure: Exclude<LlmServeFailure, { kind: 'internal' }>,
-  endpoint: string,
-): { status: number; body: { type: 'error'; error: { type: string; message: string } } } => {
+const renderMessagesFailure = (failure: LlmServeFailure, endpoint: LlmEndpointName): ExecuteResult<ProtocolFrame<MessagesStreamEvent>> => {
+  if (failure.kind === 'internal') return sourceErrorResult<MessagesStreamEvent>(failure.error, { sourceApi: 'messages', internalStatus: 502 });
+  const endpointPath = endpoint === 'countTokens' ? '/messages/count_tokens' : '/messages';
   const [status, type, message]: [number, string, string] = (() => {
     switch (failure.kind) {
     case 'item-not-found': return [400, 'invalid_request_error', `Item with id '${failure.itemId}' not found.`];
     case 'routing-unavailable': return [400, 'invalid_request_error', failure.message];
     case 'model-missing': return [404, 'not_found_error', `Model ${failure.model} is not available on any configured upstream.`];
-    case 'model-unsupported': return [400, 'invalid_request_error', `Model ${failure.model} does not support the ${endpoint} endpoint.`];
+    case 'model-unsupported': return [400, 'invalid_request_error', `Model ${failure.model} does not support the ${endpointPath} endpoint.`];
     }
   })();
-  return { status, body: { type: 'error', error: { type, message } } };
-};
-
-const renderMessagesFailure = (failure: LlmServeFailure, endpoint: LlmEndpointName): ExecuteResult<ProtocolFrame<MessagesStreamEvent>> => {
-  if (failure.kind === 'internal') return sourceErrorResult<MessagesStreamEvent>(failure.error, { sourceApi: 'messages', internalStatus: 502 });
-  const { status, body } = messagesFailureEnvelope(failure, endpoint === 'countTokens' ? '/messages/count_tokens' : '/messages');
+  const body = { type: 'error', error: { type, message } };
   return jsonUpstreamErrorResult(status, body);
 };
 

--- a/apps/api/src/data-plane/llm/sources/messages/traits_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/traits_test.ts
@@ -1,15 +1,19 @@
 import { test } from 'vitest';
 
-import { messagesFailureEnvelope } from './traits.ts';
+import { messagesTraits } from './traits.ts';
 import { assertEquals } from '../../../../test-assert.ts';
 
 // The same `LlmServeFailure` the Responses source renders as an OpenAI body must
 // answer in the Anthropic envelope here, never borrowing OpenAI's shape — the
 // failure carries no pre-shaped body, so each protocol owns its own rendering.
 
+const decodeUpstreamError = (result: ReturnType<typeof messagesTraits.renderFailure>) => {
+  if (result.type !== 'upstream-error') throw new Error(`expected upstream-error, got ${result.type}`);
+  return { status: result.status, body: JSON.parse(new TextDecoder().decode(result.body)) as unknown };
+};
+
 test('Messages renders item-not-found in the Anthropic envelope', () => {
-  assertEquals(messagesFailureEnvelope({ kind: 'item-not-found', itemId: 'rs_x' }, '/messages'), {
-    status: 400,
-    body: { type: 'error', error: { type: 'invalid_request_error', message: "Item with id 'rs_x' not found." } },
-  });
+  const { status, body } = decodeUpstreamError(messagesTraits.renderFailure({ kind: 'item-not-found', itemId: 'rs_x' }, 'generate'));
+  assertEquals(status, 400);
+  assertEquals(body, { type: 'error', error: { type: 'invalid_request_error', message: "Item with id 'rs_x' not found." } });
 });

--- a/apps/api/src/data-plane/llm/sources/request-context.ts
+++ b/apps/api/src/data-plane/llm/sources/request-context.ts
@@ -1,22 +1,39 @@
 import type { Context } from 'hono';
 
-import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
+import { backgroundSchedulerFromContext, type BackgroundScheduler } from '../../../runtime/background.ts';
 import { runtimeLocationFromRequest } from '../../shared/telemetry/performance.ts';
 import type { RequestContext } from '../interceptors.ts';
 
-export const createRequestContext = (c: Context, downstreamAbortSignal: AbortSignal | undefined, clientStream: boolean): RequestContext => {
+export interface CreateRequestContextInput {
+  apiKeyId?: string;
+  apiKeyUpstreamIds?: readonly string[] | null;
+  runtimeLocation: string;
+  scheduleBackground?: BackgroundScheduler;
+  downstreamAbortSignal?: AbortSignal;
+  clientStream: boolean;
+}
+
+export const createRequestContext = (input: CreateRequestContextInput): RequestContext => ({
+  requestStartedAt: performance.now(),
+  ...(input.apiKeyId !== undefined ? { apiKeyId: input.apiKeyId } : {}),
+  apiKeyUpstreamIds: input.apiKeyUpstreamIds ?? null,
+  runtimeLocation: input.runtimeLocation,
+  ...(input.scheduleBackground !== undefined ? { scheduleBackground: input.scheduleBackground } : {}),
+  clientStream: input.clientStream,
+  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
+  ...(input.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: input.downstreamAbortSignal } : {}),
+});
+
+export const createHttpRequestContext = (c: Context, downstreamAbortSignal: AbortSignal | undefined, clientStream: boolean): RequestContext => {
   const apiKeyId = c.get('apiKeyId') as string | undefined;
   const apiKeyUpstreamIds = c.get('apiKeyUpstreamIds') as readonly string[] | null | undefined;
   const scheduleBackground = backgroundSchedulerFromContext(c);
-
-  return {
-    requestStartedAt: performance.now(),
-    apiKeyId,
-    apiKeyUpstreamIds: apiKeyUpstreamIds ?? null,
+  return createRequestContext({
+    ...(apiKeyId !== undefined ? { apiKeyId } : {}),
+    ...(apiKeyUpstreamIds !== undefined ? { apiKeyUpstreamIds } : {}),
     runtimeLocation: runtimeLocationFromRequest(c.req.raw),
-    scheduleBackground,
+    ...(scheduleBackground !== undefined ? { scheduleBackground } : {}),
     clientStream,
-    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
     ...(downstreamAbortSignal !== undefined ? { downstreamAbortSignal } : {}),
-  };
+  });
 };

--- a/apps/api/src/data-plane/llm/sources/request-context.ts
+++ b/apps/api/src/data-plane/llm/sources/request-context.ts
@@ -1,39 +1,21 @@
 import type { Context } from 'hono';
 
-import { backgroundSchedulerFromContext, type BackgroundScheduler } from '../../../runtime/background.ts';
+import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { runtimeLocationFromRequest } from '../../shared/telemetry/performance.ts';
 import type { RequestContext } from '../interceptors.ts';
-
-export interface CreateRequestContextInput {
-  apiKeyId?: string;
-  apiKeyUpstreamIds?: readonly string[] | null;
-  runtimeLocation: string;
-  scheduleBackground?: BackgroundScheduler;
-  downstreamAbortSignal?: AbortSignal;
-  clientStream: boolean;
-}
-
-export const createRequestContext = (input: CreateRequestContextInput): RequestContext => ({
-  requestStartedAt: performance.now(),
-  ...(input.apiKeyId !== undefined ? { apiKeyId: input.apiKeyId } : {}),
-  apiKeyUpstreamIds: input.apiKeyUpstreamIds ?? null,
-  runtimeLocation: input.runtimeLocation,
-  ...(input.scheduleBackground !== undefined ? { scheduleBackground: input.scheduleBackground } : {}),
-  clientStream: input.clientStream,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
-  ...(input.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: input.downstreamAbortSignal } : {}),
-});
 
 export const createHttpRequestContext = (c: Context, downstreamAbortSignal: AbortSignal | undefined, clientStream: boolean): RequestContext => {
   const apiKeyId = c.get('apiKeyId') as string | undefined;
   const apiKeyUpstreamIds = c.get('apiKeyUpstreamIds') as readonly string[] | null | undefined;
   const scheduleBackground = backgroundSchedulerFromContext(c);
-  return createRequestContext({
+  return {
+    requestStartedAt: performance.now(),
     ...(apiKeyId !== undefined ? { apiKeyId } : {}),
-    ...(apiKeyUpstreamIds !== undefined ? { apiKeyUpstreamIds } : {}),
+    apiKeyUpstreamIds: apiKeyUpstreamIds ?? null,
     runtimeLocation: runtimeLocationFromRequest(c.req.raw),
     ...(scheduleBackground !== undefined ? { scheduleBackground } : {}),
     clientStream,
+    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
     ...(downstreamAbortSignal !== undefined ? { downstreamAbortSignal } : {}),
-  });
+  };
 };

--- a/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
+++ b/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
@@ -121,6 +121,7 @@ const testTelemetryModelIdentity = {
 const requestStartedAt = performance.now();
 const request = (): RequestContext => ({
   requestStartedAt,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: true,

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
@@ -329,6 +329,7 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
 
 const makeRequest = (apiKeyId: string | undefined = 'k1'): RequestContext => ({
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: true,
@@ -4470,6 +4471,7 @@ test('downstream AbortSignal threads through to provider search / fetchPage and 
   const inv = makeInvocation();
   const request: RequestContext = {
     requestStartedAt: 0,
+    apiKeyUpstreamIds: null,
     statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
     runtimeLocation: 'test',
     clientStream: true,

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -116,7 +116,7 @@ const makeCtx = (input: unknown[], action: 'generate' | 'edit' | 'auto' = 'auto'
   enabledFlags: new Set<string>(['responses-image-generation-shim']), headers: {},
   payload: { model: 'orchestrator', input, tools: [{ type: 'image_generation', action, ...extraTool }] } as never,
 });
-const REQ = { requestStartedAt: 0, runtimeLocation: 'test', clientStream: true, statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() } } as RequestContext;
+const REQ = { requestStartedAt: 0, apiKeyUpstreamIds: null, runtimeLocation: 'test', clientStream: true, statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() } } as RequestContext;
 
 const drain = async (result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesStreamEvent[]> => {
   if (result.type !== 'events') throw new Error(`expected events, got ${result.type}`);

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation_test.ts
@@ -37,7 +37,7 @@ const makeCtx = (payload: Partial<ResponsesPayload>): ResponsesInvocation => ({
   headers: {},
   payload: { model: 'm', input: [], ...payload } as ResponsesPayload,
 });
-const REQ = { requestStartedAt: 0, runtimeLocation: 'test', clientStream: true } as RequestContext;
+const REQ = { requestStartedAt: 0, apiKeyUpstreamIds: null, runtimeLocation: 'test', clientStream: true } as RequestContext;
 
 const imageMessage = (mime: string): ResponsesInputItem => ({
   type: 'message', role: 'user', content: [{ type: 'input_image', image_url: `data:${mime};base64,${PNG_B64}`, detail: 'auto' }],

--- a/apps/api/src/data-plane/llm/sources/responses/items/image-generation-replay_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/image-generation-replay_test.ts
@@ -43,9 +43,11 @@ test('a stored image_generation_call referenced by id is inline-expanded with it
     upstreamId: null, // synthetic / portable — no upstream owns it
     upstreamItemId: null,
     itemType: 'image_generation_call',
+    origin: 'synthetic',
     payload: { item: { type: 'image_generation_call', id: storedId, status: 'completed', result: PNG_B64, revised_prompt: 'a cat', output_format: 'png' } },
     encryptedContentHash: null,
     createdAt: Date.now(),
+    refreshedAt: Date.now(),
   };
   const repo = new InMemoryRepo();
   initRepo(repo);

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -96,8 +96,41 @@ export const storeResponsesOutputItems = <TFrame>(
   };
 
   const buffer: StoredResponsesItem[] = [];
+
+  const buildRow = async (newId: string, originalItem: ResponsesInputItem): Promise<StoredResponsesItem> => {
+    const upstreamId = responsesItemId(originalItem);
+    if (upstreamId === null) {
+      throw new Error(`Cannot persist Responses item without an upstream id (newId=${newId}, type=${originalItem.type})`);
+    }
+    // A native Responses upstream owns its items — except those a source
+    // interceptor synthesized this request, whose gateway-minted ids the
+    // upstream never issued. Those persist with no upstream identity so they
+    // stay non_affinity.
+    const upstreamOwned = context.targetApi === 'responses' && !request.statefulResponsesContext.newSyntheticIds.has(upstreamId);
+    const encryptedContent = responsesItemEncryptedContent(originalItem);
+    // Source interceptors register the per-item server-only payload under the
+    // wire id transformItems sees; the same id is `upstreamId` here. Attaching
+    // it lets a later turn restore the real success/failure state even when the
+    // client stripped fields from the echoed wire item.
+    const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
+    const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
+    const now = Date.now();
+    return {
+      id: newId,
+      apiKeyId: request.apiKeyId ?? null,
+      upstreamId: upstreamOwned ? context.upstream : null,
+      upstreamItemId: upstreamOwned ? upstreamId : null,
+      itemType: originalItem.type,
+      origin: upstreamOwned ? 'upstream' : 'synthetic',
+      payload: context.store === false ? null : persistedPayload,
+      encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
+      createdAt: now,
+      refreshedAt: now,
+    };
+  };
+
   const onItemFinalized: ResponsesItemFinalizedHandler = async (originalItem, newId) => {
-    const row = await buildRow(newId, originalItem, context, request);
+    const row = await buildRow(newId, originalItem);
     if (wantsStream) await insertStoredItems([row]);
     else buffer.push(row);
   };
@@ -107,41 +140,4 @@ export const storeResponsesOutputItems = <TFrame>(
   const commitForNonStreaming = wantsStream ? undefined : (): Promise<void> => insertStoredItems(buffer);
 
   return { events: view.streamMapIdAsResponsesItems(frames, idMapper, onItemFinalized), commitForNonStreaming };
-};
-
-const buildRow = async (
-  newId: string,
-  originalItem: ResponsesInputItem,
-  context: StoreResponsesContext,
-  request: RequestContext,
-): Promise<StoredResponsesItem> => {
-  const upstreamId = responsesItemId(originalItem);
-  if (upstreamId === null) {
-    throw new Error(`Cannot persist Responses item without an upstream id (newId=${newId}, type=${originalItem.type})`);
-  }
-  // A native Responses upstream owns its items — except those a source
-  // interceptor synthesized this request, whose gateway-minted ids the
-  // upstream never issued. Those persist with no upstream identity so they
-  // stay non_affinity.
-  const upstreamOwned = context.targetApi === 'responses' && !request.statefulResponsesContext.newSyntheticIds.has(upstreamId);
-  const encryptedContent = responsesItemEncryptedContent(originalItem);
-  // Source interceptors register the per-item server-only payload under the
-  // wire id transformItems sees; the same id is `upstreamId` here. Attaching
-  // it lets a later turn restore the real success/failure state even when the
-  // client stripped fields from the echoed wire item.
-  const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
-  const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
-  const now = Date.now();
-  return {
-    id: newId,
-    apiKeyId: request.apiKeyId ?? null,
-    upstreamId: upstreamOwned ? context.upstream : null,
-    upstreamItemId: upstreamOwned ? upstreamId : null,
-    itemType: originalItem.type,
-    origin: upstreamOwned ? 'upstream' : 'synthetic',
-    payload: context.store === false ? null : persistedPayload,
-    encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
-    createdAt: now,
-    refreshedAt: now,
-  };
 };

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -131,14 +131,17 @@ const buildRow = async (
   // client stripped fields from the echoed wire item.
   const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
   const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
+  const now = Date.now();
   return {
     id: newId,
     apiKeyId: request.apiKeyId ?? null,
     upstreamId: upstreamOwned ? context.upstream : null,
     upstreamItemId: upstreamOwned ? upstreamId : null,
     itemType: originalItem.type,
+    origin: upstreamOwned ? 'upstream' : 'synthetic',
     payload: context.store === false ? null : persistedPayload,
     encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
-    createdAt: Date.now(),
+    createdAt: now,
+    refreshedAt: now,
   };
 };

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -28,6 +28,7 @@ const makeRequest = (
   privatePayloads: Iterable<readonly [string, unknown]> = [],
 ): RequestContext => ({
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   apiKeyId,
   runtimeLocation: 'test',
   clientStream: true,

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -118,6 +118,10 @@ class ControlledResponsesItemsRepo implements ResponsesItemsRepo {
     });
   }
 
+  refreshMany(): Promise<number> {
+    return Promise.resolve(0);
+  }
+
   clearPayloadOlderThan(): Promise<number> {
     return Promise.resolve(0);
   }

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
@@ -67,9 +67,15 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
     getRepo().responsesItems.lookupManyByEncryptedContentHash(apiKeyId, [...new Set(hashByContent.values())]),
   ]);
   const rowById = new Map(byId.map(row => [row.id, row]));
-  const rowByHash = new Map(byHash.flatMap(row => row.encryptedContentHash !== null ? [[row.encryptedContentHash, row] as const] : []));
+  const rowByHash = new Map<string, StoredResponsesItem>();
+  for (const row of byHash) {
+    if (row.encryptedContentHash !== null && !rowByHash.has(row.encryptedContentHash)) {
+      rowByHash.set(row.encryptedContentHash, row);
+    }
+  }
 
   const failures: StoredResponsesItemsFailure[] = [];
+  const touchedIds = new Set<string>();
   for (const ref of references) {
     const row = (ref.id !== undefined ? rowById.get(ref.id) : undefined)
       ?? (ref.encryptedContent !== undefined ? rowByHash.get(hashByContent.get(ref.encryptedContent)!) : undefined);
@@ -84,6 +90,7 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
     }
 
     ref.row = row;
+    touchedIds.add(row.id);
     if (ref.type === 'item_reference' && row.payload === null && row.upstreamItemId === null) {
       failures.push({ kind: 'item-not-found', itemId: row.id });
       continue;
@@ -100,6 +107,7 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
       failures.push({ kind: 'item-not-found', itemId: row.id });
     }
   }
+  if (touchedIds.size > 0) await getRepo().responsesItems.refreshMany(apiKeyId, [...touchedIds], Date.now());
 
   return {
     references,

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
@@ -43,6 +43,7 @@ const insertRows = async (rows: readonly StoredResponsesItem[]) => {
   const repo = new InMemoryRepo();
   initRepo(repo);
   await repo.responsesItems.insertMany(rows);
+  return repo;
 };
 
 const prepareResponsesItems = async (sourceItems: string | readonly ResponsesInputItem[]) =>
@@ -493,6 +494,35 @@ test('id-less reasoning is matched by encrypted_content hash and prefers its own
   // Routed elsewhere (owner unavailable): the blob would not verify, so the
   // reasoning item is dropped rather than carried.
   assertEquals(await rewriteResponsesItems(items, prepared, provider('up_b')), []);
+});
+
+test('matched stored items are refreshed during preparation', async () => {
+  const id = storedReasoningId('refresh');
+  const repo = await insertRows([
+    storedRow({ id, itemType: 'reasoning', upstreamId: 'up_a', upstreamItemId: 'raw_rs_a', payload: null, createdAt: 1_000, refreshedAt: 1_000 }),
+  ]);
+
+  await prepareResponsesItems([{ type: 'item_reference', id }]);
+
+  const [row] = await repo.responsesItems.lookupMany(API_KEY_ID, [id]);
+  assert(row.refreshedAt > 1_000);
+});
+
+test('id-less encrypted_content duplicate hash keeps the freshest stored row', async () => {
+  const enc = 'duplicate-enc';
+  const hash = await hashResponsesItemEncryptedContent(enc);
+  await insertRows([
+    storedRow({ id: storedReasoningId('old'), itemType: 'reasoning', upstreamId: 'up_old', upstreamItemId: 'raw_old', encryptedContentHash: hash, payload: null, createdAt: 1_000, refreshedAt: 1_000 }),
+    storedRow({ id: storedReasoningId('new'), itemType: 'reasoning', upstreamId: 'up_new', upstreamItemId: 'raw_new', encryptedContentHash: hash, payload: null, createdAt: 2_000, refreshedAt: 2_000 }),
+  ]);
+
+  const items = [{ type: 'reasoning', summary: [], encrypted_content: enc }] as unknown as ResponsesInputItem[];
+  const prepared = await prepareResponsesItems(items);
+  const plan = planResponsesItemProviders([provider('up_old'), provider('up_new')], prepared);
+
+  assertEquals(plan.type, 'providers');
+  if (plan.type === 'providers') assertEquals(plan.providers.map(item => item.upstream), ['up_new', 'up_old']);
+  assertEquals(await rewriteResponsesItems(items, prepared, provider('up_new')), [{ type: 'reasoning', summary: [], encrypted_content: enc, id: 'raw_new' }]);
 });
 
 test('id-less compaction is matched by encrypted_content hash and forces its owning upstream', async () => {

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
@@ -80,6 +80,7 @@ const storedRow = (
     apiKeyId: API_KEY_ID,
     upstreamId: null,
     upstreamItemId: null,
+    origin: overrides.origin ?? (overrides.upstreamId === undefined || overrides.upstreamId === null ? 'synthetic' : 'upstream'),
     encryptedContentHash: null,
     payload: payload === undefined || payload === null
       ? null
@@ -87,6 +88,7 @@ const storedRow = (
         ? payload as StoredResponsesItem['payload']
         : { item: payload },
     createdAt: 1_000,
+    refreshedAt: 1_000,
     ...rest,
   };
 };

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -138,11 +138,13 @@ test('/v1/responses expands stored synthetic item_reference before the upstream 
       upstreamId: null,
       upstreamItemId: null,
       itemType: 'message',
+      origin: 'synthetic',
       encryptedContentHash: null,
       // payload.item.id is the original wire id, distinct from the stored row
       // id; the rewriter preserves it verbatim on the wire for synthetic rows.
       payload: { item: storedItem },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -225,9 +227,11 @@ test('/v1/responses expands same-origin item_reference for Copilot because Copil
       upstreamId: copilotUpstream.id,
       upstreamItemId: 'raw_msg_copilot',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -307,9 +311,11 @@ test('/v1/responses rejects metadata-only item_reference for Copilot before upst
       upstreamId: copilotUpstream.id,
       upstreamItemId: 'raw_msg_copilot_metadata',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: null,
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
   let generationFetchCalls = 0;
@@ -397,9 +403,11 @@ test('/v1/responses prefers latest portable stored-item origin and rewrites only
       upstreamId: 'up_a',
       upstreamItemId: 'raw_rs_a',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
     {
       id: secondId,
@@ -407,9 +415,11 @@ test('/v1/responses prefers latest portable stored-item origin and rewrites only
       upstreamId: 'up_b',
       upstreamItemId: 'raw_rs_b',
       itemType: 'reasoning',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -498,9 +508,11 @@ test('/v1/responses falls back with portable non-origin message items using temp
       upstreamId: 'up_a',
       upstreamItemId: 'raw_msg_a',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
     {
       id: secondId,
@@ -508,9 +520,11 @@ test('/v1/responses falls back with portable non-origin message items using temp
       upstreamId: 'up_b',
       upstreamItemId: 'raw_msg_b',
       itemType: 'message',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
 
@@ -584,9 +598,11 @@ test('/v1/responses rejects multiple forcing stored-item origins before generati
       upstreamId: 'up_a',
       upstreamItemId: 'raw_cmp_a',
       itemType: 'compaction',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
     {
       id: secondId,
@@ -594,9 +610,11 @@ test('/v1/responses rejects multiple forcing stored-item origins before generati
       upstreamId: 'up_b',
       upstreamItemId: 'raw_cmp_b',
       itemType: 'compaction',
+      origin: 'upstream',
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
+      refreshedAt: Date.now(),
     },
   ]);
   let generationFetchCalls = 0;

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -15,23 +15,6 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 import { type SourceEmit, translateResponsesViaChatCompletions, translateResponsesViaMessages, viaTranslation } from '@floway-dev/translate';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
-const rewriteResponsesEntryModelAlias = (payload: ResponsesPayload): ResponsesPayload => {
-  if (payload.model !== 'codex-auto-review') return payload;
-
-  // TODO: Replace this source-entry hardcode with generic model alias support.
-  // Codex sends auto-review requests over the Responses wire API, so rewriting
-  // here keeps downstream routing, performance telemetry, and usage accounting
-  // on the real model name.
-  // References:
-  // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/model-provider/src/provider.rs#L73-L96
-  // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/codex-api/src/endpoint/responses.rs#L102-L134
-  return {
-    ...payload,
-    model: 'gpt-5.4',
-    reasoning: { ...(payload.reasoning ?? {}), effort: 'low' },
-  };
-};
-
 const responsesInvocation = <TPayload extends { model: string }>(
   binding: ProviderModelRecord,
   targetApi: LlmTargetApi,
@@ -75,7 +58,7 @@ const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[],
   respond: async ({ c, result, runtime }) =>
     await respondResponses(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
   prepare: async c => {
-    const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>());
+    const sourcePayload = await c.req.json<ResponsesPayload>();
     // previous_response_id relies on server-side conversation state that this
     // gateway does not implement. Stored Responses item ids are handled below; a
     // plain previous response pointer still gets OpenAI's not-found contract so
@@ -85,11 +68,11 @@ const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[],
     // - https://github.com/microsoft/semantic-kernel/issues/13128
     // - https://github.com/router-for-me/CLIProxyAPI/issues/999
     // - https://github.com/openai/openai-agents-python/issues/2020
-    if (payload.previous_response_id !== undefined && payload.previous_response_id !== null) {
+    if (sourcePayload.previous_response_id !== undefined && sourcePayload.previous_response_id !== null) {
       return Response.json(
         {
           error: {
-            message: `Previous response with id '${payload.previous_response_id}' not found.`,
+            message: `Previous response with id '${sourcePayload.previous_response_id}' not found.`,
             type: 'invalid_request_error',
             param: 'previous_response_id',
             code: 'previous_response_not_found',
@@ -98,6 +81,20 @@ const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[],
         { status: 400 },
       );
     }
+    // TODO: Replace this source-entry hardcode with generic model alias support.
+    // Codex sends auto-review requests over the Responses wire API, so rewriting
+    // here keeps downstream routing, performance telemetry, and usage accounting
+    // on the real model name.
+    // References:
+    // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/model-provider/src/provider.rs#L73-L96
+    // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/codex-api/src/endpoint/responses.rs#L102-L134
+    const payload: ResponsesPayload = sourcePayload.model === 'codex-auto-review'
+      ? {
+          ...sourcePayload,
+          model: 'gpt-5.4',
+          reasoning: { ...(sourcePayload.reasoning ?? {}), effort: 'low' },
+        }
+      : sourcePayload;
     const wantsStream = payload.stream === true;
     const downstreamAbortController = wantsStream ? new AbortController() : undefined;
     const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream);

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -6,8 +6,8 @@ import type { ExecuteResult } from '../../shared/errors/result.ts';
 import { emitToChatCompletions } from '../../targets/chat-completions/emit.ts';
 import { emitToMessages } from '../../targets/messages/emit.ts';
 import { emitToResponses } from '../../targets/responses/emit.ts';
-import { createRequestContext } from '../request-context.ts';
-import { jsonUpstreamErrorResult, sourceErrorResult, type LlmEndpoint, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
+import { createHttpRequestContext } from '../request-context.ts';
+import { jsonUpstreamErrorResult, sourceErrorResult, type LlmHttpEndpoint, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
@@ -100,16 +100,16 @@ const renderResponsesFailure = (failure: LlmServeFailure): ExecuteResult<Protoco
   }
 };
 
-const responsesGenerate: LlmEndpoint<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> = {
-  respond: async ({ c, result, request, wantsStream, downstreamAbortController }) =>
-    await respondResponses(c, result, wantsStream, request, downstreamAbortController),
-  setup: async c => {
+const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> = {
+  respond: async ({ c, result, runtime }) =>
+    await respondResponses(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
+  prepare: async c => {
     const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>());
     const notFound = previousResponseNotFoundResponse(payload);
     if (notFound) return notFound;
     const wantsStream = payload.stream === true;
     const downstreamAbortController = wantsStream ? new AbortController() : undefined;
-    const request = createRequestContext(c, downstreamAbortController?.signal, wantsStream);
+    const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream);
     return {
       request,
       items: payload.input,

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -15,37 +15,8 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 import { type SourceEmit, translateResponsesViaChatCompletions, translateResponsesViaMessages, viaTranslation } from '@floway-dev/translate';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
-const CODEX_AUTO_REVIEW_ALIAS = 'codex-auto-review';
-const CODEX_AUTO_REVIEW_TARGET = 'gpt-5.4';
-
-// previous_response_id relies on server-side conversation state that this
-// gateway does not implement. Stored Responses item ids are handled below; a
-// plain previous response pointer still gets OpenAI's not-found contract so
-// clients that retry with full input can keep using their existing fallback.
-// Verbatim payloads cross-verified from real upstream captures:
-// - https://github.com/cline/cline/issues/9399
-// - https://github.com/microsoft/semantic-kernel/issues/13128
-// - https://github.com/router-for-me/CLIProxyAPI/issues/999
-// - https://github.com/openai/openai-agents-python/issues/2020
-const previousResponseNotFoundResponse = (payload: ResponsesPayload): Response | undefined => {
-  if (payload.previous_response_id !== undefined && payload.previous_response_id !== null) {
-    return Response.json(
-      {
-        error: {
-          message: `Previous response with id '${payload.previous_response_id}' not found.`,
-          type: 'invalid_request_error',
-          param: 'previous_response_id',
-          code: 'previous_response_not_found',
-        },
-      },
-      { status: 400 },
-    );
-  }
-  return undefined;
-};
-
 const rewriteResponsesEntryModelAlias = (payload: ResponsesPayload): ResponsesPayload => {
-  if (payload.model !== CODEX_AUTO_REVIEW_ALIAS) return payload;
+  if (payload.model !== 'codex-auto-review') return payload;
 
   // TODO: Replace this source-entry hardcode with generic model alias support.
   // Codex sends auto-review requests over the Responses wire API, so rewriting
@@ -56,7 +27,7 @@ const rewriteResponsesEntryModelAlias = (payload: ResponsesPayload): ResponsesPa
   // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/codex-api/src/endpoint/responses.rs#L102-L134
   return {
     ...payload,
-    model: CODEX_AUTO_REVIEW_TARGET,
+    model: 'gpt-5.4',
     reasoning: { ...(payload.reasoning ?? {}), effort: 'low' },
   };
 };
@@ -105,8 +76,28 @@ const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[],
     await respondResponses(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
   prepare: async c => {
     const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>());
-    const notFound = previousResponseNotFoundResponse(payload);
-    if (notFound) return notFound;
+    // previous_response_id relies on server-side conversation state that this
+    // gateway does not implement. Stored Responses item ids are handled below; a
+    // plain previous response pointer still gets OpenAI's not-found contract so
+    // clients that retry with full input can keep using their existing fallback.
+    // Verbatim payloads cross-verified from real upstream captures:
+    // - https://github.com/cline/cline/issues/9399
+    // - https://github.com/microsoft/semantic-kernel/issues/13128
+    // - https://github.com/router-for-me/CLIProxyAPI/issues/999
+    // - https://github.com/openai/openai-agents-python/issues/2020
+    if (payload.previous_response_id !== undefined && payload.previous_response_id !== null) {
+      return Response.json(
+        {
+          error: {
+            message: `Previous response with id '${payload.previous_response_id}' not found.`,
+            type: 'invalid_request_error',
+            param: 'previous_response_id',
+            code: 'previous_response_not_found',
+          },
+        },
+        { status: 400 },
+      );
+    }
     const wantsStream = payload.stream === true;
     const downstreamAbortController = wantsStream ? new AbortController() : undefined;
     const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream);

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -8,12 +8,6 @@ import { type LlmEndpointName, type LlmServeFailure, LlmServeFailureError, type 
 // setup and Response rendering; the Hono-free execution core owns stored-item
 // lookup, provider selection, per-attempt execution, and output-item commit
 // timing.
-//
-// A source declares one or more endpoints (generate, count_tokens);
-// `serveLlm(traits, endpointName)` binds one of them to a route. `prepare(c)`
-// parses the body, runs HTTP/input-level pre-checks (returning an early
-// `Response`), and yields a plan whose `attempt` closure captures the parsed
-// payload to clone, rewrite, and run.
 
 export const serveLlm = <TItems, TEvent>(
   traits: LlmSourceTraits<TItems, TEvent>,
@@ -23,10 +17,9 @@ export const serveLlm = <TItems, TEvent>(
   if (!endpoint) throw new Error(`LLM source does not define the '${endpointName}' endpoint.`);
 
   return async (c: Context): Promise<Response> => {
-    // Runtime starts provisional so a parse or prepare throw can still be
-    // rendered with telemetry; prepare replaces it on success.
-    // `respond` closes over them so every call site — early diagnostic, main
-    // path, and catch — renders identically.
+    // Runtime starts provisional so failures thrown before prepare returns can
+    // still render with telemetry. `respond` closes over the mutable binding
+    // that prepare replaces before normal execution.
     let runtime: LlmSourceRuntime = {
       request: createHttpRequestContext(c, undefined, false),
       wantsStream: false,

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono';
 
 import { executeLlmSourcePlan } from './execution.ts';
 import { createHttpRequestContext } from './request-context.ts';
-import { type LlmEndpointName, type LlmServeFailure, LlmServeFailureError, type LlmSourceRuntime, type LlmSourceTraits, type Result } from './traits.ts';
+import { type LlmEndpointName, type LlmServeFailure, LlmServeFailureError, type LlmSourceRuntime, type LlmSourceTraits } from './traits.ts';
 
 // HTTP adapter for every LLM source endpoint. `prepare` owns parsing and real
 // runtime construction; this layer binds Hono to prepare/respond, keeps a
@@ -24,14 +24,13 @@ export const serveLlm = <TItems, TEvent>(
       wantsStream: false,
       downstreamAbortController: undefined,
     };
-    const renderFailure = (failure: LlmServeFailure): Result<TEvent> => traits.renderFailure(failure, endpointName);
 
     try {
       const plan = await endpoint.prepare(c);
       if (plan instanceof Response) return plan;
       runtime = plan;
 
-      const { result, commitForNonStreaming } = await executeLlmSourcePlan(plan, renderFailure);
+      const { result, commitForNonStreaming } = await executeLlmSourcePlan(plan, failure => traits.renderFailure(failure, endpointName));
 
       // `respond` reports only whether the response was produced; this adapter
       // owns commit timing. `commitForNonStreaming` exists solely on a successful
@@ -43,7 +42,7 @@ export const serveLlm = <TItems, TEvent>(
       return response;
     } catch (error) {
       const failure: LlmServeFailure = error instanceof LlmServeFailureError ? error.failure : { kind: 'internal', error };
-      return (await endpoint.respond({ c, result: renderFailure(failure), runtime })).response;
+      return (await endpoint.respond({ c, result: traits.renderFailure(failure, endpointName), runtime })).response;
     }
   };
 };

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -5,9 +5,9 @@ import { createHttpRequestContext } from './request-context.ts';
 import { type LlmEndpointName, type LlmServeFailure, LlmServeFailureError, type LlmSourceRuntime, type LlmSourceTraits, type Result } from './traits.ts';
 
 // HTTP adapter for every LLM source endpoint. The adapter owns Hono request
-// setup and Response rendering; the Hono-free execution core owns stored-item
-// lookup, provider selection, per-attempt execution, and output-item commit
-// timing.
+// setup, Response rendering, and the response-success gate for non-streaming
+// output-item commits. The Hono-free execution core owns stored-item lookup,
+// provider selection, per-attempt execution, and output-item wrapping.
 
 export const serveLlm = <TItems, TEvent>(
   traits: LlmSourceTraits<TItems, TEvent>,

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -4,10 +4,11 @@ import { executeLlmSourcePlan } from './execution.ts';
 import { createHttpRequestContext } from './request-context.ts';
 import { type LlmEndpointName, type LlmServeFailure, LlmServeFailureError, type LlmSourceRuntime, type LlmSourceTraits, type Result } from './traits.ts';
 
-// HTTP adapter for every LLM source endpoint. The adapter owns Hono request
-// setup, Response rendering, and the response-success gate for non-streaming
-// output-item commits. The Hono-free execution core owns stored-item lookup,
-// provider selection, per-attempt execution, and output-item wrapping.
+// HTTP adapter for every LLM source endpoint. `prepare` owns parsing and real
+// runtime construction; this layer binds Hono to prepare/respond, keeps a
+// provisional failure runtime, and gates non-streaming output-item commits.
+// The Hono-free execution core owns stored-item lookup, provider selection,
+// per-attempt execution, and output-item wrapping.
 
 export const serveLlm = <TItems, TEvent>(
   traits: LlmSourceTraits<TItems, TEvent>,
@@ -17,15 +18,13 @@ export const serveLlm = <TItems, TEvent>(
   if (!endpoint) throw new Error(`LLM source does not define the '${endpointName}' endpoint.`);
 
   return async (c: Context): Promise<Response> => {
-    // Runtime starts provisional so failures thrown before prepare returns can
-    // still render with telemetry. `respond` closes over the mutable binding
-    // that prepare replaces before normal execution.
+    // Provisional runtime lets failures thrown before prepare returns render with telemetry.
     let runtime: LlmSourceRuntime = {
       request: createHttpRequestContext(c, undefined, false),
       wantsStream: false,
       downstreamAbortController: undefined,
     };
-    const respond = (result: Result<TEvent>): Promise<{ success: boolean; response: Response }> =>
+    const respond = (runtime: LlmSourceRuntime, result: Result<TEvent>): Promise<{ success: boolean; response: Response }> =>
       endpoint.respond({ c, result, runtime });
     const renderFailure = (failure: LlmServeFailure): Result<TEvent> => traits.renderFailure(failure, endpointName);
 
@@ -36,17 +35,17 @@ export const serveLlm = <TItems, TEvent>(
 
       const { result, commitForNonStreaming } = await executeLlmSourcePlan(plan, renderFailure);
 
-      // `respond` reports only whether the response was produced; the orchestrator
+      // `respond` reports only whether the response was produced; this adapter
       // owns commit timing. `commitForNonStreaming` exists solely on a successful
       // non-streaming attempt — it flushes the buffered rows once the body is
       // known good (streaming rows were already written per frame). A failed
       // response leaves the buffer unflushed.
-      const { success, response } = await respond(result);
+      const { success, response } = await respond(runtime, result);
       if (success) await commitForNonStreaming?.();
       return response;
     } catch (error) {
       const failure: LlmServeFailure = error instanceof LlmServeFailureError ? error.failure : { kind: 'internal', error };
-      return (await respond(renderFailure(failure))).response;
+      return (await respond(runtime, renderFailure(failure))).response;
     }
   };
 };

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -1,28 +1,19 @@
 import type { Context } from 'hono';
 
-import { createRequestContext } from './request-context.ts';
-import type { RequestContext } from '../interceptors.ts';
-import { responsesItemId } from './responses/items/format.ts';
-import { type ResponsesItemsCommit, storeResponsesOutputItems } from './responses/items/output.ts';
-import { planResponsesItemProviders, type PreparedStoredResponsesItems, prepareStoredResponsesItemsForSource, rewriteStoredResponsesItemsForProvider, type StoredResponsesProviderPlan } from './responses/items/request-plan.ts';
-import { type LlmEndpointName, type LlmEndpointPlan, type LlmServeFailure, LlmServeFailureError, type LlmSourceTraits, type Result } from './traits.ts';
-import { listModelProviders, resolveModelForProvider } from '../../providers/registry.ts';
+import { executeLlmSourcePlan } from './execution.ts';
+import { createHttpRequestContext } from './request-context.ts';
+import { type LlmEndpointName, type LlmServeFailure, LlmServeFailureError, type LlmSourceRuntime, type LlmSourceTraits, type Result } from './traits.ts';
 
-// The control flow every LLM source endpoint shares: look up referenced stored
-// items, plan a provider order from their routing affinity, then walk that
-// order resolving the model, running source interceptors, and wrapping the
-// events branch so output items are persisted with the right commit timing.
-// Only the protocol-shaped pieces — payload parsing, item carrier location,
-// target preference, the interceptor-wrapped emit, response shaping — differ
-// per API/endpoint and are injected through the per-source traits.
+// HTTP adapter for every LLM source endpoint. The adapter owns Hono request
+// setup and Response rendering; the Hono-free execution core owns stored-item
+// lookup, provider selection, per-attempt execution, and output-item commit
+// timing.
 //
 // A source declares one or more endpoints (generate, count_tokens);
-// `serveLlm(traits, endpointName)` binds one of them to a route. payload and
-// request never reach this orchestrator: they live in the per-endpoint
-// closures. `setup(c)` parses the body, runs input-level pre-checks (returning
-// an early `Response`), and yields a plan whose `attempt` closure captures the
-// payload to clone, rewrite, and run. The orchestrator only drives the planner
-// and persistence, then hands every result — success or failure — to `respond`.
+// `serveLlm(traits, endpointName)` binds one of them to a route. `prepare(c)`
+// parses the body, runs HTTP/input-level pre-checks (returning an early
+// `Response`), and yields a plan whose `attempt` closure captures the parsed
+// payload to clone, rewrite, and run.
 
 export const serveLlm = <TItems, TEvent>(
   traits: LlmSourceTraits<TItems, TEvent>,
@@ -32,27 +23,25 @@ export const serveLlm = <TItems, TEvent>(
   if (!endpoint) throw new Error(`LLM source does not define the '${endpointName}' endpoint.`);
 
   return async (c: Context): Promise<Response> => {
-    // `request`/`wantsStream`/abort start provisional so a parse or setup throw
-    // can still be rendered with telemetry; `setup` replaces them on success.
+    // Runtime starts provisional so a parse or prepare throw can still be
+    // rendered with telemetry; prepare replaces it on success.
     // `respond` closes over them so every call site — early diagnostic, main
     // path, and catch — renders identically.
-    let request = createRequestContext(c, undefined, false);
-    let wantsStream = false;
-    let downstreamAbortController: AbortController | undefined;
+    let runtime: LlmSourceRuntime = {
+      request: createHttpRequestContext(c, undefined, false),
+      wantsStream: false,
+      downstreamAbortController: undefined,
+    };
     const respond = (result: Result<TEvent>): Promise<{ success: boolean; response: Response }> =>
-      endpoint.respond({ c, result, request, wantsStream, downstreamAbortController });
+      endpoint.respond({ c, result, runtime });
     const renderFailure = (failure: LlmServeFailure): Result<TEvent> => traits.renderFailure(failure, endpointName);
 
     try {
-      const plan = await endpoint.setup(c);
+      const plan = await endpoint.prepare(c);
       if (plan instanceof Response) return plan;
-      ({ request, wantsStream, downstreamAbortController } = plan);
+      runtime = plan;
 
-      const prepared = await prepareStoredResponsesItemsForSource(plan.items, request.apiKeyId ?? null, plan.responsesItemsView);
-      if (prepared.failures[0]) return (await respond(renderFailure(prepared.failures[0]))).response;
-
-      const providerPlan = planResponsesItemProviders(await listModelProviders(request.apiKeyUpstreamIds), prepared);
-      const { result, commitForNonStreaming } = await attemptProviders(providerPlan, plan, prepared, request, renderFailure);
+      const { result, commitForNonStreaming } = await executeLlmSourcePlan(plan, renderFailure);
 
       // `respond` reports only whether the response was produced; the orchestrator
       // owns commit timing. `commitForNonStreaming` exists solely on a successful
@@ -67,61 +56,4 @@ export const serveLlm = <TItems, TEvent>(
       return (await respond(renderFailure(failure))).response;
     }
   };
-};
-
-// Walk the planned providers in order: resolve the model, pick a target, run
-// the attempt; the first provider yielding an upstream result wins, with its
-// output items wrapped for persistence. A provider whose model or target does
-// not resolve is skipped. An exhausted walk renders the model diagnostic —
-// missing when no provider had the model, unsupported when one did but offered
-// no usable target.
-const attemptProviders = async <TItems, TEvent>(
-  providerPlan: StoredResponsesProviderPlan,
-  plan: LlmEndpointPlan<TItems, TEvent>,
-  prepared: PreparedStoredResponsesItems,
-  request: RequestContext,
-  renderFailure: (failure: LlmServeFailure) => Result<TEvent>,
-): Promise<{ result: Result<TEvent>; commitForNonStreaming?: ResponsesItemsCommit }> => {
-  if (providerPlan.type === 'failure') return { result: renderFailure(providerPlan.failure) };
-
-  let sawModel = false;
-  for (const provider of providerPlan.providers) {
-    const resolved = await resolveModelForProvider(provider, plan.model);
-    if (!resolved) continue;
-    sawModel = true;
-
-    const { binding } = resolved;
-    const target = plan.pickTarget(binding.upstreamModel.endpoints);
-    if (!target) continue;
-
-    // Fresh stateful bag per attempt so a failed earlier attempt's shim
-    // writes — private payloads stashed under tmp ids that won't be minted
-    // again, new synthetic ids that no output stream will reference — don't
-    // leak into the next attempt. Seed key is the wire id the rewriter will
-    // produce: only synthetic rows carry `payload.private`, and the rewriter
-    // preserves their `payload.item.id` verbatim, so the lookup reads that
-    // id directly.
-    request.statefulResponsesContext = {
-      privatePayload: new Map(prepared.references.flatMap(ref => {
-        const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });
-        return wireId && ref.row?.payload?.private !== undefined ? [[wireId, ref.row.payload.private] as const] : [];
-      })),
-      newSyntheticIds: new Set(),
-    };
-
-    const rawResult = await plan.attempt({
-      binding,
-      target,
-      model: resolved.id,
-      rewriteItems: items => rewriteStoredResponsesItemsForProvider(items, prepared, binding, plan.responsesItemsView),
-    });
-    if (rawResult.type !== 'events') return { result: rawResult };
-
-    const stored = storeResponsesOutputItems(rawResult.events, plan.responsesItemsView, { targetApi: target, upstream: binding.upstream, store: plan.store }, request, plan.wantsStream);
-    return { result: { ...rawResult, events: stored.events }, commitForNonStreaming: stored.commitForNonStreaming };
-  }
-
-  // The diagnostic names the model the client requested, not whichever upstream
-  // id a provider resolved it to.
-  return { result: renderFailure(sawModel ? { kind: 'model-unsupported', model: plan.model } : { kind: 'model-missing', model: plan.model }) };
 };

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -24,8 +24,6 @@ export const serveLlm = <TItems, TEvent>(
       wantsStream: false,
       downstreamAbortController: undefined,
     };
-    const respond = (runtime: LlmSourceRuntime, result: Result<TEvent>): Promise<{ success: boolean; response: Response }> =>
-      endpoint.respond({ c, result, runtime });
     const renderFailure = (failure: LlmServeFailure): Result<TEvent> => traits.renderFailure(failure, endpointName);
 
     try {
@@ -40,12 +38,12 @@ export const serveLlm = <TItems, TEvent>(
       // non-streaming attempt — it flushes the buffered rows once the body is
       // known good (streaming rows were already written per frame). A failed
       // response leaves the buffer unflushed.
-      const { success, response } = await respond(runtime, result);
+      const { success, response } = await endpoint.respond({ c, result, runtime });
       if (success) await commitForNonStreaming?.();
       return response;
     } catch (error) {
       const failure: LlmServeFailure = error instanceof LlmServeFailureError ? error.failure : { kind: 'internal', error };
-      return (await respond(runtime, renderFailure(failure))).response;
+      return (await endpoint.respond({ c, result: renderFailure(failure), runtime })).response;
     }
   };
 };

--- a/apps/api/src/data-plane/llm/sources/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/traits.ts
@@ -88,18 +88,21 @@ export const sourceErrorResult = <TEvent>(
   return internalErrorResult(options.internalStatus, toInternalDebugError(error, options.sourceApi));
 };
 
-export interface LlmEndpointPlan<TItems, TEvent> {
+export interface LlmSourceRuntime {
   readonly request: RequestContext;
+  readonly wantsStream: boolean;
+  readonly downstreamAbortController: AbortController | undefined;
+}
+
+export interface LlmEndpointPlan<TItems, TEvent> extends LlmSourceRuntime {
   readonly items: TItems;
   readonly responsesItemsView: ResponsesItemsView<TItems, Frame<TEvent>>;
-  readonly wantsStream: boolean;
   // `store: false` requests persist null payloads; sources that have no
   // `store` concept (Messages, Gemini) pass `undefined`.
   readonly store: boolean | null | undefined;
   // The model id the planner resolves against. Most sources read it off the
   // parsed payload; Gemini carries it on the request path instead of the body.
   readonly model: string;
-  readonly downstreamAbortController: AbortController | undefined;
   pickTarget(endpoints: ModelEndpoints): LlmTargetApi | null;
   // Clones the captured payload once, rewrites that clone's items in place via
   // `rewriteItems`, builds the fully protocol-typed invocation / emit table /
@@ -122,12 +125,12 @@ export interface LlmEndpointPlan<TItems, TEvent> {
 //   - count_tokens produces a measurement — a non-`events` result the
 //     orchestrator passes straight to `respond`, never persisting.
 //
-// `pickTarget` and `attempt` are NOT here: they live on the plan `setup`
+// `pickTarget` and `attempt` are NOT here: they live on the plan `prepare`
 // returns, because `attempt` closes over the parsed payload.
-export interface LlmEndpoint<TItems, TEvent> {
+export interface LlmHttpEndpoint<TItems, TEvent> {
   // Parses the body, runs input-level pre-checks (returning an early
   // `Response`), and yields the plan the orchestrator drives.
-  setup(c: Context): Promise<LlmEndpointPlan<TItems, TEvent> | Response>;
+  prepare(c: Context): Promise<LlmEndpointPlan<TItems, TEvent> | Response>;
   // Shapes the final Response from a result — both upstream results and the
   // `renderFailure` envelope pass through here. Reports only whether the
   // response was produced; the orchestrator owns commit timing for persisted
@@ -135,9 +138,7 @@ export interface LlmEndpoint<TItems, TEvent> {
   respond(input: {
     c: Context;
     result: Result<TEvent>;
-    request: RequestContext;
-    wantsStream: boolean;
-    downstreamAbortController: AbortController | undefined;
+    runtime: LlmSourceRuntime;
   }): Promise<{ success: boolean; response: Response }>;
 }
 
@@ -146,8 +147,8 @@ export type LlmEndpointName = 'generate' | 'countTokens';
 // A source exposes one or more endpoints that share its input and error
 // envelope. `renderFailure` is source-wide — every endpoint answers a failure
 // in the same protocol shape — while the per-endpoint pieces live on
-// `LlmEndpoint`.
+// `LlmHttpEndpoint`.
 export interface LlmSourceTraits<TItems, TEvent> {
   renderFailure(failure: LlmServeFailure, endpoint: LlmEndpointName): Result<TEvent>;
-  endpoints: Partial<Record<LlmEndpointName, LlmEndpoint<TItems, TEvent>>>;
+  endpoints: Partial<Record<LlmEndpointName, LlmHttpEndpoint<TItems, TEvent>>>;
 }

--- a/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
+++ b/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
@@ -18,6 +18,7 @@ export const chatCompletionsInvocation = (payload: ChatCompletionsPayload, enabl
 
 export const stubRequestContext: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/emit_test.ts
+++ b/apps/api/src/data-plane/llm/targets/emit_test.ts
@@ -19,6 +19,7 @@ const baseInvocation = (): Invocation<{ model: string; stream?: boolean }> => ({
 
 const baseRequest = (): RequestContext => ({
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  apiKeyId: 'key_a',
   clientStream: true,
   runtimeLocation: 'SJC',

--- a/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -25,6 +25,7 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
@@ -37,6 +37,7 @@ const makeInvocation = (payload: ResponsesPayload): ResponsesInvocation => ({
 
 const stubRequest = (overrides: { downstreamAbortSignal?: AbortSignal } = {}): RequestContext => ({
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: true,
   ...(overrides.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: overrides.downstreamAbortSignal } : {}),

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/telemetry_test.ts
+++ b/apps/api/src/data-plane/llm/targets/telemetry_test.ts
@@ -51,6 +51,7 @@ const baseRequest = (
   overrides: { downstreamAbortSignal?: AbortSignal; stream?: boolean; apiKeyId?: string | undefined } = {},
 ): RequestContext => ({
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  apiKeyId: 'apiKeyId' in overrides ? overrides.apiKeyId : 'key_a',
   clientStream: overrides.stream ?? true,
   runtimeLocation: 'SJC',
@@ -317,6 +318,7 @@ test('withUpstreamTelemetry skips recording when apiKeyId is absent', async () =
     },
     {
       requestStartedAt: 0,
+      apiKeyUpstreamIds: null,
       statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },      clientStream: true,
       runtimeLocation: 'SJC',
       scheduleBackground: promise => background.push(promise),

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
@@ -23,6 +23,7 @@ const invocation = (): ChatCompletionsInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
@@ -10,6 +10,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
@@ -12,6 +12,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
@@ -10,6 +10,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
@@ -10,6 +10,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/apply-top-level-cache-control_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/apply-top-level-cache-control_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: false,

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
@@ -12,6 +12,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
@@ -39,6 +39,7 @@ const makeCtx = (
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
@@ -11,6 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
@@ -11,6 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-cache-control-extensions_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-cache-control-extensions_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: false,

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
@@ -10,6 +10,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
@@ -36,6 +36,7 @@ const invocation = (): ResponsesInvocation => ({
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
@@ -12,6 +12,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
@@ -10,6 +10,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
   statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/provider_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider_test.ts
@@ -369,6 +369,7 @@ test('Copilot provider sets copilot-vision-request when an image is nested insid
 
   const stubRequest: RequestContext = {
     requestStartedAt: 0,
+    apiKeyUpstreamIds: null,
     statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },    runtimeLocation: 'test',
     clientStream: false,
   };

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -691,7 +691,18 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
         .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
-      return await Promise.all(results.map(toStoredResponsesItem));
+      return await Promise.all(results.map(async row => ({
+        id: row.id,
+        apiKeyId: row.api_key_id,
+        upstreamId: row.upstream_id,
+        upstreamItemId: row.upstream_item_id,
+        itemType: row.item_type,
+        origin: row.origin,
+        payload: await parseStoredResponsesPayload(row.id, row.payload_json),
+        encryptedContentHash: row.encrypted_content_hash,
+        createdAt: row.created_at,
+        refreshedAt: row.refreshed_at,
+      })));
     }));
     return perChunk.flat();
   }
@@ -769,19 +780,6 @@ interface ResponsesItemRow {
   created_at: number;
   refreshed_at: number;
 }
-
-const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredResponsesItem> => ({
-  id: row.id,
-  apiKeyId: row.api_key_id,
-  upstreamId: row.upstream_id,
-  upstreamItemId: row.upstream_item_id,
-  itemType: row.item_type,
-  origin: row.origin,
-  payload: await parseStoredResponsesPayload(row.id, row.payload_json),
-  encryptedContentHash: row.encrypted_content_hash,
-  createdAt: row.created_at,
-  refreshedAt: row.refreshed_at,
-});
 
 class D1SearchConfigRepo implements SearchConfigRepo {
   constructor(private db: D1Database) {}

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -655,6 +655,7 @@ class D1CacheRepo implements CacheRepo {
 }
 
 const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, encrypted_content_hash, created_at, refreshed_at';
+const RESPONSES_ITEM_ID_SCOPE_SQL = "COALESCE(api_key_id, '') = COALESCE(?, '')";
 
 class D1ResponsesItemsRepo implements ResponsesItemsRepo {
   constructor(private db: D1Database) {}
@@ -685,8 +686,9 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     const perChunk = await Promise.all(chunks.map(async chunk => {
       const placeholders = chunk.map(() => '?').join(', ');
       const orderSql = column === 'id' ? '' : ' ORDER BY refreshed_at DESC, created_at DESC, id ASC';
+      const scopeSql = column === 'id' ? RESPONSES_ITEM_ID_SCOPE_SQL : 'api_key_id IS ?';
       const { results } = await this.db
-        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE api_key_id IS ? AND ${column} IN (${placeholders})${orderSql}`)
+        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
       return await Promise.all(results.map(toStoredResponsesItem));
@@ -723,7 +725,7 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     const results = await Promise.all(chunks.map(async chunk => {
       const placeholders = chunk.map(() => '?').join(', ');
       return await this.db
-        .prepare(`UPDATE responses_items SET refreshed_at = ? WHERE api_key_id IS ? AND id IN (${placeholders}) AND refreshed_at < ?`)
+        .prepare(`UPDATE responses_items SET refreshed_at = ? WHERE ${RESPONSES_ITEM_ID_SCOPE_SQL} AND id IN (${placeholders}) AND refreshed_at < ?`)
         .bind(refreshedAt, apiKeyId, ...chunk, refreshedAt)
         .run();
     }));

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -654,7 +654,7 @@ class D1CacheRepo implements CacheRepo {
   }
 }
 
-const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, payload_json, encrypted_content_hash, created_at';
+const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, encrypted_content_hash, created_at, refreshed_at';
 
 class D1ResponsesItemsRepo implements ResponsesItemsRepo {
   constructor(private db: D1Database) {}
@@ -684,8 +684,9 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
 
     const perChunk = await Promise.all(chunks.map(async chunk => {
       const placeholders = chunk.map(() => '?').join(', ');
+      const orderSql = column === 'id' ? '' : ' ORDER BY refreshed_at DESC, created_at DESC, id ASC';
       const { results } = await this.db
-        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE api_key_id IS ? AND ${column} IN (${placeholders})`)
+        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE api_key_id IS ? AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
       return await Promise.all(results.map(toStoredResponsesItem));
@@ -704,21 +705,38 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
       // happen.
       return this.db
         .prepare(
-          `INSERT INTO responses_items (${RESPONSES_ITEM_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO responses_items (${RESPONSES_ITEM_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT (id, COALESCE(api_key_id, '')) DO NOTHING`,
         )
-        .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, payload, item.encryptedContentHash, item.createdAt);
+        .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, item.origin, payload, item.encryptedContentHash, item.createdAt, item.refreshedAt);
     }));
     await this.runStatements(statements);
   }
 
-  async clearPayloadOlderThan(createdBefore: number): Promise<number> {
-    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND created_at < ?').bind(createdBefore).run();
+  async refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number> {
+    const unique = [...new Set(ids)];
+    if (unique.length === 0) return 0;
+
+    const CHUNK = 88;
+    const chunks: string[][] = [];
+    for (let i = 0; i < unique.length; i += CHUNK) chunks.push(unique.slice(i, i + CHUNK));
+    const results = await Promise.all(chunks.map(async chunk => {
+      const placeholders = chunk.map(() => '?').join(', ');
+      return await this.db
+        .prepare(`UPDATE responses_items SET refreshed_at = ? WHERE api_key_id IS ? AND id IN (${placeholders}) AND refreshed_at < ?`)
+        .bind(refreshedAt, apiKeyId, ...chunk, refreshedAt)
+        .run();
+    }));
+    return results.reduce((sum, result) => sum + ((result.meta.changes as number | undefined) ?? 0), 0);
+  }
+
+  async clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
+    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND refreshed_at < ?').bind(refreshedBefore).run();
     return (result.meta.changes as number | undefined) ?? 0;
   }
 
-  async deleteOlderThan(createdBefore: number): Promise<number> {
-    const result = await this.db.prepare('DELETE FROM responses_items WHERE created_at < ?').bind(createdBefore).run();
+  async deleteOlderThan(refreshedBefore: number): Promise<number> {
+    const result = await this.db.prepare('DELETE FROM responses_items WHERE refreshed_at < ?').bind(refreshedBefore).run();
     return (result.meta.changes as number | undefined) ?? 0;
   }
 
@@ -743,9 +761,11 @@ interface ResponsesItemRow {
   upstream_id: string | null;
   upstream_item_id: string | null;
   item_type: string;
+  origin: StoredResponsesItem['origin'];
   payload_json: string | null;
   encrypted_content_hash: string | null;
   created_at: number;
+  refreshed_at: number;
 }
 
 const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredResponsesItem> => ({
@@ -754,9 +774,11 @@ const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredRespo
   upstreamId: row.upstream_id,
   upstreamItemId: row.upstream_item_id,
   itemType: row.item_type,
+  origin: row.origin,
   payload: await parseStoredResponsesPayload(row.id, row.payload_json),
   encryptedContentHash: row.encrypted_content_hash,
   createdAt: row.created_at,
+  refreshedAt: row.refreshed_at,
 });
 
 class D1SearchConfigRepo implements SearchConfigRepo {

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -743,8 +743,8 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     return results.reduce((sum, result) => sum + ((result.meta.changes as number | undefined) ?? 0), 0);
   }
 
-  async clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
-    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND refreshed_at < ?').bind(refreshedBefore).run();
+  async clearPayloadOlderThan(createdBefore: number): Promise<number> {
+    const result = await this.db.prepare('UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND created_at < ?').bind(createdBefore).run();
     return (result.meta.changes as number | undefined) ?? 0;
   }
 

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -676,6 +676,19 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
   // well under the cap (the `api_key_id` bind shares the budget) and union
   // the results.
   private async lookupByColumn(apiKeyId: string | null, column: 'id' | 'encrypted_content_hash', values: readonly string[]): Promise<StoredResponsesItem[]> {
+    interface ResponsesItemRow {
+      id: string;
+      api_key_id: string | null;
+      upstream_id: string | null;
+      upstream_item_id: string | null;
+      item_type: string;
+      origin: StoredResponsesItem['origin'];
+      payload_json: string | null;
+      encrypted_content_hash: string | null;
+      created_at: number;
+      refreshed_at: number;
+    }
+
     const unique = [...new Set(values)];
     if (unique.length === 0) return [];
 
@@ -766,19 +779,6 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     }
     for (const statement of statements) await statement.run();
   }
-}
-
-interface ResponsesItemRow {
-  id: string;
-  api_key_id: string | null;
-  upstream_id: string | null;
-  upstream_item_id: string | null;
-  item_type: string;
-  origin: StoredResponsesItem['origin'];
-  payload_json: string | null;
-  encrypted_content_hash: string | null;
-  created_at: number;
-  refreshed_at: number;
 }
 
 class D1SearchConfigRepo implements SearchConfigRepo {

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -449,10 +449,10 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     return Promise.resolve(changes);
   }
 
-  clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
+  clearPayloadOlderThan(createdBefore: number): Promise<number> {
     let changes = 0;
     for (const row of this.store.values()) {
-      if (row.refreshedAt < refreshedBefore && row.payload !== null) {
+      if (row.createdAt < createdBefore && row.payload !== null) {
         row.payload = null;
         changes += 1;
       }

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -425,7 +425,7 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
         rows.push(cloneStoredResponsesItem(row));
       }
     }
-    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
+    return Promise.resolve(rows.toSorted((a, b) => b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id)));
   }
 
   insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
@@ -481,9 +481,6 @@ const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesIte
   ...item,
   payload: item.payload === null ? null : structuredClone(item.payload),
 });
-
-const compareResponsesItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
-  b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);
 
 const responsesItemStoreKey = (apiKeyId: string | null, id: string): string => `${apiKeyId ?? ''}\0${id}`;
 

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -425,7 +425,7 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
         rows.push(cloneStoredResponsesItem(row));
       }
     }
-    return Promise.resolve(rows);
+    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
   }
 
   insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
@@ -437,10 +437,22 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     return Promise.resolve();
   }
 
-  clearPayloadOlderThan(createdBefore: number): Promise<number> {
+  refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number> {
+    let changes = 0;
+    for (const id of new Set(ids)) {
+      const row = this.store.get(responsesItemStoreKey(apiKeyId, id));
+      if (row && row.refreshedAt < refreshedAt) {
+        row.refreshedAt = refreshedAt;
+        changes += 1;
+      }
+    }
+    return Promise.resolve(changes);
+  }
+
+  clearPayloadOlderThan(refreshedBefore: number): Promise<number> {
     let changes = 0;
     for (const row of this.store.values()) {
-      if (row.createdAt < createdBefore && row.payload !== null) {
+      if (row.refreshedAt < refreshedBefore && row.payload !== null) {
         row.payload = null;
         changes += 1;
       }
@@ -448,10 +460,10 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     return Promise.resolve(changes);
   }
 
-  deleteOlderThan(createdBefore: number): Promise<number> {
+  deleteOlderThan(refreshedBefore: number): Promise<number> {
     let changes = 0;
     for (const [id, row] of this.store) {
-      if (row.createdAt < createdBefore) {
+      if (row.refreshedAt < refreshedBefore) {
         this.store.delete(id);
         changes += 1;
       }
@@ -469,6 +481,9 @@ const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesIte
   ...item,
   payload: item.payload === null ? null : structuredClone(item.payload),
 });
+
+const compareResponsesItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
+  b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);
 
 const responsesItemStoreKey = (apiKeyId: string | null, id: string): string => `${apiKeyId ?? ''}\0${id}`;
 

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -11,8 +11,10 @@ const storedItem = (overrides: Partial<StoredResponsesItem> & Pick<StoredRespons
   upstreamId: null,
   upstreamItemId: null,
   itemType: 'message',
+  origin: 'upstream',
   encryptedContentHash: null,
   payload: { item: { id: overrides.id, type: 'message', content: [{ type: 'output_text', text: overrides.id }] } },
+  refreshedAt: overrides.createdAt,
   ...overrides,
 });
 
@@ -50,19 +52,33 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
   assertEquals(await repo.lookupMany('key_b', [first.id, second.id, adminScoped.id]), []);
   assertEquals(await repo.lookupMany('key_a', []), []);
 
-  assertEquals(await repo.clearPayloadOlderThan(2_500), 2);
+  assertEquals(await repo.refreshMany('key_a', [first.id, first.id, second.id, adminScoped.id, 'missing'], 4_000), 2);
   assertEquals(
     await repo.lookupMany('key_a', [first.id, second.id]),
     [
-      { ...first, payload: null },
-      { ...second, payload: null },
+      { ...first, refreshedAt: 4_000 },
+      { ...second, refreshedAt: 4_000 },
     ],
   );
-  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [adminScoped]);
+  assertEquals(await repo.refreshMany('key_a', [first.id], 3_500), 0);
+  assertEquals(await repo.refreshMany(null, [adminScoped.id], 5_000), 1);
+  const refreshedAdminScoped = { ...adminScoped, refreshedAt: 5_000 };
 
-  assertEquals(await repo.deleteOlderThan(3_000), 2);
+  assertEquals(await repo.clearPayloadOlderThan(2_500), 0);
+  assertEquals(await repo.clearPayloadOlderThan(4_500), 2);
+  assertEquals(
+    await repo.lookupMany('key_a', [first.id, second.id]),
+    [
+      { ...first, payload: null, refreshedAt: 4_000 },
+      { ...second, payload: null, refreshedAt: 4_000 },
+    ],
+  );
+  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [refreshedAdminScoped]);
+
+  assertEquals(await repo.deleteOlderThan(3_000), 0);
+  assertEquals(await repo.deleteOlderThan(4_500), 2);
   assertEquals(await repo.lookupMany('key_a', [first.id, second.id]), []);
-  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [adminScoped]);
+  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [refreshedAdminScoped]);
 
   await repo.deleteAll();
   assertEquals(await repo.lookupMany(null, [adminScoped.id]), []);
@@ -120,9 +136,11 @@ test('D1 responses items repo rejects malformed stored payload_json', async () =
     upstream_id: null,
     upstream_item_id: null,
     item_type: 'message',
+    origin: 'synthetic',
     payload_json: '{bad json',
     encrypted_content_hash: null,
     created_at: 1_000,
+    refreshed_at: 1_000,
   });
 
   await assertRejects(() => new D1Repo(db).responsesItems.lookupMany('key_a', ['msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA']), Error, 'Malformed responses_items.payload_json JSON');
@@ -234,15 +252,59 @@ test('migration 0023 creates the responses_items table and cleanup indexes', asy
   }
 });
 
+test('migration 0025 adds responses item metadata and refresh index', async () => {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  try {
+    applySqlJsFile(db, '0023_responses_items.sql');
+    db.run(`
+      INSERT INTO responses_items (id, upstream_id, upstream_item_id, item_type, created_at)
+      VALUES
+        ('msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA', NULL, NULL, 'message', 1),
+        ('rs_mFBDiA_Lh1uXb7nD_bQb4I1CUYH2w', 'up_a', 'raw_rs_a', 'reasoning', 2)
+    `);
+    applySqlJsFile(db, '0025_responses_item_metadata.sql');
+
+    assertEquals(
+      sqlJsRows<{ name: string }>(db, 'PRAGMA table_info(responses_items)').map(row => row.name).filter(name => name === 'origin' || name === 'refreshed_at'),
+      ['origin', 'refreshed_at'],
+    );
+    assertEquals(
+      sqlJsRows<{ id: string; origin: string; refreshed_at: number }>(db, 'SELECT id, origin, refreshed_at FROM responses_items ORDER BY created_at'),
+      [
+        { id: 'msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA', origin: 'synthetic', refreshed_at: 1 },
+        { id: 'rs_mFBDiA_Lh1uXb7nD_bQb4I1CUYH2w', origin: 'upstream', refreshed_at: 2 },
+      ],
+    );
+    assertEquals(
+      sqlJsRows<{ name: string }>(db, "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'responses_items' ORDER BY name").map(row => row.name),
+      ['idx_responses_items_api_key_id', 'idx_responses_items_enc_hash', 'idx_responses_items_id_scope', 'idx_responses_items_refreshed_at'],
+    );
+    db.run("INSERT INTO responses_items (id, item_type, created_at) VALUES ('ws_WGRXTA_sVlhxg6BAV0BUzj0KkWSqA', 'web_search_call', 3)");
+    assertEquals(
+      sqlJsRows<{ origin: string; refreshed_at: number }>(db, "SELECT origin, refreshed_at FROM responses_items WHERE id = 'ws_WGRXTA_sVlhxg6BAV0BUzj0KkWSqA'")[0],
+      { origin: 'upstream', refreshed_at: 3 },
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN DELETE FROM responses_items WHERE refreshed_at < 10')
+        .some(row => row.detail.includes('idx_responses_items_refreshed_at')),
+    );
+  } finally {
+    db.close();
+  }
+});
+
 type FakeResponsesItemRow = {
   id: string;
   api_key_id: string | null;
   upstream_id: string | null;
   upstream_item_id: string | null;
   item_type: string;
+  origin: StoredResponsesItem['origin'];
   payload_json: string | null;
   encrypted_content_hash: string | null;
   created_at: number;
+  refreshed_at: number;
 };
 
 class FakeResponsesItemsD1PreparedStatement {
@@ -276,11 +338,15 @@ class FakeResponsesItemsD1PreparedStatement {
       this.db.insert(this.binds);
       return Promise.resolve({ results: [], success: true, meta: { changes: 1 } });
     }
+    if (this.query.startsWith('UPDATE responses_items SET refreshed_at = ?')) {
+      const changes = this.db.refresh(this.binds);
+      return Promise.resolve({ results: [], success: true, meta: { changes } });
+    }
     if (this.query.startsWith('UPDATE responses_items SET payload_json = NULL')) {
       const changes = this.db.clearPayloadOlderThan(this.binds[0] as number);
       return Promise.resolve({ results: [], success: true, meta: { changes } });
     }
-    if (this.query.startsWith('DELETE FROM responses_items WHERE created_at < ?')) {
+    if (this.query.startsWith('DELETE FROM responses_items WHERE refreshed_at < ?')) {
       const changes = this.db.deleteOlderThan(this.binds[0] as number);
       return Promise.resolve({ results: [], success: true, meta: { changes } });
     }
@@ -308,7 +374,18 @@ class FakeResponsesItemsD1Database implements D1Database {
   }
 
   insert(binds: unknown[]): void {
-    const [id, apiKeyId, upstreamId, upstreamItemId, itemType, payload, encryptedContentHash, createdAt] = binds as [string, string | null, string | null, string | null, string, string | null, string | null, number];
+    const [id, apiKeyId, upstreamId, upstreamItemId, itemType, origin, payload, encryptedContentHash, createdAt, refreshedAt] = binds as [
+      string,
+      string | null,
+      string | null,
+      string | null,
+      string,
+      StoredResponsesItem['origin'],
+      string | null,
+      string | null,
+      number,
+      number,
+    ];
     const existing = this.rows.find(row => row.id === id && row.api_key_id === apiKeyId);
     if (existing) return;  // mirrors d1.ts `ON CONFLICT DO NOTHING`
     this.rows.push({
@@ -317,10 +394,26 @@ class FakeResponsesItemsD1Database implements D1Database {
       upstream_id: upstreamId,
       upstream_item_id: upstreamItemId,
       item_type: itemType,
+      origin,
       payload_json: payload,
       encrypted_content_hash: encryptedContentHash,
       created_at: createdAt,
+      refreshed_at: refreshedAt,
     });
+  }
+
+  refresh(binds: unknown[]): number {
+    const [refreshedAt, apiKeyId, ...rest] = binds as [number, string | null, ...Array<string | number>];
+    const ids = new Set(rest.slice(0, -1) as string[]);
+    const maxExisting = rest.at(-1) as number;
+    let changes = 0;
+    for (const row of this.rows) {
+      if (row.api_key_id === apiKeyId && ids.has(row.id) && row.refreshed_at < maxExisting) {
+        row.refreshed_at = refreshedAt;
+        changes += 1;
+      }
+    }
+    return changes;
   }
 
   lookup(query: string, binds: unknown[]): FakeResponsesItemRow[] {
@@ -329,7 +422,8 @@ class FakeResponsesItemsD1Database implements D1Database {
     if (query.includes('encrypted_content_hash IN')) {
       return this.rows
         .filter(row => row.api_key_id === apiKeyId && row.encrypted_content_hash !== null && wanted.has(row.encrypted_content_hash))
-        .map(row => ({ ...row }));
+        .map(row => ({ ...row }))
+        .toSorted(compareFakeResponsesItemsByFreshness);
     }
     const matches = this.rows.filter(row => wanted.has(row.id) && row.api_key_id === apiKeyId);
     const order = new Map(keys.map((id, index) => [id, index]));
@@ -339,7 +433,7 @@ class FakeResponsesItemsD1Database implements D1Database {
   clearPayloadOlderThan(createdBefore: number): number {
     let changes = 0;
     for (const row of this.rows) {
-      if (row.created_at < createdBefore && row.payload_json !== null) {
+      if (row.refreshed_at < createdBefore && row.payload_json !== null) {
         row.payload_json = null;
         changes += 1;
       }
@@ -349,10 +443,13 @@ class FakeResponsesItemsD1Database implements D1Database {
 
   deleteOlderThan(createdBefore: number): number {
     const previousLength = this.rows.length;
-    this.rows = this.rows.filter(row => row.created_at >= createdBefore);
+    this.rows = this.rows.filter(row => row.refreshed_at >= createdBefore);
     return previousLength - this.rows.length;
   }
 }
+
+const compareFakeResponsesItemsByFreshness = (a: FakeResponsesItemRow, b: FakeResponsesItemRow): number =>
+  b.refreshed_at - a.refreshed_at || b.created_at - a.created_at || a.id.localeCompare(b.id);
 
 type SqlJsDatabase = {
   run(sql: string): void;

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -289,6 +289,18 @@ test('migration 0025 adds responses item metadata and refresh index', async () =
       sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN DELETE FROM responses_items WHERE refreshed_at < 10')
         .some(row => row.detail.includes('idx_responses_items_refreshed_at')),
     );
+    assert(
+      sqlJsRows<{ detail: string }>(
+        db,
+        "EXPLAIN QUERY PLAN SELECT id FROM responses_items WHERE COALESCE(api_key_id, '') = COALESCE('key_a', '') AND id IN ('msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA')",
+      ).some(row => row.detail.includes('idx_responses_items_id_scope')),
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(
+        db,
+        "EXPLAIN QUERY PLAN UPDATE responses_items SET refreshed_at = 10 WHERE COALESCE(api_key_id, '') = COALESCE('key_a', '') AND id IN ('msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA') AND refreshed_at < 10",
+      ).some(row => row.detail.includes('idx_responses_items_id_scope')),
+    );
   } finally {
     db.close();
   }

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -64,8 +64,8 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
   assertEquals(await repo.refreshMany(null, [adminScoped.id], 5_000), 1);
   const refreshedAdminScoped = { ...adminScoped, refreshedAt: 5_000 };
 
-  assertEquals(await repo.clearPayloadOlderThan(2_500), 0);
-  assertEquals(await repo.clearPayloadOlderThan(4_500), 2);
+  assertEquals(await repo.clearPayloadOlderThan(500), 0);
+  assertEquals(await repo.clearPayloadOlderThan(2_500), 2);
   assertEquals(
     await repo.lookupMany('key_a', [first.id, second.id]),
     [
@@ -278,7 +278,7 @@ test('migration 0025 adds responses item metadata and refresh index', async () =
     );
     assertEquals(
       sqlJsRows<{ name: string }>(db, "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'responses_items' ORDER BY name").map(row => row.name),
-      ['idx_responses_items_api_key_id', 'idx_responses_items_enc_hash', 'idx_responses_items_id_scope', 'idx_responses_items_refreshed_at'],
+      ['idx_responses_items_api_key_id', 'idx_responses_items_created_at', 'idx_responses_items_enc_hash', 'idx_responses_items_id_scope', 'idx_responses_items_refreshed_at'],
     );
     db.run("INSERT INTO responses_items (id, item_type, created_at) VALUES ('ws_WGRXTA_sVlhxg6BAV0BUzj0KkWSqA', 'web_search_call', 3)");
     assertEquals(
@@ -288,6 +288,10 @@ test('migration 0025 adds responses item metadata and refresh index', async () =
     assert(
       sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN DELETE FROM responses_items WHERE refreshed_at < 10')
         .some(row => row.detail.includes('idx_responses_items_refreshed_at')),
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN UPDATE responses_items SET payload_json = NULL WHERE payload_json IS NOT NULL AND created_at < 10')
+        .some(row => row.detail.includes('idx_responses_items_created_at')),
     );
     assert(
       sqlJsRows<{ detail: string }>(
@@ -445,7 +449,7 @@ class FakeResponsesItemsD1Database implements D1Database {
   clearPayloadOlderThan(createdBefore: number): number {
     let changes = 0;
     for (const row of this.rows) {
-      if (row.refreshed_at < createdBefore && row.payload_json !== null) {
+      if (row.created_at < createdBefore && row.payload_json !== null) {
         row.payload_json = null;
         changes += 1;
       }

--- a/apps/api/src/repo/types.ts
+++ b/apps/api/src/repo/types.ts
@@ -166,12 +166,14 @@ export interface StoredResponsesItem {
   upstreamId: string | null;
   upstreamItemId: string | null;
   itemType: string;
+  origin: 'input' | 'upstream' | 'synthetic';
   payload: StoredResponsesItemPayload | null;
   // sha256 of the item's `encrypted_content`, when it carries one (reasoning /
   // compaction). Lets a later turn that echoes the blob without a gateway id
   // recover this row's owning upstream for affinity routing.
   encryptedContentHash: string | null;
   createdAt: number;
+  refreshedAt: number;
 }
 
 export interface StoredResponsesItemPayload {
@@ -188,8 +190,9 @@ export interface ResponsesItemsRepo {
   lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItem[]>;
   lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   insertMany(items: readonly StoredResponsesItem[]): Promise<void>;
-  clearPayloadOlderThan(createdBefore: number): Promise<number>;
-  deleteOlderThan(createdBefore: number): Promise<number>;
+  refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number>;
+  clearPayloadOlderThan(refreshedBefore: number): Promise<number>;
+  deleteOlderThan(refreshedBefore: number): Promise<number>;
   deleteAll(): Promise<void>;
 }
 

--- a/apps/api/src/repo/types.ts
+++ b/apps/api/src/repo/types.ts
@@ -191,7 +191,7 @@ export interface ResponsesItemsRepo {
   lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   insertMany(items: readonly StoredResponsesItem[]): Promise<void>;
   refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number>;
-  clearPayloadOlderThan(refreshedBefore: number): Promise<number>;
+  clearPayloadOlderThan(createdBefore: number): Promise<number>;
   deleteOlderThan(refreshedBefore: number): Promise<number>;
   deleteAll(): Promise<void>;
 }


### PR DESCRIPTION
Extract a Hono-free source execution core for stored-item lookup, provider planning, provider attempts, and output item commit timing.

Keep serveLlm as the HTTP adapter, rename endpoint setup to prepare, pass response rendering a compact runtime object, and split RequestContext construction into direct and Hono-backed factories.

Remove the intermediate serve failure wrapper and keep the endpoint trait boundary focused on prepare/respond while shared execution stays transport-agnostic.