### PR TITLE
fix(translate): reject unknown request input item types instead of silent passthrough

### DIFF
--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -69,7 +69,11 @@ const convertUserContent = async (message: ChatCompletionsMessage, loadRemoteIma
         return Promise.resolve({ type: 'text', text: part.text } as MessagesUserContentBlock);
       }
 
-      return resolveImageUrlToMessagesImage(part.image_url.url, loadRemoteImage);
+      if (part.type === 'image_url') {
+        return resolveImageUrlToMessagesImage(part.image_url.url, loadRemoteImage);
+      }
+
+      throw new Error(`Chat Completions → Messages translator does not accept ${(part as { type: string }).type} content parts.`);
     }),
   );
 
@@ -105,6 +109,8 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
         },
       ]);
       break;
+    default:
+      throw new Error(`Chat Completions → Messages translator does not accept ${message.role} messages.`);
     }
   }
 

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { translateChatCompletionsToMessages } from './request.ts';
 import type { RemoteImageLoader } from '../shared/via-messages/remote-images.ts';
 import { assertEquals, assertExists, assertRejects } from '../test-assert.ts';
-import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
+import type { ChatCompletionsMessage, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import {
   MESSAGES_FALLBACK_MAX_TOKENS,
   type MessagesAssistantContentBlock,
@@ -1111,4 +1111,28 @@ test('translateChatCompletionsToMessages drops response_format json_object (no A
   );
 
   assertEquals(result.output_config, undefined);
+});
+
+test('translateChatCompletionsToMessages rejects an unknown message role', async () => {
+  await assertRejects(
+    () =>
+      translateChatCompletionsToMessages({
+        model: 'claude-test',
+        messages: [{ role: 'function', content: 'hi' } as unknown as ChatCompletionsMessage],
+      }),
+    Error,
+    'does not accept function messages',
+  );
+});
+
+test('translateChatCompletionsToMessages rejects an unknown user content part type', async () => {
+  await assertRejects(
+    () =>
+      translateChatCompletionsToMessages({
+        model: 'claude-test',
+        messages: [{ role: 'user', content: [{ type: 'video_url' }] } as unknown as ChatCompletionsMessage],
+      }),
+    Error,
+    'does not accept video_url content parts',
+  );
 });

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -95,6 +95,10 @@ export const translateChatCompletionsToResponses = (payload: ChatCompletionsPayl
       continue;
     }
 
+    if (message.role !== 'tool') {
+      throw new Error(`Chat Completions → Responses translator does not accept ${(message as { role: string }).role} messages.`);
+    }
+
     if (!message.tool_call_id) {
       throw new Error('tool message requires tool_call_id for Responses translation');
     }

--- a/packages/translate/src/chat-completions-via-responses/request_test.ts
+++ b/packages/translate/src/chat-completions-via-responses/request_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { translateChatCompletionsToResponses } from './request.ts';
 import { createChatCompletionsToResponsesStreamState, flushChatCompletionsToResponsesEvents, translateChatCompletionsChunkToResponsesEvents } from '../responses-via-chat-completions/events.ts';
 import { assertEquals, assertFalse, assertThrows } from '../test-assert.ts';
-import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
+import type { ChatCompletionsMessage, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ResponsesInputReasoning, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 type ResponsesOutputItemDoneEvent = Extract<ResponsesStreamEvent, { type: 'response.output_item.done' }>;
@@ -418,4 +418,16 @@ test('translateChatCompletionsChunkToResponsesEvents ignores empty tool_calls ar
   const deltaEvents = events2.filter(e => e.type === 'response.output_text.delta');
   assertEquals(deltaEvents.length, 1);
   assertEquals((deltaEvents[0] as { delta: string }).delta, 'hello');
+});
+
+test('translateChatCompletionsToResponses rejects an unknown message role', () => {
+  assertThrows(
+    () =>
+      translateChatCompletionsToResponses({
+        model: 'gpt-test',
+        messages: [{ role: 'function', content: 'hi' } as unknown as ChatCompletionsMessage],
+      }),
+    Error,
+    'does not accept function messages',
+  );
 });

