### PR TITLE
fix(ui): prevent display:contents on OverlayScrollbars fallback mode

### DIFF
--- a/packages/ui/src/OverlayScrollbars.vue
+++ b/packages/ui/src/OverlayScrollbars.vue
@@ -133,7 +133,7 @@ defineExpose({
   >
     <div
       ref="contentWrapperRef"
-      data-overlayscrollbars-contents=""
+      :data-overlayscrollbars-contents="shouldUseOverlay ? '' : undefined"
       :class="contentClass"
     >
       <slot :os-enabled="shouldUseOverlay" />


### PR DESCRIPTION
## Summary

- Fix dashboard tab bar showing a vertical scrollbar on mobile DPI / touch devices
- The overlayscrollbars library's CSS forces `display: contents` on elements with `data-overlayscrollbars-contents` when the library isn't initialized (native scrollbar size = 0 on mobile), collapsing the flex/padding layout of the content wrapper and causing vertical overflow
- Conditionally render the attribute only when `shouldUseOverlay` is true so the CSS rule doesn't match in fallback mode

## Test plan

- [x] Desktop DPI (e.g. Chrome DevTools 1280x800, DPR=2): confirm tabs render normally with OverlayScrollbars active
- [x] Mobile DPI (e.g. Chrome DevTools 1280x800, DPR=3, mobile, touch): refresh and confirm no scrollbar on the tab container
- [x] Narrow viewport (375px width, mobile): confirm horizontal touch-scrolling still works for tabs
- [x] Verify other OverlayScrollbars usages (tables, chat panel, settings page scroll) still function correctly in both modes