### PR TITLE
fix(codex): throw on malformed catalog responses instead of inventing defaults

### DIFF
--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -11,10 +11,11 @@ import { type Fetcher, type UpstreamModel } from '@floway-dev/provider';
 export interface CodexRawModel {
   id: string;
   display_name: string;
-  // Per-request hard context window.
+  // Per-request context window. Upstream also returns a sibling
+  // `max_context_window` field as the upper bound for config overrides
+  // (https://github.com/openai/codex/blob/d66708232299bdbf373ec55b0d6b938c246cfa60/codex-rs/protocol/src/openai_models.rs#L383-L386);
+  // floway has no override path, so only the operational value is kept.
   context_window: number;
-  // Plan-level upper bound; used when context_window is unset.
-  max_context_window: number;
 }
 
 // `fetcher` is required so the catalog refresh traverses the same proxy/
@@ -42,16 +43,17 @@ export const fetchCodexCatalog = async (opts: { accessToken: string; accountId: 
 
 const isPlainRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
 
+// Fail loud on malformed upstream catalog responses: a missing field
+// signals an upstream contract change we need to notice.
 const assertRawModel = (value: unknown): CodexRawModel => {
   if (!isPlainRecord(value)) throw new TypeError('Codex model entry is not an object');
   const slug = value.slug;
   if (typeof slug !== 'string') throw new TypeError('Codex model entry missing slug');
-  return {
-    id: slug,
-    display_name: typeof value.display_name === 'string' ? value.display_name : slug,
-    context_window: typeof value.context_window === 'number' ? value.context_window : 0,
-    max_context_window: typeof value.max_context_window === 'number' ? value.max_context_window : 0,
-  };
+  const display_name = value.display_name;
+  if (typeof display_name !== 'string') throw new TypeError(`Codex model entry ${slug} missing display_name`);
+  const context_window = value.context_window;
+  if (typeof context_window !== 'number') throw new TypeError(`Codex model entry ${slug} missing context_window`);
+  return { id: slug, display_name, context_window };
 };
 
 // Codex exposes only the Responses endpoint. Pricing is looked up from the
@@ -69,7 +71,7 @@ export const codexRawToUpstreamModel = (raw: CodexRawModel, enabledFlags: Readon
     owned_by: 'openai',
     kind: 'chat',
     limits: {
-      max_context_window_tokens: raw.context_window || raw.max_context_window || undefined,
+      max_context_window_tokens: raw.context_window,
     },
     endpoints: { responses: {} },
     enabledFlags,

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -19,8 +19,8 @@ describe('fetchCodexCatalog', () => {
     }));
     const catalog = await fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher });
     expect(catalog).toHaveLength(3);
-    expect(catalog[0]).toEqual({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 });
-    expect(catalog[2]).toEqual({ id: 'codex-auto-review', display_name: 'Codex Auto Review', context_window: 272000, max_context_window: 1000000 });
+    expect(catalog[0]).toEqual({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 });
+    expect(catalog[2]).toEqual({ id: 'codex-auto-review', display_name: 'Codex Auto Review', context_window: 272000 });
     expect(spy).toHaveBeenCalledTimes(1);
     const [url, init] = spy.mock.calls[0];
     expect(url).toBe(`https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_CLI_VERSION}`);
@@ -46,6 +46,16 @@ describe('fetchCodexCatalog', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({ models: [{ display_name: 'no slug here' }] }));
     await expect(fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher })).rejects.toThrow(/slug/);
   });
+
+  test('throws on entry missing display_name', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({ models: [{ slug: 'gpt-x', context_window: 1 }] }));
+    await expect(fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher })).rejects.toThrow(/display_name/);
+  });
+
+  test('throws on entry missing context_window', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({ models: [{ slug: 'gpt-x', display_name: 'GPT-X' }] }));
+    await expect(fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher })).rejects.toThrow(/context_window/);
+  });
 });
 
 describe('codexRawToUpstreamModel', () => {
@@ -55,7 +65,7 @@ describe('codexRawToUpstreamModel', () => {
   const noFlags: ReadonlySet<string> = new Set();
 
   test('shapes raw → UpstreamModel with responses-only endpoint and per-request context window', () => {
-    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 }, noFlags);
+    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 }, noFlags);
     expect(m.id).toBe('gpt-5.4');
     expect(m.display_name).toBe('GPT-5.4');
     expect(m.endpoints).toEqual({ responses: {} });
@@ -64,26 +74,21 @@ describe('codexRawToUpstreamModel', () => {
     expect(m.owned_by).toBe('openai');
   });
 
-  test('falls back to max_context_window when context_window is zero', () => {
-    const m = codexRawToUpstreamModel({ id: 'm', display_name: 'm', context_window: 0, max_context_window: 50000 }, noFlags);
-    expect(m.limits.max_context_window_tokens).toBe(50000);
-  });
-
   test('attaches OpenAI-API-rate cost for known slugs and treats codex-auto-review as gpt-5.4', () => {
-    const flagship = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 }, noFlags);
+    const flagship = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 }, noFlags);
     expect(flagship.cost).toEqual({ input: 2.5, input_cache_read: 0.25, output: 15 });
-    const review = codexRawToUpstreamModel({ id: 'codex-auto-review', display_name: 'Codex Auto Review', context_window: 272000, max_context_window: 1000000 }, noFlags);
+    const review = codexRawToUpstreamModel({ id: 'codex-auto-review', display_name: 'Codex Auto Review', context_window: 272000 }, noFlags);
     expect(review.cost).toEqual(flagship.cost);
   });
 
   test('omits cost for unknown slugs (forward-compat with new upstream models)', () => {
-    const m = codexRawToUpstreamModel({ id: 'gpt-future-unreleased', display_name: 'X', context_window: 1, max_context_window: 1 }, noFlags);
+    const m = codexRawToUpstreamModel({ id: 'gpt-future-unreleased', display_name: 'X', context_window: 1 }, noFlags);
     expect(m.cost).toBeUndefined();
   });
 
   test('threads the supplied enabledFlags onto the produced model', () => {
     const flags: ReadonlySet<string> = new Set(['responses-web-search-shim']);
-    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 }, flags);
+    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 }, flags);
     expect(m.enabledFlags).toBe(flags);
   });
 });


### PR DESCRIPTION
## Summary

The codex catalog mapper previously substituted defaults when the upstream `/codex/models` response carried unexpected shapes (missing keys, wrong types, etc.). Silently inventing defaults masks upstream regressions: operators see ghost models with placeholder limits while the real upstream is returning broken data.

Throw on malformed entries instead. The catalog refresh fails loudly with the offending shape in the error message; operators investigate the upstream regression instead of running on fabricated catalog state.

## Test plan

- [x] typecheck + test + lint clean