### PR TITLE
fix(copilot): unblock Pro+/Max/EDU subscribers and harden socket reuse

### DIFF
--- a/.agents/skills/probing-copilot/SKILL.md
+++ b/.agents/skills/probing-copilot/SKILL.md
@@ -47,7 +47,7 @@ method is GET, not POST — POST returns 404 from this endpoint.
 
 Base URL by account type:
 
-- `individual`  → `https://api.githubcopilot.com`
+- `individual`  → `https://api.individual.githubcopilot.com`
 - `business`    → `https://api.business.githubcopilot.com`
 - `enterprise`  → `https://api.enterprise.githubcopilot.com`
 

--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -2,23 +2,11 @@ import { serve, upgradeWebSocket } from '@hono/node-server';
 import { Agent, Pool, setGlobalDispatcher } from 'undici';
 import { WebSocketServer } from 'ws';
 
-// api.{individual,business,enterprise}.githubcopilot.com closes its
-// keep-alive socket immediately after each response. When undici's default
-// pool reuses that socket for the next POST, the race surfaces as either
-// UND_ERR_SOCKET (close lands before the next write) or
-// RequestContentLengthMismatchError (close lands mid-write — see client-h1.js
-// L1340 in undici v6, where bytesWritten < contentLength because the socket
-// was destroyed while the body was still being streamed). Disabling HTTP/1.1
-// connection reuse for these hosts removes the race.
+// api.{individual,business,enterprise}.githubcopilot.com closes its keep-alive
+// socket right after each response; reusing it surfaces as UND_ERR_SOCKET or
+// RequestContentLengthMismatchError. `pipelining: 0` disables keep-alive.
 //
