### PR TITLE
feat(platform): add Node deployment target via sharp + node:sqlite

### DIFF
--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -1,0 +1,43 @@
+import { serve } from '@hono/node-server';
+
+import { bootstrapNodePlatform } from './src/bootstrap.ts';
+import { applyMigrations } from './src/migrate.ts';
+import {
+  app,
+  initBackgroundSchedulerResolver,
+  initRepo,
+  runScheduledMaintenance,
+  SqlRepo,
+} from '@floway-dev/proxy';
+
+// In Node we don't have Workers' executionCtx.waitUntil — there's no request
+// lifecycle to attach background work to — so the resolver fire-and-forgets
+// the promise. Logging the rejection here is the only signal we get; without
+// it a swallowed background failure would be silent.
+initBackgroundSchedulerResolver(_c => promise => {
+  promise.catch(err => console.error('[background]', err));
+});
+
+const dbPath = process.env.FLOWAY_DB_PATH ?? './data/floway.db';
+const filesDir = process.env.FLOWAY_FILES_DIR ?? './data/files';
+const port = Number(process.env.PORT ?? 8788);
+
+const SCHEDULED_INTERVAL_MS = 60 * 60 * 1000;
+
+const { db } = bootstrapNodePlatform({ dbPath, filesDir });
+await applyMigrations(db);
+initRepo(new SqlRepo(db));
+
+// CF triggers scheduled maintenance via cron; on Node we run the same job on
+// a wall-clock interval. unref() lets the process exit cleanly on SIGINT
+// even though the timer is still pending.
+setInterval(
+  () => {
+    runScheduledMaintenance().catch(err => console.error('[scheduled]', err));
+  },
+  SCHEDULED_INTERVAL_MS,
+).unref();
+
+serve({ fetch: app.fetch, port }, info => {
+  console.log(`floway listening on http://localhost:${info.port}`);
+});

--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -28,15 +28,18 @@ const { db } = bootstrapNodePlatform({ dbPath, filesDir });
 await applyMigrations(db);
 initRepo(new SqlRepo(db));
 
-// CF triggers scheduled maintenance via cron; on Node we run the same job on
-// a wall-clock interval. unref() lets the process exit cleanly on SIGINT
-// even though the timer is still pending.
-setInterval(
-  () => {
-    runScheduledMaintenance().catch(err => console.error('[scheduled]', err));
-  },
-  SCHEDULED_INTERVAL_MS,
-).unref();
+// Run the scheduled maintenance job once after a short startup delay and
+// then every hour. Without the startup run, a process that restarts more
+// often than the interval (crash loop, frequent deploys) would never run
+// maintenance and the responses-items expiry sweep would silently lag. The
+// 30s delay keeps the very first request after boot from racing the sweep.
+// unref() on both timers lets the process exit cleanly on SIGINT.
+const STARTUP_DELAY_MS = 30 * 1000;
+const sweep = (): void => {
+  runScheduledMaintenance().catch(err => console.error('[scheduled]', err));
+};
+setTimeout(sweep, STARTUP_DELAY_MS).unref();
+setInterval(sweep, SCHEDULED_INTERVAL_MS).unref();
 
 serve({ fetch: app.fetch, port }, info => {
   console.log(`floway listening on http://localhost:${info.port}`);

--- a/apps/platform-node/package.json
+++ b/apps/platform-node/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@floway-dev/platform-node",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "start": "tsx entry.ts"
+  },
+  "dependencies": {
+    "@floway-dev/platform": "workspace:*",
+    "@floway-dev/proxy": "workspace:*",
+    "@hono/node-server": "^2.0.4",
+    "hono": "^4",
+    "sharp": "^0.33.5"
+  },
+  "devDependencies": {
+    "@floway-dev/test-utils": "workspace:*",
+    "@types/node": "^22",
+    "tsx": "^4"
+  }
+}

--- a/apps/platform-node/package.json
+++ b/apps/platform-node/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=22.5"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "start": "tsx entry.ts"

--- a/apps/platform-node/src/bootstrap.ts
+++ b/apps/platform-node/src/bootstrap.ts
@@ -1,14 +1,12 @@
-import { mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
-
 import { FsFileProvider } from './fs-file-provider.ts';
-import { createNodeSqliteDatabase, type NodeSqliteDatabaseHandle } from './node-sqlite-database.ts';
+import { createNodeSqliteDatabase } from './node-sqlite-database.ts';
 import { createMemoryImageCache, createSharpImageProcessor } from './sharp-image-processor.ts';
 import {
   initEnv,
   initFileProvider,
   initImageProcessor,
   type ImageCache,
+  type SqlDatabase,
 } from '@floway-dev/platform';
 
 export interface NodePlatformOptions {
@@ -17,21 +15,13 @@ export interface NodePlatformOptions {
   imageCache?: ImageCache;
 }
 
-// Wires the Node-specific platform implementations and returns the database
-// handle so the caller can run migrations before constructing the repo.
-// `imageCache` is optional: a single-process Node deployment gets an in-memory
-// LRU by default, but a multi-instance deployment can pass a shared
-// implementation (e.g. backed by Redis) without touching this code.
-export const bootstrapNodePlatform = (
-  opts: NodePlatformOptions,
-): { db: NodeSqliteDatabaseHandle } => {
-  // Ensure parent directories exist before sqlite tries to open the file and
-  // before FsFileProvider writes its first object — `node:sqlite` returns
-  // ERR_SQLITE_ERROR ("unable to open database file") when the parent is
-  // missing, which is unhelpful to a fresh deploy.
-  mkdirSync(dirname(opts.dbPath), { recursive: true });
-  mkdirSync(opts.filesDir, { recursive: true });
-
+// Wires the Node-specific platform implementations. Each component
+// (createNodeSqliteDatabase, FsFileProvider) ensures its own root directory
+// exists, so bootstrap stays a pure wiring step. `imageCache` is optional:
+// a single-process Node deployment gets an in-memory LRU by default, but a
+// multi-instance deployment can pass a shared implementation (e.g. backed
+// by Redis) without touching this code.
+export const bootstrapNodePlatform = (opts: NodePlatformOptions): { db: SqlDatabase } => {
   initEnv(name => process.env[name] ?? '');
   initFileProvider(new FsFileProvider(opts.filesDir));
   initImageProcessor(createSharpImageProcessor({ cache: opts.imageCache ?? createMemoryImageCache() }));

--- a/apps/platform-node/src/bootstrap.ts
+++ b/apps/platform-node/src/bootstrap.ts
@@ -1,0 +1,39 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { FsFileProvider } from './fs-file-provider.ts';
+import { createNodeSqliteDatabase, type NodeSqliteDatabaseHandle } from './node-sqlite-database.ts';
+import { createMemoryImageCache, createSharpImageProcessor } from './sharp-image-processor.ts';
+import {
+  initEnv,
+  initFileProvider,
+  initImageProcessor,
+  type ImageCache,
+} from '@floway-dev/platform';
+
+export interface NodePlatformOptions {
+  dbPath: string;
+  filesDir: string;
+  imageCache?: ImageCache;
+}
+
+// Wires the Node-specific platform implementations and returns the database
+// handle so the caller can run migrations before constructing the repo.
+// `imageCache` is optional: a single-process Node deployment gets an in-memory
+// LRU by default, but a multi-instance deployment can pass a shared
+// implementation (e.g. backed by Redis) without touching this code.
+export const bootstrapNodePlatform = (
+  opts: NodePlatformOptions,
+): { db: NodeSqliteDatabaseHandle } => {
+  // Ensure parent directories exist before sqlite tries to open the file and
+  // before FsFileProvider writes its first object — `node:sqlite` returns
+  // ERR_SQLITE_ERROR ("unable to open database file") when the parent is
+  // missing, which is unhelpful to a fresh deploy.
+  mkdirSync(dirname(opts.dbPath), { recursive: true });
+  mkdirSync(opts.filesDir, { recursive: true });
+
+  initEnv(name => process.env[name] ?? '');
+  initFileProvider(new FsFileProvider(opts.filesDir));
+  initImageProcessor(createSharpImageProcessor({ cache: opts.imageCache ?? createMemoryImageCache() }));
+  return { db: createNodeSqliteDatabase(opts.dbPath) };
+};

--- a/apps/platform-node/src/fs-file-provider.ts
+++ b/apps/platform-node/src/fs-file-provider.ts
@@ -1,0 +1,55 @@
+import type { Dirent } from 'node:fs';
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+
+import type { FileProvider } from '@floway-dev/platform';
+
+// Filesystem-backed FileProvider. Every key resolves to a path under `root`,
+// so listKeys / deletePrefix walk the filesystem rather than maintaining a
+// separate index. Keys use forward-slash POSIX separators (matching R2's
+// surface) and are translated to native path segments on the way in/out so
+// the same key reads identically on Windows and POSIX hosts.
+export class FsFileProvider implements FileProvider {
+  constructor(private readonly root: string) {}
+
+  async put(key: string, body: Uint8Array): Promise<void> {
+    const path = this.pathFor(key);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, body);
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    try {
+      return new Uint8Array(await readFile(this.pathFor(key)));
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw e;
+    }
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    await rm(this.pathFor(prefix), { recursive: true, force: true });
+  }
+
+  async listKeys(prefix: string): Promise<string[]> {
+    const dir = this.pathFor(prefix);
+    let entries: Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true, recursive: true });
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw e;
+    }
+    const keys: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const fullPath = join(entry.parentPath, entry.name);
+      keys.push(relative(this.root, fullPath).split(sep).join('/'));
+    }
+    return keys;
+  }
+
+  private pathFor(key: string): string {
+    return join(this.root, ...key.split('/'));
+  }
+}

