### PR TITLE
feat(provider): plumb UpstreamCallOptions.waitUntil for fire-and-forget persistence

### DIFF
--- a/packages/gateway/src/data-plane/llm/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/llm/chat-completions/attempt.ts
@@ -108,7 +108,7 @@ const callChatCompletionsAsExecuteResult = async (
     body,
     ctx.abortSignal,
     invocationHeaders,
-    { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record },
+    { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record, waitUntil: ctx.backgroundScheduler },
   );
   return await providerStreamResultToExecuteResult(providerResult, candidate, ctx, recorder.durationMs());
 };

--- a/packages/gateway/src/data-plane/llm/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/llm/messages/attempt.ts
@@ -58,7 +58,7 @@ export const messagesAttempt = {
           ctx.abortSignal,
           invocation.headers,
           invocation.anthropicBeta,
-          { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record },
+          { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record, waitUntil: ctx.backgroundScheduler },
         );
         return await providerStreamResultToExecuteResult(providerResult, candidate, ctx, recorder.durationMs());
       }
@@ -110,7 +110,7 @@ export const messagesAttempt = {
         ctx.abortSignal,
         invocation.headers,
         invocation.anthropicBeta,
-        { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record },
+        { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record, waitUntil: ctx.backgroundScheduler },
       );
       return response;
     });

--- a/packages/gateway/src/data-plane/llm/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/llm/responses/attempt.ts
@@ -190,7 +190,7 @@ const dispatchResponses = async (
       body,
       ctx.abortSignal,
       invocationHeaders,
-      { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record },
+      { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record, waitUntil: ctx.backgroundScheduler },
     );
     return await providerStreamResultToExecuteResult(providerResult, candidate, ctx, recorder.durationMs());
   }
