### PR TITLE
feat(responses): implement /responses/compact

### DIFF
--- a/apps/api/src/data-plane/llm/routes.ts
+++ b/apps/api/src/data-plane/llm/routes.ts
@@ -10,6 +10,7 @@ import { serveLlm } from './sources/serve.ts';
 export const mountLlmRoutes = (app: Hono) => {
   const serveChatCompletions = serveLlm(chatCompletionsTraits, 'generate');
   const serveResponses = serveLlm(responsesTraits, 'generate');
+  const serveResponsesCompact = serveLlm(responsesTraits, 'compact');
   const serveMessages = serveLlm(messagesTraits, 'generate');
   const serveMessagesCountTokens = serveLlm(messagesTraits, 'countTokens');
   const serveGeminiGenerate = serveLlm(geminiTraits, 'generate');
@@ -23,6 +24,8 @@ export const mountLlmRoutes = (app: Hono) => {
   app.post('/chat/completions', serveChatCompletions);
   app.post('/v1/responses', serveResponses);
   app.post('/responses', serveResponses);
+  app.post('/v1/responses/compact', serveResponsesCompact);
+  app.post('/responses/compact', serveResponsesCompact);
   app.get('/v1/responses', responsesWebSocket);
   app.get('/responses', responsesWebSocket);
   app.post('/v1/messages', serveMessages);

--- a/apps/api/src/data-plane/llm/sources/execution.ts
+++ b/apps/api/src/data-plane/llm/sources/execution.ts
@@ -49,7 +49,7 @@ export const executeLlmSourcePlan = async <TItems, TEvent>(
       targetApi: target,
       upstream: binding.upstream,
       store: plan.store,
-      commitSnapshot: plan.commitStatefulResponsesSnapshot === true,
+      snapshotMode: plan.responsesSnapshotMode ?? 'none',
     }, plan.request, plan.wantsStream);
     return { result: { ...rawResult, events: stored.events }, commitForNonStreaming: stored.commitForNonStreaming };
   }

--- a/apps/api/src/data-plane/llm/sources/responses/items/output.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output.ts
@@ -1,6 +1,7 @@
 import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StoredResponsesItem } from '../../../../../repo/types.ts';
 import type { LlmTargetApi, RequestContext } from '../../../interceptors.ts';
+import type { ResponsesSnapshotMode } from '../stateful-store.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type {
   ResponsesItemFinalizedHandler,
@@ -47,7 +48,7 @@ export interface StoreResponsesContext {
   readonly targetApi: LlmTargetApi;
   readonly upstream: string;
   readonly store: boolean | null | undefined;
-  readonly commitSnapshot?: boolean;
+  readonly snapshotMode: ResponsesSnapshotMode;
 }
 
 // Flushes the rows buffered during a non-streaming drain. Streaming has no
@@ -91,9 +92,9 @@ export const storeResponsesOutputItems = <TFrame>(
       console.error('Failed to persist stored Responses items:', error);
     }
   };