--- a/packages/translate/src/gemini-via-chat-completions/request.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request.ts
@@ -4,6 +4,7 @@ import {
   geminiFunctionDeclarations,
   geminiFunctionResponsePart,
   geminiInlineDataUrl,
+  geminiPartKind,
   geminiPartText,
   geminiReasoningEffort,
   geminiText,
@@ -56,9 +57,12 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
   content.parts.forEach((part, partIndex) => {
     reasoningOpaque = appendOpaque(reasoningOpaque, part.thoughtSignature);
 
-    const functionCallPart = geminiFunctionCallPart(part, unmatchedToolCallIds, turnIndex, partIndex);
-    if (functionCallPart) {
-      const { call, id } = functionCallPart;
+    const kind = geminiPartKind(part);
+    switch (kind) {
+    case null:
+      return;
+    case 'function_call': {
+      const { call, id } = geminiFunctionCallPart(part, unmatchedToolCallIds, turnIndex, partIndex)!;
       toolCalls.push({
         id,
         type: 'function',
@@ -69,15 +73,20 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
       });
       return;
     }
-
-    const thoughtText = geminiThoughtText(part);
-    if (thoughtText !== null) {
-      thoughtTexts.push(thoughtText);
+    case 'text': {
+      const thoughtText = geminiThoughtText(part);
+      if (thoughtText !== null) {
+        thoughtTexts.push(thoughtText);
+        return;
+      }
+      if (geminiVisibleText(part) !== null) visibleParts.push(part);
       return;
     }
-
-    if (geminiVisibleText(part) !== null || part.inlineData) {
+    case 'inline_data':
       visibleParts.push(part);
+      return;
+    default:
+      throw new Error(`Gemini → Chat Completions translator does not accept ${kind} parts in model content.`);
     }
   });
 
@@ -93,14 +102,13 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
   return message.content !== null || message.tool_calls?.length || message.reasoning_text !== undefined || message.reasoning_opaque !== undefined ? message : null;
 };
 
-const buildToolMessage = (part: GeminiPart, turnIndex: number, partIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ChatCompletionsMessage | null => {
-  const functionResponsePart = geminiFunctionResponsePart(part, unmatchedToolCallIds, turnIndex, partIndex);
-  if (!functionResponsePart) return null;
+const buildToolMessage = (part: GeminiPart, turnIndex: number, partIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ChatCompletionsMessage => {
+  const { response, id } = geminiFunctionResponsePart(part, unmatchedToolCallIds, turnIndex, partIndex)!;
 
   return {
     role: 'tool',
-    tool_call_id: functionResponsePart.id,
-    content: JSON.stringify(functionResponsePart.response.response),
+    tool_call_id: id,
+    content: JSON.stringify(response.response),
   };
 };
 
@@ -117,14 +125,21 @@ const buildUserMessages = (content: GeminiContent, turnIndex: number, unmatchedT
   };
 
   content.parts.forEach((part, partIndex) => {
-    const toolMessage = buildToolMessage(part, turnIndex, partIndex, unmatchedToolCallIds);
-    if (toolMessage) {
-      flushUserParts();
-      messages.push(toolMessage);
+    const kind = geminiPartKind(part);
+    switch (kind) {
+    case null:
       return;
+    case 'function_response':
+      flushUserParts();
+      messages.push(buildToolMessage(part, turnIndex, partIndex, unmatchedToolCallIds));
+      return;
+    case 'text':
+    case 'inline_data':
+      pendingParts.push(part);
+      return;
+    default:
+      throw new Error(`Gemini → Chat Completions translator does not accept ${kind} parts in user content.`);
     }
-
-    if (part.text !== undefined || part.inlineData) pendingParts.push(part);
   });
 
   flushUserParts();
@@ -202,13 +217,19 @@ export const buildTargetRequest = (payload: GeminiPayload, model: string): ChatC
   }
 
   payload.contents?.forEach((content, turnIndex) => {
-    if (content.role === 'model') {
+    switch (content.role) {
+    case 'model': {
       const message = buildAssistantMessage(content, turnIndex, unmatchedToolCallIds);
       if (message) request.messages.push(message);
       return;
     }
-
-    request.messages.push(...buildUserMessages(content, turnIndex, unmatchedToolCallIds));
+    case 'user':
+    case undefined:
+      request.messages.push(...buildUserMessages(content, turnIndex, unmatchedToolCallIds));
+      return;
+    default:
+      throw new Error(`Gemini → Chat Completions translator does not accept ${(content as { role: string }).role} content roles.`);
+    }
   });
 
   applyGenerationConfig(request, payload.generationConfig);

--- a/packages/translate/src/gemini-via-chat-completions/request_test.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request_test.ts
@@ -1,8 +1,8 @@
 import { test } from 'vitest';
 
 import { buildTargetRequest } from './request.ts';
-import { assertEquals } from '../test-assert.ts';
-import type { GeminiPayload } from '@floway-dev/protocols/gemini';
+import { assertEquals, assertThrows } from '../test-assert.ts';
+import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 
 test('buildTargetRequest maps system instruction and multimodal user content', () => {
   const payload: GeminiPayload = {
@@ -392,4 +392,88 @@ test('buildTargetRequest maps thinking budget thresholds', () => {
   assertEquals(buildTargetRequest({ generationConfig: { thinkingConfig: { thinkingBudget: 2048 } } }, 'gpt-test').reasoning_effort, 'low');
   assertEquals(buildTargetRequest({ generationConfig: { thinkingConfig: { thinkingBudget: 8192 } } }, 'gpt-test').reasoning_effort, 'medium');
   assertEquals(buildTargetRequest({ generationConfig: { thinkingConfig: { thinkingBudget: 8193 } } }, 'gpt-test').reasoning_effort, 'high');
+});
+
+test('buildTargetRequest rejects an unknown content role', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'system', parts: [{ text: 'Hi' }] } as unknown as GeminiContent],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept system content roles',
+  );
+});
+
+test('buildTargetRequest rejects a part with an unsupported kind in user content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{ executableCode: { language: 'PYTHON', code: 'print(1)' } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept executable_code parts in user content',
+  );
+});
+
+test('buildTargetRequest rejects a function_call part in user content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{ functionCall: { name: 'x', args: {} } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept function_call parts in user content',
+  );
+});
+
+test('buildTargetRequest rejects a function_response part in model content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'model', parts: [{ functionResponse: { name: 'x', response: {} } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept function_response parts in model content',
+  );
+});
+
+test('buildTargetRequest rejects a part that sets conflicting content fields', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'model', parts: [{ text: 'foo', functionCall: { name: 'x', args: {} } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'sets conflicting content fields',
+  );
+});
+
+test('buildTargetRequest rejects a part with no recognized content field', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{}] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'has no recognized content',
+  );
 });