@@ -238,7 +238,7 @@ const callResponsesCompactAsExecuteResult = async (
     body,
     ctx.abortSignal,
     invocationHeaders,
-    { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record },
+    { fetcher: candidate.fetcher, recordUpstreamLatency: recorder.record, waitUntil: ctx.backgroundScheduler },
   );
   const context = upstreamPerformanceContext(ctx, candidate, providerResult.modelKey);
   if (!providerResult.ok) {

--- a/packages/gateway/src/data-plane/llm/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/llm/responses/interceptors/server-tools/image-generation.ts
@@ -607,8 +607,8 @@ const issueImageCall = async (
   for (let attempt = 0; ; attempt++) {
     const recorder = createUpstreamLatencyRecorder();
     const { response, modelKey } = await (isEdit
-      ? binding.provider.callImagesEdits(binding.upstreamModel, buildEditsForm(prompt, state.config, sources, stream), state.downstreamAbortSignal, undefined, { fetcher, recordUpstreamLatency: recorder.record })
-      : binding.provider.callImagesGenerations(binding.upstreamModel, buildGenerationsBody(prompt, state.config, stream), state.downstreamAbortSignal, undefined, { fetcher, recordUpstreamLatency: recorder.record }));
+      ? binding.provider.callImagesEdits(binding.upstreamModel, buildEditsForm(prompt, state.config, sources, stream), state.downstreamAbortSignal, undefined, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler })
+      : binding.provider.callImagesGenerations(binding.upstreamModel, buildGenerationsBody(prompt, state.config, stream), state.downstreamAbortSignal, undefined, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler }));
     const context: PerformanceTelemetryContext = {
       keyId: state.apiKeyId,
       model: binding.upstreamModel.id,

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -129,7 +129,7 @@ export const passthroughServe = async (ctx: PassthroughServeContext): Promise<Re
       if (!bindingServesEndpoint(binding)) continue;
 
       const recorder = createUpstreamLatencyRecorder();
-      const { response, modelKey } = await call(binding, { fetcher: fetcherForUpstream(binding.upstream), recordUpstreamLatency: recorder.record });
+      const { response, modelKey } = await call(binding, { fetcher: fetcherForUpstream(binding.upstream), recordUpstreamLatency: recorder.record, waitUntil: backgroundScheduler });
       const upstreamDurationMs = recorder.durationMs();
       const performanceContext: PerformanceTelemetryContext = {
         keyId: apiKeyId,

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -109,18 +109,14 @@ const performUpstreamCall = async (
     if (response.ok) {
       const responseNow = new Date();
       const snapshot = parseCodexQuotaHeaders(response.headers, { now: responseNow, isRateLimited: false });
-      // Quota persistence is best-effort — getCodexQuota already treats a
-      // missing or stale snapshot as null, so a CAS loss or transient
-      // storage error is recoverable noise rather than something to crash
-      // the request on.
-      putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot).catch(() => {});
+      registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
       return ensureSseContentType(response);
     }
 
     if (response.status === 429) {
       const responseNow = new Date();
       const snapshot = parseCodexQuotaHeaders(response.headers, { now: responseNow, isRateLimited: true });
-      putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot).catch(() => {});
+      registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
       return response;
     }
 
@@ -154,7 +150,7 @@ const performUpstreamCall = async (
     let newAccessToken: string;
     try {
       const minted = await mintAccessToken(opts, opts.account.refresh_token);
-      putCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId, minted).catch(() => {});
+      registerBackgroundWrite(opts, putCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId, minted));
       newAccessToken = minted.token;
     } catch (err) {
       if (err instanceof CodexOAuthSessionTerminatedError) {
@@ -205,4 +201,12 @@ const ensureSseContentType = (response: Response): Response => {
   const headers = new Headers(response.headers);
   headers.set('content-type', 'text/event-stream');
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+};
+
+// Hand best-effort writes to waitUntil so workerd does not cancel them when
+// the streaming response returns; the swallow guards against recoverable
+// noise (CAS losses on access-token / quota state_json rows, transient
+// storage errors) tripping the request.
+const registerBackgroundWrite = (opts: CallCodexResponsesOptions, write: Promise<void>): void => {
+  opts.call.waitUntil(write.catch(() => {}));
 };

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -259,6 +259,42 @@ describe('callCodexResponses — upstream classification', () => {
   });
 });
 
