### PR TITLE
fix(codex): thread proxy fetcher through credential import

### DIFF
--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -296,6 +296,11 @@ const codexCredentialFields = {
     // picks `callback_url` first when present.
     callback_url: z.string().min(1).optional(),
   }).optional(),
+  // Edit-form override carried through the import dialog. The PKCE token
+  // exchange runs before the upstream record exists, so re-import uses the
+  // persisted row's list as a fallback; on first-time import only the
+  // override path is available.
+  proxy_fallback_list: proxyFallbackListSchema.optional(),
 };
 
 const requireExactlyOneCredential = (b: { auth_json?: unknown; callback?: unknown }): boolean =>

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -15,8 +15,15 @@ import { shortId } from '../../shared/short-id.ts';
 import { detectAccountType, fetchGitHubUser, pollGitHubDeviceFlow, startGitHubDeviceFlow } from '../auth/github-device-flow.ts';
 import type { codexImportBody, codexPkceStartBody, codexRefreshNowBody, codexReimportBody, copilotAuthPollBody, createUpstreamBody, fetchModelsBody, updateUpstreamBody } from '../schemas.ts';
 import { copilotConfigField, type CopilotUpstreamConfig, isRecord } from '../shared/field-validators.ts';
-import { directFetcher, ProviderModelsUnavailableError, getFlagCatalog } from '@floway-dev/provider';
-import type { ProxyFallbackEntry, UpstreamProviderKind, UpstreamRecord } from '@floway-dev/provider';
+import {
+  directFetcher,
+  getFlagCatalog,
+  ProviderModelsUnavailableError,
+  type Fetcher,
+  type ProxyFallbackEntry,
+  type UpstreamProviderKind,
+  type UpstreamRecord,
+} from '@floway-dev/provider';
 import { assertAzureUpstreamRecord } from '@floway-dev/provider-azure';
 import {
   type CodexQuotaSnapshot,
@@ -489,6 +496,7 @@ type CodexCredentialBody = z.infer<typeof codexImportBody> | z.infer<typeof code
 
 const ingestCodexCredential = async (
   body: CodexCredentialBody,
+  fetcher: Fetcher,
 ): Promise<{ ok: true; config: CodexUpstreamConfig; state: CodexUpstreamState } | { ok: false; error: string }> => {
   try {
     if (body.auth_json !== undefined) {
@@ -513,7 +521,7 @@ const ingestCodexCredential = async (
     if (!pending) {
       return { ok: false, error: 'PKCE state not found or expired; restart the flow' };
     }
-    const out = await importCodexFromCallback({ code, codeVerifier: pending.verifier });
+    const out = await importCodexFromCallback({ code, codeVerifier: pending.verifier, fetcher });
     return { ok: true, ...out };
   } catch (err) {
     return { ok: false, error: errorMessage(err) };
@@ -522,7 +530,15 @@ const ingestCodexCredential = async (
 
 export const codexImport = async (c: CtxWithJson<typeof codexImportBody>) => {
   const body = c.req.valid('json');
-  const ingestion = await ingestCodexCredential(body);
+  let fetcher: Fetcher;
+  try {
+    // First-time import has no upstream id, so the resolver falls back to
+    // direct egress when the operator left the override empty.
+    fetcher = await resolveControlPlaneFetcher({ override: body.proxy_fallback_list });
+  } catch (err) {
+    return c.json({ error: errorMessage(err) }, 400);
+  }
+  const ingestion = await ingestCodexCredential(body, fetcher);
   if (!ingestion.ok) return c.json({ error: ingestion.error }, 400);
 
   const existing = await getRepo().upstreams.list();
@@ -558,7 +574,15 @@ export const codexReimport = async (c: CtxWithJson<typeof codexReimportBody>) =>
   }
 
   const body = c.req.valid('json');
-  const ingestion = await ingestCodexCredential(body);
+  let fetcher: Fetcher;
+  try {
+    // Re-import threads the override through the same resolver as
+    // `codexRefreshNow`; absent falls back to the persisted row's list.
+    fetcher = await resolveControlPlaneFetcher({ override: body.proxy_fallback_list, upstreamId: id });
+  } catch (err) {
+    return c.json({ error: errorMessage(err) }, 400);
+  }
+  const ingestion = await ingestCodexCredential(body, fetcher);
   if (!ingestion.ok) return c.json({ error: ingestion.error }, 400);
 
   const next: UpstreamRecord = {

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -1120,3 +1120,42 @@ test('POST /api/upstreams/:id/codex-refresh-now without an override falls back t
     },
   );
 });
+
+test('POST /api/upstreams/codex-import honors the proxy_fallback_list override over the persisted list', async () => {
+  const { adminSession } = await setupAppTest();
+
+  const startResp = await requestApp('/api/upstreams/codex-pkce-start', authed(adminSession, {}));
+  const { state } = (await startResp.json()) as { state: string };
+
+  const resp = await requestApp(
+    '/api/upstreams/codex-import',
+    authed(adminSession, {
+      callback: { code: 'AUTH_CODE', state },
+      proxy_fallback_list: [{ id: 'p_unknown' }],
+    }),
+  );
+  assertEquals(resp.status, 400);
+  const body = (await resp.json()) as { error: string };
+  assertEquals(body.error.toLowerCase().includes('unknown proxy id'), true);
+});
+
+test('POST /api/upstreams/:id/codex-reimport honors the proxy_fallback_list override over the persisted list', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+
+  const created = (await (await requestApp('/api/upstreams/codex-import', authed(adminSession, codexAuthJsonImport()))).json()) as { id: string };
+
+  const startResp = await requestApp('/api/upstreams/codex-pkce-start', authed(adminSession, {}));
+  const { state } = (await startResp.json()) as { state: string };
+
+  const resp = await requestApp(
+    `/api/upstreams/${created.id}/codex-reimport`,
+    authed(adminSession, {
+      callback: { code: 'AUTH_CODE', state },
+      proxy_fallback_list: [{ id: 'p_unknown' }],
+    }),
+  );
+  assertEquals(resp.status, 400);
+  const body = (await resp.json()) as { error: string };
+  assertEquals(body.error.toLowerCase().includes('unknown proxy id'), true);
+});

--- a/packages/provider-codex/src/auth/import.ts
+++ b/packages/provider-codex/src/auth/import.ts
@@ -3,6 +3,7 @@ import type { CodexUpstreamState } from '../state.ts';
 import type { CodexIdTokenIdentity } from './jwt.ts';
 import { parseCodexIdTokenClaims } from './jwt.ts';
 import { exchangeCodexAuthorizationCode } from './oauth.ts';
+import type { Fetcher } from '@floway-dev/provider';
 
 export interface CodexImportResult {
   config: CodexUpstreamConfig;
@@ -98,9 +99,11 @@ export const extractCodexCallbackParams = (input: string): { code: string; state
 
 // Exchange the authorization code for tokens, then derive identity from the
 // returned id_token. The PKCE verifier was stored at PKCE-start time and is
-// supplied here.
-export const importCodexFromCallback = async (opts: { code: string; codeVerifier: string }): Promise<CodexImportResult> => {
-  const tokens = await exchangeCodexAuthorizationCode({ code: opts.code, codeVerifier: opts.codeVerifier });
+// supplied here. The token exchange is the only network hop on this path
+// (identity parses locally from the id_token), so `fetcher` is where the
+// caller picks egress for the whole import.
+export const importCodexFromCallback = async (opts: { code: string; codeVerifier: string; fetcher: Fetcher }): Promise<CodexImportResult> => {
+  const tokens = await exchangeCodexAuthorizationCode({ code: opts.code, codeVerifier: opts.codeVerifier, fetcher: opts.fetcher });
   const identity = parseCodexIdTokenClaims(tokens.id_token);
   return buildCodexImportResult({
     identity,

--- a/packages/provider-codex/src/auth/import_test.ts
+++ b/packages/provider-codex/src/auth/import_test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { extractCodexCallbackParams, importCodexFromAuthJson, importCodexFromCallback } from './import.ts';
+import { directFetcher, type Fetcher } from '@floway-dev/provider';
 
 const encodeBase64Url = (input: string): string => {
   const b64 = btoa(input);
@@ -73,9 +74,18 @@ describe('importCodexFromCallback', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
       access_token: 'at', refresh_token: 'rt', id_token: makeJwt(identityPayload), expires_in: 600,
     }), { status: 200, headers: { 'content-type': 'application/json' } }));
-    const result = await importCodexFromCallback({ code: 'CODE', codeVerifier: 'VER' });
+    const result = await importCodexFromCallback({ code: 'CODE', codeVerifier: 'VER', fetcher: directFetcher });
     expect(result.config.accounts[0].email).toBe('a@b.com');
     expect(result.state.accounts[0].refresh_token).toBe('rt');
     expect(result.state.accounts[0].accessToken?.token).toBe('at');
+  });
+
+  test('routes the token exchange through the supplied fetcher', async () => {
+    const fetcher = vi.fn<Fetcher>(async () => new Response(JSON.stringify({
+      access_token: 'at', refresh_token: 'rt', id_token: makeJwt(identityPayload), expires_in: 600,
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    await importCodexFromCallback({ code: 'CODE', codeVerifier: 'VER', fetcher });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher.mock.calls[0][0]).toBe('https://auth.openai.com/oauth/token');
   });
 });

--- a/packages/provider-codex/src/auth/oauth.ts
+++ b/packages/provider-codex/src/auth/oauth.ts
@@ -5,7 +5,7 @@ import {
   CODEX_OAUTH_USER_AGENT,
   CODEX_REDIRECT_URI,
 } from '../constants.ts';
-import { directFetcher, type Fetcher } from '@floway-dev/provider';
+import type { Fetcher } from '@floway-dev/provider';
 
 export interface CodexOAuthTokens {
   access_token: string;
@@ -122,9 +122,13 @@ const codexTokenRequest = async (
   };
 };
 
-// PKCE exchange has no upstream context yet — the upstream is minted from
-// this response.
-export const exchangeCodexAuthorizationCode = async (opts: { code: string; codeVerifier: string }): Promise<CodexOAuthTokens> => {
+// PKCE exchange runs before the upstream record exists, so there is no
+// persisted proxy chain to read here — the caller must supply the fetcher
+// explicitly. Making `fetcher` required (rather than defaulting to direct
+// egress) keeps every call site honest: callers that want direct egress
+// pass `directFetcher` themselves, and the import path can't accidentally
+// bypass an operator-configured proxy.
+export const exchangeCodexAuthorizationCode = async (opts: { code: string; codeVerifier: string; fetcher: Fetcher }): Promise<CodexOAuthTokens> => {
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
     client_id: CODEX_CLIENT_ID,
@@ -136,7 +140,7 @@ export const exchangeCodexAuthorizationCode = async (opts: { code: string; codeV
   // exchange typically means the operator pasted a stale or wrong callback
   // URL, which is recoverable by restarting the PKCE flow rather than
   // re-importing.
-  return await codexTokenRequest(body, EXCHANGE_TERMINAL_OAUTH_CODES, directFetcher);
+  return await codexTokenRequest(body, EXCHANGE_TERMINAL_OAUTH_CODES, opts.fetcher);
 };
 
 // `fetcher` is required because the refresh has an associated upstream

--- a/packages/provider-codex/src/auth/oauth_test.ts
+++ b/packages/provider-codex/src/auth/oauth_test.ts
@@ -13,7 +13,7 @@ describe('exchangeCodexAuthorizationCode', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(okResponse({
       access_token: 'at', refresh_token: 'rt', id_token: 'it', expires_in: 600,
     }));
-    const result = await exchangeCodexAuthorizationCode({ code: 'CODE', codeVerifier: 'VER' });
+    const result = await exchangeCodexAuthorizationCode({ code: 'CODE', codeVerifier: 'VER', fetcher: directFetcher });
     expect(result).toEqual({ access_token: 'at', refresh_token: 'rt', id_token: 'it', expires_in: 600 });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0];
@@ -33,12 +33,12 @@ describe('exchangeCodexAuthorizationCode', () => {
 
   test('throws session-terminated on app_session_terminated', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorResponse(400, { error: { code: 'app_session_terminated', message: 'Session ended' } }));
-    await expect(exchangeCodexAuthorizationCode({ code: 'CODE', codeVerifier: 'VER' })).rejects.toBeInstanceOf(CodexOAuthSessionTerminatedError);
+    await expect(exchangeCodexAuthorizationCode({ code: 'CODE', codeVerifier: 'VER', fetcher: directFetcher })).rejects.toBeInstanceOf(CodexOAuthSessionTerminatedError);
   });
 
   test('throws generic error on other 4xx, message includes status', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorResponse(400, { error: { code: 'invalid_grant', message: 'bad code' } }));
-    await expect(exchangeCodexAuthorizationCode({ code: 'CODE', codeVerifier: 'VER' })).rejects.toThrow(/400/);
+    await expect(exchangeCodexAuthorizationCode({ code: 'CODE', codeVerifier: 'VER', fetcher: directFetcher })).rejects.toThrow(/400/);
   });
 });
 


### PR DESCRIPTION
## Summary

The codex import dialog already lets the operator configure a `proxy_fallback_list` on the upstream-to-be, but the import-time PKCE token exchange always ran through direct egress: the helper signatures on `importCodexFromCallback` and `exchangeCodexAuthorizationCode` did not accept a fetcher at all, so the control-plane route had no way to honor the form value.

The fetcher is now **required** (not optional with a `directFetcher` fallback) on both helpers — matching `refreshCodexAccessToken` and `fetchCodexCatalog`, the only other network calls in this package — so every call site must think about which egress path it wants.

The `codexImport` and `codexReimport` routes resolve a `resolveControlPlaneFetcher` from the in-flight `proxy_fallback_list` (plus the persisted row's list on reimport, where the upstream id is known) and pass it down through `ingestCodexCredential`. The `auth_json` ingest path remains fetcher-free because identity is parsed locally from the id_token.

`codexImportBody` and `codexReimportBody` schemas pick up the `proxy_fallback_list` field that `codexRefreshNowBody` already carries.

## Test plan

- [x] typecheck + test + lint clean