--- a/packages/translate/src/gemini-via-messages/request.ts
+++ b/packages/translate/src/gemini-via-messages/request.ts
@@ -4,6 +4,7 @@ import {
   geminiFunctionDeclarations,
   geminiFunctionResponsePart,
   geminiInlineData,
+  geminiPartKind,
   geminiPartText,
   geminiText,
   geminiThinkingLevelEffort,
@@ -20,7 +21,6 @@ import {
   type MessagesPayload,
   type MessagesTextBlock,
   type MessagesTool,
-  type MessagesToolResultBlock,
   type MessagesUserContentBlock,
 } from '@floway-dev/protocols/messages';
 
@@ -38,35 +38,36 @@ const inlineDataToImageBlock = (part: GeminiPart): MessagesImageBlock | null => 
   };
 };
 
-const buildToolResultBlock = (part: GeminiPart, turnIndex: number, partIndex: number, unmatchedToolCallIds: GeminiToolCallIds): MessagesToolResultBlock | null => {
-  const functionResponsePart = geminiFunctionResponsePart(part, unmatchedToolCallIds, turnIndex, partIndex, 'last');
-  if (!functionResponsePart) return null;
-
-  return {
-    type: 'tool_result',
-    tool_use_id: functionResponsePart.id,
-    content: JSON.stringify(functionResponsePart.response.response),
-  };
-};
-
 const buildUserMessage = (content: GeminiContent, turnIndex: number, unmatchedToolCallIds: GeminiToolCallIds): MessagesPayload['messages'][number] | null => {
   const blocks: MessagesUserContentBlock[] = [];
 
   content.parts.forEach((part, partIndex) => {
-    const toolResult = buildToolResultBlock(part, turnIndex, partIndex, unmatchedToolCallIds);
-    if (toolResult) {
-      blocks.push(toolResult);
+    const kind = geminiPartKind(part);
+    switch (kind) {
+    case null:
+      return;
+    case 'function_response': {
+      const { response, id } = geminiFunctionResponsePart(part, unmatchedToolCallIds, turnIndex, partIndex, 'last')!;
+      blocks.push({
+        type: 'tool_result',
+        tool_use_id: id,
+        content: JSON.stringify(response.response),
+      });
       return;
     }
-
-    const text = geminiPartText(part);
-    if (text !== null) {
-      blocks.push({ type: 'text', text });
+    case 'text': {
+      const text = geminiPartText(part);
+      if (text !== null) blocks.push({ type: 'text', text });
       return;
     }
-
-    const image = inlineDataToImageBlock(part);
-    if (image) blocks.push(image);
+    case 'inline_data': {
+      const image = inlineDataToImageBlock(part);
+      if (image) blocks.push(image);
+      return;
+    }
+    default:
+      throw new Error(`Gemini → Messages translator does not accept ${kind} parts in user content.`);
+    }
   });
 
   return blocks.length ? { role: 'user', content: blocks } : null;
@@ -94,18 +95,6 @@ const attachSignatureToThinking = (
   }
 };
 
-const buildToolUseBlock = (part: GeminiPart, turnIndex: number, partIndex: number, unmatchedToolCallIds: GeminiToolCallIds): MessagesAssistantContentBlock | null => {
-  const functionCallPart = geminiFunctionCallPart(part, unmatchedToolCallIds, turnIndex, partIndex);
-  if (!functionCallPart) return null;
-
-  return {
-    type: 'tool_use',
-    id: functionCallPart.id,
-    name: functionCallPart.call.name,
-    input: functionCallPart.call.args,
-  };
-};
-
 const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatchedToolCallIds: GeminiToolCallIds): MessagesPayload['messages'][number] | null => {
   const blocks: MessagesAssistantContentBlock[] = [];
   let firstThinkingIndex: number | undefined;
@@ -117,28 +106,37 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
       firstActionSignature = part.thoughtSignature;
     }
 
-    const thoughtText = geminiThoughtText(part);
-    if (thoughtText !== null) {
-      firstThinkingIndex ??= blocks.length;
-      blocks.push({ type: 'thinking', thinking: thoughtText });
+    const kind = geminiPartKind(part);
+    switch (kind) {
+    case null:
+      return;
+    case 'function_call': {
+      const { call, id } = geminiFunctionCallPart(part, unmatchedToolCallIds, turnIndex, partIndex)!;
+      if (part.thoughtSignature !== undefined) firstSignedActionIndex ??= blocks.length;
+      blocks.push({
+        type: 'tool_use',
+        id,
+        name: call.name,
+        input: call.args,
+      });
       return;
     }
-
-    const toolUse = buildToolUseBlock(part, turnIndex, partIndex, unmatchedToolCallIds);
-    if (toolUse) {
-      if (part.thoughtSignature !== undefined) {
-        firstSignedActionIndex ??= blocks.length;
+    case 'text': {
+      const thoughtText = geminiThoughtText(part);
+      if (thoughtText !== null) {
+        firstThinkingIndex ??= blocks.length;
+        blocks.push({ type: 'thinking', thinking: thoughtText });
+        return;
       }
-      blocks.push(toolUse);
+      const text = geminiVisibleText(part);
+      if (text !== null) {
+        if (part.thoughtSignature !== undefined) firstSignedActionIndex ??= blocks.length;
+        blocks.push({ type: 'text', text });
+      }
       return;
     }
-
-    const text = geminiVisibleText(part);
-    if (text !== null) {
-      if (part.thoughtSignature !== undefined) {
-        firstSignedActionIndex ??= blocks.length;
-      }
-      blocks.push({ type: 'text', text });
+    default:
+      throw new Error(`Gemini → Messages translator does not accept ${kind} parts in model content.`);
     }
   });
 
@@ -245,7 +243,18 @@ export const buildTargetRequest = (
   }
 
   payload.contents?.forEach((content, turnIndex) => {
-    const message = content.role === 'model' ? buildAssistantMessage(content, turnIndex, unmatchedToolCallIds) : buildUserMessage(content, turnIndex, unmatchedToolCallIds);
+    let message: MessagesPayload['messages'][number] | null;
+    switch (content.role) {
+    case 'model':
+      message = buildAssistantMessage(content, turnIndex, unmatchedToolCallIds);
+      break;
+    case 'user':
+    case undefined:
+      message = buildUserMessage(content, turnIndex, unmatchedToolCallIds);
+      break;
+    default:
+      throw new Error(`Gemini → Messages translator does not accept ${(content as { role: string }).role} content roles.`);
+    }
     if (message) request.messages.push(message);
   });
 

--- a/packages/translate/src/gemini-via-messages/request_test.ts
+++ b/packages/translate/src/gemini-via-messages/request_test.ts
@@ -1,8 +1,8 @@
 import { test } from 'vitest';
 
 import { buildTargetRequest } from './request.ts';
-import { assertEquals } from '../test-assert.ts';
-import type { GeminiPayload } from '@floway-dev/protocols/gemini';
+import { assertEquals, assertThrows } from '../test-assert.ts';
+import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 import { MESSAGES_FALLBACK_MAX_TOKENS } from '@floway-dev/protocols/messages';
 
 const noOptions = {};
@@ -314,4 +314,94 @@ test('buildTargetRequest merges thinking-level effort with responseSchema format
   );
 
   assertEquals(request.output_config, { effort: 'high', format: { type: 'json_schema', schema } });
+});
+
+test('buildTargetRequest rejects an unknown content role', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'system', parts: [{ text: 'Hi' }] } as unknown as GeminiContent],
+        },
+        'claude-test',
+        noOptions,
+      ),
+    Error,
+    'does not accept system content roles',
+  );
+});
+
+test('buildTargetRequest rejects a part with an unsupported kind in user content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{ fileData: { mimeType: 'text/plain', fileUri: 'files/abc' } }] }],
+        },
+        'claude-test',
+        noOptions,
+      ),
+    Error,
+    'does not accept file_data parts in user content',
+  );
+});
+
+test('buildTargetRequest rejects a function_call part in user content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{ functionCall: { name: 'x', args: {} } }] }],
+        },
+        'claude-test',
+        noOptions,
+      ),
+    Error,
+    'does not accept function_call parts in user content',
+  );
+});
+
+test('buildTargetRequest rejects an inline_data part in model content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'model', parts: [{ inlineData: { mimeType: 'image/png', data: 'aW1n' } }] }],
+        },
+        'claude-test',
+        noOptions,
+      ),
+    Error,
+    'does not accept inline_data parts in model content',
+  );
+});
+
+test('buildTargetRequest rejects a part that sets conflicting content fields', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'model', parts: [{ text: 'foo', functionCall: { name: 'x', args: {} } }] }],
+        },
+        'claude-test',
+        noOptions,
+      ),
+    Error,
+    'sets conflicting content fields',
+  );
+});
+
+test('buildTargetRequest rejects a part with no recognized content field', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{}] }],
+        },
+        'claude-test',
+        noOptions,
+      ),
+    Error,
+    'has no recognized content',
+  );
 });