+describe('callCodexResponses — background-write registration', () => {
+  // Background state writes (quota snapshot on 2xx/429, access-token put on
+  // 401-retry) must reach the runtime's waitUntil slot so workerd does not
+  // cancel them the instant the streaming response returns to the client.
+  // Without this, freshly-minted Codex tokens and quota snapshots get dropped
+  // on the floor and the next request re-mints / re-races the upstream.
+  test('2xx persists quota snapshot via opts.call.waitUntil', async () => {
+    seedFreshAccessToken();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
+    await callCodexResponses({
+      upstreamId, account: activeAccount,
+      model, body: { input: [], stream: true }, headers: {}, effects: makeEffects(),
+      call: { ...noopUpstreamCallOptions, waitUntil },
+    });
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  test('401-retry registers the freshly-minted access-token put via opts.call.waitUntil', async () => {
+    seedFreshAccessToken();
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at2', refresh_token: 'rt_v2', id_token: 'it', expires_in: 600 }), { status: 200 }))
+      .mockResolvedValueOnce(sseResponse());
+    const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
+    await callCodexResponses({
+      upstreamId, account: activeAccount,
+      model, body: { input: [], stream: true }, headers: {}, effects: makeEffects(),
+      call: { ...noopUpstreamCallOptions, waitUntil },
+    });
+    // Two writes get registered: the freshly-minted access token (401 retry
+    // path) and the quota snapshot from the successful second attempt.
+    expect(waitUntil).toHaveBeenCalledTimes(2);
+  });
+});
+
 // Provider-level tests need their own enforcing recorder so they can assert
 // the wrap-once contract without depending on the gateway package. The
 // `fetcher` honours the third-arg recorder because data-plane POSTs thread
@@ -279,6 +315,7 @@ const enforcingRecorder = () => {
     options: {
       fetcher,
       recordUpstreamLatency: record,
+      waitUntil: () => {},
     },
     invocations: () => wrappedPromises.length,
     durationMs: (): number => {

--- a/packages/provider-ollama/src/provider_test.ts
+++ b/packages/provider-ollama/src/provider_test.ts
@@ -158,7 +158,7 @@ test('call* methods POST to /v1/<endpoint> with the upstream model id and Bearer
         { messages: [{ role: 'user', content: 'hi' }] },
         undefined,
         undefined,
-        { fetcher: directFetcher, recordUpstreamLatency: p => p },
+        { fetcher: directFetcher, recordUpstreamLatency: p => p, waitUntil: () => {} },
       );
       assertEquals(result.modelKey, 'gpt-oss:120b');
     },

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -74,9 +74,16 @@ export type ProviderCompactionResult =
 // once; the gateway throws on a violation so missing wraps fail loud. On
 // retries (e.g. invalidate-token-and-redo), only the most recent invocation's
 // measurement is kept.
+//
+// `waitUntil` registers a fire-and-forget promise that must outlive the
+// response. On workerd it maps to `ExecutionContext.waitUntil` so the
+// isolate is not terminated when the response is returned; on Node it is a
+// no-op. Providers use it for post-response persistence the caller has
+// already stopped waiting on.
 export interface UpstreamCallOptions {
   fetcher: Fetcher;
   recordUpstreamLatency: <T>(promise: Promise<T>) => Promise<T>;
+  waitUntil: (promise: Promise<unknown>) => void;
 }
 
 export interface ModelProvider {

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -3,10 +3,12 @@ import { directFetcher, type LlmTargetApi, type ModelProvider, type ModelProvide
 // No-op UpstreamCallOptions for tests calling provider methods directly:
 // identity recordUpstreamLatency satisfies the contract without piping
 // latency anywhere; the fetcher uses runtime fetch so `globalThis.fetch`
-// spies still intercept.
+// spies still intercept; waitUntil drops the promise (the runtime would
+// have absorbed it in production).
 export const noopUpstreamCallOptions: UpstreamCallOptions = {
   fetcher: directFetcher,
   recordUpstreamLatency: <T>(promise: Promise<T>): Promise<T> => promise,
+  waitUntil: () => {},
 };
 
 export const stubUpstreamModel = (overrides: Partial<UpstreamModel> = {}): UpstreamModel => ({


### PR DESCRIPTION
## Summary

Add `waitUntil: (promise) => void` to `UpstreamCallOptions`. Maps to `ExecutionContext.waitUntil` on Cloudflare Workers; no-op on Node. Reuses the existing per-request `backgroundScheduler` — the runtime primitive is the same, the per-call name reads more naturally at the provider boundary.

Providers use this to register fire-and-forget persistence promises that must outlive the response — quota snapshot writes, access-token rotation persistence, anything the data-plane wants to commit AFTER the response has shipped to the client. Without `waitUntil`, workerd cancels the orphan promise the moment we return, dropping the write.

### Wired consumers

- **Codex `fetch.ts` quota persist (2xx + 429 paths)** — every `/responses` call's quota snapshot now persists through `waitUntil` so the row updates even when the request returns immediately
- **Codex `fetch.ts` access-token put (401-retry path)** — refresh-token rotation persistence registered through `waitUntil`

A single `registerBackgroundWrite(opts, promise)` helper in `fetch.ts` keeps the `.catch(() => {})` swallow (CAS losses / transient storage errors are recoverable noise that must not crash the request) but the swallow now happens inside a lifetime the runtime promises us.

### Test stub

`noopUpstreamCallOptions` provides a no-op `waitUntil` for tests.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run test` — 2708 tests pass (2 new in `provider-codex/fetch_test.ts`)
- [x] `pnpm run lint` clean