### PR TITLE
chore(codex): drop dead defensive patterns + trim restating comments

### DIFF
--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -8,8 +8,6 @@ import {
 import { pricingForCodexModelKey } from './pricing.ts';
 import { type Fetcher, type UpstreamModel } from '@floway-dev/provider';
 
-// Narrowed shape from /codex/models. Upstream returns
-// `{ models: [{ slug, display_name, visibility, context_window, max_context_window, ... }] }`.
 export interface CodexRawModel {
   id: string;
   display_name: string;
@@ -42,16 +40,17 @@ export const fetchCodexCatalog = async (opts: { accessToken: string; accountId: 
   return parsed.models.map(assertRawModel);
 };
 
+const isPlainRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
+
 const assertRawModel = (value: unknown): CodexRawModel => {
-  if (typeof value !== 'object' || value === null) throw new TypeError('Codex model entry is not an object');
-  const obj = value as Record<string, unknown>;
-  const slug = obj.slug;
+  if (!isPlainRecord(value)) throw new TypeError('Codex model entry is not an object');
+  const slug = value.slug;
   if (typeof slug !== 'string') throw new TypeError('Codex model entry missing slug');
   return {
     id: slug,
-    display_name: typeof obj.display_name === 'string' ? obj.display_name : slug,
-    context_window: typeof obj.context_window === 'number' ? obj.context_window : 0,
-    max_context_window: typeof obj.max_context_window === 'number' ? obj.max_context_window : 0,
+    display_name: typeof value.display_name === 'string' ? value.display_name : slug,
+    context_window: typeof value.context_window === 'number' ? value.context_window : 0,
+    max_context_window: typeof value.max_context_window === 'number' ? value.max_context_window : 0,
   };
 };
 

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -99,7 +99,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
     callResponses: async (model, body, signal, headers, opts) => {
       const ctx: ResponsesBoundaryCtx = {
         payload: { ...body, model: model.id },
-        headers: { ...(headers ?? {}) },
+        headers: { ...headers },
         model,
       };
       return await runInterceptors<ResponsesBoundaryCtx, object, ProviderStreamResult<ResponsesStreamEvent>>(
@@ -123,7 +123,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
     callResponsesCompact: async (model, body, signal, headers, opts) => {
       const ctx: ResponsesBoundaryCtx = {
         payload: { ...body, model: model.id },
-        headers: { ...(headers ?? {}) },
+        headers: { ...headers },
         model,
       };
       return await runInterceptors<ResponsesBoundaryCtx, object, ProviderCompactionResult>(

--- a/packages/provider-codex/src/provider_test.ts
+++ b/packages/provider-codex/src/provider_test.ts
@@ -24,7 +24,6 @@ const baseRecord: UpstreamRecord = {
   proxyFallbackList: [],
 };
 
-// Access token lives in the state slot — there is no separate cache.
 const recordWithAccessToken = (entry: CodexAccessTokenEntry = freshAccessToken): UpstreamRecord => ({
   ...baseRecord,
   state: { accounts: [{ chatgptAccountId: 'acc', refresh_token: 'rt_v1', state: 'active', state_updated_at: '2026-01-01T00:00:00Z', accessToken: entry, quotaSnapshot: null }] },
@@ -85,7 +84,6 @@ describe('createCodexProvider', () => {
     // can dispatch to `codex-auto-review` even though ChatGPT's UI hides it.
     expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review']);
     expect(models[0].endpoints).toEqual({ responses: {} });
-    // No OAuth refresh hit: the only fetch is the catalog.
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toMatch(/\/codex\/models/);
   });


### PR DESCRIPTION
## Summary

Codex package code-quality sweep:

- **Drop a `??` headers-fallback and an unnecessary type cast** that the type system already rules out at the boundary — defensive scaffolding that masked a contract the caller already honors.
- **Trim restating-obvious comments** across the codex package that paraphrase the function name or repeat what the code says without adding decision-rationale value.

Behavioral diff is zero — code reads cleaner.

## Test plan

- [x] typecheck + test + lint clean