### PR TITLE
refactor(capabilities): drop endpoints.messages.countTokens sub-field

### DIFF
--- a/apps/api/migrations/0025_drop_messages_count_tokens.sql
+++ b/apps/api/migrations/0025_drop_messages_count_tokens.sql
@@ -1,0 +1,37 @@
+-- Strip the now-removed `endpoints.messages.countTokens` sub-field from stored
+-- upstream configs. `messages` presence alone implies count_tokens (mirroring
+-- the way `responses` presence implies the compact sub-path), so the boolean
+-- sub-field is dead weight. The runtime validator already discards unknown
+-- sub-fields on load, so this is cosmetic: it keeps stored data aligned with
+-- the type definition.
+
+-- Per-model (azure + custom): walk $.models[*].endpoints.messages and drop
+-- countTokens. json_group_array over json_each rebuilds the array in place.
+UPDATE upstreams
+SET config_json = json_set(
+  config_json,
+  '$.models',
+  (
+    SELECT json_group_array(
+      CASE
+        WHEN json_type(model.value, '$.endpoints.messages') = 'object'
+          THEN json_set(model.value, '$.endpoints.messages', json_remove(json_extract(model.value, '$.endpoints.messages'), '$.countTokens'))
+        ELSE model.value
+      END
+    )
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+  )
+)
+WHERE provider IN ('azure', 'custom')
+  AND json_type(config_json, '$.models') = 'array'
+  AND json_array_length(json_extract(config_json, '$.models')) > 0;
+
+-- Custom upstream-level fallback: $.endpoints.messages.countTokens.
+UPDATE upstreams
+SET config_json = json_set(
+  config_json,
+  '$.endpoints.messages',
+  json_remove(json_extract(config_json, '$.endpoints.messages'), '$.countTokens')
+)
+WHERE provider = 'custom'
+  AND json_type(config_json, '$.endpoints.messages') = 'object';

