### PR TITLE
fix(codex): resolve operator flagOverrides through getProvidedModels

### DIFF
--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -58,7 +58,11 @@ const assertRawModel = (value: unknown): CodexRawModel => {
 // Codex exposes only the Responses endpoint. Pricing is looked up from the
 // per-slug table in pricing.ts so the dashboard can report a notional
 // API-rate cost even though Codex itself bills as a flat-fee subscription.
-export const codexRawToUpstreamModel = (raw: CodexRawModel): UpstreamModel => {
+//
+// `enabledFlags` is the upstream-resolved flag set (provider defaults
+// merged with the row's `flagOverrides`); it propagates per-model so
+// downstream interceptors can read the effective set without re-resolving.
+export const codexRawToUpstreamModel = (raw: CodexRawModel, enabledFlags: ReadonlySet<string>): UpstreamModel => {
   const cost = pricingForCodexModelKey(raw.id);
   return {
     id: raw.id,
@@ -69,7 +73,7 @@ export const codexRawToUpstreamModel = (raw: CodexRawModel): UpstreamModel => {
       max_context_window_tokens: raw.context_window || raw.max_context_window || undefined,
     },
     endpoints: { responses: {} },
-    enabledFlags: new Set<string>(),
+    enabledFlags,
     ...(cost ? { cost } : {}),
   };
 };

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -49,8 +49,13 @@ describe('fetchCodexCatalog', () => {
 });
 
 describe('codexRawToUpstreamModel', () => {
+  // The mapper just threads `enabledFlags` through onto the produced model;
+  // these unit tests exercise the rest of the shape with the empty set, and
+  // a dedicated test asserts the threading.
+  const noFlags: ReadonlySet<string> = new Set();
+
   test('shapes raw → UpstreamModel with responses-only endpoint and per-request context window', () => {
-    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 });
+    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 }, noFlags);
     expect(m.id).toBe('gpt-5.4');
     expect(m.display_name).toBe('GPT-5.4');
     expect(m.endpoints).toEqual({ responses: {} });
@@ -60,19 +65,25 @@ describe('codexRawToUpstreamModel', () => {
   });
 
   test('falls back to max_context_window when context_window is zero', () => {
-    const m = codexRawToUpstreamModel({ id: 'm', display_name: 'm', context_window: 0, max_context_window: 50000 });
+    const m = codexRawToUpstreamModel({ id: 'm', display_name: 'm', context_window: 0, max_context_window: 50000 }, noFlags);
     expect(m.limits.max_context_window_tokens).toBe(50000);
   });
 
   test('attaches OpenAI-API-rate cost for known slugs and treats codex-auto-review as gpt-5.4', () => {
-    const flagship = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 });
+    const flagship = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 }, noFlags);
     expect(flagship.cost).toEqual({ input: 2.5, input_cache_read: 0.25, output: 15 });
-    const review = codexRawToUpstreamModel({ id: 'codex-auto-review', display_name: 'Codex Auto Review', context_window: 272000, max_context_window: 1000000 });
+    const review = codexRawToUpstreamModel({ id: 'codex-auto-review', display_name: 'Codex Auto Review', context_window: 272000, max_context_window: 1000000 }, noFlags);
     expect(review.cost).toEqual(flagship.cost);
   });
 
   test('omits cost for unknown slugs (forward-compat with new upstream models)', () => {
-    const m = codexRawToUpstreamModel({ id: 'gpt-future-unreleased', display_name: 'X', context_window: 1, max_context_window: 1 });
+    const m = codexRawToUpstreamModel({ id: 'gpt-future-unreleased', display_name: 'X', context_window: 1, max_context_window: 1 }, noFlags);
     expect(m.cost).toBeUndefined();
+  });
+
+  test('threads the supplied enabledFlags onto the produced model', () => {
+    const flags: ReadonlySet<string> = new Set(['responses-web-search-shim']);
+    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000, max_context_window: 1000000 }, flags);
+    expect(m.enabledFlags).toBe(flags);
   });
 });

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -10,7 +10,7 @@ import { pricingForCodexModelKey } from './pricing.ts';
 import { assertCodexUpstreamState, type CodexUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { getProviderRepo, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderCompactionResult, type ProviderStreamResult, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { defaultsForProvider, getProviderRepo, resolveEffectiveFlags, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderCompactionResult, type ProviderStreamResult, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 export const createCodexProvider = async (record: UpstreamRecord): Promise<ModelProviderInstance> => {
   assertCodexUpstreamRecord(record);
@@ -20,6 +20,12 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
   // pool. The schema carries an array so a future fan-out can pick a
   // different active account per call without a wire migration.
   const accountIdentity = config.accounts[0];
+
+  // Computed once per provider instance: only the upstream layer applies
+  // (no per-model override layer). Threaded into every UpstreamModel emitted
+  // by getProvidedModels so interceptors can read the effective flag set
+  // without re-resolving — same pattern as the claude-code provider.
+  const enabledFlags = resolveEffectiveFlags(defaultsForProvider('codex'), [record.flagOverrides]);
 
   // Re-read upstream state on every request rather than capturing the record's
   // state at construction. Refresh-token rotation, terminal-state transitions,
@@ -88,7 +94,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
       // operator's gateway is its own surface — they can dispatch to those
       // models even though the ChatGPT UI hides them — and the dashboard
       // toggles them per-upstream when needed.
-      return raw.map(codexRawToUpstreamModel);
+      return raw.map(r => codexRawToUpstreamModel(r, enabledFlags));
     },
 
     // Codex itself is a flat-fee subscription, but the dashboard reports

--- a/packages/provider-codex/src/provider_test.ts
+++ b/packages/provider-codex/src/provider_test.ts
@@ -130,6 +130,24 @@ describe('createCodexProvider', () => {
     await expect(instance.provider.getProvidedModels(directFetcher)).rejects.toThrow(/Codex OAuth session terminated/);
   });
 
+  test('getProvidedModels resolves operator flag overrides into every UpstreamModel', async () => {
+    // The codex provider has no provider-default flags, so an operator
+    // toggling `responses-web-search-shim` on at the upstream layer is the
+    // only signal downstream interceptors get. A previous regression
+    // hardcoded `enabledFlags: new Set()` in the catalog mapper, dropping
+    // the override on the floor — this test guards against that.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(modelsResponse());
+    const recordWithOverride: UpstreamRecord = {
+      ...baseRecord,
+      flagOverrides: { 'responses-web-search-shim': true },
+    };
+    const instance = await createCodexProvider(recordWithOverride);
+    const models = await instance.provider.getProvidedModels(directFetcher);
+    for (const m of models) {
+      expect(m.enabledFlags.has('responses-web-search-shim')).toBe(true);
+    }
+  });
+
   test('callResponses round-trips through fetch transport', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
     const instance = await createCodexProvider(baseRecord);


### PR DESCRIPTION
## Summary

The codex catalog mapper hardcodes `enabledFlags: new Set<string>()` on every `UpstreamModel` it produces. Operator-configured `flagOverrides` for a codex upstream survive the control-plane schema validation + the SQL round-trip, but get silently dropped at catalog-resolution time before any interceptor can read them. Every codex upstream effectively ignores its declared flag overrides today.

Resolve `enabledFlags` through `resolveEffectiveFlags(defaultsForProvider('codex'), [record.flagOverrides])` in `getProvidedModels`, the same pattern other providers use, and pass the resolved set into the catalog mapper. The catalog mapper accepts `enabledFlags` as a parameter so individual model rows reflect the operator's overrides.

## Test plan

- [x] typecheck + test + lint clean