### PR TITLE
feat(responses): add websocket transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ an Azure deployment through whichever API shape the agent already speaks.
 | Source API                              | Path                          |
 | --------------------------------------- | ----------------------------- |
 | Anthropic Messages                      | `POST /v1/messages`           |
-| OpenAI Responses                        | `POST /v1/responses`          |
+| OpenAI Responses                        | `POST /v1/responses`, `GET /v1/responses` WebSocket |
 | OpenAI Chat Completions                 | `POST /v1/chat/completions`   |
 | OpenAI Embeddings                       | `POST /v1/embeddings`         |
 | OpenAI Images                           | `POST /v1/images/generations` |
@@ -75,13 +75,17 @@ the shim driving the internal multi-turn loop and replaying prior
 ## Stateful Responses
 
 `/v1/responses` stores replayable Responses input and output items for API-key
-scoped requests. Clients can send `previous_response_id` to continue from a
-stored snapshot, or resend full input history; repeated full-history input is
-deduplicated by content hash instead of stored again. The same endpoint accepts
-`GET` WebSocket upgrades for streaming Responses events. `store: false` does
+scoped HTTP requests. Clients can send `previous_response_id` to continue from
+a stored snapshot, or resend full input history; repeated full-history input is
+deduplicated by content hash instead of stored again. HTTP `store: false` does
 not create durable snapshots or input payload rows, but it keeps output item
 metadata for routing; if a later `store: true` request echoes that item with a
 full payload, the metadata row is filled in place.
+
+The same endpoint accepts `GET` WebSocket upgrades for streaming Responses
+events. WebSocket `store: false` keeps replay state only inside the open
+session, so same-socket `previous_response_id` works without writing those
+items or snapshots to durable storage.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ the shim driving the internal multi-turn loop and replaying prior
 `/v1/responses` stores replayable Responses input and output items for API-key
 scoped requests. Clients can send `previous_response_id` to continue from a
 stored snapshot, or resend full input history; repeated full-history input is
-deduplicated by content hash instead of stored again. `store: false` does not
-create durable snapshots or input payload rows, but it keeps output item
+deduplicated by content hash instead of stored again. The same endpoint accepts
+`GET` WebSocket upgrades for streaming Responses events. `store: false` does
+not create durable snapshots or input payload rows, but it keeps output item
 metadata for routing; if a later `store: true` request echoes that item with a
 full payload, the metadata row is filled in place.
 

--- a/apps/api/src/data-plane/llm/routes.ts
+++ b/apps/api/src/data-plane/llm/routes.ts
@@ -4,6 +4,7 @@ import { chatCompletionsTraits } from './sources/chat-completions/traits.ts';
 import { geminiTraits } from './sources/gemini/traits.ts';
 import { messagesTraits } from './sources/messages/traits.ts';
 import { responsesTraits } from './sources/responses/traits.ts';
