### PR TITLE
feat(responses): store previous response state

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Search**), and emitted back as Responses `web_search_call` items, with
 the shim driving the internal multi-turn loop and replaying prior
 `web_search_call` items across turns.
 
+## Stateful Responses
+
+`/v1/responses` stores replayable Responses input and output items for API-key
+scoped requests. Clients can send `previous_response_id` to continue from a
+stored snapshot, or resend full input history; repeated full-history input is
+deduplicated by content hash instead of stored again. `store: false` keeps
+output item metadata for routing but does not create durable snapshots or full
+input payload rows.
+
 ## Development
 
 ```bash
@@ -87,7 +96,7 @@ Vite in dev and by Workers Static Assets from `apps/web/dist` after build.
 `wrangler.example.jsonc` keeps API/data-plane routes Worker-first and lets
 other direct browser routes fall through to the SPA's `index.html`. It also
 includes an hourly cron trigger used by the Worker to age out retained Responses
-payloads and metadata. Cross-package imports go through each package's
+snapshots, payloads, and metadata. Cross-package imports go through each package's
 `exports` map; deep imports are blocked by ESLint.
 
 See [AGENTS.md](./AGENTS.md) for architecture, provider routing, deployment,

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ the shim driving the internal multi-turn loop and replaying prior
 `/v1/responses` stores replayable Responses input and output items for API-key
 scoped requests. Clients can send `previous_response_id` to continue from a
 stored snapshot, or resend full input history; repeated full-history input is
-deduplicated by content hash instead of stored again. `store: false` keeps
-output item metadata for routing but does not create durable snapshots or full
-input payload rows.
+deduplicated by content hash instead of stored again. `store: false` does not
+create durable snapshots or input payload rows, but it keeps output item
+metadata for routing; if a later `store: true` request echoes that item with a
+full payload, the metadata row is filled in place.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Open the deployed URL, log in with `ADMIN_KEY`, and:
    agent config.
 
 Import/export of upstreams, keys, and search config is in Settings; it uses the
-latest `version: 2` payload shape.
+latest `version: 3` payload shape.
 
 ## Server Tools
 

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -333,9 +333,9 @@ Known losses:
 
 - generic Responses `metadata` is omitted; it is not coerced into
   `metadata.user_id`.
-- `previous_response_id` and response-level Responses state are not emulated on
-  translated Messages paths. Responses item ids are handled by the API data
-  plane's stored-item layer, not by the pure translation package alone.
+- Pure Responses-to-Messages translation does not own response-level state.
+  The API data plane expands `previous_response_id` and stored item ids before
+  invoking this translator.
 - Freeform `custom` tool `format.definition` is preserved as a
   `Lark grammar: ${definition}` description on the wrapped `input` parameter;
   other `format` fields are not preserved.
@@ -500,9 +500,9 @@ Known losses:
 
 - Responses request-level `reasoning` has no Chat request counterpart except
   explicit effort.
-- `previous_response_id` and response-level Responses state are not emulated on
-  translated Chat paths. Responses item ids are handled by the API data plane's
-  stored-item layer, with readable reasoning ids carried through
+- Pure Responses-to-Chat translation does not own response-level state. The API
+  data plane expands `previous_response_id` and stored item ids before invoking
+  this translator, with readable reasoning ids then carried through
   `reasoning_items[]`.
 - Freeform `custom` tool `format.definition` is preserved as a
   `Lark grammar: ${definition}` description on the wrapped `input` parameter;

--- a/apps/api/entry-cloudflare.ts
+++ b/apps/api/entry-cloudflare.ts
@@ -66,6 +66,7 @@ export default {
     ctx.waitUntil((async () => {
       await getRepo().responsesItems.clearPayloadOlderThan(now - RESPONSES_ITEM_PAYLOAD_TTL_MS);
       await sweepExpiredResponsesItemPayloadFiles(now);
+      await getRepo().responsesSnapshots.deleteOlderThan(now - RESPONSES_ITEM_ROW_TTL_MS);
       await getRepo().responsesItems.deleteOlderThan(now - RESPONSES_ITEM_ROW_TTL_MS);
     })());
   },

--- a/apps/api/migrations/0026_responses_state.sql
+++ b/apps/api/migrations/0026_responses_state.sql
@@ -1,0 +1,16 @@
+ALTER TABLE responses_items ADD COLUMN content_hash TEXT;
+
+CREATE INDEX idx_responses_items_content_hash ON responses_items (api_key_id, content_hash);
+
+CREATE TABLE responses_snapshots (
+  id TEXT NOT NULL,
+  api_key_id TEXT,
+  item_ids_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  refreshed_at INTEGER NOT NULL,
+  CHECK (length(id) > 0),
+  CHECK (length(item_ids_json) > 0)
+);
+
+CREATE UNIQUE INDEX idx_responses_snapshots_id_scope ON responses_snapshots (id, COALESCE(api_key_id, ''));
+CREATE INDEX idx_responses_snapshots_refreshed_at ON responses_snapshots (refreshed_at);

--- a/apps/api/src/control-plane/data-transfer/routes.ts
+++ b/apps/api/src/control-plane/data-transfer/routes.ts
@@ -1,6 +1,6 @@
 // Data transfer routes — export/import operator-managed database data as JSON.
-// Ephemeral stored Responses items are omitted from exports and cleared on
-// replace imports; clients can regenerate them through normal Responses use.
+// Ephemeral stored Responses state is omitted from exports and cleared on
+// replace imports; clients can regenerate it through normal Responses use.
 
 import { parseFlagOverridesWire } from '../../data-plane/providers/flags.ts';
 import { invalidateModelsStore } from '../../data-plane/providers/models-store.ts';
@@ -467,7 +467,7 @@ export const importData = async (c: CtxWithJson<typeof importBody>) => {
     // prepared statements. A failure between the deleteAll wave and the per-record save loop
     // leaves the deployment partially wiped. Operators should back up before running replace mode.
     const existingUpstreams = await repo.upstreams.list();
-    const deletes = [repo.apiKeys.deleteAll(), repo.usage.deleteAll(), repo.searchUsage.deleteAll(), repo.upstreams.deleteAll(), repo.responsesItems.deleteAll()];
+    const deletes = [repo.apiKeys.deleteAll(), repo.usage.deleteAll(), repo.searchUsage.deleteAll(), repo.upstreams.deleteAll(), repo.responsesSnapshots.deleteAll(), repo.responsesItems.deleteAll()];
     if (performanceIncluded) deletes.push(repo.performance.deleteAll());
     await Promise.all(deletes);
     await Promise.all([...existingUpstreams, ...upstreams].map(upstream => invalidateModelsStore(upstream.id)));

--- a/apps/api/src/control-plane/data-transfer/routes_test.ts
+++ b/apps/api/src/control-plane/data-transfer/routes_test.ts
@@ -144,6 +144,7 @@ const STORED_RESPONSES_ITEM: StoredResponsesItem = {
   upstreamItemId: null,
   itemType: 'message',
   origin: 'synthetic',
+  contentHash: null,
   encryptedContentHash: null,
   payload: { item: { type: 'message', id: 'msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA', role: 'assistant', content: [] } },
   createdAt: 1_000,

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -1,6 +1,7 @@
 import type { BackgroundScheduler } from '../../runtime/background.ts';
 import type { ModelProvider, ProviderTargetInterceptors, UpstreamModel } from '../providers/types.ts';
 import type { ExecuteResult } from './shared/errors/result.ts';
+import type { StatefulResponsesStore } from './sources/responses/stateful-store.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
@@ -56,6 +57,7 @@ export interface RequestContext {
   readonly downstreamAbortSignal?: AbortSignal;
   readonly clientStream: boolean;
   statefulResponsesContext: StatefulResponsesContext;
+  statefulResponsesStore?: StatefulResponsesStore;
 }
 
 /**

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -13,35 +13,10 @@ export type LlmSourceApi = 'messages' | 'responses' | 'chat-completions' | 'gemi
 export type LlmTargetApi = 'messages' | 'responses' | 'chat-completions';
 
 /**
- * Per-attempt bag the Responses pipeline uses to thread server-tool shim
- * state across layers (source serve → source interceptors → persistence)
- * within a single provider-binding attempt. The whole bag is reassigned at
- * the top of every attempt, so a failed attempt's writes don't leak forward.
- *
- * - `privatePayload`: wire item id → shim-defined opaque blob, round-tripped
- *   verbatim by persistence as `payload.private`. The shape is shim-specific.
- * - `newSyntheticIds`: gateway-minted item ids no upstream issued, persisted
- *   as non_affinity.
- */
-export interface StatefulResponsesContext {
-  readonly privatePayload: Map<string, unknown>;
-  readonly newSyntheticIds: Set<string>;
-}
-
-/**
  * Per client request scope. Constructed once in `createHttpRequestContext` and
  * threaded through every layer (source interceptors, target emits, target
- * interceptors, telemetry). Holds both immutable identities/adapters and
- * mutable per-request bags that cross-layer producers and consumers share.
- *
- * Anything that varies per provider-binding attempt belongs on `Invocation`,
- * not here. `statefulResponsesContext` is the one exception: the serve loop
- * reassigns it per attempt so cross-layer readers outside `Invocation`
- * plumbing (output persistence, source-interceptor `transformItems`) reach it
- * via the only handle they have. Read it through
- * `request.statefulResponsesContext` at access time; never capture the
- * inner object in a closure or background task — that snapshot belongs to
- * one attempt only.
+ * interceptors, telemetry). Holds immutable identities/adapters plus the
+ * Responses state store that owns mutable request and provider-attempt state.
  *
  * Telemetry recording is done via global helpers that accept `apiKeyId` (and
  * `scheduleBackground` for performance) explicitly so call sites stay visible
@@ -56,8 +31,7 @@ export interface RequestContext {
   readonly scheduleBackground?: BackgroundScheduler;
   readonly downstreamAbortSignal?: AbortSignal;
   readonly clientStream: boolean;
-  statefulResponsesContext: StatefulResponsesContext;
-  statefulResponsesStore: StatefulResponsesStore;
+  statefulResponsesStore?: StatefulResponsesStore;
 }
 
 /**

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -31,7 +31,7 @@ export interface RequestContext {
   readonly scheduleBackground?: BackgroundScheduler;
   readonly downstreamAbortSignal?: AbortSignal;
   readonly clientStream: boolean;
-  statefulResponsesStore?: StatefulResponsesStore;
+  statefulResponsesStore: StatefulResponsesStore;
 }
 
 /**

--- a/apps/api/src/data-plane/llm/interceptors.ts
+++ b/apps/api/src/data-plane/llm/interceptors.ts
@@ -57,7 +57,7 @@ export interface RequestContext {
   readonly downstreamAbortSignal?: AbortSignal;
   readonly clientStream: boolean;
   statefulResponsesContext: StatefulResponsesContext;
-  statefulResponsesStore?: StatefulResponsesStore;
+  statefulResponsesStore: StatefulResponsesStore;
 }
 
 /**

--- a/apps/api/src/data-plane/llm/sources/chat-completions/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/chat-completions/serve_test.ts
@@ -81,6 +81,7 @@ test('/v1/chat/completions rewrites stored Responses reasoning_items before the 
       upstreamItemId: 'raw_rs_chat',
       itemType: 'reasoning',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -1,19 +1,26 @@
 import { listModelProviders, resolveModelForProvider } from '../../providers/registry.ts';
-import { responsesItemId } from './responses/items/format.ts';
 import { type ResponsesItemsCommit, storeResponsesOutputItems } from './responses/items/output.ts';
 import {
   planResponsesItemProviders,
   prepareStoredResponsesItemsForSource,
   rewriteStoredResponsesItemsForProvider,
 } from './responses/items/request-plan.ts';
+import { statefulResponsesStoreForRequest } from './responses/stateful-store.ts';
 import type { LlmEndpointPlan, LlmServeFailure, Result } from './traits.ts';
 
 export const executeLlmSourcePlan = async <TItems, TEvent>(
   plan: LlmEndpointPlan<TItems, TEvent>,
   renderFailure: (failure: LlmServeFailure) => Result<TEvent>,
 ): Promise<{ result: Result<TEvent>; commitForNonStreaming?: ResponsesItemsCommit }> => {
-  const prepared = await prepareStoredResponsesItemsForSource(plan.items, plan.request.apiKeyId ?? null, plan.responsesItemsView);
+  const statefulResponsesStore = statefulResponsesStoreForRequest(plan.request);
+  await statefulResponsesStore.loadInputItems({
+    sourceItems: plan.items,
+    view: plan.responsesItemsView,
+    ...(plan.statefulResponsesInputItems !== undefined ? { inputItemsToStage: plan.statefulResponsesInputItems } : {}),
+  });
+  const prepared = await prepareStoredResponsesItemsForSource(plan.items, plan.responsesItemsView, statefulResponsesStore);
   if (prepared.failures[0]) return { result: renderFailure(prepared.failures[0]) };
+  if (plan.statefulResponsesInputItems !== undefined) await statefulResponsesStore.stageInputItems(plan.statefulResponsesInputItems);
 
   const providerPlan = planResponsesItemProviders(await listModelProviders(plan.request.apiKeyUpstreamIds), prepared);
   if (providerPlan.type === 'failure') return { result: renderFailure(providerPlan.failure) };
@@ -28,13 +35,7 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
     const target = plan.pickTarget(binding.upstreamModel.endpoints);
     if (!target) continue;
 
-    plan.request.statefulResponsesContext = {
-      privatePayload: new Map(prepared.references.flatMap(ref => {
-        const wireId = ref.row?.payload && responsesItemId(ref.row.payload.item as { id?: unknown });
-        return wireId && ref.row?.payload?.private !== undefined ? [[wireId, ref.row.payload.private] as const] : [];
-      })),
-      newSyntheticIds: new Set(),
-    };
+    plan.request.statefulResponsesContext = statefulResponsesStore.beginAttempt(prepared.references);
 
     const rawResult = await plan.attempt({
       binding,
@@ -44,7 +45,12 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
     });
     if (rawResult.type !== 'events') return { result: rawResult };
 
-    const stored = storeResponsesOutputItems(rawResult.events, plan.responsesItemsView, { targetApi: target, upstream: binding.upstream, store: plan.store }, plan.request, plan.wantsStream);
+    const stored = storeResponsesOutputItems(rawResult.events, plan.responsesItemsView, {
+      targetApi: target,
+      upstream: binding.upstream,
+      store: plan.store,
+      commitSnapshot: plan.commitStatefulResponsesSnapshot === true,
+    }, plan.request, plan.wantsStream);
     return { result: { ...rawResult, events: stored.events }, commitForNonStreaming: stored.commitForNonStreaming };
   }
 

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -5,14 +5,13 @@ import {
   prepareStoredResponsesItemsForSource,
   rewriteStoredResponsesItemsForProvider,
 } from './responses/items/request-plan.ts';
-import { statefulResponsesStoreForRequest } from './responses/stateful-store.ts';
 import type { LlmEndpointPlan, LlmServeFailure, Result } from './traits.ts';
 
 export const executeLlmSourcePlan = async <TItems, TEvent>(
   plan: LlmEndpointPlan<TItems, TEvent>,
   renderFailure: (failure: LlmServeFailure) => Result<TEvent>,
 ): Promise<{ result: Result<TEvent>; commitForNonStreaming?: ResponsesItemsCommit }> => {
-  const statefulResponsesStore = statefulResponsesStoreForRequest(plan.request);
+  const statefulResponsesStore = plan.request.statefulResponsesStore;
   await statefulResponsesStore.loadInputItems({
     sourceItems: plan.items,
     view: plan.responsesItemsView,
@@ -21,6 +20,7 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
   const prepared = await prepareStoredResponsesItemsForSource(plan.items, plan.responsesItemsView, statefulResponsesStore);
   if (prepared.failures[0]) return { result: renderFailure(prepared.failures[0]) };
   if (plan.statefulResponsesInputItems !== undefined) await statefulResponsesStore.stageInputItems(plan.statefulResponsesInputItems);
+  await statefulResponsesStore.refreshTouchedItems();
 
   const providerPlan = planResponsesItemProviders(await listModelProviders(plan.request.apiKeyUpstreamIds), prepared);
   if (providerPlan.type === 'failure') return { result: renderFailure(providerPlan.failure) };

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -35,7 +35,7 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
     const target = plan.pickTarget(binding.upstreamModel.endpoints);
     if (!target) continue;
 
-    plan.request.statefulResponsesContext = statefulResponsesStore.beginAttempt(prepared.references);
+    statefulResponsesStore.beginAttempt(prepared.references);
 
     const rawResult = await plan.attempt({
       binding,

--- a/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
@@ -5,6 +5,7 @@ import { stripUnsupportedPartFieldsFromPayload } from './strip-unsupported-part-
 import { stripUnsupportedToolsFromPayload } from './strip-unsupported-tools.ts';
 import { assertEquals } from '../../../../../test-assert.ts';
 import type { GeminiInvocation, RequestContext } from '../../../interceptors.ts';
+import { createHttpStatefulResponsesStore } from '../../responses/stateful-store.ts';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 
 const testTelemetryModelIdentity = {
@@ -31,6 +32,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const runStripSafetySettings = async (payload: GeminiPayload): Promise<void> => {

--- a/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/interceptors/normalize_test.ts
@@ -29,7 +29,7 @@ const invocation = (payload: GeminiPayload): GeminiInvocation => ({
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
@@ -6,6 +6,7 @@ import { assertEquals, assertExists } from '../../../../test-assert.ts';
 import type { RequestContext } from '../../interceptors.ts';
 import type { InternalDebugError } from '../../shared/errors/internal-debug-error.ts';
 import type { ExecuteResult } from '../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { GeminiErrorResponse } from '@floway-dev/protocols/gemini';
@@ -23,6 +24,7 @@ const request = (): RequestContext => ({
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 });
 
 const requestGeminiResponse = async (result: ExecuteResult<ProtocolFrame<GeminiErrorResponse>>): Promise<Response> => {

--- a/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/respond_test.ts
@@ -21,7 +21,7 @@ const testTelemetryModelIdentity = {
 const request = (): RequestContext => ({
   requestStartedAt: performance.now(),
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 });
 

--- a/apps/api/src/data-plane/llm/sources/messages/count-tokens_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/count-tokens_test.ts
@@ -238,6 +238,7 @@ test('/v1/messages/count_tokens rewrites stored Responses reasoning signatures b
       upstreamItemId: 'raw_rs_count',
       itemType: 'reasoning',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),

--- a/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
@@ -16,6 +16,7 @@ import { assertEquals, assertExists, assertRejects } from '../../../../../test-a
 import { DEFAULT_SEARCH_CONFIG } from '../../../../tools/web-search/search-config.ts';
 import type { WebSearchProvider, WebSearchProviderResult } from '../../../../tools/web-search/types.ts';
 import type { MessagesInvocation, RequestContext } from '../../../interceptors.ts';
+import { createHttpStatefulResponsesStore } from '../../responses/stateful-store.ts';
 import { messagesProtocolFrameToSSEFrame } from '../events/to-sse.ts';
 import { type ProtocolFrame, eventFrame } from '@floway-dev/protocols/common';
 import type {
@@ -54,6 +55,7 @@ const requestContext = (apiKeyId?: string): RequestContext => ({
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
   ...(apiKeyId !== undefined ? { apiKeyId } : {}),
 });
 

--- a/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/interceptors/web-search-shim_test.ts
@@ -52,7 +52,6 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
 const requestContext = (apiKeyId?: string): RequestContext => ({
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: false,
   ...(apiKeyId !== undefined ? { apiKeyId } : {}),

--- a/apps/api/src/data-plane/llm/sources/messages/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/serve_test.ts
@@ -349,6 +349,7 @@ test('/v1/messages rewrites stored Responses reasoning signatures before the ups
       upstreamItemId: 'raw_rs_messages',
       itemType: 'reasoning',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),

--- a/apps/api/src/data-plane/llm/sources/request-context.ts
+++ b/apps/api/src/data-plane/llm/sources/request-context.ts
@@ -1,21 +1,52 @@
 import type { Context } from 'hono';
 
-import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
+import { createHttpStatefulResponsesStore, type StatefulResponsesStore } from './responses/stateful-store.ts';
+import { backgroundSchedulerFromContext, type BackgroundScheduler } from '../../../runtime/background.ts';
 import { runtimeLocationFromRequest } from '../../shared/telemetry/performance.ts';
 import type { RequestContext } from '../interceptors.ts';
 
-export const createHttpRequestContext = (c: Context, downstreamAbortSignal: AbortSignal | undefined, clientStream: boolean): RequestContext => {
+export interface CreateRequestContextInput {
+  apiKeyId?: string;
+  apiKeyUpstreamIds?: readonly string[] | null;
+  runtimeLocation: string;
+  scheduleBackground?: BackgroundScheduler;
+  downstreamAbortSignal?: AbortSignal;
+  clientStream: boolean;
+  statefulResponsesStore?: StatefulResponsesStore;
+}
+
+export const createRequestContext = (input: CreateRequestContextInput): RequestContext => {
+  const statefulResponsesStore = input.statefulResponsesStore ?? createHttpStatefulResponsesStore(input.apiKeyId ?? null, undefined);
+  return {
+    requestStartedAt: performance.now(),
+    ...(input.apiKeyId !== undefined ? { apiKeyId: input.apiKeyId } : {}),
+    apiKeyUpstreamIds: input.apiKeyUpstreamIds ?? null,
+    runtimeLocation: input.runtimeLocation,
+    ...(input.scheduleBackground !== undefined ? { scheduleBackground: input.scheduleBackground } : {}),
+    clientStream: input.clientStream,
+    statefulResponsesContext: statefulResponsesStore.attemptContext,
+    statefulResponsesStore,
+    ...(input.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: input.downstreamAbortSignal } : {}),
+  };
+};
+
+export const createHttpRequestContext = (
+  c: Context,
+  downstreamAbortSignal: AbortSignal | undefined,
+  clientStream: boolean,
+  options: { readonly store?: boolean | null | undefined } = {},
+): RequestContext => {
   const apiKeyId = c.get('apiKeyId') as string | undefined;
   const apiKeyUpstreamIds = c.get('apiKeyUpstreamIds') as readonly string[] | null | undefined;
   const scheduleBackground = backgroundSchedulerFromContext(c);
-  return {
-    requestStartedAt: performance.now(),
+  const statefulResponsesStore = createHttpStatefulResponsesStore(apiKeyId ?? null, options.store);
+  return createRequestContext({
     ...(apiKeyId !== undefined ? { apiKeyId } : {}),
-    apiKeyUpstreamIds: apiKeyUpstreamIds ?? null,
+    ...(apiKeyUpstreamIds !== undefined ? { apiKeyUpstreamIds } : {}),
     runtimeLocation: runtimeLocationFromRequest(c.req.raw),
     ...(scheduleBackground !== undefined ? { scheduleBackground } : {}),
     clientStream,
-    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
+    statefulResponsesStore,
     ...(downstreamAbortSignal !== undefined ? { downstreamAbortSignal } : {}),
-  };
+  });
 };

--- a/apps/api/src/data-plane/llm/sources/request-context.ts
+++ b/apps/api/src/data-plane/llm/sources/request-context.ts
@@ -24,7 +24,6 @@ export const createRequestContext = (input: CreateRequestContextInput): RequestC
     runtimeLocation: input.runtimeLocation,
     ...(input.scheduleBackground !== undefined ? { scheduleBackground: input.scheduleBackground } : {}),
     clientStream: input.clientStream,
-    statefulResponsesContext: statefulResponsesStore.attemptContext,
     statefulResponsesStore,
     ...(input.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: input.downstreamAbortSignal } : {}),
   };

--- a/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
+++ b/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
@@ -6,6 +6,7 @@ import { respondChatCompletions } from './chat-completions/respond.ts';
 import { respondGemini } from './gemini/respond.ts';
 import { respondMessages } from './messages/respond.ts';
 import { respondResponses } from './responses/respond.ts';
+import { createHttpStatefulResponsesStore } from './responses/stateful-store.ts';
 import { assertEquals } from '../../../test-assert.ts';
 import { FakeTime } from '../../../test-time.ts';
 import { eventResult } from '../shared/errors/result.ts';
@@ -124,6 +125,7 @@ const request = (): RequestContext => ({
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: true,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 });
 
 test('Messages streaming keepalive uses Anthropic ping events', async () => {

--- a/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
+++ b/apps/api/src/data-plane/llm/sources/respond-keep-alive_test.ts
@@ -122,7 +122,6 @@ const requestStartedAt = performance.now();
 const request = (): RequestContext => ({
   requestStartedAt,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: true,
 });

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
@@ -1,8 +1,9 @@
 import { jsonrepair } from 'jsonrepair';
 
-import type { InterceptorRun, RequestContext, ResponsesInterceptor, ResponsesInvocation, StatefulResponsesContext } from '../../../interceptors.ts';
+import type { InterceptorRun, RequestContext, ResponsesInterceptor, ResponsesInvocation } from '../../../interceptors.ts';
 import type { EventResultMetadata, ExecuteResult } from '../../../shared/errors/result.ts';
 import { truncatePreservingCodePoints } from '../../../shared/text.ts';
+import { statefulResponsesStoreForRequest, type StatefulResponsesStore } from '../stateful-store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
   ResponsesInputItem,
@@ -52,7 +53,7 @@ export interface ServerToolTerminal {
   endEvents: ServerToolLifecycleEvent[];
   /**
    * Optional server-only blob registered on
-   * `request.statefulResponsesContext.privatePayload` under `slot.id` before
+   * `request.statefulResponsesStore` under `slot.id` before
    * the slot's wire item leaves materialize. The persistence layer stores it in
    * `payload.private`; the replay-side `transformItems` reads it back to
    * reconstruct the full IR.
@@ -809,7 +810,7 @@ export const synthesizeTerminalEnvelope = (
 async function* materializeServerToolItems(
   dispatched: ReadonlyArray<{ slots: DispatchedServerToolSlot[] }>,
   merge: MergeState,
-  statefulResponsesContext: StatefulResponsesContext,
+  statefulResponsesStore: StatefulResponsesStore,
 ): AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>, void> {
   for (const d of dispatched) {
     for (const { slot, outputIndex } of d.slots) {
@@ -825,8 +826,7 @@ async function* materializeServerToolItems(
       // produced one) registers under the same id so persistence captures it
       // and the next loop turn's replay-side `transformItems` finds it by the
       // accumulated output item's id.
-      statefulResponsesContext.newSyntheticIds.add(slot.id);
-      if (step.value.privatePayload !== undefined) statefulResponsesContext.privatePayload.set(slot.id, step.value.privatePayload);
+      statefulResponsesStore.addSyntheticItem(slot.id, step.value.privatePayload);
       yield* serverToolEndFrames(merge, outputIndex, slot, step.value);
     }
   }
@@ -840,13 +840,13 @@ async function* runMultiTurnLoop(args: {
   demoteForcedServerToolChoiceAfterFirstTurn: boolean;
   turn1Iter: AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>, TurnSummary>;
   dispatchers: ReadonlyMap<string, ServerToolDispatcher>;
-  statefulResponsesContext: StatefulResponsesContext;
+  statefulResponsesStore: StatefulResponsesStore;
   canonicalInput: ResponsesInputItem[];
   active: readonly ActiveServerTool[];
   metadata: LatestUpstreamMetadata;
   resolveFinalMetadata: (m: EventResultMetadata) => void;
 }): AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>> {
-  const { ctx, run, merge, loopState, demoteForcedServerToolChoiceAfterFirstTurn, turn1Iter, dispatchers, statefulResponsesContext, active, metadata, resolveFinalMetadata } = args;
+  const { ctx, run, merge, loopState, demoteForcedServerToolChoiceAfterFirstTurn, turn1Iter, dispatchers, statefulResponsesStore, active, metadata, resolveFinalMetadata } = args;
   const baseInput = args.canonicalInput;
   let midStreamError: unknown = undefined;
   try {
@@ -857,12 +857,12 @@ async function* runMultiTurnLoop(args: {
       const executedShim = turn.dispatched.length > 0;
 
       if (turn.terminalStatus.kind === 'failed') {
-        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesContext);
+        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesStore);
         yield synthesizeTerminalEnvelope(merge, { kind: 'failed', error: turn.terminalStatus.response.error });
         return;
       }
       if (turn.terminalStatus.kind === 'incomplete') {
-        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesContext);
+        if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesStore);
         yield synthesizeTerminalEnvelope(merge, { kind: 'incomplete', incompleteDetails: turn.terminalStatus.response.incomplete_details });
         return;
       }
@@ -878,7 +878,7 @@ async function* runMultiTurnLoop(args: {
         return;
       }
 
-      yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesContext);
+      yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesStore);
       if (turn.sawClientToolCall) {
         yield synthesizeTerminalEnvelope(merge, { kind: 'completed' });
         return;
@@ -1009,7 +1009,7 @@ export const withResponsesServerToolShim = (
       demoteForcedServerToolChoiceAfterFirstTurn,
       turn1Iter,
       dispatchers,
-      statefulResponsesContext: request.statefulResponsesContext,
+      statefulResponsesStore: statefulResponsesStoreForRequest(request),
       canonicalInput,
       active,
       metadata,

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim.ts
@@ -3,7 +3,7 @@ import { jsonrepair } from 'jsonrepair';
 import type { InterceptorRun, RequestContext, ResponsesInterceptor, ResponsesInvocation } from '../../../interceptors.ts';
 import type { EventResultMetadata, ExecuteResult } from '../../../shared/errors/result.ts';
 import { truncatePreservingCodePoints } from '../../../shared/text.ts';
-import { statefulResponsesStoreForRequest, type StatefulResponsesStore } from '../stateful-store.ts';
+import type { StatefulResponsesStore } from '../stateful-store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
   ResponsesInputItem,
@@ -1009,7 +1009,7 @@ export const withResponsesServerToolShim = (
       demoteForcedServerToolChoiceAfterFirstTurn,
       turn1Iter,
       dispatchers,
-      statefulResponsesStore: statefulResponsesStoreForRequest(request),
+      statefulResponsesStore: request.statefulResponsesStore,
       canonicalInput,
       active,
       metadata,

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
@@ -29,6 +29,7 @@ import type {
 } from '../../../../tools/web-search/types.ts';
 import type { RequestContext, ResponsesInterceptor, ResponsesInvocation } from '../../../interceptors.ts';
 import type { EventResult, ExecuteResult } from '../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore, statefulResponsesStoreForRequest } from '../stateful-store.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
@@ -327,14 +328,17 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
   } as ResponsesPayload,
 });
 
-const makeRequest = (apiKeyId: string | undefined = 'k1'): RequestContext => ({
-  requestStartedAt: 0,
-  apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
-  runtimeLocation: 'test',
-  clientStream: true,
-  ...(apiKeyId !== undefined ? { apiKeyId } : {}),
-});
+const makeRequest = (apiKeyId: string | undefined = 'k1'): RequestContext => {
+  const statefulResponsesStore = createHttpStatefulResponsesStore(apiKeyId ?? null, undefined);
+  return {
+    requestStartedAt: 0,
+    apiKeyUpstreamIds: null,
+    runtimeLocation: 'test',
+    clientStream: true,
+    statefulResponsesStore,
+    ...(apiKeyId !== undefined ? { apiKeyId } : {}),
+  };
+};
 
 const collectFrames = async <T>(iter: AsyncIterable<T>): Promise<T[]> => {
   const out: T[] = [];
@@ -650,14 +654,15 @@ test('synthesized web_search_call ids are registered as gateway-synthetic on the
   // them with no upstream identity (non_affinity).
   const doneEvents = outputItemDoneEvents(frames);
   const wsCallDoneIds = doneEvents.filter(e => e.item.type === 'web_search_call').map(e => e.item.id!);
+  const store = statefulResponsesStoreForRequest(request);
   assert(wsCallDoneIds.length > 0, 'expected a synthesized web_search_call');
   for (const id of wsCallDoneIds) {
     assert(id.startsWith('ws_gw_'));
-    assert(request.statefulResponsesContext.newSyntheticIds.has(id), `expected ${id} registered as synthetic`);
+    assert(store.isSyntheticItem(id), `expected ${id} registered as synthetic`);
   }
   // A genuine upstream item (the final message) is not registered.
   for (const e of doneEvents.filter(e => e.item.type === 'message')) {
-    assertFalse(request.statefulResponsesContext.newSyntheticIds.has(e.item.id!));
+    assertFalse(store.isSyntheticItem(e.item.id!));
   }
 });
 
@@ -4472,9 +4477,9 @@ test('downstream AbortSignal threads through to provider search / fetchPage and 
   const request: RequestContext = {
     requestStartedAt: 0,
     apiKeyUpstreamIds: null,
-    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
     runtimeLocation: 'test',
     clientStream: true,
+    statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
     apiKeyId: 'k1',
     downstreamAbortSignal: controller.signal,
   };

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tool-shim_test.ts
@@ -29,7 +29,7 @@ import type {
 } from '../../../../tools/web-search/types.ts';
 import type { RequestContext, ResponsesInterceptor, ResponsesInvocation } from '../../../interceptors.ts';
 import type { EventResult, ExecuteResult } from '../../../shared/errors/result.ts';
-import { createHttpStatefulResponsesStore, statefulResponsesStoreForRequest } from '../stateful-store.ts';
+import { createHttpStatefulResponsesStore } from '../stateful-store.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
@@ -654,7 +654,7 @@ test('synthesized web_search_call ids are registered as gateway-synthetic on the
   // them with no upstream identity (non_affinity).
   const doneEvents = outputItemDoneEvents(frames);
   const wsCallDoneIds = doneEvents.filter(e => e.item.type === 'web_search_call').map(e => e.item.id!);
-  const store = statefulResponsesStoreForRequest(request);
+  const store = request.statefulResponsesStore;
   assert(wsCallDoneIds.length > 0, 'expected a synthesized web_search_call');
   for (const id of wsCallDoneIds) {
     assert(id.startsWith('ws_gw_'));

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, test, vi } from 'vitest';
 
+import { initRepo } from '../../../../../../repo/index.ts';
+import { InMemoryRepo } from '../../../../../../repo/memory.ts';
 import { assert, assertEquals } from '../../../../../../test-assert.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../interceptors.ts';
 import type { EventResult, ExecuteResult } from '../../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../stateful-store.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -116,7 +119,13 @@ const makeCtx = (input: unknown[], action: 'generate' | 'edit' | 'auto' = 'auto'
   enabledFlags: new Set<string>(['responses-image-generation-shim']), headers: {},
   payload: { model: 'orchestrator', input, tools: [{ type: 'image_generation', action, ...extraTool }] } as never,
 });
-const REQ = { requestStartedAt: 0, apiKeyUpstreamIds: null, runtimeLocation: 'test', clientStream: true, statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() } } as RequestContext;
+const request = (): RequestContext => ({
+  requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
+  runtimeLocation: 'test',
+  clientStream: true,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
+});
 
 const drain = async (result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesStreamEvent[]> => {
   if (result.type !== 'events') throw new Error(`expected events, got ${result.type}`);
@@ -126,6 +135,7 @@ const drain = async (result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>)
 };
 
 beforeEach(() => {
+  initRepo(new InMemoryRepo());
   stub.generationsCalls = [];
   stub.editsForms = [];
   stub.nextGenerations = [];
@@ -134,7 +144,7 @@ beforeEach(() => {
 
 test('generates an image end-to-end and emits the native lifecycle', async () => {
   stub.nextGenerations = [jsonResponse('R0VO')]; // "GEN"
-  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw a cat' }]), REQ, scriptedRun([
+  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw a cat' }]), request(), scriptedRun([
     callTurn(0, 'call_1', 'a cat'),
     messageTurn('here it is'),
   ]));
@@ -156,7 +166,7 @@ test('relays real partial_image frames when partial_images > 0', async () => {
     JSON.stringify({ type: 'image_generation.partial_image', partial_image_index: 1, b64_json: 'UDE=' }),
     JSON.stringify({ type: 'image_generation.completed', b64_json: 'RklO' }),
   ])];
-  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw a cat' }], 'auto', { partial_images: 2 }), REQ, scriptedRun([
+  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw a cat' }], 'auto', { partial_images: 2 }), request(), scriptedRun([
     callTurn(0, 'call_1', 'a cat'),
     messageTurn('done'),
   ]));
@@ -177,7 +187,7 @@ test('an image generated in turn 1 is re-collected as an edit source in turn 2',
   // a frozen registration-time snapshot.
   stub.nextGenerations = [jsonResponse('QUFBQQ==')]; // "AAAA"
   stub.nextEdits = [jsonResponse('QkJCQg==')]; // "BBBB"
-  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw then border it' }]), REQ, scriptedRun([
+  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw then border it' }]), request(), scriptedRun([
     callTurn(0, 'call_1', 'a cat'),
     callTurn(0, 'call_2', 'add a black border'),
     messageTurn('done'),
@@ -199,7 +209,7 @@ test('retries on 429 and surfaces the eventual success', async () => {
     rateLimitResponse(1),
     jsonResponse('T0s='),
   ];
-  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw' }]), REQ, scriptedRun([
+  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw' }]), request(), scriptedRun([
     callTurn(0, 'call_1', 'a cat'),
     messageTurn('done'),
   ]));
@@ -220,7 +230,7 @@ test('gives up after MAX_RATE_LIMIT_RETRIES on persistent 429 and surfaces a fai
     rateLimitResponse(1),
     rateLimitResponse(1),
   ];
-  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw' }]), REQ, scriptedRun([
+  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw' }]), request(), scriptedRun([
     callTurn(0, 'call_1', 'a cat'),
     messageTurn('sorry'),
   ]));
@@ -242,7 +252,7 @@ test('does not retry non-rate-limit upstream failures', async () => {
       { status: 400, headers: { 'content-type': 'application/json' } },
     ),
   ];
-  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw' }]), REQ, scriptedRun([
+  const result = await shim(makeCtx([{ type: 'message', role: 'user', content: 'draw' }]), request(), scriptedRun([
     callTurn(0, 'call_1', 'a cat'),
     messageTurn('sorry'),
   ]));

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/image-generation_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { beforeEach, test } from 'vitest';
 
 import {
   buildGenerationsBody,
@@ -17,8 +17,11 @@ import {
   synthesizeImageGenerationCallId,
   transformInputItemsForImageGeneration,
 } from './image-generation.ts';
+import { initRepo } from '../../../../../../repo/index.ts';
+import { InMemoryRepo } from '../../../../../../repo/memory.ts';
 import { assert, assertEquals, assertFalse, assertStringIncludes } from '../../../../../../test-assert.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../interceptors.ts';
+import { createHttpStatefulResponsesStore } from '../../stateful-store.ts';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
 
 const PNG_B64 = 'aGVsbG8='; // "hello" — any decodable base64 works for source tests.
@@ -37,7 +40,17 @@ const makeCtx = (payload: Partial<ResponsesPayload>): ResponsesInvocation => ({
   headers: {},
   payload: { model: 'm', input: [], ...payload } as ResponsesPayload,
 });
-const REQ = { requestStartedAt: 0, apiKeyUpstreamIds: null, runtimeLocation: 'test', clientStream: true } as RequestContext;
+const request = (): RequestContext => ({
+  requestStartedAt: 0,
+  apiKeyUpstreamIds: null,
+  runtimeLocation: 'test',
+  clientStream: true,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
+});
+
+beforeEach(() => {
+  initRepo(new InMemoryRepo());
+});
 
 const imageMessage = (mime: string): ResponsesInputItem => ({
   type: 'message', role: 'user', content: [{ type: 'input_image', image_url: `data:${mime};base64,${PNG_B64}`, detail: 'auto' }],
@@ -488,7 +501,7 @@ test('synthesizeImageGenerationCallId produces an ig_gw_-prefixed id', () => {
 test('imageGenerationServerTool rejects an unsupported edit input format up front', async () => {
   const result = await imageGenerationServerTool(
     makeCtx({ tools: [{ type: 'image_generation' }], input: [imageMessage('image/gif')] }),
-    REQ,
+    request(),
   );
   assert(result.type === 'invalid-request');
   assertEquals(result.code, 'unsupported_file_mimetype');
@@ -499,7 +512,7 @@ test('imageGenerationServerTool rejects an unsupported edit input format up fron
 test('imageGenerationServerTool accepts webp input for editing', async () => {
   const result = await imageGenerationServerTool(
     makeCtx({ tools: [{ type: 'image_generation' }], input: [imageMessage('image/webp')] }),
-    REQ,
+    request(),
   );
   assert(result.type === 'active');
 });
@@ -509,7 +522,7 @@ test('imageGenerationServerTool ignores input format when action is generate', a
   // to the edit backend, so the format is not validated.
   const result = await imageGenerationServerTool(
     makeCtx({ tools: [{ type: 'image_generation', action: 'generate' }], input: [imageMessage('image/gif')] }),
-    REQ,
+    request(),
   );
   assert(result.type === 'active');
 });
@@ -517,7 +530,7 @@ test('imageGenerationServerTool ignores input format when action is generate', a
 // ── imageGenerationServerTool: per-response dispatch budget (B) ──
 
 test('image dispatch budget caps real backend calls per response, not ReAct turns', async () => {
-  const result = await imageGenerationServerTool(makeCtx({ tools: [{ type: 'image_generation', action: 'generate' }] }), REQ);
+  const result = await imageGenerationServerTool(makeCtx({ tools: [{ type: 'image_generation', action: 'generate' }] }), request());
   assert(result.type === 'active' && result.hosted !== undefined);
   const dispatch = result.hosted.dispatcher;
   const intercepted = { callId: 'c', name: SHIM_TOOL_NAME, argumentsJson: '{}', arguments: { prompt: 'x' } };

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
@@ -5,7 +5,6 @@ import { loadSearchConfig } from '../../../../../tools/web-search/search-config.
 import { searchWebAndRecordUsage, searchWebWithoutRecordingUsage } from '../../../../../tools/web-search/search.ts';
 import type { ConfiguredWebSearchProvider, WebSearchProvider, WebSearchProviderName } from '../../../../../tools/web-search/types.ts';
 import { truncatePreservingCodePoints } from '../../../../shared/text.ts';
-import { statefulResponsesStoreForRequest } from '../../stateful-store.ts';
 import { serverToolResultSlot, type ServerToolLoopState, type ServerToolOutputItem, type ServerToolRegistration } from '../server-tool-shim.ts';
 import type { ResponsesFunctionTool, ResponsesFunctionToolCallItem, ResponsesHostedTool, ResponsesInputItem, ResponsesOutputWebSearchCall, ResponsesTool, ResponsesWebSearchAction, ResponsesWebSearchResult } from '@floway-dev/protocols/responses';
 import { WEB_SEARCH_HOSTED_TYPE_NAMES } from '@floway-dev/protocols/responses';
@@ -1335,7 +1334,7 @@ export const webSearchServerTool: ServerToolRegistration = (ctx, request) => {
   return {
     type: 'active',
     baseToolName: SHIM_TOOL_NAME,
-    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName, id => statefulResponsesStoreForRequest(request).getPrivatePayload(id)),
+    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName, id => request.statefulResponsesStore.getPrivatePayload(id)),
     ...(hasHostedWebSearch
       ? {
           hosted: {

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search.ts
@@ -5,6 +5,7 @@ import { loadSearchConfig } from '../../../../../tools/web-search/search-config.
 import { searchWebAndRecordUsage, searchWebWithoutRecordingUsage } from '../../../../../tools/web-search/search.ts';
 import type { ConfiguredWebSearchProvider, WebSearchProvider, WebSearchProviderName } from '../../../../../tools/web-search/types.ts';
 import { truncatePreservingCodePoints } from '../../../../shared/text.ts';
+import { statefulResponsesStoreForRequest } from '../../stateful-store.ts';
 import { serverToolResultSlot, type ServerToolLoopState, type ServerToolOutputItem, type ServerToolRegistration } from '../server-tool-shim.ts';
 import type { ResponsesFunctionTool, ResponsesFunctionToolCallItem, ResponsesHostedTool, ResponsesInputItem, ResponsesOutputWebSearchCall, ResponsesTool, ResponsesWebSearchAction, ResponsesWebSearchResult } from '@floway-dev/protocols/responses';
 import { WEB_SEARCH_HOSTED_TYPE_NAMES } from '@floway-dev/protocols/responses';
@@ -673,7 +674,7 @@ const renderOpOutputText = (action: ResponsesWebSearchAction, results: Responses
 export const transformInputItemsForWebSearch = (
   input: ResponsesInputItem[],
   toolName: string,
-  privatePayloads?: ReadonlyMap<string, unknown>,
+  getPrivatePayload?: (id: string) => unknown,
 ): ResponsesInputItem[] => {
   const out: ResponsesInputItem[] = [];
 
@@ -683,7 +684,7 @@ export const transformInputItemsForWebSearch = (
       continue;
     }
 
-    const candidatePayload = item.id !== undefined ? privatePayloads?.get(item.id) : undefined;
+    const candidatePayload = item.id !== undefined ? getPrivatePayload?.(item.id) : undefined;
     if (isWebSearchCallPrivatePayload(candidatePayload)) {
       out.push(
         candidatePayload.functionCallItem,
@@ -1334,7 +1335,7 @@ export const webSearchServerTool: ServerToolRegistration = (ctx, request) => {
   return {
     type: 'active',
     baseToolName: SHIM_TOOL_NAME,
-    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName, request.statefulResponsesContext.privatePayload),
+    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName, id => statefulResponsesStoreForRequest(request).getPrivatePayload(id)),
     ...(hasHostedWebSearch
       ? {
           hosted: {

--- a/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/interceptors/server-tools/web-search_test.ts
@@ -417,7 +417,7 @@ test('transformInputItemsForWebSearch replays the upstream function_call verbati
   const out = transformInputItemsForWebSearch(
     [{ type: 'web_search_call', id: 'ws_xxx_abc' }],
     'web_search',
-    map,
+    id => map.get(id),
   );
   assertEquals(out.length, 2);
   const [fc, fco] = out as [{ type: string; name: string; arguments: string; call_id: string }, { type: string; output: string; call_id: string }];
@@ -445,7 +445,7 @@ test('transformInputItemsForWebSearch replays each echoed wsc independently (one
       { type: 'web_search_call', id: 'ws_two' },
     ],
     'web_search',
-    map,
+    id => map.get(id),
   );
   assertEquals(out.length, 4);
   const callIds = out.map(it => (it as { call_id?: unknown }).call_id).filter((id): id is string => typeof id === 'string');
@@ -491,7 +491,7 @@ test('transformInputItemsForWebSearch ignores a stashed value with the wrong sch
   const out = transformInputItemsForWebSearch(
     [{ type: 'web_search_call', id: 'ws_xxx_abc', action: { type: 'search', queries: ['q'] } }],
     'web_search',
-    map,
+    id => map.get(id),
   );
   const fco = out[1] as { type: string; output: string };
   assertEquals(fco.output, 'Prior search results were not preserved in the conversation history. Call web_search again if you need them.');

--- a/apps/api/src/data-plane/llm/sources/responses/items/format.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/format.ts
@@ -80,6 +80,11 @@ export const hashResponsesItemEncryptedContent = async (encryptedContent: string
   return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
 };
 
+export const hashResponsesItemContent = async (item: ResponsesInputItem): Promise<string> => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(stableJson(item)));
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+};
+
 export const createTemporaryResponsesItemId = (itemType: string): string => `${prefixForItemType(itemType)}_tmp_${randomBody()}`;
 
 const prefixForItemType = (itemType: string): string => {
@@ -103,4 +108,17 @@ const base64UrlEncode = (bytes: Uint8Array): string => {
 const crc32Checksum = (input: string): string => {
   const crc = crc32(new TextEncoder().encode(input)) >>> 0;
   return base64UrlEncode(new Uint8Array([(crc >>> 24) & 0xff, (crc >>> 16) & 0xff, (crc >>> 8) & 0xff, crc & 0xff]));
+};
+
+const stableJson = (value: unknown): string => JSON.stringify(sortJson(value));
+
+const sortJson = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value === null || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([key, entry]) => [key, sortJson(entry)]),
+  );
 };

--- a/apps/api/src/data-plane/llm/sources/responses/items/format_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/format_test.ts
@@ -3,6 +3,7 @@ import { test } from 'vitest';
 import {
   createStoredResponsesItemId,
   createTemporaryResponsesItemId,
+  hashResponsesItemContent,
   isStoredResponsesItemId,
 } from './format.ts';
 import { assert, assertFalse, assertThrows } from '../../../../../test-assert.ts';
@@ -75,4 +76,11 @@ test('temporary ids use the item prefix without becoming stored ids', () => {
   const temporary = createTemporaryResponsesItemId('reasoning');
   assert(/^rs_tmp_[A-Za-z0-9_-]{22}$/.test(temporary), temporary);
   assertFalse(isStoredResponsesItemId(temporary));
+});
+
+test('input content hashing includes the item id', async () => {
+  const first = await hashResponsesItemContent({ type: 'message', id: 'msg_a', role: 'user', content: 'same' });
+  const second = await hashResponsesItemContent({ type: 'message', id: 'msg_b', role: 'user', content: 'same' });
+
+  assertFalse(first === second);
 });

--- a/apps/api/src/data-plane/llm/sources/responses/items/image-generation-replay_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/image-generation-replay_test.ts
@@ -9,6 +9,7 @@ import { assert, assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel } from '../../../../../test-helpers.ts';
 import type { ModelProviderInstance, ProviderModelRecord } from '../../../../providers/types.ts';
 import { collectImageSources } from '../interceptors/server-tools/image-generation.ts';
+import { createHttpStatefulResponsesStore } from '../stateful-store.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -45,6 +46,7 @@ test('a stored image_generation_call referenced by id is inline-expanded with it
     itemType: 'image_generation_call',
     origin: 'synthetic',
     payload: { item: { type: 'image_generation_call', id: storedId, status: 'completed', result: PNG_B64, revised_prompt: 'a cat', output_format: 'png' } },
+    contentHash: null,
     encryptedContentHash: null,
     createdAt: Date.now(),
     refreshedAt: Date.now(),
@@ -56,7 +58,9 @@ test('a stored image_generation_call referenced by id is inline-expanded with it
   // The client echoes only the id back, with the bytes stripped.
   const input: ResponsesInputItem[] = [{ type: 'image_generation_call', id: storedId, status: 'completed' } as ResponsesInputItem];
 
-  const prepared = await prepareStoredResponsesItemsForSource(input, API_KEY_ID, responsesItemsView);
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
+  await store.loadInputItems({ sourceItems: input, view: responsesItemsView });
+  const prepared = await prepareStoredResponsesItemsForSource(input, responsesItemsView, store);
   assertEquals(prepared.failures.length, 0);
   const expanded = await rewriteStoredResponsesItemsForProvider(input, prepared, provider('up'), responsesItemsView) as ResponsesInputItem[];
 

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -1,7 +1,7 @@
-import { createStoredResponsesItemId, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
-import { getRepo } from '../../../../../repo/index.ts';
+import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StoredResponsesItem } from '../../../../../repo/types.ts';
 import type { LlmTargetApi, RequestContext } from '../../../interceptors.ts';
+import { statefulResponsesStoreForRequest } from '../stateful-store.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type {
   ResponsesItemFinalizedHandler,
@@ -48,6 +48,7 @@ export interface StoreResponsesContext {
   readonly targetApi: LlmTargetApi;
   readonly upstream: string;
   readonly store: boolean | null | undefined;
+  readonly commitSnapshot?: boolean;
 }
 
 // Flushes the rows buffered during a non-streaming drain. Streaming has no
@@ -68,6 +69,7 @@ export const storeResponsesOutputItems = <TFrame>(
   wantsStream: boolean,
 ): StoredResponsesItemsStream<TFrame> => {
   const upstreamToStored = new Map<string, string>();
+  const statefulResponsesStore = statefulResponsesStoreForRequest(request);
 
   // An upstream id that happens to parse as a gateway stored id is not
   // special-cased: `request-plan.ts` rewrites our stored ids away before the
@@ -83,61 +85,112 @@ export const storeResponsesOutputItems = <TFrame>(
     return storedId;
   };
 
-  // Opportunistic and read-after-write: the insert is awaited so a caller that
-  // has exposed the stored id can reference the row, but its failure is logged
-  // and swallowed so storage never sinks an already-billable response.
-  const insertStoredItems = async (rows: readonly StoredResponsesItem[]): Promise<void> => {
-    if (rows.length === 0) return;
+  const commitStoredItems = async (): Promise<void> => {
     try {
-      await getRepo().responsesItems.insertMany(rows);
+      await statefulResponsesStore.commitOutputItems();
     } catch (error) {
       console.error('Failed to persist stored Responses items:', error);
     }
   };
-
-  const buffer: StoredResponsesItem[] = [];
-
-  const buildRow = async (newId: string, originalItem: ResponsesInputItem): Promise<StoredResponsesItem> => {
-    const upstreamId = responsesItemId(originalItem);
-    if (upstreamId === null) {
-      throw new Error(`Cannot persist Responses item without an upstream id (newId=${newId}, type=${originalItem.type})`);
+  const commitSnapshot = async (responseId: string): Promise<void> => {
+    try {
+      await statefulResponsesStore.commitSnapshot(responseId);
+    } catch (error) {
+      console.error('Failed to persist stored Responses snapshot:', error);
     }
-    // A native Responses upstream owns its items — except those a source
-    // interceptor synthesized this request, whose gateway-minted ids the
-    // upstream never issued. Those persist with no upstream identity so they
-    // stay non_affinity.
-    const upstreamOwned = context.targetApi === 'responses' && !request.statefulResponsesContext.newSyntheticIds.has(upstreamId);
-    const encryptedContent = responsesItemEncryptedContent(originalItem);
-    // Source interceptors register the per-item server-only payload under the
-    // wire id transformItems sees; the same id is `upstreamId` here. Attaching
-    // it lets a later turn restore the real success/failure state even when the
-    // client stripped fields from the echoed wire item.
-    const privatePayload = request.statefulResponsesContext.privatePayload.get(upstreamId);
-    const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
-    const now = Date.now();
-    return {
-      id: newId,
-      apiKeyId: request.apiKeyId ?? null,
-      upstreamId: upstreamOwned ? context.upstream : null,
-      upstreamItemId: upstreamOwned ? upstreamId : null,
-      itemType: originalItem.type,
-      origin: upstreamOwned ? 'upstream' : 'synthetic',
-      payload: context.store === false ? null : persistedPayload,
-      encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
-      createdAt: now,
-      refreshedAt: now,
-    };
   };
 
   const onItemFinalized: ResponsesItemFinalizedHandler = async (originalItem, newId) => {
-    const row = await buildRow(newId, originalItem);
-    if (wantsStream) await insertStoredItems([row]);
-    else buffer.push(row);
+    const row = await buildRow(newId, originalItem, context, request);
+    statefulResponsesStore.stageOutputItem(row);
+    if (wantsStream) await commitStoredItems();
   };
 
   // Streaming writes each row at its done frame, so there is nothing to flush;
   // only a non-streaming drain buffers rows for a single commit at the end.
-  const commitForNonStreaming = wantsStream ? undefined : (): Promise<void> => insertStoredItems(buffer);
+  let terminalResponseId: string | null = null;
+  const commitForNonStreaming = wantsStream
+    ? undefined
+    : async (): Promise<void> => {
+      await commitStoredItems();
+      if (context.commitSnapshot && terminalResponseId !== null) await commitSnapshot(terminalResponseId);
+    };
 
-  return { events: view.streamMapIdAsResponsesItems(frames, idMapper, onItemFinalized), commitForNonStreaming };
+  const events = commitSnapshotFromTerminal(
+    view.streamMapIdAsResponsesItems(frames, idMapper, onItemFinalized),
+    context,
+    wantsStream,
+    id => { terminalResponseId = id; },
+    commitSnapshot,
+  );
+
+  return { events, commitForNonStreaming };
+};
+
+const buildRow = async (
+  newId: string,
+  originalItem: ResponsesInputItem,
+  context: StoreResponsesContext,
+  request: RequestContext,
+): Promise<StoredResponsesItem> => {
+  const upstreamId = responsesItemId(originalItem);
+  if (upstreamId === null) {
+    throw new Error(`Cannot persist Responses item without an upstream id (newId=${newId}, type=${originalItem.type})`);
+  }
+  // A native Responses upstream owns its items — except those a source
+  // interceptor synthesized this request, whose gateway-minted ids the
+  // upstream never issued. Those persist with no upstream identity so they
+  // stay non_affinity.
+  const statefulResponsesStore = statefulResponsesStoreForRequest(request);
+  const upstreamOwned = context.targetApi === 'responses' && !statefulResponsesStore.isSyntheticItem(upstreamId);
+  const encryptedContent = responsesItemEncryptedContent(originalItem);
+  // Source interceptors register the per-item server-only payload under the
+  // wire id transformItems sees; the same id is `upstreamId` here. Attaching
+  // it lets a later turn restore the real success/failure state even when the
+  // client stripped fields from the echoed wire item.
+  const privatePayload = statefulResponsesStore.getPrivatePayload(upstreamId);
+  const persistedPayload = privatePayload !== undefined ? { item: originalItem, private: privatePayload } : { item: originalItem };
+  const now = Date.now();
+  return {
+    id: newId,
+    apiKeyId: request.apiKeyId ?? null,
+    upstreamId: upstreamOwned ? context.upstream : null,
+    upstreamItemId: upstreamOwned ? upstreamId : null,
+    itemType: originalItem.type,
+    origin: upstreamOwned ? 'upstream' : 'synthetic',
+    payload: context.store === false ? null : persistedPayload,
+    contentHash: await hashResponsesItemContent(originalItem),
+    encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
+    createdAt: now,
+    refreshedAt: now,
+  };
+};
+
+const commitSnapshotFromTerminal = async function* <TFrame>(
+  frames: AsyncIterable<TFrame>,
+  context: StoreResponsesContext,
+  wantsStream: boolean,
+  rememberTerminalResponseId: (id: string) => void,
+  commitSnapshot: (id: string) => Promise<void>,
+): AsyncGenerator<TFrame> {
+  for await (const frame of frames) {
+    const responseId = terminalResponseId(frame);
+    if (responseId !== null) {
+      rememberTerminalResponseId(responseId);
+      if (wantsStream && context.commitSnapshot) await commitSnapshot(responseId);
+    }
+    yield frame;
+  }
+};
+
+const terminalResponseId = (frame: unknown): string | null => {
+  if (!frame || typeof frame !== 'object' || (frame as { type?: unknown }).type !== 'event') return null;
+  const event = (frame as { event?: unknown }).event;
+  if (!event || typeof event !== 'object') return null;
+  const eventType = (event as { type?: unknown }).type;
+  if (eventType !== 'response.completed' && eventType !== 'response.incomplete' && eventType !== 'response.failed') return null;
+  const response = (event as { response?: unknown }).response;
+  if (!response || typeof response !== 'object') return null;
+  const id = (response as { id?: unknown }).id;
+  return typeof id === 'string' && id.length > 0 ? id : null;
 };

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -1,7 +1,6 @@
 import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StoredResponsesItem } from '../../../../../repo/types.ts';
 import type { LlmTargetApi, RequestContext } from '../../../interceptors.ts';
-import { statefulResponsesStoreForRequest } from '../stateful-store.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type {
   ResponsesItemFinalizedHandler,
@@ -69,7 +68,7 @@ export const storeResponsesOutputItems = <TFrame>(
   wantsStream: boolean,
 ): StoredResponsesItemsStream<TFrame> => {
   const upstreamToStored = new Map<string, string>();
-  const statefulResponsesStore = statefulResponsesStoreForRequest(request);
+  const statefulResponsesStore = request.statefulResponsesStore;
 
   // An upstream id that happens to parse as a gateway stored id is not
   // special-cased: `request-plan.ts` rewrites our stored ids away before the
@@ -141,7 +140,7 @@ const buildRow = async (
   // interceptor synthesized this request, whose gateway-minted ids the
   // upstream never issued. Those persist with no upstream identity so they
   // stay non_affinity.
-  const statefulResponsesStore = statefulResponsesStoreForRequest(request);
+  const statefulResponsesStore = request.statefulResponsesStore;
   const upstreamOwned = context.targetApi === 'responses' && !statefulResponsesStore.isSyntheticItem(upstreamId);
   const encryptedContent = responsesItemEncryptedContent(originalItem);
   // Source interceptors register the per-item server-only payload under the

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -29,14 +29,14 @@ const makeRequest = (
   privatePayloads: Iterable<readonly [string, unknown]> = [],
 ): RequestContext => {
   const statefulResponsesStore = createHttpStatefulResponsesStore(apiKeyId, undefined);
-  for (const id of syntheticItemIds) statefulResponsesStore.addSyntheticItem(id);
-  for (const [id, payload] of privatePayloads) statefulResponsesStore.attemptContext.privatePayload.set(id, payload);
+  const privatePayloadById = new Map(privatePayloads);
+  for (const id of syntheticItemIds) statefulResponsesStore.addSyntheticItem(id, privatePayloadById.get(id));
   return {
     requestStartedAt: 0,
     apiKeyId,
+    apiKeyUpstreamIds: null,
     runtimeLocation: 'test',
     clientStream: true,
-    statefulResponsesContext: statefulResponsesStore.attemptContext,
     statefulResponsesStore,
   };
 };
@@ -135,6 +135,10 @@ class ControlledResponsesItemsRepo implements ResponsesItemsRepo {
       this.resolveInsert = resolve;
       this.rejectInsert = reject;
     });
+  }
+
+  fillPayloads(): Promise<number> {
+    return Promise.resolve(0);
   }
 
   refreshMany(): Promise<number> {
@@ -387,10 +391,9 @@ test('gateway-synthesized items registered this request do not claim upstream ow
 test('private payload registered on the request is attached to the persisted row by upstream id', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);
-  // The shim registers `statefulResponsesContext.privatePayload[slot.id] = {...}` before
-  // yielding the wire item. The persistence layer keys off the wire item's id
-  // (which equals slot.id here), so the row picks up `payload.private` even
-  // though the wire item itself never carries it.
+  // The shim registers the private payload before yielding the wire item. The
+  // persistence layer keys off that wire id (which equals slot.id here), so the
+  // row picks up `payload.private` even though the wire item never carries it.
   const synthetic: Extract<ResponsesOutputItem, { type: 'web_search_call' }> = {
     type: 'web_search_call',
     id: 'ws_gw_priv00000000000000000',

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -7,6 +7,7 @@ import { InMemoryRepo } from '../../../../../repo/memory.ts';
 import type { ResponsesItemsRepo, StoredResponsesItem } from '../../../../../repo/types.ts';
 import { assert, assertEquals } from '../../../../../test-assert.ts';
 import type { RequestContext } from '../../../../llm/interceptors.ts';
+import { createHttpStatefulResponsesStore } from '../stateful-store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesOutputItem, ResponsesResult, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -26,14 +27,19 @@ const makeContext = (overrides: Partial<StoreResponsesContext> = {}): StoreRespo
 const makeRequest = (
   syntheticItemIds: Iterable<string> = [],
   privatePayloads: Iterable<readonly [string, unknown]> = [],
-): RequestContext => ({
-  requestStartedAt: 0,
-  apiKeyUpstreamIds: null,
-  apiKeyId,
-  runtimeLocation: 'test',
-  clientStream: true,
-  statefulResponsesContext: { privatePayload: new Map(privatePayloads), newSyntheticIds: new Set(syntheticItemIds) },
-});
+): RequestContext => {
+  const statefulResponsesStore = createHttpStatefulResponsesStore(apiKeyId, undefined);
+  for (const id of syntheticItemIds) statefulResponsesStore.addSyntheticItem(id);
+  for (const [id, payload] of privatePayloads) statefulResponsesStore.attemptContext.privatePayload.set(id, payload);
+  return {
+    requestStartedAt: 0,
+    apiKeyId,
+    runtimeLocation: 'test',
+    clientStream: true,
+    statefulResponsesContext: statefulResponsesStore.attemptContext,
+    statefulResponsesStore,
+  };
+};
 
 const messageItem = (id: string, text: string): Extract<ResponsesOutputItem, { type: 'message' }> => ({
   type: 'message',
@@ -98,6 +104,14 @@ const promiseStateAfterMicrotasks = async (promise: IteratorResultPromise): Prom
   return state;
 };
 
+const waitForInsertCall = async (repo: ControlledResponsesItemsRepo): Promise<void> => {
+  for (let i = 0; i < 50; i += 1) {
+    if (repo.calls.length > 0) return;
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  throw new Error('timed out waiting for insertMany');
+};
+
 class ControlledResponsesItemsRepo implements ResponsesItemsRepo {
   calls: StoredResponsesItem[][] = [];
   resolveInsert: (() => void) | undefined;
@@ -108,6 +122,10 @@ class ControlledResponsesItemsRepo implements ResponsesItemsRepo {
   }
 
   lookupManyByEncryptedContentHash(): Promise<StoredResponsesItem[]> {
+    return Promise.resolve([]);
+  }
+
+  lookupManyByContentHash(): Promise<StoredResponsesItem[]> {
     return Promise.resolve([]);
   }
 
@@ -183,6 +201,7 @@ test('persists each row before yielding the item-done frame', async () => {
   // `done` can reference the row on its next turn.
   const doneFrame = iterator.next();
   assertEquals(await promiseStateAfterMicrotasks(doneFrame), 'pending');
+  await waitForInsertCall(controlled);
   assertEquals(controlled.calls.length, 1);
   controlled.resolveInsert?.();
   assertEquals(((await doneFrame).value as ProtocolFrame<RawResponsesStreamEvent>).type, 'event');
@@ -208,6 +227,7 @@ test('insert failure does not sink the stream', async () => {
     // the frame still flows, so storage can never sink the stream.
     const doneFrame = iterator.next();
     assertEquals(await promiseStateAfterMicrotasks(doneFrame), 'pending');
+    await waitForInsertCall(controlled);
     controlled.rejectInsert?.(new Error('insert failed'));
     assertEquals(((await doneFrame).value as ProtocolFrame<RawResponsesStreamEvent>).type, 'event');
 

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
@@ -1,8 +1,8 @@
 import { createTemporaryResponsesItemId, hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
-import { getRepo } from '../../../../../repo/index.ts';
 import type { StoredResponsesItem } from '../../../../../repo/types.ts';
 import type { ModelProviderInstance, ProviderModelRecord } from '../../../../providers/types.ts';
 import { throwLlmServeFailure, type LlmServeFailure } from '../../traits.ts';
+import type { StatefulResponsesStore } from '../stateful-store.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { Mutable, ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -49,8 +49,8 @@ const isUpstreamOwned = (row: StoredResponsesItem): row is StoredResponsesItem &
 
 export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
   sourceItems: TSourceItems,
-  apiKeyId: string | null,
   view: Pick<ResponsesItemsView<TSourceItems>, 'visitAsResponsesItems'>,
+  store: StatefulResponsesStore,
 ): Promise<PreparedStoredResponsesItems> => {
   const references = await collectStoredResponsesItemRefs(sourceItems, view);
 
@@ -62,23 +62,10 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
     [...new Set(references.flatMap(ref => ref.encryptedContent !== undefined ? [ref.encryptedContent] : []))]
       .map(async content => [content, await hashResponsesItemEncryptedContent(content)] as const),
   ));
-  const [byId, byHash] = await Promise.all([
-    getRepo().responsesItems.lookupMany(apiKeyId, [...queryableIds]),
-    getRepo().responsesItems.lookupManyByEncryptedContentHash(apiKeyId, [...new Set(hashByContent.values())]),
-  ]);
-  const rowById = new Map(byId.map(row => [row.id, row]));
-  const rowByHash = new Map<string, StoredResponsesItem>();
-  for (const row of byHash) {
-    if (row.encryptedContentHash !== null && !rowByHash.has(row.encryptedContentHash)) {
-      rowByHash.set(row.encryptedContentHash, row);
-    }
-  }
-
   const failures: StoredResponsesItemsFailure[] = [];
-  const touchedIds = new Set<string>();
   for (const ref of references) {
-    const row = (ref.id !== undefined ? rowById.get(ref.id) : undefined)
-      ?? (ref.encryptedContent !== undefined ? rowByHash.get(hashByContent.get(ref.encryptedContent)!) : undefined);
+    const row = (ref.id !== undefined ? store.getItemById(ref.id) : undefined)
+      ?? (ref.encryptedContent !== undefined ? store.getItemByEncryptedContentHash(hashByContent.get(ref.encryptedContent)!) : undefined);
     if (row === undefined) {
       // `item_reference` asserts a stored row, and a parseable gateway id names
       // one too, so either resolving to nothing is a hard not-found. An id-less
@@ -90,7 +77,6 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
     }
 
     ref.row = row;
-    touchedIds.add(row.id);
     if (ref.type === 'item_reference' && row.payload === null && row.upstreamItemId === null) {
       failures.push({ kind: 'item-not-found', itemId: row.id });
       continue;
@@ -107,7 +93,6 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
       failures.push({ kind: 'item-not-found', itemId: row.id });
     }
   }
-  if (touchedIds.size > 0) await getRepo().responsesItems.refreshMany(apiKeyId, [...touchedIds], Date.now());
 
   return {
     references,

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan.ts
@@ -65,7 +65,7 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
   const failures: StoredResponsesItemsFailure[] = [];
   for (const ref of references) {
     const row = (ref.id !== undefined ? store.getItemById(ref.id) : undefined)
-      ?? (ref.encryptedContent !== undefined ? store.getItemByEncryptedContentHash(hashByContent.get(ref.encryptedContent)!) : undefined);
+      ?? (ref.encryptedContent !== undefined ? selectEncryptedContentRow(ref, store.getItemsByEncryptedContentHash(hashByContent.get(ref.encryptedContent)!)) : undefined);
     if (row === undefined) {
       // `item_reference` asserts a stored row, and a parseable gateway id names
       // one too, so either resolving to nothing is a hard not-found. An id-less
@@ -76,6 +76,7 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
       continue;
     }
 
+    store.touchItem(row.id);
     ref.row = row;
     if (ref.type === 'item_reference' && row.payload === null && row.upstreamItemId === null) {
       failures.push({ kind: 'item-not-found', itemId: row.id });
@@ -101,6 +102,12 @@ export const prepareStoredResponsesItemsForSource = async <TSourceItems>(
     preferredUpstreamIds: collectPreferredUpstreams(references),
   };
 };
+
+const selectEncryptedContentRow = (
+  ref: StoredResponsesItemRef,
+  candidates: readonly StoredResponsesItem[],
+): StoredResponsesItem | undefined =>
+  candidates.find(row => ref.type === 'item_reference' || row.itemType === ref.type) ?? candidates[0];
 
 export const planResponsesItemProviders = (
   providers: readonly ModelProviderInstance[],

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
@@ -507,13 +507,17 @@ test('id-less reasoning is matched by encrypted_content hash and prefers its own
   assertEquals(await rewriteResponsesItems(items, prepared, provider('up_b')), []);
 });
 
-test('matched stored items are refreshed during preparation', async () => {
+test('matched stored items are refreshed when selected touches are flushed', async () => {
   const id = storedReasoningId('refresh');
   const repo = await insertRows([
     storedRow({ id, itemType: 'reasoning', upstreamId: 'up_a', upstreamItemId: 'raw_rs_a', payload: null, createdAt: 1_000, refreshedAt: 1_000 }),
   ]);
+  const items = [{ type: 'item_reference', id }] as const;
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
 
-  await prepareResponsesItems([{ type: 'item_reference', id }]);
+  await store.loadInputItems({ sourceItems: items, view: responsesItemsView });
+  await prepareStoredResponsesItemsForSource(items, responsesItemsView, store);
+  await store.refreshTouchedItems();
 
   const [row] = await repo.responsesItems.lookupMany(API_KEY_ID, [id]);
   assert(row.refreshedAt > 1_000);
@@ -556,6 +560,36 @@ test('id-less compaction is matched by encrypted_content hash and forces its own
 
   // At the forced owner the compaction is stamped with the upstream's item id.
   assertEquals(await rewriteResponsesItems(items, prepared, provider('up_a')), [{ type: 'compaction', encrypted_content: enc, id: 'raw_cmp_a' }]);
+});
+
+test('id-less encrypted_content skips fresher incompatible hash candidates', async () => {
+  const enc = 'shared-encrypted-content';
+  const hash = await hashResponsesItemEncryptedContent(enc);
+  const incompatible = storedRow({
+    id: storedMessageId('incompatible'),
+    itemType: 'message',
+    upstreamId: 'up_b',
+    upstreamItemId: 'raw_msg_b',
+    encryptedContentHash: hash,
+    createdAt: 3_000,
+    refreshedAt: 3_000,
+  });
+  const compatible = storedRow({
+    id: storedReasoningId('compatible'),
+    itemType: 'reasoning',
+    upstreamId: 'up_a',
+    upstreamItemId: 'raw_rs_a',
+    encryptedContentHash: hash,
+    createdAt: 2_000,
+    refreshedAt: 2_000,
+  });
+  await insertRows([compatible, incompatible]);
+
+  const items = [{ type: 'reasoning', encrypted_content: enc, summary: [] }] as unknown as ResponsesInputItem[];
+  const prepared = await prepareResponsesItems(items);
+
+  assertEquals(prepared.references[0].row?.id, compatible.id);
+  assertEquals(await rewriteResponsesItems(items, prepared, provider('up_a')), [{ type: 'reasoning', encrypted_content: enc, summary: [], id: 'raw_rs_a' }]);
 });
 
 test('id-less encrypted_content with no stored match is a benign passthrough', async () => {

--- a/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/request-plan_test.ts
@@ -12,6 +12,7 @@ import type { StoredResponsesItem } from '../../../../../repo/types.ts';
 import { assert, assertEquals, assertFalse } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel } from '../../../../../test-helpers.ts';
 import type { ModelProviderInstance, ProviderModelRecord } from '../../../../providers/types.ts';
+import { createHttpStatefulResponsesStore } from '../stateful-store.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
@@ -46,8 +47,11 @@ const insertRows = async (rows: readonly StoredResponsesItem[]) => {
   return repo;
 };
 
-const prepareResponsesItems = async (sourceItems: string | readonly ResponsesInputItem[]) =>
-  await prepareStoredResponsesItemsForSource(sourceItems, API_KEY_ID, responsesItemsView);
+const prepareResponsesItems = async (sourceItems: string | readonly ResponsesInputItem[]) => {
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
+  await store.loadInputItems({ sourceItems, view: responsesItemsView });
+  return await prepareStoredResponsesItemsForSource(sourceItems, responsesItemsView, store);
+};
 
 const rewriteResponsesItems = async (
   sourceItems: string | readonly ResponsesInputItem[],
@@ -55,8 +59,11 @@ const rewriteResponsesItems = async (
   binding: ProviderModelRecord,
 ) => await rewriteStoredResponsesItemsForProvider(sourceItems, prepared, binding, responsesItemsView);
 
-const prepareChatItems = async (messages: ChatCompletionsPayload['messages']) =>
-  await prepareStoredResponsesItemsForSource(messages, API_KEY_ID, chatCompletionsViaResponsesItemsView);
+const prepareChatItems = async (messages: ChatCompletionsPayload['messages']) => {
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
+  await store.loadInputItems({ sourceItems: messages, view: chatCompletionsViaResponsesItemsView });
+  return await prepareStoredResponsesItemsForSource(messages, chatCompletionsViaResponsesItemsView, store);
+};
 
 const rewriteChatItems = async (
   messages: ChatCompletionsPayload['messages'],
@@ -64,8 +71,11 @@ const rewriteChatItems = async (
   binding: ProviderModelRecord,
 ) => await rewriteStoredResponsesItemsForProvider(messages, prepared, binding, chatCompletionsViaResponsesItemsView);
 
-const prepareMessagesItems = async (messages: MessagesPayload['messages']) =>
-  await prepareStoredResponsesItemsForSource(messages, API_KEY_ID, messagesViaResponsesItemsView);
+const prepareMessagesItems = async (messages: MessagesPayload['messages']) => {
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
+  await store.loadInputItems({ sourceItems: messages, view: messagesViaResponsesItemsView });
+  return await prepareStoredResponsesItemsForSource(messages, messagesViaResponsesItemsView, store);
+};
 
 const rewriteMessagesItems = async (
   messages: MessagesPayload['messages'],
@@ -82,6 +92,7 @@ const storedRow = (
     upstreamId: null,
     upstreamItemId: null,
     origin: overrides.origin ?? (overrides.upstreamId === undefined || overrides.upstreamId === null ? 'synthetic' : 'upstream'),
+    contentHash: null,
     encryptedContentHash: null,
     payload: payload === undefined || payload === null
       ? null

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -147,6 +147,60 @@ test('/v1/responses expands previous_response_id from the stored snapshot', asyn
   assertEquals(secondInput[2].content, 'Continue');
 });
 
+test('/v1/responses treats snapshots with expired input payloads as missing previous responses', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const id = createStoredResponsesItemId('message');
+  await repo.responsesItems.insertMany([
+    {
+      id,
+      apiKeyId: apiKey.id,
+      upstreamId: null,
+      upstreamItemId: null,
+      itemType: 'message',
+      origin: 'input',
+      contentHash: null,
+      encryptedContentHash: null,
+      payload: null,
+      createdAt: Date.now(),
+      refreshedAt: Date.now(),
+    },
+  ]);
+  await repo.responsesSnapshots.insert({
+    id: 'resp_expired_input',
+    apiKeyId: apiKey.id,
+    itemIds: [id],
+    createdAt: Date.now(),
+    refreshedAt: Date.now(),
+  });
+  let fetchCalls = 0;
+
+  await withMockedFetch(
+    () => {
+      fetchCalls++;
+      throw new Error('unexpected upstream fetch');
+    },
+    async () => {
+      const response = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_expired_input',
+          input: [{ type: 'message', role: 'user', content: 'Continue' }],
+          stream: false,
+        }),
+      });
+
+      assertEquals(response.status, 400);
+      const body = await response.json();
+      assertEquals(body.error.param, 'previous_response_id');
+      assertEquals(body.error.code, 'previous_response_not_found');
+    },
+  );
+
+  assertEquals(fetchCalls, 0);
+});
+
 test('/v1/responses reuses stored input items when clients resend full history', async () => {
   const { apiKey, repo } = await setupAppTest();
   const userItem = { type: 'message' as const, role: 'user' as const, content: 'Repeat me' };

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { createStoredResponsesItemId, isStoredResponsesItemId } from './items/format.ts';
+import { createStoredResponsesItemId, hashResponsesItemContent, isStoredResponsesItemId } from './items/format.ts';
 import { clearCopilotTokenCache } from '../../../../shared/copilot.ts';
 import { assertEquals, assertExists, assertFalse, assertStringIncludes } from '../../../../test-assert.ts';
 import { buildCustomUpstreamRecord, copilotModels, jsonResponse, parseSSEText, requestApp, setupAppTest, sseChatCompletionsResponse, sseResponse, sseResponsesResponse, withMockedFetch } from '../../../../test-helpers.ts';
@@ -63,6 +63,135 @@ test('/v1/responses rejects previous_response_id at the entrypoint', async () =>
   );
 
   assertEquals(fetchCalls, 0);
+});
+
+test('/v1/responses expands previous_response_id from the stored snapshot', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const upstreamBodies: Array<Record<string, any>> = [];
+  const assistantItem = {
+    type: 'message',
+    id: 'raw_assistant_turn1',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ type: 'output_text', text: 'First answer' }],
+  };
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()) as Record<string, any>);
+        const turn = upstreamBodies.length;
+        return sseResponsesResponse({
+          id: turn === 1 ? 'resp_turn1' : 'resp_turn2',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: turn === 1 ? [assistantItem] : [],
+          output_text: turn === 1 ? 'First answer' : 'Second answer',
+          usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+        });
+      }
+
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const first = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          input: [{ type: 'message', role: 'user', content: 'First question' }],
+          stream: false,
+        }),
+      });
+      assertEquals(first.status, 200);
+      await first.json();
+
+      const snapshot = await repo.responsesSnapshots.lookup(apiKey.id, 'resp_turn1');
+      assertExists(snapshot);
+      assertEquals(snapshot.itemIds.length, 2);
+
+      const second = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_turn1',
+          input: [{ type: 'message', role: 'user', content: 'Continue' }],
+          stream: false,
+        }),
+      });
+      assertEquals(second.status, 200);
+      await second.json();
+    },
+  );
+
+  assertEquals(upstreamBodies.length, 2);
+  assertEquals(Object.hasOwn(upstreamBodies[1], 'previous_response_id'), false);
+  const secondInput = upstreamBodies[1].input as Array<Record<string, unknown>>;
+  assertEquals(secondInput.map(item => item.type), ['message', 'message', 'message']);
+  assertEquals(secondInput[0].role, 'user');
+  assertEquals(secondInput[0].content, 'First question');
+  assertEquals(secondInput[1].role, 'assistant');
+  assertEquals(secondInput[1].content, [{ type: 'output_text', text: 'First answer' }]);
+  assertEquals(secondInput[2].role, 'user');
+  assertEquals(secondInput[2].content, 'Continue');
+});
+
+test('/v1/responses reuses stored input items when clients resend full history', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const userItem = { type: 'message' as const, role: 'user' as const, content: 'Repeat me' };
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        return sseResponsesResponse({
+          id: `resp_${crypto.randomUUID().replace(/-/g, '')}`,
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: [],
+          output_text: 'ok',
+          usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+        });
+      }
+
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      for (let i = 0; i < 2; i += 1) {
+        const response = await requestApp('/v1/responses', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+          body: JSON.stringify({ model: 'gpt-direct-responses', input: [userItem], stream: false }),
+        });
+        assertEquals(response.status, 200);
+        await response.json();
+      }
+    },
+  );
+
+  const contentHash = await hashResponsesItemContent(userItem);
+  const rows = await repo.responsesItems.lookupManyByContentHash(apiKey.id, [contentHash]);
+  assertEquals(rows.filter(row => row.origin === 'input').length, 1);
 });
 
 test('/v1/responses returns planner not_found for non-stored item_reference without generation', async () => {
@@ -139,6 +268,7 @@ test('/v1/responses expands stored synthetic item_reference before the upstream 
       upstreamItemId: null,
       itemType: 'message',
       origin: 'synthetic',
+      contentHash: null,
       encryptedContentHash: null,
       // payload.item.id is the original wire id, distinct from the stored row
       // id; the rewriter preserves it verbatim on the wire for synthetic rows.
@@ -228,6 +358,7 @@ test('/v1/responses expands same-origin item_reference for Copilot because Copil
       upstreamItemId: 'raw_msg_copilot',
       itemType: 'message',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...storedItem, id } },
       createdAt: Date.now(),
@@ -312,6 +443,7 @@ test('/v1/responses rejects metadata-only item_reference for Copilot before upst
       upstreamItemId: 'raw_msg_copilot_metadata',
       itemType: 'message',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: null,
       createdAt: Date.now(),
@@ -404,6 +536,7 @@ test('/v1/responses prefers latest portable stored-item origin and rewrites only
       upstreamItemId: 'raw_rs_a',
       itemType: 'reasoning',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
@@ -416,6 +549,7 @@ test('/v1/responses prefers latest portable stored-item origin and rewrites only
       upstreamItemId: 'raw_rs_b',
       itemType: 'reasoning',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
@@ -509,6 +643,7 @@ test('/v1/responses falls back with portable non-origin message items using temp
       upstreamItemId: 'raw_msg_a',
       itemType: 'message',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
@@ -521,6 +656,7 @@ test('/v1/responses falls back with portable non-origin message items using temp
       upstreamItemId: 'raw_msg_b',
       itemType: 'message',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),
@@ -599,6 +735,7 @@ test('/v1/responses rejects multiple forcing stored-item origins before generati
       upstreamItemId: 'raw_cmp_a',
       itemType: 'compaction',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...firstItem, id: firstId } },
       createdAt: Date.now(),
@@ -611,6 +748,7 @@ test('/v1/responses rejects multiple forcing stored-item origins before generati
       upstreamItemId: 'raw_cmp_b',
       itemType: 'compaction',
       origin: 'upstream',
+      contentHash: null,
       encryptedContentHash: null,
       payload: { item: { ...secondItem, id: secondId } },
       createdAt: Date.now(),

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -194,6 +194,85 @@ test('/v1/responses reuses stored input items when clients resend full history',
   assertEquals(rows.filter(row => row.origin === 'input').length, 1);
 });
 
+test('/v1/responses fills a metadata-only output row when store true input echoes it', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const assistantItem = {
+    type: 'message' as const,
+    id: 'raw_assistant_store_false',
+    role: 'assistant' as const,
+    status: 'completed' as const,
+    content: [{ type: 'output_text' as const, text: 'Persist me later' }],
+  };
+  const upstreamBodies: Array<Record<string, any>> = [];
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()) as Record<string, any>);
+        return sseResponsesResponse({
+          id: upstreamBodies.length === 1 ? 'resp_store_false' : 'resp_store_true',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: upstreamBodies.length === 1 ? [assistantItem] : [],
+          output_text: 'ok',
+          usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+        });
+      }
+
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const first = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          input: [{ type: 'message', role: 'user', content: 'First question' }],
+          store: false,
+          stream: false,
+        }),
+      });
+      assertEquals(first.status, 200);
+      const firstBody = await first.json() as { output: Array<{ id: string }> };
+      const storedId = firstBody.output[0].id;
+      const [metadataOnly] = await repo.responsesItems.lookupMany(apiKey.id, [storedId]);
+      assertExists(metadataOnly);
+      assertEquals(metadataOnly.payload, null);
+
+      const echoedInput = { ...assistantItem, id: storedId };
+      const second = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          input: [echoedInput],
+          stream: false,
+        }),
+      });
+      assertEquals(second.status, 200);
+      await second.json();
+
+      const [filled] = await repo.responsesItems.lookupMany(apiKey.id, [storedId]);
+      assertExists(filled);
+      assertEquals(filled.payload?.item, echoedInput);
+      const rows = await repo.responsesItems.lookupManyByContentHash(apiKey.id, [await hashResponsesItemContent(echoedInput)]);
+      assertEquals(rows.map(row => row.id), [storedId]);
+    },
+  );
+
+  assertEquals((upstreamBodies[1].input as Array<{ id?: string }>)[0].id, assistantItem.id);
+});
+
 test('/v1/responses returns planner not_found for non-stored item_reference without generation', async () => {
   const { apiKey } = await setupAppTest();
   let generationFetchCalls = 0;

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
@@ -1,7 +1,6 @@
 import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './items/format.ts';
 import { getRepo } from '../../../../repo/index.ts';
 import type { Repo, StoredResponsesItem, StoredResponsesSnapshot } from '../../../../repo/types.ts';
-import type { RequestContext } from '../../interceptors.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -13,7 +12,8 @@ export interface StatefulResponsesStore {
     readonly inputItemsToStage?: readonly ResponsesInputItem[];
   }): Promise<void>;
   getItemById(id: string): StoredResponsesItem | undefined;
-  getItemByEncryptedContentHash(hash: string): StoredResponsesItem | undefined;
+  getItemsByEncryptedContentHash(hash: string): StoredResponsesItem[];
+  touchItem(id: string): void;
   stageInputItems(items: readonly ResponsesInputItem[]): Promise<void>;
   beginAttempt(references: Iterable<{ readonly row?: StoredResponsesItem }>): void;
   addSyntheticItem(id: string, privatePayload?: unknown): void;
@@ -22,6 +22,7 @@ export interface StatefulResponsesStore {
   stageOutputItem(row: StoredResponsesItem): void;
   commitOutputItems(): Promise<void>;
   commitSnapshot(responseId: string): Promise<void>;
+  refreshTouchedItems(): Promise<void>;
 }
 
 class HttpStatefulResponsesStore implements StatefulResponsesStore {
@@ -43,10 +44,14 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   private readonly refreshedItemIds = new Set<string>();
 
   constructor(
-    private readonly repo: Repo,
+    private readonly repoProvider: Repo | (() => Repo),
     private readonly apiKeyId: string | null,
     private readonly store: boolean | null | undefined,
   ) {}
+
+  private get repo(): Repo {
+    return typeof this.repoProvider === 'function' ? this.repoProvider() : this.repoProvider;
+  }
 
   async loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null> {
     const cached = this.snapshotsById.get(id);
@@ -57,6 +62,11 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
 
     const snapshot = await this.repo.responsesSnapshots.lookup(this.apiKeyId, id);
     if (snapshot === null) return null;
+    await this.loadItems({ ids: snapshot.itemIds, contentHashes: [], encryptedContentHashes: [] });
+    if (!snapshot.itemIds.every(itemId => {
+      const row = this.loadedItemsById.get(itemId);
+      return row !== undefined && isReplayableSnapshotRow(row);
+    })) return null;
     this.rememberSnapshot(snapshot);
     this.previousSnapshotItemIds = [...snapshot.itemIds];
     for (const itemId of snapshot.itemIds) this.touchedItemIds.add(itemId);
@@ -89,17 +99,20 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       contentHashes: [...contentHashes],
       encryptedContentHashes: [...encryptedContentHashes],
     });
-    await this.refreshTouchedItems();
   }
 
   getItemById(id: string): StoredResponsesItem | undefined {
     const row = this.loadedItemsById.get(id) ?? this.stagedInputItems.get(id) ?? this.stagedOutputItems.get(id);
+    if (row) this.touchItem(row.id);
     return row ? cloneStoredResponsesItem(row) : undefined;
   }
 
-  getItemByEncryptedContentHash(hash: string): StoredResponsesItem | undefined {
-    const row = this.loadedItemsByEncryptedContentHash.get(hash)?.[0];
-    return row ? cloneStoredResponsesItem(row) : undefined;
+  getItemsByEncryptedContentHash(hash: string): StoredResponsesItem[] {
+    return (this.loadedItemsByEncryptedContentHash.get(hash) ?? []).map(cloneStoredResponsesItem);
+  }
+
+  touchItem(id: string): void {
+    this.touchedItemIds.add(id);
   }
 
   async stageInputItems(items: readonly ResponsesInputItem[]): Promise<void> {
@@ -173,7 +186,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       this.repo.responsesItems.lookupManyByContentHash(this.apiKeyId, contentHashes),
       this.repo.responsesItems.lookupManyByEncryptedContentHash(this.apiKeyId, encryptedContentHashes),
     ]);
-    for (const row of [...byId, ...byContentHash, ...byEncryptedContentHash]) this.rememberItem(row, { touch: true });
+    for (const row of [...byId, ...byContentHash, ...byEncryptedContentHash]) this.rememberItem(row);
   }
 
   private async stageInputItem(item: ResponsesInputItem): Promise<void> {
@@ -199,8 +212,10 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
 
     const encryptedContent = responsesItemEncryptedContent(item);
     if (encryptedContent !== null) {
-      const row = this.getItemByEncryptedContentHash(await hashResponsesItemEncryptedContent(encryptedContent));
+      const row = this.getItemsByEncryptedContentHash(await hashResponsesItemEncryptedContent(encryptedContent))
+        .find(candidate => candidate.itemType === item.type);
       if (row !== undefined) {
+        this.touchItem(row.id);
         if (row.payload !== null) {
           this.stagedInputItemIds.push(row.id);
           return;
@@ -213,6 +228,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     const contentHash = await hashResponsesItemContent(item);
     const existing = this.reusableItemByContentHash(contentHash);
     if (existing) {
+      this.touchItem(existing.id);
       this.stagedInputItemIds.push(existing.id);
       return;
     }
@@ -258,10 +274,9 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     return this.loadedItemsByContentHash.get(hash)?.find(row => row.payload !== null);
   }
 
-  private rememberItem(row: StoredResponsesItem, options: { readonly touch?: boolean } = {}): void {
+  private rememberItem(row: StoredResponsesItem): void {
     const cloned = cloneStoredResponsesItem(row);
     this.loadedItemsById.set(cloned.id, cloned);
-    if (options.touch === true) this.touchedItemIds.add(cloned.id);
     if (cloned.contentHash !== null) pushByHash(this.loadedItemsByContentHash, cloned.contentHash, cloned);
     if (cloned.encryptedContentHash !== null) pushByHash(this.loadedItemsByEncryptedContentHash, cloned.encryptedContentHash, cloned);
   }
@@ -277,7 +292,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       if (seen.has(id)) continue;
       seen.add(id);
       const row = this.loadedItemsById.get(id) ?? this.stagedInputItems.get(id) ?? this.stagedOutputItems.get(id);
-      if (row?.payload === undefined || row.payload === null) {
+      if (row === undefined || !isReplayableSnapshotRow(row)) {
         throw new Error(`Cannot persist Responses snapshot with non-replayable item id=${id}`);
       }
       rows.push(row);
@@ -298,7 +313,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     await this.refreshTouchedItems();
   }
 
-  private async refreshTouchedItems(): Promise<void> {
+  async refreshTouchedItems(): Promise<void> {
     const ids = [...this.touchedItemIds].filter(id => !this.refreshedItemIds.has(id));
     if (ids.length === 0) return;
     const refreshedAt = Date.now();
@@ -308,14 +323,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
 }
 
 export const createHttpStatefulResponsesStore = (apiKeyId: string | null, store: boolean | null | undefined): StatefulResponsesStore =>
-  new HttpStatefulResponsesStore(getRepo(), apiKeyId, store);
-
-export const statefulResponsesStoreForRequest = (request: RequestContext): StatefulResponsesStore => {
-  if (request.statefulResponsesStore === undefined) {
-    throw new Error('RequestContext is missing statefulResponsesStore.');
-  }
-  return request.statefulResponsesStore;
-};
+  new HttpStatefulResponsesStore(getRepo, apiKeyId, store);
 
 const pushByHash = (target: Map<string, StoredResponsesItem[]>, hash: string, row: StoredResponsesItem): void => {
   const rows = target.get(hash) ?? [];
@@ -325,6 +333,9 @@ const pushByHash = (target: Map<string, StoredResponsesItem[]>, hash: string, ro
   }
   target.set(hash, rows);
 };
+
+const isReplayableSnapshotRow = (row: StoredResponsesItem): boolean =>
+  row.payload !== null || (row.upstreamId !== null && row.upstreamItemId !== null);
 
 const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesItem => ({
   ...item,

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
@@ -1,12 +1,11 @@
 import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './items/format.ts';
 import { getRepo } from '../../../../repo/index.ts';
 import type { Repo, StoredResponsesItem, StoredResponsesSnapshot } from '../../../../repo/types.ts';
-import type { RequestContext, StatefulResponsesContext } from '../../interceptors.ts';
+import type { RequestContext } from '../../interceptors.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 export interface StatefulResponsesStore {
-  readonly attemptContext: StatefulResponsesContext;
   loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null>;
   loadInputItems<TSourceItems>(options: {
     readonly sourceItems: TSourceItems;
@@ -26,11 +25,11 @@ export interface StatefulResponsesStore {
 }
 
 class HttpStatefulResponsesStore implements StatefulResponsesStore {
-  readonly attemptContext: StatefulResponsesContext = { privatePayload: new Map(), newSyntheticIds: new Set() };
-
   private readonly loadedItemsById = new Map<string, StoredResponsesItem>();
   private readonly loadedItemsByContentHash = new Map<string, StoredResponsesItem[]>();
   private readonly loadedItemsByEncryptedContentHash = new Map<string, StoredResponsesItem[]>();
+  private readonly privatePayload = new Map<string, unknown>();
+  private readonly syntheticItemIds = new Set<string>();
   private readonly snapshotsById = new Map<string, StoredResponsesSnapshot>();
   private readonly stagedInputItems = new Map<string, StoredResponsesItem>();
   private readonly stagedInputItemIds: string[] = [];
@@ -38,6 +37,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   private readonly stagedOutputItems = new Map<string, StoredResponsesItem>();
   private readonly stagedOutputItemIds: string[] = [];
   private readonly committedItemIds = new Set<string>();
+  private readonly payloadUpgradeIds = new Set<string>();
   private readonly committedSnapshotIds = new Set<string>();
   private readonly touchedItemIds = new Set<string>();
   private readonly refreshedItemIds = new Set<string>();
@@ -110,26 +110,26 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   beginAttempt(references: Iterable<{ readonly row?: StoredResponsesItem }>): void {
     this.stagedOutputItems.clear();
     this.stagedOutputItemIds.length = 0;
-    this.attemptContext.privatePayload.clear();
-    this.attemptContext.newSyntheticIds.clear();
+    this.privatePayload.clear();
+    this.syntheticItemIds.clear();
     for (const ref of references) {
       if (ref.row?.payload?.private === undefined) continue;
       const wireId = responsesItemId(ref.row.payload.item as { id?: unknown });
-      if (wireId !== null) this.attemptContext.privatePayload.set(wireId, ref.row.payload.private);
+      if (wireId !== null) this.privatePayload.set(wireId, ref.row.payload.private);
     }
   }
 
   addSyntheticItem(id: string, privatePayload?: unknown): void {
-    this.attemptContext.newSyntheticIds.add(id);
-    if (privatePayload !== undefined) this.attemptContext.privatePayload.set(id, privatePayload);
+    this.syntheticItemIds.add(id);
+    if (privatePayload !== undefined) this.privatePayload.set(id, privatePayload);
   }
 
   isSyntheticItem(id: string): boolean {
-    return this.attemptContext.newSyntheticIds.has(id);
+    return this.syntheticItemIds.has(id);
   }
 
   getPrivatePayload(id: string): unknown {
-    return this.attemptContext.privatePayload.get(id);
+    return this.privatePayload.get(id);
   }
 
   stageOutputItem(row: StoredResponsesItem): void {
@@ -184,6 +184,32 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       return;
     }
 
+    const storedId = responsesItemId(item);
+    if (storedId !== null && isStoredResponsesItemId(storedId)) {
+      const row = this.getItemById(storedId);
+      if (row !== undefined) {
+        if (row.payload !== null) {
+          this.stagedInputItemIds.push(row.id);
+          return;
+        }
+        await this.stagePayloadUpgrade(row, item, responsesItemEncryptedContent(item));
+        return;
+      }
+    }
+
+    const encryptedContent = responsesItemEncryptedContent(item);
+    if (encryptedContent !== null) {
+      const row = this.getItemByEncryptedContentHash(await hashResponsesItemEncryptedContent(encryptedContent));
+      if (row !== undefined) {
+        if (row.payload !== null) {
+          this.stagedInputItemIds.push(row.id);
+          return;
+        }
+        await this.stagePayloadUpgrade(row, item, encryptedContent);
+        return;
+      }
+    }
+
     const contentHash = await hashResponsesItemContent(item);
     const existing = this.reusableItemByContentHash(contentHash);
     if (existing) {
@@ -191,7 +217,6 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       return;
     }
 
-    const encryptedContent = responsesItemEncryptedContent(item);
     const now = Date.now();
     const row: StoredResponsesItem = {
       id: createStoredResponsesItemId(item.type),
@@ -209,6 +234,22 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     this.stagedInputItems.set(row.id, row);
     this.stagedInputItemIds.push(row.id);
     this.rememberItem(row);
+  }
+
+  private async stagePayloadUpgrade(row: StoredResponsesItem, item: ResponsesInputItem, encryptedContent: string | null): Promise<void> {
+    const now = Date.now();
+    const upgraded: StoredResponsesItem = {
+      ...row,
+      payload: { item: structuredClone(item) },
+      contentHash: await hashResponsesItemContent(item),
+      encryptedContentHash: encryptedContent === null ? row.encryptedContentHash : await hashResponsesItemEncryptedContent(encryptedContent),
+      createdAt: now,
+      refreshedAt: now,
+    };
+    this.stagedInputItems.set(upgraded.id, upgraded);
+    this.payloadUpgradeIds.add(upgraded.id);
+    this.stagedInputItemIds.push(upgraded.id);
+    this.rememberItem(upgraded);
   }
 
   private reusableItemByContentHash(hash: string): StoredResponsesItem | undefined {
@@ -247,7 +288,12 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   private async commitItems(rows: readonly StoredResponsesItem[]): Promise<void> {
     const pending = rows.filter(row => !this.committedItemIds.has(row.id));
     if (pending.length === 0) return;
-    await this.repo.responsesItems.insertMany(pending);
+    const payloadUpgrades = pending.filter(row => this.payloadUpgradeIds.has(row.id));
+    const inserts = pending.filter(row => !this.payloadUpgradeIds.has(row.id));
+    await Promise.all([
+      this.repo.responsesItems.insertMany(inserts),
+      this.repo.responsesItems.fillPayloads(payloadUpgrades),
+    ]);
     for (const row of pending) this.committedItemIds.add(row.id);
     await this.refreshTouchedItems();
   }

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
@@ -1,0 +1,294 @@
+import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './items/format.ts';
+import { getRepo } from '../../../../repo/index.ts';
+import type { Repo, StoredResponsesItem, StoredResponsesSnapshot } from '../../../../repo/types.ts';
+import type { RequestContext, StatefulResponsesContext } from '../../interceptors.ts';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+
+export interface StatefulResponsesStore {
+  readonly attemptContext: StatefulResponsesContext;
+  loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null>;
+  loadInputItems<TSourceItems>(options: {
+    readonly sourceItems: TSourceItems;
+    readonly view: Pick<ResponsesItemsView<TSourceItems>, 'visitAsResponsesItems'>;
+    readonly inputItemsToStage?: readonly ResponsesInputItem[];
+  }): Promise<void>;
+  getItemById(id: string): StoredResponsesItem | undefined;
+  getItemByEncryptedContentHash(hash: string): StoredResponsesItem | undefined;
+  stageInputItems(items: readonly ResponsesInputItem[]): Promise<void>;
+  beginAttempt(references: Iterable<{ readonly row?: StoredResponsesItem }>): void;
+  addSyntheticItem(id: string, privatePayload?: unknown): void;
+  isSyntheticItem(id: string): boolean;
+  getPrivatePayload(id: string): unknown;
+  stageOutputItem(row: StoredResponsesItem): void;
+  commitOutputItems(): Promise<void>;
+  commitSnapshot(responseId: string): Promise<void>;
+}
+
+class HttpStatefulResponsesStore implements StatefulResponsesStore {
+  readonly attemptContext: StatefulResponsesContext = { privatePayload: new Map(), newSyntheticIds: new Set() };
+
+  private readonly loadedItemsById = new Map<string, StoredResponsesItem>();
+  private readonly loadedItemsByContentHash = new Map<string, StoredResponsesItem[]>();
+  private readonly loadedItemsByEncryptedContentHash = new Map<string, StoredResponsesItem[]>();
+  private readonly snapshotsById = new Map<string, StoredResponsesSnapshot>();
+  private readonly stagedInputItems = new Map<string, StoredResponsesItem>();
+  private readonly stagedInputItemIds: string[] = [];
+  private previousSnapshotItemIds: string[] = [];
+  private readonly stagedOutputItems = new Map<string, StoredResponsesItem>();
+  private readonly stagedOutputItemIds: string[] = [];
+  private readonly committedItemIds = new Set<string>();
+  private readonly committedSnapshotIds = new Set<string>();
+  private readonly touchedItemIds = new Set<string>();
+  private readonly refreshedItemIds = new Set<string>();
+
+  constructor(
+    private readonly repo: Repo,
+    private readonly apiKeyId: string | null,
+    private readonly store: boolean | null | undefined,
+  ) {}
+
+  async loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null> {
+    const cached = this.snapshotsById.get(id);
+    if (cached) {
+      this.previousSnapshotItemIds = [...cached.itemIds];
+      return cloneStoredResponsesSnapshot(cached);
+    }
+
+    const snapshot = await this.repo.responsesSnapshots.lookup(this.apiKeyId, id);
+    if (snapshot === null) return null;
+    this.rememberSnapshot(snapshot);
+    this.previousSnapshotItemIds = [...snapshot.itemIds];
+    for (const itemId of snapshot.itemIds) this.touchedItemIds.add(itemId);
+    await this.repo.responsesSnapshots.refresh(this.apiKeyId, id, Date.now());
+    return cloneStoredResponsesSnapshot(snapshot);
+  }
+
+  async loadInputItems<TSourceItems>(options: {
+    readonly sourceItems: TSourceItems;
+    readonly view: Pick<ResponsesItemsView<TSourceItems>, 'visitAsResponsesItems'>;
+    readonly inputItemsToStage?: readonly ResponsesInputItem[];
+  }): Promise<void> {
+    const ids = new Set<string>();
+    const encryptedContents = new Set<string>();
+    await options.view.visitAsResponsesItems(options.sourceItems, item => {
+      const id = responsesItemId(item);
+      if (id !== null && isStoredResponsesItemId(id)) ids.add(id);
+      const encryptedContent = responsesItemEncryptedContent(item);
+      if (encryptedContent !== null) encryptedContents.add(encryptedContent);
+    });
+
+    const contentHashes = new Set<string>();
+    for (const item of options.inputItemsToStage ?? []) contentHashes.add(await hashResponsesItemContent(item));
+
+    const encryptedContentHashes = new Set<string>();
+    for (const encryptedContent of encryptedContents) encryptedContentHashes.add(await hashResponsesItemEncryptedContent(encryptedContent));
+
+    await this.loadItems({
+      ids: [...ids],
+      contentHashes: [...contentHashes],
+      encryptedContentHashes: [...encryptedContentHashes],
+    });
+    await this.refreshTouchedItems();
+  }
+
+  getItemById(id: string): StoredResponsesItem | undefined {
+    const row = this.loadedItemsById.get(id) ?? this.stagedInputItems.get(id) ?? this.stagedOutputItems.get(id);
+    return row ? cloneStoredResponsesItem(row) : undefined;
+  }
+
+  getItemByEncryptedContentHash(hash: string): StoredResponsesItem | undefined {
+    const row = this.loadedItemsByEncryptedContentHash.get(hash)?.[0];
+    return row ? cloneStoredResponsesItem(row) : undefined;
+  }
+
+  async stageInputItems(items: readonly ResponsesInputItem[]): Promise<void> {
+    if (this.store === false) return;
+    for (const item of items) await this.stageInputItem(item);
+  }
+
+  beginAttempt(references: Iterable<{ readonly row?: StoredResponsesItem }>): void {
+    this.stagedOutputItems.clear();
+    this.stagedOutputItemIds.length = 0;
+    this.attemptContext.privatePayload.clear();
+    this.attemptContext.newSyntheticIds.clear();
+    for (const ref of references) {
+      if (ref.row?.payload?.private === undefined) continue;
+      const wireId = responsesItemId(ref.row.payload.item as { id?: unknown });
+      if (wireId !== null) this.attemptContext.privatePayload.set(wireId, ref.row.payload.private);
+    }
+  }
+
+  addSyntheticItem(id: string, privatePayload?: unknown): void {
+    this.attemptContext.newSyntheticIds.add(id);
+    if (privatePayload !== undefined) this.attemptContext.privatePayload.set(id, privatePayload);
+  }
+
+  isSyntheticItem(id: string): boolean {
+    return this.attemptContext.newSyntheticIds.has(id);
+  }
+
+  getPrivatePayload(id: string): unknown {
+    return this.attemptContext.privatePayload.get(id);
+  }
+
+  stageOutputItem(row: StoredResponsesItem): void {
+    const cloned = cloneStoredResponsesItem(row);
+    this.stagedOutputItems.set(cloned.id, cloned);
+    this.stagedOutputItemIds.push(cloned.id);
+    this.rememberItem(cloned);
+  }
+
+  async commitOutputItems(): Promise<void> {
+    await this.commitItems([...this.stagedOutputItems.values()]);
+  }
+
+  async commitSnapshot(responseId: string): Promise<void> {
+    if (this.store === false || this.committedSnapshotIds.has(responseId)) return;
+    await this.commitItems([...this.stagedInputItems.values(), ...this.stagedOutputItems.values()]);
+    const itemIds = [...this.previousSnapshotItemIds, ...this.stagedInputItemIds, ...this.stagedOutputItemIds];
+    if (itemIds.length === 0) return;
+
+    const replayableRows = this.replayableRowsForSnapshot(itemIds);
+    await this.commitItems(replayableRows);
+    const now = Date.now();
+    const snapshot: StoredResponsesSnapshot = {
+      id: responseId,
+      apiKeyId: this.apiKeyId,
+      itemIds,
+      createdAt: now,
+      refreshedAt: now,
+    };
+    await this.repo.responsesSnapshots.insert(snapshot);
+    this.rememberSnapshot(snapshot);
+    this.committedSnapshotIds.add(responseId);
+  }
+
+  private async loadItems(query: { ids: readonly string[]; contentHashes: readonly string[]; encryptedContentHashes: readonly string[] }): Promise<void> {
+    const ids = query.ids.filter(id => !this.loadedItemsById.has(id));
+    const contentHashes = query.contentHashes.filter(hash => !this.loadedItemsByContentHash.has(hash));
+    const encryptedContentHashes = query.encryptedContentHashes.filter(hash => !this.loadedItemsByEncryptedContentHash.has(hash));
+    const [byId, byContentHash, byEncryptedContentHash] = await Promise.all([
+      this.repo.responsesItems.lookupMany(this.apiKeyId, ids),
+      this.repo.responsesItems.lookupManyByContentHash(this.apiKeyId, contentHashes),
+      this.repo.responsesItems.lookupManyByEncryptedContentHash(this.apiKeyId, encryptedContentHashes),
+    ]);
+    for (const row of [...byId, ...byContentHash, ...byEncryptedContentHash]) this.rememberItem(row, { touch: true });
+  }
+
+  private async stageInputItem(item: ResponsesInputItem): Promise<void> {
+    if (item.type === 'item_reference') {
+      const row = this.getItemById(item.id);
+      if (row === undefined) throw new Error(`Cannot stage unresolved Responses item_reference id=${item.id}`);
+      this.stagedInputItemIds.push(row.id);
+      return;
+    }
+
+    const contentHash = await hashResponsesItemContent(item);
+    const existing = this.reusableItemByContentHash(contentHash);
+    if (existing) {
+      this.stagedInputItemIds.push(existing.id);
+      return;
+    }
+
+    const encryptedContent = responsesItemEncryptedContent(item);
+    const now = Date.now();
+    const row: StoredResponsesItem = {
+      id: createStoredResponsesItemId(item.type),
+      apiKeyId: this.apiKeyId,
+      upstreamId: null,
+      upstreamItemId: null,
+      itemType: item.type,
+      origin: 'input',
+      payload: { item: structuredClone(item) },
+      contentHash,
+      encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
+      createdAt: now,
+      refreshedAt: now,
+    };
+    this.stagedInputItems.set(row.id, row);
+    this.stagedInputItemIds.push(row.id);
+    this.rememberItem(row);
+  }
+
+  private reusableItemByContentHash(hash: string): StoredResponsesItem | undefined {
+    const staged = [...this.stagedInputItems.values(), ...this.stagedOutputItems.values()].find(row => row.contentHash === hash);
+    if (staged) return staged;
+    return this.loadedItemsByContentHash.get(hash)?.find(row => row.payload !== null);
+  }
+
+  private rememberItem(row: StoredResponsesItem, options: { readonly touch?: boolean } = {}): void {
+    const cloned = cloneStoredResponsesItem(row);
+    this.loadedItemsById.set(cloned.id, cloned);
+    if (options.touch === true) this.touchedItemIds.add(cloned.id);
+    if (cloned.contentHash !== null) pushByHash(this.loadedItemsByContentHash, cloned.contentHash, cloned);
+    if (cloned.encryptedContentHash !== null) pushByHash(this.loadedItemsByEncryptedContentHash, cloned.encryptedContentHash, cloned);
+  }
+
+  private rememberSnapshot(snapshot: StoredResponsesSnapshot): void {
+    this.snapshotsById.set(snapshot.id, cloneStoredResponsesSnapshot(snapshot));
+  }
+
+  private replayableRowsForSnapshot(itemIds: readonly string[]): StoredResponsesItem[] {
+    const rows: StoredResponsesItem[] = [];
+    const seen = new Set<string>();
+    for (const id of itemIds) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const row = this.loadedItemsById.get(id) ?? this.stagedInputItems.get(id) ?? this.stagedOutputItems.get(id);
+      if (row?.payload === undefined || row.payload === null) {
+        throw new Error(`Cannot persist Responses snapshot with non-replayable item id=${id}`);
+      }
+      rows.push(row);
+    }
+    return rows;
+  }
+
+  private async commitItems(rows: readonly StoredResponsesItem[]): Promise<void> {
+    const pending = rows.filter(row => !this.committedItemIds.has(row.id));
+    if (pending.length === 0) return;
+    await this.repo.responsesItems.insertMany(pending);
+    for (const row of pending) this.committedItemIds.add(row.id);
+    await this.refreshTouchedItems();
+  }
+
+  private async refreshTouchedItems(): Promise<void> {
+    const ids = [...this.touchedItemIds].filter(id => !this.refreshedItemIds.has(id));
+    if (ids.length === 0) return;
+    const refreshedAt = Date.now();
+    await this.repo.responsesItems.refreshMany(this.apiKeyId, ids, refreshedAt);
+    for (const id of ids) this.refreshedItemIds.add(id);
+  }
+}
+
+export const createHttpStatefulResponsesStore = (apiKeyId: string | null, store: boolean | null | undefined): StatefulResponsesStore =>
+  new HttpStatefulResponsesStore(getRepo(), apiKeyId, store);
+
+export const statefulResponsesStoreForRequest = (request: RequestContext): StatefulResponsesStore => {
+  if (request.statefulResponsesStore === undefined) {
+    throw new Error('RequestContext is missing statefulResponsesStore.');
+  }
+  return request.statefulResponsesStore;
+};
+
+const pushByHash = (target: Map<string, StoredResponsesItem[]>, hash: string, row: StoredResponsesItem): void => {
+  const rows = target.get(hash) ?? [];
+  if (!rows.some(existing => existing.id === row.id && existing.apiKeyId === row.apiKeyId)) {
+    rows.push(cloneStoredResponsesItem(row));
+    rows.sort(compareItemsByFreshness);
+  }
+  target.set(hash, rows);
+};
+
+const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesItem => ({
+  ...item,
+  payload: item.payload === null ? null : structuredClone(item.payload),
+});
+
+const cloneStoredResponsesSnapshot = (snapshot: StoredResponsesSnapshot): StoredResponsesSnapshot => ({
+  ...snapshot,
+  itemIds: [...snapshot.itemIds],
+});
+
+const compareItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
+  b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store_test.ts
@@ -1,0 +1,117 @@
+import { test } from 'vitest';
+
+import { createStoredResponsesItemId, hashResponsesItemEncryptedContent } from './items/format.ts';
+import { prepareStoredResponsesItemsForSource } from './items/request-plan.ts';
+import { createHttpStatefulResponsesStore } from './stateful-store.ts';
+import { initRepo } from '../../../../repo/index.ts';
+import { InMemoryRepo } from '../../../../repo/memory.ts';
+import type { StoredResponsesItem } from '../../../../repo/types.ts';
+import { assertEquals, assertExists } from '../../../../test-assert.ts';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+
+const API_KEY_ID = 'key_stateful_store';
+
+const storedRow = (overrides: Partial<StoredResponsesItem> & Pick<StoredResponsesItem, 'id' | 'itemType'>): StoredResponsesItem => ({
+  apiKeyId: API_KEY_ID,
+  upstreamId: null,
+  upstreamItemId: null,
+  origin: 'upstream',
+  payload: { item: { type: overrides.itemType, id: overrides.id } },
+  contentHash: null,
+  encryptedContentHash: null,
+  createdAt: 1_000,
+  refreshedAt: 1_000,
+  ...overrides,
+});
+
+test('encrypted-content lookup refreshes only the selected compatible candidate', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const encryptedContent = 'shared-encrypted-content';
+  const encryptedContentHash = await hashResponsesItemEncryptedContent(encryptedContent);
+  const compatible = storedRow({
+    id: createStoredResponsesItemId('reasoning'),
+    itemType: 'reasoning',
+    upstreamId: 'up_a',
+    upstreamItemId: 'raw_rs_a',
+    encryptedContentHash,
+    createdAt: 2_000,
+    refreshedAt: 2_000,
+  });
+  const incompatible = storedRow({
+    id: createStoredResponsesItemId('message'),
+    itemType: 'message',
+    upstreamId: 'up_b',
+    upstreamItemId: 'raw_msg_b',
+    encryptedContentHash,
+    createdAt: 3_000,
+    refreshedAt: 3_000,
+  });
+  await repo.responsesItems.insertMany([compatible, incompatible]);
+
+  const input = [{ type: 'reasoning', encrypted_content: encryptedContent, summary: [] }] as unknown as ResponsesInputItem[];
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
+  await store.loadInputItems({ sourceItems: input, view: responsesItemsView });
+  await prepareStoredResponsesItemsForSource(input, responsesItemsView, store);
+  await store.refreshTouchedItems();
+
+  const [readCompatible, readIncompatible] = await repo.responsesItems.lookupMany(API_KEY_ID, [compatible.id, incompatible.id]);
+  assertExists(readCompatible);
+  assertExists(readIncompatible);
+  assertEquals(readCompatible.refreshedAt > compatible.refreshedAt, true);
+  assertEquals(readIncompatible.refreshedAt, incompatible.refreshedAt);
+});
+
+test('snapshots with non-replayable metadata-only rows load as missing', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const missingPayload = storedRow({
+    id: createStoredResponsesItemId('message'),
+    itemType: 'message',
+    origin: 'input',
+    payload: null,
+    createdAt: 1_000,
+    refreshedAt: 1_000,
+  });
+  await repo.responsesItems.insertMany([missingPayload]);
+  await repo.responsesSnapshots.insert({
+    id: 'resp_expired',
+    apiKeyId: API_KEY_ID,
+    itemIds: [missingPayload.id],
+    createdAt: 1_000,
+    refreshedAt: 1_000,
+  });
+
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
+
+  assertEquals(await store.loadSnapshot('resp_expired'), null);
+});
+
+test('snapshots with upstream-owned metadata-only rows remain replayable', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const upstreamOwned = storedRow({
+    id: createStoredResponsesItemId('reasoning'),
+    itemType: 'reasoning',
+    upstreamId: 'up_a',
+    upstreamItemId: 'raw_rs_a',
+    payload: null,
+    createdAt: 1_000,
+    refreshedAt: 1_000,
+  });
+  await repo.responsesItems.insertMany([upstreamOwned]);
+  await repo.responsesSnapshots.insert({
+    id: 'resp_metadata',
+    apiKeyId: API_KEY_ID,
+    itemIds: [upstreamOwned.id],
+    createdAt: 1_000,
+    refreshedAt: 1_000,
+  });
+
+  const store = createHttpStatefulResponsesStore(API_KEY_ID, undefined);
+  const snapshot = await store.loadSnapshot('resp_metadata');
+
+  assertExists(snapshot);
+  assertEquals(snapshot.itemIds, [upstreamOwned.id]);
+});

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -1,5 +1,6 @@
 import { responsesSourceInterceptors } from './interceptors/index.ts';
 import { respondResponses } from './respond.ts';
+import { statefulResponsesStoreForRequest } from './stateful-store.ts';
 import type { ProviderModelRecord } from '../../../providers/types.ts';
 import { type LlmTargetApi, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
 import type { ExecuteResult } from '../../shared/errors/result.ts';
@@ -14,6 +15,50 @@ import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type SourceEmit, translateResponsesViaChatCompletions, translateResponsesViaMessages, viaTranslation } from '@floway-dev/translate';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+
+const CODEX_AUTO_REVIEW_ALIAS = 'codex-auto-review';
+const CODEX_AUTO_REVIEW_TARGET = 'gpt-5.4';
+
+// Previous-response pointers are gateway snapshots over stored Responses item
+// ids. A pointer miss intentionally matches OpenAI's not-found contract so
+// clients that retry with full input can keep using their existing fallback.
+// Verbatim payloads cross-verified from real upstream captures:
+// - https://github.com/cline/cline/issues/9399
+// - https://github.com/microsoft/semantic-kernel/issues/13128
+// - https://github.com/router-for-me/CLIProxyAPI/issues/999
+// - https://github.com/openai/openai-agents-python/issues/2020
+const previousResponseNotFoundResponse = (id: string): Response =>
+  Response.json(
+    {
+      error: {
+        message: `Previous response with id '${id}' not found.`,
+        type: 'invalid_request_error',
+        param: 'previous_response_id',
+        code: 'previous_response_not_found',
+      },
+    },
+    { status: 400 },
+  );
+
+const rewriteResponsesEntryModelAlias = (payload: ResponsesPayload): ResponsesPayload => {
+  if (payload.model !== CODEX_AUTO_REVIEW_ALIAS) return payload;
+
+  // TODO: Replace this source-entry hardcode with generic model alias support.
+  // Codex sends auto-review requests over the Responses wire API, so rewriting
+  // here keeps downstream routing, performance telemetry, and usage accounting
+  // on the real model name.
+  // References:
+  // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/model-provider/src/provider.rs#L73-L96
+  // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/codex-api/src/endpoint/responses.rs#L102-L134
+  return {
+    ...payload,
+    model: CODEX_AUTO_REVIEW_TARGET,
+    reasoning: { ...(payload.reasoning ?? {}), effort: 'low' },
+  };
+};
+
+const responsesInputItemsForStorage = (input: ResponsesPayload['input']): ResponsesInputItem[] =>
+  typeof input === 'string' ? [{ type: 'message', role: 'user', content: input }] : [...input];
 
 const responsesInvocation = <TPayload extends { model: string }>(
   binding: ProviderModelRecord,
@@ -58,58 +103,36 @@ const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[],
   respond: async ({ c, result, runtime }) =>
     await respondResponses(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
   prepare: async c => {
-    const sourcePayload = await c.req.json<ResponsesPayload>();
-    // previous_response_id relies on server-side conversation state that this
-    // gateway does not implement. Stored Responses item ids are handled below; a
-    // plain previous response pointer still gets OpenAI's not-found contract so
-    // clients that retry with full input can keep using their existing fallback.
-    // Verbatim payloads cross-verified from real upstream captures:
-    // - https://github.com/cline/cline/issues/9399
-    // - https://github.com/microsoft/semantic-kernel/issues/13128
-    // - https://github.com/router-for-me/CLIProxyAPI/issues/999
-    // - https://github.com/openai/openai-agents-python/issues/2020
-    if (sourcePayload.previous_response_id !== undefined && sourcePayload.previous_response_id !== null) {
-      return Response.json(
-        {
-          error: {
-            message: `Previous response with id '${sourcePayload.previous_response_id}' not found.`,
-            type: 'invalid_request_error',
-            param: 'previous_response_id',
-            code: 'previous_response_not_found',
-          },
-        },
-        { status: 400 },
-      );
-    }
-    // TODO: Replace this source-entry hardcode with generic model alias support.
-    // Codex sends auto-review requests over the Responses wire API, so rewriting
-    // here keeps downstream routing, performance telemetry, and usage accounting
-    // on the real model name.
-    // References:
-    // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/model-provider/src/provider.rs#L73-L96
-    // https://github.com/openai/codex/blob/e7bffc5a20e92cbc64d6c16a1b257d0b2e4cd5df/codex-rs/codex-api/src/endpoint/responses.rs#L102-L134
-    const payload: ResponsesPayload = sourcePayload.model === 'codex-auto-review'
-      ? {
-          ...sourcePayload,
-          model: 'gpt-5.4',
-          reasoning: { ...(sourcePayload.reasoning ?? {}), effort: 'low' },
-        }
-      : sourcePayload;
+    const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>());
     const wantsStream = payload.stream === true;
     const downstreamAbortController = wantsStream ? new AbortController() : undefined;
-    const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream);
+    const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream, { store: payload.store });
+    const currentInputItems = responsesInputItemsForStorage(payload.input);
+    const previousResponseId = payload.previous_response_id ?? null;
+    const statefulResponsesStore = statefulResponsesStoreForRequest(request);
+    if (previousResponseId !== null) {
+      const snapshot = await statefulResponsesStore.loadSnapshot(previousResponseId);
+      if (snapshot === null) return previousResponseNotFoundResponse(previousResponseId);
+      payload.input = [
+        ...snapshot.itemIds.map(id => ({ type: 'item_reference' as const, id })),
+        ...currentInputItems,
+      ];
+    }
     return {
       request,
       items: payload.input,
       responsesItemsView,
       wantsStream,
       store: payload.store,
+      statefulResponsesInputItems: currentInputItems,
+      commitStatefulResponsesSnapshot: payload.store !== false,
       model: payload.model,
       downstreamAbortController,
       pickTarget: endpoints => endpoints.responses ? 'responses' : endpoints.messages ? 'messages' : endpoints.chatCompletions ? 'chat-completions' : null,
       attempt: async ({ binding, target, model, rewriteItems }) => {
         const attemptPayload = structuredClone(payload);
         attemptPayload.model = model;
+        delete attemptPayload.previous_response_id;
         attemptPayload.input = await rewriteItems(attemptPayload.input);
         const invocation: ResponsesInvocation = responsesInvocation(binding, target, model, attemptPayload);
         const emits: Record<LlmTargetApi, SourceEmit<ResponsesPayload, { fallbackMaxOutputTokens?: number }, ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>>> = {

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -1,6 +1,5 @@
 import { responsesSourceInterceptors } from './interceptors/index.ts';
 import { respondResponses } from './respond.ts';
-import { statefulResponsesStoreForRequest } from './stateful-store.ts';
 import type { ProviderModelRecord } from '../../../providers/types.ts';
 import { type LlmTargetApi, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
 import type { ExecuteResult } from '../../shared/errors/result.ts';
@@ -109,7 +108,7 @@ const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[],
     const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream, { store: payload.store });
     const currentInputItems = responsesInputItemsForStorage(payload.input);
     const previousResponseId = payload.previous_response_id ?? null;
-    const statefulResponsesStore = statefulResponsesStoreForRequest(request);
+    const statefulResponsesStore = request.statefulResponsesStore;
     if (previousResponseId !== null) {
       const snapshot = await statefulResponsesStore.loadSnapshot(previousResponseId);
       if (snapshot === null) return previousResponseNotFoundResponse(previousResponseId);

--- a/apps/api/src/data-plane/llm/sources/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/traits.ts
@@ -98,8 +98,9 @@ export interface LlmSourceRuntime {
 export interface LlmEndpointPlan<TItems, TEvent> extends LlmSourceRuntime {
   readonly items: TItems;
   readonly responsesItemsView: ResponsesItemsView<TItems, Frame<TEvent>>;
-  // `store: false` requests persist null payloads; sources that have no
-  // `store` concept (Messages, Gemini) pass `undefined`.
+  // Controls Responses output item persistence: `store: false` keeps routing
+  // metadata with null payloads. Input staging and snapshot commits are gated
+  // separately because only native Responses requests expose those concepts.
   readonly store: boolean | null | undefined;
   readonly statefulResponsesInputItems?: readonly ResponsesInputItem[];
   readonly commitStatefulResponsesSnapshot?: boolean;

--- a/apps/api/src/data-plane/llm/sources/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/traits.ts
@@ -8,6 +8,7 @@ import { toInternalDebugError } from '../shared/errors/internal-debug-error.ts';
 import { internalErrorResult, type ExecuteResult, type PlainResult, type UpstreamErrorResult } from '../shared/errors/result.ts';
 import { thrownUpstreamErrorResult } from '../shared/errors/upstream-error.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { Mutable, ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 type Frame<TEvent> = ProtocolFrame<TEvent>;
@@ -100,6 +101,8 @@ export interface LlmEndpointPlan<TItems, TEvent> extends LlmSourceRuntime {
   // `store: false` requests persist null payloads; sources that have no
   // `store` concept (Messages, Gemini) pass `undefined`.
   readonly store: boolean | null | undefined;
+  readonly statefulResponsesInputItems?: readonly ResponsesInputItem[];
+  readonly commitStatefulResponsesSnapshot?: boolean;
   // The model id the planner resolves against. Most sources read it off the
   // parsed payload; Gemini carries it on the request path instead of the body.
   readonly model: string;

--- a/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
+++ b/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
@@ -19,6 +19,6 @@ export const chatCompletionsInvocation = (payload: ChatCompletionsPayload, enabl
 export const stubRequestContext: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
+++ b/apps/api/src/data-plane/llm/targets/chat-completions/interceptors/test-helpers.ts
@@ -1,5 +1,6 @@
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { ChatCompletionsInvocation, RequestContext } from '../../../interceptors.ts';
+import { createHttpStatefulResponsesStore } from '../../../sources/responses/stateful-store.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 
 export { stubProvider, stubUpstreamModel, testTelemetryModelIdentity };
@@ -21,4 +22,5 @@ export const stubRequestContext: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };

--- a/apps/api/src/data-plane/llm/targets/emit_test.ts
+++ b/apps/api/src/data-plane/llm/targets/emit_test.ts
@@ -4,6 +4,7 @@ import { targetProviderResultToFrames } from './emit.ts';
 import { assertEquals, assertStringIncludes } from '../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel } from '../../../test-helpers.ts';
 import type { Invocation, RequestContext } from '../interceptors.ts';
+import { createHttpStatefulResponsesStore } from '../sources/responses/stateful-store.ts';
 
 const baseInvocation = (): Invocation<{ model: string; stream?: boolean }> => ({
   sourceApi: 'messages',
@@ -22,6 +23,7 @@ const baseRequest = (): RequestContext => ({
   apiKeyUpstreamIds: null,
   apiKeyId: 'key_a',
   clientStream: true,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
   runtimeLocation: 'SJC',
 });
 

--- a/apps/api/src/data-plane/llm/targets/emit_test.ts
+++ b/apps/api/src/data-plane/llm/targets/emit_test.ts
@@ -20,7 +20,7 @@ const baseInvocation = (): Invocation<{ model: string; stream?: boolean }> => ({
 const baseRequest = (): RequestContext => ({
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  apiKeyId: 'key_a',
+  apiKeyId: 'key_a',
   clientStream: true,
   runtimeLocation: 'SJC',
 });

--- a/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -28,6 +29,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 test('messages forced tool_choice disables thinking and strips output_config', async () => {

--- a/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -26,7 +26,7 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/canonicalize-encrypted-content_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../sources/responses/stateful-store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const invocation = (): ResponsesInvocation => ({

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../interceptors.ts';
 import { eventResult } from '../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../sources/responses/stateful-store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = () =>

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../sources/responses/stateful-store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesResult, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -40,6 +41,7 @@ const stubRequest = (overrides: { downstreamAbortSignal?: AbortSignal } = {}): R
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: true,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
   ...(overrides.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: overrides.downstreamAbortSignal } : {}),
 });
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/retry-cyber-policy_test.ts
@@ -38,7 +38,7 @@ const makeInvocation = (payload: ResponsesPayload): ResponsesInvocation => ({
 const stubRequest = (overrides: { downstreamAbortSignal?: AbortSignal } = {}): RequestContext => ({
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: true,
   ...(overrides.downstreamAbortSignal !== undefined ? { downstreamAbortSignal: overrides.downstreamAbortSignal } : {}),
 });

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../interceptors.ts';
 import { eventResult } from '../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../sources/responses/stateful-store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = () =>

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../interceptors.ts';
 import { eventResult } from '../../../shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../sources/responses/stateful-store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = () =>

--- a/apps/api/src/data-plane/llm/targets/telemetry_test.ts
+++ b/apps/api/src/data-plane/llm/targets/telemetry_test.ts
@@ -6,6 +6,7 @@ import { InMemoryRepo } from '../../../repo/memory.ts';
 import { assertEquals } from '../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel } from '../../../test-helpers.ts';
 import type { Invocation, RequestContext } from '../interceptors.ts';
+import { createHttpStatefulResponsesStore } from '../sources/responses/stateful-store.ts';
 
 interface TelemetryHarness {
   repo: InMemoryRepo;
@@ -54,6 +55,7 @@ const baseRequest = (
   apiKeyUpstreamIds: null,
   apiKeyId: 'apiKeyId' in overrides ? overrides.apiKeyId : 'key_a',
   clientStream: overrides.stream ?? true,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
   runtimeLocation: 'SJC',
   scheduleBackground: (promise: Promise<unknown>) => {
     harness.background.push(promise);
@@ -320,6 +322,7 @@ test('withUpstreamTelemetry skips recording when apiKeyId is absent', async () =
       requestStartedAt: 0,
       apiKeyUpstreamIds: null,
       clientStream: true,
+      statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
       runtimeLocation: 'SJC',
       scheduleBackground: promise => background.push(promise),
     },

--- a/apps/api/src/data-plane/llm/targets/telemetry_test.ts
+++ b/apps/api/src/data-plane/llm/targets/telemetry_test.ts
@@ -52,7 +52,7 @@ const baseRequest = (
 ): RequestContext => ({
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  apiKeyId: 'apiKeyId' in overrides ? overrides.apiKeyId : 'key_a',
+  apiKeyId: 'apiKeyId' in overrides ? overrides.apiKeyId : 'key_a',
   clientStream: overrides.stream ?? true,
   runtimeLocation: 'SJC',
   scheduleBackground: (promise: Promise<unknown>) => {
@@ -319,7 +319,7 @@ test('withUpstreamTelemetry skips recording when apiKeyId is absent', async () =
     {
       requestStartedAt: 0,
       apiKeyUpstreamIds: null,
-      statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },      clientStream: true,
+      clientStream: true,
       runtimeLocation: 'SJC',
       scheduleBackground: promise => background.push(promise),
     },

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
@@ -5,6 +5,7 @@ import { assert, assertEquals, assertStringIncludes } from '../../../../../test-
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { ChatCompletionsInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import { MAX_CONSECUTIVE_WHITESPACE } from '../shared/whitespace-overflow.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
@@ -26,6 +27,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const baseChunk = (overrides: Partial<ChatCompletionsStreamEvent>): ChatCompletionsStreamEvent => ({

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/abort-on-tool-argument-whitespace_test.ts
@@ -24,7 +24,7 @@ const invocation = (): ChatCompletionsInvocation => ({
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
@@ -5,6 +5,7 @@ import { assert, assertEquals, assertFalse } from '../../../../../test-assert.ts
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { ChatCompletionsInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsMessage } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/attach-cache-control-markers_test.ts
@@ -11,7 +11,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
@@ -7,6 +7,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { ChatCompletionsInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
@@ -15,6 +16,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/compress-images_test.ts
@@ -13,7 +13,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
@@ -11,7 +11,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-initiator-header_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { ChatCompletionsInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
@@ -11,7 +11,7 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/chat-completions/set-vision-header_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { ChatCompletionsInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/apply-top-level-cache-control_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/apply-top-level-cache-control_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/apply-top-level-cache-control_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/apply-top-level-cache-control_test.ts
@@ -11,7 +11,6 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
@@ -13,7 +13,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/compress-images_test.ts
@@ -7,6 +7,7 @@ import { assert, assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -15,6 +16,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/filter-anthropic-beta-header_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -42,6 +43,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => Promise.resolve(eventResult((async function* (): AsyncGenerator<ProtocolFrame<MessagesStreamEvent>> {})(), testTelemetryModelIdentity));

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/promote-thinking-display_test.ts
@@ -40,7 +40,7 @@ const makeCtx = (
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
@@ -6,6 +6,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -14,6 +15,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-claude-agent-headers_test.ts
@@ -12,7 +12,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-compact-headers_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-initiator-header_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-interaction-id-header_test.ts
@@ -5,6 +5,7 @@ import { assert, assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/set-vision-header_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
@@ -6,6 +6,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import { runInterceptors, type MessagesInvocation, type RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -14,6 +15,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/source-chain_test.ts
@@ -12,7 +12,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-cache-control-extensions_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-cache-control-extensions_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-cache-control-extensions_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-cache-control-extensions_test.ts
@@ -11,7 +11,6 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },
   runtimeLocation: 'test',
   clientStream: false,
 };

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-structured-output-format_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
@@ -11,7 +11,7 @@ import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/messages/strip-tool-strict_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { MessagesInvocation, RequestContext } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import { MAX_CONSECUTIVE_WHITESPACE } from '../shared/whitespace-overflow.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -39,6 +40,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const argsDelta = (outputIndex: number, delta: string): RawResponsesStreamEvent =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
@@ -37,7 +37,7 @@ const invocation = (): ResponsesInvocation => ({
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
@@ -13,7 +13,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/compress-images_test.ts
@@ -7,6 +7,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -15,6 +16,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/force-store-false_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-initiator-header_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/set-vision-header_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesInputItem, ResponsesPayload, RawResponsesStreamEvent } fr
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/strip-safety-identifier_test.ts
@@ -5,6 +5,7 @@ import { assertEquals, assertFalse } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { LlmSourceApi, RequestContext, ResponsesInvocation } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 const stubRequest: RequestContext = {
   requestStartedAt: 0,
   apiKeyUpstreamIds: null,
-  statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },  runtimeLocation: 'test',
+  runtimeLocation: 'test',
   clientStream: false,
 };
 

--- a/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/interceptors/responses/synchronize-output-item-ids_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from '../../../../../test-assert.ts';
 import { stubProvider, stubUpstreamModel, testTelemetryModelIdentity } from '../../../../../test-helpers.ts';
 import type { RequestContext, ResponsesInvocation } from '../../../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../../../llm/sources/responses/stateful-store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
@@ -13,6 +14,7 @@ const stubRequest: RequestContext = {
   apiKeyUpstreamIds: null,
   runtimeLocation: 'test',
   clientStream: false,
+  statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
 };
 
 const invocation = (): ResponsesInvocation => ({

--- a/apps/api/src/data-plane/providers/copilot/provider_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider_test.ts
@@ -370,7 +370,7 @@ test('Copilot provider sets copilot-vision-request when an image is nested insid
   const stubRequest: RequestContext = {
     requestStartedAt: 0,
     apiKeyUpstreamIds: null,
-    statefulResponsesContext: { privatePayload: new Map(), newSyntheticIds: new Set() },    runtimeLocation: 'test',
+    runtimeLocation: 'test',
     clientStream: false,
   };
 

--- a/apps/api/src/data-plane/providers/copilot/provider_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider_test.ts
@@ -6,6 +6,7 @@ import { assertEquals, assertRejects } from '../../../test-assert.ts';
 import { copilotModels, jsonResponse, setupAppTest, withMockedFetch } from '../../../test-helpers.ts';
 import { runInterceptors, type MessagesInvocation, type RequestContext } from '../../llm/interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../llm/shared/errors/result.ts';
+import { createHttpStatefulResponsesStore } from '../../llm/sources/responses/stateful-store.ts';
 import { clearModelsStore, ProviderModelsUnavailableError } from '../models-store.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -372,6 +373,7 @@ test('Copilot provider sets copilot-vision-request when an image is nested insid
     apiKeyUpstreamIds: null,
     runtimeLocation: 'test',
     clientStream: false,
+    statefulResponsesStore: createHttpStatefulResponsesStore(null, undefined),
   };
 
   const testTelemetryModelIdentity = {

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -721,6 +721,22 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     await this.runStatements(statements);
   }
 
+  async fillPayloads(items: readonly StoredResponsesItem[]): Promise<number> {
+    const statements = await Promise.all(items.flatMap(item => {
+      if (item.payload === null) return [];
+      return [serializeStoredResponsesPayload(item.id, item.apiKeyId, item.createdAt, item.payload).then(payload =>
+        this.db
+          .prepare(
+            `UPDATE responses_items
+             SET payload_json = ?, content_hash = ?, encrypted_content_hash = ?, created_at = ?, refreshed_at = ?
+             WHERE ${RESPONSES_ITEM_ID_SCOPE_SQL} AND id = ? AND payload_json IS NULL`,
+          )
+          .bind(payload, item.contentHash, item.encryptedContentHash, item.createdAt, item.refreshedAt, item.apiKeyId, item.id))];
+    }));
+    const results = await this.runStatements(statements);
+    return results.reduce((sum, result) => sum + ((result.meta.changes as number | undefined) ?? 0), 0);
+  }
+
   async refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number> {
     const unique = [...new Set(ids)];
     if (unique.length === 0) return 0;
@@ -753,13 +769,14 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     await deleteAllResponsesItemPayloadFiles();
   }
 
-  private async runStatements(statements: D1PreparedStatement[]): Promise<void> {
-    if (statements.length === 0) return;
+  private async runStatements(statements: D1PreparedStatement[]): Promise<Array<{ results: unknown[]; success: boolean; meta: Record<string, unknown> }>> {
+    if (statements.length === 0) return [];
     if (this.db.batch) {
-      await this.db.batch(statements);
-      return;
+      return await this.db.batch(statements);
     }
-    for (const statement of statements) await statement.run();
+    const results = [];
+    for (const statement of statements) results.push(await statement.run());
+    return results;
   }
 }
 

--- a/apps/api/src/repo/d1.ts
+++ b/apps/api/src/repo/d1.ts
@@ -13,10 +13,12 @@ import type {
   PerformanceTelemetryRecord,
   Repo,
   ResponsesItemsRepo,
+  ResponsesSnapshotsRepo,
   SearchConfigRepo,
   SearchUsageRecord,
   SearchUsageRepo,
   StoredResponsesItem,
+  StoredResponsesSnapshot,
   UpstreamProviderKind,
   UpstreamRecord,
   UpstreamRepo,
@@ -654,7 +656,7 @@ class D1CacheRepo implements CacheRepo {
   }
 }
 
-const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, encrypted_content_hash, created_at, refreshed_at';
+const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, content_hash, encrypted_content_hash, created_at, refreshed_at';
 const RESPONSES_ITEM_ID_SCOPE_SQL = "COALESCE(api_key_id, '') = COALESCE(?, '')";
 
 class D1ResponsesItemsRepo implements ResponsesItemsRepo {
@@ -670,25 +672,16 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     return await this.lookupByColumn(apiKeyId, 'encrypted_content_hash', hashes);
   }
 
+  async lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]> {
+    return await this.lookupByColumn(apiKeyId, 'content_hash', hashes);
+  }
+
   // D1 caps bound parameters at 100 per query. A single Responses request can
   // echo back more stored items than that — long agentic sessions resubmit
   // every prior reasoning/compaction item each turn — so chunk the IN-list
   // well under the cap (the `api_key_id` bind shares the budget) and union
   // the results.
-  private async lookupByColumn(apiKeyId: string | null, column: 'id' | 'encrypted_content_hash', values: readonly string[]): Promise<StoredResponsesItem[]> {
-    interface ResponsesItemRow {
-      id: string;
-      api_key_id: string | null;
-      upstream_id: string | null;
-      upstream_item_id: string | null;
-      item_type: string;
-      origin: StoredResponsesItem['origin'];
-      payload_json: string | null;
-      encrypted_content_hash: string | null;
-      created_at: number;
-      refreshed_at: number;
-    }
-
+  private async lookupByColumn(apiKeyId: string | null, column: 'id' | 'content_hash' | 'encrypted_content_hash', values: readonly string[]): Promise<StoredResponsesItem[]> {
     const unique = [...new Set(values)];
     if (unique.length === 0) return [];
 
@@ -704,18 +697,7 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
         .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
-      return await Promise.all(results.map(async row => ({
-        id: row.id,
-        apiKeyId: row.api_key_id,
-        upstreamId: row.upstream_id,
-        upstreamItemId: row.upstream_item_id,
-        itemType: row.item_type,
-        origin: row.origin,
-        payload: await parseStoredResponsesPayload(row.id, row.payload_json),
-        encryptedContentHash: row.encrypted_content_hash,
-        createdAt: row.created_at,
-        refreshedAt: row.refreshed_at,
-      })));
+      return await Promise.all(results.map(toStoredResponsesItem));
     }));
     return perChunk.flat();
   }
@@ -731,10 +713,10 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
       // happen.
       return this.db
         .prepare(
-          `INSERT INTO responses_items (${RESPONSES_ITEM_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO responses_items (${RESPONSES_ITEM_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT (id, COALESCE(api_key_id, '')) DO NOTHING`,
         )
-        .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, item.origin, payload, item.encryptedContentHash, item.createdAt, item.refreshedAt);
+        .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, item.origin, payload, item.contentHash, item.encryptedContentHash, item.createdAt, item.refreshedAt);
     }));
     await this.runStatements(statements);
   }
@@ -780,6 +762,95 @@ class D1ResponsesItemsRepo implements ResponsesItemsRepo {
     for (const statement of statements) await statement.run();
   }
 }
+
+interface ResponsesItemRow {
+  id: string;
+  api_key_id: string | null;
+  upstream_id: string | null;
+  upstream_item_id: string | null;
+  item_type: string;
+  origin: StoredResponsesItem['origin'];
+  payload_json: string | null;
+  content_hash: string | null;
+  encrypted_content_hash: string | null;
+  created_at: number;
+  refreshed_at: number;
+}
+
+const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredResponsesItem> => ({
+  id: row.id,
+  apiKeyId: row.api_key_id,
+  upstreamId: row.upstream_id,
+  upstreamItemId: row.upstream_item_id,
+  itemType: row.item_type,
+  origin: row.origin,
+  payload: await parseStoredResponsesPayload(row.id, row.payload_json),
+  contentHash: row.content_hash,
+  encryptedContentHash: row.encrypted_content_hash,
+  createdAt: row.created_at,
+  refreshedAt: row.refreshed_at,
+});
+
+class D1ResponsesSnapshotsRepo implements ResponsesSnapshotsRepo {
+  constructor(private db: D1Database) {}
+
+  async lookup(apiKeyId: string | null, id: string): Promise<StoredResponsesSnapshot | null> {
+    const row = await this.db
+      .prepare('SELECT id, api_key_id, item_ids_json, created_at, refreshed_at FROM responses_snapshots WHERE id = ? AND COALESCE(api_key_id, \'\') = COALESCE(?, \'\')')
+      .bind(id, apiKeyId)
+      .first<ResponsesSnapshotRow>();
+    return row ? toStoredResponsesSnapshot(row) : null;
+  }
+
+  async insert(snapshot: StoredResponsesSnapshot): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO responses_snapshots (id, api_key_id, item_ids_json, created_at, refreshed_at) VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT (id, COALESCE(api_key_id, '')) DO UPDATE SET item_ids_json = excluded.item_ids_json, refreshed_at = excluded.refreshed_at`,
+      )
+      .bind(snapshot.id, snapshot.apiKeyId, JSON.stringify(snapshot.itemIds), snapshot.createdAt, snapshot.refreshedAt)
+      .run();
+  }
+
+  async refresh(apiKeyId: string | null, id: string, refreshedAt: number): Promise<boolean> {
+    const result = await this.db
+      .prepare('UPDATE responses_snapshots SET refreshed_at = ? WHERE id = ? AND COALESCE(api_key_id, \'\') = COALESCE(?, \'\') AND refreshed_at < ?')
+      .bind(refreshedAt, id, apiKeyId, refreshedAt)
+      .run();
+    return ((result.meta.changes as number | undefined) ?? 0) > 0;
+  }
+
+  async deleteOlderThan(refreshedBefore: number): Promise<number> {
+    const result = await this.db.prepare('DELETE FROM responses_snapshots WHERE refreshed_at < ?').bind(refreshedBefore).run();
+    return (result.meta.changes as number | undefined) ?? 0;
+  }
+
+  async deleteAll(): Promise<void> {
+    await this.db.prepare('DELETE FROM responses_snapshots').run();
+  }
+}
+
+interface ResponsesSnapshotRow {
+  id: string;
+  api_key_id: string | null;
+  item_ids_json: string;
+  created_at: number;
+  refreshed_at: number;
+}
+
+const toStoredResponsesSnapshot = (row: ResponsesSnapshotRow): StoredResponsesSnapshot => {
+  const parsed: unknown = JSON.parse(row.item_ids_json);
+  if (!Array.isArray(parsed) || parsed.some(item => typeof item !== 'string')) {
+    throw new Error(`Invalid responses_snapshots.item_ids_json for id=${row.id}`);
+  }
+  return {
+    id: row.id,
+    apiKeyId: row.api_key_id,
+    itemIds: parsed,
+    createdAt: row.created_at,
+    refreshedAt: row.refreshed_at,
+  };
+};
 
 class D1SearchConfigRepo implements SearchConfigRepo {
   constructor(private db: D1Database) {}
@@ -962,6 +1033,7 @@ export class D1Repo implements Repo {
   searchConfig: SearchConfigRepo;
   upstreams: UpstreamRepo;
   responsesItems: ResponsesItemsRepo;
+  responsesSnapshots: ResponsesSnapshotsRepo;
 
   constructor(db: D1Database) {
     this.apiKeys = new D1ApiKeyRepo(db);
@@ -972,5 +1044,6 @@ export class D1Repo implements Repo {
     this.searchConfig = new D1SearchConfigRepo(db);
     this.upstreams = new D1UpstreamRepo(db);
     this.responsesItems = new D1ResponsesItemsRepo(db);
+    this.responsesSnapshots = new D1ResponsesSnapshotsRepo(db);
   }
 }

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -13,10 +13,12 @@ import type {
   PerformanceTelemetryRecord,
   Repo,
   ResponsesItemsRepo,
+  ResponsesSnapshotsRepo,
   SearchConfigRepo,
   SearchUsageRecord,
   SearchUsageRepo,
   StoredResponsesItem,
+  StoredResponsesSnapshot,
   UpstreamRecord,
   UpstreamRepo,
   UsageRecord,
@@ -425,7 +427,19 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
         rows.push(cloneStoredResponsesItem(row));
       }
     }
-    return Promise.resolve(rows.toSorted((a, b) => b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id)));
+    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
+  }
+
+  lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]> {
+    const wanted = new Set(hashes);
+    if (wanted.size === 0) return Promise.resolve([]);
+    const rows: StoredResponsesItem[] = [];
+    for (const row of this.store.values()) {
+      if (row.apiKeyId === apiKeyId && row.contentHash !== null && wanted.has(row.contentHash)) {
+        rows.push(cloneStoredResponsesItem(row));
+      }
+    }
+    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
   }
 
   insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