--- a/apps/api/src/control-plane/schemas.ts
+++ b/apps/api/src/control-plane/schemas.ts
@@ -56,7 +56,7 @@ const disabledPublicModelIdsSchema = z.array(z.string()).transform(normalizeDisa
 const modelEndpointsSchema = z.object({
   chatCompletions: z.object({}).optional(),
   responses: z.object({}).optional(),
-  messages: z.object({ countTokens: z.boolean().optional() }).optional(),
+  messages: z.object({}).optional(),
   embeddings: z.object({}).optional(),
   imagesGenerations: z.object({}).optional(),
   imagesEdits: z.object({}).optional(),

--- a/apps/api/src/data-plane/llm/sources/gemini/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/gemini/traits.ts
@@ -131,7 +131,7 @@ const geminiCountTokens: LlmHttpEndpoint<readonly GeminiContent[], GeminiStreamE
       store: undefined,
       model: parsed.model,
       downstreamAbortController: undefined,
-      pickTarget: endpoints => endpoints.messages?.countTokens ? 'messages' : null,
+      pickTarget: endpoints => endpoints.messages ? 'messages' : null,
       attempt: async ({ binding, model: resolvedModelId, rewriteItems }) => {
         const countRequest = structuredClone(generateContentRequest);
         if (countRequest.contents !== undefined) countRequest.contents = await rewriteItems(countRequest.contents);

--- a/apps/api/src/data-plane/llm/sources/messages/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/messages/traits.ts
@@ -137,9 +137,11 @@ const messagesGenerate: LlmHttpEndpoint<readonly MessagesMessage[], MessagesStre
 };
 
 // count_tokens shares the Messages input and provider walk but produces a
-// measurement, not a stream: it gates on the `messages.countTokens` upstream
-// capability, calls that endpoint through the same count_tokens interceptors,
-// and proxies the upstream body back as a plain result.
+// count_tokens shares the Messages input and provider walk but produces a
+// measurement, not a stream: it routes alongside the Messages capability
+// (presence of `messages` implies count_tokens), calls the count_tokens
+// endpoint through the same count_tokens interceptors, and proxies the
+// upstream body back as a plain result.
 const messagesCountTokens: LlmHttpEndpoint<readonly MessagesMessage[], MessagesStreamEvent> = {
   respond: async ({ c, result, runtime }) =>
     await respondMessages(c, result, runtime.wantsStream, runtime.request, runtime.downstreamAbortController),
@@ -157,7 +159,7 @@ const messagesCountTokens: LlmHttpEndpoint<readonly MessagesMessage[], MessagesS
       store: undefined,
       model: payload.model,
       downstreamAbortController: undefined,
-      pickTarget: endpoints => endpoints.messages?.countTokens ? 'messages' : null,
+      pickTarget: endpoints => endpoints.messages ? 'messages' : null,
       attempt: async ({ binding, model, rewriteItems }) => {
         const attemptPayload = structuredClone(payload);
         attemptPayload.model = model;

--- a/apps/api/src/data-plane/providers/azure/provider.ts
+++ b/apps/api/src/data-plane/providers/azure/provider.ts
@@ -3,7 +3,7 @@ import { assertAzureUpstreamRecord, createAzureUpstream } from '../../../shared/
 import { publicModelId, type UpstreamModelConfig } from '../../../shared/upstream/model-config.ts';
 import type { EndpointKey } from '../../../shared/upstream/types.ts';
 import { mergeAnthropicBetaHeader } from '../anthropic-beta.ts';
-import { isStreamingEndpoint, modelConfigEndpoints } from '../endpoints.ts';
+import { isStreamingEndpoint } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
 import type { ModelProvider, ModelProviderInstance, ProviderCallResult, UpstreamModel } from '../types.ts';
@@ -50,7 +50,7 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
         // defaults or the upstream. See `resolveEffectiveFlags` for layer semantics.
         const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
         const effective = resolveEffectiveFlags(defaultsForProvider('azure'), [azure.flagOverrides, modelLayer]);
-        const endpoints = modelConfigEndpoints(model);
+        const endpoints = model.endpoints;
         return {
           ...azureInternalModel(model),
           kind: kindForEndpoints(endpoints),

--- a/apps/api/src/data-plane/providers/azure/provider_test.ts
+++ b/apps/api/src/data-plane/providers/azure/provider_test.ts
@@ -194,7 +194,7 @@ test('createAzureProvider supports native Azure Anthropic Messages models', asyn
   const seen: Array<{ url: string; xApiKey: string | null; body: Record<string, unknown>; beta: string | null }> = [];
 
   assertEquals(model.id, 'claude-public');
-  assertEquals(model.endpoints, { messages: { countTokens: true } });
+  assertEquals(model.endpoints, { messages: {} });
 
   await withMockedFetch(
     async request => {

--- a/apps/api/src/data-plane/providers/copilot/provider.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider.ts
@@ -12,7 +12,7 @@ import type { UpstreamRecord } from '../../../repo/types.ts';
 import { isCopilotAccountType, type CopilotAccountType } from '../../../shared/copilot.ts';
 import { createCopilotUpstream } from '../../../shared/upstream/copilot.ts';
 import type { EndpointKey } from '../../../shared/upstream/types.ts';
-import { isStreamingEndpoint, withMessagesCountTokens } from '../endpoints.ts';
+import { isStreamingEndpoint } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
 import { inProcessMemo, readModelsStore, writeModelsStore } from '../models-store.ts';
@@ -171,7 +171,7 @@ const copilotModelEndpoints = (publicModel: CopilotRawModel, rawModels: readonly
   }
 
   if (publicModel.id.startsWith('claude-') || rawModels.some(model => rawModelSupportsEndpoint(model, 'messages'))) {
-    return withMessagesCountTokens({ messages: {} });
+    return { messages: {} };
   }
 
   if (rawModels.some(model => rawModelSupportsEndpoint(model, 'chatCompletions'))) {

--- a/apps/api/src/data-plane/providers/copilot/provider_test.ts
+++ b/apps/api/src/data-plane/providers/copilot/provider_test.ts
@@ -154,7 +154,7 @@ test('Copilot provider owns the claude-* Messages capability workaround', async 
       const [model] = await provider.getProvidedModels();
 
       assertEquals(model.id, 'claude-haiku-chat-listed');
-      assertEquals(model.endpoints, { messages: { countTokens: true } });
+      assertEquals(model.endpoints, { messages: {} });
 
       await provider.callMessages(model, {
         max_tokens: 100,

--- a/apps/api/src/data-plane/providers/custom/provider.ts
+++ b/apps/api/src/data-plane/providers/custom/provider.ts
@@ -5,7 +5,7 @@ import { assertCustomUpstreamRecord, createCustomUpstream } from '../../../share
 import { publicModelId } from '../../../shared/upstream/model-config.ts';
 import type { EndpointKey } from '../../../shared/upstream/types.ts';
 import { mergeAnthropicBetaHeader } from '../anthropic-beta.ts';
-import { isStreamingEndpoint, modelConfigEndpoints } from '../endpoints.ts';
+import { isStreamingEndpoint } from '../endpoints.ts';
 import { resolveEffectiveFlags } from '../flags-resolve.ts';
 import { defaultsForProvider } from '../flags.ts';
 import { inProcessMemo, isProviderModelsHttpStatus, readModelsStore, writeModelsStore } from '../models-store.ts';
@@ -113,7 +113,7 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     // `resolveEffectiveFlags` for layer semantics.
     const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
     const enabledFlags = resolveEffectiveFlags(defaultsForProvider('custom'), [record.flagOverrides, modelLayer]);
-    const endpoints = modelConfigEndpoints(model);
+    const endpoints = model.endpoints;
     const internal: UpstreamModel = {
       id: publicModelId(model),
       limits: { ...(model.limits ?? {}) },

--- a/apps/api/src/data-plane/providers/endpoints.ts
+++ b/apps/api/src/data-plane/providers/endpoints.ts
@@ -1,7 +1,6 @@
-import type { UpstreamModelConfig } from '../../shared/upstream/model-config.ts';
 import type { EndpointKey } from '../../shared/upstream/types.ts';
 import type { LlmTargetApi } from '../llm/interceptors.ts';
-import type { ModelEndpointKey, ModelEndpoints } from '@floway-dev/protocols/common';
+import type { ModelEndpointKey } from '@floway-dev/protocols/common';
 
 export const llmTargetApiToModelEndpoint = (target: LlmTargetApi): ModelEndpointKey => {
   switch (target) {
@@ -20,13 +19,3 @@ export const llmTargetApiToModelEndpoint = (target: LlmTargetApi): ModelEndpoint
 // `messages_count_tokens` and `embeddings` remain non-streaming JSON.
 export const isStreamingEndpoint = (endpoint: EndpointKey): boolean =>
   endpoint === 'chat_completions' || endpoint === 'responses' || endpoint === 'messages';
-
-// `messages.countTokens` is not operator-configured: it is derived here whenever
-// `messages` is present so the count-tokens endpoint routes alongside it.
-export const withMessagesCountTokens = (endpoints: ModelEndpoints): ModelEndpoints =>
-  endpoints.messages ? { ...endpoints, messages: { ...endpoints.messages, countTokens: true } } : { ...endpoints };
-
-// A manually configured model declares its structured `endpoints` directly; we
-// only derive the `messages.countTokens` sub-capability on top.
-export const modelConfigEndpoints = (model: UpstreamModelConfig): ModelEndpoints =>
-  withMessagesCountTokens(model.endpoints);

--- a/apps/api/src/data-plane/providers/registry_test.ts
+++ b/apps/api/src/data-plane/providers/registry_test.ts
@@ -183,7 +183,7 @@ test('getInternalModels returns the catalog projection without execution binding
       assertEquals(Object.hasOwn(model!, 'providerData'), false);
 
       const resolved = await resolveModelForRequest('shared-model');
-      assertEquals(resolved.model?.endpoints, { messages: { countTokens: true }, chatCompletions: {} });
+      assertEquals(resolved.model?.endpoints, { messages: {}, chatCompletions: {} });
       assertEquals(
         resolved.model?.providers.map(({ upstream }) => upstream),
         ['up_copilot', 'up_custom'],
@@ -235,7 +235,7 @@ test('resolveModelForRequest applies provider-owned aliases only to that provide
       const resolved = await resolveModelForRequest('claude-opus-4-7-20300101');
 
       assertEquals(resolved.id, 'claude-opus-4-7');
-      assertEquals(resolved.model?.endpoints, { messages: { countTokens: true } });
+      assertEquals(resolved.model?.endpoints, { messages: {} });
       assertEquals(
         resolved.model?.providers.map(({ upstream }) => upstream),
         ['up_copilot'],

--- a/apps/api/src/shared/upstream/model-config.ts
+++ b/apps/api/src/shared/upstream/model-config.ts
@@ -53,11 +53,10 @@ const MODEL_ENDPOINT_KEYS: ReadonlySet<ModelEndpointKey> = new Set<ModelEndpoint
 ]);
 
 // The structured per-model capability map. A present key declares the model is
-// served by that endpoint; its value object carries that endpoint's
-// sub-capabilities (`messages.countTokens` is derived at load time, so no
-// operator-configurable sub-capability is stored here today). `allowEmpty` is
-// set for the upstream-level fallback map (an upstream may serve only
-// kind-derived embedding/image models and declare no chat endpoint).
+// served by that endpoint; the empty value object is a placeholder reserved
+// for future per-endpoint sub-capabilities. `allowEmpty` is set for the
+// upstream-level fallback map (an upstream may serve only kind-derived
+// embedding/image models and declare no chat endpoint).
 export const endpointsField = (value: unknown, label: string, options: { allowEmpty?: boolean } = {}): ModelEndpoints => {
   if (!isRecord(value)) throw new Error(`Malformed ${label}: must be an object`);
   const endpoints: ModelEndpoints = {};

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -12,7 +12,7 @@ export type ModelKind = 'chat' | 'embedding' | 'image';
 export interface ModelEndpoints {
   chatCompletions?: {};
   responses?: {};
-  messages?: { countTokens?: boolean };
+  messages?: {};
   embeddings?: {};
   imagesGenerations?: {};
   imagesEdits?: {};

--- a/packages/protocols/src/common/capabilities.ts
+++ b/packages/protocols/src/common/capabilities.ts
@@ -4,14 +4,16 @@
 
 import type { ModelKind } from './models.ts';
 
-// Structured per-endpoint capability map. A key being present means the model is
-// served by that endpoint; its value object carries that endpoint's
-// sub-capabilities. `messages.countTokens` is an auxiliary sub-path of its
-// primary endpoint, not an independently advertised endpoint.
+// Structured per-endpoint capability map. A key being present means the model
+// is served by that endpoint; its value object carries that endpoint's
+// sub-capabilities, if any. Sub-paths derived from a base endpoint
+// (`/messages/count_tokens` from `messages`, `/responses/compact` from
+// `responses`) are not modeled separately — presence of the base endpoint
+// implies them.
 export interface ModelEndpoints {
   chatCompletions?: {};
   responses?: {};
-  messages?: { countTokens?: boolean };
+  messages?: {};
   embeddings?: {};
   imagesGenerations?: {};
   imagesEdits?: {};


### PR DESCRIPTION
Presence of `messages` always implies the count_tokens sub-path. The validator already discards any operator-set `countTokens` value (it writes `{}` regardless of input) and `withMessagesCountTokens` unconditionally set `countTokens: true` whenever messages was present — so the sub-field carried no information.

Mirror the same shape `responses` takes (presence implies the compact sub-path with no operator-configurable sub-field):

- Drop the boolean from `ModelEndpoints`, the Zod schema, and the web type.
- Source endpoints that gated on `endpoints.messages?.countTokens` now check `endpoints.messages` directly.
- `withMessagesCountTokens` becomes dead code; the one-line `modelConfigEndpoints` wrapper around it goes too. Azure/custom inline `model.endpoints`; copilot's claude-* branch returns `{ messages: {} }` directly.

## Migration

`0025_drop_messages_count_tokens.sql` strips the now-unused sub-field from stored upstream configs:
- Per-model (azure + custom): walks `$.models[*].endpoints.messages` and drops `countTokens` via `json_remove`.
- Upstream-level (custom only): drops `$.endpoints.messages.countTokens`.

Verified the migration on sample data with `sqlite3` before commit.

## Tests

Existing test fixtures that asserted `{ messages: { countTokens: true } }` (4 sites) updated to `{ messages: {} }`. Full suite green: typecheck + lint + 1194 api tests + 16 protocols tests + 371 translate tests.