+import { responsesWebSocket } from './sources/responses/websocket.ts';
 import { serveLlm } from './sources/serve.ts';
 
 export const mountLlmRoutes = (app: Hono) => {
@@ -22,6 +23,8 @@ export const mountLlmRoutes = (app: Hono) => {
   app.post('/chat/completions', serveChatCompletions);
   app.post('/v1/responses', serveResponses);
   app.post('/responses', serveResponses);
+  app.get('/v1/responses', responsesWebSocket);
+  app.get('/responses', responsesWebSocket);
   app.post('/v1/messages', serveMessages);
   app.post('/messages', serveMessages);
   app.post('/v1/messages/count_tokens', serveMessagesCountTokens);

--- a/apps/api/src/data-plane/llm/sources/request-context.ts
+++ b/apps/api/src/data-plane/llm/sources/request-context.ts
@@ -33,12 +33,12 @@ export const createHttpRequestContext = (
   c: Context,
   downstreamAbortSignal: AbortSignal | undefined,
   clientStream: boolean,
-  options: { readonly store?: boolean | null | undefined } = {},
+  options: { readonly store?: boolean | null | undefined; readonly statefulResponsesStore?: StatefulResponsesStore } = {},
 ): RequestContext => {
   const apiKeyId = c.get('apiKeyId') as string | undefined;
   const apiKeyUpstreamIds = c.get('apiKeyUpstreamIds') as readonly string[] | null | undefined;
   const scheduleBackground = backgroundSchedulerFromContext(c);
-  const statefulResponsesStore = createHttpStatefulResponsesStore(apiKeyId ?? null, options.store);
+  const statefulResponsesStore = options.statefulResponsesStore ?? createHttpStatefulResponsesStore(apiKeyId ?? null, options.store);
   return createRequestContext({
     ...(apiKeyId !== undefined ? { apiKeyId } : {}),
     ...(apiKeyUpstreamIds !== undefined ? { apiKeyUpstreamIds } : {}),

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
@@ -26,13 +26,17 @@ interface StatefulResponsesBacking {
   refreshSnapshot(apiKeyId: string | null, id: string, refreshedAt: number): Promise<void>;
 }
 
-interface StatefulResponsesReadTarget {
-  readonly backing: StatefulResponsesBacking;
-}
-
 interface StatefulResponsesWriteTarget {
   readonly backing: StatefulResponsesBacking;
   readonly durable: boolean;
+}
+
+interface LayeredStatefulResponsesStoreOptions {
+  readonly apiKeyId: string | null;
+  readonly reads: readonly StatefulResponsesBacking[];
+  readonly itemWrites: readonly StatefulResponsesWriteTarget[];
+  readonly snapshotWrites: readonly StatefulResponsesWriteTarget[];
+  readonly stageInputs: boolean;
 }
 
 export interface WebSocketStatefulResponsesStoragePolicy {
@@ -62,7 +66,7 @@ export interface StatefulResponsesStore {
   refreshTouchedItems(): Promise<void>;
 }
 
-class HttpStatefulResponsesStore implements StatefulResponsesStore {
+class LayeredStatefulResponsesStore implements StatefulResponsesStore {
   private readonly loadedItemsById = new Map<string, StoredResponsesItem>();
   private readonly loadedItemsByContentHash = new Map<string, StoredResponsesItem[]>();
   private readonly loadedItemsByEncryptedContentHash = new Map<string, StoredResponsesItem[]>();
@@ -81,15 +85,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   private readonly refreshedItemIds = new Set<string>();
   private readonly durableItemIds = new Set<string>();
 
-  constructor(
-    private readonly options: {
-      readonly apiKeyId: string | null;
-      readonly reads: readonly StatefulResponsesReadTarget[];
-      readonly itemWrites: readonly StatefulResponsesWriteTarget[];
-      readonly snapshotWrites: readonly StatefulResponsesWriteTarget[];
-      readonly stageInputs: boolean;
-    },
-  ) {}
+  constructor(private readonly options: LayeredStatefulResponsesStoreOptions) {}
 
   async loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null> {
     const cached = this.snapshotsById.get(id);
@@ -98,8 +94,8 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       return cloneStoredResponsesSnapshot(cached);
     }
 
-    for (const read of this.options.reads) {
-      const snapshot = await read.backing.lookupSnapshot(this.options.apiKeyId, id);
+    for (const backing of this.options.reads) {
+      const snapshot = await backing.lookupSnapshot(this.options.apiKeyId, id);
       if (snapshot === null) continue;
       await this.loadItems({ ids: snapshot.itemIds, contentHashes: [], encryptedContentHashes: [] });
       if (!snapshot.itemIds.every(itemId => {
@@ -222,12 +218,12 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
 
   private async loadItems(query: { ids: readonly string[]; contentHashes: readonly string[]; encryptedContentHashes: readonly string[] }): Promise<void> {
     let ids = query.ids.filter(id => !this.loadedItemsById.has(id));
-    let contentHashes = query.contentHashes.filter(hash => !this.loadedItemsByContentHash.has(hash));
-    let encryptedContentHashes = query.encryptedContentHashes.filter(hash => !this.loadedItemsByEncryptedContentHash.has(hash));
+    const contentHashes = [...new Set(query.contentHashes)];
+    const encryptedContentHashes = [...new Set(query.encryptedContentHashes)];
 
-    for (const read of this.options.reads) {
+    for (const backing of this.options.reads) {
       if (ids.length === 0 && contentHashes.length === 0 && encryptedContentHashes.length === 0) return;
-      const results = await read.backing.lookupItems({
+      const results = await backing.lookupItems({
         apiKeyId: this.options.apiKeyId,
         ids,
         contentHashes,
@@ -235,8 +231,6 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       });
       for (const result of results) this.rememberItem(result.row, { durable: result.durable });
       ids = ids.filter(id => !this.loadedItemsById.has(id));
-      contentHashes = contentHashes.filter(hash => !this.loadedItemsByContentHash.has(hash));
-      encryptedContentHashes = encryptedContentHashes.filter(hash => !this.loadedItemsByEncryptedContentHash.has(hash));
     }
   }
 
@@ -520,9 +514,9 @@ class MemoryStatefulResponsesBacking implements StatefulResponsesBacking {
 }
 
 export const createHttpStatefulResponsesStore = (apiKeyId: string | null, store: boolean | null | undefined): StatefulResponsesStore =>
-  createStatefulResponsesStore({
+  new LayeredStatefulResponsesStore({
     apiKeyId,
-    reads: [{ backing: new RepoStatefulResponsesBacking(getRepo) }],
+    reads: [new RepoStatefulResponsesBacking(getRepo)],
     itemWrites: [{ backing: new RepoStatefulResponsesBacking(getRepo), durable: true }],
     snapshotWrites: store === false ? [] : [{ backing: new RepoStatefulResponsesBacking(getRepo), durable: true }],
     stageInputs: store !== false,
@@ -533,27 +527,49 @@ export const createWebSocketStatefulResponsesSession = () => {
   const repoBacking = new RepoStatefulResponsesBacking(getRepo);
   return {
     createStore(apiKeyId: string | null, store: boolean | null | undefined): WebSocketStatefulResponsesStoragePolicy {
-      const reads = [{ backing: localBacking }, { backing: repoBacking }];
-      const localWrite = { backing: localBacking, durable: false };
-      const repoWrite = { backing: repoBacking, durable: true };
-      const statefulResponsesStore = createStatefulResponsesStore({
-        apiKeyId,
-        reads,
-        itemWrites: store === false ? [localWrite] : [localWrite, repoWrite],
-        snapshotWrites: store === false ? [localWrite] : [localWrite, repoWrite],
-        stageInputs: store !== false,
-      });
-      return {
-        statefulResponsesStore,
-        outputStore: store === false ? true : store,
-        commitSnapshot: true,
-      };
+      return store === false
+        ? webSocketSessionOnlyPolicy(apiKeyId, localBacking, repoBacking)
+        : webSocketDurablePolicy(apiKeyId, store, localBacking, repoBacking);
     },
   };
 };
 
-const createStatefulResponsesStore = (options: ConstructorParameters<typeof HttpStatefulResponsesStore>[0]): StatefulResponsesStore =>
-  new HttpStatefulResponsesStore(options);
+const webSocketSessionOnlyPolicy = (
+  apiKeyId: string | null,
+  localBacking: StatefulResponsesBacking,
+  repoBacking: StatefulResponsesBacking,
+): WebSocketStatefulResponsesStoragePolicy => ({
+  statefulResponsesStore: new LayeredStatefulResponsesStore({
+    apiKeyId,
+    reads: [localBacking, repoBacking],
+    itemWrites: [{ backing: localBacking, durable: false }],
+    snapshotWrites: [{ backing: localBacking, durable: false }],
+    stageInputs: true,
+  }),
+  outputStore: true,
+  commitSnapshot: true,
+});
+
+const webSocketDurablePolicy = (
+  apiKeyId: string | null,
+  store: boolean | null | undefined,
+  localBacking: StatefulResponsesBacking,
+  repoBacking: StatefulResponsesBacking,
+): WebSocketStatefulResponsesStoragePolicy => {
+  const localWrite = { backing: localBacking, durable: false };
+  const repoWrite = { backing: repoBacking, durable: true };
+  return {
+    statefulResponsesStore: new LayeredStatefulResponsesStore({
+      apiKeyId,
+      reads: [localBacking, repoBacking],
+      itemWrites: [localWrite, repoWrite],
+      snapshotWrites: [localWrite, repoWrite],
+      stageInputs: true,
+    }),
+    outputStore: store,
+    commitSnapshot: true,
+  };
+};
 
 const pushByHash = (target: Map<string, StoredResponsesItem[]>, hash: string, row: StoredResponsesItem): void => {
   const rows = target.get(hash) ?? [];

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
@@ -4,6 +4,43 @@ import type { Repo, StoredResponsesItem, StoredResponsesSnapshot } from '../../.
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
+interface StatefulResponsesItemLookup {
+  readonly apiKeyId: string | null;
+  readonly ids: readonly string[];
+  readonly contentHashes: readonly string[];
+  readonly encryptedContentHashes: readonly string[];
+}
+
+interface StatefulResponsesItemLookupResult {
+  readonly row: StoredResponsesItem;
+  readonly durable: boolean;
+}
+
+interface StatefulResponsesBacking {
+  lookupItems(query: StatefulResponsesItemLookup): Promise<StatefulResponsesItemLookupResult[]>;
+  insertItems(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<void>;
+  fillPayloads(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<number>;
+  refreshItems(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<void>;
+  lookupSnapshot(apiKeyId: string | null, id: string): Promise<StoredResponsesSnapshot | null>;
+  insertSnapshot(snapshot: StoredResponsesSnapshot): Promise<void>;
+  refreshSnapshot(apiKeyId: string | null, id: string, refreshedAt: number): Promise<void>;
+}
+
+interface StatefulResponsesReadTarget {
+  readonly backing: StatefulResponsesBacking;
+}
+
+interface StatefulResponsesWriteTarget {
+  readonly backing: StatefulResponsesBacking;
+  readonly durable: boolean;
+}
+
+export interface WebSocketStatefulResponsesStoragePolicy {
+  readonly statefulResponsesStore: StatefulResponsesStore;
+  readonly outputStore: boolean | null | undefined;
+  readonly commitSnapshot: boolean;
+}
+
 export interface StatefulResponsesStore {
   loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null>;
   loadInputItems<TSourceItems>(options: {
@@ -42,16 +79,17 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   private readonly committedSnapshotIds = new Set<string>();
   private readonly touchedItemIds = new Set<string>();
   private readonly refreshedItemIds = new Set<string>();
+  private readonly durableItemIds = new Set<string>();
 
   constructor(
-    private readonly repoProvider: Repo | (() => Repo),
-    private readonly apiKeyId: string | null,
-    private readonly store: boolean | null | undefined,
+    private readonly options: {
+      readonly apiKeyId: string | null;
+      readonly reads: readonly StatefulResponsesReadTarget[];
+      readonly itemWrites: readonly StatefulResponsesWriteTarget[];
+      readonly snapshotWrites: readonly StatefulResponsesWriteTarget[];
+      readonly stageInputs: boolean;
+    },
   ) {}
-
-  private get repo(): Repo {
-    return typeof this.repoProvider === 'function' ? this.repoProvider() : this.repoProvider;
-  }
 
   async loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null> {
     const cached = this.snapshotsById.get(id);
@@ -60,18 +98,21 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
       return cloneStoredResponsesSnapshot(cached);
     }
 
-    const snapshot = await this.repo.responsesSnapshots.lookup(this.apiKeyId, id);
-    if (snapshot === null) return null;
-    await this.loadItems({ ids: snapshot.itemIds, contentHashes: [], encryptedContentHashes: [] });
-    if (!snapshot.itemIds.every(itemId => {
-      const row = this.loadedItemsById.get(itemId);
-      return row !== undefined && isReplayableSnapshotRow(row);
-    })) return null;
-    this.rememberSnapshot(snapshot);
-    this.previousSnapshotItemIds = [...snapshot.itemIds];
-    for (const itemId of snapshot.itemIds) this.touchedItemIds.add(itemId);
-    await this.repo.responsesSnapshots.refresh(this.apiKeyId, id, Date.now());
-    return cloneStoredResponsesSnapshot(snapshot);
+    for (const read of this.options.reads) {
+      const snapshot = await read.backing.lookupSnapshot(this.options.apiKeyId, id);
+      if (snapshot === null) continue;
+      await this.loadItems({ ids: snapshot.itemIds, contentHashes: [], encryptedContentHashes: [] });
+      if (!snapshot.itemIds.every(itemId => {
+        const row = this.loadedItemsById.get(itemId);
+        return row !== undefined && isReplayableSnapshotRow(row);
+      })) continue;
+      this.rememberSnapshot(snapshot);
+      this.previousSnapshotItemIds = [...snapshot.itemIds];
+      for (const itemId of snapshot.itemIds) this.touchedItemIds.add(itemId);
+      await Promise.all(this.options.snapshotWrites.map(write => write.backing.refreshSnapshot(this.options.apiKeyId, id, Date.now())));
+      return cloneStoredResponsesSnapshot(snapshot);
+    }
+    return null;
   }
 
   async loadInputItems<TSourceItems>(options: {
@@ -116,7 +157,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   }
 
   async stageInputItems(items: readonly ResponsesInputItem[]): Promise<void> {
-    if (this.store === false) return;
+    if (!this.options.stageInputs) return;
     for (const item of items) await this.stageInputItem(item);
   }
 
@@ -157,7 +198,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   }
 
   async commitSnapshot(responseId: string): Promise<void> {
-    if (this.store === false || this.committedSnapshotIds.has(responseId)) return;
+    if (this.options.snapshotWrites.length === 0 || this.committedSnapshotIds.has(responseId)) return;
     await this.commitItems([...this.stagedInputItems.values(), ...this.stagedOutputItems.values()]);
     const itemIds = [...this.previousSnapshotItemIds, ...this.stagedInputItemIds, ...this.stagedOutputItemIds];
     if (itemIds.length === 0) return;
@@ -167,26 +208,36 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     const now = Date.now();
     const snapshot: StoredResponsesSnapshot = {
       id: responseId,
-      apiKeyId: this.apiKeyId,
+      apiKeyId: this.options.apiKeyId,
       itemIds,
       createdAt: now,
       refreshedAt: now,
     };
-    await this.repo.responsesSnapshots.insert(snapshot);
+    await Promise.all(this.options.snapshotWrites
+      .filter(write => !write.durable || itemIds.every(id => this.durableItemIds.has(id)))
+      .map(write => write.backing.insertSnapshot(snapshot)));
     this.rememberSnapshot(snapshot);
     this.committedSnapshotIds.add(responseId);
   }
 
   private async loadItems(query: { ids: readonly string[]; contentHashes: readonly string[]; encryptedContentHashes: readonly string[] }): Promise<void> {
-    const ids = query.ids.filter(id => !this.loadedItemsById.has(id));
-    const contentHashes = query.contentHashes.filter(hash => !this.loadedItemsByContentHash.has(hash));
-    const encryptedContentHashes = query.encryptedContentHashes.filter(hash => !this.loadedItemsByEncryptedContentHash.has(hash));
-    const [byId, byContentHash, byEncryptedContentHash] = await Promise.all([
-      this.repo.responsesItems.lookupMany(this.apiKeyId, ids),
-      this.repo.responsesItems.lookupManyByContentHash(this.apiKeyId, contentHashes),
-      this.repo.responsesItems.lookupManyByEncryptedContentHash(this.apiKeyId, encryptedContentHashes),
-    ]);
-    for (const row of [...byId, ...byContentHash, ...byEncryptedContentHash]) this.rememberItem(row);
+    let ids = query.ids.filter(id => !this.loadedItemsById.has(id));
+    let contentHashes = query.contentHashes.filter(hash => !this.loadedItemsByContentHash.has(hash));
+    let encryptedContentHashes = query.encryptedContentHashes.filter(hash => !this.loadedItemsByEncryptedContentHash.has(hash));
+
+    for (const read of this.options.reads) {
+      if (ids.length === 0 && contentHashes.length === 0 && encryptedContentHashes.length === 0) return;
+      const results = await read.backing.lookupItems({
+        apiKeyId: this.options.apiKeyId,
+        ids,
+        contentHashes,
+        encryptedContentHashes,
+      });
+      for (const result of results) this.rememberItem(result.row, { durable: result.durable });
+      ids = ids.filter(id => !this.loadedItemsById.has(id));
+      contentHashes = contentHashes.filter(hash => !this.loadedItemsByContentHash.has(hash));
+      encryptedContentHashes = encryptedContentHashes.filter(hash => !this.loadedItemsByEncryptedContentHash.has(hash));
+    }
   }
 
   private async stageInputItem(item: ResponsesInputItem): Promise<void> {
@@ -236,7 +287,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     const now = Date.now();
     const row: StoredResponsesItem = {
       id: createStoredResponsesItemId(item.type),
-      apiKeyId: this.apiKeyId,
+      apiKeyId: this.options.apiKeyId,
       upstreamId: null,
       upstreamItemId: null,
       itemType: item.type,
@@ -249,7 +300,7 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     };
     this.stagedInputItems.set(row.id, row);
     this.stagedInputItemIds.push(row.id);
-    this.rememberItem(row);
+    this.rememberItem(row, { durable: this.durableItemIds.has(row.id) });
   }
 
   private async stagePayloadUpgrade(row: StoredResponsesItem, item: ResponsesInputItem, encryptedContent: string | null): Promise<void> {
@@ -274,9 +325,10 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
     return this.loadedItemsByContentHash.get(hash)?.find(row => row.payload !== null);
   }
 
-  private rememberItem(row: StoredResponsesItem): void {
+  private rememberItem(row: StoredResponsesItem, options: { readonly durable?: boolean } = {}): void {
     const cloned = cloneStoredResponsesItem(row);
     this.loadedItemsById.set(cloned.id, cloned);
+    if (options.durable === true) this.durableItemIds.add(cloned.id);
     if (cloned.contentHash !== null) pushByHash(this.loadedItemsByContentHash, cloned.contentHash, cloned);
     if (cloned.encryptedContentHash !== null) pushByHash(this.loadedItemsByEncryptedContentHash, cloned.encryptedContentHash, cloned);
   }
@@ -303,27 +355,205 @@ class HttpStatefulResponsesStore implements StatefulResponsesStore {
   private async commitItems(rows: readonly StoredResponsesItem[]): Promise<void> {
     const pending = rows.filter(row => !this.committedItemIds.has(row.id));
     if (pending.length === 0) return;
-    const payloadUpgrades = pending.filter(row => this.payloadUpgradeIds.has(row.id));
-    const inserts = pending.filter(row => !this.payloadUpgradeIds.has(row.id));
-    await Promise.all([
-      this.repo.responsesItems.insertMany(inserts),
-      this.repo.responsesItems.fillPayloads(payloadUpgrades),
-    ]);
+    await Promise.all(this.options.itemWrites.map(async write => {
+      const writable = write.durable ? pending.filter(row => this.isDurableWriteEligible(row)) : pending;
+      const payloadUpgrades = writable.filter(row => this.payloadUpgradeIds.has(row.id) && (!write.durable || this.durableItemIds.has(row.id)));
+      const inserts = writable.filter(row => !this.payloadUpgradeIds.has(row.id) || (write.durable && !this.durableItemIds.has(row.id)));
+      await Promise.all([
+        write.backing.insertItems(inserts, { durable: write.durable }),
+        write.backing.fillPayloads(payloadUpgrades, { durable: write.durable }),
+      ]);
+      if (write.durable) {
+        for (const row of writable) this.durableItemIds.add(row.id);
+      }
+    }));
     for (const row of pending) this.committedItemIds.add(row.id);
     await this.refreshTouchedItems();
+  }
+
+  private isDurableWriteEligible(row: StoredResponsesItem): boolean {
+    return this.durableItemIds.has(row.id)
+      || this.stagedInputItems.has(row.id)
+      || this.stagedOutputItems.has(row.id)
+      || this.payloadUpgradeIds.has(row.id);
   }
 
   async refreshTouchedItems(): Promise<void> {
     const ids = [...this.touchedItemIds].filter(id => !this.refreshedItemIds.has(id));
     if (ids.length === 0) return;
     const refreshedAt = Date.now();
-    await this.repo.responsesItems.refreshMany(this.apiKeyId, ids, refreshedAt);
+    await Promise.all(this.options.itemWrites.map(write => {
+      const writableIds = write.durable ? ids.filter(id => this.durableItemIds.has(id)) : ids;
+      return write.backing.refreshItems(this.options.apiKeyId, writableIds, refreshedAt);
+    }));
     for (const id of ids) this.refreshedItemIds.add(id);
   }
 }
 
+class RepoStatefulResponsesBacking implements StatefulResponsesBacking {
+  constructor(private readonly repoProvider: Repo | (() => Repo)) {}
+
+  private get repo(): Repo {
+    return typeof this.repoProvider === 'function' ? this.repoProvider() : this.repoProvider;
+  }
+
+  async lookupItems(query: StatefulResponsesItemLookup): Promise<StatefulResponsesItemLookupResult[]> {
+    const [byId, byContentHash, byEncryptedContentHash] = await Promise.all([
+      this.repo.responsesItems.lookupMany(query.apiKeyId, query.ids),
+      this.repo.responsesItems.lookupManyByContentHash(query.apiKeyId, query.contentHashes),
+      this.repo.responsesItems.lookupManyByEncryptedContentHash(query.apiKeyId, query.encryptedContentHashes),
+    ]);
+    const rowsByKey = new Map<string, StoredResponsesItem>();
+    for (const row of [...byId, ...byContentHash, ...byEncryptedContentHash]) {
+      rowsByKey.set(scopedKey(row.apiKeyId, row.id), cloneStoredResponsesItem(row));
+    }
+    return [...rowsByKey.values()].map(row => ({ row, durable: true }));
+  }
+
+  async insertItems(items: readonly StoredResponsesItem[]): Promise<void> {
+    await this.repo.responsesItems.insertMany(items);
+  }
+
+  async fillPayloads(items: readonly StoredResponsesItem[]): Promise<number> {
+    return await this.repo.responsesItems.fillPayloads(items);
+  }
+
+  async refreshItems(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<void> {
+    await this.repo.responsesItems.refreshMany(apiKeyId, ids, refreshedAt);
+  }
+
+  async lookupSnapshot(apiKeyId: string | null, id: string): Promise<StoredResponsesSnapshot | null> {
+    return await this.repo.responsesSnapshots.lookup(apiKeyId, id);
+  }
+
+  async insertSnapshot(snapshot: StoredResponsesSnapshot): Promise<void> {
+    await this.repo.responsesSnapshots.insert(snapshot);
+  }
+
+  async refreshSnapshot(apiKeyId: string | null, id: string, refreshedAt: number): Promise<void> {
+    await this.repo.responsesSnapshots.refresh(apiKeyId, id, refreshedAt);
+  }
+}
+
+class MemoryStatefulResponsesBacking implements StatefulResponsesBacking {
+  private readonly items = new Map<string, { row: StoredResponsesItem; durable: boolean }>();
+  private readonly snapshots = new Map<string, StoredResponsesSnapshot>();
+
+  lookupItems(query: StatefulResponsesItemLookup): Promise<StatefulResponsesItemLookupResult[]> {
+    const ids = new Set(query.ids);
+    const contentHashes = new Set(query.contentHashes);
+    const encryptedContentHashes = new Set(query.encryptedContentHashes);
+    return Promise.resolve([...this.items.values()]
+      .filter(({ row }) =>
+        row.apiKeyId === query.apiKeyId
+        && (
+          ids.has(row.id)
+          || (row.contentHash !== null && contentHashes.has(row.contentHash))
+          || (row.encryptedContentHash !== null && encryptedContentHashes.has(row.encryptedContentHash))
+        ))
+      .map(({ row, durable }) => ({ row: cloneStoredResponsesItem(row), durable }))
+      .toSorted((a, b) => compareItemsByFreshness(a.row, b.row)));
+  }
+
+  insertItems(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<void> {
+    for (const item of items) {
+      const key = scopedKey(item.apiKeyId, item.id);
+      const existing = this.items.get(key);
+      if (existing) {
+        if (options.durable) existing.durable = true;
+        continue;
+      }
+      this.items.set(key, { row: cloneStoredResponsesItem(item), durable: options.durable });
+    }
+    return Promise.resolve();
+  }
+
+  fillPayloads(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<number> {
+    let changes = 0;
+    for (const item of items) {
+      if (item.payload === null) continue;
+      const existing = this.items.get(scopedKey(item.apiKeyId, item.id));
+      if (existing?.row.payload !== null) continue;
+      existing.row = {
+        ...existing.row,
+        payload: structuredClone(item.payload),
+        contentHash: item.contentHash,
+        encryptedContentHash: item.encryptedContentHash,
+        createdAt: item.createdAt,
+        refreshedAt: Math.max(existing.row.refreshedAt, item.refreshedAt),
+      };
+      if (options.durable) existing.durable = true;
+      changes += 1;
+    }
+    return Promise.resolve(changes);
+  }
+
+  refreshItems(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<void> {
+    for (const id of new Set(ids)) {
+      const existing = this.items.get(scopedKey(apiKeyId, id));
+      if (existing && existing.row.refreshedAt < refreshedAt) {
+        existing.row = { ...existing.row, refreshedAt };
+      }
+    }
+    return Promise.resolve();
+  }
+
+  lookupSnapshot(apiKeyId: string | null, id: string): Promise<StoredResponsesSnapshot | null> {
+    const snapshot = this.snapshots.get(scopedKey(apiKeyId, id));
+    return Promise.resolve(snapshot ? cloneStoredResponsesSnapshot(snapshot) : null);
+  }
+
+  insertSnapshot(snapshot: StoredResponsesSnapshot): Promise<void> {
+    const key = scopedKey(snapshot.apiKeyId, snapshot.id);
+    if (!this.snapshots.has(key)) this.snapshots.set(key, cloneStoredResponsesSnapshot(snapshot));
+    return Promise.resolve();
+  }
+
+  refreshSnapshot(apiKeyId: string | null, id: string, refreshedAt: number): Promise<void> {
+    const key = scopedKey(apiKeyId, id);
+    const snapshot = this.snapshots.get(key);
+    if (snapshot && snapshot.refreshedAt < refreshedAt) {
+      this.snapshots.set(key, { ...snapshot, refreshedAt });
+    }
+    return Promise.resolve();
+  }
+}
+
 export const createHttpStatefulResponsesStore = (apiKeyId: string | null, store: boolean | null | undefined): StatefulResponsesStore =>
-  new HttpStatefulResponsesStore(getRepo, apiKeyId, store);
+  createStatefulResponsesStore({
+    apiKeyId,
+    reads: [{ backing: new RepoStatefulResponsesBacking(getRepo) }],
+    itemWrites: [{ backing: new RepoStatefulResponsesBacking(getRepo), durable: true }],
+    snapshotWrites: store === false ? [] : [{ backing: new RepoStatefulResponsesBacking(getRepo), durable: true }],
+    stageInputs: store !== false,
+  });
+
+export const createWebSocketStatefulResponsesSession = () => {
+  const localBacking = new MemoryStatefulResponsesBacking();
+  const repoBacking = new RepoStatefulResponsesBacking(getRepo);
+  return {
+    createStore(apiKeyId: string | null, store: boolean | null | undefined): WebSocketStatefulResponsesStoragePolicy {
+      const reads = [{ backing: localBacking }, { backing: repoBacking }];
+      const localWrite = { backing: localBacking, durable: false };
+      const repoWrite = { backing: repoBacking, durable: true };
+      const statefulResponsesStore = createStatefulResponsesStore({
+        apiKeyId,
+        reads,
+        itemWrites: store === false ? [localWrite] : [localWrite, repoWrite],
+        snapshotWrites: store === false ? [localWrite] : [localWrite, repoWrite],
+        stageInputs: store !== false,
+      });
+      return {
+        statefulResponsesStore,
+        outputStore: store === false ? true : store,
+        commitSnapshot: true,
+      };
+    },
+  };
+};
+
+const createStatefulResponsesStore = (options: ConstructorParameters<typeof HttpStatefulResponsesStore>[0]): StatefulResponsesStore =>
+  new HttpStatefulResponsesStore(options);
 
 const pushByHash = (target: Map<string, StoredResponsesItem[]>, hash: string, row: StoredResponsesItem): void => {
   const rows = target.get(hash) ?? [];
@@ -346,6 +576,8 @@ const cloneStoredResponsesSnapshot = (snapshot: StoredResponsesSnapshot): Stored
   ...snapshot,
   itemIds: [...snapshot.itemIds],
 });
+
+const scopedKey = (apiKeyId: string | null, id: string): string => `${apiKeyId ?? ''}\0${id}`;
 
 const compareItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
   b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
@@ -20,6 +20,7 @@ interface StatefulResponsesBacking {
   lookupItems(query: StatefulResponsesItemLookup): Promise<StatefulResponsesItemLookupResult[]>;
   insertItems(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<void>;
   fillPayloads(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<number>;
+  markDurable?(apiKeyId: string | null, id: string): void;
   refreshItems(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<void>;
   lookupSnapshot(apiKeyId: string | null, id: string): Promise<StoredResponsesSnapshot | null>;
   insertSnapshot(snapshot: StoredResponsesSnapshot): Promise<void>;
@@ -358,7 +359,7 @@ class LayeredStatefulResponsesStore implements StatefulResponsesStore {
         write.backing.fillPayloads(payloadUpgrades, { durable: write.durable }),
       ]);
       if (write.durable) {
-        for (const row of writable) this.durableItemIds.add(row.id);
+        for (const row of writable) this.markDurable(row.apiKeyId, row.id);
       }
     }));
     for (const row of pending) this.committedItemIds.add(row.id);
@@ -370,6 +371,13 @@ class LayeredStatefulResponsesStore implements StatefulResponsesStore {
       || this.stagedInputItems.has(row.id)
       || this.stagedOutputItems.has(row.id)
       || this.payloadUpgradeIds.has(row.id);
+  }
+
+  private markDurable(apiKeyId: string | null, id: string): void {
+    this.durableItemIds.add(id);
+    for (const write of this.options.itemWrites) {
+      if (!write.durable) write.backing.markDurable?.(apiKeyId, id);
+    }
   }
 
   async refreshTouchedItems(): Promise<void> {
@@ -480,6 +488,11 @@ class MemoryStatefulResponsesBacking implements StatefulResponsesBacking {
       changes += 1;
     }
     return Promise.resolve(changes);
+  }
+
+  markDurable(apiKeyId: string | null, id: string): void {
+    const existing = this.items.get(scopedKey(apiKeyId, id));
+    if (existing) existing.durable = true;
   }
 
   refreshItems(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<void> {

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { createStoredResponsesItemId, hashResponsesItemEncryptedContent } from './items/format.ts';
 import { prepareStoredResponsesItemsForSource } from './items/request-plan.ts';
-import { createHttpStatefulResponsesStore } from './stateful-store.ts';
+import { createHttpStatefulResponsesStore, createWebSocketStatefulResponsesSession } from './stateful-store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
@@ -61,6 +61,43 @@ test('encrypted-content lookup refreshes only the selected compatible candidate'
   assertExists(readIncompatible);
   assertEquals(readCompatible.refreshedAt > compatible.refreshedAt, true);
   assertEquals(readIncompatible.refreshedAt, incompatible.refreshedAt);
+});
+
+test('websocket local incompatible encrypted-content candidates do not mask durable compatible rows', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const encryptedContent = 'websocket-shared-encrypted-content';
+  const encryptedContentHash = await hashResponsesItemEncryptedContent(encryptedContent);
+  const localIncompatible = storedRow({
+    id: createStoredResponsesItemId('message'),
+    itemType: 'message',
+    upstreamId: 'up_local',
+    upstreamItemId: 'raw_msg_local',
+    encryptedContentHash,
+    createdAt: 3_000,
+    refreshedAt: 3_000,
+  });
+  const durableCompatible = storedRow({
+    id: createStoredResponsesItemId('reasoning'),
+    itemType: 'reasoning',
+    upstreamId: 'up_durable',
+    upstreamItemId: 'raw_rs_durable',
+    encryptedContentHash,
+    createdAt: 2_000,
+    refreshedAt: 2_000,
+  });
+  await repo.responsesItems.insertMany([durableCompatible]);
+  const session = createWebSocketStatefulResponsesSession();
+  const localStore = session.createStore(API_KEY_ID, false).statefulResponsesStore;
+  localStore.stageOutputItem(localIncompatible);
+  await localStore.commitOutputItems();
+
+  const input = [{ type: 'reasoning', encrypted_content: encryptedContent, summary: [] }] as unknown as ResponsesInputItem[];
+  const store = session.createStore(API_KEY_ID, undefined).statefulResponsesStore;
+  await store.loadInputItems({ sourceItems: input, view: responsesItemsView });
+  const prepared = await prepareStoredResponsesItemsForSource(input, responsesItemsView, store);
+
+  assertEquals(prepared.references[0].row?.id, durableCompatible.id);
 });
 
 test('snapshots with non-replayable metadata-only rows load as missing', async () => {

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono';
 
 import { responsesSourceInterceptors } from './interceptors/index.ts';
 import { respondResponses } from './respond.ts';
-import type { StatefulResponsesStore, WebSocketStatefulResponsesStoragePolicy } from './stateful-store.ts';
+import type { StatefulResponsesStore } from './stateful-store.ts';
 import type { ProviderModelRecord } from '../../../providers/types.ts';
 import { type LlmTargetApi, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
 import type { ExecuteResult } from '../../shared/errors/result.ts';
@@ -161,21 +161,6 @@ export const setupResponsesSource = async (
     },
   };
 };
-
-export const setupResponsesWebSocketSource = async (
-  c: Context,
-  payload: ResponsesPayload,
-  options: {
-    readonly downstreamAbortController: AbortController;
-    readonly storage: WebSocketStatefulResponsesStoragePolicy;
-  },
-): Promise<LlmEndpointPlan<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> | Response> =>
-  await setupResponsesSource(c, payload, {
-    downstreamAbortController: options.downstreamAbortController,
-    statefulResponsesStore: options.storage.statefulResponsesStore,
-    storedItemsStore: options.storage.outputStore,
-    commitSnapshot: options.storage.commitSnapshot,
-  });
 
 const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> = {
   respond: async ({ c, result, runtime }) =>

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -1,5 +1,8 @@
+import type { Context } from 'hono';
+
 import { responsesSourceInterceptors } from './interceptors/index.ts';
 import { respondResponses } from './respond.ts';
+import type { StatefulResponsesStore, WebSocketStatefulResponsesStoragePolicy } from './stateful-store.ts';
 import type { ProviderModelRecord } from '../../../providers/types.ts';
 import { type LlmTargetApi, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
 import type { ExecuteResult } from '../../shared/errors/result.ts';
@@ -7,7 +10,7 @@ import { emitToChatCompletions } from '../../targets/chat-completions/emit.ts';
 import { emitToMessages } from '../../targets/messages/emit.ts';
 import { emitToResponses } from '../../targets/responses/emit.ts';
 import { createHttpRequestContext } from '../request-context.ts';
-import { jsonUpstreamErrorResult, sourceErrorResult, type LlmHttpEndpoint, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
+import { jsonUpstreamErrorResult, sourceErrorResult, type LlmEndpointPlan, type LlmHttpEndpoint, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
@@ -98,55 +101,86 @@ const renderResponsesFailure = (failure: LlmServeFailure): ExecuteResult<Protoco
   }
 };
 
+interface SetupResponsesSourceOptions {
+  readonly downstreamAbortController?: AbortController;
+  readonly statefulResponsesStore?: StatefulResponsesStore;
+  readonly storedItemsStore?: boolean | null | undefined;
+  readonly commitSnapshot?: boolean;
+}
+
+export const setupResponsesSource = async (
+  c: Context,
+  sourcePayload: ResponsesPayload,
+  options: SetupResponsesSourceOptions = {},
+): Promise<LlmEndpointPlan<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> | Response> => {
+  const payload = rewriteResponsesEntryModelAlias(sourcePayload);
+  const wantsStream = payload.stream === true;
+  const downstreamAbortController = options.downstreamAbortController ?? (wantsStream ? new AbortController() : undefined);
+  const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream, {
+    store: payload.store,
+    ...(options.statefulResponsesStore !== undefined ? { statefulResponsesStore: options.statefulResponsesStore } : {}),
+  });
+  const currentInputItems = responsesInputItemsForStorage(payload.input);
+  const previousResponseId = payload.previous_response_id ?? null;
+  const statefulResponsesStore = request.statefulResponsesStore;
+  if (previousResponseId !== null) {
+    const snapshot = await statefulResponsesStore.loadSnapshot(previousResponseId);
+    if (snapshot === null) return previousResponseNotFoundResponse(previousResponseId);
+    payload.input = [
+      ...snapshot.itemIds.map(id => ({ type: 'item_reference' as const, id })),
+      ...currentInputItems,
+    ];
+  }
+  return {
+    request,
+    items: payload.input,
+    responsesItemsView,
+    wantsStream,
+    store: options.storedItemsStore ?? payload.store,
+    statefulResponsesInputItems: currentInputItems,
+    commitStatefulResponsesSnapshot: options.commitSnapshot ?? payload.store !== false,
+    model: payload.model,
+    downstreamAbortController,
+    pickTarget: endpoints => endpoints.responses ? 'responses' : endpoints.messages ? 'messages' : endpoints.chatCompletions ? 'chat-completions' : null,
+    attempt: async ({ binding, target, model, rewriteItems }) => {
+      const attemptPayload = structuredClone(payload);
+      attemptPayload.model = model;
+      delete attemptPayload.previous_response_id;
+      attemptPayload.input = await rewriteItems(attemptPayload.input);
+      const invocation: ResponsesInvocation = responsesInvocation(binding, target, model, attemptPayload);
+      const emits: Record<LlmTargetApi, SourceEmit<ResponsesPayload, { fallbackMaxOutputTokens?: number }, ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>>> = {
+        responses: async srcPayload => await emitToResponses({ ...invocation, payload: srcPayload }, request),
+        messages: viaTranslation(translateResponsesViaMessages, async (tgtPayload: MessagesPayload) =>
+          await emitToMessages(responsesInvocation(binding, 'messages', model, tgtPayload), request)),
+        'chat-completions': viaTranslation(translateResponsesViaChatCompletions, async (tgtPayload: ChatCompletionsPayload) =>
+          await emitToChatCompletions(responsesInvocation(binding, 'chat-completions', model, tgtPayload), request)),
+      };
+      const interceptors = [...responsesSourceInterceptors, ...(binding.sourceInterceptors?.responses ?? [])];
+      return await runInterceptors(invocation, request, interceptors, () =>
+        emits[target](invocation.payload, { model, fallbackMaxOutputTokens: binding.upstreamModel.limits.max_output_tokens }));
+    },
+  };
+};
+
+export const setupResponsesWebSocketSource = async (
+  c: Context,
+  payload: ResponsesPayload,
+  options: {
+    readonly downstreamAbortController: AbortController;
+    readonly storage: WebSocketStatefulResponsesStoragePolicy;
+  },
+): Promise<LlmEndpointPlan<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> | Response> =>
+  await setupResponsesSource(c, payload, {
+    downstreamAbortController: options.downstreamAbortController,
+    statefulResponsesStore: options.storage.statefulResponsesStore,
+    storedItemsStore: options.storage.outputStore,
+    commitSnapshot: options.storage.commitSnapshot,
+  });
+
 const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> = {
   respond: async ({ c, result, runtime }) =>
     await respondResponses(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
-  prepare: async c => {
-    const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>());
-    const wantsStream = payload.stream === true;
-    const downstreamAbortController = wantsStream ? new AbortController() : undefined;
-    const request = createHttpRequestContext(c, downstreamAbortController?.signal, wantsStream, { store: payload.store });
-    const currentInputItems = responsesInputItemsForStorage(payload.input);
-    const previousResponseId = payload.previous_response_id ?? null;
-    const statefulResponsesStore = request.statefulResponsesStore;
-    if (previousResponseId !== null) {
-      const snapshot = await statefulResponsesStore.loadSnapshot(previousResponseId);
-      if (snapshot === null) return previousResponseNotFoundResponse(previousResponseId);
-      payload.input = [
-        ...snapshot.itemIds.map(id => ({ type: 'item_reference' as const, id })),
-        ...currentInputItems,
-      ];
-    }
-    return {
-      request,
-      items: payload.input,
-      responsesItemsView,
-      wantsStream,
-      store: payload.store,
-      statefulResponsesInputItems: currentInputItems,
-      commitStatefulResponsesSnapshot: payload.store !== false,
-      model: payload.model,
-      downstreamAbortController,
-      pickTarget: endpoints => endpoints.responses ? 'responses' : endpoints.messages ? 'messages' : endpoints.chatCompletions ? 'chat-completions' : null,
-      attempt: async ({ binding, target, model, rewriteItems }) => {
-        const attemptPayload = structuredClone(payload);
-        attemptPayload.model = model;
-        delete attemptPayload.previous_response_id;
-        attemptPayload.input = await rewriteItems(attemptPayload.input);
-        const invocation: ResponsesInvocation = responsesInvocation(binding, target, model, attemptPayload);
-        const emits: Record<LlmTargetApi, SourceEmit<ResponsesPayload, { fallbackMaxOutputTokens?: number }, ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>>> = {
-          responses: async srcPayload => await emitToResponses({ ...invocation, payload: srcPayload }, request),
-          messages: viaTranslation(translateResponsesViaMessages, async (tgtPayload: MessagesPayload) =>
-            await emitToMessages(responsesInvocation(binding, 'messages', model, tgtPayload), request)),
-          'chat-completions': viaTranslation(translateResponsesViaChatCompletions, async (tgtPayload: ChatCompletionsPayload) =>
-            await emitToChatCompletions(responsesInvocation(binding, 'chat-completions', model, tgtPayload), request)),
-        };
-        const interceptors = [...responsesSourceInterceptors, ...(binding.sourceInterceptors?.responses ?? [])];
-        return await runInterceptors(invocation, request, interceptors, () =>
-          emits[target](invocation.payload, { model, fallbackMaxOutputTokens: binding.upstreamModel.limits.max_output_tokens }));
-      },
-    };
-  },
+  prepare: async c => await setupResponsesSource(c, await c.req.json<ResponsesPayload>()),
 };
 
 export const responsesTraits: LlmSourceTraits<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> = {

--- a/apps/api/src/data-plane/llm/sources/responses/websocket.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/websocket.ts
@@ -1,0 +1,351 @@
+import type { Context } from 'hono';
+
+import { RESPONSES_MISSING_TERMINAL_MESSAGE } from './events/to-result.ts';
+import { createWebSocketStatefulResponsesSession } from './stateful-store.ts';
+import { responsesTraits, setupResponsesWebSocketSource } from './traits.ts';
+import { tokenUsage } from '../../../shared/telemetry/usage.ts';
+import type { RequestContext } from '../../interceptors.ts';
+import type { ExecuteResult, PlainResult } from '../../shared/errors/result.ts';
+import type { StreamCompletion } from '../../shared/stream/proxy-sse.ts';
+import { executeLlmSourcePlan } from '../execution.ts';
+import { eventResultMetadata, recordSourcePerformance, recordSourceUsage, SourceStreamState } from '../respond.ts';
+import type { ProtocolFrame } from '@floway-dev/protocols/common';
+import { isResponsesTerminalEvent, type RawResponsesStreamEvent, type ResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
+
+interface WorkerWebSocket extends WebSocket {
+  accept(): void;
+}
+
+declare const WebSocketPair: {
+  new(): {
+    0: WorkerWebSocket;
+    1: WorkerWebSocket;
+  };
+};
+
+interface ResponsesWebSocketClientEvent {
+  type: string;
+  event_id?: string;
+  response?: Partial<ResponsesPayload>;
+  [key: string]: unknown;
+}
+
+export const responsesWebSocket = async (c: Context): Promise<Response> => {
+  if (c.req.header('upgrade')?.toLowerCase() !== 'websocket') {
+    return Response.json({ error: 'Expected Upgrade: websocket' }, { status: 426 });
+  }
+
+  const pair = new WebSocketPair();
+  const client = pair[0];
+  const server = pair[1];
+  server.accept();
+
+  const session = createWebSocketStatefulResponsesSession();
+  let closed = false;
+  let activeAbortController: AbortController | undefined;
+  let queue = Promise.resolve();
+
+  const closeActiveRequest = (): void => {
+    closed = true;
+    activeAbortController?.abort();
+  };
+  server.addEventListener('close', closeActiveRequest);
+  server.addEventListener('error', closeActiveRequest);
+  server.addEventListener('message', event => {
+    queue = queue
+      .then(async () => {
+        if (closed) return;
+        const abortController = new AbortController();
+        activeAbortController = abortController;
+        try {
+          await handleClientMessage(c, server, session, event.data, abortController, () => closed);
+        } finally {
+          if (activeAbortController === abortController) activeAbortController = undefined;
+        }
+      })
+      .catch(error => {
+        if (!closed) sendError(server, 500, serverErrorEnvelope(error));
+      });
+  });
+
+  return new Response(null, { status: 101, webSocket: client } as ResponseInit & { readonly webSocket: WebSocket });
+};
+
+const handleClientMessage = async (
+  c: Context,
+  socket: WebSocket,
+  session: ReturnType<typeof createWebSocketStatefulResponsesSession>,
+  data: unknown,
+  downstreamAbortController: AbortController,
+  isClosed: () => boolean,
+): Promise<void> => {
+  const signal = downstreamAbortController.signal;
+  let eventId: string | undefined;
+  try {
+    const parsed = parseClientMessageData(data);
+    eventId = parsed && typeof parsed === 'object' && typeof (parsed as { event_id?: unknown }).event_id === 'string'
+      ? (parsed as { event_id: string }).event_id
+      : undefined;
+    const message = validateClientMessage(parsed);
+    if (message.type !== 'response.create') {
+      sendError(socket, 400, {
+        type: 'invalid_request_error',
+        code: 'invalid_request_error',
+        message: `Unsupported WebSocket event type '${message.type}'.`,
+      }, eventId);
+      return;
+    }
+
+    const source = message.response && typeof message.response === 'object'
+      ? message.response
+      : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
+    const payload = responsesPayloadFromClientSource(source);
+    const storage = session.createStore((c.get('apiKeyId') as string | undefined) ?? null, payload.store);
+    const plan = await setupResponsesWebSocketSource(c, payload, {
+      downstreamAbortController,
+      storage,
+    });
+    if (plan instanceof Response) {
+      if (signal.aborted || isClosed()) return;
+      const contentType = plan.headers.get('content-type') ?? '';
+      const body = contentType.includes('application/json') ? await plan.json() : { message: await plan.text() };
+      if (signal.aborted || isClosed()) return;
+      if (!plan.ok) {
+        sendError(socket, plan.status, normalizeErrorBody(body, plan.status), eventId);
+        return;
+      }
+      sendJson(socket, body, eventId);
+      return;
+    }
+
+    const { result, commitForNonStreaming } = await executeLlmSourcePlan(plan, failure => responsesTraits.renderFailure(failure, 'generate'));
+    const success = await respondResponsesWebSocket({
+      socket,
+      eventId,
+      signal,
+      isClosed,
+      result,
+      request: plan.request,
+    });
+    if (success) await commitForNonStreaming?.();
+  } catch (error) {
+    if (signal.aborted || isClosed()) return;
+    if (error instanceof WebSocketClientMessageError) {
+      sendError(socket, 400, {
+        type: 'invalid_request_error',
+        code: 'invalid_request_error',
+        message: error.message,
+      }, eventId);
+      return;
+    }
+    sendError(socket, 500, serverErrorEnvelope(error), eventId);
+  }
+};
+
+class WebSocketClientMessageError extends Error {}
+
+const parseClientMessageData = (data: unknown): unknown => {
+  const text = typeof data === 'string'
+    ? data
+    : data instanceof ArrayBuffer
+      ? new TextDecoder().decode(data)
+      : ArrayBuffer.isView(data)
+        ? new TextDecoder().decode(data)
+        : null;
+  if (text === null) throw new WebSocketClientMessageError(`Unsupported WebSocket message data: ${typeof data}`);
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (cause) {
+    throw new WebSocketClientMessageError(`WebSocket message must be valid JSON: ${cause instanceof Error ? cause.message : String(cause)}`);
+  }
+};
+
+const validateClientMessage = (parsed: unknown): ResponsesWebSocketClientEvent => {
+  if (!parsed || typeof parsed !== 'object' || typeof (parsed as { type?: unknown }).type !== 'string') {
+    throw new WebSocketClientMessageError('WebSocket message must be a JSON object with a string type.');
+  }
+  return parsed as ResponsesWebSocketClientEvent;
+};
+
+const responsesPayloadFromClientSource = (source: object): ResponsesPayload => {
+  const candidate = source as { model?: unknown; input?: unknown };
+  if (typeof candidate.model !== 'string' || candidate.model.length === 0) {
+    throw new WebSocketClientMessageError('response.create requires response.model to be a non-empty string.');
+  }
+  if (typeof candidate.input !== 'string' && !Array.isArray(candidate.input)) {
+    throw new WebSocketClientMessageError('response.create requires response.input to be a string or an array.');
+  }
+  return { ...source, stream: true } as ResponsesPayload;
+};
+
+const respondResponsesWebSocket = async (input: {
+  readonly socket: WebSocket;
+  readonly eventId: string | undefined;
+  readonly signal: AbortSignal;
+  readonly isClosed: () => boolean;
+  readonly result: ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>> | PlainResult;
+  readonly request: RequestContext;
+}): Promise<boolean> => {
+  const { socket, eventId, signal, isClosed, result, request } = input;
+  if (result.type === 'upstream-error') {
+    recordSourcePerformance(request, result.performance, true);
+    sendError(socket, result.status, normalizeErrorBody(parseMaybeJson(result.body, result.headers), result.status), eventId);
+    return false;
+  }
+
+  if (result.type === 'internal-error') {
+    recordSourcePerformance(request, result.performance, true);
+    sendError(socket, result.status, internalErrorEnvelope(result.error), eventId);
+    return false;
+  }
+
+  if (result.type === 'plain') {
+    if (result.status >= 400) sendError(socket, result.status, normalizeErrorBody(parseMaybeJson(result.body, result.headers), result.status), eventId);
+    else sendJson(socket, parseMaybeJson(result.body, result.headers), eventId);
+    return result.status < 400;
+  }
+
+  const state = new SourceStreamState();
+  let completion: StreamCompletion = 'error';
+  try {
+    for await (const frame of result.events) {
+      if (signal.aborted || isClosed()) {
+        completion = 'cancel';
+        return true;
+      }
+      if (frame.type !== 'event') continue;
+
+      const event = frame.event;
+      const failed = event.type === 'error' || event.type === 'response.failed';
+      if (failed) state.failed = true;
+      state.rememberUsage('response' in event ? tokenUsageFromResponsesResult((event as { response: ResponsesResult }).response) : null);
+
+      if (isResponsesTerminalEvent(event)) {
+        if (!sendJson(socket, event, eventId)) {
+          completion = 'cancel';
+          return true;
+        }
+        const done = responseDoneSummary(event);
+        if (!failed) state.completed = true;
+        if (done !== null && !sendJson(socket, { type: 'response.done', response: done }, eventId)) {
+          completion = 'cancel';
+          return true;
+        }
+        completion = 'eof';
+        return true;
+      }
+
+      if (!sendJson(socket, event, eventId)) {
+        completion = 'cancel';
+        return true;
+      }
+    }
+
+    throw new Error(RESPONSES_MISSING_TERMINAL_MESSAGE);
+  } catch (error) {
+    if (signal.aborted || isClosed()) {
+      completion = 'cancel';
+      return true;
+    }
+    state.failed = true;
+    sendError(socket, 500, serverErrorEnvelope(error), eventId);
+    return false;
+  } finally {
+    const metadata = await eventResultMetadata(result);
+    try {
+      await recordSourceUsage(request, metadata.modelIdentity, state.usage);
+    } catch (error) {
+      console.error('Failed to record Responses WebSocket usage:', error);
+    } finally {
+      recordSourcePerformance(request, metadata.performance, state.failedAfter(completion));
+    }
+  }
+};
+
+const parseMaybeJson = (body: Uint8Array, headers: Headers): unknown => {
+  const text = new TextDecoder().decode(body);
+  if (!(headers.get('content-type') ?? '').includes('application/json')) return { message: text };
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { message: text };
+  }
+};
+
+const internalErrorEnvelope = (error: Extract<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>, { type: 'internal-error' }>['error']): Record<string, unknown> => ({
+  type: error.type,
+  code: error.type,
+  name: error.name,
+  message: error.message,
+  stack: error.stack,
+  cause: error.cause,
+  source_api: error.source_api,
+  target_api: error.target_api,
+});
+
+const serverErrorEnvelope = (error: unknown): Record<string, unknown> => ({
+  type: 'server_error',
+  code: 'server_error',
+  message: error instanceof Error ? error.message : String(error),
+});
+
+const tokenUsageFromResponsesResult = (response: ResponsesResult) => {
+  const usage = response.usage;
+  if (!usage) return null;
+  const cacheRead = usage.input_tokens_details?.cached_tokens ?? 0;
+  return tokenUsage({
+    input: usage.input_tokens - cacheRead,
+    input_cache_read: cacheRead,
+    output: usage.output_tokens,
+  });
+};
+
+const responseDoneSummary = (event: unknown) => {
+  if (!event || typeof event !== 'object') return null;
+  const type = (event as { type?: unknown }).type;
+  if (type !== 'response.completed' && type !== 'response.failed' && type !== 'response.incomplete') return null;
+  const response = (event as { response?: unknown }).response;
+  if (!response || typeof response !== 'object') return null;
+  const id = (response as { id?: unknown }).id;
+  if (typeof id !== 'string') return null;
+  const usage = (response as { usage?: ResponsesResult['usage'] }).usage;
+  return usage === undefined ? { id } : { id, usage };
+};
+
+const normalizeErrorBody = (body: unknown, statusCode: number): Record<string, unknown> => {
+  const source = body && typeof body === 'object' && 'error' in body && typeof (body as { error?: unknown }).error === 'object'
+    ? (body as { error: Record<string, unknown> }).error
+    : body && typeof body === 'object'
+      ? body as Record<string, unknown>
+      : {};
+  const type = typeof source.type === 'string'
+    ? source.type
+    : statusCode >= 500 ? 'server_error' : 'invalid_request_error';
+  const message = typeof source.message === 'string'
+    ? source.message
+    : `Responses request failed with status ${statusCode}.`;
+  return {
+    ...source,
+    type,
+    code: typeof source.code === 'string' ? source.code : type,
+    message,
+  };
+};
+
+const sendError = (socket: WebSocket, statusCode: number, error: Record<string, unknown>, eventId?: string): void => {
+  sendJson(socket, { type: 'error', status_code: statusCode, error }, eventId);
+};
+
+const sendJson = (socket: WebSocket, value: unknown, eventId?: string): boolean => {
+  if (socket.readyState !== WebSocket.OPEN) return false;
+  const payload = eventId === undefined || !value || typeof value !== 'object'
+    ? value
+    : { ...value, event_id: eventId };
+  try {
+    socket.send(JSON.stringify(payload));
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/apps/api/src/data-plane/llm/sources/responses/websocket.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/websocket.ts
@@ -2,9 +2,10 @@ import type { Context } from 'hono';
 
 import { RESPONSES_MISSING_TERMINAL_MESSAGE } from './events/to-result.ts';
 import { createWebSocketStatefulResponsesSession } from './stateful-store.ts';
-import { responsesTraits, setupResponsesWebSocketSource } from './traits.ts';
+import { responsesTraits, setupResponsesSource } from './traits.ts';
 import { tokenUsage } from '../../../shared/telemetry/usage.ts';
 import type { RequestContext } from '../../interceptors.ts';
+import { toInternalDebugError } from '../../shared/errors/internal-debug-error.ts';
 import type { ExecuteResult, PlainResult } from '../../shared/errors/result.ts';
 import type { StreamCompletion } from '../../shared/stream/proxy-sse.ts';
 import { executeLlmSourcePlan } from '../execution.ts';
@@ -101,9 +102,11 @@ const handleClientMessage = async (
       : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
     const payload = responsesPayloadFromClientSource(source);
     const storage = session.createStore((c.get('apiKeyId') as string | undefined) ?? null, payload.store);
-    const plan = await setupResponsesWebSocketSource(c, payload, {
+    const plan = await setupResponsesSource(c, payload, {
       downstreamAbortController,
-      storage,
+      statefulResponsesStore: storage.statefulResponsesStore,
+      storedItemsStore: storage.outputStore,
+      commitSnapshot: storage.commitSnapshot,
     });
     if (plan instanceof Response) {
       if (signal.aborted || isClosed()) return;
@@ -285,9 +288,8 @@ const internalErrorEnvelope = (error: Extract<ExecuteResult<ProtocolFrame<RawRes
 });
 
 const serverErrorEnvelope = (error: unknown): Record<string, unknown> => ({
-  type: 'server_error',
-  code: 'server_error',
-  message: error instanceof Error ? error.message : String(error),
+  ...toInternalDebugError(error, 'responses'),
+  code: 'internal_error',
 });
 
 const tokenUsageFromResponsesResult = (response: ResponsesResult) => {

--- a/apps/api/src/data-plane/llm/sources/responses/websocket_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/websocket_test.ts
@@ -394,6 +394,58 @@ test('Responses WebSocket store:false keeps previous_response_id state in the se
   ]);
 });
 
+test('Responses WebSocket store:true durable snapshots can chain through local session cache', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  let turn = 0;
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        turn += 1;
+        return sseResponsesResponse({
+          id: `resp_ws_durable_${turn}`,
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output_text: `answer ${turn}`,
+          output: [{
+            id: `assistant_ws_durable_${turn}`,
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: `answer ${turn}` }],
+          }],
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      client.send(JSON.stringify({ type: 'response.create', response: { model: 'gpt-direct-responses', input: 'first' } }));
+      await firstDone;
+
+      const secondDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      client.send(JSON.stringify({ type: 'response.create', response: { model: 'gpt-direct-responses', previous_response_id: 'resp_ws_durable_1', input: 'second' } }));
+      await secondDone;
+    }),
+  );
+
+  const firstSnapshot = await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_durable_1');
+  const secondSnapshot = await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_durable_2');
+  assertExists(firstSnapshot);
+  assertExists(secondSnapshot);
+  assertEquals(secondSnapshot.itemIds.length > firstSnapshot.itemIds.length, true);
+});
+
 test('Responses WebSocket aborts the in-flight Responses request when the client closes', async () => {
   const { apiKey } = await setupAppTest();
   let resolveResponsesStarted: (() => void) | undefined;

--- a/apps/api/src/data-plane/llm/sources/responses/websocket_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/websocket_test.ts
@@ -1,0 +1,440 @@
+import type { ExecutionContext } from 'hono';
+import { test } from 'vitest';
+
+import { app } from '../../../../app.ts';
+import { assert, assertEquals, assertExists, assertStringIncludes } from '../../../../test-assert.ts';
+import { copilotModels, jsonResponse, setupAppTest, sseResponsesResponse, withMockedFetch } from '../../../../test-helpers.ts';
+
+type WorkerResponseInit = ResponseInit & { readonly webSocket?: WebSocket };
+
+class TestWorkerWebSocket extends EventTarget {
+  peer?: TestWorkerWebSocket;
+  readyState: number = WebSocket.OPEN;
+
+  accept(): void {}
+
+  send(data: string): void {
+    this.peer?.dispatchEvent(new MessageEvent('message', { data }));
+  }
+
+  close(): void {
+    this.readyState = WebSocket.CLOSED;
+    if (this.peer) {
+      this.peer.readyState = WebSocket.CLOSED;
+      this.peer.dispatchEvent(new Event('close'));
+    }
+  }
+}
+
+const installWorkerWebSocketRuntime = (): {
+  readonly pairs: Array<{ readonly client: TestWorkerWebSocket; readonly server: TestWorkerWebSocket }>;
+  restore(): void;
+} => {
+  const globals = globalThis as typeof globalThis & {
+    WebSocketPair?: unknown;
+    Response: typeof Response;
+  };
+  const originalWebSocketPair = globals.WebSocketPair;
+  const OriginalResponse = globals.Response;
+  const pairs: Array<{ readonly client: TestWorkerWebSocket; readonly server: TestWorkerWebSocket }> = [];
+
+  globals.WebSocketPair = class {
+    constructor() {
+      const client = new TestWorkerWebSocket();
+      const server = new TestWorkerWebSocket();
+      client.peer = server;
+      server.peer = client;
+      pairs.push({ client, server });
+      return { 0: client, 1: server };
+    }
+  };
+
+  globals.Response = class extends OriginalResponse {
+    constructor(body?: BodyInit | null, init?: WorkerResponseInit) {
+      if (init?.status === 101) {
+        const { webSocket, status: _status, ...rest } = init;
+        super(null, { ...rest, status: 200 });
+        Object.defineProperty(this, 'status', { value: 101 });
+        Object.defineProperty(this, 'webSocket', { value: webSocket });
+        return;
+      }
+      super(body, init);
+    }
+  };
+
+  return {
+    pairs,
+    restore: () => {
+      globals.WebSocketPair = originalWebSocketPair;
+      globals.Response = OriginalResponse;
+    },
+  };
+};
+
+const waitForMessages = async (
+  socket: TestWorkerWebSocket,
+  done: (messages: readonly Record<string, unknown>[]) => boolean,
+): Promise<readonly Record<string, unknown>[]> => {
+  const messages: Record<string, unknown>[] = [];
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.removeEventListener('message', onMessage);
+      reject(new Error(`Timed out waiting for WebSocket messages; received ${JSON.stringify(messages)}`));
+    }, 1_000);
+    const onMessage = (event: Event): void => {
+      const data = (event as MessageEvent<string>).data;
+      messages.push(JSON.parse(data) as Record<string, unknown>);
+      if (!done(messages)) return;
+      clearTimeout(timeout);
+      socket.removeEventListener('message', onMessage);
+      resolve(messages);
+    };
+    socket.addEventListener('message', onMessage);
+  });
+};
+
+const connectResponsesWebSocket = async (apiKey: string): Promise<TestWorkerWebSocket> => {
+  const executionCtx = {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    props: {},
+  } satisfies ExecutionContext;
+  const response = await app.fetch(new Request('https://example.test/v1/responses', {
+    method: 'GET',
+    headers: {
+      upgrade: 'websocket',
+      'x-api-key': apiKey,
+    },
+  }), {}, executionCtx);
+  assertEquals(response.status, 101);
+
+  const runtime = activeRuntime();
+  const pair = runtime.pairs[0];
+  assertExists(pair);
+  return pair.client;
+};
+
+let currentRuntime: ReturnType<typeof installWorkerWebSocketRuntime> | undefined;
+
+const activeRuntime = (): ReturnType<typeof installWorkerWebSocketRuntime> => {
+  assertExists(currentRuntime);
+  return currentRuntime;
+};
+
+const withWorkerWebSocketRuntime = async <T>(run: () => Promise<T>): Promise<T> => {
+  const runtime = installWorkerWebSocketRuntime();
+  currentRuntime = runtime;
+  try {
+    return await run();
+  } finally {
+    runtime.restore();
+    currentRuntime = undefined;
+  }
+};
+
+test('Responses WebSocket forwards stream events, echoes event_id, and sends response.done', async () => {
+  const { apiKey } = await setupAppTest();
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        return sseResponsesResponse({
+          id: 'resp_ws',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: [],
+          output_text: 'done',
+          usage: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const received = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_1',
+        response: {
+          model: 'gpt-direct-responses',
+          input: 'hello',
+        },
+      }));
+
+      const messages = await received;
+      assert(messages.every(message => message.event_id === 'evt_1'));
+      assert(messages.some(message => message.type === 'response.completed'));
+      assertEquals(messages.at(-1), {
+        type: 'response.done',
+        event_id: 'evt_1',
+        response: {
+          id: 'resp_ws',
+          usage: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
+        },
+      });
+    }),
+  );
+});
+
+test('Responses WebSocket returns OpenAI-style error envelopes for unsupported client events', async () => {
+  const { apiKey } = await setupAppTest();
+  await withWorkerWebSocketRuntime(async () => {
+    const client = await connectResponsesWebSocket(apiKey.key);
+    const received = waitForMessages(client, messages => messages.length === 1);
+
+    client.send(JSON.stringify({ type: 'session.update', event_id: 'evt_bad' }));
+
+    assertEquals(await received, [{
+      type: 'error',
+      event_id: 'evt_bad',
+      status_code: 400,
+      error: {
+        type: 'invalid_request_error',
+        code: 'invalid_request_error',
+        message: "Unsupported WebSocket event type 'session.update'.",
+      },
+    }]);
+  });
+});
+
+test('Responses WebSocket returns invalid_request_error for malformed client messages', async () => {
+  const { apiKey } = await setupAppTest();
+  await withWorkerWebSocketRuntime(async () => {
+    const client = await connectResponsesWebSocket(apiKey.key);
+    const invalidJson = waitForMessages(client, messages => messages.length === 1);
+
+    client.send('{bad json');
+
+    const [invalidJsonMessage] = await invalidJson;
+    assertExists(invalidJsonMessage);
+    assertEquals(invalidJsonMessage.type, 'error');
+    assertEquals(invalidJsonMessage.status_code, 400);
+    assertEquals((invalidJsonMessage.error as { type?: unknown; code?: unknown }).type, 'invalid_request_error');
+    assertEquals((invalidJsonMessage.error as { type?: unknown; code?: unknown }).code, 'invalid_request_error');
+    assertStringIncludes((invalidJsonMessage.error as { message: string }).message, 'valid JSON');
+
+    const invalidShape = waitForMessages(client, messages => messages.length === 1);
+    client.send(JSON.stringify({ event_id: 'evt_shape', response: {} }));
+
+    assertEquals(await invalidShape, [{
+      type: 'error',
+      event_id: 'evt_shape',
+      status_code: 400,
+      error: {
+        type: 'invalid_request_error',
+        code: 'invalid_request_error',
+        message: 'WebSocket message must be a JSON object with a string type.',
+      },
+    }]);
+
+    const invalidResponse = waitForMessages(client, messages => messages.length === 1);
+    client.send(JSON.stringify({ type: 'response.create', event_id: 'evt_response', response: {} }));
+
+    assertEquals(await invalidResponse, [{
+      type: 'error',
+      event_id: 'evt_response',
+      status_code: 400,
+      error: {
+        type: 'invalid_request_error',
+        code: 'invalid_request_error',
+        message: 'response.create requires response.model to be a non-empty string.',
+      },
+    }]);
+  });
+});
+
+test('Responses WebSocket forwards HTTP failures with status_code, error.code, and event_id', async () => {
+  const { apiKey } = await setupAppTest();
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') return jsonResponse(copilotModels([]));
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const received = waitForMessages(client, messages => messages.length === 1);
+
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_missing',
+        response: {
+          model: 'missing-model',
+          input: 'hello',
+        },
+      }));
+
+      assertEquals(await received, [{
+        type: 'error',
+        event_id: 'evt_missing',
+        status_code: 404,
+        error: {
+          type: 'invalid_request_error',
+          code: 'invalid_request_error',
+          message: 'Model missing-model is not available on any configured upstream.',
+        },
+      }]);
+    }),
+  );
+});
+
+test('Responses WebSocket store:false keeps previous_response_id state in the session only', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const upstreamBodies: unknown[] = [];
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()));
+        const turn = upstreamBodies.length;
+        const label = turn === 1 ? 'first' : turn === 2 ? 'second' : 'third';
+        return sseResponsesResponse({
+          id: `resp_ws_${label}`,
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output_text: `${label} answer`,
+          output: [{
+            id: `assistant_ws_${turn}`,
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: `${label} answer` }],
+          }],
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        response: {
+          model: 'gpt-direct-responses',
+          input: 'first question',
+          store: false,
+        },
+      }));
+      await firstDone;
+
+      assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_first'), null);
+
+      const secondDone = waitForMessages(client, messages => messages.filter(message => message.type === 'response.done').length === 1);
+      client.send(JSON.stringify({
+        type: 'response.create',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_ws_first',
+          input: 'second question',
+          store: false,
+        },
+      }));
+      await secondDone;
+
+      const thirdDone = waitForMessages(client, messages => messages.filter(message => message.type === 'response.done').length === 1);
+      client.send(JSON.stringify({
+        type: 'response.create',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_ws_second',
+          input: 'third question',
+        },
+      }));
+      await thirdDone;
+    }),
+  );
+
+  assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_second'), null);
+  assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_third'), null);
+  const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
+  assertEquals(secondBody.previous_response_id, undefined);
+  assertEquals(secondBody.input.map(item => [item.type, item.role, item.content]), [
+    ['message', 'assistant', [{ type: 'output_text', text: 'first answer' }]],
+    ['message', 'user', 'second question'],
+  ]);
+  const thirdBody = upstreamBodies[2] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
+  assertEquals(thirdBody.previous_response_id, undefined);
+  assertEquals(thirdBody.input.map(item => [item.type, item.role, item.content]), [
+    ['message', 'assistant', [{ type: 'output_text', text: 'first answer' }]],
+    ['message', 'assistant', [{ type: 'output_text', text: 'second answer' }]],
+    ['message', 'user', 'third question'],
+  ]);
+});
+
+test('Responses WebSocket aborts the in-flight Responses request when the client closes', async () => {
+  const { apiKey } = await setupAppTest();
+  let resolveResponsesStarted: (() => void) | undefined;
+  const responsesStarted = new Promise<void>(resolve => {
+    resolveResponsesStarted = resolve;
+  });
+  let resolveUpstreamAborted: (() => void) | undefined;
+  const upstreamAborted = new Promise<void>(resolve => {
+    resolveUpstreamAborted = resolve;
+  });
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        resolveResponsesStarted?.();
+        return await new Promise<Response>(resolve => {
+          request.signal.addEventListener('abort', () => {
+            resolveUpstreamAborted?.();
+            resolve(sseResponsesResponse({
+              id: 'resp_ws_abort',
+              object: 'response',
+              model: 'gpt-direct-responses',
+              status: 'completed',
+              output: [],
+              output_text: '',
+            }));
+          }, { once: true });
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      client.send(JSON.stringify({
+        type: 'response.create',
+        response: {
+          model: 'gpt-direct-responses',
+          input: 'hello',
+        },
+      }));
+
+      await responsesStarted;
+      client.close();
+      await upstreamAborted;
+    }),
+  );
+});

--- a/apps/api/src/data-plane/llm/sources/responses/websocket_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/websocket_test.ts
@@ -1,6 +1,7 @@
 import type { ExecutionContext } from 'hono';
 import { test } from 'vitest';
 
+import { hashResponsesItemContent } from './items/format.ts';
 import { app } from '../../../../app.ts';
 import { assert, assertEquals, assertExists, assertStringIncludes } from '../../../../test-assert.ts';
 import { copilotModels, jsonResponse, setupAppTest, sseResponsesResponse, withMockedFetch } from '../../../../test-helpers.ts';
@@ -337,9 +338,16 @@ test('Responses WebSocket store:false keeps previous_response_id state in the se
           store: false,
         },
       }));
-      await firstDone;
+      const firstMessages = await firstDone;
 
       assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_first'), null);
+      const firstOutput = firstMessages.find(message => message.type === 'response.output_item.done') as { item?: { id?: string } } | undefined;
+      assertExists(firstOutput?.item?.id);
+      assertEquals(await repo.responsesItems.lookupMany(apiKey.id, [firstOutput.item.id]), []);
+      assertEquals(
+        await repo.responsesItems.lookupManyByContentHash(apiKey.id, [await hashResponsesItemContent({ type: 'message', role: 'user', content: 'first question' })]),
+        [],
+      );
 
       const secondDone = waitForMessages(client, messages => messages.filter(message => message.type === 'response.done').length === 1);
       client.send(JSON.stringify({
@@ -371,13 +379,16 @@ test('Responses WebSocket store:false keeps previous_response_id state in the se
   const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
   assertEquals(secondBody.previous_response_id, undefined);
   assertEquals(secondBody.input.map(item => [item.type, item.role, item.content]), [
+    ['message', 'user', 'first question'],
     ['message', 'assistant', [{ type: 'output_text', text: 'first answer' }]],
     ['message', 'user', 'second question'],
   ]);
   const thirdBody = upstreamBodies[2] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
   assertEquals(thirdBody.previous_response_id, undefined);
   assertEquals(thirdBody.input.map(item => [item.type, item.role, item.content]), [
+    ['message', 'user', 'first question'],
     ['message', 'assistant', [{ type: 'output_text', text: 'first answer' }]],
+    ['message', 'user', 'second question'],
     ['message', 'assistant', [{ type: 'output_text', text: 'second answer' }]],
     ['message', 'user', 'third question'],
   ]);


### PR DESCRIPTION
Add GET WebSocket upgrades on the Responses endpoint and route response.create messages through the existing Responses execution pipeline. The WebSocket handler stays a transport adapter while routing, interceptors, telemetry, item storage, and snapshot commits stay in the shared Responses source path.

The WebSocket session owns local stateful Responses storage for store:false and same-session previous_response_id while durable writes continue to use D1 policy. Store:false input and output replay state stays session-local, later store:true turns cannot durable-snapshot local-only history, and local cache rows are promoted after durable writes so same-socket durable snapshot chaining remains valid.

Echo client event_id, emit response.done after terminal Responses events, return OpenAI-style WebSocket error envelopes with status_code/error.code, and abort in-flight upstream work when the client closes.