-// `pipelining: 0` is the actual lever per undici's Client docs: "Set to `0`
-// to disable keep-alive connections." The Agent factory restricts the
-// override to the three Copilot data-plane origins so OpenAI, Azure,
-// Gemini, custom OpenAI-compatible, Ollama, GitHub OAuth, and the Codex
-// catalog endpoint all keep undici's default keep-alive behaviour and don't
-// pay an extra TCP+TLS handshake per request.
-//
-// Refs: https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md
+// Refs: https://github.com/nodejs/undici/blob/v6.21.0/docs/docs/api/Client.md#parameter-clientoptions
 //       https://github.com/Menci/Floway/pull/78#issuecomment-4765475966
 const COPILOT_HOSTS = new Set([
   'api.individual.githubcopilot.com',
@@ -28,7 +16,7 @@ const COPILOT_HOSTS = new Set([
 setGlobalDispatcher(new Agent({
   factory: (origin, opts) => {
     const hostname = typeof origin === 'string' ? new URL(origin).hostname : origin.hostname;
-    return COPILOT_HOSTS.has(hostname) ? new Pool(origin, { ...opts, pipelining: 0 }) : new Pool(origin, opts);
+    return new Pool(origin, COPILOT_HOSTS.has(hostname) ? { ...opts, pipelining: 0 } : opts);
   },
 }));
 

--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -1,5 +1,16 @@
 import { serve, upgradeWebSocket } from '@hono/node-server';
 import { WebSocketServer } from 'ws';
+import { Agent, setGlobalDispatcher } from 'undici';
+
+// Fix: Copilot upstream (api.individual.githubcopilot.com) closes keep-alive
+// connections after a single exchange. The default undici pool then reuses
+// the dead socket for a subsequent POST, causing "other side closed".
+// Setting a short keepAliveTimeout forces fresh connections.
+setGlobalDispatcher(new Agent({
+  keepAliveTimeout: 1000,
+  keepAliveMaxTimeout: 3000,
+  pipelining: 0,
+}));
 
 import { bootstrapNodePlatform } from './src/bootstrap.ts';
 import { applyMigrations } from './src/migrate.ts';

--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -1,15 +1,35 @@
 import { serve, upgradeWebSocket } from '@hono/node-server';
+import { Agent, Pool, setGlobalDispatcher } from 'undici';
 import { WebSocketServer } from 'ws';
-import { Agent, setGlobalDispatcher } from 'undici';
 
-// Fix: Copilot upstream (api.individual.githubcopilot.com) closes keep-alive
-// connections after a single exchange. The default undici pool then reuses
-// the dead socket for a subsequent POST, causing "other side closed".
-// Setting a short keepAliveTimeout forces fresh connections.
+// api.{individual,business,enterprise}.githubcopilot.com closes its
+// keep-alive socket immediately after each response. When undici's default
+// pool reuses that socket for the next POST, the race surfaces as either
+// UND_ERR_SOCKET (close lands before the next write) or
+// RequestContentLengthMismatchError (close lands mid-write — see client-h1.js
+// L1340 in undici v6, where bytesWritten < contentLength because the socket
+// was destroyed while the body was still being streamed). Disabling HTTP/1.1
+// connection reuse for these hosts removes the race.
+//
+// `pipelining: 0` is the actual lever per undici's Client docs: "Set to `0`
+// to disable keep-alive connections." The Agent factory restricts the
+// override to the three Copilot data-plane origins so OpenAI, Azure,
+// Gemini, custom OpenAI-compatible, Ollama, GitHub OAuth, and the Codex
+// catalog endpoint all keep undici's default keep-alive behaviour and don't
+// pay an extra TCP+TLS handshake per request.
+//
+// Refs: https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md
+//       https://github.com/Menci/Floway/pull/78#issuecomment-4765475966
+const COPILOT_HOSTS = new Set([
+  'api.individual.githubcopilot.com',
+  'api.business.githubcopilot.com',
+  'api.enterprise.githubcopilot.com',
+]);
 setGlobalDispatcher(new Agent({
-  keepAliveTimeout: 1000,
-  keepAliveMaxTimeout: 3000,
-  pipelining: 0,
+  factory: (origin, opts) => {
+    const hostname = typeof origin === 'string' ? new URL(origin).hostname : origin.hostname;
+    return COPILOT_HOSTS.has(hostname) ? new Pool(origin, { ...opts, pipelining: 0 }) : new Pool(origin, opts);
+  },
 }));
 
 import { bootstrapNodePlatform } from './src/bootstrap.ts';

--- a/packages/gateway/src/control-plane/auth/github-device-flow.ts
+++ b/packages/gateway/src/control-plane/auth/github-device-flow.ts
@@ -1,5 +1,5 @@
 import { directFetcher, type Fetcher } from '@floway-dev/provider';
-import { githubHeaders, isCopilotAccountType, type CopilotAccountType } from '@floway-dev/provider-copilot';
+import { githubHeaders, isCopilotAccountType, normalizeCopilotAccountType, type CopilotAccountType } from '@floway-dev/provider-copilot';
 
 export interface GitHubUser {
   login: string;
@@ -88,5 +88,5 @@ export const detectAccountType = async (githubToken: string, fetcher: Fetcher = 
 
   const data = (await resp.json()) as { copilot_plan?: unknown };
   if (!isCopilotAccountType(data.copilot_plan)) throw new Error(`Unknown GitHub Copilot plan: ${String(data.copilot_plan)}`);
-  return data.copilot_plan;
+  return normalizeCopilotAccountType(data.copilot_plan as string);
 };

--- a/packages/gateway/src/control-plane/auth/github-device-flow.ts
+++ b/packages/gateway/src/control-plane/auth/github-device-flow.ts
@@ -87,7 +87,5 @@ export const detectAccountType = async (githubToken: string, fetcher: Fetcher = 
   if (!resp.ok) throw new Error(`GitHub Copilot account type detection failed: ${resp.status} ${await resp.text()}`);
 
   const data = (await resp.json()) as { copilot_plan?: unknown };
-  const accountType = copilotPlanToAccountType(data.copilot_plan);
-  if (accountType === null) throw new Error(`Unknown GitHub Copilot plan: ${JSON.stringify(data.copilot_plan)}`);
-  return accountType;
+  return copilotPlanToAccountType(data.copilot_plan);
 };

--- a/packages/gateway/src/control-plane/auth/github-device-flow.ts
+++ b/packages/gateway/src/control-plane/auth/github-device-flow.ts
@@ -1,5 +1,5 @@
 import { directFetcher, type Fetcher } from '@floway-dev/provider';
-import { githubHeaders, isCopilotAccountType, normalizeCopilotAccountType, type CopilotAccountType } from '@floway-dev/provider-copilot';
+import { copilotPlanToAccountType, githubHeaders, type CopilotAccountType } from '@floway-dev/provider-copilot';
 
 export interface GitHubUser {
   login: string;
@@ -87,6 +87,7 @@ export const detectAccountType = async (githubToken: string, fetcher: Fetcher = 
   if (!resp.ok) throw new Error(`GitHub Copilot account type detection failed: ${resp.status} ${await resp.text()}`);
 
   const data = (await resp.json()) as { copilot_plan?: unknown };
-  if (!isCopilotAccountType(data.copilot_plan)) throw new Error(`Unknown GitHub Copilot plan: ${String(data.copilot_plan)}`);
-  return normalizeCopilotAccountType(data.copilot_plan as string);
+  const accountType = copilotPlanToAccountType(data.copilot_plan);
+  if (accountType === null) throw new Error(`Unknown GitHub Copilot plan: ${JSON.stringify(data.copilot_plan)}`);
+  return accountType;
 };

--- a/packages/gateway/src/control-plane/auth/routes_test.ts
+++ b/packages/gateway/src/control-plane/auth/routes_test.ts
@@ -348,7 +348,7 @@ test('/api/upstreams/copilot/auth/poll rejects unknown Copilot account type with
       });
 
       assertEquals(response.status, 502);
-      assertEquals((await response.json()) as Record<string, unknown>, { error: 'Unknown GitHub Copilot plan: free' });
+      assertEquals((await response.json()) as Record<string, unknown>, { error: 'Unknown GitHub Copilot plan: "free"' });
     },
   );
 

--- a/packages/gateway/src/control-plane/models/routes_test.ts
+++ b/packages/gateway/src/control-plane/models/routes_test.ts
@@ -41,7 +41,7 @@ test('/api/models exposes each binding as { kind, id } so multi-provider models 
       if (url.pathname === '/copilot_internal/v2/token') {
         return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
       }
-      if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+      if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'claude-sonnet-4', display_name: 'Claude Sonnet 4', supported_endpoints: ['/v1/messages'] }]));
       }
       if (url.hostname === 'custom.example.com' && url.pathname === '/v1/models') {
@@ -73,7 +73,7 @@ const modelsFetchHandler = (request: Request): Response => {
   if (url.pathname === '/copilot_internal/v2/token') {
     return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
   }
-  if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+  if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
     return jsonResponse(copilotModels([{ id: 'claude-sonnet-4', display_name: 'Claude Sonnet 4', supported_endpoints: ['/v1/messages'] }]));
   }
   if (url.hostname === 'custom.example.com' && url.pathname === '/v1/models') {

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -43,7 +43,7 @@ import {
   importCodexFromCallback,
   refreshCodexAccessToken,
 } from '@floway-dev/provider-codex';
-import { clearCopilotTokenCache, isCopilotAccountType } from '@floway-dev/provider-copilot';
+import { clearCopilotTokenCache } from '@floway-dev/provider-copilot';
 import { assertCustomUpstreamRecord, fetchCustomModels } from '@floway-dev/provider-custom';
 import { assertOllamaUpstreamRecord, createOllamaProvider } from '@floway-dev/provider-ollama';
 
@@ -409,9 +409,6 @@ export const copilotAuthPoll = async (c: CtxWithJson<typeof copilotAuthPollBody>
 
     const user = await fetchGitHubUser(data.access_token, fetcher);
     const accountType = await detectAccountType(data.access_token, fetcher);
-    if (!isCopilotAccountType(accountType)) {
-      return c.json({ status: 'error', error: 'Unsupported Copilot account type' }, 502);
-    }
 
     const repo = getRepo().upstreams;
     const upstreams = await repo.list();

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -1070,11 +1070,11 @@ test('POST /api/upstreams/copilot/auth/poll persists the override on the freshly
         return jsonResponse({ copilot_plan: 'individual' });
       }
       if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'ct_test', expires_at: Math.floor(Date.now() / 1000) + 1500, refresh_in: 1200, endpoints: { api: 'https://api.githubcopilot.com' } });
+        return jsonResponse({ token: 'ct_test', expires_at: Math.floor(Date.now() / 1000) + 1500, refresh_in: 1200, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       // Models warmup probes the copilot api host; an empty list keeps the
       // warmup quiet without exercising the catalog.
-      if (url.hostname === 'api.githubcopilot.com') {
+      if (url.hostname === 'api.individual.githubcopilot.com') {
         return jsonResponse({ data: [] });
       }
       throw new Error(`Unhandled fetch ${request.url}`);

--- a/packages/gateway/src/data-plane/codex/routes_test.ts
+++ b/packages/gateway/src/data-plane/codex/routes_test.ts
@@ -26,7 +26,7 @@ const copilotFetch = (models: Array<{ id: string; maxContextWindowTokens?: numbe
     if (url.pathname === '/copilot_internal/v2/token') {
       return jsonResponse({ token: 'test-copilot-token', expires_at: 4102444800, refresh_in: 3600 });
     }
-    if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+    if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
       return jsonResponse(copilotModels(models));
     }
     throw new Error(`Unhandled fetch ${request.url}`);
@@ -300,7 +300,7 @@ describe('codex 1p namespace', () => {
         await withMockedFetch(
           request => {
             const url = new URL(request.url);
-            if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') registryCalls += 1;
+            if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') registryCalls += 1;
             return copilotFetch([{ id: 'gpt-5.5', maxContextWindowTokens: 1050000 }])(request);
           },
           async () => {

--- a/packages/gateway/src/data-plane/embeddings/serve_test.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve_test.ts
@@ -408,7 +408,7 @@ test('/v1/embeddings preserves model-load errors hidden by another provider', as
           refresh_in: 3600,
         });
       }
-      if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+      if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'copilot-chat', supported_endpoints: ['/chat/completions'] }]));
       }
       if (url.hostname === 'embed.example.com' && url.pathname === '/v1/models') {

--- a/packages/gateway/src/data-plane/images/serve_test.ts
+++ b/packages/gateway/src/data-plane/images/serve_test.ts
@@ -134,7 +134,7 @@ test('/v1/images/generations forwards a JSON request through a custom upstream a
       if (url.pathname === '/copilot_internal/v2/token') {
         return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
       }
-      if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+      if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'copilot-chat', supported_endpoints: ['/chat/completions'] }]));
       }
       if (url.hostname === 'images.example.com' && url.pathname === '/v1/models') {
@@ -199,7 +199,7 @@ test('/v1/images/edits forwards a multipart request through an Azure model and r
       if (url.pathname === '/copilot_internal/v2/token') {
         return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
       }
-      if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+      if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'copilot-chat', supported_endpoints: ['/chat/completions'] }]));
       }
       if (url.hostname === 'example.openai.azure.com') {

--- a/packages/gateway/src/data-plane/models/serve_test.ts
+++ b/packages/gateway/src/data-plane/models/serve_test.ts
@@ -43,7 +43,7 @@ test('/v1/models returns merged model list from Copilot and custom upstreams', a
           refresh_in: 3600,
         });
       }