@@ -482,6 +496,51 @@ const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesIte
   payload: item.payload === null ? null : structuredClone(item.payload),
 });
 
+class MemoryResponsesSnapshotsRepo implements ResponsesSnapshotsRepo {
+  private store = new Map<string, StoredResponsesSnapshot>();
+
+  lookup(apiKeyId: string | null, id: string): Promise<StoredResponsesSnapshot | null> {
+    const snapshot = this.store.get(responsesItemStoreKey(apiKeyId, id));
+    return Promise.resolve(snapshot ? cloneStoredResponsesSnapshot(snapshot) : null);
+  }
+
+  insert(snapshot: StoredResponsesSnapshot): Promise<void> {
+    this.store.set(responsesItemStoreKey(snapshot.apiKeyId, snapshot.id), cloneStoredResponsesSnapshot(snapshot));
+    return Promise.resolve();
+  }
+
+  refresh(apiKeyId: string | null, id: string, refreshedAt: number): Promise<boolean> {
+    const snapshot = this.store.get(responsesItemStoreKey(apiKeyId, id));
+    if (!snapshot || snapshot.refreshedAt >= refreshedAt) return Promise.resolve(false);
+    snapshot.refreshedAt = refreshedAt;
+    return Promise.resolve(true);
+  }
+
+  deleteOlderThan(refreshedBefore: number): Promise<number> {
+    let changes = 0;
+    for (const [key, snapshot] of this.store) {
+      if (snapshot.refreshedAt < refreshedBefore) {
+        this.store.delete(key);
+        changes += 1;
+      }
+    }
+    return Promise.resolve(changes);
+  }
+
+  deleteAll(): Promise<void> {
+    this.store.clear();
+    return Promise.resolve();
+  }
+}
+
+const cloneStoredResponsesSnapshot = (snapshot: StoredResponsesSnapshot): StoredResponsesSnapshot => ({
+  ...snapshot,
+  itemIds: [...snapshot.itemIds],
+});
+
+const compareResponsesItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
+  b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);
+
 const responsesItemStoreKey = (apiKeyId: string | null, id: string): string => `${apiKeyId ?? ''}\0${id}`;
 
 export class InMemoryRepo implements Repo {
@@ -493,6 +552,7 @@ export class InMemoryRepo implements Repo {
   searchConfig: SearchConfigRepo;
   upstreams: UpstreamRepo;
   responsesItems: ResponsesItemsRepo;
+  responsesSnapshots: ResponsesSnapshotsRepo;
 
   constructor() {
     this.apiKeys = new MemoryApiKeyRepo();
@@ -503,5 +563,6 @@ export class InMemoryRepo implements Repo {
     this.searchConfig = new MemorySearchConfigRepo();
     this.upstreams = new MemoryUpstreamRepo();
     this.responsesItems = new MemoryResponsesItemsRepo();
+    this.responsesSnapshots = new MemoryResponsesSnapshotsRepo();
   }
 }

--- a/apps/api/src/repo/memory.ts
+++ b/apps/api/src/repo/memory.ts
@@ -451,6 +451,22 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     return Promise.resolve();
   }
 
+  fillPayloads(items: readonly StoredResponsesItem[]): Promise<number> {
+    let changes = 0;
+    for (const item of items) {
+      if (item.payload === null) continue;
+      const existing = this.store.get(responsesItemStoreKey(item.apiKeyId, item.id));
+      if (existing?.payload !== null) continue;
+      existing.payload = structuredClone(item.payload);
+      existing.contentHash = item.contentHash;
+      existing.encryptedContentHash = item.encryptedContentHash;
+      existing.createdAt = item.createdAt;
+      existing.refreshedAt = Math.max(existing.refreshedAt, item.refreshedAt);
+      changes += 1;
+    }
+    return Promise.resolve(changes);
+  }
+
   refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number> {
     let changes = 0;
     for (const id of new Set(ids)) {

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -128,6 +128,37 @@ test('memory responses items repo scopes ids by api key and treats duplicate sco
   assertEquals(await repo.lookupMany('key_b', [item.id]), [{ ...item, apiKeyId: 'key_b' }]);
 });
 
+const exerciseResponsesItemsRepoPayloadFill = async (repo: ResponsesItemsRepo) => {
+  initFileProvider(new MemoryFileProvider());
+  const metadata = storedItem({
+    id: 'msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA',
+    apiKeyId: 'key_a',
+    upstreamId: 'up_responses',
+    upstreamItemId: 'upstream_msg',
+    payload: null,
+    createdAt: 1_000,
+  });
+  const filled = {
+    ...metadata,
+    payload: { item: { type: 'message', id: metadata.id, role: 'user', content: 'captured later' } },
+    contentHash: 'content_hash_later',
+    encryptedContentHash: 'encrypted_content_hash_later',
+    createdAt: 2_000,
+    refreshedAt: 2_000,
+  } satisfies StoredResponsesItem;
+
+  await repo.insertMany([metadata]);
+
+  assertEquals(await repo.fillPayloads([filled]), 1);
+  assertEquals(await repo.lookupMany('key_a', [metadata.id]), [filled]);
+  assertEquals(await repo.fillPayloads([{ ...filled, payload: { item: { changed: true } }, createdAt: 3_000, refreshedAt: 3_000 }]), 0);
+  assertEquals(await repo.lookupMany('key_a', [metadata.id]), [filled]);
+};
+
+test('memory responses items repo fills metadata-only payloads once', async () => {
+  await exerciseResponsesItemsRepoPayloadFill(new InMemoryRepo().responsesItems);
+});
+
 test('D1 responses items repo inserts, looks up by scope, cleans payloads, deletes rows, and clears', async () => {
   await exerciseResponsesItemsRepo(new D1Repo(new FakeResponsesItemsD1Database()).responsesItems);
 });
@@ -162,6 +193,10 @@ test('D1 responses items repo scopes ids by api key and treats duplicate scoped 
 
   assertEquals(await repo.lookupMany('key_a', [item.id]), [item]);
   assertEquals(await repo.lookupMany('key_b', [item.id]), [{ ...item, apiKeyId: 'key_b' }]);
+});
+
+test('D1 responses items repo fills metadata-only payloads once', async () => {
+  await exerciseResponsesItemsRepoPayloadFill(new D1Repo(new FakeResponsesItemsD1Database()).responsesItems);
 });
 
 test('D1 responses items repo chunks lookups exceeding D1 100-parameter limit and unions the results', async () => {
@@ -409,6 +444,10 @@ class FakeResponsesItemsD1PreparedStatement {
       const changes = this.db.refresh(this.binds);
       return Promise.resolve({ results: [], success: true, meta: { changes } });
     }
+    if (this.query.includes('SET payload_json = ?, content_hash = ?, encrypted_content_hash = ?, created_at = ?, refreshed_at = ?')) {
+      const changes = this.db.fillPayload(this.binds);
+      return Promise.resolve({ results: [], success: true, meta: { changes } });
+    }
     if (this.query.startsWith('UPDATE responses_items SET payload_json = NULL')) {
       const changes = this.db.clearPayloadOlderThan(this.binds[0] as number);
       return Promise.resolve({ results: [], success: true, meta: { changes } });
@@ -483,6 +522,26 @@ class FakeResponsesItemsD1Database implements D1Database {
       }
     }
     return changes;
+  }
+
+  fillPayload(binds: unknown[]): number {
+    const [payload, contentHash, encryptedContentHash, createdAt, refreshedAt, apiKeyId, id] = binds as [
+      string,
+      string | null,
+      string | null,
+      number,
+      number,
+      string | null,
+      string,
+    ];
+    const row = this.rows.find(candidate => candidate.id === id && candidate.api_key_id === apiKeyId);
+    if (row?.payload_json !== null) return 0;
+    row.payload_json = payload;
+    row.content_hash = contentHash;
+    row.encrypted_content_hash = encryptedContentHash;
+    row.created_at = createdAt;
+    row.refreshed_at = refreshedAt;
+    return 1;
   }
 
   lookup(query: string, binds: unknown[]): FakeResponsesItemRow[] {

--- a/apps/api/src/repo/responses-items_test.ts
+++ b/apps/api/src/repo/responses-items_test.ts
@@ -12,6 +12,7 @@ const storedItem = (overrides: Partial<StoredResponsesItem> & Pick<StoredRespons
   upstreamItemId: null,
   itemType: 'message',
   origin: 'upstream',
+  contentHash: null,
   encryptedContentHash: null,
   payload: { item: { id: overrides.id, type: 'message', content: [{ type: 'output_text', text: overrides.id }] } },
   refreshedAt: overrides.createdAt,
@@ -26,6 +27,7 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
     upstreamId: 'up_azure',
     upstreamItemId: 'upstream_msg_a',
     itemType: 'message',
+    contentHash: 'content_hash_a',
     createdAt: 1_000,
   });
   const second = storedItem({
@@ -51,6 +53,8 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
   assertEquals(await repo.lookupMany(null, [first.id, adminScoped.id]), [adminScoped]);
   assertEquals(await repo.lookupMany('key_b', [first.id, second.id, adminScoped.id]), []);
   assertEquals(await repo.lookupMany('key_a', []), []);
+  assertEquals(await repo.lookupManyByContentHash('key_a', ['content_hash_a']), [first]);
+  assertEquals(await repo.lookupManyByContentHash('key_b', ['content_hash_a']), []);
 
   assertEquals(await repo.refreshMany('key_a', [first.id, first.id, second.id, adminScoped.id, 'missing'], 4_000), 2);
   assertEquals(
@@ -138,6 +142,7 @@ test('D1 responses items repo rejects malformed stored payload_json', async () =
     item_type: 'message',
     origin: 'synthetic',
     payload_json: '{bad json',
+    content_hash: null,
     encrypted_content_hash: null,
     created_at: 1_000,
     refreshed_at: 1_000,
@@ -310,6 +315,51 @@ test('migration 0025 adds responses item metadata and refresh index', async () =
   }
 });
 
+test('migration 0026 adds Responses state snapshots and content hash index', async () => {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  try {
+    applySqlJsFile(db, '0023_responses_items.sql');
+    applySqlJsFile(db, '0025_responses_item_metadata.sql');
+    applySqlJsFile(db, '0026_responses_state.sql');
+
+    assertEquals(
+      sqlJsRows<{ name: string }>(db, 'PRAGMA table_info(responses_items)').map(row => row.name).filter(name => name === 'content_hash'),
+      ['content_hash'],
+    );
+    assertEquals(
+      sqlJsRows<{ sql: string }>(db, "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'responses_snapshots'")[0].sql,
+      `CREATE TABLE responses_snapshots (
+  id TEXT NOT NULL,
+  api_key_id TEXT,
+  item_ids_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  refreshed_at INTEGER NOT NULL,
+  CHECK (length(id) > 0),
+  CHECK (length(item_ids_json) > 0)
+)`,
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(
+        db,
+        "EXPLAIN QUERY PLAN SELECT id FROM responses_items WHERE api_key_id IS 'key_a' AND content_hash IN ('hash_a') ORDER BY refreshed_at DESC, created_at DESC, id ASC",
+      ).some(row => row.detail.includes('idx_responses_items_content_hash')),
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(
+        db,
+        "EXPLAIN QUERY PLAN SELECT id FROM responses_snapshots WHERE id = 'resp_a' AND COALESCE(api_key_id, '') = COALESCE('key_a', '')",
+      ).some(row => row.detail.includes('idx_responses_snapshots_id_scope')),
+    );
+    assert(
+      sqlJsRows<{ detail: string }>(db, 'EXPLAIN QUERY PLAN DELETE FROM responses_snapshots WHERE refreshed_at < 10')
+        .some(row => row.detail.includes('idx_responses_snapshots_refreshed_at')),
+    );
+  } finally {
+    db.close();
+  }
+});
+
 type FakeResponsesItemRow = {
   id: string;
   api_key_id: string | null;
@@ -318,6 +368,7 @@ type FakeResponsesItemRow = {
   item_type: string;
   origin: StoredResponsesItem['origin'];
   payload_json: string | null;
+  content_hash: string | null;
   encrypted_content_hash: string | null;
   created_at: number;
   refreshed_at: number;
@@ -390,13 +441,14 @@ class FakeResponsesItemsD1Database implements D1Database {
   }
 
   insert(binds: unknown[]): void {
-    const [id, apiKeyId, upstreamId, upstreamItemId, itemType, origin, payload, encryptedContentHash, createdAt, refreshedAt] = binds as [
+    const [id, apiKeyId, upstreamId, upstreamItemId, itemType, origin, payload, contentHash, encryptedContentHash, createdAt, refreshedAt] = binds as [
       string,
       string | null,
       string | null,
       string | null,
       string,
       StoredResponsesItem['origin'],
+      string | null,
       string | null,
       string | null,
       number,
@@ -412,6 +464,7 @@ class FakeResponsesItemsD1Database implements D1Database {
       item_type: itemType,
       origin,
       payload_json: payload,
+      content_hash: contentHash,
       encrypted_content_hash: encryptedContentHash,
       created_at: createdAt,
       refreshed_at: refreshedAt,
@@ -438,6 +491,12 @@ class FakeResponsesItemsD1Database implements D1Database {
     if (query.includes('encrypted_content_hash IN')) {
       return this.rows
         .filter(row => row.api_key_id === apiKeyId && row.encrypted_content_hash !== null && wanted.has(row.encrypted_content_hash))
+        .map(row => ({ ...row }))
+        .toSorted(compareFakeResponsesItemsByFreshness);
+    }
+    if (query.includes('content_hash IN')) {
+      return this.rows
+        .filter(row => row.api_key_id === apiKeyId && row.content_hash !== null && wanted.has(row.content_hash))
         .map(row => ({ ...row }))
         .toSorted(compareFakeResponsesItemsByFreshness);
     }

--- a/apps/api/src/repo/types.ts
+++ b/apps/api/src/repo/types.ts
@@ -182,8 +182,7 @@ export interface StoredResponsesItemPayload {
   // Ancillary state stashed alongside the public `item` body but never sent on
   // the wire: a server-only slot to preserve data a stateless client strips
   // from the echoed item (e.g. the real `web_search_call` results) so a later
-  // turn can restore it on replay. Persisted and round-tripped verbatim; not
-  // yet populated by any producer.
+  // turn can restore it on replay. Persisted and round-tripped verbatim.
   private?: unknown;
 }
 

--- a/apps/api/src/repo/types.ts
+++ b/apps/api/src/repo/types.ts
@@ -192,6 +192,7 @@ export interface ResponsesItemsRepo {
   lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   insertMany(items: readonly StoredResponsesItem[]): Promise<void>;
+  fillPayloads(items: readonly StoredResponsesItem[]): Promise<number>;
   refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number>;
   clearPayloadOlderThan(createdBefore: number): Promise<number>;
   deleteOlderThan(refreshedBefore: number): Promise<number>;

--- a/apps/api/src/repo/types.ts
+++ b/apps/api/src/repo/types.ts
@@ -168,6 +168,7 @@ export interface StoredResponsesItem {
   itemType: string;
   origin: 'input' | 'upstream' | 'synthetic';
   payload: StoredResponsesItemPayload | null;
+  contentHash: string | null;
   // sha256 of the item's `encrypted_content`, when it carries one (reasoning /
   // compaction). Lets a later turn that echoes the blob without a gateway id
   // recover this row's owning upstream for affinity routing.
@@ -188,10 +189,27 @@ export interface StoredResponsesItemPayload {
 
 export interface ResponsesItemsRepo {
   lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItem[]>;
+  lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
   insertMany(items: readonly StoredResponsesItem[]): Promise<void>;
   refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number>;
   clearPayloadOlderThan(createdBefore: number): Promise<number>;
+  deleteOlderThan(refreshedBefore: number): Promise<number>;
+  deleteAll(): Promise<void>;
+}
+
+export interface StoredResponsesSnapshot {
+  id: string;
+  apiKeyId: string | null;
+  itemIds: string[];
+  createdAt: number;
+  refreshedAt: number;
+}
+
+export interface ResponsesSnapshotsRepo {
+  lookup(apiKeyId: string | null, id: string): Promise<StoredResponsesSnapshot | null>;
+  insert(snapshot: StoredResponsesSnapshot): Promise<void>;
+  refresh(apiKeyId: string | null, id: string, refreshedAt: number): Promise<boolean>;
   deleteOlderThan(refreshedBefore: number): Promise<number>;
   deleteAll(): Promise<void>;
 }
@@ -205,4 +223,5 @@ export interface Repo {
   searchConfig: SearchConfigRepo;
   upstreams: UpstreamRepo;
   responsesItems: ResponsesItemsRepo;
+  responsesSnapshots: ResponsesSnapshotsRepo;
 }


### PR DESCRIPTION
Add Responses snapshots keyed by response id and content hashes on stored items so repeated full-history input can reuse existing rows instead of writing duplicates.

Route previous_response_id through the stored snapshot, stage input and output items in a per-request StatefulResponsesStore, and commit snapshots only for stored Responses requests.

Fill metadata-only output rows in place when a later store:true input echoes the same stored id, route server-tool attempt state through StatefulResponsesStore, and refresh only the rows actually selected by request planning or input staging. Snapshots load as missing when referenced rows are no longer replayable, while upstream-owned metadata-only rows remain valid for routing.