-  const commitSnapshot = async (responseId: string): Promise<void> => {
+  const commitSnapshot = async (responseId: string, mode: 'append' | 'replace'): Promise<void> => {
     try {
-      await statefulResponsesStore.commitSnapshot(responseId);
+      await statefulResponsesStore.commitSnapshot(responseId, mode);
     } catch (error) {
       console.error('Failed to persist stored Responses snapshot:', error);
     }
@@ -112,7 +113,7 @@ export const storeResponsesOutputItems = <TFrame>(
     ? undefined
     : async (): Promise<void> => {
       await commitStoredItems();
-      if (context.commitSnapshot && terminalResponseId !== null) await commitSnapshot(terminalResponseId);
+      if (context.snapshotMode !== 'none' && terminalResponseId !== null) await commitSnapshot(terminalResponseId, context.snapshotMode);
     };
 
   const events = commitSnapshotFromTerminal(
@@ -170,13 +171,13 @@ const commitSnapshotFromTerminal = async function* <TFrame>(
   context: StoreResponsesContext,
   wantsStream: boolean,
   rememberTerminalResponseId: (id: string) => void,
-  commitSnapshot: (id: string) => Promise<void>,
+  commitSnapshot: (id: string, mode: 'append' | 'replace') => Promise<void>,
 ): AsyncGenerator<TFrame> {
   for await (const frame of frames) {
     const responseId = terminalResponseId(frame);
     if (responseId !== null) {
       rememberTerminalResponseId(responseId);
-      if (wantsStream && context.commitSnapshot) await commitSnapshot(responseId);
+      if (wantsStream && context.snapshotMode !== 'none') await commitSnapshot(responseId, context.snapshotMode);
     }
     yield frame;
   }

--- a/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/items/output_test.ts
@@ -22,6 +22,7 @@ const makeContext = (overrides: Partial<StoreResponsesContext> = {}): StoreRespo
   targetApi: overrides.targetApi ?? 'responses',
   upstream: overrides.upstream ?? 'up_native',
   store: overrides.store,
+  snapshotMode: overrides.snapshotMode ?? 'none',
 });
 
 const makeRequest = (

--- a/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/serve_test.ts
@@ -2102,3 +2102,385 @@ test('/v1/responses preserves custom upstream /models HTTP errors', async () => 
     },
   );
 });
+
+test('/v1/responses/compact rebuilds a compaction envelope from Copilot via compaction_trigger', async () => {
+  const { apiKey } = await setupAppTest();
+  let upstreamBody: Record<string, unknown> | undefined;
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      if (url.pathname === '/models') return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      if (url.pathname === '/responses') {
+        upstreamBody = JSON.parse(await request.text()) as Record<string, unknown>;
+        // Copilot has no native /responses/compact: it drives /responses with a
+        // trailing compaction_trigger and gets back the single compaction item.
+        return jsonResponse({
+          id: 'resp_trigger',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: [{ type: 'compaction', id: 'cmp_upstream', encrypted_content: 'BLOB' }],
+          usage: { input_tokens: 5, output_tokens: 0, total_tokens: 5 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'gpt-direct-responses', input: [{ type: 'message', role: 'user', content: 'summarize me' }] }),
+      });
+
+      assertEquals(response.status, 200);
+      const body = (await response.json()) as { object: string; output: Array<Record<string, unknown>> };
+      assertEquals(body.object, 'response.compaction');
+      const output = body.output;
+      const last = output[output.length - 1];
+      assertEquals(last.type, 'compaction');
+      assertEquals(last.encrypted_content, 'BLOB');
+      assertEquals(output[0].type, 'message');
+      assertEquals(output[0].role, 'user');
+    },
+  );
+
+  assertExists(upstreamBody);
+  const input = upstreamBody.input as Array<Record<string, unknown>>;
+  assertEquals(input[input.length - 1].type, 'compaction_trigger');
+  assertEquals(upstreamBody.stream, false);
+});
+
+test('/v1/responses/compact passes a native custom /responses/compact through', async () => {
+  const { repo, apiKey, copilotUpstream } = await setupAppTest();
+  await repo.upstreams.delete(copilotUpstream.id);
+  clearModelsStore();
+  await clearCopilotTokenCache();
+  await repo.upstreams.save(buildCustomUpstreamRecord({
+    id: 'up_native',
+    config: { baseUrl: 'https://native.example.com', bearerToken: 'sk-n', endpoints: { responses: {} } },
+  }));
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'native.example.com' && url.pathname === '/v1/models') return jsonResponse({ data: [{ id: 'native-model' }] });
+      if (url.hostname === 'native.example.com' && url.pathname === '/v1/responses/compact') {
+        return jsonResponse({
+          id: 'resp_native',
+          object: 'response.compaction',
+          model: 'native-model',
+          output: [
+            { type: 'message', id: 'msg_u', role: 'user', status: 'completed', content: [{ type: 'input_text', text: 'kept' }] },
+            { type: 'compaction', id: 'cmp_native', encrypted_content: 'NATIVE' },
+          ],
+          usage: { input_tokens: 3, output_tokens: 0, total_tokens: 3 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'native-model', input: [{ type: 'message', role: 'user', content: 'compact me' }] }),
+      });
+
+      assertEquals(response.status, 200);
+      const body = (await response.json()) as { object: string; output: Array<Record<string, unknown>> };
+      assertEquals(body.object, 'response.compaction');
+      const last = body.output[body.output.length - 1];
+      assertEquals(last.type, 'compaction');
+      assertEquals(last.encrypted_content, 'NATIVE');
+    },
+  );
+});
+
+test('/v1/responses/compact rejects a model without a native /responses endpoint', async () => {
+  const { apiKey } = await setupAppTest();
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      if (url.pathname === '/models') return jsonResponse(copilotModels([{ id: 'gpt-chat-only', supported_endpoints: ['/chat/completions'] }]));
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'gpt-chat-only', input: [{ type: 'message', role: 'user', content: 'hi' }] }),
+      });
+
+      assertEquals(response.status, 400);
+      const body = (await response.json()) as { error: { message: string } };
+      assertStringIncludes(body.error.message, 'does not support the /responses endpoint');
+    },
+  );
+});
+
+test('/v1/responses/compact relays a non-2xx native upstream response verbatim', async () => {
+  const { repo, apiKey, copilotUpstream } = await setupAppTest();
+  await repo.upstreams.delete(copilotUpstream.id);
+  clearModelsStore();
+  await clearCopilotTokenCache();
+  await repo.upstreams.save(buildCustomUpstreamRecord({
+    id: 'up_native_err',
+    config: { baseUrl: 'https://err.example.com', bearerToken: 'sk-e', endpoints: { responses: {} } },
+  }));
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'err.example.com' && url.pathname === '/v1/models') return jsonResponse({ data: [{ id: 'failing-model' }] });
+      if (url.hostname === 'err.example.com' && url.pathname === '/v1/responses/compact') {
+        return new Response(JSON.stringify({ error: { message: 'upstream blew up', type: 'server_error' } }), { status: 503, headers: { 'content-type': 'application/json' } });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'failing-model', input: [{ type: 'message', role: 'user', content: 'compact me' }] }),
+      });
+
+      assertEquals(response.status, 503);
+      const body = (await response.json()) as { error: { message: string; type: string } };
+      assertEquals(body.error.message, 'upstream blew up');
+      assertEquals(body.error.type, 'server_error');
+    },
+  );
+});
+
+test('/v1/responses/compact rejects an unknown previous_response_id with the OpenAI not-found envelope', async () => {
+  const { apiKey } = await setupAppTest();
+
+  await withMockedFetch(
+    async request => {
+      throw new Error(`Unexpected fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_does_not_exist',
+          input: [{ type: 'message', role: 'user', content: 'summarize me' }],
+        }),
+      });
+
+      assertEquals(response.status, 400);
+      const body = (await response.json()) as { error: { code: string; param: string; type: string } };
+      assertEquals(body.error.code, 'previous_response_not_found');
+      assertEquals(body.error.param, 'previous_response_id');
+      assertEquals(body.error.type, 'invalid_request_error');
+    },
+  );
+});
+
+test('/v1/responses/compact expands previous_response_id snapshot in front of the current input', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const upstreamBodies: Array<Record<string, unknown>> = [];
+  const assistantItem = {
+    type: 'message',
+    id: 'raw_assistant_turn1',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ type: 'output_text', text: 'First answer' }],
+  };
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      if (url.pathname === '/models') return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      if (url.pathname === '/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()) as Record<string, unknown>);
+        const turn = upstreamBodies.length;
+        if (turn === 1) {
+          return sseResponsesResponse({
+            id: 'resp_turn1',
+            object: 'response',
+            model: 'gpt-direct-responses',
+            status: 'completed',
+            output: [assistantItem],
+            output_text: 'First answer',
+            usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+          });
+        }
+        return jsonResponse({
+          id: 'resp_trigger',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: [{ type: 'compaction', id: 'cmp_upstream', encrypted_content: 'BLOB' }],
+          usage: { input_tokens: 5, output_tokens: 0, total_tokens: 5 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const first = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          input: [{ type: 'message', role: 'user', content: 'First question' }],
+          stream: false,
+        }),
+      });
+      assertEquals(first.status, 200);
+      await first.json();
+
+      const snapshot = await repo.responsesSnapshots.lookup(apiKey.id, 'resp_turn1');
+      assertExists(snapshot);
+      assertEquals(snapshot.itemIds.length, 2);
+
+      const compact = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_turn1',
+          input: [{ type: 'message', role: 'user', content: 'compact me' }],
+        }),
+      });
+      assertEquals(compact.status, 200);
+      await compact.json();
+    },
+  );
+
+  assertEquals(upstreamBodies.length, 2);
+  // Gateway resolves previous_response_id in-process: snapshot items first, current input next, compaction_trigger last.
+  assertEquals(Object.hasOwn(upstreamBodies[1], 'previous_response_id'), false);
+  assertEquals(upstreamBodies[1].stream, false);
+  const compactInput = upstreamBodies[1].input as Array<Record<string, unknown>>;
+  assertEquals(compactInput.map(item => item.type), ['message', 'message', 'message', 'compaction_trigger']);
+  assertEquals(compactInput[0].role, 'user');
+  assertEquals(compactInput[0].content, 'First question');
+  assertEquals(compactInput[1].role, 'assistant');
+  assertEquals(compactInput[2].role, 'user');
+  assertEquals(compactInput[2].content, 'compact me');
+});
+
+test('/v1/responses → /v1/responses/compact → /v1/responses chain: compact snapshot replaces history, third turn replays only the compact output', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const upstreamBodies: Array<Record<string, unknown>> = [];
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+      if (url.pathname === '/models') return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      if (url.pathname === '/responses') {
+        const body = JSON.parse(await request.text()) as Record<string, unknown>;
+        upstreamBodies.push(body);
+        const turn = upstreamBodies.length;
+        if (turn === 2) {
+          return jsonResponse({
+            id: 'resp_compact',
+            object: 'response',
+            model: 'gpt-direct-responses',
+            status: 'completed',
+            output: [{ type: 'compaction', id: 'cmp_upstream', encrypted_content: 'BLOB' }],
+            usage: { input_tokens: 5, output_tokens: 0, total_tokens: 5 },
+          });
+        }
+        return sseResponsesResponse({
+          id: turn === 1 ? 'resp_turn1' : 'resp_turn3',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: turn === 1
+            ? [{ type: 'message', id: 'raw_a1', role: 'assistant', status: 'completed', content: [{ type: 'output_text', text: 'First answer' }] }]
+            : [{ type: 'message', id: 'raw_a3', role: 'assistant', status: 'completed', content: [{ type: 'output_text', text: 'Third answer' }] }],
+          output_text: turn === 1 ? 'First answer' : 'Third answer',
+          usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      // Turn 1: a normal /responses call seeds a snapshot for resp_turn1
+      // containing the user's "First question" + the assistant's reply.
+      const first = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          input: [{ type: 'message', role: 'user', content: 'First question' }],
+          stream: false,
+        }),
+      });
+      assertEquals(first.status, 200);
+      await first.json();
+
+      // Turn 2: /responses/compact with previous_response_id=resp_turn1.
+      // Its snapshot should commit in 'replace' mode — output ONLY (the
+      // compaction blob), not previous + input + output.
+      const compact = await requestApp('/v1/responses/compact', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_turn1',
+          input: [{ type: 'message', role: 'user', content: 'compact me' }],
+        }),
+      });
+      assertEquals(compact.status, 200);
+      await compact.json();
+
+      const turn1Snapshot = await repo.responsesSnapshots.lookup(apiKey.id, 'resp_turn1');
+      assertExists(turn1Snapshot);
+      // Compact snapshot in 'replace' mode = compact response's output items
+      // only. The pre-compact resp_turn1 itemIds must NOT appear in the
+      // compact snapshot — that's the whole point: a follow-up call with
+      // previous_response_id=resp_compact replays only the compact context.
+      const compactSnapshot = await repo.responsesSnapshots.lookup(apiKey.id, 'resp_compact');
+      assertExists(compactSnapshot);
+      assertEquals(compactSnapshot.itemIds.some(id => turn1Snapshot.itemIds.includes(id)), false);
+      // The compact response's output here is `compactionResponse` reshaped:
+      // 3 retained input-shape messages (first_question, first_answer,
+      // "compact me") + the compaction blob = 4 items.
+      assertEquals(compactSnapshot.itemIds.length, 4);
+
+      // Turn 3: a follow-up /responses with previous_response_id=resp_compact.
+      // The upstream's input must be the compact output only — no original
+      // first-question/first-answer leakage.
+      const third = await requestApp('/v1/responses', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({
+          model: 'gpt-direct-responses',
+          previous_response_id: 'resp_compact',
+          input: [{ type: 'message', role: 'user', content: 'continue' }],
+          stream: false,
+        }),
+      });
+      assertEquals(third.status, 200);
+      await third.json();
+    },
+  );
+
+  assertEquals(upstreamBodies.length, 3);
+  const thirdInput = upstreamBodies[2].input as Array<Record<string, unknown>>;
+  // Replayed input carries the compaction blob + the new "continue" message.
+  // The snapshot-itemIds assertion above already pins the no-leakage
+  // invariant; here we just check the blob made it onto the wire and the
+  // new turn lands at the tail.
+  const types = thirdInput.map(item => item.type);
+  assertEquals(types.includes('compaction'), true);
+  const tail = thirdInput[thirdInput.length - 1];
+  assertEquals(tail.role, 'user');
+  const tailContent = tail.content;
+  const tailText = typeof tailContent === 'string' ? tailContent : (tailContent as Array<{ text?: string }>)[0]?.text;
+  assertEquals(tailText, 'continue');
+});

--- a/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/stateful-store.ts
@@ -40,10 +40,21 @@ interface LayeredStatefulResponsesStoreOptions {
   readonly stageInputs: boolean;
 }
 
+// How a Responses turn should commit its snapshot:
+//   - 'none'    : do not write a snapshot at all
+//   - 'append'  : conversation continuation — previous snapshot + this turn's
+//                 input + this turn's output. Default for /responses generate.
+//   - 'replace' : the turn's output IS the new conversation — drop prior
+//                 history and the stitched-in input. Used by /responses/compact
+//                 so that referencing the compact response via
+//                 previous_response_id replays only the retained messages +
+//                 the encrypted compaction blob, not the original full history.
+export type ResponsesSnapshotMode = 'none' | 'append' | 'replace';
+
 export interface WebSocketStatefulResponsesStoragePolicy {
   readonly statefulResponsesStore: StatefulResponsesStore;
   readonly outputStore: boolean | null | undefined;
-  readonly commitSnapshot: boolean;
+  readonly snapshotMode: ResponsesSnapshotMode;
 }
 
 export interface StatefulResponsesStore {
@@ -63,7 +74,7 @@ export interface StatefulResponsesStore {
   getPrivatePayload(id: string): unknown;
   stageOutputItem(row: StoredResponsesItem): void;
   commitOutputItems(): Promise<void>;
-  commitSnapshot(responseId: string): Promise<void>;
+  commitSnapshot(responseId: string, mode: 'append' | 'replace'): Promise<void>;
   refreshTouchedItems(): Promise<void>;
 }
 
@@ -194,10 +205,18 @@ class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     await this.commitItems([...this.stagedOutputItems.values()]);
   }
 
-  async commitSnapshot(responseId: string): Promise<void> {
+  async commitSnapshot(responseId: string, mode: 'append' | 'replace'): Promise<void> {
     if (this.options.snapshotWrites.length === 0 || this.committedSnapshotIds.has(responseId)) return;
     await this.commitItems([...this.stagedInputItems.values(), ...this.stagedOutputItems.values()]);
-    const itemIds = [...this.previousSnapshotItemIds, ...this.stagedInputItemIds, ...this.stagedOutputItemIds];
+    // 'append' is the conversation continuation default: previous snapshot +
+    // this turn's input + this turn's output. 'replace' (used by
+    // /responses/compact) drops the prior history and the stitched-in input
+    // — the upstream's compact output already echoes the retained messages
+    // and carries the encrypted blob, which is the entire context the next
+    // turn should see.
+    const itemIds = mode === 'replace'
+      ? [...this.stagedOutputItemIds]
+      : [...this.previousSnapshotItemIds, ...this.stagedInputItemIds, ...this.stagedOutputItemIds];
     if (itemIds.length === 0) return;
 
     const replayableRows = this.replayableRowsForSnapshot(itemIds);
@@ -560,7 +579,7 @@ const webSocketSessionOnlyPolicy = (
     stageInputs: true,
   }),
   outputStore: true,
-  commitSnapshot: true,
+  snapshotMode: 'append',
 });
 
 const webSocketDurablePolicy = (
@@ -580,7 +599,7 @@ const webSocketDurablePolicy = (
       stageInputs: true,
     }),
     outputStore: store,
-    commitSnapshot: true,
+    snapshotMode: 'append',
   };
 };
 

--- a/apps/api/src/data-plane/llm/sources/responses/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/traits.ts
@@ -2,17 +2,17 @@ import type { Context } from 'hono';
 
 import { responsesSourceInterceptors } from './interceptors/index.ts';
 import { respondResponses } from './respond.ts';
-import type { StatefulResponsesStore } from './stateful-store.ts';
+import type { ResponsesSnapshotMode, StatefulResponsesStore } from './stateful-store.ts';
 import { type LlmTargetApi, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
 import { emitToChatCompletions } from '../../targets/chat-completions/emit.ts';
 import { emitToMessages } from '../../targets/messages/emit.ts';
-import { emitToResponses } from '../../targets/responses/emit.ts';
+import { emitToResponses, emitToResponsesCompact } from '../../targets/responses/emit.ts';
 import { createHttpRequestContext } from '../request-context.ts';
 import { jsonUpstreamErrorResult, sourceErrorResult, type LlmEndpointPlan, type LlmHttpEndpoint, type LlmServeFailure, type LlmSourceTraits } from '../traits.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
-import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesCompactPayload, ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult, ProviderModelRecord } from '@floway-dev/provider';
 import { type SourceEmit, translateResponsesViaChatCompletions, translateResponsesViaMessages, viaTranslation } from '@floway-dev/translate';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
@@ -57,6 +57,12 @@ const rewriteResponsesEntryModelAlias = (payload: ResponsesPayload): ResponsesPa
     reasoning: { ...(payload.reasoning ?? {}), effort: 'low' },
   };
 };
+
+// Compact has no `reasoning` field, so only the model swap applies. The
+// codex alias rerouting is per-request semantics, not per-endpoint, so we
+// honour it here too.
+const rewriteResponsesCompactEntryModelAlias = (payload: ResponsesCompactPayload): ResponsesCompactPayload =>
+  payload.model === CODEX_AUTO_REVIEW_ALIAS ? { ...payload, model: CODEX_AUTO_REVIEW_TARGET } : payload;
 
 const responsesInputItemsForStorage = (input: ResponsesPayload['input']): ResponsesInputItem[] =>
   typeof input === 'string' ? [{ type: 'message', role: 'user', content: input }] : [...input];
@@ -104,7 +110,7 @@ interface SetupResponsesSourceOptions {
   readonly downstreamAbortController?: AbortController;
   readonly statefulResponsesStore?: StatefulResponsesStore;
   readonly storedItemsStore?: boolean | null | undefined;
-  readonly commitSnapshot?: boolean;
+  readonly snapshotMode?: ResponsesSnapshotMode;
 }
 
 export const setupResponsesSource = async (
@@ -137,7 +143,7 @@ export const setupResponsesSource = async (
     wantsStream,
     store: options.storedItemsStore ?? payload.store,
     statefulResponsesInputItems: currentInputItems,
-    commitStatefulResponsesSnapshot: options.commitSnapshot ?? payload.store !== false,
+    responsesSnapshotMode: options.snapshotMode ?? (payload.store !== false ? 'append' : 'none'),
     model: payload.model,
     downstreamAbortController,
     pickTarget: endpoints => endpoints.responses ? 'responses' : endpoints.messages ? 'messages' : endpoints.chatCompletions ? 'chat-completions' : null,
@@ -167,7 +173,68 @@ const responsesGenerate: LlmHttpEndpoint<string | readonly ResponsesInputItem[],
   prepare: async c => await setupResponsesSource(c, await c.req.json<ResponsesPayload>()),
 };
 
+// `/responses/compact` reuses the input stitching of /responses (alias
+// rewrite + previous_response_id snapshot expansion) and answers with a
+// single non-streaming `response.compaction` envelope. It gates on
+// `endpoints.responses` only (no translation) — models without that
+// endpoint surface `model-unsupported` → 400.
+//
+// The retained + compaction items DO commit through the same staging path
+// the generate endpoint uses so the returned `id` is a usable
+// `previous_response_id` handle for a follow-up `/responses` or
+// `/responses/compact` turn (matching the official endpoint, which
+// documents `previous_response_id` as accepted on /responses/compact).
+//
+// `stream` is ignored — the upstream's answer is one blob; the gateway
+// always collects it into one JSON body regardless of the client's flag.
+const setupResponsesCompactSource = async (
+  c: Context,
+  sourcePayload: ResponsesCompactPayload,
+): Promise<LlmEndpointPlan<string | readonly ResponsesInputItem[], ResponsesStreamEvent> | Response> => {
+  const payload = rewriteResponsesCompactEntryModelAlias(sourcePayload);
+  const request = createHttpRequestContext(c, undefined, false, { store: payload.store });
+  const currentInputItems = responsesInputItemsForStorage(payload.input);
+  const previousResponseId = payload.previous_response_id ?? null;
+  if (previousResponseId !== null) {
+    const snapshot = await request.statefulResponsesStore.loadSnapshot(previousResponseId);
+    if (snapshot === null) return previousResponseNotFoundResponse(previousResponseId);
+    payload.input = [
+      ...snapshot.itemIds.map(id => ({ type: 'item_reference' as const, id })),
+      ...currentInputItems,
+    ];
+  }
+  return {
+    request,
+    items: payload.input,
+    responsesItemsView,
+    wantsStream: false,
+    store: payload.store,
+    statefulResponsesInputItems: currentInputItems,
+    responsesSnapshotMode: payload.store !== false ? 'replace' : 'none',
+    downstreamAbortController: undefined,
+    model: payload.model,
+    pickTarget: endpoints => endpoints.responses ? 'responses' : null,
+    // `target` is always 'responses' here — pickTarget above gates on it —
+    // so we destructure it away rather than threading it through.
+    attempt: async ({ binding, model, rewriteItems }) => {
+      // store is a gateway-only policy and never reaches the wire; the
+      // narrow ResponsesCompactPayload already strips create-only fields
+      // (tools, temperature, reasoning, ...).
+      const { store: _store, model: _model, previous_response_id: _previous, ...callBody } = payload;
+      const attemptPayload = { ...callBody, model, input: await rewriteItems(payload.input) };
+      const invocation: ResponsesInvocation = responsesInvocation(binding, 'responses', model, attemptPayload);
+      const interceptors = [...responsesSourceInterceptors, ...(binding.sourceInterceptors?.responses ?? [])];
+      return await runInterceptors(invocation, request, interceptors, () => emitToResponsesCompact(invocation, request));
+    },
+  };
+};
+
+const responsesCompact: LlmHttpEndpoint<string | readonly ResponsesInputItem[], ResponsesStreamEvent> = {
+  respond: async ({ c, result, runtime }) => await respondResponses(c, result, false, runtime.request, undefined),
+  prepare: async c => await setupResponsesCompactSource(c, await c.req.json<ResponsesCompactPayload>()),
+};
+
 export const responsesTraits: LlmSourceTraits<string | readonly ResponsesInputItem[], ResponsesStreamEvent> = {
   renderFailure: renderResponsesFailure,
-  endpoints: { generate: responsesGenerate },
+  endpoints: { generate: responsesGenerate, compact: responsesCompact },
 };

--- a/apps/api/src/data-plane/llm/sources/responses/websocket.ts
+++ b/apps/api/src/data-plane/llm/sources/responses/websocket.ts
@@ -106,7 +106,7 @@ const handleClientMessage = async (
       downstreamAbortController,
       statefulResponsesStore: storage.statefulResponsesStore,
       storedItemsStore: storage.outputStore,
-      commitSnapshot: storage.commitSnapshot,
+      snapshotMode: storage.snapshotMode,
     });
     if (plan instanceof Response) {
       if (signal.aborted || isClosed()) return;

--- a/apps/api/src/data-plane/llm/sources/traits.ts
+++ b/apps/api/src/data-plane/llm/sources/traits.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono';
 
 import type { NonLlmServeApiName } from '../../shared/api-names.ts';
 import type { LlmTargetApi, RequestContext } from '../interceptors.ts';
+import type { ResponsesSnapshotMode } from './responses/stateful-store.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import { type PerformanceApiName, type ProviderModelRecord, type ExecuteResult, type PlainResult, type UpstreamErrorResult, internalErrorResult } from '@floway-dev/provider';
@@ -115,7 +116,10 @@ export interface LlmEndpointPlan<TItems, TEvent> extends LlmSourceRuntime {
   // separately because only native Responses requests expose those concepts.
   readonly store: boolean | null | undefined;
   readonly statefulResponsesInputItems?: readonly ResponsesInputItem[];
-  readonly commitStatefulResponsesSnapshot?: boolean;
+  // How to compose this turn's snapshot (default 'none' — no snapshot
+  // commit). `/responses` generate uses 'append' (previous + input + output);
+  // `/responses/compact` uses 'replace' (output only — see ResponsesSnapshotMode).
+  readonly responsesSnapshotMode?: ResponsesSnapshotMode;
   // The model id the planner resolves against. Most sources read it off the
   // parsed payload; Gemini carries it on the request path instead of the body.
   readonly model: string;
@@ -158,7 +162,7 @@ export interface LlmHttpEndpoint<TItems, TEvent> {
   }): Promise<{ success: boolean; response: Response }>;
 }
 
-export type LlmEndpointName = 'generate' | 'countTokens';
+export type LlmEndpointName = 'generate' | 'countTokens' | 'compact';
 
 // A source exposes one or more endpoints that share its input and error
 // envelope. `renderFailure` is source-wide — every endpoint answers a failure

--- a/apps/api/src/data-plane/llm/targets/emit.ts
+++ b/apps/api/src/data-plane/llm/targets/emit.ts
@@ -2,7 +2,7 @@ import { recordUpstreamHttpFailure, targetPerformanceContext, withUpstreamTeleme
 import type { NonLlmServeApiName } from '../../shared/api-names.ts';
 import type { Invocation, RequestContext } from '../interceptors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { type PerformanceApiName, type TelemetryModelIdentity, type ProviderStreamResult, type ExecuteResult, type InternalErrorResult, eventResult, internalErrorResult } from '@floway-dev/provider';
+import { type PerformanceApiName, type TelemetryModelIdentity, type ProviderStreamResult, type UpstreamErrorResult, type ExecuteResult, type InternalErrorResult, eventResult, internalErrorResult } from '@floway-dev/provider';
 import { toInternalDebugError, readUpstreamError } from '@floway-dev/provider';
 
 export type TargetEmitApiName = Exclude<PerformanceApiName, NonLlmServeApiName | 'gemini'>;
@@ -38,6 +38,21 @@ export const targetStreamResultToExecuteResult = async <TEvent>(
     modelIdentity,
     perfContext,
   );
+};
+
+// Boundary helper for the non-streaming `/responses/compact` path. The
+// streaming pipeline's UpstreamError translation is reused here because both
+// shapes relay the upstream response verbatim — the difference is only that
+// compact does not have a frame stream to wrap with telemetry.
+export const targetUpstreamErrorResult = async (
+  response: Response,
+  invocation: Invocation<unknown>,
+  request: RequestContext,
+  targetApi: TargetEmitApiName,
+  modelIdentity: TelemetryModelIdentity,
+): Promise<UpstreamErrorResult> => {
+  recordUpstreamHttpFailure(invocation, request, targetApi, modelIdentity);
+  return { ...(await readUpstreamError(response)), performance: targetPerformanceContext(invocation, request, targetApi, modelIdentity) };
 };
 
 export const targetInternalError = (

--- a/apps/api/src/data-plane/llm/targets/responses/emit.ts
+++ b/apps/api/src/data-plane/llm/targets/responses/emit.ts
@@ -1,9 +1,10 @@
-import { targetInternalError, targetModelIdentity, targetStreamResultToExecuteResult } from '../emit.ts';
-import { responsesBaseInterceptors } from './interceptors/index.ts';
 import { type RequestContext, type ResponsesInvocation, runInterceptors } from '../../interceptors.ts';
-import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type TelemetryModelIdentity, type ExecuteResult } from '@floway-dev/provider';
+import { targetInternalError, targetModelIdentity, targetStreamResultToExecuteResult, targetUpstreamErrorResult } from '../emit.ts';
+import { recordUpstreamLatency, targetPerformanceContext } from '../telemetry.ts';
+import { responsesBaseInterceptors } from './interceptors/index.ts';
+import { doneFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import { responsesResultToEvents, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { type TelemetryModelIdentity, type ExecuteResult, eventResult } from '@floway-dev/provider';
 
 const targetApi = 'responses';
 
@@ -21,4 +22,34 @@ export const emitToResponses = async (invocation: ResponsesInvocation, request: 
   } catch (error) {
     return targetInternalError(invocation, request, targetApi, error, modelIdentity);
   }
+};
+
+// `/responses/compact` is non-streaming: the provider yields the compaction
+// envelope as a value, so we build the canonical event frames here — generic
+// item expansion keeps the input-shaped retained messages intact — instead of
+// pretending the result came from an SSE body. Runs the same interceptor
+// stack as generation. `stream` is dropped before reaching the provider so
+// the upstream request stays non-streaming.
+export const emitToResponsesCompact = async (invocation: ResponsesInvocation, request: RequestContext): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
+  let modelIdentity: TelemetryModelIdentity | undefined;
+
+  try {
+    return await runInterceptors(invocation, request, [...responsesBaseInterceptors, ...(invocation.targetInterceptors?.responses ?? [])], async () => {
+      const upstreamStartedAt = performance.now();
+      const { model: _model, stream: _stream, ...body } = invocation.payload;
+      const providerResult = await invocation.provider.callResponsesCompact(invocation.upstreamModel, body, request.downstreamAbortSignal, invocation.headers);
+      modelIdentity = targetModelIdentity(invocation, providerResult.modelKey);
+      if (!providerResult.ok) return await targetUpstreamErrorResult(providerResult.response, invocation, request, targetApi, modelIdentity);
+
+      recordUpstreamLatency(invocation, request, targetApi, modelIdentity, performance.now() - upstreamStartedAt);
+      return eventResult(compactionFrames(providerResult.result), modelIdentity, targetPerformanceContext(invocation, request, targetApi, modelIdentity));
+    });
+  } catch (error) {
+    return targetInternalError(invocation, request, targetApi, error, modelIdentity);
+  }
+};
+
+const compactionFrames = async function* (result: ResponsesResult): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+  yield* responsesResultToEvents(result, { genericOutputItems: true });
+  yield doneFrame();
 };

--- a/apps/api/src/data-plane/llm/targets/telemetry.ts
+++ b/apps/api/src/data-plane/llm/targets/telemetry.ts
@@ -67,6 +67,15 @@ export function recordUpstreamHttpFailure(invocation: Invocation<unknown>, reque
   request.scheduleBackground ? request.scheduleBackground(promise) : void promise;
 }
 
+// Non-streaming endpoints can't be instrumented via withUpstreamTelemetry
+// (no frame stream to observe), so they call this directly with the
+// already-measured wall-clock duration once the upstream Response is in hand.
+export function recordUpstreamLatency(invocation: Invocation<unknown>, request: RequestContext, targetApi: PerformanceApiName, modelIdentity: TelemetryModelIdentity, durationMs: number): void {
+  if (!request.apiKeyId) return;
+  const promise = recordPerformanceLatency(targetPerformanceContext(invocation, request, targetApi, modelIdentity), 'upstream_success', durationMs);
+  request.scheduleBackground ? request.scheduleBackground(promise) : void promise;
+}
+
 function classifyTerminalFrame<T>(frame: ProtocolFrame<T>, targetApi: PerformanceApiName): TerminalKind | null {
   if (frame.type === 'done') {
     // Chat Completions's terminal signal IS the `[DONE]` sentinel; Messages

--- a/packages/protocols/src/responses/from-result.ts
+++ b/packages/protocols/src/responses/from-result.ts
@@ -286,12 +286,23 @@ const responsesOutputItemEvents = (item: ResponsesOutputItem, outputIndex: numbe
   }
 };
 
-export const responsesResultToEvents = (response: ResponsesResult): EventFrame<ResponsesStreamEvent>[] => {
+// `genericOutputItems` collapses every output item — assistant messages,
+// reasoning, tool calls, the lot — into the bare `output_item.added` /
+// `output_item.done` envelope (no inner content_part / output_text expansion).
+// `/responses/compact` callers need this because the retained items are
+// input-shaped (user/assistant messages echoed as `input_text`) and the
+// compaction blob is opaque; expanding them as assistant-message content
+// would mint mid-stream `output_text.delta` events that would not match the
+// item shape.
+export const responsesResultToEvents = (response: ResponsesResult, options?: { genericOutputItems?: boolean }): EventFrame<ResponsesStreamEvent>[] => {
   const started = responsesStartSnapshot(response);
+  const outputEvents = options?.genericOutputItems
+    ? response.output.flatMap(responsesGenericOutputItemEvents)
+    : response.output.flatMap(responsesOutputItemEvents);
   const events: ResponsesStreamEvent[] = [
     { type: 'response.created', response: started },
     { type: 'response.in_progress', response: started },
-    ...response.output.flatMap(responsesOutputItemEvents),
+    ...outputEvents,
     { type: getTerminalEventName(response), response },
   ];
 

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -35,6 +35,28 @@ export interface ResponsesPayload {
   service_tier?: string | null;
 }
 
+// Narrower payload for `/responses/compact`. The official endpoint accepts a
+// strict subset of `/responses` fields — model/input/instructions/
+// previous_response_id/prompt_cache_*/service_tier — plus we honour `store`
+// as a gateway-policy hint for snapshot persistence. Anything from
+// `ResponsesPayload` not listed here (tools, temperature, max_output_tokens,
+// reasoning, stream, etc.) is create-only and would be rejected or silently
+// ignored by the upstream compact endpoint.
+// Reference: https://developers.openai.com/api/reference/resources/responses/methods/compact
+export interface ResponsesCompactPayload {
+  model: string;
+  input: string | ResponsesInputItem[];
+  instructions?: string | null;
+  previous_response_id?: string | null;
+  prompt_cache_key?: string | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
+  service_tier?: string | null;
+  // Gateway-only: controls whether the compact response's output items + the
+  // committed snapshot persist. Forwarded NEITHER to upstream nor to the
+  // provider call body.
+  store?: boolean | null;
+}
+
 export type ResponsesInputItem =
   | ResponsesInputMessage
   | ResponsesFunctionToolCallItem
@@ -50,6 +72,7 @@ export type ResponsesInputItem =
   | ResponsesToolSearchCallItem
   | ResponsesToolSearchOutputItem
   | ResponsesCompactionItem
+  | ResponsesCompactionTriggerItem
   | ResponsesInputImageGenerationCall
   | ResponsesCodeInterpreterCallItem
   | ResponsesLocalShellCallItem
@@ -191,6 +214,12 @@ export interface ResponsesToolSearchOutputItem extends ResponsesPermissiveItem<'
 }
 
 export type ResponsesCompactionItem = ResponsesPermissiveItem<'compaction'>;
+
+// Trailing input item recognised by codex's RemoteCompactionV2: the upstream
+// turns a normal `/responses` call into a compaction round-trip and replies
+// with a single `compaction` output item. Payload-free on the wire (any extra
+// keys are tolerated by the permissive base).
+export type ResponsesCompactionTriggerItem = ResponsesPermissiveItem<'compaction_trigger'>;
 
 export interface ResponsesCodeInterpreterCallItem extends ResponsesPermissiveItem<'code_interpreter_call'> {
   call_id?: string;

--- a/packages/provider-azure/src/fetch.ts
+++ b/packages/provider-azure/src/fetch.ts
@@ -82,6 +82,8 @@ export const azureFetchChatCompletions = (config: AzureUpstreamConfig, init: Req
   azureFetchInternal(config, 'openai', '/chat/completions', init, options);
 export const azureFetchResponses = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/responses', init, options);
+export const azureFetchResponsesCompact = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'openai', '/responses/compact', init, options);
 export const azureFetchEmbeddings = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/embeddings', init, options);
 // gpt-image-2 (released 2026-04-21) and the gpt-image-1 family are exposed

--- a/packages/provider-azure/src/fetch_test.ts
+++ b/packages/provider-azure/src/fetch_test.ts
@@ -9,6 +9,7 @@ import {
   azureFetchMessagesCountTokens,
   azureFetchModels,
   azureFetchResponses,
+  azureFetchResponsesCompact,
 } from './fetch.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals, withMockedFetch } from '@floway-dev/test-utils';
@@ -52,6 +53,7 @@ test('OpenAI v1 transports apply api-key auth and the canonical paths', async ()
     async () => {
       await azureFetchChatCompletions(config, { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
       await azureFetchResponses(config, { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
+      await azureFetchResponsesCompact(config, { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
       await azureFetchEmbeddings(config, { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
       await azureFetchModels(config, { method: 'GET' });
     },
@@ -62,17 +64,18 @@ test('OpenAI v1 transports apply api-key auth and the canonical paths', async ()
     [
       'https://example.openai.azure.com/openai/v1/chat/completions',
       'https://example.openai.azure.com/openai/v1/responses',
+      'https://example.openai.azure.com/openai/v1/responses/compact',
       'https://example.openai.azure.com/openai/v1/embeddings',
       'https://example.openai.azure.com/openai/v1/models',
     ],
   );
   assertEquals(
     seen.map(item => item.apiKey),
-    ['az-key', 'az-key', 'az-key', 'az-key'],
+    ['az-key', 'az-key', 'az-key', 'az-key', 'az-key'],
   );
   assertEquals(
     seen.map(item => item.contentType),
-    ['application/json', 'application/json', 'application/json', null],
+    ['application/json', 'application/json', 'application/json', 'application/json', null],
   );
   assertEquals(seen[0].body, { model: 'set-by-provider' });
 });

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -1,9 +1,9 @@
 import { assertAzureUpstreamRecord } from './config.ts';
-import { azureFetchChatCompletions, azureFetchEmbeddings, azureFetchImagesEdits, azureFetchImagesGenerations, azureFetchMessages, azureFetchMessagesCountTokens, azureFetchResponses } from './fetch.ts';
+import { azureFetchChatCompletions, azureFetchEmbeddings, azureFetchImagesEdits, azureFetchImagesGenerations, azureFetchMessages, azureFetchMessagesCountTokens, azureFetchResponses, azureFetchResponsesCompact } from './fetch.ts';
 import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completions';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
-import { parseResponsesStream } from '@floway-dev/protocols/responses';
+import { parseResponsesStream, type ResponsesResult } from '@floway-dev/protocols/responses';
 import { type ModelProvider, type ModelProviderInstance, type ProviderStreamParser, type UpstreamFetchOptions, type UpstreamModel, type UpstreamModelConfig, type UpstreamRecord, defaultsForProvider, mergeAnthropicBetaHeader, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
 
 interface AzureProviderData {
@@ -82,6 +82,17 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
     },
     callChatCompletions: (model, body, signal, headers) => callStreaming(azureFetchChatCompletions, model, body, signal, headers, parseChatCompletionsStream),
     callResponses: (model, body, signal, headers) => callStreaming(azureFetchResponses, model, body, signal, headers, parseResponsesStream),
+    callResponsesCompact: async (model, body, signal, headers) => {
+      const upstreamModelId = providerData(model).upstreamModelId;
+      const response = await azureFetchResponsesCompact(
+        azure.config,
+        { method: 'POST', body: JSON.stringify({ ...body, model: upstreamModelId }), signal },
+        { extraHeaders: headers },
+      );
+      return response.ok
+        ? { ok: true, result: (await response.json()) as ResponsesResult, modelKey: upstreamModelId }
+        : { ok: false, response, modelKey: upstreamModelId };
+    },
     callMessages: (model, body, signal, headers, anthropicBeta) => callStreaming(azureFetchMessages, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta), parseMessagesStream),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => callNonStreaming(azureFetchMessagesCountTokens, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callEmbeddings: (model, body, signal, headers) => callNonStreaming(azureFetchEmbeddings, model, body, signal, headers),

--- a/packages/provider-copilot/src/compaction.ts
+++ b/packages/provider-copilot/src/compaction.ts
@@ -1,0 +1,93 @@
+import type { ResponsesCompactionTriggerItem, ResponsesInputContent, ResponsesInputItem, ResponsesInputMessage, ResponsesOutputItem, ResponsesResult } from '@floway-dev/protocols/responses';
+
+// Copilot has no native `/responses/compact`, so we replicate codex's
+// RemoteCompactionV2: drive a normal `/responses` turn with a trailing
+// `compaction_trigger` input item, keep the single `compaction` output item the
+// server returns, and rebuild the `response.compaction` envelope client-side.
+// Retained-message reconstruction matches the shape a native Azure
+// `/responses/compact` echoes: every retained user/assistant/developer/system
+// message verbatim (content normalized to `input_text` so the client can
+// resend `output` directly as the next turn's `input`), then the compaction
+// item last.
+//
+// References (codex @ ebb79803697acee75baf24073ef49af87ad7e483):
+//   codex-rs/core/src/compact_remote_v2.rs#L409-L457
+//   codex-rs/utils/string/src/truncate.rs#L71-L74
+export const COMPACTION_TRIGGER: ResponsesCompactionTriggerItem = { type: 'compaction_trigger' };
+
+// Native compact retains `user` + `assistant` + `developer` + `system` —
+// confirmed empirically against an OpenAI long fixture (287 user + 286
+// assistant messages co-retained). Only tool/function items are absorbed by
+// the encrypted blob. codex's `is_retained_for_remote_compaction_v2` drops
+// assistant; production captures show the server keeps it.
+const RETAINED_ROLES = new Set(['user', 'assistant', 'developer', 'system']);
+
+// codex's retained-message budget (its comment notes it mirrors the server-side
+// `/responses/compact` default) and its token heuristic `ceil(utf8_bytes / 4)`,
+// with images costing nothing.
+const RETAINED_BUDGET_TOKENS = 64_000;
+const APPROX_BYTES_PER_TOKEN = 4;
+const encoder = new TextEncoder();
+
+// Native compact echoes every text part — including assistant `output_text` —
+// as `input_text` so the client can resend `output` verbatim as next-turn
+// `input`. Normalize unconditionally; images pass through (and cost 0 tokens
+// against the retained budget).
+const normalizeContent = (content: ResponsesInputMessage['content']): ResponsesInputContent[] => {
+  if (typeof content === 'string') return [{ type: 'input_text', text: content }];
+  return content.map(part => (part.type === 'input_image' ? part : { type: 'input_text', text: part.text }));
+};
+
+// OpenAI accepts input messages with the `type` field omitted (implicit
+// `type: "message"`); accept the same so a hand-rolled client that emits
+// `{role, content}` without `type` still routes correctly.
+const isRetainedMessage = (item: ResponsesInputItem): item is ResponsesInputMessage =>
+  (item.type === 'message' || (item.type === undefined && 'role' in (item as { role?: unknown })))
+  && RETAINED_ROLES.has((item as ResponsesInputMessage).role);
+
+// The retained items are input-shaped messages (role + `input_text` content),
+// which is what `/responses/compact` echoes so the client can resend `output`
+// as the next turn's `input`. `ResponsesOutputItem` does not model user/system
+// roles, so the final cast records that the compaction envelope's `output` is
+// deliberately input-shaped.
+//
+// A retained message with no id gets a synthetic one (so the store can mint
+// a stored id and persist it). That means Copilot-rebuilt retained items
+// persist as upstream-owned with an id the upstream never issued (giving them
+// `portable` affinity); the compaction blob carries the real `forcing`
+// affinity. Benign: retained messages are resent as full content rather than
+// `item_reference`s, so the synthetic id is never replayed to the upstream.
+export const compactionResponse = (input: ResponsesInputItem[], generated: ResponsesResult): ResponsesResult => {
+  const kept: ResponsesInputMessage[] = [];
+  let used = 0;
+  for (let i = input.length - 1; i >= 0; i -= 1) {
+    const item = input[i];
+    if (!isRetainedMessage(item)) continue;
+
+    const content = normalizeContent(item.content);
+    const tokens = content.reduce((sum, part) => (part.type === 'input_image' ? sum : sum + Math.ceil(encoder.encode(part.text).length / APPROX_BYTES_PER_TOKEN)), 0);
+    used += Math.max(tokens, 1);
+    if (used > RETAINED_BUDGET_TOKENS && kept.length > 0) break;
+
+    kept.push({
+      type: 'message',
+      id: item.id ?? `msg_${crypto.randomUUID().replace(/-/g, '')}`,
+      status: item.status ?? 'completed',
+      role: item.role,
+      content,
+    });
+  }
+
+  // The trigger turn may also emit a stray assistant message; codex ignores
+  // everything but the lone compaction item and errors if it is not exactly one.
+  const compactionItems = generated.output.filter(it => it.type === 'compaction');
+  if (compactionItems.length !== 1) {
+    throw new Error(`Expected exactly one compaction output item from the Copilot trigger turn, got ${compactionItems.length}`);
+  }
+
+  return {
+    ...generated,
+    object: 'response.compaction',
+    output: [...kept.reverse(), compactionItems[0]] as unknown as ResponsesOutputItem[],
+  };
+};

--- a/packages/provider-copilot/src/compaction_test.ts
+++ b/packages/provider-copilot/src/compaction_test.ts
@@ -1,0 +1,155 @@
+import { expect, test } from 'vitest';
+
+import { compactionResponse } from './compaction.ts';
+import type { ResponsesInputItem, ResponsesResult } from '@floway-dev/protocols/responses';
+
+const generatedResult = (output: unknown[]): ResponsesResult =>
+  ({
+    id: 'resp_1',
+    object: 'response',
+    model: 'gpt-5.2-codex',
+    output: output as ResponsesResult['output'],
+    status: 'completed',
+    incomplete_details: null,
+    error: null,
+    usage: { input_tokens: 10, output_tokens: 0, total_tokens: 10 },
+  }) as ResponsesResult;
+
+const compaction = { type: 'compaction', id: 'cmp_1', encrypted_content: 'BLOB' };
+
+const shape = (result: ResponsesResult): string[] =>
+  result.output.map(item => (item.type === 'compaction' ? 'compaction' : `${item.type}:${(item as { role?: string }).role}`));
+
+test('keeps retained user/assistant/developer/system messages and appends the compaction item, absorbing tool/function items into the blob', () => {
+  const input: ResponsesInputItem[] = [
+    { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] },
+    { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'lookup', arguments: '{}', status: 'completed' },
+    { type: 'message', role: 'system', content: 'be nice' },
+  ];
+  // The trigger turn may also emit a stray assistant message; only the lone
+  // compaction item survives, regardless of the generated assistant output.
+  const result = compactionResponse(input, generatedResult([{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'stray' }] }, compaction]));
+
+  expect(result.object).toBe('response.compaction');
+  expect(shape(result)).toEqual(['message:user', 'message:assistant', 'message:system', 'compaction']);
+  expect(result.output.at(-1)).toEqual(compaction);
+});
+
+test('normalizes every retained text part to input_text — assistant output_text included', () => {
+  const input: ResponsesInputItem[] = [
+    { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'reply' }] },
+    { type: 'message', role: 'user', content: 'plain string' },
+  ];
+  const result = compactionResponse(input, generatedResult([compaction]));
+
+  // Both retained messages echo with `input_text` parts, regardless of original part type.
+  const assistantPart = (result.output[0] as { content: Array<{ type: string }> }).content[0];
+  const userPart = (result.output[1] as { content: Array<{ type: string }> }).content[0];
+  expect(assistantPart.type).toBe('input_text');
+  expect(userPart.type).toBe('input_text');
+});
+
+test('accepts input messages with the type field omitted (implicit message)', () => {
+  // OpenAI accepts `{role, content}` without `type`; we follow.
+  const input = [{ role: 'user', content: 'hi' }] as unknown as ResponsesInputItem[];
+  const result = compactionResponse(input, generatedResult([compaction]));
+  expect(shape(result)).toEqual(['message:user', 'compaction']);
+});
+
+test('throws when the trigger turn did not return exactly one compaction item', () => {
+  expect(() => compactionResponse([], generatedResult([]))).toThrow(/exactly one compaction/);
+  expect(() => compactionResponse([], generatedResult([compaction, { type: 'compaction', id: 'cmp_2', encrypted_content: 'X' }]))).toThrow(/exactly one compaction/);
+});
+
+test('truncates retained messages newest-first to the 64k token budget', () => {
+  // codex token heuristic is ceil(utf8_bytes / 4); 4 ASCII bytes ≈ 1 token.
+  const oldest: ResponsesInputItem = { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'x'.repeat(64_001 * 4) }] };
+  const newest: ResponsesInputItem = { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'recent' }] };
+  const result = compactionResponse([oldest, newest], generatedResult([compaction]));
+
+  // The oldest message alone exceeds the budget once the newest is kept, so it
+  // drops entirely; only the recent message and the compaction blob remain.
+  expect(result.output).toHaveLength(2);
+  expect((result.output[0] as { role?: string }).role).toBe('user');
+  expect((result.output[0] as { content?: unknown }).content).toEqual([{ type: 'input_text', text: 'recent' }]);
+  expect(result.output[1]).toEqual(compaction);
+});
+
+test('retains a message whose content is a plain string', () => {
+  const result = compactionResponse([{ type: 'message', role: 'user', content: 'hi there' }], generatedResult([compaction]));
+  expect(shape(result)).toEqual(['message:user', 'compaction']);
+});
+
+test('retains the newest message even when it alone exceeds the 64k budget', () => {
+  // A single oversized message must still be retained — losing it would
+  // strip the user's most recent turn from the compaction round-trip,
+  // which would defeat the point of the call.
+  const huge: ResponsesInputItem = { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'x'.repeat(64_001 * 4) }] };
+  const result = compactionResponse([huge], generatedResult([compaction]));
+
+  expect(result.output).toHaveLength(2);
+  expect((result.output[0] as { role?: string }).role).toBe('user');
+  expect(result.output[1]).toEqual(compaction);
+});
+
+test('the empty-message minimum-1-token charge prevents unbounded retention', () => {
+  // Empty-text messages would otherwise consume zero budget; the
+  // `Math.max(tokens, 1)` floor stops them from accumulating without bound.
+  // 64_001 empty messages cannot all survive the budget.
+  const empties: ResponsesInputItem[] = Array.from({ length: 64_001 }, () => ({ type: 'message', role: 'user', content: '' }));
+  const result = compactionResponse(empties, generatedResult([compaction]));
+
+  // The retained-message count is strictly under the input count.
+  expect(result.output.length - 1).toBeLessThan(empties.length);
+  // And exactly equals the budget (each empty message charges 1 token, so
+  // the cap is hit at RETAINED_BUDGET_TOKENS kept entries).
+  expect(result.output).toHaveLength(64_000 + 1);
+});
+
+test('preserves input_image parts verbatim in retained content', () => {
+  // Native compact echoes images alongside text in retained messages; we
+  // match that — `input_image` parts pass through `normalizeContent`
+  // unchanged so the client can resend the multimodal turn as the next
+  // input.
+  const input: ResponsesInputItem[] = [{
+    type: 'message',
+    role: 'user',
+    content: [
+      { type: 'input_text', text: 'look at this' },
+      { type: 'input_image', image_url: 'data:image/png;base64,AAA', detail: 'auto' },
+      { type: 'input_text', text: 'and tell me' },
+    ],
+  }];
+  const result = compactionResponse(input, generatedResult([compaction]));
+
+  const retained = result.output[0] as unknown as { content: Array<Record<string, unknown>> };
+  expect(retained.content).toEqual([
+    { type: 'input_text', text: 'look at this' },
+    { type: 'input_image', image_url: 'data:image/png;base64,AAA', detail: 'auto' },
+    { type: 'input_text', text: 'and tell me' },
+  ]);
+});
+
+test('input_image parts do not consume token budget', () => {
+  // The token heuristic costs images at 0 — codex parity. A retained turn
+  // dominated by an image must not push out earlier turns that would
+  // otherwise have fit.
+  const earlier: ResponsesInputItem = { type: 'message', role: 'user', content: 'kept' };
+  const newest: ResponsesInputItem = {
+    type: 'message',
+    role: 'user',
+    content: [
+      // A 1 MiB base64 blob would be ~262_144 tokens by the utf8/4 heuristic
+      // if charged; charging 0 means the earlier turn still survives.
+      { type: 'input_image', image_url: `data:image/png;base64,${'A'.repeat(1_048_576)}`, detail: 'auto' },
+    ],
+  };
+  const result = compactionResponse([earlier, newest], generatedResult([compaction]));
+
+  // Both retained, plus the compaction blob.
+  expect(result.output).toHaveLength(3);
+  expect((result.output[0] as { role?: string }).role).toBe('user');
+  expect((result.output[0] as { content: Array<{ text?: string }> }).content[0]?.text).toBe('kept');
+  expect((result.output[1] as { content: Array<{ type: string }> }).content[0]?.type).toBe('input_image');
+});

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -1,3 +1,4 @@
+import { COMPACTION_TRIGGER, compactionResponse } from './compaction.ts';
 import { assertCopilotUpstreamRecord } from './config.ts';
 import { fetchCopilotModels } from './fetch-models.ts';
 import { copilotFetchChatCompletions, copilotFetchEmbeddings, copilotFetchMessages, copilotFetchMessagesCountTokens, copilotFetchResponses } from './fetch.ts';
@@ -13,7 +14,7 @@ import type { CopilotRawModel } from './types.ts';
 import { parseChatCompletionsStream, type ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { type ModelEndpointKey, type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream, type MessagesPayload } from '@floway-dev/protocols/messages';
-import { parseResponsesStream, type ResponsesPayload } from '@floway-dev/protocols/responses';
+import { parseResponsesStream, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
 import { inProcessMemo, readModelsStore, writeModelsStore, defaultsForProvider, resolveEffectiveFlags, streamingProviderCall, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CopilotProviderData {
@@ -247,6 +248,25 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
       callStreaming(copilotFetchChatCompletions, body, signal, rawModelFor(model, 'chatCompletions', { reasoningEffort: chatReasoningEffort(body) }), headers, parseChatCompletionsStream),
     callResponses: (model, body, signal, headers) =>
       callStreaming(copilotFetchResponses, body, signal, rawModelFor(model, 'responses', { reasoningEffort: responsesReasoningEffort(body) }), headers, parseResponsesStream),
+    callResponsesCompact: async (model, body, signal, headers) => {
+      const rawModel = rawModelFor(model, 'responses', { reasoningEffort: responsesReasoningEffort(body) });
+      // Normalize `input` to an item array so the trigger item can be appended
+      // regardless of whether the caller sent the convenience string form.
+      const input: ResponsesInputItem[] = typeof body.input === 'string' ? [{ type: 'message', role: 'user', content: body.input }] : (body.input ?? []);
+      // Compaction is inherently non-streaming — a single encrypted blob, not
+      // a token stream — so we drive /responses with stream:false (bypassing
+      // the SSE-forcing callStreaming helper) and reshape the response into
+      // the canonical `response.compaction` envelope.
+      const triggered = { ...body, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
+      const response = await copilotFetchResponses(
+        upstreamConfig,
+        { method: 'POST', body: JSON.stringify(triggered), signal },
+        headers && Object.keys(headers).length > 0 ? { extraHeaders: headers } : undefined,
+      );
+      if (!response.ok) return { ok: false, response, modelKey: rawModel.id };
+      const generated = (await response.json()) as ResponsesResult;
+      return { ok: true, result: compactionResponse(input, generated), modelKey: rawModel.id };
+    },
     callMessages: (model, body, signal, headers, anthropicBeta) =>
       callStreaming(copilotFetchMessages, body, signal, messagesRawModel(model, body, anthropicBeta), headers, parseMessagesStream),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) =>

--- a/packages/provider-custom/src/fetch.ts
+++ b/packages/provider-custom/src/fetch.ts
@@ -6,8 +6,8 @@ const ANTHROPIC_VERSION = '2023-06-01';
 const trimTrailingSlash = (s: string): string => s.replace(/\/+$/, '');
 
 // Per-endpoint default paths. Admin pathOverrides (see config.ts) replace
-// these one-for-one; messages_count_tokens tracks the override of its parent
-// endpoint (suffix appended).
+// these one-for-one; messages_count_tokens / responses_compact track the
+// override of their parent endpoint (suffix appended).
 const CUSTOM_DEFAULT_PATHS = {
   chat_completions: '/v1/chat/completions',
   responses: '/v1/responses',
@@ -45,14 +45,16 @@ const customFetchInternal = async (
   return await fetch(joinBaseAndPath(trimTrailingSlash(config.baseUrl), path), { ...init, headers });
 };
 
-// Typed transports — one per logical endpoint Custom serves. count_tokens
-// derives its path by suffixing the (possibly admin-overridden) parent
-// endpoint, so renaming `messages` to `/custom/messages` implicitly moves
-// `messages/count_tokens` to `/custom/messages/count_tokens`.
+// Typed transports — one per logical endpoint Custom serves. count_tokens /
+// responses_compact derive their path by suffixing the (possibly admin-
+// overridden) parent endpoint, so renaming `messages` to `/custom/messages`
+// implicitly moves `messages/count_tokens` to `/custom/messages/count_tokens`.
 export const customFetchChatCompletions = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, resolveOverridable(config, 'chat_completions'), init, options);
 export const customFetchResponses = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, resolveOverridable(config, 'responses'), init, options);
+export const customFetchResponsesCompact = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, `${resolveOverridable(config, 'responses')}/compact`, init, options);
 export const customFetchMessages = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, resolveOverridable(config, 'messages'), init, options);
 export const customFetchMessagesCountTokens = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>

--- a/packages/provider-custom/src/fetch_test.ts
+++ b/packages/provider-custom/src/fetch_test.ts
@@ -8,6 +8,7 @@ import {
   customFetchMessagesCountTokens,
   customFetchModels,
   customFetchResponses,
+  customFetchResponsesCompact,
 } from './fetch.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals, withMockedFetch } from '@floway-dev/test-utils';
@@ -41,6 +42,7 @@ test('typed transports use default /v1/* paths', async () => {
     async () => {
       await customFetchChatCompletions(config, { method: 'POST', body: '{}' });
       await customFetchResponses(config, { method: 'POST', body: '{}' });
+      await customFetchResponsesCompact(config, { method: 'POST', body: '{}' });
       await customFetchMessages(config, { method: 'POST', body: '{}' });
       await customFetchMessagesCountTokens(config, { method: 'POST', body: '{}' });
       await customFetchEmbeddings(config, { method: 'POST', body: '{}' });
@@ -51,6 +53,7 @@ test('typed transports use default /v1/* paths', async () => {
   assertEquals(seen, [
     'https://custom.example.com/v1/chat/completions',
     'https://custom.example.com/v1/responses',
+    'https://custom.example.com/v1/responses/compact',
     'https://custom.example.com/v1/messages',
     'https://custom.example.com/v1/messages/count_tokens',
     'https://custom.example.com/v1/embeddings',
@@ -65,6 +68,7 @@ test('admin pathOverrides replace defaults and propagate to derived sub-paths', 
       ...(baseRecord.config as Record<string, unknown>),
       pathOverrides: {
         messages: '/api/v1/messages',
+        responses: '/api/v1/responses',
       },
     },
   });
@@ -76,8 +80,9 @@ test('admin pathOverrides replace defaults and propagate to derived sub-paths', 
     },
     async () => {
       await customFetchMessages(config, { method: 'POST', body: '{}' });
-      // count_tokens follows its parent override.
+      // count_tokens / compact follow their parent override.
       await customFetchMessagesCountTokens(config, { method: 'POST', body: '{}' });
+      await customFetchResponsesCompact(config, { method: 'POST', body: '{}' });
       // Endpoints without an override fall back to the OpenAI default.
       await customFetchChatCompletions(config, { method: 'POST', body: '{}' });
     },
@@ -86,6 +91,7 @@ test('admin pathOverrides replace defaults and propagate to derived sub-paths', 
   assertEquals(seen, [
     'https://custom.example.com/api/v1/messages',
     'https://custom.example.com/api/v1/messages/count_tokens',
+    'https://custom.example.com/api/v1/responses/compact',
     'https://custom.example.com/v1/chat/completions',
   ]);
 });

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -1,11 +1,11 @@
 import { assertCustomUpstreamRecord, type CustomUpstreamConfig } from './config.ts';
 import { fetchCustomModels, type CustomModelsResponse, type CustomRawModel } from './fetch-models.ts';
-import { customFetchChatCompletions, customFetchEmbeddings, customFetchImagesEdits, customFetchImagesGenerations, customFetchMessages, customFetchMessagesCountTokens, customFetchResponses } from './fetch.ts';
+import { customFetchChatCompletions, customFetchEmbeddings, customFetchImagesEdits, customFetchImagesGenerations, customFetchMessages, customFetchMessagesCountTokens, customFetchResponses, customFetchResponsesCompact } from './fetch.ts';
 import { inferEndpointsFromModelId } from './infer-endpoints.ts';
 import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completions';
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
-import { parseResponsesStream } from '@floway-dev/protocols/responses';
+import { parseResponsesStream, type ResponsesResult } from '@floway-dev/protocols/responses';
 import { mergeAnthropicBetaHeader, publicModelId, resolveEffectiveFlags, defaultsForProvider, inProcessMemo, isProviderModelsHttpStatus, readModelsStore, writeModelsStore, streamingProviderCall, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderStreamParser, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CustomProviderData {
@@ -206,6 +206,17 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     getPricingForModelKey: modelKey => manualPricingByUpstreamId.get(modelKey) ?? pricingByRawId.get(modelKey) ?? null,
     callChatCompletions: (model, body, signal, headers) => callStreaming(customFetchChatCompletions, model, body, signal, headers, parseChatCompletionsStream),
     callResponses: (model, body, signal, headers) => callStreaming(customFetchResponses, model, body, signal, headers, parseResponsesStream),
+    callResponsesCompact: async (model, body, signal, headers) => {
+      const rawModelId = providerData(model).rawModelId;
+      const response = await customFetchResponsesCompact(
+        config,
+        { method: 'POST', body: JSON.stringify({ ...body, model: rawModelId }), signal },
+        { extraHeaders: headers },
+      );
+      return response.ok
+        ? { ok: true, result: (await response.json()) as ResponsesResult, modelKey: rawModelId }
+        : { ok: false, response, modelKey: rawModelId };
+    },
     callMessages: (model, body, signal, headers, anthropicBeta) => callStreaming(customFetchMessages, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta), parseMessagesStream),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call(customFetchMessagesCountTokens, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
     callEmbeddings: (model, body, signal, headers) => call(customFetchEmbeddings, model, body, signal, headers),

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -5,7 +5,7 @@ import type { ModelEndpoints, ModelPricing, ProtocolFrame } from '@floway-dev/pr
 import type { EmbeddingsPayload } from '@floway-dev/protocols/embeddings';
 import type { ImagesGenerationsPayload } from '@floway-dev/protocols/images';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesCompactPayload, ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 export interface ProviderModelRecord {
   upstream: string;
@@ -104,6 +104,12 @@ export interface ModelProvider {
   // interceptor stack today, but the parameter stays for interface uniformity.
   callChatCompletions(model: UpstreamModel, body: Omit<ChatCompletionsPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callResponses(model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderStreamResult<ResponsesStreamEvent>>;
+  // `/responses/compact` is non-streaming: the upstream returns a single
+  // `response.compaction` envelope rather than a token stream. Azure/custom
+  // pass the native sub-path straight through; Copilot has no native endpoint
+  // and replicates codex's RemoteCompactionV2 inside the provider, returning
+  // the synthesized envelope as the result value.
+  callResponsesCompact(model: UpstreamModel, body: Omit<ResponsesCompactPayload, 'model' | 'store'>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCompactionResult>;
   // Messages and count_tokens additionally receive the source-derived
   // `anthropicBeta` slice as a typed read-only input separate from the wire
   // headers. Copilot uses it to pick a raw upstream model variant

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -54,6 +54,7 @@ export const stubProvider = (overrides: Partial<ModelProvider> = {}): ModelProvi
   getPricingForModelKey: () => null,
   callChatCompletions: () => Promise.reject(new Error('stubProvider.callChatCompletions was called')),
   callResponses: () => Promise.reject(new Error('stubProvider.callResponses was called')),
+  callResponsesCompact: () => Promise.reject(new Error('stubProvider.callResponsesCompact was called')),
   callMessages: () => Promise.reject(new Error('stubProvider.callMessages was called')),
   callMessagesCountTokens: () => Promise.reject(new Error('stubProvider.callMessagesCountTokens was called')),
   callEmbeddings: () => Promise.reject(new Error('stubProvider.callEmbeddings was called')),


### PR DESCRIPTION
## Summary

Adds `/responses/compact` end-to-end. The endpoint mirrors OpenAI's official Responses contract: same model routing, stateful `previous_response_id` stitching, target interceptors, telemetry, and response persistence — the payload type (`ResponsesCompactPayload`) is the narrower official-spec field set (model / input / instructions / previous_response_id / prompt_cache_key / prompt_cache_retention / service_tier) plus our gateway-only `store`.

Provider behaviour splits on capability:

- **Azure & custom** forward to the native `/responses/compact` via the typed `xxxFetchResponsesCompact` transports added in this PR. Each provider's `callResponsesCompact` issues the call and parses the `response.compaction` envelope inline — no shared helper, the two callsites are short and identical except for which transport they use.
- **Copilot** has no native compaction endpoint. The provider fabricates one by appending a `compaction_trigger` item to a non-streaming `/responses` call, capping the retained tokens against the codex RemoteCompactionV2 budget (64k UTF-8 bytes / 4 ≈ retained_tokens), and reshaping the generated output into the canonical compaction envelope.

### Snapshot composition

`commitStatefulResponsesSnapshot` (boolean) is replaced by `ResponsesSnapshotMode = 'none' | 'append' | 'replace'`. Regular `/responses` uses `'append'` (previous + input + output — existing behaviour); compact uses `'replace'` so the compact response id's snapshot is exactly the compact output, not the pre-compact history with output appended. This is what makes the chain

```
/responses → /responses/compact(previous_response_id=A)
           → /responses(previous_response_id=<compact id>)
```

actually compact the context — otherwise the final call replays everything.

## Test plan

- `serve_test.ts` covers: Copilot trigger flow; native pass-through for Azure & custom; unsupported-model rejection; upstream-error pass-through; unknown `previous_response_id`; image item semantics; `previous_response_id` hit case; the end-to-end three-step chain that asserts the third call's snapshot does not include the pre-compact turn's `itemIds`.
- `compaction_test.ts` covers the codex RemoteCompactionV2 retained-token budget and the input-shaped retained-message reshape.
- `pnpm run typecheck`, `pnpm run lint`, `pnpm run test` (170 files, 1618 tests) all green.