### PR TITLE
fix(gateway): record partial-stream usage on client disconnect

### DIFF
--- a/packages/gateway/src/data-plane/llm/messages/respond.ts
+++ b/packages/gateway/src/data-plane/llm/messages/respond.ts
@@ -103,6 +103,12 @@ export const createMessagesStreamUsageState = () => ({
 
 type MessagesStreamUsageState = ReturnType<typeof createMessagesStreamUsageState>;
 
+// Returns a snapshot of the running usage on every frame that revises it, not
+// only on `message_stop`, so the observer can checkpoint billing state into
+// `SourceStreamState.usage` as the stream progresses. A client disconnect that
+// races the terminal frame would otherwise discard the last `message_delta`'s
+// output count. Each call returns a fresh object so the snapshot stored in
+// `SourceStreamState.usage` does not silently mutate when the next delta lands.
 export const tokenUsageFromMessagesFrame = (frame: ProtocolFrame<MessagesStreamEvent>, state: MessagesStreamUsageState) => {
   if (frame.type !== 'event') return null;
   const { event } = frame;
@@ -113,13 +119,15 @@ export const tokenUsageFromMessagesFrame = (frame: ProtocolFrame<MessagesStreamE
     // every input-side dimension, not bare input alone — otherwise a later
     // delta carrying input_tokens re-merges and drops the cache counts.
     state.gotInputFromStart ||= (state.current.input ?? 0) + (state.current.input_cache_read ?? 0) + (state.current.input_cache_write ?? 0) + (state.current.input_cache_write_1h ?? 0) > 0;
+    return { ...state.current };
   }
   if (event.type === 'message_delta' && event.usage) {
     if (!state.gotInputFromStart && event.usage.input_tokens !== undefined) {
       state.current = tokenUsageFromMessagesUsage(event.usage);
     } else state.current.output = event.usage.output_tokens;
+    return { ...state.current };
   }
-  return event.type === 'message_stop' ? state.current : null;
+  return event.type === 'message_stop' ? { ...state.current } : null;
 };
 
 const internalMessagesErrorPayload = (error: InternalDebugError) => ({

--- a/packages/gateway/src/data-plane/llm/messages/respond_test.ts
+++ b/packages/gateway/src/data-plane/llm/messages/respond_test.ts
@@ -37,7 +37,12 @@ test('Messages stream usage keeps start input and delta output', () => {
       } satisfies MessagesStreamEvent),
       state,
     ),
-    null,
+    {
+      input: 12,
+      input_cache_read: 3,
+      input_cache_write: 4,
+      output: 1,
+    },
   );
   assertEquals(
     tokenUsageFromMessagesFrame(
@@ -48,7 +53,12 @@ test('Messages stream usage keeps start input and delta output', () => {
       } satisfies MessagesStreamEvent),
       state,
     ),
-    null,
+    {
+      input: 12,
+      input_cache_read: 3,
+      input_cache_write: 4,
+      output: 7,
+    },
   );
 
   assertEquals(tokenUsageFromMessagesFrame(stop(), state), {
@@ -326,4 +336,87 @@ test('respondMessages forwards upstream headers and strips hop-by-hop / framing 
   // background `finally` block in `streamSSE` doesn't keep the test runner
   // alive.
   await response.text();
+});
+
+// --- partial usage checkpointing on client disconnect ---
+
+interface ControlledEvents {
+  events: AsyncIterable<ProtocolFrame<MessagesStreamEvent>>;
+  emit: (event: MessagesStreamEvent) => void;
+}
+
+// A generator whose next() resolves only when emit() supplies the next event.
+// Lets a test interleave "upstream emitted frame X" with "downstream cancels",
+// so the streaming finally block fires while message_stop is still in flight.
+const controlledMessagesEvents = (): ControlledEvents => {
+  const queue: Array<MessagesStreamEvent> = [];
+  const waiters: Array<(value: MessagesStreamEvent) => void> = [];
+  const events: AsyncIterable<ProtocolFrame<MessagesStreamEvent>> = (async function* () {
+    while (true) {
+      const event = queue.shift() ?? (await new Promise<MessagesStreamEvent>(resolve => waiters.push(resolve)));
+      yield eventFrame(event);
+      if (event.type === 'message_stop') return;
+    }
+  })();
+  return {
+    events,
+    emit: event => {
+      const waiter = waiters.shift();
+      if (waiter) waiter(event);
+      else queue.push(event);
+    },
+  };
+};
+
+test('respondMessages records the last observed message_delta usage when the client disconnects mid-stream', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const controlled = controlledMessagesEvents();
+  const app = new Hono();
+  app.get('/', c => {
+    const result: ExecuteResult<ProtocolFrame<MessagesStreamEvent>> = eventResult(
+      controlled.events,
+      testTelemetryModelIdentity,
+      { headers: new Headers({ 'content-type': 'text/event-stream' }) },
+    );
+    const downstreamAbortController = new AbortController();
+    const ctx: GatewayCtx = { ...makeRespondCtx(), wantsStream: true, downstreamAbortController };
+    return respondMessages(c, result, true, ctx).then(({ response }) => response);
+  });
+  const response = await app.request('/');
+  const reader = response.body!.getReader();
+
+  controlled.emit({
+    type: 'message_start',
+    message: {
+      id: 'msg_abort', type: 'message', role: 'assistant', content: [], model: 'claude-test',
+      stop_reason: null, stop_sequence: null,
+      usage: { input_tokens: 20, output_tokens: 0 },
+    },
+  });
+  await reader.read();
+  controlled.emit({ type: 'message_delta', delta: {}, usage: { output_tokens: 5 } });
+  await reader.read();
+  controlled.emit({ type: 'message_delta', delta: {}, usage: { output_tokens: 11 } });
+  await reader.read();
+  controlled.emit({ type: 'message_delta', delta: {}, usage: { output_tokens: 17 } });
+  await reader.read();
+
+  // Disconnect before message_stop. The streamSSE finally block must still
+  // record the latest message_delta's output count.
+  await reader.cancel();
+
+  // `recordTokenUsage` on InMemoryRepo is synchronous, but the finally block
+  // runs after cancellation propagates through streamSSE. Poll briefly to
+  // cover that hand-off without coupling to a fixed schedule. The cap is
+  // generous so it survives CI contention; the healthy path resolves on the
+  // first iteration.
+  for (let i = 0; i < 200; i++) {
+    if ((await repo.usage.listAll()).length > 0) break;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+
+  const rows = await repo.usage.listAll();
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].tokens, { input: 20, output: 17 });
 });

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*_test.ts'],
     restoreMocks: false,
-    testTimeout: 10_000,
+    // `setupAppTest` builds the full Hono app + memory D1 + admin session per
+    // test; under workspace-parallel load that occasionally pushes past 10s.
+    // 30s absorbs the contention without masking actual hangs.
+    testTimeout: 30_000,
     setupFiles: ['./vitest.setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary

`tokenUsageFromMessagesFrame` previously returned the running snapshot only on `message_stop`, so the per-stream usage state never advanced past the initial `message_start`. On client disconnect mid-stream the recorded telemetry under-counted output tokens that Anthropic actually billed. Fix: snapshot on every revising frame so disconnect-time recording reflects actual partial consumption.

Bumps the gateway vitest default `testTimeout` from 10s → 30s in the same PR — control-plane route tests using `setupAppTest` (full Hono app + memory D1 + admin session per test) flake under workspace-parallel load; real test work is hundreds of milliseconds, and 30s gives headroom without masking actual hangs.

## Test plan

- [x] typecheck + test + lint clean