### PR TITLE
refactor(providers): typed per-endpoint fetch transports; drop EndpointKey from public surface

### DIFF
--- a/packages/provider-azure/src/fetch.ts
+++ b/packages/provider-azure/src/fetch.ts
@@ -1,29 +1,5 @@
 import { type AzureUpstreamConfig, isFoundryProjectRootPath, trimTrailingSlash } from './config.ts';
-import { type EndpointKey, type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
-
-const AZURE_OPENAI_PATHS: Partial<Record<EndpointKey, string>> = {
-  chat_completions: '/chat/completions',
-  responses: '/responses',
-  embeddings: '/embeddings',
-  models: '/models',
-  images_generations: '/images/generations',
-  images_edits: '/images/edits',
-};
-
-// Per-endpoint query suffix appended to the resolved request URL. Image
-// endpoints on Azure's /openai/v1 surface currently require
-// ?api-version=preview because gpt-image-2 (released 2026-04-21) and the
-// gpt-image-1 family are exposed only under the preview lifecycle. We will
-// drop this entry once Azure promotes the image endpoints to the GA default.
-const AZURE_OPENAI_QUERY: Partial<Record<EndpointKey, string>> = {
-  images_generations: 'api-version=preview',
-  images_edits: 'api-version=preview',
-};
-
-const AZURE_ANTHROPIC_PATHS: Partial<Record<EndpointKey, string>> = {
-  messages: '/v1/messages',
-  messages_count_tokens: '/v1/messages/count_tokens',
-};
+import { type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
 
 const azureOpenAiV1BaseUrl = (endpoint: string): string => {
   const url = new URL(trimTrailingSlash(endpoint));
@@ -63,44 +39,21 @@ const azureAnthropicBaseUrl = (endpoint: string): string => {
   return trimTrailingSlash(url.href);
 };
 
-const requestUrl = (openAiBaseUrl: string | undefined, anthropicBaseUrl: string | undefined, endpoint: EndpointKey): string => {
-  const openAiPath = AZURE_OPENAI_PATHS[endpoint];
-  if (openAiPath) {
-    if (!openAiBaseUrl) throw new Error('Azure upstream config does not include an OpenAI v1 endpoint');
-    const url = joinBaseAndPath(openAiBaseUrl, openAiPath);
-    const query = AZURE_OPENAI_QUERY[endpoint];
-    if (!query) return url;
-    // Append per-endpoint query through URL.searchParams so a future path
-    // that itself carries a query suffix does not produce `path?a?b`.
-    // AZURE_OPENAI_QUERY stores already-encoded pairs (e.g. `api-version=
-    // preview`); parsing-then-appending preserves their encoding.
-    const parsed = new URL(url);
-    for (const [key, value] of new URLSearchParams(query).entries()) {
-      parsed.searchParams.append(key, value);
-    }
-    return parsed.href;
-  }
-
-  const anthropicPath = AZURE_ANTHROPIC_PATHS[endpoint];
-  if (anthropicPath) {
-    if (!anthropicBaseUrl) throw new Error('Azure upstream config does not include an Anthropic endpoint');
-    return joinBaseAndPath(anthropicBaseUrl, anthropicPath);
-  }
-
-  throw new Error(`Unsupported Azure upstream endpoint ${endpoint}`);
-};
-
-const isAnthropicEndpoint = (endpoint: EndpointKey): boolean => endpoint === 'messages' || endpoint === 'messages_count_tokens';
-
-// Issue an HTTP call against the Azure upstream described by `config`. Applies
-// the right credential header per surface (api-key for OpenAI v1, x-api-key +
-// anthropic-version for /anthropic), default JSON Content-Type, any extra
-// headers, and resolves the URL through the per-surface base/path logic above.
-export const azureFetch = async (config: AzureUpstreamConfig, endpoint: EndpointKey, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> => {
-  const openAiBaseUrl = azureOpenAiV1BaseUrl(config.endpoint);
-  const anthropicBaseUrl = azureAnthropicBaseUrl(config.endpoint);
+// Private base dispatcher: applies the right credential header per surface
+// (api-key for OpenAI v1, x-api-key + anthropic-version for /anthropic),
+// JSON Content-Type when carrying a body, plus any extra headers, then
+// resolves URL on the per-surface base.
+const azureFetchInternal = async (
+  config: AzureUpstreamConfig,
+  surface: 'openai' | 'anthropic',
+  path: string,
+  init: RequestInit,
+  options?: UpstreamFetchOptions,
+  query?: string,
+): Promise<Response> => {
+  const baseUrl = surface === 'openai' ? azureOpenAiV1BaseUrl(config.endpoint) : azureAnthropicBaseUrl(config.endpoint);
   const headers = new Headers(init.headers);
-  if (isAnthropicEndpoint(endpoint)) {
+  if (surface === 'anthropic') {
     headers.set('x-api-key', config.apiKey);
     headers.set('anthropic-version', '2023-06-01');
   } else {
@@ -112,5 +65,35 @@ export const azureFetch = async (config: AzureUpstreamConfig, endpoint: Endpoint
   if (options?.extraHeaders) {
     for (const [key, value] of Object.entries(options.extraHeaders)) headers.set(key, value);
   }
-  return await fetch(requestUrl(openAiBaseUrl, anthropicBaseUrl, endpoint), { ...init, headers });
+  const url = joinBaseAndPath(baseUrl, path);
+  if (!query) return await fetch(url, { ...init, headers });
+  // Append per-endpoint query through URL.searchParams so a future path
+  // that itself carries a query suffix does not produce `path?a?b`.
+  const parsed = new URL(url);
+  for (const [key, value] of new URLSearchParams(query).entries()) parsed.searchParams.append(key, value);
+  return await fetch(parsed.href, { ...init, headers });
 };
+
+// Typed transports — one per logical endpoint Azure serves. Streaming and
+// non-streaming alike return a raw Response; per-endpoint return-type
+// wrapping (event stream parse, compaction envelope parse) lives in the
+// provider call methods that consume these.
+export const azureFetchChatCompletions = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'openai', '/chat/completions', init, options);
+export const azureFetchResponses = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'openai', '/responses', init, options);
+export const azureFetchEmbeddings = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'openai', '/embeddings', init, options);
+// gpt-image-2 (released 2026-04-21) and the gpt-image-1 family are exposed
+// only under Azure's preview lifecycle today. We will drop the query suffix
+// once Azure promotes the image endpoints to the GA default.
+export const azureFetchImagesGenerations = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'openai', '/images/generations', init, options, 'api-version=preview');
+export const azureFetchImagesEdits = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'openai', '/images/edits', init, options, 'api-version=preview');
+export const azureFetchModels = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'openai', '/models', init, options);
+export const azureFetchMessages = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'anthropic', '/v1/messages', init, options);
+export const azureFetchMessagesCountTokens = (config: AzureUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  azureFetchInternal(config, 'anthropic', '/v1/messages/count_tokens', init, options);

--- a/packages/provider-azure/src/fetch_test.ts
+++ b/packages/provider-azure/src/fetch_test.ts
@@ -1,6 +1,15 @@
 import { test } from 'vitest';
 
-import { azureFetch, assertAzureUpstreamRecord } from './index.ts';
+import { assertAzureUpstreamRecord } from './config.ts';
+import {
+  azureFetchChatCompletions,
+  azureFetchEmbeddings,
+  azureFetchImagesGenerations,
+  azureFetchMessages,
+  azureFetchMessagesCountTokens,
+  azureFetchModels,
+  azureFetchResponses,
+} from './fetch.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals, withMockedFetch } from '@floway-dev/test-utils';
 
@@ -26,9 +35,9 @@ const baseRecord: UpstreamRecord = {
   disabledPublicModelIds: [],
 };
 
-test('azureFetch uses Azure OpenAI v1 paths with api-key auth', async () => {
+test('OpenAI v1 transports apply api-key auth and the canonical paths', async () => {
   const { config } = assertAzureUpstreamRecord(baseRecord);
-  const seen: Array<{ url: string; apiKey: string | null; contentType: string | null; beta: string | null; body: unknown }> = [];
+  const seen: Array<{ url: string; apiKey: string | null; contentType: string | null; body: unknown }> = [];
 
   await withMockedFetch(
     async request => {
@@ -36,16 +45,15 @@ test('azureFetch uses Azure OpenAI v1 paths with api-key auth', async () => {
         url: request.url,
         apiKey: request.headers.get('api-key'),
         contentType: request.headers.get('content-type'),
-        beta: request.headers.get('anthropic-beta'),
         body: request.method === 'GET' ? null : await request.json(),
       });
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await azureFetch(config, 'chat_completions', { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
-      await azureFetch(config, 'responses', { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
-      await azureFetch(config, 'embeddings', { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
-      await azureFetch(config, 'models', { method: 'GET' });
+      await azureFetchChatCompletions(config, { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
+      await azureFetchResponses(config, { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
+      await azureFetchEmbeddings(config, { method: 'POST', body: JSON.stringify({ model: 'set-by-provider' }) });
+      await azureFetchModels(config, { method: 'GET' });
     },
   );
 
@@ -69,7 +77,24 @@ test('azureFetch uses Azure OpenAI v1 paths with api-key auth', async () => {
   assertEquals(seen[0].body, { model: 'set-by-provider' });
 });
 
-test('azureFetch accepts an endpoint that already includes /openai/v1', async () => {
+test('image transports append the Azure preview api-version', async () => {
+  const { config } = assertAzureUpstreamRecord(baseRecord);
+  let seenUrl = '';
+
+  await withMockedFetch(
+    request => {
+      seenUrl = request.url;
+      return new Response('{}', { status: 200 });
+    },
+    async () => {
+      await azureFetchImagesGenerations(config, { method: 'POST', body: '{}' });
+    },
+  );
+
+  assertEquals(seenUrl, 'https://example.openai.azure.com/openai/v1/images/generations?api-version=preview');
+});
+
+test('endpoint that already includes /openai/v1 routes through unchanged', async () => {
   const { config } = assertAzureUpstreamRecord({
     ...baseRecord,
     config: {
@@ -85,14 +110,14 @@ test('azureFetch accepts an endpoint that already includes /openai/v1', async ()
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await azureFetch(config, 'responses', { method: 'POST', body: '{}' });
+      await azureFetchResponses(config, { method: 'POST', body: '{}' });
     },
   );
 
   assertEquals(seenUrl, 'https://example.openai.azure.com/openai/v1/responses');
 });
 
-test('azureFetch accepts Foundry project endpoints for OpenAI v1 calls', async () => {
+test('Foundry project endpoints route OpenAI v1 calls under the project base', async () => {
   const { config } = assertAzureUpstreamRecord({
     ...baseRecord,
     config: {
@@ -114,14 +139,14 @@ test('azureFetch accepts Foundry project endpoints for OpenAI v1 calls', async (
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await azureFetch(config, 'responses', { method: 'POST', body: '{}' });
+      await azureFetchResponses(config, { method: 'POST', body: '{}' });
     },
   );
 
   assertEquals(seenUrl, 'https://example.services.ai.azure.com/api/projects/prod/openai/v1/responses');
 });
 
-test('azureFetch accepts Foundry project OpenAI v1 base URLs', async () => {
+test('Foundry project endpoints split OpenAI v1 vs Anthropic surfaces', async () => {
   const { config } = assertAzureUpstreamRecord({
     ...baseRecord,
     config: {
@@ -143,8 +168,8 @@ test('azureFetch accepts Foundry project OpenAI v1 base URLs', async () => {
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await azureFetch(config, 'responses', { method: 'POST', body: '{}' });
-      await azureFetch(config, 'messages', { method: 'POST', body: '{}' });
+      await azureFetchResponses(config, { method: 'POST', body: '{}' });
+      await azureFetchMessages(config, { method: 'POST', body: '{}' });
     },
   );
 
@@ -154,7 +179,7 @@ test('azureFetch accepts Foundry project OpenAI v1 base URLs', async () => {
   ]);
 });
 
-test('azureFetch keeps native Anthropic calls on the resource Anthropic base when a project endpoint is entered', async () => {
+test('native Anthropic calls land on the resource Anthropic base when a project endpoint is entered', async () => {
   const { config } = assertAzureUpstreamRecord({
     ...baseRecord,
     config: {
@@ -176,14 +201,14 @@ test('azureFetch keeps native Anthropic calls on the resource Anthropic base whe
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await azureFetch(config, 'messages', { method: 'POST', body: '{}' });
+      await azureFetchMessages(config, { method: 'POST', body: '{}' });
     },
   );
 
   assertEquals(seenUrl, 'https://example.services.ai.azure.com/anthropic/v1/messages');
 });
 
-test('azureFetch supports Azure Foundry Anthropic Messages with x-api-key auth', async () => {
+test('Azure Foundry Anthropic surface uses x-api-key + anthropic-version', async () => {
   const { config } = assertAzureUpstreamRecord({
     ...baseRecord,
     config: {
@@ -211,8 +236,8 @@ test('azureFetch supports Azure Foundry Anthropic Messages with x-api-key auth',
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await azureFetch(config, 'messages', { method: 'POST', body: '{}' }, { extraHeaders: { 'anthropic-beta': 'context-1m' } });
-      await azureFetch(config, 'messages_count_tokens', { method: 'POST', body: '{}' });
+      await azureFetchMessages(config, { method: 'POST', body: '{}' }, { extraHeaders: { 'anthropic-beta': 'context-1m' } });
+      await azureFetchMessagesCountTokens(config, { method: 'POST', body: '{}' });
     },
   );
 
@@ -234,7 +259,7 @@ test('azureFetch supports Azure Foundry Anthropic Messages with x-api-key auth',
   ]);
 });
 
-test('azureFetch accepts an Azure Foundry Anthropic messages target URI', async () => {
+test('Foundry Anthropic messages target URI is accepted and splits per surface', async () => {
   const { config } = assertAzureUpstreamRecord({
     ...baseRecord,
     config: {
@@ -256,8 +281,8 @@ test('azureFetch accepts an Azure Foundry Anthropic messages target URI', async 
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await azureFetch(config, 'messages', { method: 'POST', body: '{}' });
-      await azureFetch(config, 'models', { method: 'GET' });
+      await azureFetchMessages(config, { method: 'POST', body: '{}' });
+      await azureFetchModels(config, { method: 'GET' });
     },
   );
 

--- a/packages/provider-azure/src/index.ts
+++ b/packages/provider-azure/src/index.ts
@@ -3,4 +3,3 @@ export {
   assertAzureUpstreamRecord,
   configuredEndpoints,
 } from './config.ts';
-export { azureFetch } from './fetch.ts';

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -1,10 +1,10 @@
 import { assertAzureUpstreamRecord } from './config.ts';
-import { azureFetch } from './fetch.ts';
+import { azureFetchChatCompletions, azureFetchEmbeddings, azureFetchImagesEdits, azureFetchImagesGenerations, azureFetchMessages, azureFetchMessagesCountTokens, azureFetchResponses } from './fetch.ts';
 import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completions';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
-import { type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderStreamParser, type StreamingEndpointKey, type UpstreamModel, type UpstreamModelConfig, type UpstreamRecord, defaultsForProvider, mergeAnthropicBetaHeader, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
+import { type ModelProvider, type ModelProviderInstance, type ProviderStreamParser, type UpstreamFetchOptions, type UpstreamModel, type UpstreamModelConfig, type UpstreamRecord, defaultsForProvider, mergeAnthropicBetaHeader, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
 
 interface AzureProviderData {
   upstreamModelId: string;
@@ -24,20 +24,13 @@ const azureInternalModel = (model: UpstreamModelConfig): Omit<UpstreamModel, 'ki
   return internal;
 };
 
+type AzureTypedFetch = (config: ReturnType<typeof assertAzureUpstreamRecord>['config'], init: RequestInit, options?: UpstreamFetchOptions) => Promise<Response>;
+
 export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstance => {
   const azure = assertAzureUpstreamRecord(record);
 
-  const call = (endpoint: 'messages_count_tokens' | 'embeddings' | 'images_generations', model: UpstreamModel, body: Record<string, unknown>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult> => {
-    const upstreamModelId = providerData(model).upstreamModelId;
-    return azureFetch(azure.config, endpoint, { method: 'POST', body: JSON.stringify({ ...body, model: upstreamModelId }), signal }, { extraHeaders: headers })
-      .then(response => ({
-        response,
-        modelKey: upstreamModelId,
-      }));
-  };
-
   const callStreaming = <TEvent>(
-    endpoint: StreamingEndpointKey,
+    transport: AzureTypedFetch,
     model: UpstreamModel,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
@@ -46,9 +39,8 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
   ) => {
     const upstreamModelId = providerData(model).upstreamModelId;
     return streamingProviderCall(
-      azureFetch(
+      transport(
         azure.config,
-        endpoint,
         { method: 'POST', body: JSON.stringify({ ...body, stream: true, model: upstreamModelId }), signal },
         { extraHeaders: headers },
       ),
@@ -56,6 +48,12 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
       upstreamModelId,
       signal,
     );
+  };
+
+  const callNonStreaming = async (transport: AzureTypedFetch, model: UpstreamModel, body: Record<string, unknown>, signal?: AbortSignal, headers?: Record<string, string>) => {
+    const upstreamModelId = providerData(model).upstreamModelId;
+    const response = await transport(azure.config, { method: 'POST', body: JSON.stringify({ ...body, model: upstreamModelId }), signal }, { extraHeaders: headers });
+    return { response, modelKey: upstreamModelId };
   };
 
   const provider: ModelProvider = {
@@ -82,19 +80,19 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
     getPricingForModelKey(modelKey) {
       return azure.config.models.find(model => model.upstreamModelId === modelKey)?.cost ?? null;
     },
-    callChatCompletions: (model, body, signal, headers) => callStreaming('chat_completions', model, body, signal, headers, parseChatCompletionsStream),
-    callResponses: (model, body, signal, headers) => callStreaming('responses', model, body, signal, headers, parseResponsesStream),
-    callMessages: (model, body, signal, headers, anthropicBeta) => callStreaming('messages', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta), parseMessagesStream),
-    callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call('messages_count_tokens', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
-    callEmbeddings: (model, body, signal, headers) => call('embeddings', model, body, signal, headers),
-    callImagesGenerations: (model, body, signal, headers) => call('images_generations', model, body, signal, headers),
+    callChatCompletions: (model, body, signal, headers) => callStreaming(azureFetchChatCompletions, model, body, signal, headers, parseChatCompletionsStream),
+    callResponses: (model, body, signal, headers) => callStreaming(azureFetchResponses, model, body, signal, headers, parseResponsesStream),
+    callMessages: (model, body, signal, headers, anthropicBeta) => callStreaming(azureFetchMessages, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta), parseMessagesStream),
+    callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => callNonStreaming(azureFetchMessagesCountTokens, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
+    callEmbeddings: (model, body, signal, headers) => callNonStreaming(azureFetchEmbeddings, model, body, signal, headers),
+    callImagesGenerations: (model, body, signal, headers) => callNonStreaming(azureFetchImagesGenerations, model, body, signal, headers),
     callImagesEdits: async (model, body, signal, headers) => {
       // Azure routes by upstream model id in the multipart `model` field; the
       // runtime re-encodes the FormData with a fresh boundary and sets
       // Content-Type itself.
       const upstreamModelId = providerData(model).upstreamModelId;
       body.append('model', upstreamModelId);
-      const response = await azureFetch(azure.config, 'images_edits', { method: 'POST', body, signal }, { extraHeaders: headers });
+      const response = await azureFetchImagesEdits(azure.config, { method: 'POST', body, signal }, { extraHeaders: headers });
       return { response, modelKey: upstreamModelId };
     },
   };

--- a/packages/provider-copilot/src/fetch-models.ts
+++ b/packages/provider-copilot/src/fetch-models.ts
@@ -1,5 +1,5 @@
 import type { CopilotUpstreamConfig } from './config.ts';
-import { copilotFetch } from './fetch.ts';
+import { copilotFetchModels } from './fetch.ts';
 import type { CopilotModelsResponse } from './types.ts';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 
@@ -29,7 +29,7 @@ const MODELS_HEADER_OVERRIDES: Record<string, string> = {
 export const fetchCopilotModels = async (config: Pick<CopilotUpstreamConfig, 'githubToken' | 'accountType'>): Promise<CopilotModelsResponse> => {
   let response: Response;
   try {
-    response = await copilotFetch(config, 'models', { method: 'GET' }, { extraHeaders: MODELS_HEADER_OVERRIDES });
+    response = await copilotFetchModels(config, { method: 'GET' }, { extraHeaders: MODELS_HEADER_OVERRIDES });
   } catch (cause) {
     throw new ProviderModelsUnavailableError(null, cause);
   }

--- a/packages/provider-copilot/src/fetch.ts
+++ b/packages/provider-copilot/src/fetch.ts
@@ -1,41 +1,36 @@
 // Copilot upstream transport. The auth.ts layer owns the GitHub-token → short
-// lived Copilot-token exchange and KV cache; this module maps a logical
-// endpoint to the path Copilot serves it on, then dispatches through that
+// lived Copilot-token exchange and KV cache; this module maps each logical
+// endpoint to the path Copilot serves it on, then dispatches through the
 // authed fetch.
 
 import { copilotAuthedFetch, isCopilotTokenFetchError } from './auth.ts';
 import type { CopilotUpstreamConfig } from './config.ts';
-import type { EndpointKey, UpstreamFetchOptions } from '@floway-dev/provider';
+import type { UpstreamFetchOptions } from '@floway-dev/provider';
 
 // Copilot mounts its API at the host root and uses an Anthropic-style
 // `/v1/messages` for the Messages endpoint while keeping `/chat/completions`,
 // `/responses`, `/embeddings`, `/images/*`, and `/models` un-prefixed. These
-// paths are not admin-configurable: they reflect Copilot's own contract, not
-// a deployment choice.
-const COPILOT_PATHS: Record<EndpointKey, string> = {
-  chat_completions: '/chat/completions',
-  responses: '/responses',
-  messages: '/v1/messages',
-  messages_count_tokens: '/v1/messages/count_tokens',
-  embeddings: '/embeddings',
-  images_generations: '/images/generations',
-  images_edits: '/images/edits',
-  models: '/models',
-};
+// paths reflect Copilot's contract and are not admin-configurable.
+// `responses_compact` is intentionally absent — Copilot has no native
+// `/responses/compact` endpoint; compaction is fabricated by the provider via
+// `compaction_trigger` against `/responses`.
 
 // Subset of the persisted copilot upstream record's config the transport needs;
-// `user` is irrelevant to the wire, so the parameter type names only the auth
+// `user` is irrelevant on the wire, so the parameter type only names the auth
 // fields. Any CopilotUpstreamConfig satisfies it structurally.
 type CopilotFetchConfig = Pick<CopilotUpstreamConfig, 'githubToken' | 'accountType'>;
 
-// Issue an HTTP call against Copilot's upstream for a named endpoint. Wraps
-// `copilotAuthedFetch` (which owns the token exchange + KV cache) with the
-// endpoint→path mapping above and converts a CopilotTokenFetchError into a
-// regular Response so callers can treat token-exchange failures the same as
-// any other 4xx/5xx.
-export const copilotFetch = async (config: CopilotFetchConfig, endpoint: EndpointKey, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> => {
+// Private base dispatcher. Wraps `copilotAuthedFetch` (which owns the token
+// exchange + KV cache) and converts a CopilotTokenFetchError into a regular
+// Response so callers treat token-exchange failures like any other 4xx/5xx.
+const copilotFetchInternal = async (
+  config: CopilotFetchConfig,
+  path: string,
+  init: RequestInit,
+  options?: UpstreamFetchOptions,
+): Promise<Response> => {
   try {
-    return await copilotAuthedFetch(COPILOT_PATHS[endpoint], init, config.githubToken, config.accountType, options?.extraHeaders ? { headers: options.extraHeaders } : undefined);
+    return await copilotAuthedFetch(path, init, config.githubToken, config.accountType, options?.extraHeaders ? { headers: options.extraHeaders } : undefined);
   } catch (error) {
     if (!isCopilotTokenFetchError(error)) throw error;
     return new Response(error.body, {
@@ -44,3 +39,19 @@ export const copilotFetch = async (config: CopilotFetchConfig, endpoint: Endpoin
     });
   }
 };
+
+// Typed transports — one per logical endpoint Copilot serves. Copilot has no
+// `/responses/compact`; the provider fabricates compaction by POSTing a
+// compaction_trigger item to `/responses` via `copilotFetchResponses`.
+export const copilotFetchChatCompletions = (config: CopilotFetchConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  copilotFetchInternal(config, '/chat/completions', init, options);
+export const copilotFetchResponses = (config: CopilotFetchConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  copilotFetchInternal(config, '/responses', init, options);
+export const copilotFetchMessages = (config: CopilotFetchConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  copilotFetchInternal(config, '/v1/messages', init, options);
+export const copilotFetchMessagesCountTokens = (config: CopilotFetchConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  copilotFetchInternal(config, '/v1/messages/count_tokens', init, options);
+export const copilotFetchEmbeddings = (config: CopilotFetchConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  copilotFetchInternal(config, '/embeddings', init, options);
+export const copilotFetchModels = (config: CopilotFetchConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  copilotFetchInternal(config, '/models', init, options);

--- a/packages/provider-copilot/src/index.ts
+++ b/packages/provider-copilot/src/index.ts
@@ -5,4 +5,3 @@ export {
   isCopilotAccountType,
   type CopilotAccountType,
 } from './auth.ts';
-export { copilotFetch } from './fetch.ts';

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -1,6 +1,6 @@
 import { assertCopilotUpstreamRecord } from './config.ts';
 import { fetchCopilotModels } from './fetch-models.ts';
-import { copilotFetch } from './fetch.ts';
+import { copilotFetchChatCompletions, copilotFetchEmbeddings, copilotFetchMessages, copilotFetchMessagesCountTokens, copilotFetchResponses } from './fetch.ts';
 import { chatCompletionsCopilotInterceptors } from './interceptors/chat-completions/index.ts';
 import { messagesCopilotInterceptors, messagesCopilotSourceInterceptors, messagesCountTokensCopilotInterceptors } from './interceptors/messages/index.ts';
 import { responsesCopilotInterceptors } from './interceptors/responses/index.ts';
@@ -14,8 +14,7 @@ import { parseChatCompletionsStream, type ChatCompletionsPayload } from '@floway
 import { type ModelEndpointKey, type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream, type MessagesPayload } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesPayload } from '@floway-dev/protocols/responses';
-import { inProcessMemo, readModelsStore, writeModelsStore, defaultsForProvider, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
-import type { ModelProvider, ModelProviderInstance, ProviderCallResult, StreamingEndpointKey, UpstreamModel, UpstreamRecord } from '@floway-dev/provider';
+import { inProcessMemo, readModelsStore, writeModelsStore, defaultsForProvider, resolveEffectiveFlags, streamingProviderCall, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CopilotProviderData {
   rawModels: CopilotRawModel[];
@@ -175,15 +174,14 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
   const upstreamFlags = resolveEffectiveFlags(defaultsForProvider('copilot'), [copilot.flagOverrides]);
 
   const call = async (
-    endpoint: 'messages_count_tokens' | 'embeddings',
+    transport: (config: typeof upstreamConfig, init: RequestInit, options?: UpstreamFetchOptions) => Promise<Response>,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
     rawModel: CopilotRawModel,
     headers: Record<string, string> | undefined,
   ): Promise<ProviderCallResult> => {
-    const response = await copilotFetch(
+    const response = await transport(
       upstreamConfig,
-      endpoint,
       {
         method: 'POST',
         body: JSON.stringify({ ...body, model: rawModel.id }),
@@ -195,7 +193,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
   };
 
   const callStreaming = <TEvent>(
-    endpoint: StreamingEndpointKey,
+    transport: (config: typeof upstreamConfig, init: RequestInit, options?: UpstreamFetchOptions) => Promise<Response>,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
     rawModel: CopilotRawModel,
@@ -203,9 +201,8 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
     parser: Parameters<typeof streamingProviderCall<TEvent>>[1],
   ) =>
     streamingProviderCall(
-      copilotFetch(
+      transport(
         upstreamConfig,
-        endpoint,
         {
           method: 'POST',
           body: JSON.stringify({ ...body, stream: true, model: rawModel.id }),
@@ -247,14 +244,14 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
       }),
     getPricingForModelKey: pricingForCopilotModelKey,
     callChatCompletions: (model, body, signal, headers) =>
-      callStreaming('chat_completions', body, signal, rawModelFor(model, 'chatCompletions', { reasoningEffort: chatReasoningEffort(body) }), headers, parseChatCompletionsStream),
+      callStreaming(copilotFetchChatCompletions, body, signal, rawModelFor(model, 'chatCompletions', { reasoningEffort: chatReasoningEffort(body) }), headers, parseChatCompletionsStream),
     callResponses: (model, body, signal, headers) =>
-      callStreaming('responses', body, signal, rawModelFor(model, 'responses', { reasoningEffort: responsesReasoningEffort(body) }), headers, parseResponsesStream),
+      callStreaming(copilotFetchResponses, body, signal, rawModelFor(model, 'responses', { reasoningEffort: responsesReasoningEffort(body) }), headers, parseResponsesStream),
     callMessages: (model, body, signal, headers, anthropicBeta) =>
-      callStreaming('messages', body, signal, messagesRawModel(model, body, anthropicBeta), headers, parseMessagesStream),
+      callStreaming(copilotFetchMessages, body, signal, messagesRawModel(model, body, anthropicBeta), headers, parseMessagesStream),
     callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) =>
-      call('messages_count_tokens', body, signal, messagesRawModel(model, body, anthropicBeta), headers),
-    callEmbeddings: (model, body, signal, headers) => call('embeddings', copilotEmbeddingsBody(body), signal, rawModelFor(model, 'embeddings'), headers),
+      call(copilotFetchMessagesCountTokens, body, signal, messagesRawModel(model, body, anthropicBeta), headers),
+    callEmbeddings: (model, body, signal, headers) => call(copilotFetchEmbeddings, copilotEmbeddingsBody(body), signal, rawModelFor(model, 'embeddings'), headers),
     // Copilot has no /images/... upstream. getProvidedModels never emits a
     // kind='image' model for Copilot bindings, so the source-side dispatcher
     // in apps/api/src/data-plane/images/serve.ts never selects this provider

--- a/packages/provider-custom/src/config.ts
+++ b/packages/provider-custom/src/config.ts
@@ -19,10 +19,18 @@
 // path override, because it only matters when fetching is enabled.
 
 import type { ModelEndpoints } from '@floway-dev/protocols/common';
-import type { EndpointKey, UpstreamModelConfig, UpstreamRecord } from '@floway-dev/provider';
+import type { UpstreamModelConfig, UpstreamRecord } from '@floway-dev/provider';
 import { endpointsField, modelsField, validateUpstreamPath } from '@floway-dev/provider';
 
 export type CustomAuthStyle = 'bearer' | 'anthropic';
+
+// Logical endpoints the admin may override. Sub-paths (messages_count_tokens,
+// responses_compact) and the catalog (models — owned by modelsFetch.endpoint)
+// are intentionally absent: they derive their URL from a parent override or
+// a separate field. Kept package-internal because outside callers reach the
+// upstream through the typed `customFetchXxx` transports, not by naming an
+// endpoint key.
+type CustomPathOverrideKey = 'chat_completions' | 'responses' | 'messages' | 'embeddings' | 'images_generations' | 'images_edits';
 
 export interface CustomModelsFetch {
   enabled: boolean;
@@ -34,7 +42,7 @@ export interface CustomUpstreamConfig {
   bearerToken: string;
   authStyle: CustomAuthStyle;
   endpoints: ModelEndpoints;
-  pathOverrides?: Partial<Record<Exclude<EndpointKey, 'messages_count_tokens' | 'models'>, string>>;
+  pathOverrides?: Partial<Record<CustomPathOverrideKey, string>>;
   modelsFetch: CustomModelsFetch;
   models: UpstreamModelConfig[];
 }
@@ -76,7 +84,7 @@ const baseUrlField = (value: unknown): string => {
   return baseUrl;
 };
 
-const PATH_OVERRIDE_KEYS = new Set<Exclude<EndpointKey, 'messages_count_tokens' | 'models'>>(['chat_completions', 'responses', 'messages', 'embeddings', 'images_generations', 'images_edits']);
+const PATH_OVERRIDE_KEYS = new Set<CustomPathOverrideKey>(['chat_completions', 'responses', 'messages', 'embeddings', 'images_generations', 'images_edits']);
 
 const pathOverridesField = (value: unknown): CustomUpstreamConfig['pathOverrides'] => {
   if (value === undefined) return undefined;
@@ -84,12 +92,12 @@ const pathOverridesField = (value: unknown): CustomUpstreamConfig['pathOverrides
 
   const pathOverrides: NonNullable<CustomUpstreamConfig['pathOverrides']> = {};
   for (const [key, path] of Object.entries(value)) {
-    if (!PATH_OVERRIDE_KEYS.has(key as Exclude<EndpointKey, 'messages_count_tokens' | 'models'>)) {
+    if (!PATH_OVERRIDE_KEYS.has(key as CustomPathOverrideKey)) {
       throw new Error(`Malformed custom upstream config: unsupported pathOverrides key ${key}`);
     }
     const validPath = validateUpstreamPath(path, `pathOverrides.${key}`);
     if (!validPath.ok) throw new Error(`Malformed custom upstream config: ${validPath.error}`);
-    pathOverrides[key as Exclude<EndpointKey, 'messages_count_tokens' | 'models'>] = validPath.value;
+    pathOverrides[key as CustomPathOverrideKey] = validPath.value;
   }
   return pathOverrides;
 };

--- a/packages/provider-custom/src/fetch-models.ts
+++ b/packages/provider-custom/src/fetch-models.ts
@@ -14,7 +14,7 @@
 // heuristic; the chat default takes the per-upstream `endpoints` config).
 
 import type { CustomUpstreamConfig } from './config.ts';
-import { customFetch } from './fetch.ts';
+import { customFetchModels } from './fetch.ts';
 import type { ModelKind, ModelPricing } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 
@@ -121,7 +121,7 @@ const parseCustomModelsResponse = (value: unknown): CustomModelsResponse | null 
 export const fetchCustomModels = async (config: CustomUpstreamConfig): Promise<CustomModelsResponse> => {
   let response: Response;
   try {
-    response = await customFetch(config, 'models', { method: 'GET' });
+    response = await customFetchModels(config, { method: 'GET' });
   } catch (cause) {
     throw new ProviderModelsUnavailableError(null, cause);
   }

--- a/packages/provider-custom/src/fetch.ts
+++ b/packages/provider-custom/src/fetch.ts
@@ -1,39 +1,34 @@
 import type { CustomUpstreamConfig } from './config.ts';
-import { type EndpointKey, type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
+import { type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
 
 const ANTHROPIC_VERSION = '2023-06-01';
 
 const trimTrailingSlash = (s: string): string => s.replace(/\/+$/, '');
 
-const CUSTOM_DEFAULT_PATHS: Record<EndpointKey, string> = {
+// Per-endpoint default paths. Admin pathOverrides (see config.ts) replace
+// these one-for-one; messages_count_tokens tracks the override of its parent
+// endpoint (suffix appended).
+const CUSTOM_DEFAULT_PATHS = {
   chat_completions: '/v1/chat/completions',
   responses: '/v1/responses',
   messages: '/v1/messages',
-  messages_count_tokens: '/v1/messages/count_tokens',
   embeddings: '/v1/embeddings',
   images_generations: '/v1/images/generations',
   images_edits: '/v1/images/edits',
-  models: '/v1/models',
-};
+} as const;
 
-const resolveCustomPath = (config: CustomUpstreamConfig, endpoint: EndpointKey): string => {
-  // count_tokens is intentionally not independently overridable — it tracks
-  // whatever path the admin chose for `messages` so the two stay in sync.
-  if (endpoint === 'messages_count_tokens') {
-    const messagesPath = config.pathOverrides?.messages ?? CUSTOM_DEFAULT_PATHS.messages;
-    return `${messagesPath}/count_tokens`;
-  }
-  // The /models path lives on the fetch toggle, not in pathOverrides.
-  if (endpoint === 'models') {
-    return config.modelsFetch.endpoint ?? CUSTOM_DEFAULT_PATHS.models;
-  }
-  return config.pathOverrides?.[endpoint] ?? CUSTOM_DEFAULT_PATHS[endpoint];
-};
+// Internal: parent path for a logical endpoint, honouring admin overrides.
+const resolveOverridable = (config: CustomUpstreamConfig, key: keyof typeof CUSTOM_DEFAULT_PATHS): string =>
+  config.pathOverrides?.[key] ?? CUSTOM_DEFAULT_PATHS[key];
 
-// Issue an HTTP call against the custom upstream described by `config`. Applies
-// the configured auth header, default Content-Type for JSON bodies, and any
-// extra headers, then dispatches to the resolved per-endpoint URL.
-export const customFetch = async (config: CustomUpstreamConfig, endpoint: EndpointKey, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> => {
+// Private base dispatcher: applies the configured auth header per authStyle,
+// JSON Content-Type when carrying a body, plus any extra headers.
+const customFetchInternal = async (
+  config: CustomUpstreamConfig,
+  path: string,
+  init: RequestInit,
+  options?: UpstreamFetchOptions,
+): Promise<Response> => {
   const headers = new Headers(init.headers);
   if (config.authStyle === 'anthropic') {
     headers.set('x-api-key', config.bearerToken);
@@ -47,6 +42,28 @@ export const customFetch = async (config: CustomUpstreamConfig, endpoint: Endpoi
   if (options?.extraHeaders) {
     for (const [k, v] of Object.entries(options.extraHeaders)) headers.set(k, v);
   }
-  const url = joinBaseAndPath(trimTrailingSlash(config.baseUrl), resolveCustomPath(config, endpoint));
-  return await fetch(url, { ...init, headers });
+  return await fetch(joinBaseAndPath(trimTrailingSlash(config.baseUrl), path), { ...init, headers });
 };
+
+// Typed transports — one per logical endpoint Custom serves. count_tokens
+// derives its path by suffixing the (possibly admin-overridden) parent
+// endpoint, so renaming `messages` to `/custom/messages` implicitly moves
+// `messages/count_tokens` to `/custom/messages/count_tokens`.
+export const customFetchChatCompletions = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, resolveOverridable(config, 'chat_completions'), init, options);
+export const customFetchResponses = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, resolveOverridable(config, 'responses'), init, options);
+export const customFetchMessages = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, resolveOverridable(config, 'messages'), init, options);
+export const customFetchMessagesCountTokens = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, `${resolveOverridable(config, 'messages')}/count_tokens`, init, options);
+export const customFetchEmbeddings = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, resolveOverridable(config, 'embeddings'), init, options);
+export const customFetchImagesGenerations = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, resolveOverridable(config, 'images_generations'), init, options);
+export const customFetchImagesEdits = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, resolveOverridable(config, 'images_edits'), init, options);
+// /models lives on its own fetch toggle (see config.modelsFetch.endpoint),
+// not in pathOverrides.
+export const customFetchModels = (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions): Promise<Response> =>
+  customFetchInternal(config, config.modelsFetch.endpoint ?? '/v1/models', init, options);

--- a/packages/provider-custom/src/fetch_test.ts
+++ b/packages/provider-custom/src/fetch_test.ts
@@ -1,6 +1,14 @@
 import { test } from 'vitest';
 
-import { customFetch, assertCustomUpstreamRecord } from './index.ts';
+import { assertCustomUpstreamRecord } from './config.ts';
+import {
+  customFetchChatCompletions,
+  customFetchEmbeddings,
+  customFetchMessages,
+  customFetchMessagesCountTokens,
+  customFetchModels,
+  customFetchResponses,
+} from './fetch.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals, withMockedFetch } from '@floway-dev/test-utils';
 
@@ -21,7 +29,7 @@ const baseRecord: UpstreamRecord = {
   disabledPublicModelIds: [],
 };
 
-test('customFetch uses default /v1/* paths', async () => {
+test('typed transports use default /v1/* paths', async () => {
   const { config } = assertCustomUpstreamRecord(baseRecord);
 
   const seen: string[] = [];
@@ -31,12 +39,12 @@ test('customFetch uses default /v1/* paths', async () => {
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await customFetch(config, 'chat_completions', { method: 'POST', body: '{}' });
-      await customFetch(config, 'responses', { method: 'POST', body: '{}' });
-      await customFetch(config, 'messages', { method: 'POST', body: '{}' });
-      await customFetch(config, 'messages_count_tokens', { method: 'POST', body: '{}' });
-      await customFetch(config, 'embeddings', { method: 'POST', body: '{}' });
-      await customFetch(config, 'models', { method: 'GET' });
+      await customFetchChatCompletions(config, { method: 'POST', body: '{}' });
+      await customFetchResponses(config, { method: 'POST', body: '{}' });
+      await customFetchMessages(config, { method: 'POST', body: '{}' });
+      await customFetchMessagesCountTokens(config, { method: 'POST', body: '{}' });
+      await customFetchEmbeddings(config, { method: 'POST', body: '{}' });
+      await customFetchModels(config, { method: 'GET' });
     },
   );
 
@@ -50,7 +58,7 @@ test('customFetch uses default /v1/* paths', async () => {
   ]);
 });
 
-test('customFetch applies path overrides without an automatic /v1 prefix', async () => {
+test('admin pathOverrides replace defaults and propagate to derived sub-paths', async () => {
   const { config } = assertCustomUpstreamRecord({
     ...baseRecord,
     config: {
@@ -67,22 +75,22 @@ test('customFetch applies path overrides without an automatic /v1 prefix', async
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await customFetch(config, 'messages', { method: 'POST', body: '{}' });
-      await customFetch(config, 'messages_count_tokens', { method: 'POST', body: '{}' });
-      await customFetch(config, 'chat_completions', { method: 'POST', body: '{}' });
+      await customFetchMessages(config, { method: 'POST', body: '{}' });
+      // count_tokens follows its parent override.
+      await customFetchMessagesCountTokens(config, { method: 'POST', body: '{}' });
+      // Endpoints without an override fall back to the OpenAI default.
+      await customFetchChatCompletions(config, { method: 'POST', body: '{}' });
     },
   );
 
   assertEquals(seen, [
     'https://custom.example.com/api/v1/messages',
-    // count_tokens follows the messages override path.
     'https://custom.example.com/api/v1/messages/count_tokens',
-    // Endpoints without an override fall back to the OpenAI default.
     'https://custom.example.com/v1/chat/completions',
   ]);
 });
 
-test('customFetch resolves the /models path from modelsFetch.endpoint', async () => {
+test('customFetchModels resolves the path from modelsFetch.endpoint', async () => {
   const { config } = assertCustomUpstreamRecord({
     ...baseRecord,
     config: {
@@ -97,14 +105,14 @@ test('customFetch resolves the /models path from modelsFetch.endpoint', async ()
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await customFetch(config, 'models', { method: 'GET' });
+      await customFetchModels(config, { method: 'GET' });
     },
   );
 
   assertEquals(seen, 'https://custom.example.com/models');
 });
 
-test('customFetch falls back to the default /models path when modelsFetch.endpoint is absent', async () => {
+test('customFetchModels falls back to the default /v1/models path when modelsFetch.endpoint is absent', async () => {
   const { config } = assertCustomUpstreamRecord({
     ...baseRecord,
     config: {
@@ -119,30 +127,14 @@ test('customFetch falls back to the default /models path when modelsFetch.endpoi
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await customFetch(config, 'models', { method: 'GET' });
+      await customFetchModels(config, { method: 'GET' });
     },
   );
 
   assertEquals(seen, 'https://custom.example.com/v1/models');
 });
 
-test('customFetch sends the configured bearer token', async () => {
-  const { config } = assertCustomUpstreamRecord(baseRecord);
-  let authHeader: string | null = null;
-  await withMockedFetch(
-    request => {
-      authHeader = request.headers.get('authorization');
-      return new Response('{}', { status: 200 });
-    },
-    async () => {
-      await customFetch(config, 'models', { method: 'GET' });
-    },
-  );
-
-  assertEquals(authHeader, 'Bearer sk-test');
-});
-
-test('customFetch defaults authStyle to bearer when omitted', async () => {
+test('bearer authStyle sends the configured token via Authorization', async () => {
   const { config } = assertCustomUpstreamRecord(baseRecord);
   let authHeader: string | null = null;
   let xApiKey: string | null = null;
@@ -153,7 +145,7 @@ test('customFetch defaults authStyle to bearer when omitted', async () => {
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await customFetch(config, 'models', { method: 'GET' });
+      await customFetchModels(config, { method: 'GET' });
     },
   );
 
@@ -161,7 +153,7 @@ test('customFetch defaults authStyle to bearer when omitted', async () => {
   assertEquals(xApiKey, null);
 });
 
-test('customFetch with authStyle "anthropic" sends x-api-key + anthropic-version', async () => {
+test('authStyle "anthropic" sends x-api-key + anthropic-version', async () => {
   const { config } = assertCustomUpstreamRecord({
     ...baseRecord,
     config: {
@@ -180,7 +172,7 @@ test('customFetch with authStyle "anthropic" sends x-api-key + anthropic-version
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await customFetch(config, 'messages', { method: 'POST', body: '{}' });
+      await customFetchMessages(config, { method: 'POST', body: '{}' });
     },
   );
 
@@ -189,7 +181,7 @@ test('customFetch with authStyle "anthropic" sends x-api-key + anthropic-version
   assertEquals(anthropicVersion, '2023-06-01');
 });
 
-test('customFetch with authStyle "anthropic" preserves a caller-supplied anthropic-version', async () => {
+test('authStyle "anthropic" preserves a caller-supplied anthropic-version', async () => {
   const { config } = assertCustomUpstreamRecord({
     ...baseRecord,
     config: {
@@ -204,9 +196,8 @@ test('customFetch with authStyle "anthropic" preserves a caller-supplied anthrop
       return new Response('{}', { status: 200 });
     },
     async () => {
-      await customFetch(
+      await customFetchMessages(
         config,
-        'messages',
         { method: 'POST', body: '{}', headers: { 'anthropic-version': '2024-01-01' } },
       );
     },

--- a/packages/provider-custom/src/index.ts
+++ b/packages/provider-custom/src/index.ts
@@ -1,4 +1,3 @@
 export { createCustomProvider } from './provider.ts';
 export { assertCustomUpstreamRecord } from './config.ts';
-export { customFetch } from './fetch.ts';
 export { fetchCustomModels } from './fetch-models.ts';

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -1,13 +1,12 @@
-import { assertCustomUpstreamRecord } from './config.ts';
+import { assertCustomUpstreamRecord, type CustomUpstreamConfig } from './config.ts';
 import { fetchCustomModels, type CustomModelsResponse, type CustomRawModel } from './fetch-models.ts';
-import { customFetch } from './fetch.ts';
+import { customFetchChatCompletions, customFetchEmbeddings, customFetchImagesEdits, customFetchImagesGenerations, customFetchMessages, customFetchMessagesCountTokens, customFetchResponses } from './fetch.ts';
 import { inferEndpointsFromModelId } from './infer-endpoints.ts';
 import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completions';
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
-import { mergeAnthropicBetaHeader, publicModelId, resolveEffectiveFlags, defaultsForProvider, inProcessMemo, isProviderModelsHttpStatus, readModelsStore, writeModelsStore, streamingProviderCall } from '@floway-dev/provider';
-import type { ModelProvider, ModelProviderInstance, ProviderCallResult, ProviderStreamParser, StreamingEndpointKey, UpstreamModel, UpstreamRecord } from '@floway-dev/provider';
+import { mergeAnthropicBetaHeader, publicModelId, resolveEffectiveFlags, defaultsForProvider, inProcessMemo, isProviderModelsHttpStatus, readModelsStore, writeModelsStore, streamingProviderCall, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderStreamParser, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CustomProviderData {
   rawModelId: string;
@@ -142,16 +141,21 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
   // models so their pinned ids win.
   const withManual = (auto: UpstreamModel[]): UpstreamModel[] => [...manualModels, ...auto];
 
-  const call = (endpoint: 'messages_count_tokens' | 'embeddings' | 'images_generations', model: UpstreamModel, body: Record<string, unknown>, signal?: AbortSignal, headers?: Record<string, string>): Promise<ProviderCallResult> => {
-    return customFetch(config, endpoint, { method: 'POST', body: JSON.stringify({ ...body, model: providerData(model).rawModelId }), signal }, { extraHeaders: headers })
+  const call = (
+    transport: (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions) => Promise<Response>,
+    model: UpstreamModel,
+    body: Record<string, unknown>,
+    signal?: AbortSignal,
+    headers?: Record<string, string>,
+  ): Promise<ProviderCallResult> =>
+    transport(config, { method: 'POST', body: JSON.stringify({ ...body, model: providerData(model).rawModelId }), signal }, { extraHeaders: headers })
       .then(response => ({
         response,
         modelKey: providerData(model).rawModelId,
       }));
-  };
 
   const callStreaming = <TEvent>(
-    endpoint: StreamingEndpointKey,
+    transport: (config: CustomUpstreamConfig, init: RequestInit, options?: UpstreamFetchOptions) => Promise<Response>,
     model: UpstreamModel,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
@@ -160,9 +164,8 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
   ) => {
     const rawModelId = providerData(model).rawModelId;
     return streamingProviderCall(
-      customFetch(
+      transport(
         config,
-        endpoint,
         { method: 'POST', body: JSON.stringify({ ...body, stream: true, model: rawModelId }), signal },
         { extraHeaders: headers },
       ),
@@ -201,17 +204,17 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     },
     // Manual configuration wins over the cached upstream pricing for the same id.
     getPricingForModelKey: modelKey => manualPricingByUpstreamId.get(modelKey) ?? pricingByRawId.get(modelKey) ?? null,
-    callChatCompletions: (model, body, signal, headers) => callStreaming('chat_completions', model, body, signal, headers, parseChatCompletionsStream),
-    callResponses: (model, body, signal, headers) => callStreaming('responses', model, body, signal, headers, parseResponsesStream),
-    callMessages: (model, body, signal, headers, anthropicBeta) => callStreaming('messages', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta), parseMessagesStream),
-    callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call('messages_count_tokens', model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
-    callEmbeddings: (model, body, signal, headers) => call('embeddings', model, body, signal, headers),
-    callImagesGenerations: (model, body, signal, headers) => call('images_generations', model, body, signal, headers),
+    callChatCompletions: (model, body, signal, headers) => callStreaming(customFetchChatCompletions, model, body, signal, headers, parseChatCompletionsStream),
+    callResponses: (model, body, signal, headers) => callStreaming(customFetchResponses, model, body, signal, headers, parseResponsesStream),
+    callMessages: (model, body, signal, headers, anthropicBeta) => callStreaming(customFetchMessages, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta), parseMessagesStream),
+    callMessagesCountTokens: (model, body, signal, headers, anthropicBeta) => call(customFetchMessagesCountTokens, model, body, signal, mergeAnthropicBetaHeader(headers, anthropicBeta)),
+    callEmbeddings: (model, body, signal, headers) => call(customFetchEmbeddings, model, body, signal, headers),
+    callImagesGenerations: (model, body, signal, headers) => call(customFetchImagesGenerations, model, body, signal, headers),
     callImagesEdits: async (model, body, signal, headers) => {
       // Custom forwards the resolved upstream model id. The runtime auto-encodes
       // the FormData with a fresh boundary and sets Content-Type itself.
       body.append('model', providerData(model).rawModelId);
-      const response = await customFetch(config, 'images_edits', { method: 'POST', body, signal }, { extraHeaders: headers });
+      const response = await customFetchImagesEdits(config, { method: 'POST', body, signal }, { extraHeaders: headers });
       return { response, modelKey: providerData(model).rawModelId };
     },
   };

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -106,7 +106,7 @@ export { joinBaseAndPath, validateUpstreamPath } from './join.ts';
 
 export { mergeAnthropicBetaHeader } from './anthropic-beta.ts';
 
-export type { EndpointKey, StreamingEndpointKey, UpstreamFetchOptions } from './upstream.ts';
+export type { UpstreamFetchOptions } from './upstream.ts';
 
 export type { ImageDimensions, ImageProcessor, ImageSizeCalculator, SizeCaps } from './image-processor.ts';
 export {

--- a/packages/provider/src/upstream.ts
+++ b/packages/provider/src/upstream.ts
@@ -1,15 +1,3 @@
-// Logical endpoint keys used by the gateway-internal upstream dispatcher.
-// Each provider package owns its own path resolution per key; this enum is the
-// single shared vocabulary the api uses when asking a provider to issue a call
-// at a named endpoint (registry probes, route mounts, etc.).
-// `messages_count_tokens` is intentionally a logical key: it is a sub-path of
-// `messages` and follows the same provider-owned path policy, so the UI never
-// exposes it as a separate configurable endpoint.
-export type EndpointKey = 'chat_completions' | 'responses' | 'messages' | 'messages_count_tokens' | 'embeddings' | 'images_generations' | 'images_edits' | 'models';
-
-// Subset of EndpointKey whose calls go over SSE.
-export type StreamingEndpointKey = 'chat_completions' | 'responses' | 'messages';
-
 export interface UpstreamFetchOptions {
   extraHeaders?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary

- Each provider package now exposes one typed transport per logical endpoint (`xxxFetchChatCompletions`, `xxxFetchResponses`, `xxxFetchMessages`, `xxxFetchEmbeddings`, …) — thin wrappers around a package-private dispatcher that owns credential headers, surface selection, and path resolution.
- The provider's \`call\` / \`callStreaming\` helpers now take a transport thunk instead of a string endpoint key, so upstream call sites read as \`customFetchResponses(config, init)\` rather than \`customFetch(config, 'responses', init)\`.
- \`EndpointKey\` / \`StreamingEndpointKey\` are removed from \`@floway-dev/provider\`'s public surface, and the generic \`azureFetch\` / \`copilotFetch\` / \`customFetch\` exports are dropped from each provider package's \`index.ts\`.
- Custom's admin path-override key set becomes a package-internal literal union derived only from the endpoints Custom itself serves — no longer borrowed from the cross-provider enum.

## Why

The shared \`EndpointKey\` enum was a leaky vocabulary that several provider-specific concerns piggybacked on (Custom's admin path overrides, Azure's OpenAI-vs-Anthropic surface split, Copilot's hard-coded path map). Each provider owns its own endpoint vocabulary now; the public surface only carries what's structurally shared.

This is a pure structural refactor — no behavior change, no public API change beyond removing the now-unused types and exports.

## Test plan

- [x] \`pnpm run typecheck\` (all 10 packages + 2 apps green)
- [x] \`pnpm run lint\` clean
- [x] \`pnpm run test\` — 169 files, 1601 tests (unchanged from main)