### PR TITLE
fix(gateway): listModelProviders throws on unknown upstream id

### DIFF
--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -40,13 +40,29 @@ export const listModelProviders = async (
 ): Promise<ModelProviderInstance[]> => {
   const upstreams = await getRepo().upstreams.list();
   const enabledById = new Map<string, UpstreamRecord>();
+  const knownIds = new Set<string>();
   for (const upstream of upstreams) {
+    knownIds.add(upstream.id);
     if (upstream.enabled) enabledById.set(upstream.id, upstream);
   }
 
-  const selection: UpstreamRecord[] = upstreamFilter
-    ? upstreamFilter.map(id => enabledById.get(id)).filter((u): u is UpstreamRecord => u !== undefined)
-    : [...enabledById.values()];
+  let selection: UpstreamRecord[];
+  if (upstreamFilter) {
+    // Unknown ids are a caller-side configuration error (the filter is the
+    // intersection of per-user + per-api-key caps; both reference upstreams
+    // by id); surface them so the operator notices instead of silently
+    // serving a smaller subset. Disabled-but-known ids stay silent: a user
+    // cap may legitimately mention an upstream the operator just disabled.
+    const unknown = upstreamFilter.filter(id => !knownIds.has(id));
+    if (unknown.length > 0) {
+      throw new Error(`Unknown upstream id(s) in filter: ${unknown.join(', ')}`);
+    }
+    selection = upstreamFilter
+      .map(id => enabledById.get(id))
+      .filter((u): u is UpstreamRecord => u !== undefined);
+  } else {
+    selection = [...enabledById.values()];
+  }
 
   const providers: ModelProviderInstance[] = [];
   for (const upstream of selection) {

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { clearInFlightForTesting } from './models-cache.ts';
 import { compareModelIds, getInternalModels, listModelProviders, resolveModelForProvider, resolveModelForRequest } from './registry.ts';
@@ -402,15 +402,26 @@ test('resolveModelForProvider rejects a model id disabled on that upstream (filt
   assertEquals(await resolveModelForProvider(provider, 'disabled-model', directFetcher, testScheduler).then(r => r?.id), undefined);
 });
 
-test('listModelProviders drops stale ids (deleted or disabled upstreams) from a whitelist', async () => {
+test('listModelProviders silently drops disabled upstreams from a whitelist', async () => {
+  // A per-user cap legitimately references an upstream the operator just
+  // disabled; the cap survives that transition without surfacing an error.
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
   await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_a', name: 'A', sortOrder: 10 }));
   await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_b', name: 'B', sortOrder: 20, enabled: false }));
 
-  // up_ghost was never saved; up_b is disabled. Both vanish silently.
-  const providers = await listModelProviders(['up_ghost', 'up_b', 'up_a']);
+  const providers = await listModelProviders(['up_b', 'up_a']);
   assertEquals(providers.map(p => p.upstream), ['up_a']);
+});
+
+test('listModelProviders throws on unknown upstream ids in the whitelist', async () => {
+  // Unknown ids are a caller-side configuration error, not a runtime state;
+  // surface them instead of silently serving a smaller subset.
+  const { repo } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+  await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_a', name: 'A', sortOrder: 10 }));
+
+  await expect(listModelProviders(['up_ghost', 'up_a'])).rejects.toThrow(/up_ghost/);
 });
 
 // Per-upstream catalog fetches fan out in parallel: total wall-clock time


### PR DESCRIPTION
## Summary

`listModelProviders` previously collapsed two very different filter
outcomes — "id is disabled" and "id does not exist" — into the same
silent drop. This change keeps the disabled-id branch silent (it is a
legitimate transient state during operator toggling) but throws on
unknown ids, since an unknown id in the per-user cap or per-API-key
whitelist means the cap/whitelist is out of sync with the `upstreams`
table and the caller deserves a loud signal instead of a mysteriously
shrunken model list.

## Approach

A `knownIds: Set<string>` is built from the full `upstreams.list()`
(enabled + disabled). When `upstreamFilter` is supplied, the unknown
subset is computed up front and a single error is thrown listing
every offending id, prefixed with `Unknown upstream id(s) in
filter:` so the responsible API key / user can be located in logs.
Disabled-but-known ids continue to fall out of the enabled-only map
without surfacing — the existing tolerant behavior for transient
operator toggles is preserved.

## Scope

- `packages/gateway/src/data-plane/providers/registry.ts` — add
  `knownIds` set, throw on unknown ids in `upstreamFilter`.
- `packages/gateway/src/data-plane/providers/registry_test.ts` —
  split the combined assertion into one test for the
  disabled-silent-drop case and one test for the
  unknown-id-throws case.

## Test plan

- [x] typecheck clean on touched packages
- [x] vitest passes on touched packages (with the new regression tests for both branches)
- [x] lint clean