--- a/packages/translate/src/gemini-via-responses/request.ts
+++ b/packages/translate/src/gemini-via-responses/request.ts
@@ -4,6 +4,7 @@ import {
   geminiFunctionDeclarations,
   geminiFunctionResponsePart,
   geminiInlineDataUrl,
+  geminiPartKind,
   geminiPartText,
   geminiReasoningEffort,
   geminiReasoningId,
@@ -12,7 +13,7 @@ import {
   type GeminiToolCallIds,
   geminiVisibleText,
 } from '../shared/gemini-via/gemini.ts';
-import type { GeminiPayload, GeminiGenerationConfig, GeminiPart } from '@floway-dev/protocols/gemini';
+import type { GeminiContent, GeminiPayload, GeminiGenerationConfig, GeminiPart } from '@floway-dev/protocols/gemini';
 import type { ResponsesInputContent, ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
 
 const flushPendingContent = (input: ResponsesInputItem[], pending: ResponsesInputContent[], role: 'user' | 'assistant'): void => {
@@ -32,91 +33,84 @@ const inlineDataToInputImage = (part: GeminiPart): ResponsesInputContent | null 
   };
 };
 
-const buildFunctionCallOutput = (part: GeminiPart, turnIndex: number, partIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ResponsesInputItem | null => {
-  const functionResponsePart = geminiFunctionResponsePart(part, unmatchedToolCallIds, turnIndex, partIndex);
-  if (!functionResponsePart) return null;
-
-  return {
-    type: 'function_call_output',
-    call_id: functionResponsePart.id,
-    output: JSON.stringify(functionResponsePart.response.response),
-    status: 'completed',
-  };
-};
-
-const buildFunctionCall = (part: GeminiPart, turnIndex: number, partIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ResponsesInputItem | null => {
-  const functionCallPart = geminiFunctionCallPart(part, unmatchedToolCallIds, turnIndex, partIndex);
-  if (!functionCallPart) return null;
-
-  return {
-    type: 'function_call',
-    call_id: functionCallPart.id,
-    name: functionCallPart.call.name,
-    arguments: JSON.stringify(functionCallPart.call.args),
-    status: 'completed',
-  };
-};
-
-const buildReasoningItem = (part: GeminiPart, turnIndex: number, partIndex: number): ResponsesInputItem | null => {
-  const text = geminiThoughtText(part) ?? '';
-
-  if (!text) return null;
-
-  return {
-    type: 'reasoning',
-    id: geminiReasoningId(turnIndex, partIndex),
-    summary: text ? [{ type: 'summary_text', text }] : [],
-  };
-};
-
-const buildUserInputItems = (content: NonNullable<GeminiPayload['contents']>[number], turnIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ResponsesInputItem[] => {
+const buildUserInputItems = (content: GeminiContent, turnIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ResponsesInputItem[] => {
   const input: ResponsesInputItem[] = [];
   const pendingContent: ResponsesInputContent[] = [];
 
   content.parts.forEach((part, partIndex) => {
-    const functionOutput = buildFunctionCallOutput(part, turnIndex, partIndex, unmatchedToolCallIds);
-    if (functionOutput) {
+    const kind = geminiPartKind(part);
+    switch (kind) {
+    case null:
+      return;
+    case 'function_response': {
+      const { response, id } = geminiFunctionResponsePart(part, unmatchedToolCallIds, turnIndex, partIndex)!;
       flushPendingContent(input, pendingContent, 'user');
-      input.push(functionOutput);
+      input.push({
+        type: 'function_call_output',
+        call_id: id,
+        output: JSON.stringify(response.response),
+        status: 'completed',
+      });
       return;
     }
-
-    const text = geminiPartText(part);
-    if (text !== null) {
-      pendingContent.push({ type: 'input_text', text });
+    case 'text': {
+      const text = geminiPartText(part);
+      if (text !== null) pendingContent.push({ type: 'input_text', text });
       return;
     }
-
-    const image = inlineDataToInputImage(part);
-    if (image) pendingContent.push(image);
+    case 'inline_data': {
+      const image = inlineDataToInputImage(part);
+      if (image) pendingContent.push(image);
+      return;
+    }
+    default:
+      throw new Error(`Gemini → Responses translator does not accept ${kind} parts in user content.`);
+    }
   });
 
   flushPendingContent(input, pendingContent, 'user');
   return input;
 };
 
-const buildAssistantInputItems = (content: NonNullable<GeminiPayload['contents']>[number], turnIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ResponsesInputItem[] => {
+const buildAssistantInputItems = (content: GeminiContent, turnIndex: number, unmatchedToolCallIds: GeminiToolCallIds): ResponsesInputItem[] => {
   const input: ResponsesInputItem[] = [];
   const pendingContent: ResponsesInputContent[] = [];
 
   content.parts.forEach((part, partIndex) => {
-    const reasoning = buildReasoningItem(part, turnIndex, partIndex);
-    if (reasoning) {
+    const kind = geminiPartKind(part);
+    switch (kind) {
+    case null:
+      return;
+    case 'function_call': {
+      const { call, id } = geminiFunctionCallPart(part, unmatchedToolCallIds, turnIndex, partIndex)!;
       flushPendingContent(input, pendingContent, 'assistant');
-      input.push(reasoning);
-
-      if (part.thought === true && !part.functionCall) return;
-    }
-
-    const functionCall = buildFunctionCall(part, turnIndex, partIndex, unmatchedToolCallIds);
-    if (functionCall) {
-      flushPendingContent(input, pendingContent, 'assistant');
-      input.push(functionCall);
+      input.push({
+        type: 'function_call',
+        call_id: id,
+        name: call.name,
+        arguments: JSON.stringify(call.args),
+        status: 'completed',
+      });
       return;
     }
-
-    const text = geminiVisibleText(part);
-    if (text !== null) pendingContent.push({ type: 'output_text', text });
+    case 'text': {
+      const thoughtText = geminiThoughtText(part);
+      if (thoughtText !== null) {
+        flushPendingContent(input, pendingContent, 'assistant');
+        input.push({
+          type: 'reasoning',
+          id: geminiReasoningId(turnIndex, partIndex),
+          summary: [{ type: 'summary_text', text: thoughtText }],
+        });
+        return;
+      }
+      const visible = geminiVisibleText(part);
+      if (visible !== null) pendingContent.push({ type: 'output_text', text: visible });
+      return;
+    }
+    default:
+      throw new Error(`Gemini → Responses translator does not accept ${kind} parts in model content.`);
+    }
   });
 
   flushPendingContent(input, pendingContent, 'assistant');
@@ -184,7 +178,17 @@ export const buildTargetRequest = (payload: GeminiPayload, model: string): Respo
 
   const input = request.input as ResponsesInputItem[];
   payload.contents?.forEach((content, turnIndex) => {
-    input.push(...(content.role === 'model' ? buildAssistantInputItems(content, turnIndex, unmatchedToolCallIds) : buildUserInputItems(content, turnIndex, unmatchedToolCallIds)));
+    switch (content.role) {
+    case 'model':
+      input.push(...buildAssistantInputItems(content, turnIndex, unmatchedToolCallIds));
+      return;
+    case 'user':
+    case undefined:
+      input.push(...buildUserInputItems(content, turnIndex, unmatchedToolCallIds));
+      return;
+    default:
+      throw new Error(`Gemini → Responses translator does not accept ${(content as { role: string }).role} content roles.`);
+    }
   });
 
   applyGenerationConfig(request, payload.generationConfig);

--- a/packages/translate/src/gemini-via-responses/request_test.ts
+++ b/packages/translate/src/gemini-via-responses/request_test.ts
@@ -1,8 +1,8 @@
 import { test } from 'vitest';
 
 import { buildTargetRequest } from './request.ts';
-import { assertEquals } from '../test-assert.ts';
-import type { GeminiPayload } from '@floway-dev/protocols/gemini';
+import { assertEquals, assertThrows } from '../test-assert.ts';
+import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 
 test('buildTargetRequest maps instructions and multimodal user input without defaults', () => {
   const payload: GeminiPayload = {
@@ -326,4 +326,88 @@ test('buildTargetRequest maps tool declarations and tool choice modes only when 
     'required',
   );
   assertEquals(buildTargetRequest({ toolConfig: { functionCallingConfig: { mode: 'ANY' } } }, 'gpt-test').tool_choice, undefined);
+});
+
+test('buildTargetRequest rejects an unknown content role', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'tool', parts: [{ text: 'Hi' }] } as unknown as GeminiContent],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept tool content roles',
+  );
+});
+
+test('buildTargetRequest rejects a part with an unsupported kind in user content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{ codeExecutionResult: { outcome: 'OK' } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept code_execution_result parts in user content',
+  );
+});
+
+test('buildTargetRequest rejects a function_call part in user content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{ functionCall: { name: 'x', args: {} } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept function_call parts in user content',
+  );
+});
+
+test('buildTargetRequest rejects an inline_data part in model content', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'model', parts: [{ inlineData: { mimeType: 'image/png', data: 'aW1n' } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'does not accept inline_data parts in model content',
+  );
+});
+
+test('buildTargetRequest rejects a part that sets conflicting content fields', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'model', parts: [{ text: 'foo', functionCall: { name: 'x', args: {} } }] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'sets conflicting content fields',
+  );
+});
+
+test('buildTargetRequest rejects a part with no recognized content field', () => {
+  assertThrows(
+    () =>
+      buildTargetRequest(
+        {
+          contents: [{ role: 'user', parts: [{}] }],
+        },
+        'gpt-test',
+      ),
+    Error,
+    'has no recognized content',
+  );
 });

--- a/packages/translate/src/messages-via-chat-completions/request.ts
+++ b/packages/translate/src/messages-via-chat-completions/request.ts
@@ -19,6 +19,12 @@ import type {
 const toChatCompletionsContent = (content: string | MessagesUserContentBlock[] | MessagesAssistantContentBlock[]): string | ChatCompletionsContentPart[] | null => {
   if (typeof content === 'string') return content;
 
+  for (const block of content) {
+    if (block.type !== 'text' && block.type !== 'image') {
+      throw new Error(`Messages → Chat Completions translator does not accept ${block.type} content blocks in message content.`);
+    }
+  }
+
   if (!content.some(block => block.type === 'image')) {
     return content
       .filter((block): block is MessagesTextBlock => block.type === 'text')
@@ -34,14 +40,14 @@ const toChatCompletionsContent = (content: string | MessagesUserContentBlock[] |
       continue;
     }
 
-    if (block.type !== 'image') continue;
-
-    parts.push({
-      type: 'image_url',
-      image_url: {
-        url: `data:${block.source.media_type};base64,${block.source.data}`,
-      },
-    });
+    if (block.type === 'image') {
+      parts.push({
+        type: 'image_url',
+        image_url: {
+          url: `data:${block.source.media_type};base64,${block.source.data}`,
+        },
+      });
+    }
   }
 
   return parts;
@@ -193,6 +199,8 @@ const translateMessagesAssistant = (message: MessagesAssistantMessage): ChatComp
         content: JSON.stringify(block.content),
       });
       break;
+    default:
+      throw new Error(`Messages → Chat Completions translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
     }
   }
 

--- a/packages/translate/src/messages-via-chat-completions/request_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/request_test.ts
@@ -1,7 +1,8 @@
 import { test } from 'vitest';
 
 import { translateMessagesToChatCompletions } from './request.ts';
-import { assertEquals, assertFalse } from '../test-assert.ts';
+import { assertEquals, assertFalse, assertThrows } from '../test-assert.ts';
+import type { MessagesAssistantContentBlock, MessagesUserContentBlock } from '@floway-dev/protocols/messages';
 
 test('translateMessagesToChatCompletions maps thinking.disabled to reasoning_effort none', () => {
   const result = translateMessagesToChatCompletions({
@@ -343,4 +344,30 @@ test('translateMessagesToChatCompletions omits response_format when output_confi
   });
 
   assertFalse('response_format' in result);
+});
+
+test('translateMessagesToChatCompletions rejects an unknown assistant content block type', () => {
+  assertThrows(
+    () =>
+      translateMessagesToChatCompletions({
+        model: 'gpt-test',
+        max_tokens: 256,
+        messages: [{ role: 'assistant', content: [{ type: 'audio' } as unknown as MessagesAssistantContentBlock] }],
+      }),
+    Error,
+    'does not accept audio assistant content blocks',
+  );
+});
+
+test('translateMessagesToChatCompletions rejects an unknown user content block type', () => {
+  assertThrows(
+    () =>
+      translateMessagesToChatCompletions({
+        model: 'gpt-test',
+        max_tokens: 256,
+        messages: [{ role: 'user', content: [{ type: 'audio' } as unknown as MessagesUserContentBlock] }],
+      }),
+    Error,
+    'does not accept audio content blocks',
+  );
 });

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -22,15 +22,17 @@ const flushPendingContent = (pending: ResponsesInputContent[], input: ResponsesI
   pending.length = 0;
 };
 
-const translateUserContentBlock = (block: MessagesUserContentBlock): ResponsesInputContent | undefined => {
+const translateUserContentBlock = (block: Exclude<MessagesUserContentBlock, MessagesToolResultBlock>): ResponsesInputContent => {
   if (block.type === 'text') return { type: 'input_text', text: block.text };
-  if (block.type !== 'image') return undefined;
+  if (block.type === 'image') {
+    return {
+      type: 'input_image',
+      image_url: `data:${block.source.media_type};base64,${block.source.data}`,
+      detail: 'auto',
+    };
+  }
 
-  return {
-    type: 'input_image',
-    image_url: `data:${block.source.media_type};base64,${block.source.data}`,
-    detail: 'auto',
-  };
+  throw new Error(`Messages → Responses translator does not accept ${(block as { type: string }).type} user content blocks.`);
 };
 
 const toResponsesToolResultOutput = (content: MessagesToolResultBlock['content']): string => {
@@ -91,8 +93,7 @@ const translateUserMessage = (message: MessagesUserMessage): ResponsesInputItem[
       continue;
     }
 
-    const content = translateUserContentBlock(block);
-    if (content) pendingContent.push(content);
+    pendingContent.push(translateUserContentBlock(block));
   }
 
   flushPendingContent(pendingContent, input, 'user');
@@ -128,7 +129,10 @@ const translateAssistantMessage = (message: MessagesAssistantMessage): Responses
 
     if (block.type === 'text') {
       pendingContent.push({ type: 'output_text', text: block.text });
+      continue;
     }
+
+    throw new Error(`Messages → Responses translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
   }
 
   flushPendingContent(pendingContent, input, 'assistant');

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -2,7 +2,8 @@ import { test } from 'vitest';
 
 import { translateMessagesToResponses } from './request.ts';
 import { packReasoningSignature } from '../shared/messages-and-responses/reasoning.ts';
-import { assertEquals, assertFalse } from '../test-assert.ts';
+import { assertEquals, assertFalse, assertThrows } from '../test-assert.ts';
+import type { MessagesAssistantContentBlock, MessagesUserContentBlock } from '@floway-dev/protocols/messages';
 import type { ResponsesFunctionTool, ResponsesInputReasoning } from '@floway-dev/protocols/responses';
 
 test('translateMessagesToResponses preserves a native thinking signature as encrypted_content with a synthesized id', () => {
@@ -388,4 +389,30 @@ test('translateMessagesToResponses omits text when output_config has no format',
   });
 
   assertFalse('text' in result);
+});
+
+test('translateMessagesToResponses rejects an unknown assistant content block type', () => {
+  assertThrows(
+    () =>
+      translateMessagesToResponses({
+        model: 'gpt-test',
+        max_tokens: 256,
+        messages: [{ role: 'assistant', content: [{ type: 'audio' } as unknown as MessagesAssistantContentBlock] }],
+      }),
+    Error,
+    'does not accept audio assistant content blocks',
+  );
+});
+
+test('translateMessagesToResponses rejects an unknown user content block type', () => {
+  assertThrows(
+    () =>
+      translateMessagesToResponses({
+        model: 'gpt-test',
+        max_tokens: 256,
+        messages: [{ role: 'user', content: [{ type: 'audio' } as unknown as MessagesUserContentBlock] }],
+      }),
+    Error,
+    'does not accept audio user content blocks',
+  );
 });

--- a/packages/translate/src/shared/gemini-via/gemini.ts
+++ b/packages/translate/src/shared/gemini-via/gemini.ts
@@ -27,6 +27,42 @@ export const geminiToolCallId = (turnIndex: number, partIndex: number): string =
 
 export const geminiReasoningId = (turnIndex: number, partIndex: number): string => `gemini_reasoning_${turnIndex}_${partIndex}`;
 
+export type GeminiPartKind = 'text' | 'inline_data' | 'function_call' | 'function_response' | 'file_data' | 'executable_code' | 'code_execution_result';
+
+type GeminiPartDataField = keyof Omit<GeminiPart, 'thought' | 'thoughtSignature'>;
+
+// Source of truth for "what counts as a content-bearing field on a part".
+// Record<GeminiPartDataField, _> forces a matching entry whenever a new field
+// is added to GeminiPart, so request translators cannot silently start
+// dropping it.
+const GEMINI_PART_FIELD_TO_KIND: Record<GeminiPartDataField, GeminiPartKind> = {
+  text: 'text',
+  inlineData: 'inline_data',
+  functionCall: 'function_call',
+  functionResponse: 'function_response',
+  fileData: 'file_data',
+  executableCode: 'executable_code',
+  codeExecutionResult: 'code_execution_result',
+};
+
+const GEMINI_PART_DATA_FIELDS = Object.keys(GEMINI_PART_FIELD_TO_KIND) as GeminiPartDataField[];
+
+// Classify the part by its single content-bearing field. Returns null when
+// the part only carries a thoughtSignature (a valid signature carrier with
+// no body). Throws when the part sets zero or multiple content fields —
+// both are silent-data-loss shapes the request translators must refuse
+// rather than coerce.
+export const geminiPartKind = (part: GeminiPart): GeminiPartKind | null => {
+  const presentFields = GEMINI_PART_DATA_FIELDS.filter(field => part[field] !== undefined);
+  if (presentFields.length === 1) return GEMINI_PART_FIELD_TO_KIND[presentFields[0]];
+  if (presentFields.length > 1) {
+    throw new Error(`Gemini part sets conflicting content fields: ${presentFields.join(', ')}.`);
+  }
+  if (part.thoughtSignature !== undefined) return null;
+  const keys = Object.keys(part);
+  throw new Error(`Gemini part has no recognized content. Keys present: ${keys.length ? keys.join(', ') : '(none)'}.`);
+};
+
 export const geminiPartText = (part: GeminiPart): string | null => (typeof part.text === 'string' ? part.text : null);
 
 export const geminiThoughtText = (part: GeminiPart): string | null => (part.thought === true && typeof part.text === 'string' ? part.text : null);


### PR DESCRIPTION
## What

Cross-protocol request translators in `packages/translate/` silently dropped or mishandled any input item type they did not explicitly recognize. This makes every request-path per-item dispatch **fail loud**: an unrecognized discriminated `type`, message `role`, or — for Gemini — part shape now throws an `Error` naming both the offending value and the translation pair.

This matches the project's "fail loud, never mask" / anti-fake-robust rule, and the behavior the Responses-source translators already enforced.

## Scope: INPUT (request) items only

Only request-path item handling changed. Event/output (response) translation is untouched, since the goal is to reject unknown items a *client sends*.

## Pairs changed (source → target)

| Pair | Silent behavior before | Now |
|---|---|---|
| `chat-completions-via-messages` | unknown `message.role` dropped; unknown content part coerced to image | throws naming the role / part type |
| `chat-completions-via-responses` | unknown `message.role` fell through to the `tool` branch | throws naming the role |
| `messages-via-chat-completions` | unknown assistant content block dropped; unknown user content block dropped | throws naming the block type |
| `messages-via-responses` | unknown assistant content block dropped; unknown user content block returned `undefined` and dropped | throws naming the block type |
| `gemini-via-chat-completions` | unknown role fell through to user; unsupported / multi-field / empty parts silently dropped | throws naming the role / part kind |
| `gemini-via-messages` | unknown role fell through to user; unsupported / multi-field / empty parts silently dropped | throws naming the role / part kind |
| `gemini-via-responses` | unknown role fell through to user; unsupported / multi-field / empty parts silently dropped | throws naming the role / part kind |

## Gemini: structural policy

`GeminiPart` has no single discriminating `type`, but the protocol contract is that **exactly one** content-bearing field is set per part: `text`, `inlineData`, `functionCall`, `functionResponse`, `fileData`, `executableCode`, or `codeExecutionResult` (with `thought` and `thoughtSignature` as modifiers). A new `geminiPartKind` classifier in `shared/gemini-via/gemini.ts` enforces that contract, throwing on parts that set zero or multiple content fields. Each `gemini-via-*` request translator then dispatches on the kind and refuses any variant the target protocol cannot accept — e.g. `fileData`, `executableCode`, `codeExecutionResult`, a `function_response` on a model turn, or a `function_call` on a user turn. Content `role` is likewise narrowed to the documented `'user' | 'model' | undefined` set.

## Left unchanged

- **Responses-source translators** (`responses-via-chat-completions`, `responses-via-messages`): already threw on every unhandled `ResponsesInputItem` variant (the `default` exhaustiveness guard / `if (item.type !== 'message') throw`), including all `ResponsesPermissiveItem` types (`mcp_call`, `file_search_call`, `computer_call`, …). No change needed.
- **Inline-data MIME filtering**: `geminiInlineData` continues to silently drop unsupported MIME types (e.g. PDFs in `inlineData`), matching how `resolveImageUrlToMessagesImage` drops unsupported image URLs. That is a content-semantics filter, not an unknown-shape rejection, and stays consistent across pairs.

## Tests

Added throw-behavior coverage to all seven changed pairs' co-located `request_test.ts` (unknown role, unknown / unsupported / conflicting / empty parts).

## Verification

- `pnpm run typecheck` — pass
- `pnpm run lint` — pass
- `pnpm run test` — 1580 passed