--- a/apps/platform-node/src/fs-file-provider.ts
+++ b/apps/platform-node/src/fs-file-provider.ts
@@ -1,6 +1,7 @@
 import type { Dirent } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
-import { dirname, join, relative, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 import type { FileProvider } from '@floway-dev/platform';
 
@@ -10,7 +11,15 @@ import type { FileProvider } from '@floway-dev/platform';
 // surface) and are translated to native path segments on the way in/out so
 // the same key reads identically on Windows and POSIX hosts.
 export class FsFileProvider implements FileProvider {
-  constructor(private readonly root: string) {}
+  private readonly root: string;
+
+  constructor(root: string) {
+    // Resolve once so `pathFor` can verify resolved paths still live under it.
+    this.root = resolve(root);
+    // Ensure the root exists so the first put() doesn't race against a missing
+    // directory and so tests / fresh deploys see a consistent structure.
+    mkdirSync(this.root, { recursive: true });
+  }
 
   async put(key: string, body: Uint8Array): Promise<void> {
     const path = this.pathFor(key);
@@ -28,6 +37,11 @@ export class FsFileProvider implements FileProvider {
   }
 
   async deletePrefix(prefix: string): Promise<void> {
+    // Refuse to delete the entire root: a stray empty-string prefix would
+    // otherwise wipe every spilled payload, including ones from concurrent
+    // requests. Callers that genuinely want to clear everything should call
+    // deleteAllResponsesItemPayloadFiles or the equivalent at a higher layer.
+    if (prefix === '') throw new Error('FsFileProvider.deletePrefix: refusing empty prefix');
     await rm(this.pathFor(prefix), { recursive: true, force: true });
   }
 
@@ -37,7 +51,11 @@ export class FsFileProvider implements FileProvider {
     try {
       entries = await readdir(dir, { withFileTypes: true, recursive: true });
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      const code = (e as NodeJS.ErrnoException).code;
+      // ENOENT is "the prefix has nothing under it"; ENOTDIR is "the prefix
+      // points at a file, not a directory" — both should yield an empty list,
+      // matching R2's "list of zero objects" semantics for a missing prefix.
+      if (code === 'ENOENT' || code === 'ENOTDIR') return [];
       throw e;
     }
     const keys: string[] = [];
@@ -49,7 +67,16 @@ export class FsFileProvider implements FileProvider {
     return keys;
   }
 
+  // Resolve a key against `root` and reject paths that escape it. Even though
+  // the FileProvider contract treats keys as opaque, callers are not required
+  // to scrub user-controlled segments and a `..`-laden key would otherwise
+  // walk to arbitrary host paths under R2 it would simply be a strange key.
   private pathFor(key: string): string {
-    return join(this.root, ...key.split('/'));
+    if (isAbsolute(key)) throw new Error(`FsFileProvider: absolute keys are not supported (${key})`);
+    const path = resolve(this.root, ...key.split('/'));
+    if (path !== this.root && !path.startsWith(this.root + sep)) {
+      throw new Error(`FsFileProvider: key escapes root (${key})`);
+    }
+    return path;
   }
 }

--- a/apps/platform-node/src/fs-file-provider_test.ts
+++ b/apps/platform-node/src/fs-file-provider_test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { test } from 'vitest';
+
+import { FsFileProvider } from './fs-file-provider.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+const withTempRoot = async (fn: (root: string) => Promise<void>): Promise<void> => {
+  const root = await mkdtemp(join(tmpdir(), 'fs-file-provider-'));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+};
+
+test('put then get round-trips binary content', () => withTempRoot(async root => {
+  const provider = new FsFileProvider(root);
+  const bytes = new Uint8Array([0, 1, 2, 0xff, 0xfe, 0x80]);
+  await provider.put('blobs/a.bin', bytes);
+  const read = await provider.get('blobs/a.bin');
+  assertEquals(read, bytes);
+}));
+
+test('get returns null for missing keys', () => withTempRoot(async root => {
+  const provider = new FsFileProvider(root);
+  const read = await provider.get('missing');
+  assertEquals(read, null);
+}));
+
+test('listKeys returns empty array for missing prefix', () => withTempRoot(async root => {
+  const provider = new FsFileProvider(root);
+  assertEquals(await provider.listKeys('absent/dir'), []);
+}));
+
+test('listKeys returns recursive file paths under prefix using forward slashes', () => withTempRoot(async root => {
+  const provider = new FsFileProvider(root);
+  await provider.put('p/a.bin', new Uint8Array([1]));
+  await provider.put('p/sub/b.bin', new Uint8Array([2]));
+  await provider.put('q/c.bin', new Uint8Array([3]));
+  const keys = (await provider.listKeys('p')).toSorted();
+  assertEquals(keys, ['p/a.bin', 'p/sub/b.bin']);
+}));
+
+test('deletePrefix removes everything under the prefix and is no-op for missing', () => withTempRoot(async root => {
+  const provider = new FsFileProvider(root);
+  await provider.put('cleanup/a.bin', new Uint8Array([1]));
+  await provider.put('cleanup/nested/b.bin', new Uint8Array([2]));
+  await provider.put('keep/c.bin', new Uint8Array([3]));
+
+  await provider.deletePrefix('cleanup');
+  assertEquals(await provider.listKeys('cleanup'), []);
+  assertEquals(await provider.get('keep/c.bin'), new Uint8Array([3]));
+
+  // Second call on an already-cleaned prefix must not throw.
+  await provider.deletePrefix('cleanup');
+}));
+
+test('put creates intermediate directories', () => withTempRoot(async root => {
+  const provider = new FsFileProvider(root);
+  await provider.put('deeply/nested/path/file.bin', new Uint8Array([42]));
+  const read = await provider.get('deeply/nested/path/file.bin');
+  assertEquals(read, new Uint8Array([42]));
+}));

--- a/apps/platform-node/src/migrate.ts
+++ b/apps/platform-node/src/migrate.ts
@@ -1,0 +1,67 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { NodeSqliteDatabaseHandle } from './node-sqlite-database.ts';
+
+// Resolve packages/proxy/migrations/ relative to this file's location in the
+// workspace. The Node deployment target runs under tsx against the source
+// tree, so the workspace layout is the source of truth — we walk three
+// directories up from apps/platform-node/src/ to the workspace root, then
+// down into packages/proxy/migrations/.
+//
+// We can't use require.resolve('@floway-dev/proxy/package.json') here because
+// the proxy package's `exports` field intentionally exposes only its public
+// surface; package.json is not subpath-exported and ESM resolution refuses
+// undeclared subpaths.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_MIGRATIONS_DIR = join(HERE, '..', '..', '..', 'packages', 'proxy', 'migrations');
+
+export interface ApplyMigrationsOptions {
+  // Override the migrations directory. Defaults to packages/proxy/migrations/
+  // resolved via the workspace layout.
+  dir?: string;
+}
+
+// Applies every pending migration in `dir`, recording each one's name in a
+// `_migrations` table so reruns are no-ops. Each file's full contents go
+// through node:sqlite's `exec()` rather than a hand-rolled statement split,
+// because the migration corpus contains:
+//   * trailing comment-only chunks that a `;` split turns into empty
+//     statements, which `prepare()` rejects with "statement has been
+//     finalized";
+//   * `CREATE TRIGGER ... BEGIN ... END;` blocks whose embedded `;` characters
+//     are part of the trigger body, which a regex split cannot honour.
+// `exec()` is sqlite's native multi-statement entry point — the same one D1
+// uses to apply migrations server-side.
+//
+// We bracket each file with our own BEGIN/COMMIT so a mid-file failure rolls
+// the whole file back; without that bracket, the partial DDL from earlier
+// statements would persist after a later one threw.
+export const applyMigrations = async (
+  db: NodeSqliteDatabaseHandle,
+  options: ApplyMigrationsOptions = {},
+): Promise<void> => {
+  const dir = options.dir ?? DEFAULT_MIGRATIONS_DIR;
+  db.raw.exec('CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)');
+
+  const appliedRows = await db.prepare('SELECT name FROM _migrations').all<{ name: string }>();
+  const applied = new Set(appliedRows.results.map(r => r.name));
+
+  const files = (await readdir(dir)).filter(f => f.endsWith('.sql')).toSorted();
+  for (const file of files) {
+    if (applied.has(file)) continue;
+    const sql = await readFile(join(dir, file), 'utf8');
+
+    db.raw.exec('BEGIN');
+    try {
+      db.raw.exec(sql);
+      await db.prepare('INSERT INTO _migrations (name, applied_at) VALUES (?, ?)')
+        .bind(file, Date.now()).run();
+      db.raw.exec('COMMIT');
+    } catch (e) {
+      db.raw.exec('ROLLBACK');
+      throw e;
+    }
+  }
+};

--- a/apps/platform-node/src/migrate.ts
+++ b/apps/platform-node/src/migrate.ts
@@ -2,30 +2,19 @@ import { readdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { NodeSqliteDatabaseHandle } from './node-sqlite-database.ts';
+import type { SqlDatabase } from '@floway-dev/platform';
 
 // Resolve packages/proxy/migrations/ relative to this file's location in the
 // workspace. The Node deployment target runs under tsx against the source
 // tree, so the workspace layout is the source of truth — we walk three
 // directories up from apps/platform-node/src/ to the workspace root, then
 // down into packages/proxy/migrations/.
-//
-// We can't use require.resolve('@floway-dev/proxy/package.json') here because
-// the proxy package's `exports` field intentionally exposes only its public
-// surface; package.json is not subpath-exported and ESM resolution refuses
-// undeclared subpaths.
 const HERE = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_MIGRATIONS_DIR = join(HERE, '..', '..', '..', 'packages', 'proxy', 'migrations');
 
-export interface ApplyMigrationsOptions {
-  // Override the migrations directory. Defaults to packages/proxy/migrations/
-  // resolved via the workspace layout.
-  dir?: string;
-}
-
-// Applies every pending migration in `dir`, recording each one's name in a
+// Applies every pending migration, recording each one's name in a
 // `_migrations` table so reruns are no-ops. Each file's full contents go
-// through node:sqlite's `exec()` rather than a hand-rolled statement split,
+// through SqlDatabase.exec() rather than a hand-rolled statement split,
 // because the migration corpus contains:
 //   * trailing comment-only chunks that a `;` split turns into empty
 //     statements, which `prepare()` rejects with "statement has been
@@ -38,12 +27,8 @@ export interface ApplyMigrationsOptions {
 // We bracket each file with our own BEGIN/COMMIT so a mid-file failure rolls
 // the whole file back; without that bracket, the partial DDL from earlier
 // statements would persist after a later one threw.
-export const applyMigrations = async (
-  db: NodeSqliteDatabaseHandle,
-  options: ApplyMigrationsOptions = {},
-): Promise<void> => {
-  const dir = options.dir ?? DEFAULT_MIGRATIONS_DIR;
-  db.raw.exec('CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)');
+export const applyMigrations = async (db: SqlDatabase, dir: string = DEFAULT_MIGRATIONS_DIR): Promise<void> => {
+  await db.exec('CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY)');
 
   const appliedRows = await db.prepare('SELECT name FROM _migrations').all<{ name: string }>();
   const applied = new Set(appliedRows.results.map(r => r.name));
@@ -53,14 +38,13 @@ export const applyMigrations = async (
     if (applied.has(file)) continue;
     const sql = await readFile(join(dir, file), 'utf8');
 
-    db.raw.exec('BEGIN');
+    await db.exec('BEGIN');
     try {
-      db.raw.exec(sql);
-      await db.prepare('INSERT INTO _migrations (name, applied_at) VALUES (?, ?)')
-        .bind(file, Date.now()).run();
-      db.raw.exec('COMMIT');
+      await db.exec(sql);
+      await db.prepare('INSERT INTO _migrations (name) VALUES (?)').bind(file).run();
+      await db.exec('COMMIT');
     } catch (e) {
-      db.raw.exec('ROLLBACK');
+      await db.exec('ROLLBACK');
       throw e;
     }
   }

--- a/apps/platform-node/src/migrate_test.ts
+++ b/apps/platform-node/src/migrate_test.ts
@@ -57,7 +57,7 @@ test('mid-migration failure rolls back and leaves no partial schema', () => with
   );
 
   const db = createNodeSqliteDatabase(join(dir, 'rollback.db'));
-  await assertRejects(() => applyMigrations(db, { dir: migrationsDir }));
+  await assertRejects(() => applyMigrations(db, migrationsDir));
 
   const tables = await db.prepare(
     'SELECT name FROM sqlite_master WHERE type = \'table\' AND name = ?',
@@ -76,12 +76,12 @@ test('skips already-applied migrations on partial state', () => withTemp(async d
   await writeFile(join(migrationsDir, '0002_b.sql'), 'CREATE TABLE b (id INTEGER);');
 
   const db = createNodeSqliteDatabase(join(dir, 'partial.db'));
-  await applyMigrations(db, { dir: migrationsDir });
+  await applyMigrations(db, migrationsDir);
 
   // Add a third migration; rerun. Only the new one should execute — the first
   // two would error if re-run because the tables already exist.
   await writeFile(join(migrationsDir, '0003_c.sql'), 'CREATE TABLE c (id INTEGER);');
-  await applyMigrations(db, { dir: migrationsDir });
+  await applyMigrations(db, migrationsDir);
 
   const recorded = await db.prepare('SELECT name FROM _migrations ORDER BY name').all<{ name: string }>();
   assertEquals(recorded.results.map(r => r.name), ['0001_a.sql', '0002_b.sql', '0003_c.sql']);

--- a/apps/platform-node/src/migrate_test.ts
+++ b/apps/platform-node/src/migrate_test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { test } from 'vitest';
+
+import { applyMigrations } from './migrate.ts';
+import { createNodeSqliteDatabase } from './node-sqlite-database.ts';
+import { assertEquals, assertRejects } from '@floway-dev/test-utils';
+
+const withTemp = async (fn: (dir: string) => Promise<void>): Promise<void> => {
+  const dir = await mkdtemp(join(tmpdir(), 'migrate-test-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+test('applies all real migration files against a fresh sqlite', () => withTemp(async dir => {
+  const db = createNodeSqliteDatabase(join(dir, 'real.db'));
+  await applyMigrations(db);
+
+  // Schema check: a stable table from migration 0001 exists with expected columns.
+  const apiKeyCols = await db.prepare('PRAGMA table_info(api_keys)').all<{ name: string }>();
+  const colNames = apiKeyCols.results.map(r => r.name).toSorted();
+  assertEquals(colNames.includes('id'), true);
+  assertEquals(colNames.includes('key'), true);
+
+  // Every migration was recorded.
+  const recorded = await db.prepare('SELECT COUNT(*) AS n FROM _migrations').first<{ n: number }>();
+  assertEquals(recorded !== null && recorded.n > 0, true);
+}));
+
+test('rerun is a no-op once all migrations are applied', () => withTemp(async dir => {
+  const db = createNodeSqliteDatabase(join(dir, 'idempotent.db'));
+  await applyMigrations(db);
+  const firstCount = await db.prepare('SELECT COUNT(*) AS n FROM _migrations').first<{ n: number }>();
+
+  await applyMigrations(db);
+  const secondCount = await db.prepare('SELECT COUNT(*) AS n FROM _migrations').first<{ n: number }>();
+  assertEquals(secondCount?.n, firstCount?.n);
+}));
+
+test('mid-migration failure rolls back and leaves no partial schema', () => withTemp(async dir => {
+  const migrationsDir = join(dir, 'migrations');
+  await rm(migrationsDir, { recursive: true, force: true });
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(migrationsDir, { recursive: true });
+
+  // First statement creates a table; second is invalid SQL — the transaction
+  // must roll back so the table from the first statement does not survive.
+  await writeFile(
+    join(migrationsDir, '0001_bad.sql'),
+    'CREATE TABLE only_in_failed_migration (id INTEGER);\n'
+    + 'NOT VALID SQL HERE;\n',
+  );
+
+  const db = createNodeSqliteDatabase(join(dir, 'rollback.db'));
+  await assertRejects(() => applyMigrations(db, { dir: migrationsDir }));
+
+  const tables = await db.prepare(
+    'SELECT name FROM sqlite_master WHERE type = \'table\' AND name = ?',
+  ).bind('only_in_failed_migration').all<{ name: string }>();
+  assertEquals(tables.results, []);
+
+  const recorded = await db.prepare('SELECT name FROM _migrations').all<{ name: string }>();
+  assertEquals(recorded.results, []);
+}));
+
+test('skips already-applied migrations on partial state', () => withTemp(async dir => {
+  const migrationsDir = join(dir, 'migrations');
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(migrationsDir, { recursive: true });
+  await writeFile(join(migrationsDir, '0001_a.sql'), 'CREATE TABLE a (id INTEGER);');
+  await writeFile(join(migrationsDir, '0002_b.sql'), 'CREATE TABLE b (id INTEGER);');
+
+  const db = createNodeSqliteDatabase(join(dir, 'partial.db'));
+  await applyMigrations(db, { dir: migrationsDir });
+
+  // Add a third migration; rerun. Only the new one should execute — the first
+  // two would error if re-run because the tables already exist.
+  await writeFile(join(migrationsDir, '0003_c.sql'), 'CREATE TABLE c (id INTEGER);');
+  await applyMigrations(db, { dir: migrationsDir });
+
+  const recorded = await db.prepare('SELECT name FROM _migrations ORDER BY name').all<{ name: string }>();
+  assertEquals(recorded.results.map(r => r.name), ['0001_a.sql', '0002_b.sql', '0003_c.sql']);
+}));

--- a/apps/platform-node/src/node-sqlite-database.ts
+++ b/apps/platform-node/src/node-sqlite-database.ts
@@ -1,0 +1,78 @@
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
+
+import type { SqlDatabase, SqlPreparedStatement, SqlResult } from '@floway-dev/platform';
+
+// node:sqlite's prepared statement is synchronous and returns plain rows.
+// We adapt it to the platform's async, enveloped contract: bind() captures
+// values for the next call (matching D1's chained shape), run() reports
+// `meta.changes` from the underlying result.
+class NodeSqlitePreparedStatement implements SqlPreparedStatement {
+  private bound: unknown[] = [];
+
+  constructor(private readonly stmt: StatementSync) {}
+
+  bind(...values: unknown[]): SqlPreparedStatement {
+    this.bound = values;
+    return this;
+  }
+
+  first<T = Record<string, unknown>>(): Promise<T | null> {
+    const row = this.stmt.get(...(this.bound as never[]));
+    return Promise.resolve((row as T | undefined) ?? null);
+  }
+
+  all<T = Record<string, unknown>>(): Promise<SqlResult<T>> {
+    const rows = this.stmt.all(...(this.bound as never[])) as T[];
+    return Promise.resolve({ results: rows, success: true, meta: {} });
+  }
+
+  run(): Promise<SqlResult> {
+    const result = this.stmt.run(...(this.bound as never[]));
+    return Promise.resolve({
+      results: [],
+      success: true,
+      meta: { changes: Number(result.changes ?? 0) },
+    });
+  }
+}
+
+class NodeSqliteDatabase implements SqlDatabase {
+  constructor(readonly raw: DatabaseSync) {}
+
+  prepare(query: string): SqlPreparedStatement {
+    return new NodeSqlitePreparedStatement(this.raw.prepare(query));
+  }
+
+  // batch() runs the supplied statements inside one transaction so the
+  // multi-statement repo writes are atomic on this backend, matching D1's
+  // batch semantics.
+  async batch(statements: SqlPreparedStatement[]): Promise<SqlResult[]> {
+    const results: SqlResult[] = [];
+    this.raw.exec('BEGIN');
+    try {
+      for (const stmt of statements) results.push(await stmt.run());
+      this.raw.exec('COMMIT');
+    } catch (e) {
+      this.raw.exec('ROLLBACK');
+      throw e;
+    }
+    return results;
+  }
+}
+
+// `raw` exposes the underlying DatabaseSync to bootstrap-time helpers in this
+// package (the migration runner, which needs `exec()` to handle hand-authored
+// migration files containing comments and trigger BEGIN/END blocks that
+// statement-level prepare/run cannot parse).
+export interface NodeSqliteDatabaseHandle extends SqlDatabase {
+  readonly raw: DatabaseSync;
+}
+
+export const createNodeSqliteDatabase = (path: string): NodeSqliteDatabaseHandle => {
+  const db = new DatabaseSync(path);
+  // Match the schema's relational expectations; node:sqlite leaves foreign
+  // key enforcement off by default while D1 keeps it on, so without this the
+  // two backends drift.
+  db.exec('PRAGMA foreign_keys = ON');
+  return new NodeSqliteDatabase(db);
+};

--- a/apps/platform-node/src/node-sqlite-database.ts
+++ b/apps/platform-node/src/node-sqlite-database.ts
@@ -1,19 +1,23 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { DatabaseSync, type StatementSync } from 'node:sqlite';
 
 import type { SqlDatabase, SqlPreparedStatement, SqlResult } from '@floway-dev/platform';
 
 // node:sqlite's prepared statement is synchronous and returns plain rows.
-// We adapt it to the platform's async, enveloped contract: bind() captures
-// values for the next call (matching D1's chained shape), run() reports
-// `meta.changes` from the underlying result.
+// We adapt it to the platform's async, enveloped contract. bind() returns a
+// fresh statement object so repeated bind calls on the same prepared statement
+// each produce an independent bound view — matching D1's immutable bind shape
+// (mutating self would cause two awaited binds on the same statement to
+// share state under load).
 class NodeSqlitePreparedStatement implements SqlPreparedStatement {
-  private bound: unknown[] = [];
-
-  constructor(private readonly stmt: StatementSync) {}
+  constructor(
+    private readonly stmt: StatementSync,
+    private readonly bound: readonly unknown[] = [],
+  ) {}
 
   bind(...values: unknown[]): SqlPreparedStatement {
-    this.bound = values;
-    return this;
+    return new NodeSqlitePreparedStatement(this.stmt, values);
   }
 
   first<T = Record<string, unknown>>(): Promise<T | null> {
@@ -37,10 +41,10 @@ class NodeSqlitePreparedStatement implements SqlPreparedStatement {
 }
 
 class NodeSqliteDatabase implements SqlDatabase {
-  constructor(readonly raw: DatabaseSync) {}
+  constructor(private readonly db: DatabaseSync) {}
 
   prepare(query: string): SqlPreparedStatement {
-    return new NodeSqlitePreparedStatement(this.raw.prepare(query));
+    return new NodeSqlitePreparedStatement(this.db.prepare(query));
   }
 
   // batch() runs the supplied statements inside one transaction so the
@@ -48,27 +52,28 @@ class NodeSqliteDatabase implements SqlDatabase {
   // batch semantics.
   async batch(statements: SqlPreparedStatement[]): Promise<SqlResult[]> {
     const results: SqlResult[] = [];
-    this.raw.exec('BEGIN');
+    this.db.exec('BEGIN');
     try {
       for (const stmt of statements) results.push(await stmt.run());
-      this.raw.exec('COMMIT');
+      this.db.exec('COMMIT');
     } catch (e) {
-      this.raw.exec('ROLLBACK');
+      this.db.exec('ROLLBACK');
       throw e;
     }
     return results;
   }
+
+  exec(sql: string): Promise<unknown> {
+    this.db.exec(sql);
+    return Promise.resolve(undefined);
+  }
 }
 
-// `raw` exposes the underlying DatabaseSync to bootstrap-time helpers in this
-// package (the migration runner, which needs `exec()` to handle hand-authored
-// migration files containing comments and trigger BEGIN/END blocks that
-// statement-level prepare/run cannot parse).
-export interface NodeSqliteDatabaseHandle extends SqlDatabase {
-  readonly raw: DatabaseSync;
-}
-
-export const createNodeSqliteDatabase = (path: string): NodeSqliteDatabaseHandle => {
+export const createNodeSqliteDatabase = (path: string): SqlDatabase => {
+  // node:sqlite throws ERR_SQLITE_ERROR ("unable to open database file") when
+  // the parent directory is missing — unhelpful on a fresh deploy. Each
+  // component owns its own root.
+  mkdirSync(dirname(path), { recursive: true });
   const db = new DatabaseSync(path);
   // Match the schema's relational expectations; node:sqlite leaves foreign
   // key enforcement off by default while D1 keeps it on, so without this the

--- a/apps/platform-node/src/node-sqlite-database_test.ts
+++ b/apps/platform-node/src/node-sqlite-database_test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { test } from 'vitest';
+
+import { createNodeSqliteDatabase } from './node-sqlite-database.ts';
+import { assert, assertEquals, assertRejects } from '@floway-dev/test-utils';
+
+const withTempDb = async (fn: (dbPath: string) => Promise<void>): Promise<void> => {
+  const dir = await mkdtemp(join(tmpdir(), 'node-sqlite-db-'));
+  try {
+    await fn(join(dir, 'test.db'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+test('prepare/all returns rows in SqlResult envelope', () => withTempDb(async path => {
+  const db = createNodeSqliteDatabase(path);
+  await db.prepare('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)').run();
+  await db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(1, 'a').run();
+  await db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(2, 'b').run();
+
+  const result = await db.prepare('SELECT id, name FROM t ORDER BY id').all<{ id: number; name: string }>();
+  assertEquals(result.success, true);
+  assertEquals(result.results, [{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
+}));
+
+test('first returns first row or null', () => withTempDb(async path => {
+  const db = createNodeSqliteDatabase(path);
+  await db.prepare('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)').run();
+  await db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(7, 'seven').run();
+
+  const hit = await db.prepare('SELECT id, name FROM t WHERE id = ?').bind(7).first<{ id: number; name: string }>();
+  assertEquals(hit, { id: 7, name: 'seven' });
+
+  const miss = await db.prepare('SELECT id, name FROM t WHERE id = ?').bind(99).first();
+  assertEquals(miss, null);
+}));
+
+test('run reports changes for INSERT / UPDATE / DELETE', () => withTempDb(async path => {
+  const db = createNodeSqliteDatabase(path);
+  await db.prepare('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)').run();
+
+  const ins = await db.prepare('INSERT INTO t (id, name) VALUES (?, ?), (?, ?)').bind(1, 'a', 2, 'b').run();
+  assertEquals(ins.meta.changes, 2);
+
+  const upd = await db.prepare('UPDATE t SET name = ? WHERE id = ?').bind('A', 1).run();
+  assertEquals(upd.meta.changes, 1);
+
+  const del = await db.prepare('DELETE FROM t WHERE id = ?').bind(1).run();
+  assertEquals(del.meta.changes, 1);
+}));
+
+test('batch executes statements in order and returns each result', () => withTempDb(async path => {
+  const db = createNodeSqliteDatabase(path);
+  assert(db.batch !== undefined, 'batch must be implemented');
+  await db.prepare('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)').run();
+
+  const results = await db.batch([
+    db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(1, 'a'),
+    db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(2, 'b'),
+    db.prepare('UPDATE t SET name = ? WHERE id = ?').bind('A', 1),
+  ]);
+  assertEquals(results.length, 3);
+  assertEquals(results.map(r => r.meta.changes), [1, 1, 1]);
+
+  const rows = await db.prepare('SELECT id, name FROM t ORDER BY id').all<{ id: number; name: string }>();
+  assertEquals(rows.results, [{ id: 1, name: 'A' }, { id: 2, name: 'b' }]);
+}));
+
+test('batch rolls back on mid-batch failure', () => withTempDb(async path => {
+  const db = createNodeSqliteDatabase(path);
+  await db.prepare('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)').run();
+  await db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(1, 'a').run();
+
+  await assertRejects(
+    () => db.batch!([
+      db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(2, 'b'),
+      // Duplicate primary key — fails after the first succeeds.
+      db.prepare('INSERT INTO t (id, name) VALUES (?, ?)').bind(1, 'dup'),
+    ]),
+  );
+
+  const rows = await db.prepare('SELECT id FROM t ORDER BY id').all<{ id: number }>();
+  // Only the pre-batch insert should remain — the in-batch INSERT(id=2) was rolled back.
+  assertEquals(rows.results, [{ id: 1 }]);
+}));
+
+test('foreign key enforcement is on', () => withTempDb(async path => {
+  const db = createNodeSqliteDatabase(path);
+  await db.prepare('CREATE TABLE parent (id INTEGER PRIMARY KEY)').run();
+  await db.prepare('CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))').run();
+
+  await assertRejects(
+    () => db.prepare('INSERT INTO child (id, parent_id) VALUES (?, ?)').bind(1, 999).run(),
+  );
+}));

--- a/apps/platform-node/src/sharp-image-processor.ts
+++ b/apps/platform-node/src/sharp-image-processor.ts
@@ -11,55 +11,57 @@ const WEBP_QUALITY = 82;
 const CACHE_KEY_PREFIX = 'imgwebp';
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
 
-class SharpImageProcessor implements ImageProcessor {
-  constructor(private readonly cache: ImageCache | null) {}
+export const createSharpImageProcessor = (opts: { cache?: ImageCache } = {}): ImageProcessor => {
+  const cache = opts.cache ?? null;
+  return {
+    async compressToWebp(input: Uint8Array, target: ImageDimensions | null): Promise<Uint8Array> {
+      const cacheKey = cache
+        ? `${CACHE_KEY_PREFIX}:${await sha256Hex(input)}:${target ? `${target.width}x${target.height}` : 'orig'}:webp:q${WEBP_QUALITY}`
+        : null;
+      if (cache && cacheKey) {
+        const hit = await cache.get(cacheKey);
+        if (hit) return hit;
+      }
 
-  async compressToWebp(input: Uint8Array, target: ImageDimensions | null): Promise<Uint8Array> {
-    let cacheKey: string | null = null;
-    if (this.cache) {
-      const targetKey = target ? `${target.width}x${target.height}` : 'orig';
-      cacheKey = `${CACHE_KEY_PREFIX}:${await sha256Hex(input)}:${targetKey}:webp:q${WEBP_QUALITY}`;
-      const hit = await this.cache.get(cacheKey);
-      if (hit) return hit;
-    }
+      let pipeline = sharp(input);
+      // `fit: 'inside'` already implies never-enlarge; the `withoutEnlargement`
+      // flag is redundant but the sharp docs recommend stating it explicitly
+      // so the intent is unambiguous when reading the call site.
+      if (target) pipeline = pipeline.resize({ width: target.width, height: target.height, fit: 'inside', withoutEnlargement: true });
+      const output = new Uint8Array(await pipeline.webp({ quality: WEBP_QUALITY }).toBuffer());
 
-    let pipeline = sharp(input);
-    if (target) {
-      // `inside` matches scale-down semantics: never enlarges, preserves aspect
-      // ratio, fits inside the target box. `withoutEnlargement` makes the
-      // never-enlarge guarantee explicit even when callers ask for a target
-      // larger than the source.
-      pipeline = pipeline.resize({
-        width: target.width,
-        height: target.height,
-        fit: 'inside',
-        withoutEnlargement: true,
-      });
-    }
-    const output = new Uint8Array(await pipeline.webp({ quality: WEBP_QUALITY }).toBuffer());
+      if (cache && cacheKey) await cache.put(cacheKey, output, CACHE_TTL_SECONDS);
+      return output;
+    },
+  };
+};
 
-    if (this.cache && cacheKey) await this.cache.put(cacheKey, output, CACHE_TTL_SECONDS);
-    return output;
-  }
-}
-
-export const createSharpImageProcessor = (opts: { cache?: ImageCache } = {}): ImageProcessor =>
-  new SharpImageProcessor(opts.cache ?? null);
-
-// Bounded in-memory ImageCache. Eviction is FIFO on size, which is enough for
-// a single-process Node deployment where the cache exists to absorb repeated
-// images within one conversation; a long-lived deployment that wants smarter
-// eviction can pass its own ImageCache implementation to bootstrap.
+// Bounded in-memory ImageCache with LRU-on-touch eviction: a hit reorders the
+// entry to the most-recent position by re-inserting, and put on an existing
+// key likewise refreshes its position. Suitable for single-process Node
+// deployments where the workload is "the same image resent across consecutive
+// turns of one conversation" — exactly the LRU access pattern. A multi-
+// instance deployment can pass its own ImageCache implementation to bootstrap.
 export const createMemoryImageCache = (maxEntries = 64): ImageCache => {
   const store = new Map<string, Uint8Array>();
   return {
     get(key) {
-      return Promise.resolve(store.get(key) ?? null);
+      const value = store.get(key);
+      if (value === undefined) return Promise.resolve(null);
+      // Re-insert to bump to the tail (Map preserves insertion order; .delete
+      // + .set is the canonical Map-LRU touch).
+      store.delete(key);
+      store.set(key, value);
+      return Promise.resolve(value);
     },
     put(key, value) {
-      if (!store.has(key) && store.size >= maxEntries) {
-        const firstKey = store.keys().next().value;
-        if (firstKey !== undefined) store.delete(firstKey);
+      // Refresh position on overwrite. .delete + .set on the existing key
+      // moves it to the tail; a fresh key falls through to the size check
+      // and may evict the least-recently-used entry first.
+      if (store.has(key)) {
+        store.delete(key);
+      } else if (store.size >= maxEntries) {
+        store.delete(store.keys().next().value as string);
       }
       store.set(key, value);
       return Promise.resolve();

--- a/apps/platform-node/src/sharp-image-processor.ts
+++ b/apps/platform-node/src/sharp-image-processor.ts
@@ -1,0 +1,68 @@
+import sharp from 'sharp';
+
+import { sha256Hex } from '@floway-dev/platform';
+import type { ImageCache, ImageDimensions, ImageProcessor } from '@floway-dev/platform';
+
+// Fixed WebP quality matching the Cloudflare encoder so both deployment
+// targets pass the same lossy budget through to the upstream model. See
+// platform-cloudflare/src/image-processor.ts for the calibration notes.
+const WEBP_QUALITY = 82;
+
+const CACHE_KEY_PREFIX = 'imgwebp';
+const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+class SharpImageProcessor implements ImageProcessor {
+  constructor(private readonly cache: ImageCache | null) {}
+
+  async compressToWebp(input: Uint8Array, target: ImageDimensions | null): Promise<Uint8Array> {
+    let cacheKey: string | null = null;
+    if (this.cache) {
+      const targetKey = target ? `${target.width}x${target.height}` : 'orig';
+      cacheKey = `${CACHE_KEY_PREFIX}:${await sha256Hex(input)}:${targetKey}:webp:q${WEBP_QUALITY}`;
+      const hit = await this.cache.get(cacheKey);
+      if (hit) return hit;
+    }
+
+    let pipeline = sharp(input);
+    if (target) {
+      // `inside` matches scale-down semantics: never enlarges, preserves aspect
+      // ratio, fits inside the target box. `withoutEnlargement` makes the
+      // never-enlarge guarantee explicit even when callers ask for a target
+      // larger than the source.
+      pipeline = pipeline.resize({
+        width: target.width,
+        height: target.height,
+        fit: 'inside',
+        withoutEnlargement: true,
+      });
+    }
+    const output = new Uint8Array(await pipeline.webp({ quality: WEBP_QUALITY }).toBuffer());
+
+    if (this.cache && cacheKey) await this.cache.put(cacheKey, output, CACHE_TTL_SECONDS);
+    return output;
+  }
+}
+
+export const createSharpImageProcessor = (opts: { cache?: ImageCache } = {}): ImageProcessor =>
+  new SharpImageProcessor(opts.cache ?? null);
+
+// Bounded in-memory ImageCache. Eviction is FIFO on size, which is enough for
+// a single-process Node deployment where the cache exists to absorb repeated
+// images within one conversation; a long-lived deployment that wants smarter
+// eviction can pass its own ImageCache implementation to bootstrap.
+export const createMemoryImageCache = (maxEntries = 64): ImageCache => {
+  const store = new Map<string, Uint8Array>();
+  return {
+    get(key) {
+      return Promise.resolve(store.get(key) ?? null);
+    },
+    put(key, value) {
+      if (!store.has(key) && store.size >= maxEntries) {
+        const firstKey = store.keys().next().value;
+        if (firstKey !== undefined) store.delete(firstKey);
+      }
+      store.set(key, value);
+      return Promise.resolve();
+    },
+  };
+};

--- a/apps/platform-node/src/sharp-image-processor_test.ts
+++ b/apps/platform-node/src/sharp-image-processor_test.ts
@@ -1,0 +1,130 @@
+import sharp from 'sharp';
+import { test } from 'vitest';
+
+import { createMemoryImageCache, createSharpImageProcessor } from './sharp-image-processor.ts';
+import type { ImageCache } from '@floway-dev/platform';
+import { assert, assertEquals } from '@floway-dev/test-utils';
+
+const decode = (base64: string): Uint8Array => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
+// 1x1 red PNG. Used everywhere we don't care about input dimensions; sharp
+// can decode it but it's too small to exercise the resize path.
+const PNG_1x1 = decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/wEAAAAASUVORK5CYII=');
+
+const generatePng = async (width: number, height: number): Promise<Uint8Array> => {
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 200, g: 100, b: 50 },
+    },
+  }).png().toBuffer();
+  return new Uint8Array(buffer);
+};
+
+const isWebp = (bytes: Uint8Array): boolean =>
+  bytes.length >= 12
+    && bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46
+    && bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50;
+
+test('compressToWebp produces valid WebP magic bytes', async () => {
+  const processor = createSharpImageProcessor();
+  const out = await processor.compressToWebp(PNG_1x1, null);
+  assert(isWebp(out), 'output should be WebP');
+});
+
+test('compressToWebp resizes to target dimensions', async () => {
+  const processor = createSharpImageProcessor();
+  const source = await generatePng(200, 100);
+  const out = await processor.compressToWebp(source, { width: 50, height: 50 });
+  const meta = await sharp(out).metadata();
+  // fit:'inside' preserves aspect ratio: 200x100 → 50x25.
+  assertEquals(meta.width, 50);
+  assertEquals(meta.height, 25);
+});
+
+test('compressToWebp with target=null preserves source dimensions', async () => {
+  const processor = createSharpImageProcessor();
+  const source = await generatePng(80, 40);
+  const out = await processor.compressToWebp(source, null);
+  const meta = await sharp(out).metadata();
+  assertEquals(meta.width, 80);
+  assertEquals(meta.height, 40);
+});
+
+test('compressToWebp never enlarges past the source', async () => {
+  const processor = createSharpImageProcessor();
+  const source = await generatePng(40, 20);
+  const out = await processor.compressToWebp(source, { width: 4096, height: 4096 });
+  const meta = await sharp(out).metadata();
+  assertEquals(meta.width, 40);
+  assertEquals(meta.height, 20);
+});
+
+test('cache hit short-circuits encode and returns stored bytes', async () => {
+  const calls = { get: 0, put: 0 };
+  const stored = new Uint8Array([0x42, 0x42, 0x42]);
+  const cache: ImageCache = {
+    get: () => {
+      calls.get += 1;
+      return Promise.resolve(stored);
+    },
+    put: () => {
+      calls.put += 1;
+      return Promise.resolve();
+    },
+  };
+  const processor = createSharpImageProcessor({ cache });
+  const out = await processor.compressToWebp(PNG_1x1, null);
+  assertEquals(out, stored);
+  assertEquals(calls.get, 1);
+  assertEquals(calls.put, 0);
+});
+
+test('cache miss writes the encoded result', async () => {
+  const calls = { get: 0, put: 0 };
+  let lastTtl: number | null = null;
+  const cache: ImageCache = {
+    get: () => {
+      calls.get += 1;
+      return Promise.resolve(null);
+    },
+    put: (_k, _v, ttl) => {
+      calls.put += 1;
+      lastTtl = ttl;
+      return Promise.resolve();
+    },
+  };
+  const processor = createSharpImageProcessor({ cache });
+  const out = await processor.compressToWebp(PNG_1x1, null);
+  assert(isWebp(out), 'output should be WebP');
+  assertEquals(calls.get, 1);
+  assertEquals(calls.put, 1);
+  assert(lastTtl !== null && lastTtl > 0, 'TTL should be a positive number');
+});
+
+test('cache key differs by target so a resized variant is a separate entry', async () => {
+  const cache = createMemoryImageCache();
+  const processor = createSharpImageProcessor({ cache });
+  const source = await generatePng(40, 20);
+  const orig = await processor.compressToWebp(source, null);
+  const resized = await processor.compressToWebp(source, { width: 20, height: 20 });
+  // Same backing source bytes but different target boxes — outputs must differ.
+  assert(orig.length !== resized.length || !orig.every((b, i) => b === resized[i]));
+});
+
+test('createMemoryImageCache evicts the oldest entry when full', async () => {
+  const cache = createMemoryImageCache(2);
+  await cache.put('a', new Uint8Array([1]), 60);
+  await cache.put('b', new Uint8Array([2]), 60);
+  await cache.put('c', new Uint8Array([3]), 60);
+  assertEquals(await cache.get('a'), null);
+  assertEquals(await cache.get('b'), new Uint8Array([2]));
+  assertEquals(await cache.get('c'), new Uint8Array([3]));
+});

--- a/apps/platform-node/tsconfig.json
+++ b/apps/platform-node/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["entry.ts", "vitest.config.ts", "src/**/*.ts"]
+}

--- a/apps/platform-node/vitest.config.ts
+++ b/apps/platform-node/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*_test.ts'],
+    restoreMocks: false,
+    testTimeout: 10_000,
+  },
+});

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -136,7 +136,7 @@ const commonConfig: Linter.Config = {
     'import/internal-regex': '^@floway-dev/',
     'import/resolver': {
       typescript: {
-        project: ['./apps/platform-cloudflare/tsconfig.json', './apps/web/tsconfig.json', './packages/interceptor/tsconfig.json', './packages/platform/tsconfig.json', './packages/protocols/tsconfig.json', './packages/provider/tsconfig.json', './packages/provider-azure/tsconfig.json', './packages/provider-copilot/tsconfig.json', './packages/provider-custom/tsconfig.json', './packages/proxy/tsconfig.json', './packages/test-utils/tsconfig.json', './packages/translate/tsconfig.json', './packages/ui/tsconfig.json'],
+        project: ['./apps/platform-cloudflare/tsconfig.json', './apps/platform-node/tsconfig.json', './apps/web/tsconfig.json', './packages/interceptor/tsconfig.json', './packages/platform/tsconfig.json', './packages/protocols/tsconfig.json', './packages/provider/tsconfig.json', './packages/provider-azure/tsconfig.json', './packages/provider-copilot/tsconfig.json', './packages/provider-custom/tsconfig.json', './packages/proxy/tsconfig.json', './packages/test-utils/tsconfig.json', './packages/translate/tsconfig.json', './packages/ui/tsconfig.json'],
         noWarnOnMultipleProjects: true,
       },
     },
@@ -147,7 +147,7 @@ const parserOptions: Linter.ParserOptions = {
   parser: tsParser,
   ecmaVersion: 'latest',
   sourceType: 'module',
-  project: ['./apps/platform-cloudflare/tsconfig.json', './apps/web/tsconfig.json', './packages/interceptor/tsconfig.json', './packages/platform/tsconfig.json', './packages/protocols/tsconfig.json', './packages/provider/tsconfig.json', './packages/provider-azure/tsconfig.json', './packages/provider-copilot/tsconfig.json', './packages/provider-custom/tsconfig.json', './packages/proxy/tsconfig.json', './packages/test-utils/tsconfig.json', './packages/translate/tsconfig.json', './packages/ui/tsconfig.json'],
+  project: ['./apps/platform-cloudflare/tsconfig.json', './apps/platform-node/tsconfig.json', './apps/web/tsconfig.json', './packages/interceptor/tsconfig.json', './packages/platform/tsconfig.json', './packages/protocols/tsconfig.json', './packages/provider/tsconfig.json', './packages/provider-azure/tsconfig.json', './packages/provider-copilot/tsconfig.json', './packages/provider-custom/tsconfig.json', './packages/proxy/tsconfig.json', './packages/test-utils/tsconfig.json', './packages/translate/tsconfig.json', './packages/ui/tsconfig.json'],
   noWarnOnMultipleProjects: true,
 };
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "concurrently -k -n api,web -c blue,magenta \"pnpm run dev:api\" \"pnpm run dev:web\"",
     "dev:api": "jiti scripts/check-bindings.ts && wrangler dev --port 8788",
     "dev:web": "pnpm --filter @floway-dev/web run dev",
+    "dev:node": "pnpm --filter @floway-dev/platform-node run start",
     "build:web": "pnpm --filter @floway-dev/web run build",
     "deploy": "jiti scripts/check-bindings.ts && pnpm run build:web && wrangler deploy",
     "db:migrate": "wrangler d1 migrations apply $(node -p \"require('jsonc-parser').parse(require('fs').readFileSync('wrangler.jsonc','utf8')).d1_databases[0].database_name\")",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)
+        version: 4.0.18(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       vue-eslint-parser:
         specifier: ^10.4.0
         version: 10.4.0(eslint@9.39.1(jiti@2.6.1))
@@ -77,6 +77,34 @@ importers:
       '@floway-dev/test-utils':
         specifier: workspace:*
         version: link:../../packages/test-utils
+
+  apps/platform-node:
+    dependencies:
+      '@floway-dev/platform':
+        specifier: workspace:*
+        version: link:../../packages/platform
+      '@floway-dev/proxy':
+        specifier: workspace:*
+        version: link:../../packages/proxy
+      '@hono/node-server':
+        specifier: ^2.0.4
+        version: 2.0.4(hono@4.12.22)
+      hono:
+        specifier: ^4
+        version: 4.12.22
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
+    devDependencies:
+      '@floway-dev/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
+      '@types/node':
+        specifier: ^22
+        version: 22.19.19
+      tsx:
+        specifier: ^4
+        version: 4.22.4
 
   apps/web:
     dependencies:
@@ -152,19 +180,19 @@ importers:
         version: 66.7.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.7(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
+        version: 6.0.7(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       unocss:
         specifier: ^66.5.10
-        version: 66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))
+        version: 66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
       unocss-preset-animations:
         specifier: ^1.3.0
-        version: 1.3.0(@unocss/preset-wind3@66.7.0)(unocss@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)))
+        version: 1.3.0(@unocss/preset-wind3@66.7.0)(unocss@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)))
       unplugin-vue-router:
         specifier: ^0.17.0
         version: 0.17.2(@vue/compiler-sfc@3.5.34)(vue-router@4.6.4(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^2.2.0
         version: 2.2.12(typescript@5.9.3)
@@ -437,8 +465,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -449,8 +489,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -461,8 +513,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -473,8 +537,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -485,8 +561,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -497,8 +585,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -509,8 +609,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -521,8 +633,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -533,8 +657,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -545,8 +681,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -557,8 +705,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -569,8 +729,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -581,8 +753,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -637,6 +821,12 @@ packages:
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
+  '@hono/node-server@2.0.4':
+    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@hono/zod-validator@0.8.0':
     resolution: {integrity: sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w==}
     peerDependencies:
@@ -676,10 +866,22 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -688,9 +890,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
@@ -698,9 +910,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
     os: [linux]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -718,9 +940,19 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
@@ -728,9 +960,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
@@ -738,10 +980,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
     os: [linux]
 
   '@img/sharp-linux-arm@0.34.5':
@@ -762,10 +1016,22 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linux-x64@0.34.5':
@@ -774,10 +1040,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
@@ -785,6 +1063,11 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -797,10 +1080,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
@@ -1744,6 +2039,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -1904,6 +2206,11 @@ packages:
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2207,6 +2514,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -2689,6 +2999,10 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2723,6 +3037,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -2838,6 +3155,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3230,79 +3552,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1(jiti@2.6.1))':
@@ -3371,6 +3771,10 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@hono/node-server@2.0.4(hono@4.12.22)':
+    dependencies:
+      hono: 4.12.22
+
   '@hono/zod-validator@0.8.0(hono@4.12.22)(zod@4.4.3)':
     dependencies:
       hono: 4.12.22
@@ -3406,9 +3810,19 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -3416,13 +3830,25 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -3434,21 +3860,43 @@ snapshots:
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.5':
@@ -3466,9 +3914,19 @@ snapshots:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.5':
@@ -3476,14 +3934,29 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -3494,7 +3967,13 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
   '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.5':
@@ -3754,7 +4233,6 @@ snapshots:
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
-    optional: true
 
   '@types/nprogress@0.2.3': {}
 
@@ -3976,7 +4454,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.7.0
 
-  '@unocss/vite@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))':
+  '@unocss/vite@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@unocss/config': 66.7.0
@@ -3987,7 +4465,7 @@ snapshots:
       pathe: 2.0.3
       tinyglobby: 0.2.16
       unplugin-utils: 0.3.1
-      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     optional: true
@@ -4059,10 +4537,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.34(typescript@5.9.3)
 
   '@vitest/expect@4.0.18':
@@ -4074,13 +4552,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -4429,6 +4907,16 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
   colorette@2.0.20: {}
 
   concat-map@0.0.1: {}
@@ -4651,6 +5139,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -4969,6 +5486,8 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.3.4: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -5523,6 +6042,32 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -5591,6 +6136,10 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
 
   sirv@3.0.2:
     dependencies:
@@ -5698,6 +6247,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5761,8 +6316,7 @@ snapshots:
       quansync: 1.0.0
       unconfig-core: 7.5.0
 
-  undici-types@6.21.0:
-    optional: true
+  undici-types@6.21.0: {}
 
   undici@7.24.4: {}
 
@@ -5770,13 +6324,13 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  unocss-preset-animations@1.3.0(@unocss/preset-wind3@66.7.0)(unocss@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))):
+  unocss-preset-animations@1.3.0(@unocss/preset-wind3@66.7.0)(unocss@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
-      unocss: 66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))
+      unocss: 66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@unocss/preset-wind3': 66.7.0
 
-  unocss@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)):
+  unocss@66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@unocss/cli': 66.7.0
       '@unocss/core': 66.7.0
@@ -5794,7 +6348,7 @@ snapshots:
       '@unocss/transformer-compile-class': 66.7.0
       '@unocss/transformer-directives': 66.7.0
       '@unocss/transformer-variant-group': 66.7.0
-      '@unocss/vite': 66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))
+      '@unocss/vite': 66.7.0(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - vite
 
@@ -5868,7 +6422,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0):
+  vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5880,12 +6434,13 @@ snapshots:
       '@types/node': 22.19.19
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.0.18(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0):
+  vitest@4.0.18(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -5902,7 +6457,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.19)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     projects: [
       'apps/platform-cloudflare/vitest.config.ts',
+      'apps/platform-node/vitest.config.ts',
       'apps/web/vitest.config.ts',
       'packages/platform/vitest.config.ts',
       'packages/protocols/vitest.config.ts',


### PR DESCRIPTION
## Summary

Drop in a real Node.js deployment of the gateway alongside the Cloudflare Workers target. Strictly additive: every change is inside `apps/platform-node`, or one-line registrations in root scripts / vitest projects / eslint resolver.

## Impls

- **`FsFileProvider`** — local filesystem `put`/`get`/`listKeys`/`deletePrefix` over `node:fs/promises`. Resolved paths are pinned under the configured root (rejects absolute keys and any `..` segments that would escape); empty `deletePrefix` is refused so a stray empty string can't wipe the whole store; `ENOTDIR` on `listKeys` returns `[]` to match R2's "no objects under this prefix" semantics. Constructor `mkdir -p`s its own root.
- **`SharpImageProcessor`** — sharp's WebP encoder under the platform's `(bytes, target | null)` contract. Same `WEBP_QUALITY = 82` and cache-key shape as the CF processor (bytes are encoder-specific, but the key namespace is identical). Optional `ImageCache` injection. `createMemoryImageCache` is a bounded LRU-on-touch (`Map.delete` + `.set` on hit and overwrite) so a long conversation's recurring image isn't evicted by 64 newer one-shot keys.
- **`NodeSqliteDatabase`** — wraps `node:sqlite` (built-in, stable since Node 22.5) into platform's `SqlDatabase`. `bind()` returns a fresh prepared statement instead of mutating `self`, matching D1's immutable shape so two awaited binds on the same statement no longer share state. `batch()` runs statements inside a single `BEGIN`/`COMMIT`/`ROLLBACK` transaction; `exec(sql)` is the contract method the migration runner uses for multi-statement SQL. `mkdir -p`s the parent of `dbPath` before opening.
- **`applyMigrations`** — reads `packages/proxy/migrations/*.sql` and applies pending ones, tracking by filename in a `_migrations` table (just `name`; no unread `applied_at`). Each pending file goes through `SqlDatabase.exec()` inside a `BEGIN`/`COMMIT`/`ROLLBACK` bracket, so files containing `CREATE TRIGGER … BEGIN … END;` or trailing comment-only chunks (which a `;` split can't honour) apply cleanly.
- **`bootstrapNodePlatform`** + **`entry.ts`** — composes the impls and boots Hono on `@hono/node-server`. Each component (`FsFileProvider`, `NodeSqliteDatabase`) ensures its own root, so the bootstrap is pure wiring. The scheduled-maintenance sweep runs once 30s after boot in addition to the hourly `setInterval`, so a Node process that restarts more often than the interval doesn't starve the responses-items expiry sweep. Background scheduler is fire-and-forget with stderr error logging (no `ExecutionContext` to attach to). `engines` pinned to Node `>=22.5` so a pre-22.5 host fails at install rather than at module-load with "Unknown built-in module".

## Architectural proof

This PR's diff modifies no file in `packages/platform`, `packages/proxy`, `apps/platform-cloudflare`, or `packages/provider*`. The CF target is untouched.

`git diff main..HEAD --name-only`:
```
apps/platform-node/**          (all new files)
eslint.config.ts               (one-line: register apps/platform-node/tsconfig.json with the resolver)
package.json                   (root scripts: dev:node / start:node)
pnpm-lock.yaml
vitest.config.ts               (one-line: add apps/platform-node/vitest.config.ts to projects)
```

## Sanity probes (autonomous subagent)

End-to-end matrix run against `tsx apps/platform-node/entry.ts` on port 18789 with prod Copilot upstream seeded into local sqlite — all 10 probes pass:

- Control plane: `GET /api/upstreams`, `POST /api/keys`, `GET /api/keys`, `GET /api/token-usage`
- Data plane normal user (real API key): `POST /v1/chat/completions` (non-stream + stream), `POST /v1/messages` (Anthropic SSE), `POST /v1/responses` (`store=false` and `store=true`, with sqlite row-write verification)
- Data plane playground bypass (`x-models-playground: 1` + ADMIN_KEY)

Plus the unique-to-Node persistence verification: kill the process, restart with the same `FLOWAY_DB_PATH` and `FLOWAY_FILES_DIR`, re-query — the seeded upstream, the created API keys, and the stored `responses_items` rows all survive. The persisted API key still authenticates the data plane after restart.

Static-asset serving is deliberately not in scope for the Node entry — the dashboard SPA on Workers is served by Static Assets, which has no equivalent on raw Node. `GET /` returns 401 on the Node target by design.

## Test plan

- [x] `pnpm run typecheck` — green
- [x] `pnpm run test` — 175 test files / 1655 tests passing (+24 new tests: 6 fs-file-provider + 8 sharp-image-processor + 6 node-sqlite-database + 4 migrate)
- [x] `pnpm run lint` — clean
- [x] Subagent Node sanity probes — 10/10 pass
- [x] Persistence verified across kill+restart

## Local run

```bash
ADMIN_KEY=dev_admin \
FLOWAY_DB_PATH=./data/floway.db \
FLOWAY_FILES_DIR=./data/files \
PORT=8788 \
pnpm exec tsx apps/platform-node/entry.ts
```