### PR TITLE
refactor(web): consume shared types from @floway-dev/protocols

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@floway-dev/protocols": "workspace:*",
     "@floway-dev/proxy": "workspace:*",
     "@floway-dev/ui": "workspace:*",
     "@vueuse/core": "^14.1.0",

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -1,31 +1,21 @@
 // Control-plane DTOs the SPA consumes — serialized shapes the gateway emits at /api.
 
-export type UpstreamProviderKind = 'custom' | 'azure' | 'copilot' | 'codex' | 'ollama';
+import type {
+  BillingDimension,
+  ModelEndpointKey,
+  ModelEndpoints,
+  ModelKind,
+  ModelPricing,
+} from '@floway-dev/protocols/common';
 
-export type ModelKind = 'chat' | 'embedding' | 'image';
+export type { BillingDimension, ModelEndpointKey, ModelEndpoints, ModelKind, ModelPricing };
+
+export type UpstreamProviderKind = 'custom' | 'azure' | 'copilot' | 'codex' | 'ollama';
 
 export interface ProxyFallbackEntry {
   id: string;
   colos?: string[];
 }
-
-// A present key means the model is served by that endpoint.
-export interface ModelEndpoints {
-  chatCompletions?: {};
-  responses?: {};
-  messages?: {};
-  embeddings?: {};
-  imagesGenerations?: {};
-  imagesEdits?: {};
-}
-
-export type ModelEndpointKey = keyof ModelEndpoints;
-
-// USD per million tokens, keyed by billing dimension. Imported from the
-// gateway so the dashboard's pricing form stays locked to the same definition
-// the backend writes against — same pattern as `ProxyRecord` below.
-import type { BillingDimension, ModelPricing } from '@floway-dev/gateway/control-plane/pricing/types';
-export type { BillingDimension, ModelPricing };
 
 export interface UpstreamModelConfig {
   upstreamModelId: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@floway-dev/protocols':
+        specifier: workspace:*
+        version: link:../../packages/protocols
       '@floway-dev/proxy':
         specifier: workspace:*
         version: link:../../packages/proxy


### PR DESCRIPTION
## Summary

The dashboard's `api/types.ts` kept its own copies of `ModelKind`,
`ModelEndpoints`, and `ModelEndpointKey`, and reached into
`@floway-dev/gateway/control-plane/pricing/types` for
`BillingDimension` and `ModelPricing`. Both sides describe the same
wire shape, so the local copies were a latent drift bug — and
pulling pricing through the gateway entrypoint forced the SPA's
typecheck to walk a much larger type graph than it needed. This PR
deletes the local declarations and consumes all five names directly
from `@floway-dev/protocols/common`.

## Approach

`@floway-dev/protocols` is added as a workspace dependency of
`apps/web`. The local `ModelEndpoints` interface, the
`ModelEndpointKey = keyof ModelEndpoints` alias, and the `ModelKind`
literal union in `apps/web/src/api/types.ts` are removed; the file
now imports those three names plus `BillingDimension` and
`ModelPricing` from `@floway-dev/protocols/common`. The existing
`export type { ... }` block is preserved verbatim, so every call
site keeps importing from `@/api/types` as before.

The package is already the leaf-most node in the workspace
dependency graph (no runtime deps; depended on by `provider`,
`translate`, `gateway`, and every `provider-*` package). Its
`/common` subpath exports only TypeScript type declarations, so the
SPA bundle does not grow — `vite-tsc` and `vue-tsc` strip everything
at build time. The side-import from
`@floway-dev/gateway/control-plane/pricing/types` is gone, which
also removes the SPA's incidental dependency on the gateway type
graph.

## Scope

- `apps/web/package.json` — add `@floway-dev/protocols` workspace dep
- `apps/web/src/api/types.ts` — drop local declarations; import the five names from `@floway-dev/protocols/common`; keep the existing re-export surface
- `pnpm-lock.yaml` — lockfile update for the new workspace edge

## Test plan

- [x] typecheck clean on touched packages
- [x] vitest passes on touched packages
- [x] lint clean
