### PR TITLE
feat(responses): /responses/compact via native passthrough or compaction_trigger

### DIFF
--- a/apps/api/src/data-plane/llm/routes.ts
+++ b/apps/api/src/data-plane/llm/routes.ts
@@ -9,6 +9,7 @@ import { serveLlm } from './sources/serve.ts';
 export const mountLlmRoutes = (app: Hono) => {
   const serveChatCompletions = serveLlm(chatCompletionsTraits, 'generate');
   const serveResponses = serveLlm(responsesTraits, 'generate');
+  const serveResponsesCompact = serveLlm(responsesTraits, 'compact');
   const serveMessages = serveLlm(messagesTraits, 'generate');
   const serveMessagesCountTokens = serveLlm(messagesTraits, 'countTokens');
   const serveGeminiGenerate = serveLlm(geminiTraits, 'generate');
@@ -22,6 +23,8 @@ export const mountLlmRoutes = (app: Hono) => {
   app.post('/chat/completions', serveChatCompletions);
   app.post('/v1/responses', serveResponses);
   app.post('/responses', serveResponses);
+  app.post('/v1/responses/compact', serveResponsesCompact);
+  app.post('/responses/compact', serveResponsesCompact);
   app.post('/v1/messages', serveMessages);
   app.post('/messages', serveMessages);
   app.post('/v1/messages/count_tokens', serveMessagesCountTokens);

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -1813,3 +1813,124 @@ test('/v1/responses preserves custom upstream /models HTTP errors', async () => 
     },
   );
 });
+
+test('/v1/responses/compact rebuilds a compaction envelope from Copilot via compaction_trigger', async () => {
+  const { apiKey } = await setupAppTest();
+  let upstreamBody: Record<string, unknown> | undefined;
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      if (url.pathname === '/models') return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      if (url.pathname === '/responses') {
+        upstreamBody = JSON.parse(await request.text()) as Record<string, unknown>;
+        // Copilot has no native /responses/compact: it drives /responses with a
+        // trailing compaction_trigger and gets back the single compaction item.
+        return jsonResponse({
+          id: 'resp_trigger',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: [{ type: 'compaction', id: 'cmp_upstream', encrypted_content: 'BLOB' }],
+          usage: { input_tokens: 5, output_tokens: 0, total_tokens: 5 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'gpt-direct-responses', input: [{ type: 'message', role: 'user', content: 'summarize me' }] }),
+      });
+
+      assertEquals(response.status, 200);
+      const body = await response.json();
+      assertEquals(body.object, 'response.compaction');
+      const output = body.output as Array<Record<string, unknown>>;
+      const last = output[output.length - 1];
+      assertEquals(last.type, 'compaction');
+      assertEquals(last.encrypted_content, 'BLOB');
+      assertEquals(output[0].type, 'message');
+      assertEquals(output[0].role, 'user');
+    },
+  );
+
+  assertExists(upstreamBody);
+  const input = upstreamBody.input as Array<Record<string, unknown>>;
+  assertEquals(input[input.length - 1].type, 'compaction_trigger');
+  assertEquals(upstreamBody.stream, false);
+});
+
+test('/v1/responses/compact passes a native custom /responses/compact through the SSE pipeline', async () => {
+  const { repo, apiKey, copilotUpstream } = await setupAppTest();
+  await repo.upstreams.delete(copilotUpstream.id);
+  clearModelsStore();
+  await clearCopilotTokenCache();
+  await repo.upstreams.save(buildCustomUpstreamRecord({
+    id: 'up_native',
+    config: { baseUrl: 'https://native.example.com', bearerToken: 'sk-n', endpoints: { responses: {} } },
+  }));
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'native.example.com' && url.pathname === '/v1/models') return jsonResponse({ data: [{ id: 'native-model' }] });
+      if (url.hostname === 'native.example.com' && url.pathname === '/v1/responses/compact') {
+        return jsonResponse({
+          id: 'resp_native',
+          object: 'response.compaction',
+          model: 'native-model',
+          output: [
+            { type: 'message', id: 'msg_u', role: 'user', status: 'completed', content: [{ type: 'input_text', text: 'kept' }] },
+            { type: 'compaction', id: 'cmp_native', encrypted_content: 'NATIVE' },
+          ],
+          usage: { input_tokens: 3, output_tokens: 0, total_tokens: 3 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'native-model', input: [{ type: 'message', role: 'user', content: 'compact me' }] }),
+      });
+
+      assertEquals(response.status, 200);
+      const body = await response.json();
+      assertEquals(body.object, 'response.compaction');
+      const output = body.output as Array<Record<string, unknown>>;
+      const last = output[output.length - 1];
+      assertEquals(last.type, 'compaction');
+      assertEquals(last.encrypted_content, 'NATIVE');
+    },
+  );
+});
+
+test('/v1/responses/compact rejects a model without a native /responses endpoint', async () => {
+  const { apiKey } = await setupAppTest();
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      if (url.pathname === '/models') return jsonResponse(copilotModels([{ id: 'gpt-chat-only', supported_endpoints: ['/chat/completions'] }]));
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'gpt-chat-only', input: [{ type: 'message', role: 'user', content: 'hi' }] }),
+      });
+
+      assertEquals(response.status, 400);
+      const body = await response.json();
+      assertStringIncludes(body.error.message, 'does not support the /responses endpoint');
+    },
+  );
+});

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -5,7 +5,7 @@ import { type LlmTargetApi, type ResponsesInvocation, runInterceptors } from '..
 import type { ExecuteResult } from '../../shared/errors/result.ts';
 import { emitToChatCompletions } from '../../targets/chat-completions/emit.ts';
 import { emitToMessages } from '../../targets/messages/emit.ts';
-import { emitToResponses } from '../../targets/responses/emit.ts';
+import { emitToResponses, emitToResponsesCompact } from '../../targets/responses/emit.ts';
 import { createRequestContext } from '../request-context.ts';
 import { jsonUpstreamErrorResult, sourceErrorResult, type LlmEndpoint, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
@@ -139,7 +139,43 @@ const responsesGenerate: LlmEndpoint<string | readonly ResponsesInputItem[], Raw
   },
 };
 
+// `/responses/compact` rewrites the conversation into a `response.compaction`
+// envelope. It reuses the generate scaffolding (parse, store, persist output
+// items) but is non-streaming and never translates: compaction is meaningful
+// only against an upstream that natively serves `/responses`, so a model
+// without that endpoint surfaces `model-unsupported`.
+const responsesCompact: LlmEndpoint<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> = {
+  respond: async ({ c, result, request }) => await respondResponses(c, result, false, request, undefined),
+  setup: async c => {
+    const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>());
+    const notFound = previousResponseNotFoundResponse(payload);
+    if (notFound) return notFound;
+    // The upstream answer is a single encrypted blob, so the gateway always
+    // collects the rebuilt envelope into one JSON body regardless of any
+    // `stream` field the client sent.
+    const request = createRequestContext(c, undefined, false);
+    return {
+      request,
+      items: payload.input,
+      responsesItemsView,
+      wantsStream: false,
+      store: payload.store,
+      model: payload.model,
+      downstreamAbortController: undefined,
+      pickTarget: endpoints => (endpoints.responses ? 'responses' : null),
+      attempt: async ({ binding, target, model, rewriteItems }) => {
+        const attemptPayload = structuredClone(payload);
+        attemptPayload.model = model;
+        attemptPayload.input = await rewriteItems(attemptPayload.input);
+        const invocation: ResponsesInvocation = responsesInvocation(binding, target, model, attemptPayload);
+        const interceptors = [...responsesSourceInterceptors, ...(binding.sourceInterceptors?.responses ?? [])];
+        return await runInterceptors(invocation, request, interceptors, () => emitToResponsesCompact(invocation, request));
+      },
+    };
+  },
+};
+
 export const responsesTraits: LlmSourceTraits<string | readonly ResponsesInputItem[], RawResponsesStreamEvent> = {
   renderFailure: renderResponsesFailure,
-  endpoints: { generate: responsesGenerate },
+  endpoints: { generate: responsesGenerate, compact: responsesCompact },
 };

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -163,11 +163,11 @@ const responsesCompact: LlmEndpoint<string | readonly ResponsesInputItem[], RawR
       model: payload.model,
       downstreamAbortController: undefined,
       pickTarget: endpoints => (endpoints.responses ? 'responses' : null),
-      attempt: async ({ binding, target, model, rewriteItems }) => {
+      attempt: async ({ binding, model, rewriteItems }) => {
         const attemptPayload = structuredClone(payload);
         attemptPayload.model = model;
         attemptPayload.input = await rewriteItems(attemptPayload.input);
-        const invocation: ResponsesInvocation = responsesInvocation(binding, target, model, attemptPayload);
+        const invocation: ResponsesInvocation = responsesInvocation(binding, 'responses', model, attemptPayload);
         const interceptors = [...responsesSourceInterceptors, ...(binding.sourceInterceptors?.responses ?? [])];
         return await runInterceptors(invocation, request, interceptors, () => emitToResponsesCompact(invocation, request));
       },

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -162,7 +162,7 @@ const responsesCompact: LlmEndpoint<string | readonly ResponsesInputItem[], RawR
       store: payload.store,
       model: payload.model,
       downstreamAbortController: undefined,
-      pickTarget: endpoints => (endpoints.responses ? 'responses' : null),
+      pickTarget: endpoints => endpoints.responses ? 'responses' : null,
       attempt: async ({ binding, model, rewriteItems }) => {
         const attemptPayload = structuredClone(payload);
         attemptPayload.model = model;

--- a/apps/api/src/data-plane/llm/sources/serve.ts
+++ b/apps/api/src/data-plane/llm/sources/serve.ts
@@ -16,7 +16,7 @@ import { listModelProviders, resolveModelForProvider } from '../../providers/reg
 // target preference, the interceptor-wrapped emit, response shaping — differ
 // per API/endpoint and are injected through the per-source traits.
 //
-// A source declares one or more endpoints (generate, count_tokens);
+// A source declares one or more endpoints (generate, count_tokens, compact);
 // `serveLlm(traits, endpointName)` binds one of them to a route. payload and
 // request never reach this orchestrator: they live in the per-endpoint
 // closures. `setup(c)` parses the body, runs input-level pre-checks (returning

--- a/apps/api/src/data-plane/llm/sources/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/traits.ts
@@ -121,6 +121,11 @@ export interface LlmEndpointPlan<TItems, TEvent> {
 //     orchestrator persists, then `respond` renders.
 //   - count_tokens produces a measurement — a non-`events` result the
 //     orchestrator passes straight to `respond`, never persisting.
+//   - compact rewrites a conversation into a `response.compaction` envelope.
+//     Like generate it yields an `events` result the orchestrator persists (the
+//     compaction blob keeps forced upstream affinity for next-turn routing), but
+//     it never translates across protocols — only a native `/responses` upstream
+//     can compact.
 //
 // `pickTarget` and `attempt` are NOT here: they live on the plan `setup`
 // returns, because `attempt` closes over the parsed payload.
@@ -141,7 +146,7 @@ export interface LlmEndpoint<TItems, TEvent> {
   }): Promise<{ success: boolean; response: Response }>;
 }
 
-export type LlmEndpointName = 'generate' | 'countTokens';
+export type LlmEndpointName = 'generate' | 'countTokens' | 'compact';
 
 // A source exposes one or more endpoints that share its input and error
 // envelope. `renderFailure` is source-wide — every endpoint answers a failure

--- a/apps/api/src/data-plane/llm/targets/emit.ts
+++ b/apps/api/src/data-plane/llm/targets/emit.ts
@@ -4,7 +4,7 @@ import type { ProviderCallResult } from '../../providers/types.ts';
 import type { NonLlmServeApiName } from '../../shared/api-names.ts';
 import type { Invocation, RequestContext } from '../interceptors.ts';
 import { toInternalDebugError } from '../shared/errors/internal-debug-error.ts';
-import { eventResult, type ExecuteResult, type InternalErrorResult, internalErrorResult } from '../shared/errors/result.ts';
+import { eventResult, type ExecuteResult, type InternalErrorResult, internalErrorResult, type UpstreamErrorResult } from '../shared/errors/result.ts';
 import { readUpstreamError } from '../shared/errors/upstream-error.ts';
 import { parseSSEStream } from '../shared/stream/parse-sse.ts';
 import type { SseFrame } from '@floway-dev/protocols/common';
@@ -18,6 +18,20 @@ export const targetModelIdentity = (invocation: Invocation<unknown>, modelKey: s
   cost: invocation.provider.getPricingForModelKey(modelKey),
 });
 
