### PR TITLE
fix(codex): unsupported endpoints return synthetic 405 instead of leaking stack trace

### DIFF
--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -10,7 +10,7 @@ import { pricingForCodexModelKey } from './pricing.ts';
 import { assertCodexUpstreamState, type CodexUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { getProviderRepo, type ModelProvider, type ModelProviderInstance, type ProviderCompactionResult, type ProviderStreamResult, type UpstreamRecord } from '@floway-dev/provider';
+import { getProviderRepo, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderCompactionResult, type ProviderStreamResult, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 export const createCodexProvider = async (record: UpstreamRecord): Promise<ModelProviderInstance> => {
   assertCodexUpstreamRecord(record);
@@ -145,13 +145,18 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
     },
 
     // Codex upstream only exposes /responses; getProvidedModels advertises
-    // that single endpoint and no other entry point is reachable.
-    callMessages: () => Promise.reject(new Error('Codex provider does not implement callMessages')),
-    callChatCompletions: () => Promise.reject(new Error('Codex provider does not implement callChatCompletions')),
-    callMessagesCountTokens: () => Promise.reject(new Error('Codex provider does not implement callMessagesCountTokens')),
-    callEmbeddings: () => Promise.reject(new Error('Codex provider does not implement callEmbeddings')),
-    callImagesGenerations: () => Promise.reject(new Error('Codex provider does not implement callImagesGenerations')),
-    callImagesEdits: () => Promise.reject(new Error('Codex provider does not implement callImagesEdits')),
+    // that single endpoint and no other entry point is reachable. The data
+    // plane never routes these surfaces here in practice, but a stray
+    // dispatch must surface as a 405 carrying a proper JSON error rather
+    // than letting a raw stack trace bubble up the boundary. The synthetic
+    // response still flows through the per-call latency recorder so the
+    // gateway's wrap-once contract holds even for these stubs.
+    callMessages: (_model, _body, _signal, _headers, _anthropicBeta, opts) => unsupportedStreamResult(opts),
+    callMessagesCountTokens: (_model, _body, _signal, _headers, _anthropicBeta, opts) => unsupportedCallResult(opts),
+    callChatCompletions: (_model, _body, _signal, _headers, opts) => unsupportedStreamResult(opts),
+    callEmbeddings: (_model, _body, _signal, _headers, opts) => unsupportedCallResult(opts),
+    callImagesGenerations: (_model, _body, _signal, _headers, opts) => unsupportedCallResult(opts),
+    callImagesEdits: (_model, _body, _signal, _headers, opts) => unsupportedCallResult(opts),
   };
 
   return {
@@ -163,3 +168,19 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
     supportsResponsesItemReference: false,
   };
 };
+
+const synthetic405 = (): Response => new Response(
+  JSON.stringify({ error: { type: 'method_not_allowed', message: 'Endpoint not supported by codex provider' } }),
+  { status: 405, headers: { 'content-type': 'application/json' } },
+);
+
+const unsupportedStreamResult = async <TEvent>(opts: UpstreamCallOptions): Promise<ProviderStreamResult<TEvent>> => ({
+  ok: false,
+  modelKey: '',
+  response: await opts.recordUpstreamLatency(Promise.resolve(synthetic405())),
+});
+
+const unsupportedCallResult = async (opts: UpstreamCallOptions): Promise<ProviderCallResult> => ({
+  modelKey: '',
+  response: await opts.recordUpstreamLatency(Promise.resolve(synthetic405())),
+});

--- a/packages/provider-codex/src/provider_test.ts
+++ b/packages/provider-codex/src/provider_test.ts
@@ -161,11 +161,32 @@ describe('createCodexProvider', () => {
     'callEmbeddings',
     'callImagesGenerations',
     'callImagesEdits',
-    'callMessagesCountTokens',
-  ] as const)('%s throws (data plane never dispatches these to Codex)', async method => {
+    'callChatCompletions',
+  ] as const)('%s returns a synthetic 405 (data plane never dispatches these to Codex)', async method => {
     const instance = await createCodexProvider(baseRecord);
     const model = { id: 'gpt-5.4', display_name: 'gpt-5.4', kind: 'chat', limits: {}, endpoints: { responses: {} }, enabledFlags: new Set<string>() };
-    // @ts-expect-error: each method has a different param shape; we just want to assert throw.
-    await expect(instance.provider[method](model, {}, undefined, {})).rejects.toThrow(/Codex/);
+    // @ts-expect-error: each method has a different body type; we only assert
+    // the synthetic 405 envelope is what comes back.
+    const result = await instance.provider[method](model, {}, undefined, undefined, noopUpstreamCallOptions) as { response: Response };
+    expect(result.response.status).toBe(405);
+    const body = await result.response.json() as { error: { type: string; message: string } };
+    expect(body.error.type).toBe('method_not_allowed');
+    expect(body.error.message).toMatch(/codex/i);
+  });
+
+  test.each([
+    'callMessagesCountTokens',
+    'callMessages',
+  ] as const)('%s returns a synthetic 405 (data plane never dispatches these to Codex)', async method => {
+    const instance = await createCodexProvider(baseRecord);
+    const model = { id: 'gpt-5.4', display_name: 'gpt-5.4', kind: 'chat', limits: {}, endpoints: { responses: {} }, enabledFlags: new Set<string>() };
+    // @ts-expect-error: each method has a different body type; we only assert
+    // the synthetic 405 envelope is what comes back. callMessages*/CountTokens
+    // additionally take an anthropicBeta slice before opts.
+    const result = await instance.provider[method](model, {}, undefined, undefined, undefined, noopUpstreamCallOptions) as { response: Response };
+    expect(result.response.status).toBe(405);
+    const body = await result.response.json() as { error: { type: string; message: string } };
+    expect(body.error.type).toBe('method_not_allowed');
+    expect(body.error.message).toMatch(/codex/i);
   });
 });


### PR DESCRIPTION
## Summary

Codex advertises only `/responses` upstream. The other surfaces (`callMessages`, `callChatCompletions`, `callMessagesCountTokens`, `callEmbeddings`, `callImagesGenerations`, `callImagesEdits`) are routing-bug-only — a request reaching one of those today throws a bare error that bubbles a stack trace through the boundary.

Replace each unsupported surface with a synthetic 405 JSON envelope:

```json
{ "error": { "type": "method_not_allowed", "message": "Endpoint not supported by codex provider" } }
```

The response flows through `opts.recordUpstreamLatency(Promise.resolve(...))` so the recorder's wrap-once contract is honored even though no real upstream call happens.

## Test plan

- [x] typecheck + test + lint clean