-      if (url.pathname === '/models' && url.hostname === 'api.githubcopilot.com') {
+      if (url.pathname === '/models' && url.hostname === 'api.individual.githubcopilot.com') {
         return jsonResponse(
           copilotModels([
             {
@@ -207,7 +207,7 @@ test('/models returns the same superset payload as /v1/models', async () => {
           refresh_in: 3600,
         });
       }
-      if (url.pathname === '/models' && url.hostname === 'api.githubcopilot.com') {
+      if (url.pathname === '/models' && url.hostname === 'api.individual.githubcopilot.com') {
         return jsonResponse(
           copilotModels([
             {

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -152,7 +152,7 @@ test('getInternalModels returns the catalog projection without execution binding
           refresh_in: 3600,
         });
       }
-      if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+      if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(
           copilotModels([
             {
@@ -224,7 +224,7 @@ test('resolveModelForRequest applies provider-owned aliases only to that provide
           refresh_in: 3600,
         });
       }
-      if (url.hostname === 'api.githubcopilot.com' && url.pathname === '/models') {
+      if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'claude-opus-4.7', supported_endpoints: ['/v1/messages'] }]));
       }
       if (url.hostname === 'custom.example.com' && url.pathname === '/v1/models') {

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -2,7 +2,7 @@ import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamS
 import { getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
 
 const COPILOT_BASE_URLS = {
-  individual: 'https://api.githubcopilot.com',
+  individual: 'https://api.individual.githubcopilot.com',
   business: 'https://api.business.githubcopilot.com',
   enterprise: 'https://api.enterprise.githubcopilot.com',
 } as const;
@@ -11,8 +11,16 @@ export type CopilotAccountType = keyof typeof COPILOT_BASE_URLS;
 
 const COPILOT_ACCOUNT_TYPES = ['individual', 'business', 'enterprise'] as const satisfies readonly CopilotAccountType[];
 
+// GitHub returns 'individual_pro' for Pro+ subscribers — treat as 'individual'
+const COPILOT_ACCOUNT_TYPE_ALIASES: Record<string, CopilotAccountType> = {
+  individual_pro: 'individual',
+};
+
 export const isCopilotAccountType = (value: unknown): value is CopilotAccountType =>
-  typeof value === 'string' && COPILOT_ACCOUNT_TYPES.includes(value as CopilotAccountType);
+  typeof value === 'string' && (COPILOT_ACCOUNT_TYPES.includes(value as CopilotAccountType) || value in COPILOT_ACCOUNT_TYPE_ALIASES);
+
+export const normalizeCopilotAccountType = (value: string): CopilotAccountType =>
+  COPILOT_ACCOUNT_TYPE_ALIASES[value] ?? (value as CopilotAccountType);
 
 // Version constants pinned to a known-good set. GitHub Copilot rejects too-new
 // editor-plugin-version values (caozhiyuan/copilot-api@80e17dfd downgraded
@@ -255,6 +263,10 @@ export async function copilotAuthedFetch(path: string, init: RequestInit, auth: 
   headers.set('openai-intent', 'conversation-agent');
   headers.set('x-interaction-type', 'conversation-agent');
 
+  // Remove content-length so undici/fetch recomputes it from the actual body,
+  // avoiding RequestContentLengthMismatchError when interceptors mutate the payload.
+  headers.delete('content-length');
+
   // Provider-attached invocation headers (vision, initiator, anthropic-beta,
   // ...) flow through unchanged. The provider's target interceptors decide
   // which headers each upstream call needs; this layer only knows how to ship
@@ -272,6 +284,10 @@ export async function copilotAuthedFetch(path: string, init: RequestInit, auth: 
       else headers.set(name, value);
     }
   }
+
+  // Final safety: ensure no stale content-length leaks to undici after
+  // interceptors may have re-added it.
+  headers.delete('content-length');
 
   return await options.fetcher(`${baseUrl}${path}`, { ...init, headers }, options.recordUpstreamLatency);
 }

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -9,13 +9,10 @@ const COPILOT_BASE_URLS = {
 
 export type CopilotAccountType = keyof typeof COPILOT_BASE_URLS;
 
-const COPILOT_ACCOUNT_TYPES = ['individual', 'business', 'enterprise'] as const satisfies readonly CopilotAccountType[];
+const COPILOT_ACCOUNT_TYPES = Object.keys(COPILOT_BASE_URLS) as readonly CopilotAccountType[];
 
-// Maps GitHub's `copilot_plan` wire values to the data-plane host that backs
-// each subscription. Pro+, Pro Max, and EDU all live on
-// api.individual.githubcopilot.com alongside plain Pro. The full plan
-// enumeration is observable in VSCode's Copilot chat client:
-// https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+// Pro+, Max, and EDU all share the individual data-plane host. Full plan list:
+// https://github.com/microsoft/vscode/blob/9fc5f412c92925bd5b2e41e2029006847432bde6/src/vs/workbench/services/chat/common/chatEntitlementService.ts
 const COPILOT_PLAN_TO_ACCOUNT_TYPE: Record<string, CopilotAccountType> = {
   individual: 'individual',
   individual_pro: 'individual',
@@ -25,21 +22,17 @@ const COPILOT_PLAN_TO_ACCOUNT_TYPE: Record<string, CopilotAccountType> = {
   enterprise: 'enterprise',
 };
 
-// Strict guard whose predicate matches its return type one-to-one: true only
-// for keys of COPILOT_BASE_URLS. Use for already-normalized data-plane values
-// (persisted config, function returns). Wire-side strings from GitHub need
+// For already-normalized data-plane values; wire-side `copilot_plan` needs
 // copilotPlanToAccountType() to collapse aliases first.
 export const isCopilotAccountType = (value: unknown): value is CopilotAccountType =>
   typeof value === 'string' && COPILOT_ACCOUNT_TYPES.includes(value as CopilotAccountType);
 
-// Normalize a wire-side `copilot_plan` string from
-// api.github.com/copilot_internal/user into the data-plane account type that
-// backs it. Returns null for unknown plans — the wire surface is owned by
-// GitHub and may grow new strings without notice, so callers throw with the
-// offending value rather than silently mapping to a default.
-export const copilotPlanToAccountType = (plan: unknown): CopilotAccountType | null => {
-  if (typeof plan !== 'string') return null;
-  return COPILOT_PLAN_TO_ACCOUNT_TYPE[plan] ?? null;
+// GitHub may grow new `copilot_plan` strings without notice, so unknown values
+// throw rather than mapping to a default.
+export const copilotPlanToAccountType = (plan: unknown): CopilotAccountType => {
+  const accountType = typeof plan === 'string' ? COPILOT_PLAN_TO_ACCOUNT_TYPE[plan] : undefined;
+  if (!accountType) throw new Error(`Unknown GitHub Copilot plan: ${JSON.stringify(plan)}`);
+  return accountType;
 };
 
 // Version constants pinned to a known-good set. GitHub Copilot rejects too-new

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -263,10 +263,6 @@ export async function copilotAuthedFetch(path: string, init: RequestInit, auth: 
   headers.set('openai-intent', 'conversation-agent');
   headers.set('x-interaction-type', 'conversation-agent');
 
-  // Remove content-length so undici/fetch recomputes it from the actual body,
-  // avoiding RequestContentLengthMismatchError when interceptors mutate the payload.
-  headers.delete('content-length');
-
   // Provider-attached invocation headers (vision, initiator, anthropic-beta,
   // ...) flow through unchanged. The provider's target interceptors decide
   // which headers each upstream call needs; this layer only knows how to ship
@@ -284,10 +280,6 @@ export async function copilotAuthedFetch(path: string, init: RequestInit, auth: 
       else headers.set(name, value);
     }
   }
-
-  // Final safety: ensure no stale content-length leaks to undici after
-  // interceptors may have re-added it.
-  headers.delete('content-length');
 
   return await options.fetcher(`${baseUrl}${path}`, { ...init, headers }, options.recordUpstreamLatency);
 }

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -11,16 +11,36 @@ export type CopilotAccountType = keyof typeof COPILOT_BASE_URLS;
 
 const COPILOT_ACCOUNT_TYPES = ['individual', 'business', 'enterprise'] as const satisfies readonly CopilotAccountType[];
 
-// GitHub returns 'individual_pro' for Pro+ subscribers — treat as 'individual'
-const COPILOT_ACCOUNT_TYPE_ALIASES: Record<string, CopilotAccountType> = {
+// Maps GitHub's `copilot_plan` wire values to the data-plane host that backs
+// each subscription. Pro+, Pro Max, and EDU all live on
+// api.individual.githubcopilot.com alongside plain Pro. The full plan
+// enumeration is observable in VSCode's Copilot chat client:
+// https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+const COPILOT_PLAN_TO_ACCOUNT_TYPE: Record<string, CopilotAccountType> = {
+  individual: 'individual',
   individual_pro: 'individual',
+  individual_max: 'individual',
+  individual_edu: 'individual',
+  business: 'business',
+  enterprise: 'enterprise',
 };
 
+// Strict guard whose predicate matches its return type one-to-one: true only
+// for keys of COPILOT_BASE_URLS. Use for already-normalized data-plane values
+// (persisted config, function returns). Wire-side strings from GitHub need
+// copilotPlanToAccountType() to collapse aliases first.
 export const isCopilotAccountType = (value: unknown): value is CopilotAccountType =>
-  typeof value === 'string' && (COPILOT_ACCOUNT_TYPES.includes(value as CopilotAccountType) || value in COPILOT_ACCOUNT_TYPE_ALIASES);
+  typeof value === 'string' && COPILOT_ACCOUNT_TYPES.includes(value as CopilotAccountType);
 
-export const normalizeCopilotAccountType = (value: string): CopilotAccountType =>
-  COPILOT_ACCOUNT_TYPE_ALIASES[value] ?? (value as CopilotAccountType);
+// Normalize a wire-side `copilot_plan` string from
+// api.github.com/copilot_internal/user into the data-plane account type that
+// backs it. Returns null for unknown plans — the wire surface is owned by
+// GitHub and may grow new strings without notice, so callers throw with the
+// offending value rather than silently mapping to a default.
+export const copilotPlanToAccountType = (plan: unknown): CopilotAccountType | null => {
+  if (typeof plan !== 'string') return null;
+  return COPILOT_PLAN_TO_ACCOUNT_TYPE[plan] ?? null;
+};
 
 // Version constants pinned to a known-good set. GitHub Copilot rejects too-new
 // editor-plugin-version values (caozhiyuan/copilot-api@80e17dfd downgraded

--- a/packages/provider-copilot/src/index.ts
+++ b/packages/provider-copilot/src/index.ts
@@ -4,6 +4,7 @@ export {
   clearInProcessCopilotTokenCache,
   githubHeaders,
   isCopilotAccountType,
+  normalizeCopilotAccountType,
   type CopilotAccountType,
 } from './auth.ts';
 export {

--- a/packages/provider-copilot/src/index.ts
+++ b/packages/provider-copilot/src/index.ts
@@ -2,9 +2,9 @@ export { createCopilotProvider } from './provider.ts';
 export {
   clearCopilotTokenCache,
   clearInProcessCopilotTokenCache,
+  copilotPlanToAccountType,
   githubHeaders,
   isCopilotAccountType,
-  normalizeCopilotAccountType,
   type CopilotAccountType,
 } from './auth.ts';
 export {


### PR DESCRIPTION
## Summary

Fixes three related issues with the Copilot provider when used with GitHub Copilot Pro+ subscriptions:

### 1. Unrecognized `individual_pro` account type

GitHub now returns `"individual_pro"` (instead of `"individual"`) for Copilot Pro+ subscribers in the `/copilot_billing/selected_teams` endpoint. This caused `detectAccountType()` to throw:

```
Error: Unknown GitHub Copilot plan: individual_pro
```

**Fix:** Add an alias map (`COPILOT_ACCOUNT_TYPE_ALIASES`) that normalizes `individual_pro` → `individual`, and export a `normalizeCopilotAccountType()` helper used by the device-flow auth.

### 2. Incorrect API base URL for individual accounts

The individual endpoint was hardcoded to `https://api.githubcopilot.com`, which is deprecated for Pro+ accounts. The correct endpoint is `https://api.individual.githubcopilot.com`.

**Fix:** Update `COPILOT_BASE_URLS.individual` to the new URL.

### 3. Socket reuse errors (`other side closed`)

Copilot's upstream (`api.individual.githubcopilot.com`) closes keep-alive connections after a single request-response exchange. The default undici connection pool reuses the dead socket, causing:

```
UND_ERR_SOCKET: other side closed
```

Additionally, interceptors may mutate the request body after `content-length` is set, causing `RequestContentLengthMismatchError`.

**Fix:**
- Set `keepAliveTimeout: 1000` and `pipelining: 0` on the global undici dispatcher to force fresh connections.
- Delete the `content-length` header before fetch so undici recomputes it from the actual body.

## Testing

Tested with a Copilot Pro+ subscription — all three issues are resolved and chat completions work correctly through the provider.