### PR TITLE
refactor(gateway): unify GatewayCtx factory via options-bag

### DIFF
--- a/packages/gateway/src/data-plane/llm/chat-completions/http.ts
+++ b/packages/gateway/src/data-plane/llm/chat-completions/http.ts
@@ -17,7 +17,7 @@ import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider'
 const respondWithInternalError = async (c: Context, error: unknown): Promise<Response> => {
   const verbatim = providerModelsUnavailableResponse(error);
   if (verbatim !== null) return verbatim;
-  const ctx = createGatewayCtxFromHono(c, false);
+  const ctx = createGatewayCtxFromHono(c, { wantsStream: false });
   const result = internalErrorResult(502, toInternalDebugError(error, 'chat-completions'));
   const { response } = await respondChatCompletions(c, result, false, false, ctx);
   return response;
@@ -34,7 +34,7 @@ export const chatCompletionsHttp = {
       // slots — the value lives in this http-entry closure for the duration of
       // the request.
       const includeUsageChunk = payload.stream_options?.include_usage === true;
-      const ctx = createGatewayCtxFromHono(c, wantsStream);
+      const ctx = createGatewayCtxFromHono(c, { wantsStream });
       const store = createNonResponsesSourceStore(ctx.apiKeyId);
       const result = await chatCompletionsServe.generate({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondChatCompletions(c, result, wantsStream, includeUsageChunk, ctx);

--- a/packages/gateway/src/data-plane/llm/gemini/http.ts
+++ b/packages/gateway/src/data-plane/llm/gemini/http.ts
@@ -86,7 +86,7 @@ const runGeminiGenerate = async (c: Context, model: string, wantsStream: boolean
   const payload = await parseGeminiBody(c, payload => payload as GeminiPayload);
   if (payload instanceof Response) return payload;
 
-  const ctx = createGatewayCtxFromHono(c, wantsStream);
+  const ctx = createGatewayCtxFromHono(c, { wantsStream });
   const store = createNonResponsesSourceStore(ctx.apiKeyId);
   try {
     const result = await geminiServe.generate({ payload, ctx, store, model, headers: inboundHeadersForUpstream(c) });
@@ -101,7 +101,7 @@ const runGeminiCountTokens = async (c: Context, model: string): Promise<Response
   const payload = await parseGeminiBody(c, parseGeminiCountTokensPayload);
   if (payload instanceof Response) return payload;
 
-  const ctx = createGatewayCtxFromHono(c, false);
+  const ctx = createGatewayCtxFromHono(c, { wantsStream: false });
   const store = createNonResponsesSourceStore(ctx.apiKeyId);
   try {
     const result = await geminiServe.countTokens({ payload, ctx, store, model, headers: inboundHeadersForUpstream(c) });

--- a/packages/gateway/src/data-plane/llm/messages/http.ts
+++ b/packages/gateway/src/data-plane/llm/messages/http.ts
@@ -39,7 +39,7 @@ const rejectBodyBetaResponse = (payload: MessagesPayload): Response | null => {
 const respondWithInternalError = async (c: Context, error: unknown): Promise<Response> => {
   const verbatim = providerModelsUnavailableResponse(error);
   if (verbatim !== null) return verbatim;
-  const ctx = createGatewayCtxFromHono(c, false);
+  const ctx = createGatewayCtxFromHono(c, { wantsStream: false });
   const result = internalErrorResult(502, toInternalDebugError(error, 'messages'));
   const { response } = await respondMessages(c, result, false, ctx);
   return response;
@@ -53,7 +53,7 @@ export const messagesHttp = {
       if (rejected) return rejected;
 
       const wantsStream = payload.stream === true;
-      const ctx = createGatewayCtxFromHono(c, wantsStream);
+      const ctx = createGatewayCtxFromHono(c, { wantsStream });
       const store = createNonResponsesSourceStore(ctx.apiKeyId);
       const result = await messagesServe.generate({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondMessages(c, result, wantsStream, ctx);
@@ -69,7 +69,7 @@ export const messagesHttp = {
       const rejected = rejectBodyBetaResponse(payload);
       if (rejected) return rejected;
 
-      const ctx = createGatewayCtxFromHono(c, false);
+      const ctx = createGatewayCtxFromHono(c, { wantsStream: false });
       const store = createNonResponsesSourceStore(ctx.apiKeyId);
       const result = await messagesServe.countTokens({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondMessages(c, result, false, ctx);

--- a/packages/gateway/src/data-plane/llm/responses/http.ts
+++ b/packages/gateway/src/data-plane/llm/responses/http.ts
@@ -50,7 +50,7 @@ const previousResponseNotFoundResponse = (id: string): Response =>
 const respondWithInternalError = async (c: Context, error: unknown): Promise<Response> => {
   const verbatim = providerModelsUnavailableResponse(error);
   if (verbatim !== null) return verbatim;
-  const ctx = createGatewayCtxFromHono(c, false);
+  const ctx = createGatewayCtxFromHono(c, { wantsStream: false });
   const result = internalErrorResult(502, toInternalDebugError(error, 'responses'));
   const { response } = await respondResponses(c, result, false, ctx);
   return response;
@@ -61,7 +61,7 @@ export const responsesHttp = {
     try {
       const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>(), true);
       const wantsStream = payload.stream === true;
-      const ctx = createGatewayCtxFromHono(c, wantsStream);
+      const ctx = createGatewayCtxFromHono(c, { wantsStream });
       const store = createResponsesHttpStore(ctx.apiKeyId, payload.store ?? undefined);
       const result = await responsesServe.generate({ payload, ctx, store, snapshotMode: payload.store === false ? 'none' : 'append', headers: inboundHeadersForUpstream(c) });
       const { response } = await respondResponses(c, result, wantsStream, ctx);
@@ -75,7 +75,7 @@ export const responsesHttp = {
   compact: async (c: Context): Promise<Response> => {
     try {
       const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>(), false);
-      const ctx = createGatewayCtxFromHono(c, false);
+      const ctx = createGatewayCtxFromHono(c, { wantsStream: false });
       const store = createResponsesHttpStore(ctx.apiKeyId, payload.store ?? undefined);
       const result = await responsesServe.compact({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
       if (result.type === 'result') return Response.json(result.result);

--- a/packages/gateway/src/data-plane/llm/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/llm/responses/websocket.ts
@@ -6,7 +6,7 @@ import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
-import { createGatewayCtxForWs, type GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { SourceStreamState, eventResultMetadata, recordPerformance, recordUsage } from '../shared/respond.ts';
 import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS, type StreamCompletion } from '../shared/stream/sse.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
@@ -150,7 +150,7 @@ const handleClientMessage = async (
       ? message.response
       : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
     const payload = responsesPayloadFromClientSource(source);
-    const ctx = createGatewayCtxForWs(c, downstreamAbortController);
+    const ctx = createGatewayCtxFromHono(c, { wantsStream: true, downstreamAbortController });
     const store = session.createStore(payload.store ?? undefined);
     const snapshotMode = payload.store === false ? 'none' : 'append';
 

--- a/packages/gateway/src/data-plane/llm/shared/gateway-ctx.ts
+++ b/packages/gateway/src/data-plane/llm/shared/gateway-ctx.ts
@@ -35,34 +35,24 @@ export interface GatewayCtxAuthVars {
 
 type AuthedContext = Context<{ Variables: GatewayCtxAuthVars }>;
 
-export const createGatewayCtxFromHono = (c: AuthedContext, wantsStream: boolean): GatewayCtx => {
-  const apiKeyId = c.get('apiKeyId');
-  const upstreamIds = effectiveUpstreamIdsFromContext(c);
-  const downstreamAbortController = wantsStream ? new AbortController() : undefined;
-  return {
-    apiKeyId,
-    upstreamIds,
-    ...(downstreamAbortController !== undefined ? { abortSignal: downstreamAbortController.signal, downstreamAbortController } : {}),
-    wantsStream,
-    backgroundScheduler: backgroundSchedulerFromContext(c),
-    requestStartedAt: performance.now(),
-    runtimeLocation: runtimeLocationFromRequest(c.req.raw),
-    currentColo: getCurrentColo(c.req.raw),
-  };
-};
+export interface CreateGatewayCtxOptions {
+  wantsStream: boolean;
+  // WebSocket-style call sites own the AbortController (so the upgrade
+  // handler can cancel mid-stream); HTTP call sites let the factory mint one
+  // when wantsStream is true.
+  downstreamAbortController?: AbortController;
+}
 
-export const createGatewayCtxForWs = (
-  c: AuthedContext,
-  downstreamAbortController: AbortController,
-): GatewayCtx => {
+export const createGatewayCtxFromHono = (c: AuthedContext, opts: CreateGatewayCtxOptions): GatewayCtx => {
+  const controller = opts.downstreamAbortController ?? (opts.wantsStream ? new AbortController() : undefined);
   const apiKeyId = c.get('apiKeyId');
   const upstreamIds = effectiveUpstreamIdsFromContext(c);
   return {
     apiKeyId,
     upstreamIds,
-    abortSignal: downstreamAbortController.signal,
-    wantsStream: true,
-    downstreamAbortController,
+    abortSignal: controller?.signal,
+    wantsStream: opts.wantsStream,
+    downstreamAbortController: controller,
     backgroundScheduler: backgroundSchedulerFromContext(c),
     requestStartedAt: performance.now(),
     runtimeLocation: runtimeLocationFromRequest(c.req.raw),

--- a/packages/gateway/src/data-plane/llm/shared/gateway-ctx_test.ts
+++ b/packages/gateway/src/data-plane/llm/shared/gateway-ctx_test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { describe, test } from 'vitest';
 
-import { createGatewayCtxFromHono, createGatewayCtxForWs, type GatewayCtxAuthVars } from './gateway-ctx.ts';
+import { createGatewayCtxFromHono, type GatewayCtxAuthVars } from './gateway-ctx.ts';
 import { assertEquals, assertExists } from '@floway-dev/test-utils';
 
 // Mirrors the production guarantee: by the time a data-plane handler runs,
@@ -26,7 +26,7 @@ describe('createGatewayCtxFromHono', () => {
     app.get('/test', c => {
       c.set('apiKeyId', 'key-1');
       c.set('apiKeyUpstreamIds', ['up-1', 'up-2']);
-      ctx = createGatewayCtxFromHono(c, true);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: true });
       return c.text('ok');
     });
     await app.request('/test');
@@ -39,7 +39,7 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     app.get('/test', c => {
-      ctx = createGatewayCtxFromHono(c, false);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: false });
       return c.text('ok');
     });
     await app.request('/test');
@@ -52,7 +52,7 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     app.get('/test', c => {
-      ctx = createGatewayCtxFromHono(c, true);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: true });
       return c.text('ok');
     });
     await app.request('/test');
@@ -64,7 +64,7 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     app.get('/test', c => {
-      ctx = createGatewayCtxFromHono(c, false);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: false });
       return c.text('ok');
     });
     await app.request('/test');
@@ -76,7 +76,7 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     app.get('/test', c => {
-      ctx = createGatewayCtxFromHono(c, true);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: true });
       return c.text('ok');
     });
     await app.request('/test');
@@ -89,7 +89,7 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     app.get('/test', c => {
-      ctx = createGatewayCtxFromHono(c, false);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: false });
       return c.text('ok');
     });
     await app.request('/test');
@@ -98,23 +98,34 @@ describe('createGatewayCtxFromHono', () => {
     assertEquals(ctx.abortSignal, undefined);
   });
 
-  test('backgroundScheduler is present and callable without throwing', async () => {
+  test('caller-supplied downstreamAbortController overrides the factory-minted one (websocket path)', async () => {
+    const app = makeApp();
+    let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
+    let controller: AbortController | undefined;
+    app.get('/test', c => {
+      controller = new AbortController();
+      ctx = createGatewayCtxFromHono(c, { wantsStream: true, downstreamAbortController: controller });
+      return c.text('ok');
+    });
+    await app.request('/test');
+    assertExists(ctx);
+    assertExists(controller);
+    assertEquals(ctx.downstreamAbortController, controller);
+    assertEquals(ctx.abortSignal, controller.signal);
+    assertEquals(ctx.wantsStream, true);
+  });
+
+  test('backgroundScheduler is present and callable', async () => {
     const app = makeApp();
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     app.get('/test', c => {
-      ctx = createGatewayCtxFromHono(c, false);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: false });
       return c.text('ok');
     });
     await app.request('/test');
     assertExists(ctx);
     assertExists(ctx.backgroundScheduler);
-    let nothingThrown = true;
-    try {
-      ctx.backgroundScheduler(Promise.resolve());
-    } catch {
-      nothingThrown = false;
-    }
-    assertEquals(nothingThrown, true);
+    ctx.backgroundScheduler(Promise.resolve());
   });
 
   test('upstreamIds is the intersection of the per-user cap and the per-key whitelist', async () => {
@@ -123,23 +134,19 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     const collected: { capOnly?: readonly string[] | null; both?: readonly string[] | null; keyOnly?: readonly string[] | null } = {};
     app.get('/cap-only', c => {
-      // Unrestricted key (apiKeyUpstreamIds null) under a capped user.
       c.set('userUpstreamIds', ['up-a']);
-      collected.capOnly = createGatewayCtxFromHono(c, false).upstreamIds;
+      collected.capOnly = createGatewayCtxFromHono(c, { wantsStream: false }).upstreamIds;
       return c.text('ok');
     });
     app.get('/both', c => {
-      // Per-key whitelist further narrows the user cap and preserves per-key order.
       c.set('userUpstreamIds', ['up-a', 'up-b']);
       c.set('apiKeyUpstreamIds', ['up-b', 'up-c']);
-      collected.both = createGatewayCtxFromHono(c, false).upstreamIds;
+      collected.both = createGatewayCtxFromHono(c, { wantsStream: false }).upstreamIds;
       return c.text('ok');
     });
     app.get('/key-only', c => {
-      // Uncapped user with a per-key whitelist falls through to the per-key
-      // list verbatim.
       c.set('apiKeyUpstreamIds', ['up-x']);
-      collected.keyOnly = createGatewayCtxFromHono(c, false).upstreamIds;
+      collected.keyOnly = createGatewayCtxFromHono(c, { wantsStream: false }).upstreamIds;
       return c.text('ok');
     });
     await app.request('/cap-only');
@@ -155,119 +162,7 @@ describe('createGatewayCtxFromHono', () => {
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     const before = performance.now();
     app.get('/test', c => {
-      ctx = createGatewayCtxFromHono(c, false);
-      return c.text('ok');
-    });
-    await app.request('/test');
-    const after = performance.now();
-    assertExists(ctx);
-    if (!(ctx.requestStartedAt >= before && ctx.requestStartedAt <= after)) {
-      throw new Error(`requestStartedAt ${ctx.requestStartedAt} not in [${before}, ${after}]`);
-    }
-  });
-});
-
-describe('createGatewayCtxForWs', () => {
-  test('copies auth fields from Hono context', async () => {
-    const app = makeApp();
-    let ctx: ReturnType<typeof createGatewayCtxForWs> | undefined;
-    app.get('/test', c => {
-      c.set('apiKeyId', 'ws-key');
-      c.set('apiKeyUpstreamIds', ['ws-up-1']);
-      const controller = new AbortController();
-      ctx = createGatewayCtxForWs(c, controller);
-      return c.text('ok');
-    });
-    await app.request('/test');
-    assertExists(ctx);
-    assertEquals(ctx.apiKeyId, 'ws-key');
-    assertEquals(ctx.upstreamIds, ['ws-up-1']);
-  });
-
-  test('passes upstreamIds through as null on an unrestricted key + uncapped user', async () => {
-    const app = makeApp();
-    let ctx: ReturnType<typeof createGatewayCtxForWs> | undefined;
-    app.get('/test', c => {
-      const controller = new AbortController();
-      ctx = createGatewayCtxForWs(c, controller);
-      return c.text('ok');
-    });
-    await app.request('/test');
-    assertExists(ctx);
-    assertEquals(ctx.apiKeyId, 'test-key');
-    assertEquals(ctx.upstreamIds, null);
-  });
-
-  test('forces wantsStream=true', async () => {
-    const app = makeApp();
-    let ctx: ReturnType<typeof createGatewayCtxForWs> | undefined;
-    app.get('/test', c => {
-      const controller = new AbortController();
-      ctx = createGatewayCtxForWs(c, controller);
-      return c.text('ok');
-    });
-    await app.request('/test');
-    assertExists(ctx);
-    assertEquals(ctx.wantsStream, true);
-  });
-
-  test('sets abortSignal from downstreamAbortController.signal', async () => {
-    const app = makeApp();
-    let ctx: ReturnType<typeof createGatewayCtxForWs> | undefined;
-    let controller: AbortController | undefined;
-    app.get('/test', c => {
-      controller = new AbortController();
-      ctx = createGatewayCtxForWs(c, controller);
-      return c.text('ok');
-    });
-    await app.request('/test');
-    assertExists(ctx);
-    assertExists(controller);
-    assertEquals(ctx.abortSignal, controller.signal);
-  });
-
-  test('exposes downstreamAbortController', async () => {
-    const app = makeApp();
-    let ctx: ReturnType<typeof createGatewayCtxForWs> | undefined;
-    let controller: AbortController | undefined;
-    app.get('/test', c => {
-      controller = new AbortController();
-      ctx = createGatewayCtxForWs(c, controller);
-      return c.text('ok');
-    });
-    await app.request('/test');
-    assertExists(ctx);
-    assertExists(controller);
-    assertEquals(ctx.downstreamAbortController, controller);
-  });
-
-  test('backgroundScheduler is present and callable without throwing', async () => {
-    const app = makeApp();
-    let ctx: ReturnType<typeof createGatewayCtxForWs> | undefined;
-    app.get('/test', c => {
-      const controller = new AbortController();
-      ctx = createGatewayCtxForWs(c, controller);
-      return c.text('ok');
-    });
-    await app.request('/test');
-    assertExists(ctx);
-    assertExists(ctx.backgroundScheduler);
-    let nothingThrown = true;
-    try {
-      ctx.backgroundScheduler(Promise.resolve());
-    } catch {
-      nothingThrown = false;
-    }
-    assertEquals(nothingThrown, true);
-  });
-
-  test('stamps requestStartedAt from performance.now() at construction', async () => {
-    const app = makeApp();
-    let ctx: ReturnType<typeof createGatewayCtxForWs> | undefined;
-    const before = performance.now();
-    app.get('/test', c => {
-      const controller = new AbortController();
-      ctx = createGatewayCtxForWs(c, controller);
+      ctx = createGatewayCtxFromHono(c, { wantsStream: false });
       return c.text('ok');
     });
     await app.request('/test');


### PR DESCRIPTION
## Summary

Collapses the two `GatewayCtx` factories — one for HTTP entries, one for the Responses-over-WebSocket entry — into a single `createGatewayCtxFromHono(c, opts)` that takes an options-bag. The only thing the two factories ever disagreed on was who owned the `AbortController`; everything else (auth-var copy, upstream-id intersection, scheduler binding, performance timestamp, runtime location, colo lookup) was duplicated verbatim and had already drifted in the tests.

## Approach

`CreateGatewayCtxOptions = { wantsStream: boolean; downstreamAbortController?: AbortController }`. The factory's controller-resolution rule: a caller-supplied controller wins; otherwise mint one iff `wantsStream` is true; otherwise leave it `undefined`. HTTP call sites pass `{ wantsStream }` and let the factory mint. The WebSocket call site mints the controller upfront (so the upgrade-side `close` handler can abort the in-flight request) and passes `{ wantsStream: true, downstreamAbortController }`; the factory honors it. `createGatewayCtxForWs` is deleted.

Behavior is byte-identical at every call site: every HTTP call where `wantsStream` was previously truthy still gets a fresh controller, every HTTP call where it was falsy still gets `undefined`, and the WS path still uses the externally-owned controller.

## Scope

- `packages/gateway/src/ctx.ts` — single factory + `CreateGatewayCtxOptions` type; `createGatewayCtxForWs` removed
- `packages/gateway/src/routes/chat-completions/http.ts` — migrated to options-bag
- `packages/gateway/src/routes/gemini/http.ts` — `generate` and `countTokens` migrated
- `packages/gateway/src/routes/messages/http.ts` — `generate`, `countTokens`, internal-error helper migrated
- `packages/gateway/src/routes/responses/http.ts` — `generate`, `compact`, internal-error helper migrated
- `packages/gateway/src/routes/responses/websocket.ts` — passes its own controller via the options-bag
- `packages/gateway/src/ctx_test.ts` — duplicated WS-factory `describe` block removed; one new case asserts the WS contract end-to-end (caller's controller threaded to `abortSignal` and re-exposed under `downstreamAbortController`); two `try { ... } catch { nothingThrown = false }` blocks inlined to bare calls

## Test plan

- [x] typecheck clean on touched packages
- [x] vitest passes on touched packages (with the new WS-contract regression test)
- [x] lint clean
