### PR TITLE
fix(web/auth): hydrate user from /auth/me on boot, drop cached permissions

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -7,11 +7,25 @@ import { createPinia } from 'pinia';
 import { DataLoaderPlugin } from 'unplugin-vue-router/data-loaders';
 import { createApp } from 'vue';
 
+import { callApi, useApi } from './api/client.ts';
 import App from './App.vue';
 import { router } from './router.ts';
+import { type AuthUser, useAuthStore } from './stores/auth.ts';
 
 const app = createApp(App);
 app.use(createPinia());
+
+// Hydrate user identity from /auth/me before mounting so router guards and
+// per-page loaders see fresh server-side permission state on every boot —
+// localStorage would otherwise outlive an admin's promote/demote until logout.
+// authFetch already drops the token on 401; transient errors leave the token
+// intact so the next reload can retry.
+const auth = useAuthStore();
+if (auth.authToken !== null) {
+  const { data } = await callApi<{ user: AuthUser }>(() => useApi().auth.me.$get());
+  if (data) auth.setUser(data.user);
+}
+
 app.use(DataLoaderPlugin, { router });
 app.use(router);
 app.mount('#app');

--- a/apps/web/src/pages/dashboard/users.vue
+++ b/apps/web/src/pages/dashboard/users.vue
@@ -71,8 +71,9 @@ const resetPassword = (u: WireUser) => {
 
 const onUserSaved = async (savedId: number) => {
   await reload();
-  // Self-edits change the actor's own row; refresh the auth store so cached
-  // identity (e.g. upstream cap) stays in sync.
+  // The actor edited their own row; refresh the in-memory user so admin
+  // flag, telemetry visibility, and upstream cap reflect the saved values
+  // without having to reload the page (where main.ts would re-hydrate).
   if (savedId === actorUserId.value) {
     const { data, error: err } = await callApi<{ user: AuthUser }>(() => api.auth.me.$get());
     if (err) { error.value = err.message; return; }

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -1,6 +1,6 @@
 import { useLocalStorage } from '@vueuse/core';
 import { defineStore } from 'pinia';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 export interface AuthUser {
   id: number;
@@ -10,56 +10,35 @@ export interface AuthUser {
   upstreamIds: string[] | null;
 }
 
-export interface AuthIdentity {
-  token: string;
-  user: AuthUser;
-}
-
-const STORAGE_KEY = 'floway-auth';
-
-const isAuthIdentity = (value: unknown): value is AuthIdentity => {
-  if (typeof value !== 'object' || value === null) return false;
-  const v = value as { token?: unknown; user?: unknown };
-  if (typeof v.token !== 'string') return false;
-  if (typeof v.user !== 'object' || v.user === null) return false;
-  const u = v.user as { id?: unknown; username?: unknown; isAdmin?: unknown; canViewGlobalTelemetry?: unknown; upstreamIds?: unknown };
-  if (typeof u.id !== 'number' || typeof u.username !== 'string') return false;
-  if (typeof u.isAdmin !== 'boolean' || typeof u.canViewGlobalTelemetry !== 'boolean') return false;
-  if (u.upstreamIds !== null && !(Array.isArray(u.upstreamIds) && u.upstreamIds.every(x => typeof x === 'string'))) return false;
-  return true;
-};
-
+// Only the session token is persisted. Everything else (admin flag, telemetry
+// visibility, upstream cap) is server-authoritative and must be re-fetched
+// from /auth/me on every app boot — caching it in localStorage lets stale
+// permissions linger after an admin promotes/demotes the actor or rotates
+// their upstream cap.
 export const useAuthStore = defineStore('auth', () => {
-  const identity = useLocalStorage<AuthIdentity | null>(STORAGE_KEY, null, {
-    serializer: {
-      read: raw => {
-        if (!raw) return null;
-        try {
-          const parsed: unknown = JSON.parse(raw);
-          return isAuthIdentity(parsed) ? parsed : null;
-        } catch {
-          return null;
-        }
-      },
-      write: value => value === null ? '' : JSON.stringify(value),
-    },
-  });
+  const token = useLocalStorage<string | null>('floway-token', null);
+  const user = ref<AuthUser | null>(null);
 
-  const isAuthenticated = computed(() => identity.value !== null);
-  const isAdmin = computed(() => identity.value?.user.isAdmin === true);
-  const authToken = computed(() => identity.value?.token ?? null);
-  const currentUser = computed(() => identity.value?.user ?? null);
-  const canViewGlobalTelemetry = computed(() => identity.value?.user.canViewGlobalTelemetry === true);
+  const isAuthenticated = computed(() => token.value !== null && user.value !== null);
+  const isAdmin = computed(() => user.value?.isAdmin === true);
+  const canViewGlobalTelemetry = computed(() => user.value?.canViewGlobalTelemetry === true);
+  const currentUser = computed(() => user.value);
+  const authToken = computed(() => token.value);
 
-  const setAuth = (next: AuthIdentity) => { identity.value = next; };
-  const setUser = (user: AuthUser) => {
-    if (!identity.value) throw new Error('setUser called without an authenticated identity');
-    identity.value = { token: identity.value.token, user };
+  const setAuth = (next: { token: string; user: AuthUser }) => {
+    token.value = next.token;
+    user.value = next.user;
   };
-  const clearAuth = () => { identity.value = null; };
+  const setUser = (next: AuthUser) => {
+    if (token.value === null) throw new Error('setUser called without an authenticated session');
+    user.value = next;
+  };
+  const clearAuth = () => {
+    token.value = null;
+    user.value = null;
+  };
 
   return {
-    identity,
     isAuthenticated,
     isAdmin,
     authToken,


### PR DESCRIPTION
## Summary

The SPA persisted the full user object (admin flag, telemetry visibility, upstream cap) to `localStorage` at login, and only refreshed it when the actor edited their own row on the users page. Every other path — reloads, new tabs, long-running sessions — kept whatever permissions were minted at login, so an admin promoting/demoting a user, granting `canViewGlobalTelemetry`, or rotating the upstream cap had no effect on that user's UI until they signed out and back in. The most visible symptom is that the "All by user / My keys" toggle on `/dashboard/usage` and `/dashboard/performance` stayed hidden for users who had just been granted global telemetry.

This PR stops trusting cached permissions: only the session token is persisted now. `main.ts` awaits `/auth/me` before mounting so router guards and per-page loaders see fresh server-side state on every boot. The self-edit path on the users page still pulls `/auth/me` + `setUser` to update the in-memory copy without a full reload.

- `apps/web/src/stores/auth.ts` — `localStorage` key renamed `floway-auth` → `floway-token` (sessions running the old shape are silently logged out on the next boot — there's nothing to migrate, the server is the source of truth). The store now exposes `token` (persisted) and `user` (in-memory). `isAuthenticated` requires both.
- `apps/web/src/main.ts` — boot-time `await /auth/me` (top-level await, esnext target). `authFetch` already drops the token on 401; transient errors leave the token intact so the next reload can retry.
- `apps/web/src/pages/dashboard/users.vue` — comment trim; behavior unchanged (still re-fetches `/auth/me` after a self-edit so the dialog close doesn't require a full reload).

## Test plan

- [x] `pnpm --filter @floway-dev/web typecheck`
- [x] `pnpm --filter @floway-dev/web test`
- [x] `pnpm --filter @floway-dev/web build` (verifies top-level await is accepted at the SPA target)
- [ ] Manually: log in as admin, grant `canViewGlobalTelemetry` to a non-admin user already logged in elsewhere, reload that user's tab, confirm the "All by user / My keys" toggle appears without re-login
- [ ] Manually: same flow for revoking `canViewGlobalTelemetry` and for `isAdmin` toggle