### PR TITLE
fix(dashboard): keep performance chart series per-model under all-by-user view

### DIFF
--- a/packages/gateway/src/control-plane/performance/routes.ts
+++ b/packages/gateway/src/control-plane/performance/routes.ts
@@ -147,9 +147,7 @@ export const performanceOverview = async (c: Ctx) => {
   if (rawRecords === null) return c.json({ error: 'Unknown key_id' }, 404);
 
   const baseOptions = { timezoneOffsetMinutes: params.value.timezoneOffsetMinutes };
-  const series = resolved.view === 'all-by-user'
-    ? aggregatePerformanceForDisplay(rawRecords, { ...baseOptions, bucket: params.value.bucket, groupBy: 'userId', keyToUser: await buildKeyToUserMap() })
-    : aggregatePerformanceForDisplay(rawRecords, { ...baseOptions, bucket: params.value.bucket, groupBy: 'model' });
+  const series = aggregatePerformanceForDisplay(rawRecords, { ...baseOptions, bucket: params.value.bucket, groupBy: 'model' });
   const summaryRows = aggregatePerformanceForDisplay(rawRecords, { ...baseOptions, bucket: 'all', groupBy: 'none' });
   const modelRows = aggregatePerformanceForDisplay(rawRecords, { ...baseOptions, bucket: 'all', groupBy: 'model' });
   const runtimeRows = aggregatePerformanceForDisplay(rawRecords, { ...baseOptions, bucket: 'all', groupBy: 'runtimeLocation' });

--- a/packages/gateway/src/control-plane/performance/routes_test.ts
+++ b/packages/gateway/src/control-plane/performance/routes_test.ts
@@ -206,7 +206,7 @@ test('/api/performance rejects group_by=userId in self-by-key mode', async () =>
   assertEquals(body.error, 'group_by=userId is not allowed in self-by-key mode');
 });
 
-test('/api/performance/overview series pivots to per-user under all-by-user view', async () => {
+test('/api/performance/overview series stays per-model under all-by-user view', async () => {
   const { repo, adminSession, apiKey } = await setupAppTest();
   await repo.apiKeys.save({
     id: 'key_other',
@@ -235,9 +235,10 @@ test('/api/performance/overview series pivots to per-user under all-by-user view
 
   assertEquals(response.status, 200);
   const body = await response.json();
-  // Series is now grouped by user; both rows show up.
+  // Series stays per-model regardless of view — the page is a latency analysis,
+  // and per-user lines have no useful meaning there.
   const seriesGroups = body.series.map((r: { group: string; requests: number }) => [r.group, r.requests]).sort();
-  assertEquals(seriesGroups, [['1', 1], ['2', 1]]);
+  assertEquals(seriesGroups, [['gpt-5', 2]]);
   assertEquals(body.users.map((u: { id: number }) => u.id).sort(), [1, 2]);
 });
 


### PR DESCRIPTION
## Summary

- The performance dashboard's main chart drew lines per `userId` under the `All by user` view, but the page is a latency analysis — every other control on it (`By Model` / `By Percentile` toggle, p50/p95/p99 picker, `BY MODEL` table) is model-dimensioned. The legend was also literally bare numbers like `"2"` because `performance.vue` doesn't request `include_user_metadata=1`, so there isn't even a username mapping on the wire.
- The regression was introduced in 226c7451 (`feat: multi-user accounts`), which split `series` into a `groupBy: 'userId'` branch for `all-by-user` while leaving the entire frontend stuck in the model-dimension world. Before that commit, `series` was unconditionally `groupBy: 'model'` and everything was self-consistent.
- Fix is one-line: drop the view-conditional and let `series` always be `groupBy: 'model'`. The `All by user` tab still means "aggregate across every user globally" — that's the dataset, not the line-grouping dimension. `users` metadata in the response (gated on `include_user_metadata=1`) is unaffected.
- Updated the one test that asserted the regressed behavior — kept it (rather than deleting) so the per-model invariant is now explicitly guarded against re-regression.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway exec vitest run src/control-plane/performance/routes_test.ts` — all 14 tests pass, including the renamed `series stays per-model under all-by-user view`.
- [x] `pnpm --filter @floway-dev/gateway run typecheck` clean.
- [x] Manual verification via Chrome at `http://localhost:5175/dashboard/performance`: chart legend now lists model names (`claude-haiku-4-5`, `claude-opus-4-5`, …, `gemini-3.5-flash`), exactly matching the 9 rows of the `BY MODEL` table below.
- [x] Sanity-checking that no consumer of `/api/performance/overview` relied on `series.group` being a userId in `all-by-user` view (`performance.vue` is the only caller; it never asked for user metadata, so this is almost certainly safe).