+// Records an upstream HTTP failure and produces the verbatim error result.
+// Shared by the streaming SSE boundary below and the non-streaming compaction
+// path, which surface upstream errors identically.
+export const targetUpstreamErrorResult = async (
+  response: Response,
+  invocation: Invocation<unknown>,
+  request: RequestContext,
+  targetApi: TargetEmitApiName,
+  modelIdentity: TelemetryModelIdentity,
+): Promise<UpstreamErrorResult> => {
+  recordUpstreamHttpFailure(invocation, request, targetApi, modelIdentity);
+  return { ...(await readUpstreamError(response)), performance: targetPerformanceContext(invocation, request, targetApi, modelIdentity) };
+};
+
 export const targetProviderResultToFrames = async (
   invocation: Invocation<unknown>,
   request: RequestContext,
@@ -26,17 +40,11 @@ export const targetProviderResultToFrames = async (
   modelIdentity: TelemetryModelIdentity,
   upstreamStartedAt: number,
 ): Promise<ExecuteResult<SseFrame>> => {
-  const perfContext = targetPerformanceContext(invocation, request, targetApi, modelIdentity);
   const { response } = providerResult;
 
-  if (!response.ok) {
-    recordUpstreamHttpFailure(invocation, request, targetApi, modelIdentity);
-    return {
-      ...(await readUpstreamError(response)),
-      performance: perfContext,
-    };
-  }
+  if (!response.ok) return await targetUpstreamErrorResult(response, invocation, request, targetApi, modelIdentity);
 
+  const perfContext = targetPerformanceContext(invocation, request, targetApi, modelIdentity);
   if (!response.body) {
     return internalErrorResult(502, toInternalDebugError(new Error('No response body from upstream'), invocation.sourceApi, targetApi), perfContext);
   }

--- a/apps/api/src/data-plane/llm/targets/responses/emit.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/emit.ts
@@ -1,6 +1,7 @@
 import { responsesStreamFramesToEvents } from './events/from-stream.ts';
 import { responsesBaseInterceptors } from './interceptors/index.ts';
 import type { TelemetryModelIdentity } from '../../../../repo/types.ts';
+import type { ModelProvider, ProviderCallResult, UpstreamModel } from '../../../providers/types.ts';
 import { type RequestContext, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../shared/errors/result.ts';
 import { targetInternalError, targetModelIdentity, targetProviderResultToFrames } from '../emit.ts';
@@ -9,14 +10,28 @@ import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/prot
 
 const targetApi = 'responses';
 
-export const emitToResponses = async (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> => {
+type ResponsesProviderCall = (
+  provider: ModelProvider,
+  model: UpstreamModel,
+  body: Omit<ResponsesPayload, 'model'>,
+  signal: AbortSignal | undefined,
+  headers: Record<string, string> | undefined,
+) => Promise<ProviderCallResult>;
+
+// `/responses` generation and `/responses/compact` share one target pipeline:
+// both run the responses interceptor stack, hand the provider's SSE through the
+// target boundary (which fast-path-expands a terminal-only stream), and surface
+// the canonical event sequence. They differ only in the provider method called,
+// so compaction never becomes a side path that bypasses interceptors — the
+// provider layer is responsible for returning `text/event-stream` either way.
+const emitResponsesVia = async (invocation: ResponsesInvocation, request: RequestContext, providerCall: ResponsesProviderCall): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> => {
   let modelIdentity: TelemetryModelIdentity | undefined;
 
   try {
     return await runInterceptors(invocation, request, [...responsesBaseInterceptors, ...(invocation.targetInterceptors?.responses ?? [])], async () => {
       const upstreamStartedAt = performance.now();
       const { model: _model, ...body }: ResponsesPayload = invocation.payload;
-      const providerResult = await invocation.provider.callResponses(invocation.upstreamModel, body, request.downstreamAbortSignal, invocation.headers);
+      const providerResult = await providerCall(invocation.provider, invocation.upstreamModel, body, request.downstreamAbortSignal, invocation.headers);
       modelIdentity = targetModelIdentity(invocation, providerResult.modelKey);
       const result = await targetProviderResultToFrames(invocation, request, targetApi, providerResult, modelIdentity, upstreamStartedAt);
 
@@ -26,3 +41,9 @@ export const emitToResponses = async (invocation: ResponsesInvocation, request: 
     return targetInternalError(invocation, request, targetApi, error, modelIdentity);
   }
 };
+
+export const emitToResponses = (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>
+  emitResponsesVia(invocation, request, (provider, model, body, signal, headers) => provider.callResponses(model, body, signal, headers));
+
+export const emitToResponsesCompact = (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>
+  emitResponsesVia(invocation, request, (provider, model, body, signal, headers) => provider.callResponsesCompact(model, body, signal, headers));

--- a/apps/api/src/data-plane/llm/targets/responses/emit.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/emit.ts
@@ -1,37 +1,24 @@
 import { responsesStreamFramesToEvents } from './events/from-stream.ts';
 import { responsesBaseInterceptors } from './interceptors/index.ts';
 import type { TelemetryModelIdentity } from '../../../../repo/types.ts';
-import type { ModelProvider, ProviderCallResult, UpstreamModel } from '../../../providers/types.ts';
+import { recordPerformanceLatency } from '../../../shared/telemetry/performance.ts';
 import { type RequestContext, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
 import { eventResult, type ExecuteResult } from '../../shared/errors/result.ts';
-import { targetInternalError, targetModelIdentity, targetProviderResultToFrames } from '../emit.ts';
-import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { targetInternalError, targetModelIdentity, targetProviderResultToFrames, targetUpstreamErrorResult } from '../emit.ts';
+import { targetPerformanceContext } from '../telemetry.ts';
+import { doneFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import { responsesResultToEvents, type ResponsesPayload, type ResponsesResult, type RawResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 const targetApi = 'responses';
 
-type ResponsesProviderCall = (
-  provider: ModelProvider,
-  model: UpstreamModel,
-  body: Omit<ResponsesPayload, 'model'>,
-  signal: AbortSignal | undefined,
-  headers: Record<string, string> | undefined,
-) => Promise<ProviderCallResult>;
-
-// `/responses` generation and `/responses/compact` share one target pipeline:
-// both run the responses interceptor stack, hand the provider's SSE through the
-// target boundary (which fast-path-expands a terminal-only stream), and surface
-// the canonical event sequence. They differ only in the provider method called,
-// so compaction never becomes a side path that bypasses interceptors — the
-// provider layer is responsible for returning `text/event-stream` either way.
-const emitResponsesVia = async (invocation: ResponsesInvocation, request: RequestContext, providerCall: ResponsesProviderCall): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> => {
+export const emitToResponses = async (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> => {
   let modelIdentity: TelemetryModelIdentity | undefined;
 
   try {
     return await runInterceptors(invocation, request, [...responsesBaseInterceptors, ...(invocation.targetInterceptors?.responses ?? [])], async () => {
       const upstreamStartedAt = performance.now();
       const { model: _model, ...body }: ResponsesPayload = invocation.payload;
-      const providerResult = await providerCall(invocation.provider, invocation.upstreamModel, body, request.downstreamAbortSignal, invocation.headers);
+      const providerResult = await invocation.provider.callResponses(invocation.upstreamModel, body, request.downstreamAbortSignal, invocation.headers);
       modelIdentity = targetModelIdentity(invocation, providerResult.modelKey);
       const result = await targetProviderResultToFrames(invocation, request, targetApi, providerResult, modelIdentity, upstreamStartedAt);
 
@@ -42,14 +29,37 @@ const emitResponsesVia = async (invocation: ResponsesInvocation, request: Reques
   }
 };
 
-export const emitToResponses = (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>
-  emitResponsesVia(invocation, request, (provider, model, body, signal, headers) => provider.callResponses(model, body, signal, headers));
+// `/responses/compact` is non-streaming: the provider yields the compaction
+// envelope as a value, so we build the canonical event frames here — generic
+// item expansion keeps the input-shaped retained messages intact — instead of
+// re-parsing a synthesized SSE body. It runs the same interceptor stack as
+// generation; only an upstream HTTP failure shares the streaming boundary's
+// error handling. `stream` is dropped so the upstream request stays non-streaming.
+export const emitToResponsesCompact = async (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> => {
+  let modelIdentity: TelemetryModelIdentity | undefined;
 
-export const emitToResponsesCompact = (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>
-  emitResponsesVia(invocation, request, (provider, model, body, signal, headers) => {
-    // `/responses/compact` is non-streaming on every realization, so a client
-    // `stream: true` must never reach the upstream request body (the native
-    // endpoint is contractually non-streaming; Copilot forces stream:false).
-    const { stream: _stream, ...compactBody } = body;
-    return provider.callResponsesCompact(model, compactBody, signal, headers);
-  });
+  try {
+    return await runInterceptors(invocation, request, [...responsesBaseInterceptors, ...(invocation.targetInterceptors?.responses ?? [])], async () => {
+      const upstreamStartedAt = performance.now();
+      const { model: _model, stream: _stream, ...body } = invocation.payload;
+      const providerResult = await invocation.provider.callResponsesCompact(invocation.upstreamModel, body, request.downstreamAbortSignal, invocation.headers);
+      modelIdentity = targetModelIdentity(invocation, providerResult.modelKey);
+      if (!providerResult.ok) return await targetUpstreamErrorResult(providerResult.response, invocation, request, targetApi, modelIdentity);
+
+      const perfContext = targetPerformanceContext(invocation, request, targetApi, modelIdentity);
+      if (request.apiKeyId) {
+        const promise = recordPerformanceLatency(perfContext, 'upstream_success', performance.now() - upstreamStartedAt);
+        request.scheduleBackground ? request.scheduleBackground(promise) : void promise;
+      }
+      return eventResult(compactionFrames(providerResult.result), modelIdentity, perfContext);
+    });
+  } catch (error) {
+    return targetInternalError(invocation, request, targetApi, error, modelIdentity);
+  }
+};
+
+const compactionFrames = (result: ResponsesResult): AsyncGenerator<ProtocolFrame<RawResponsesStreamEvent>> =>
+  (async function* () {
+    for (const frame of responsesResultToEvents(result, { genericOutputItems: true })) yield frame;
+    yield doneFrame();
+  })();

--- a/apps/api/src/data-plane/llm/targets/responses/emit.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/emit.ts
@@ -46,4 +46,10 @@ export const emitToResponses = (invocation: ResponsesInvocation, request: Reques
   emitResponsesVia(invocation, request, (provider, model, body, signal, headers) => provider.callResponses(model, body, signal, headers));
 
 export const emitToResponsesCompact = (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<RawResponsesStreamEvent>>> =>
-  emitResponsesVia(invocation, request, (provider, model, body, signal, headers) => provider.callResponsesCompact(model, body, signal, headers));
+  emitResponsesVia(invocation, request, (provider, model, body, signal, headers) => {
+    // `/responses/compact` is non-streaming on every realization, so a client
+    // `stream: true` must never reach the upstream request body (the native
+    // endpoint is contractually non-streaming; Copilot forces stream:false).
+    const { stream: _stream, ...compactBody } = body;
+    return provider.callResponsesCompact(model, compactBody, signal, headers);
+  });

--- a/apps/api/src/data-plane/providers/azure/provider.ts
+++ b/apps/api/src/data-plane/providers/azure/provider.ts
@@ -6,7 +6,7 @@ import { mergeAnthropicBetaHeader } from '../anthropic-beta.ts';
 import { isStreamingEndpoint, modelConfigEndpoints } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
-import { nativeCompactToSse } from '../responses-compaction.ts';
+import { nativeCompactionResult } from '../responses-compaction.ts';
 import type { ModelProvider, ModelProviderInstance, ProviderCallResult, UpstreamModel } from '../types.ts';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 
@@ -69,7 +69,7 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
     },
     callChatCompletions: (model, body, signal, headers) => call('chat_completions', model, body, signal, headers),
     callResponses: (model, body, signal, headers) => call('responses', model, body, signal, headers),
-    callResponsesCompact: (model, body, signal, headers) => nativeCompactToSse(call('responses_compact', model, body, signal, headers)),
+    callResponsesCompact: (model, body, signal, headers) => nativeCompactionResult(call('responses_compact', model, body, signal, headers)),
     callMessages: (model, body, signal, headers, anthropicBeta) => call('messages', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call('messages_count_tokens', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callEmbeddings: (model, body, signal, headers) => call('embeddings', model, body, signal, headers),

--- a/apps/api/src/data-plane/providers/azure/provider.ts
+++ b/apps/api/src/data-plane/providers/azure/provider.ts
@@ -6,6 +6,7 @@ import { mergeAnthropicBetaHeader } from '../anthropic-beta.ts';
 import { isStreamingEndpoint, modelConfigEndpoints } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
+import { nativeCompactToSse } from '../responses-compaction.ts';
 import type { ModelProvider, ModelProviderInstance, ProviderCallResult, UpstreamModel } from '../types.ts';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 
@@ -68,6 +69,7 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
     },
     callChatCompletions: (model, body, signal, headers) => call('chat_completions', model, body, signal, headers),
     callResponses: (model, body, signal, headers) => call('responses', model, body, signal, headers),
+    callResponsesCompact: (model, body, signal, headers) => nativeCompactToSse(call('responses_compact', model, body, signal, headers)),
     callMessages: (model, body, signal, headers, anthropicBeta) => call('messages', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call('messages_count_tokens', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callEmbeddings: (model, body, signal, headers) => call('embeddings', model, body, signal, headers),

--- a/apps/api/src/data-plane/providers/copilot/compaction.ts
+++ b/apps/api/src/data-plane/providers/copilot/compaction.ts
@@ -58,6 +58,13 @@ const compactionItem = (generated: ResponsesResult): ResponsesCompactionItem => 
 // echoes: an id (so the store can mint a stored id and persist it), an explicit
 // `status`, and array content. The client resends `output` verbatim as the next
 // turn's `input`, so the items must be self-contained.
+//
+// A message the client sent without an id gets a synthetic one. Unlike the
+// native path — where retained ids are the upstream's own echoed ids — these
+// persist as upstream-owned with an id the upstream never issued, giving them
+// `portable` affinity. That is benign: the compaction blob carries the real
+// `forcing` affinity, and retained messages are resent as full content rather
+// than `item_reference`s, so the synthetic id is never replayed to the upstream.
 const retainedOutputMessage = (message: ResponsesInputMessage): ResponsesInputMessage => ({
   type: 'message',
   id: message.id ?? `msg_${crypto.randomUUID().replace(/-/g, '')}`,

--- a/apps/api/src/data-plane/providers/copilot/compaction.ts
+++ b/apps/api/src/data-plane/providers/copilot/compaction.ts
@@ -1,85 +1,93 @@
-import type { ResponsesCompactionItem, ResponsesCompactionTriggerItem, ResponsesInputItem, ResponsesInputMessage, ResponsesOutputItem, ResponsesResult } from '@floway-dev/protocols/responses';
+import type { ResponsesCompactionTriggerItem, ResponsesInputContent, ResponsesInputItem, ResponsesInputMessage, ResponsesOutputItem, ResponsesResult } from '@floway-dev/protocols/responses';
 
 // Copilot has no native `/responses/compact`, so we replicate codex's
 // RemoteCompactionV2: drive a normal `/responses` turn with a trailing
 // `compaction_trigger` input item, keep the single `compaction` output item the
 // server returns, and rebuild the `response.compaction` envelope client-side.
-// Retained-message reconstruction mirrors codex `build_v2_compacted_history`
-// so the result matches a native Azure `/responses/compact` answer: the retained
-// user/developer/system messages first, the compaction item last, ready for the
-// client to resend `output` verbatim as the next turn's `input`.
-// Reference (codex @ ebb79803697acee75baf24073ef49af87ad7e483):
+// Retained-message reconstruction matches the shape a native Azure
+// `/responses/compact` echoes: every retained user/assistant/developer/system
+// message verbatim (content normalized to `input_text` so the client can
+// resend `output` directly as the next turn's `input`), then the compaction
+// item last.
+//
+// References (codex @ ebb79803697acee75baf24073ef49af87ad7e483):
 //   codex-rs/core/src/compact_remote_v2.rs#L409-L457
+//   codex-rs/utils/string/src/truncate.rs#L71-L74
 export const COMPACTION_TRIGGER: ResponsesCompactionTriggerItem = { type: 'compaction_trigger' };
+
+// Native compact retains `user` + `assistant` + `developer` + `system` —
+// confirmed empirically against an OpenAI long fixture (287 user + 286
+// assistant messages co-retained). Only tool/function items are absorbed by
+// the encrypted blob. codex's `is_retained_for_remote_compaction_v2` drops
+// assistant; production captures show the server keeps it.
+const RETAINED_ROLES = new Set(['user', 'assistant', 'developer', 'system']);
 
 // codex's retained-message budget (its comment notes it mirrors the server-side
 // `/responses/compact` default) and its token heuristic `ceil(utf8_bytes / 4)`,
-// with images costing nothing. codex-rs/utils/string/src/truncate.rs#L71-L74.
-const RETAINED_MESSAGE_TOKEN_BUDGET = 64_000;
+// with images costing nothing.
+const RETAINED_BUDGET = 64_000;
 const APPROX_BYTES_PER_TOKEN = 4;
-const RETAINED_ROLES: ReadonlySet<string> = new Set(['user', 'developer', 'system']);
-
 const encoder = new TextEncoder();
-const approxTokenCount = (text: string): number => Math.ceil(encoder.encode(text).length / APPROX_BYTES_PER_TOKEN);
 
-const messageTokenCount = (message: ResponsesInputMessage): number =>
-  typeof message.content === 'string'
-    ? approxTokenCount(message.content)
-    : message.content.reduce((sum, part) => (part.type === 'input_image' ? sum : sum + approxTokenCount(part.text)), 0);
+// Native compact echoes every text part — including assistant `output_text` —
+// as `input_text` so the client can resend `output` verbatim as next-turn
+// `input`. Normalize unconditionally; images pass through (and cost 0 tokens
+// against the retained budget).
+const normalizeContent = (content: ResponsesInputMessage['content']): ResponsesInputContent[] => {
+  if (typeof content === 'string') return [{ type: 'input_text', text: content }];
+  return content.map(part => (part.type === 'input_image' ? part : { type: 'input_text', text: part.text }));
+};
 
-const isRetainedMessage = (item: ResponsesInputItem): item is ResponsesInputMessage => item.type === 'message' && RETAINED_ROLES.has(item.role);
+// OpenAI accepts input messages with the `type` field omitted (implicit
+// `type: "message"`); accept the same so a hand-rolled client that emits
+// `{role, content}` without `type` still routes correctly.
+const isRetainedMessage = (item: ResponsesInputItem): item is ResponsesInputMessage =>
+  (item.type === 'message' || (item.type === undefined && 'role' in (item as { role?: unknown })))
+  && RETAINED_ROLES.has((item as ResponsesInputMessage).role);
 
-// Newest-first within the token budget, then restored to chronological order.
-// codex additionally middle-truncates the single boundary message; we keep
-// whole-message granularity and drop it instead — the partial-truncation marker
-// is a codex display artifact, and the 64k/byte-4 figure only approximates the
-// server cutoff in the first place.
-const retainedMessages = (input: ResponsesInputItem[]): ResponsesInputMessage[] => {
-  const messages = input.filter(isRetainedMessage);
+// The retained items are input-shaped messages (role + `input_text` content),
+// which is what `/responses/compact` echoes so the client can resend `output`
+// as the next turn's `input`. `ResponsesOutputItem` does not model user/system
+// roles, so the final cast records that the compaction envelope's `output` is
+// deliberately input-shaped.
+//
+// A retained message with no id gets a synthetic one (so the store can mint
+// a stored id and persist it). That means Copilot-rebuilt retained items
+// persist as upstream-owned with an id the upstream never issued (giving them
+// `portable` affinity); the compaction blob carries the real `forcing`
+// affinity. Benign: retained messages are resent as full content rather than
+// `item_reference`s, so the synthetic id is never replayed to the upstream.
+export const compactionResponse = (input: ResponsesInputItem[], generated: ResponsesResult): ResponsesResult => {
   const kept: ResponsesInputMessage[] = [];
   let used = 0;
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    used += Math.max(messageTokenCount(messages[i]), 1);
-    if (used > RETAINED_MESSAGE_TOKEN_BUDGET && kept.length > 0) break;
-    kept.push(messages[i]);
-  }
-  return kept.reverse();
-};
+  for (let i = input.length - 1; i >= 0; i -= 1) {
+    const item = input[i];
+    if (!isRetainedMessage(item)) continue;
 
-const compactionItem = (generated: ResponsesResult): ResponsesCompactionItem => {
+    const content = normalizeContent(item.content);
+    const tokens = content.reduce((sum, part) => (part.type === 'input_image' ? sum : sum + Math.ceil(encoder.encode(part.text).length / APPROX_BYTES_PER_TOKEN)), 0);
+    used += Math.max(tokens, 1);
+    if (used > RETAINED_BUDGET && kept.length > 0) break;
+
+    kept.push({
+      type: 'message',
+      id: item.id ?? `msg_${crypto.randomUUID().replace(/-/g, '')}`,
+      status: item.status ?? 'completed',
+      role: item.role,
+      content,
+    });
+  }
+
   // The trigger turn may also emit a stray assistant message; codex ignores
   // everything but the lone compaction item and errors if it is not exactly one.
-  const items = generated.output.filter((item): item is ResponsesCompactionItem => item.type === 'compaction');
-  if (items.length !== 1) throw new Error(`Expected exactly one compaction output item from the Copilot trigger turn, got ${items.length}`);
-  return items[0];
+  const compactionItems = generated.output.filter(it => it.type === 'compaction');
+  if (compactionItems.length !== 1) {
+    throw new Error(`Expected exactly one compaction output item from the Copilot trigger turn, got ${compactionItems.length}`);
+  }
+
+  return {
+    ...generated,
+    object: 'response.compaction',
+    output: [...kept.reverse(), compactionItems[0]] as unknown as ResponsesOutputItem[],
+  };
 };
-
-// Render a retained input message in the shape a native `/responses/compact`
-// echoes: an id (so the store can mint a stored id and persist it), an explicit
-// `status`, and array content. The client resends `output` verbatim as the next
-// turn's `input`, so the items must be self-contained.
-//
-// A message the client sent without an id gets a synthetic one. Unlike the
-// native path — where retained ids are the upstream's own echoed ids — these
-// persist as upstream-owned with an id the upstream never issued, giving them
-// `portable` affinity. That is benign: the compaction blob carries the real
-// `forcing` affinity, and retained messages are resent as full content rather
-// than `item_reference`s, so the synthetic id is never replayed to the upstream.
-const retainedOutputMessage = (message: ResponsesInputMessage): ResponsesInputMessage => ({
-  type: 'message',
-  id: message.id ?? `msg_${crypto.randomUUID().replace(/-/g, '')}`,
-  status: message.status ?? 'completed',
-  role: message.role,
-  content: typeof message.content === 'string' ? [{ type: 'input_text', text: message.content }] : message.content,
-});
-
-// The retained items are input-shaped messages (role:user, input_text content),
-// which is what `/responses/compact` echoes so the client can resend `output`
-// as the next turn's `input`. ResponsesOutputItem does not model a user-role
-// message, so the cast records that the compaction envelope's output is
-// deliberately input-shaped.
-export const compactionResponse = (input: ResponsesInputItem[], generated: ResponsesResult): ResponsesResult => ({
-  ...generated,
-  object: 'response.compaction',
-  output: [...retainedMessages(input).map(retainedOutputMessage), compactionItem(generated)] as unknown as ResponsesOutputItem[],
-});

--- a/apps/api/src/data-plane/providers/copilot/compaction.ts
+++ b/apps/api/src/data-plane/providers/copilot/compaction.ts
@@ -1,4 +1,4 @@
-import type { ResponsesCompactionItem, ResponsesInputItem, ResponsesInputMessage, ResponsesOutputItem, ResponsesResult } from '@floway-dev/protocols/responses';
+import type { ResponsesCompactionItem, ResponsesCompactionTriggerItem, ResponsesInputItem, ResponsesInputMessage, ResponsesOutputItem, ResponsesResult } from '@floway-dev/protocols/responses';
 
 // Copilot has no native `/responses/compact`, so we replicate codex's
 // RemoteCompactionV2: drive a normal `/responses` turn with a trailing
@@ -10,7 +10,7 @@ import type { ResponsesCompactionItem, ResponsesInputItem, ResponsesInputMessage
 // client to resend `output` verbatim as the next turn's `input`.
 // Reference (codex @ ebb79803697acee75baf24073ef49af87ad7e483):
 //   codex-rs/core/src/compact_remote_v2.rs#L409-L457
-export const COMPACTION_TRIGGER = { type: 'compaction_trigger' } as const;
+export const COMPACTION_TRIGGER: ResponsesCompactionTriggerItem = { type: 'compaction_trigger' };
 
 // codex's retained-message budget (its comment notes it mirrors the server-side
 // `/responses/compact` default) and its token heuristic `ceil(utf8_bytes / 4)`,

--- a/apps/api/src/data-plane/providers/copilot/compaction.ts
+++ b/apps/api/src/data-plane/providers/copilot/compaction.ts
@@ -1,0 +1,78 @@
+import type { ResponsesCompactionItem, ResponsesInputItem, ResponsesInputMessage, ResponsesOutputItem, ResponsesResult } from '@floway-dev/protocols/responses';
+
+// Copilot has no native `/responses/compact`, so we replicate codex's
+// RemoteCompactionV2: drive a normal `/responses` turn with a trailing
+// `compaction_trigger` input item, keep the single `compaction` output item the
+// server returns, and rebuild the `response.compaction` envelope client-side.
+// Retained-message reconstruction mirrors codex `build_v2_compacted_history`
+// so the result matches a native Azure `/responses/compact` answer: the retained
+// user/developer/system messages first, the compaction item last, ready for the
+// client to resend `output` verbatim as the next turn's `input`.
+// Reference (codex @ ebb79803697acee75baf24073ef49af87ad7e483):
+//   codex-rs/core/src/compact_remote_v2.rs#L409-L457
+export const COMPACTION_TRIGGER = { type: 'compaction_trigger' } as const;
+
+// codex's retained-message budget (its comment notes it mirrors the server-side
+// `/responses/compact` default) and its token heuristic `ceil(utf8_bytes / 4)`,
+// with images costing nothing. codex-rs/utils/string/src/truncate.rs#L71-L74.
+const RETAINED_MESSAGE_TOKEN_BUDGET = 64_000;
+const APPROX_BYTES_PER_TOKEN = 4;
+const RETAINED_ROLES: ReadonlySet<string> = new Set(['user', 'developer', 'system']);
+
+const encoder = new TextEncoder();
+const approxTokenCount = (text: string): number => Math.ceil(encoder.encode(text).length / APPROX_BYTES_PER_TOKEN);
+
+const messageTokenCount = (message: ResponsesInputMessage): number =>
+  typeof message.content === 'string'
+    ? approxTokenCount(message.content)
+    : message.content.reduce((sum, part) => (part.type === 'input_image' ? sum : sum + approxTokenCount(part.text)), 0);
+
+const isRetainedMessage = (item: ResponsesInputItem): item is ResponsesInputMessage => item.type === 'message' && RETAINED_ROLES.has(item.role);
+
+// Newest-first within the token budget, then restored to chronological order.
+// codex additionally middle-truncates the single boundary message; we keep
+// whole-message granularity and drop it instead — the partial-truncation marker
+// is a codex display artifact, and the 64k/byte-4 figure only approximates the
+// server cutoff in the first place.
+const retainedMessages = (input: ResponsesInputItem[]): ResponsesInputMessage[] => {
+  const messages = input.filter(isRetainedMessage);
+  const kept: ResponsesInputMessage[] = [];
+  let used = 0;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    used += Math.max(messageTokenCount(messages[i]), 1);
+    if (used > RETAINED_MESSAGE_TOKEN_BUDGET && kept.length > 0) break;
+    kept.push(messages[i]);
+  }
+  return kept.reverse();
+};
+
+const compactionItem = (generated: ResponsesResult): ResponsesCompactionItem => {
+  // The trigger turn may also emit a stray assistant message; codex ignores
+  // everything but the lone compaction item and errors if it is not exactly one.
+  const items = generated.output.filter((item): item is ResponsesCompactionItem => item.type === 'compaction');
+  if (items.length !== 1) throw new Error(`Expected exactly one compaction output item from the Copilot trigger turn, got ${items.length}`);
+  return items[0];
+};
+
+// Render a retained input message in the shape a native `/responses/compact`
+// echoes: an id (so the store can mint a stored id and persist it), an explicit
+// `status`, and array content. The client resends `output` verbatim as the next
+// turn's `input`, so the items must be self-contained.
+const retainedOutputMessage = (message: ResponsesInputMessage): ResponsesInputMessage => ({
+  type: 'message',
+  id: message.id ?? `msg_${crypto.randomUUID().replace(/-/g, '')}`,
+  status: message.status ?? 'completed',
+  role: message.role,
+  content: typeof message.content === 'string' ? [{ type: 'input_text', text: message.content }] : message.content,
+});
+
+// The retained items are input-shaped messages (role:user, input_text content),
+// which is what `/responses/compact` echoes so the client can resend `output`
+// as the next turn's `input`. ResponsesOutputItem does not model a user-role
+// message, so the cast records that the compaction envelope's output is
+// deliberately input-shaped.
+export const compactionResponse = (input: ResponsesInputItem[], generated: ResponsesResult): ResponsesResult => ({
+  ...generated,
+  object: 'response.compaction',
+  output: [...retainedMessages(input).map(retainedOutputMessage), compactionItem(generated)] as unknown as ResponsesOutputItem[],
+});

--- a/apps/api/src/data-plane/providers/copilot/compaction_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/compaction_test.ts
@@ -20,10 +20,11 @@ const compaction = { type: 'compaction', id: 'cmp_1', encrypted_content: 'BLOB' 
 const shape = (result: ResponsesResult): string[] =>
   result.output.map(item => (item.type === 'compaction' ? 'compaction' : `${item.type}:${(item as { role?: string }).role}`));
 
-test('keeps retained user/developer/system messages and appends the compaction item, dropping assistant turns', () => {
+test('keeps retained user/assistant/developer/system messages and appends the compaction item, absorbing tool/function items into the blob', () => {
   const input: ResponsesInputItem[] = [
     { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
     { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] },
+    { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'lookup', arguments: '{}', status: 'completed' },
     { type: 'message', role: 'system', content: 'be nice' },
   ];
   // The trigger turn may also emit a stray assistant message; only the lone
@@ -31,8 +32,29 @@ test('keeps retained user/developer/system messages and appends the compaction i
   const result = compactionResponse(input, generatedResult([{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'stray' }] }, compaction]));
 
   expect(result.object).toBe('response.compaction');
-  expect(shape(result)).toEqual(['message:user', 'message:system', 'compaction']);
+  expect(shape(result)).toEqual(['message:user', 'message:assistant', 'message:system', 'compaction']);
   expect(result.output.at(-1)).toEqual(compaction);
+});
+
+test('normalizes every retained text part to input_text — assistant output_text included', () => {
+  const input: ResponsesInputItem[] = [
+    { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'reply' }] },
+    { type: 'message', role: 'user', content: 'plain string' },
+  ];
+  const result = compactionResponse(input, generatedResult([compaction]));
+
+  // Both retained messages echo with `input_text` parts, regardless of original part type.
+  const assistantPart = (result.output[0] as { content: Array<{ type: string }> }).content[0];
+  const userPart = (result.output[1] as { content: Array<{ type: string }> }).content[0];
+  expect(assistantPart.type).toBe('input_text');
+  expect(userPart.type).toBe('input_text');
+});
+
+test('accepts input messages with the type field omitted (implicit message)', () => {
+  // OpenAI accepts `{role, content}` without `type`; we follow.
+  const input = [{ role: 'user', content: 'hi' }] as unknown as ResponsesInputItem[];
+  const result = compactionResponse(input, generatedResult([compaction]));
+  expect(shape(result)).toEqual(['message:user', 'compaction']);
 });
 
 test('throws when the trigger turn did not return exactly one compaction item', () => {

--- a/apps/api/src/data-plane/providers/copilot/compaction_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/compaction_test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest';
+
+import { compactionResponse } from './compaction.ts';
+import type { ResponsesInputItem, ResponsesResult } from '@floway-dev/protocols/responses';
+
+const generatedResult = (output: unknown[]): ResponsesResult =>
+  ({
+    id: 'resp_1',
+    object: 'response',
+    model: 'gpt-5.2-codex',
+    output: output as ResponsesResult['output'],
+    status: 'completed',
+    incomplete_details: null,
+    error: null,
+    usage: { input_tokens: 10, output_tokens: 0, total_tokens: 10 },
+  }) as ResponsesResult;
+
+const compaction = { type: 'compaction', id: 'cmp_1', encrypted_content: 'BLOB' };
+
+const shape = (result: ResponsesResult): string[] =>
+  result.output.map(item => (item.type === 'compaction' ? 'compaction' : `${item.type}:${(item as { role?: string }).role}`));
+
+test('keeps retained user/developer/system messages and appends the compaction item, dropping assistant turns', () => {
+  const input: ResponsesInputItem[] = [
+    { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] },
+    { type: 'message', role: 'system', content: 'be nice' },
+  ];
+  // The trigger turn may also emit a stray assistant message; only the lone
+  // compaction item survives, regardless of the generated assistant output.
+  const result = compactionResponse(input, generatedResult([{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'stray' }] }, compaction]));
+
+  expect(result.object).toBe('response.compaction');
+  expect(shape(result)).toEqual(['message:user', 'message:system', 'compaction']);
+  expect(result.output.at(-1)).toEqual(compaction);
+});
+
+test('throws when the trigger turn did not return exactly one compaction item', () => {
+  expect(() => compactionResponse([], generatedResult([]))).toThrow(/exactly one compaction/);
+  expect(() => compactionResponse([], generatedResult([compaction, { type: 'compaction', id: 'cmp_2', encrypted_content: 'X' }]))).toThrow(/exactly one compaction/);
+});
+
+test('truncates retained messages newest-first to the 64k token budget', () => {
+  // codex token heuristic is ceil(utf8_bytes / 4); 4 ASCII bytes ≈ 1 token.
+  const oldest: ResponsesInputItem = { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'x'.repeat(64_001 * 4) }] };
+  const newest: ResponsesInputItem = { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'recent' }] };
+  const result = compactionResponse([oldest, newest], generatedResult([compaction]));
+
+  // The oldest message alone exceeds the budget once the newest is kept, so it
+  // drops entirely; only the recent message and the compaction blob remain.
+  expect(result.output).toHaveLength(2);
+  expect((result.output[0] as { role?: string }).role).toBe('user');
+  expect((result.output[0] as { content?: unknown }).content).toEqual([{ type: 'input_text', text: 'recent' }]);
+  expect(result.output[1]).toEqual(compaction);
+});
+
+test('retains a message whose content is a plain string', () => {
+  const result = compactionResponse([{ type: 'message', role: 'user', content: 'hi there' }], generatedResult([compaction]));
+  expect(shape(result)).toEqual(['message:user', 'compaction']);
+});

--- a/apps/api/src/data-plane/providers/copilot/provider.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider.ts
@@ -1,3 +1,4 @@
+import { COMPACTION_TRIGGER, compactionResponse } from './compaction.ts';
 import { fetchCopilotModels } from './fetch-models.ts';
 import { chatCompletionsCopilotInterceptors } from './interceptors/chat-completions/index.ts';
 import { messagesCopilotInterceptors, messagesCopilotSourceInterceptors, messagesCountTokensCopilotInterceptors } from './interceptors/messages/index.ts';
@@ -16,11 +17,12 @@ import { isStreamingEndpoint, withMessagesCountTokens } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
 import { inProcessMemo, readModelsStore, writeModelsStore } from '../models-store.ts';
+import { compactionResultToSse } from '../responses-compaction.ts';
 import type { ModelProvider, ModelProviderInstance, ProviderCallResult, UpstreamModel } from '../types.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { type ModelEndpointKey, type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/common';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { ResponsesInputItem, ResponsesPayload, ResponsesResult } from '@floway-dev/protocols/responses';
 
 interface CopilotProviderData {
   rawModels: CopilotRawModel[];
@@ -313,6 +315,20 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
         reasoningEffort: responsesReasoningEffort(body),
       });
       return call('responses', body, signal, rawModel, headers);
+    },
+    callResponsesCompact: async (model, body, signal, headers) => {
+      const rawModel = rawModelFor(model, 'responses', { reasoningEffort: responsesReasoningEffort(body) });
+      const input: ResponsesInputItem[] = typeof body.input === 'string' ? [{ type: 'message', role: 'user', content: body.input }] : (body.input ?? []);
+      // Compaction is inherently non-streaming — a single encrypted blob, not a
+      // token stream — so we drive /responses with stream:false (bypassing the
+      // SSE-forcing `call` helper) and re-emit the rebuilt envelope as SSE so it
+      // flows the same target pipeline as a native compact. compaction.ts does
+      // the codex-equivalent trigger + retained-message reshape.
+      const triggered = { ...body, input: [...input, COMPACTION_TRIGGER as unknown as ResponsesInputItem], stream: false, model: rawModel.id };
+      const response = await upstream.fetch('responses', { method: 'POST', body: JSON.stringify(triggered), signal }, headers && Object.keys(headers).length > 0 ? { extraHeaders: headers } : undefined);
+      if (!response.ok) return { response, modelKey: rawModel.id };
+      const generated = (await response.json()) as ResponsesResult;
+      return { response: compactionResultToSse(compactionResponse(input, generated)), modelKey: rawModel.id };
     },
     callMessages: callMessagesEndpoint('messages'),
     callMessagesCountTokens: callMessagesEndpoint('messages_count_tokens'),

--- a/apps/api/src/data-plane/providers/copilot/provider.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider.ts
@@ -17,7 +17,6 @@ import { isStreamingEndpoint, withMessagesCountTokens } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
 import { inProcessMemo, readModelsStore, writeModelsStore } from '../models-store.ts';
-import { compactionResultToSse } from '../responses-compaction.ts';
 import type { ModelProvider, ModelProviderInstance, ProviderCallResult, UpstreamModel } from '../types.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { type ModelEndpointKey, type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/common';
@@ -328,9 +327,9 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
       // flows the same target pipeline as a native compact.
       const triggered = { ...body, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
       const response = await upstream.fetch('responses', { method: 'POST', body: JSON.stringify(triggered), signal }, extraHeaderOptions(headers));
-      if (!response.ok) return { response, modelKey: rawModel.id };
+      if (!response.ok) return { ok: false, response, modelKey: rawModel.id };
       const generated = (await response.json()) as ResponsesResult;
-      return { response: compactionResultToSse(compactionResponse(input, generated)), modelKey: rawModel.id };
+      return { ok: true, result: compactionResponse(input, generated), modelKey: rawModel.id };
     },
     callMessages: callMessagesEndpoint('messages'),
     callMessagesCountTokens: callMessagesEndpoint('messages_count_tokens'),

--- a/apps/api/src/data-plane/providers/copilot/provider.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider.ts
@@ -187,6 +187,10 @@ const chatReasoningEffort = (body: Omit<ChatCompletionsPayload, 'model'>): strin
 
 const messagesReasoningEffort = (body: Omit<MessagesPayload, 'model'>): string | undefined => body.output_config?.effort;
 
+// The upstream fetch takes no options when there are no extra headers to attach.
+const extraHeaderOptions = (headers: Record<string, string> | undefined): { extraHeaders: Record<string, string> } | undefined =>
+  headers && Object.keys(headers).length > 0 ? { extraHeaders: headers } : undefined;
+
 const responsesReasoningEffort = (body: Omit<ResponsesPayload, 'model'>): string | undefined => (body.reasoning?.effort && body.reasoning.effort !== 'none' ? body.reasoning.effort : undefined);
 
 const rawModelFor = (model: UpstreamModel, endpoint: ModelEndpointKey, hints: ModelSelectionHints = {}): CopilotRawModel => {
@@ -268,7 +272,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
         body: JSON.stringify(requestBody),
         signal,
       },
-      headers && Object.keys(headers).length > 0 ? { extraHeaders: headers } : undefined,
+      extraHeaderOptions(headers),
     );
     return { response, modelKey: rawModel.id };
   };
@@ -325,7 +329,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
       // flows the same target pipeline as a native compact. compaction.ts does
       // the codex-equivalent trigger + retained-message reshape.
       const triggered = { ...body, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
-      const response = await upstream.fetch('responses', { method: 'POST', body: JSON.stringify(triggered), signal }, headers && Object.keys(headers).length > 0 ? { extraHeaders: headers } : undefined);
+      const response = await upstream.fetch('responses', { method: 'POST', body: JSON.stringify(triggered), signal }, extraHeaderOptions(headers));
       if (!response.ok) return { response, modelKey: rawModel.id };
       const generated = (await response.json()) as ResponsesResult;
       return { response: compactionResultToSse(compactionResponse(input, generated)), modelKey: rawModel.id };

--- a/apps/api/src/data-plane/providers/copilot/provider.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider.ts
@@ -187,7 +187,6 @@ const chatReasoningEffort = (body: Omit<ChatCompletionsPayload, 'model'>): strin
 
 const messagesReasoningEffort = (body: Omit<MessagesPayload, 'model'>): string | undefined => body.output_config?.effort;
 
-// The upstream fetch takes no options when there are no extra headers to attach.
 const extraHeaderOptions = (headers: Record<string, string> | undefined): { extraHeaders: Record<string, string> } | undefined =>
   headers && Object.keys(headers).length > 0 ? { extraHeaders: headers } : undefined;
 
@@ -326,8 +325,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
       // Compaction is inherently non-streaming — a single encrypted blob, not a
       // token stream — so we drive /responses with stream:false (bypassing the
       // SSE-forcing `call` helper) and re-emit the rebuilt envelope as SSE so it
-      // flows the same target pipeline as a native compact. compaction.ts does
-      // the codex-equivalent trigger + retained-message reshape.
+      // flows the same target pipeline as a native compact.
       const triggered = { ...body, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
       const response = await upstream.fetch('responses', { method: 'POST', body: JSON.stringify(triggered), signal }, extraHeaderOptions(headers));
       if (!response.ok) return { response, modelKey: rawModel.id };

--- a/apps/api/src/data-plane/providers/copilot/provider.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider.ts
@@ -324,7 +324,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
       // SSE-forcing `call` helper) and re-emit the rebuilt envelope as SSE so it
       // flows the same target pipeline as a native compact. compaction.ts does
       // the codex-equivalent trigger + retained-message reshape.
-      const triggered = { ...body, input: [...input, COMPACTION_TRIGGER as unknown as ResponsesInputItem], stream: false, model: rawModel.id };
+      const triggered = { ...body, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
       const response = await upstream.fetch('responses', { method: 'POST', body: JSON.stringify(triggered), signal }, headers && Object.keys(headers).length > 0 ? { extraHeaders: headers } : undefined);
       if (!response.ok) return { response, modelKey: rawModel.id };
       const generated = (await response.json()) as ResponsesResult;

--- a/apps/api/src/data-plane/providers/custom/provider.ts
+++ b/apps/api/src/data-plane/providers/custom/provider.ts
@@ -9,6 +9,7 @@ import { isStreamingEndpoint, modelConfigEndpoints } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
 import { inProcessMemo, isProviderModelsHttpStatus, readModelsStore, writeModelsStore } from '../models-store.ts';
+import { nativeCompactToSse } from '../responses-compaction.ts';
 import type { ModelProvider, ModelProviderInstance, ProviderCallResult, UpstreamModel } from '../types.ts';
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 
@@ -193,6 +194,7 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     getPricingForModelKey: modelKey => manualPricingByUpstreamId.get(modelKey) ?? pricingByRawId.get(modelKey) ?? null,
     callChatCompletions: (model, body, signal, headers) => call('chat_completions', model, body, signal, headers),
     callResponses: (model, body, signal, headers) => call('responses', model, body, signal, headers),
+    callResponsesCompact: (model, body, signal, headers) => nativeCompactToSse(call('responses_compact', model, body, signal, headers)),
     callMessages: (model, body, signal, headers, anthropicBeta) => call('messages', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call('messages_count_tokens', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callEmbeddings: (model, body, signal, headers) => call('embeddings', model, body, signal, headers),

--- a/apps/api/src/data-plane/providers/custom/provider.ts
+++ b/apps/api/src/data-plane/providers/custom/provider.ts
@@ -9,7 +9,7 @@ import { isStreamingEndpoint, modelConfigEndpoints } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
 import { inProcessMemo, isProviderModelsHttpStatus, readModelsStore, writeModelsStore } from '../models-store.ts';
-import { nativeCompactToSse } from '../responses-compaction.ts';
+import { nativeCompactionResult } from '../responses-compaction.ts';
 import type { ModelProvider, ModelProviderInstance, ProviderCallResult, UpstreamModel } from '../types.ts';
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 
@@ -194,7 +194,7 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     getPricingForModelKey: modelKey => manualPricingByUpstreamId.get(modelKey) ?? pricingByRawId.get(modelKey) ?? null,
     callChatCompletions: (model, body, signal, headers) => call('chat_completions', model, body, signal, headers),
     callResponses: (model, body, signal, headers) => call('responses', model, body, signal, headers),
-    callResponsesCompact: (model, body, signal, headers) => nativeCompactToSse(call('responses_compact', model, body, signal, headers)),
+    callResponsesCompact: (model, body, signal, headers) => nativeCompactionResult(call('responses_compact', model, body, signal, headers)),
     callMessages: (model, body, signal, headers, anthropicBeta) => call('messages', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call('messages_count_tokens', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callEmbeddings: (model, body, signal, headers) => call('embeddings', model, body, signal, headers),

--- a/apps/api/src/data-plane/providers/responses-compaction.ts
+++ b/apps/api/src/data-plane/providers/responses-compaction.ts
@@ -1,29 +1,11 @@
-import type { ProviderCallResult } from './types.ts';
-import { responsesResultToEvents, type ResponsesResult } from '@floway-dev/protocols/responses';
-
-// A `/responses/compact` upstream answer is a single non-streaming
-// `response.compaction` body, but the target pipeline only accepts
-// `text/event-stream` (it forces stream=true on every LLM endpoint). Rather
-// than teach the pipeline a non-SSE side path, every provider projects its
-// compaction envelope onto SSE here, serializing the canonical event sequence
-// `responsesResultToEvents` builds. Items expand generically (opaque
-// `output_item.added`/`.done`) so the input-shaped retained messages keep their
-// role and content rather than being rewritten as assistant output.
-export const compactionResultToSse = (result: ResponsesResult): Response => {
-  const body = responsesResultToEvents(result, { genericOutputItems: true })
-    .map(frame => `event: ${frame.event.type}\ndata: ${JSON.stringify(frame.event)}`)
-    .concat('data: [DONE]')
-    .join('\n\n');
-
-  return new Response(`${body}\n\n`, { headers: { 'content-type': 'text/event-stream' } });
-};
+import type { ProviderCallResult, ProviderCompactionResult } from './types.ts';
+import type { ResponsesResult } from '@floway-dev/protocols/responses';
 
 // Upstreams with a native `/responses/compact` (Azure, custom) answer with the
-// non-streaming envelope directly; project it onto the SSE the target pipeline
-// requires, leaving upstream error responses untouched so the boundary reports
-// them verbatim.
-export const nativeCompactToSse = async (call: Promise<ProviderCallResult>): Promise<ProviderCallResult> => {
-  const result = await call;
-  if (!result.response.ok) return result;
-  return { response: compactionResultToSse((await result.response.json()) as ResponsesResult), modelKey: result.modelKey };
+// `response.compaction` envelope directly; parse it into the result value the
+// target turns into frames, leaving an upstream error response untouched so the
+// boundary reports it verbatim.
+export const nativeCompactionResult = async (call: Promise<ProviderCallResult>): Promise<ProviderCompactionResult> => {
+  const { response, modelKey } = await call;
+  return response.ok ? { ok: true, result: (await response.json()) as ResponsesResult, modelKey } : { ok: false, response, modelKey };
 };

--- a/apps/api/src/data-plane/providers/responses-compaction.ts
+++ b/apps/api/src/data-plane/providers/responses-compaction.ts
@@ -1,33 +1,18 @@
 import type { ProviderCallResult } from './types.ts';
-import type { ResponsesResult } from '@floway-dev/protocols/responses';
+import { responsesResultToEvents, type ResponsesResult } from '@floway-dev/protocols/responses';
 
 // A `/responses/compact` upstream answer is a single non-streaming
 // `response.compaction` body, but the target pipeline only accepts
 // `text/event-stream` (it forces stream=true on every LLM endpoint). Rather
 // than teach the pipeline a non-SSE side path, every provider projects its
-// compaction envelope onto SSE here.
-//
-// The output items are emitted as opaque `output_item.added`/`.done` carriers
-// rather than via the terminal fast-path: a compaction envelope's retained
-// items are input-shaped user/developer/system messages, which the fast-path
-// expander (`responsesResultToEvents`) would rewrite as assistant output
-// messages with synthesized text deltas. Emitting them verbatim preserves their
-// role and content while still letting the source-serve store path mint stored
-// ids and persist each one (the compaction blob with forced upstream affinity).
+// compaction envelope onto SSE here, serializing the canonical event sequence
+// `responsesResultToEvents` builds. Items expand generically (opaque
+// `output_item.added`/`.done`) so the input-shaped retained messages keep their
+// role and content; the source-serve store path still mints stored ids and
+// persists each one (the compaction blob with forced upstream affinity).
 export const compactionResultToSse = (result: ResponsesResult): Response => {
-  const started = { ...result, status: 'in_progress', output: [], output_text: '' };
-  const events: Record<string, unknown>[] = [
-    { type: 'response.created', response: started },
-    { type: 'response.in_progress', response: started },
-  ];
-  result.output.forEach((item, output_index) => {
-    events.push({ type: 'response.output_item.added', output_index, item });
-    events.push({ type: 'response.output_item.done', output_index, item });
-  });
-  events.push({ type: 'response.completed', response: result });
-
-  const body = events
-    .map((event, sequence_number) => `event: ${event.type as string}\ndata: ${JSON.stringify({ ...event, sequence_number })}`)
+  const body = responsesResultToEvents(result, { genericOutputItems: true })
+    .map(frame => `event: ${frame.event.type}\ndata: ${JSON.stringify(frame.event)}`)
     .concat('data: [DONE]')
     .join('\n\n');
 

--- a/apps/api/src/data-plane/providers/responses-compaction.ts
+++ b/apps/api/src/data-plane/providers/responses-compaction.ts
@@ -8,8 +8,7 @@ import { responsesResultToEvents, type ResponsesResult } from '@floway-dev/proto
 // compaction envelope onto SSE here, serializing the canonical event sequence
 // `responsesResultToEvents` builds. Items expand generically (opaque
 // `output_item.added`/`.done`) so the input-shaped retained messages keep their
-// role and content; the source-serve store path still mints stored ids and
-// persists each one (the compaction blob with forced upstream affinity).
+// role and content rather than being rewritten as assistant output.
 export const compactionResultToSse = (result: ResponsesResult): Response => {
   const body = responsesResultToEvents(result, { genericOutputItems: true })
     .map(frame => `event: ${frame.event.type}\ndata: ${JSON.stringify(frame.event)}`)

--- a/apps/api/src/data-plane/providers/responses-compaction.ts
+++ b/apps/api/src/data-plane/providers/responses-compaction.ts
@@ -1,0 +1,45 @@
+import type { ProviderCallResult } from './types.ts';
+import type { ResponsesResult } from '@floway-dev/protocols/responses';
+
+// A `/responses/compact` upstream answer is a single non-streaming
+// `response.compaction` body, but the target pipeline only accepts
+// `text/event-stream` (it forces stream=true on every LLM endpoint). Rather
+// than teach the pipeline a non-SSE side path, every provider projects its
+// compaction envelope onto SSE here.
+//
+// The output items are emitted as opaque `output_item.added`/`.done` carriers
+// rather than via the terminal fast-path: a compaction envelope's retained
+// items are input-shaped user/developer/system messages, which the fast-path
+// expander (`responsesResultToEvents`) would rewrite as assistant output
+// messages with synthesized text deltas. Emitting them verbatim preserves their
+// role and content while still letting the source-serve store path mint stored
+// ids and persist each one (the compaction blob with forced upstream affinity).
+export const compactionResultToSse = (result: ResponsesResult): Response => {
+  const started = { ...result, status: 'in_progress', output: [], output_text: '' };
+  const events: Record<string, unknown>[] = [
+    { type: 'response.created', response: started },
+    { type: 'response.in_progress', response: started },
+  ];
+  result.output.forEach((item, output_index) => {
+    events.push({ type: 'response.output_item.added', output_index, item });
+    events.push({ type: 'response.output_item.done', output_index, item });
+  });
+  events.push({ type: 'response.completed', response: result });
+
+  const body = events
+    .map((event, sequence_number) => `event: ${event.type as string}\ndata: ${JSON.stringify({ ...event, sequence_number })}`)
+    .concat('data: [DONE]')
+    .join('\n\n');
+
+  return new Response(`${body}\n\n`, { headers: { 'content-type': 'text/event-stream' } });
+};
+
+// Upstreams with a native `/responses/compact` (Azure, custom) answer with the
+// non-streaming envelope directly; project it onto the SSE the target pipeline
+// requires, leaving upstream error responses untouched so the boundary reports
+// them verbatim.
+export const nativeCompactToSse = async (call: Promise<ProviderCallResult>): Promise<ProviderCallResult> => {
+  const result = await call;
+  if (!result.response.ok) return result;
+  return { response: compactionResultToSse((await result.response.json()) as ResponsesResult), modelKey: result.modelKey };
+};

--- a/apps/api/src/data-plane/providers/types.ts
+++ b/apps/api/src/data-plane/providers/types.ts
@@ -116,6 +116,12 @@ export interface ModelProvider {
   // interceptor stack today, but the parameter stays for interface uniformity.
   callChatCompletions(model: UpstreamModel, body: Omit<ChatCompletionsPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult>;
   callResponses(model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult>;
+  // Realizes `/responses/compact`: returns a non-streaming `response.compaction`
+  // body. Azure/custom pass the native `/responses/compact` endpoint through;
+  // Copilot has no native endpoint, so it drives `/responses` with a
+  // `compaction_trigger` input item and reshapes the result into the same
+  // envelope. A model whose upstream cannot compact surfaces the upstream error.
+  callResponsesCompact(model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult>;
   // Messages and count_tokens additionally receive the source-derived
   // `anthropicBeta` slice as a typed read-only input separate from the wire
   // headers. Copilot uses it to pick a raw upstream model variant

--- a/apps/api/src/data-plane/providers/types.ts
+++ b/apps/api/src/data-plane/providers/types.ts
@@ -5,7 +5,7 @@ import type { ModelEndpoints, ModelKind, ModelPricing } from '@floway-dev/protoc
 import type { EmbeddingsPayload } from '@floway-dev/protocols/embeddings';
 import type { ImagesGenerationsPayload } from '@floway-dev/protocols/images';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { ResponsesPayload, ResponsesResult } from '@floway-dev/protocols/responses';
 
 // The internal model shape: what providers produce and what the registry
 // stores. Only fields the data plane actually consumes — to expose downstream
@@ -102,6 +102,16 @@ export interface ProviderCallResult {
   modelKey: string;
 }
 
+// `/responses/compact` is non-streaming: the provider produces the
+// `response.compaction` envelope as a value — Azure/custom parse it from the
+// native endpoint, Copilot reshapes it from a `compaction_trigger` turn — so the
+// target builds the event frames itself rather than re-parsing a synthesized SSE
+// body. An upstream failure carries the raw Response so the boundary reports it
+// verbatim.
+export type ProviderCompactionResult =
+  | { ok: true; result: ResponsesResult; modelKey: string }
+  | { ok: false; response: Response; modelKey: string };
+
 export interface ModelProvider {
   getProvidedModels(): Promise<readonly UpstreamModel[]>;
   // Resolve pricing for a usage record's `model_key` (the raw upstream model
@@ -116,12 +126,11 @@ export interface ModelProvider {
   // interceptor stack today, but the parameter stays for interface uniformity.
   callChatCompletions(model: UpstreamModel, body: Omit<ChatCompletionsPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult>;
   callResponses(model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult>;
-  // Realizes `/responses/compact`: returns a non-streaming `response.compaction`
-  // body. Azure/custom pass the native `/responses/compact` endpoint through;
-  // Copilot has no native endpoint, so it drives `/responses` with a
-  // `compaction_trigger` input item and reshapes the result into the same
-  // envelope. A model whose upstream cannot compact surfaces the upstream error.
-  callResponsesCompact(model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult>;
+  // Realizes `/responses/compact`. Azure/custom parse the native endpoint's
+  // `response.compaction` body; Copilot has no native endpoint, so it drives
+  // `/responses` with a `compaction_trigger` input item and reshapes the result
+  // into the same envelope. See ProviderCompactionResult.
+  callResponsesCompact(model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCompactionResult>;
   // Messages and count_tokens additionally receive the source-derived
   // `anthropicBeta` slice as a typed read-only input separate from the wire
   // headers. Copilot uses it to pick a raw upstream model variant

--- a/apps/api/src/shared/upstream/azure.ts
+++ b/apps/api/src/shared/upstream/azure.ts
@@ -18,6 +18,7 @@ type AzureUpstreamRecord = UpstreamRecord & {
 const AZURE_OPENAI_PATHS: Partial<Record<EndpointKey, string>> = {
   chat_completions: '/chat/completions',
   responses: '/responses',
+  responses_compact: '/responses/compact',
   embeddings: '/embeddings',
   models: '/models',
   images_generations: '/images/generations',

--- a/apps/api/src/shared/upstream/copilot.ts
+++ b/apps/api/src/shared/upstream/copilot.ts
@@ -14,8 +14,9 @@ export interface CopilotUpstream extends Upstream {
 // `/v1/messages` for the Messages endpoint while keeping `/chat/completions`,
 // `/responses`, `/embeddings`, `/images/*`, and `/models` un-prefixed. These
 // paths are not admin-configurable: they reflect Copilot's own contract, not
-// a deployment choice.
-const COPILOT_PATHS: Record<EndpointKey, string> = {
+// a deployment choice. There is no native `/responses/compact`; the provider
+// replicates compaction over `/responses` itself, so that key is absent here.
+const COPILOT_PATHS: Partial<Record<EndpointKey, string>> = {
   chat_completions: '/chat/completions',
   responses: '/responses',
   messages: '/v1/messages',
@@ -35,8 +36,10 @@ export const createCopilotUpstream = (id: string, name: string, githubToken: str
     kind: 'copilot',
     endpoints: COPILOT_ENDPOINTS,
     fetch: async (endpoint, init, options) => {
+      const path = COPILOT_PATHS[endpoint];
+      if (path === undefined) throw new Error(`Copilot upstream does not serve the ${endpoint} endpoint`);
       try {
-        return await copilotFetch(COPILOT_PATHS[endpoint], init, githubToken, accountType, options?.extraHeaders ? { headers: options.extraHeaders } : undefined);
+        return await copilotFetch(path, init, githubToken, accountType, options?.extraHeaders ? { headers: options.extraHeaders } : undefined);
       } catch (error) {
         if (!isCopilotTokenFetchError(error)) throw error;
         return new Response(error.body, {

--- a/apps/api/src/shared/upstream/copilot.ts
+++ b/apps/api/src/shared/upstream/copilot.ts
@@ -14,8 +14,8 @@ export interface CopilotUpstream extends Upstream {
 // `/v1/messages` for the Messages endpoint while keeping `/chat/completions`,
 // `/responses`, `/embeddings`, `/images/*`, and `/models` un-prefixed. These
 // paths are not admin-configurable: they reflect Copilot's own contract, not
-// a deployment choice. There is no native `/responses/compact`; the provider
-// replicates compaction over `/responses` itself, so that key is absent here.
+// a deployment choice. Copilot has no native `/responses/compact` (compaction
+// is replicated over `/responses`), so that key is omitted.
 const COPILOT_PATHS: Partial<Record<EndpointKey, string>> = {
   chat_completions: '/chat/completions',
   responses: '/responses',

--- a/apps/api/src/shared/upstream/custom.ts
+++ b/apps/api/src/shared/upstream/custom.ts
@@ -27,6 +27,11 @@ import type { ModelEndpoints } from '@floway-dev/protocols/common';
 
 export type CustomAuthStyle = 'bearer' | 'anthropic';
 
+// Endpoints whose path an admin may override. count_tokens, the native compact
+// sub-path, and /models are derived or toggled elsewhere, never independently
+// overridable.
+type CustomPathOverrideKey = Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>;
+
 export interface CustomModelsFetch {
   enabled: boolean;
   endpoint?: string;
@@ -37,7 +42,7 @@ export interface CustomUpstreamConfig {
   bearerToken: string;
   authStyle: CustomAuthStyle;
   endpoints: ModelEndpoints;
-  pathOverrides?: Partial<Record<Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>, string>>;
+  pathOverrides?: Partial<Record<CustomPathOverrideKey, string>>;
   modelsFetch: CustomModelsFetch;
   models: UpstreamModelConfig[];
 }
@@ -83,7 +88,7 @@ const baseUrlField = (value: unknown): string => {
   return baseUrl;
 };
 
-const PATH_OVERRIDE_KEYS = new Set<Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>>(['chat_completions', 'responses', 'messages', 'embeddings', 'images_generations', 'images_edits']);
+const PATH_OVERRIDE_KEYS = new Set<CustomPathOverrideKey>(['chat_completions', 'responses', 'messages', 'embeddings', 'images_generations', 'images_edits']);
 
 const pathOverridesField = (value: unknown): CustomUpstreamConfig['pathOverrides'] => {
   if (value === undefined) return undefined;
@@ -91,12 +96,12 @@ const pathOverridesField = (value: unknown): CustomUpstreamConfig['pathOverrides
 
   const pathOverrides: NonNullable<CustomUpstreamConfig['pathOverrides']> = {};
   for (const [key, path] of Object.entries(value)) {
-    if (!PATH_OVERRIDE_KEYS.has(key as Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>)) {
+    if (!PATH_OVERRIDE_KEYS.has(key as CustomPathOverrideKey)) {
       throw new Error(`Malformed custom upstream config: unsupported pathOverrides key ${key}`);
     }
     const validPath = validateUpstreamPath(path, `pathOverrides.${key}`);
     if (!validPath.ok) throw new Error(`Malformed custom upstream config: ${validPath.error}`);
-    pathOverrides[key as Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>] = validPath.value;
+    pathOverrides[key as CustomPathOverrideKey] = validPath.value;
   }
   return pathOverrides;
 };

--- a/apps/api/src/shared/upstream/custom.ts
+++ b/apps/api/src/shared/upstream/custom.ts
@@ -37,7 +37,7 @@ export interface CustomUpstreamConfig {
   bearerToken: string;
   authStyle: CustomAuthStyle;
   endpoints: ModelEndpoints;
-  pathOverrides?: Partial<Record<Exclude<EndpointKey, 'messages_count_tokens' | 'models'>, string>>;
+  pathOverrides?: Partial<Record<Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>, string>>;
   modelsFetch: CustomModelsFetch;
   models: UpstreamModelConfig[];
 }
@@ -83,7 +83,7 @@ const baseUrlField = (value: unknown): string => {
   return baseUrl;
 };
 
-const PATH_OVERRIDE_KEYS = new Set<Exclude<EndpointKey, 'messages_count_tokens' | 'models'>>(['chat_completions', 'responses', 'messages', 'embeddings', 'images_generations', 'images_edits']);
+const PATH_OVERRIDE_KEYS = new Set<Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>>(['chat_completions', 'responses', 'messages', 'embeddings', 'images_generations', 'images_edits']);
 
 const pathOverridesField = (value: unknown): CustomUpstreamConfig['pathOverrides'] => {
   if (value === undefined) return undefined;
@@ -91,12 +91,12 @@ const pathOverridesField = (value: unknown): CustomUpstreamConfig['pathOverrides
 
   const pathOverrides: NonNullable<CustomUpstreamConfig['pathOverrides']> = {};
   for (const [key, path] of Object.entries(value)) {
-    if (!PATH_OVERRIDE_KEYS.has(key as Exclude<EndpointKey, 'messages_count_tokens' | 'models'>)) {
+    if (!PATH_OVERRIDE_KEYS.has(key as Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>)) {
       throw new Error(`Malformed custom upstream config: unsupported pathOverrides key ${key}`);
     }
     const validPath = validateUpstreamPath(path, `pathOverrides.${key}`);
     if (!validPath.ok) throw new Error(`Malformed custom upstream config: ${validPath.error}`);
-    pathOverrides[key as Exclude<EndpointKey, 'messages_count_tokens' | 'models'>] = validPath.value;
+    pathOverrides[key as Exclude<EndpointKey, 'messages_count_tokens' | 'responses_compact' | 'models'>] = validPath.value;
   }
   return pathOverrides;
 };
@@ -141,6 +141,7 @@ export const assertCustomUpstreamRecord = (record: UpstreamRecord): CustomUpstre
 const CUSTOM_DEFAULT_PATHS: Record<EndpointKey, string> = {
   chat_completions: '/v1/chat/completions',
   responses: '/v1/responses',
+  responses_compact: '/v1/responses/compact',
   messages: '/v1/messages',
   messages_count_tokens: '/v1/messages/count_tokens',
   embeddings: '/v1/embeddings',
@@ -155,6 +156,11 @@ const resolveCustomPath = (config: CustomUpstreamConfig, endpoint: EndpointKey):
   if (endpoint === 'messages_count_tokens') {
     const messagesPath = config.pathOverrides?.messages ?? CUSTOM_DEFAULT_PATHS.messages;
     return `${messagesPath}/count_tokens`;
+  }
+  // Native compact likewise tracks the `responses` path, appending `/compact`.
+  if (endpoint === 'responses_compact') {
+    const responsesPath = config.pathOverrides?.responses ?? CUSTOM_DEFAULT_PATHS.responses;
+    return `${responsesPath}/compact`;
   }
   // The /models path lives on the fetch toggle, not in pathOverrides.
   if (endpoint === 'models') {

--- a/apps/api/src/shared/upstream/types.ts
+++ b/apps/api/src/shared/upstream/types.ts
@@ -19,8 +19,9 @@ export type UpstreamKind = 'copilot' | 'custom' | 'azure';
 // Logical endpoint keys used by the gateway-internal upstream dispatcher.
 // `messages_count_tokens` is intentionally a logical key: it is a sub-path of
 // `messages` and follows the same provider-owned path policy, so the UI never
-// exposes it as a separate configurable endpoint.
-export type EndpointKey = 'chat_completions' | 'responses' | 'messages' | 'messages_count_tokens' | 'embeddings' | 'images_generations' | 'images_edits' | 'models';
+// exposes it as a separate configurable endpoint. `responses_compact` is the
+// native `/responses/compact` sub-path of `responses` (non-streaming).
+export type EndpointKey = 'chat_completions' | 'responses' | 'responses_compact' | 'messages' | 'messages_count_tokens' | 'embeddings' | 'images_generations' | 'images_edits' | 'models';
 
 export interface Upstream {
   id: string;

--- a/apps/api/src/test-helpers.ts
+++ b/apps/api/src/test-helpers.ts
@@ -361,6 +361,7 @@ export const stubProvider = (overrides: Partial<ModelProvider> = {}): ModelProvi
   getPricingForModelKey: () => null,
   callChatCompletions: () => Promise.reject(new Error('stubProvider.callChatCompletions was called')),
   callResponses: () => Promise.reject(new Error('stubProvider.callResponses was called')),
+  callResponsesCompact: () => Promise.reject(new Error('stubProvider.callResponsesCompact was called')),
   callMessages: () => Promise.reject(new Error('stubProvider.callMessages was called')),
   callMessagesCountTokens: () => Promise.reject(new Error('stubProvider.callMessagesCountTokens was called')),
   callEmbeddings: () => Promise.reject(new Error('stubProvider.callEmbeddings was called')),

--- a/packages/protocols/src/responses/from-result.ts
+++ b/packages/protocols/src/responses/from-result.ts
@@ -286,12 +286,18 @@ const responsesOutputItemEvents = (item: ResponsesOutputItem, outputIndex: numbe
   }
 };
 
-export const responsesResultToEvents = (response: ResponsesResult): EventFrame<SequencedResponsesStreamEvent>[] => {
+// `genericOutputItems` expands every output item as a bare
+// `output_item.added`/`.done` pair instead of its per-type child events
+// (content parts, text deltas, …). The compaction fast path needs this: its
+// retained items are input-shaped messages that the per-type expander would
+// rewrite as assistant `output_text`.
+export const responsesResultToEvents = (response: ResponsesResult, options?: { genericOutputItems?: boolean }): EventFrame<SequencedResponsesStreamEvent>[] => {
   const started = responsesStartSnapshot(response);
+  const expandItem = options?.genericOutputItems ? responsesGenericOutputItemEvents : responsesOutputItemEvents;
   const events: ResponsesStreamEvent[] = [
     { type: 'response.created', response: started },
     { type: 'response.in_progress', response: started },
-    ...response.output.flatMap(responsesOutputItemEvents),
+    ...response.output.flatMap((item, index) => expandItem(item, index)),
     { type: getTerminalEventName(response), response },
   ];
 

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -50,6 +50,7 @@ export type ResponsesInputItem =
   | ResponsesToolSearchCallItem
   | ResponsesToolSearchOutputItem
   | ResponsesCompactionItem
+  | ResponsesCompactionTriggerItem
   | ResponsesInputImageGenerationCall
   | ResponsesCodeInterpreterCallItem
   | ResponsesLocalShellCallItem
@@ -191,6 +192,12 @@ export interface ResponsesToolSearchOutputItem extends ResponsesPermissiveItem<'
 }
 
 export type ResponsesCompactionItem = ResponsesPermissiveItem<'compaction'>;
+
+// codex's RemoteCompactionV2 trigger: a payload-free input item appended last to
+// a `/responses` call to request a compaction. Modeled permissively so callers
+// can build it without a cast; the translators reject it like any item they do
+// not handle.
+export type ResponsesCompactionTriggerItem = ResponsesPermissiveItem<'compaction_trigger'>;
 
 export interface ResponsesCodeInterpreterCallItem extends ResponsesPermissiveItem<'code_interpreter_call'> {
   call_id?: string;


### PR DESCRIPTION
Adds `/responses/compact` as a structured endpoint on the Responses source.

## Design

`/responses/compact` is a distinct source endpoint (`LlmEndpointName` += `compact`). It reuses the generate scaffolding (parse, store, persist output items) but:
- **Non-streaming** — the upstream answer is a single `response.compaction` envelope, collected into one JSON body.
- **Never translates** — compaction is meaningful only against an upstream that natively serves `/responses`; `pickTarget` yields only the `responses` target, and a model without it is rejected at the source with `model-unsupported`. Translation can't represent a `compaction_trigger`, so it is never attempted (and #35's translators reject one defensively).
- Output items (retained messages + compaction blob) flow the shared source-serve store path; the blob persists with forced upstream affinity for next-turn routing.

## Frame-direct, no SSE round-trip

Target interceptors run on decoded `ProtocolFrame`s, not on SSE bytes, so compaction builds frames directly and still runs the same interceptor stack as generation — no synthesized-SSE serialize/reparse.

`callResponsesCompact` returns a `ProviderCompactionResult` value (`{ ok, result } | { ok: false, response }`):
- **Azure / custom**: parse the native `/responses/compact` body (`nativeCompactionResult`).
- **Copilot**: no native endpoint, so it drives `/responses` with a trailing `{"type":"compaction_trigger"}` input item (stream:false), keeps the single `compaction` output item, and reconstructs the retained `user`/`developer`/`system` messages.

`emitToResponsesCompact` then expands the result into canonical event frames via `responsesResultToEvents(..., { genericOutputItems })` (generic expansion keeps the input-shaped retained messages intact) wrapped in `runInterceptors`. The shared upstream-error handling is extracted into `targetUpstreamErrorResult`; the streaming SSE boundary is otherwise unchanged.

## Retained reconstruction (Copilot)

Mirrors codex `build_v2_compacted_history` ([codex@ebb7980](https://github.com/openai/codex/blob/ebb79803697acee75baf24073ef49af87ad7e483/codex-rs/core/src/compact_remote_v2.rs#L409-L457)) so the Copilot result matches a native Azure answer: retained user/developer/system messages first (input-message shape with a minted id where the client sent none), the compaction item last, ready to resend `output` verbatim as the next turn's `input`. Token accounting uses codex's heuristic `ceil(utf8_bytes / 4)` (images cost 0), truncating newest-first to 64k.

`responses_compact` is added as an upstream `EndpointKey` (Azure/custom only; Copilot omits it and replicates over `/responses`).

## Tests

- `compaction_test.ts`: reshape unit tests (retained filter, drop assistant, exactly-one-compaction guard, 64k truncation).
- `serve_test.ts`: serve-level tests for the Copilot trigger path, native passthrough, and unsupported-model rejection.

Typecheck + lint + full suite green.