### PR TITLE
fix(gateway): strict-throw on malformed upstream config/state in serialize

### DIFF
--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -33,8 +33,23 @@ const clone = <T>(value: T): T => structuredClone(value);
 
 const hasSecret = (value: unknown): boolean => typeof value === 'string' && value.length > 0;
 
+const assertAccountsArray = (upstream: UpstreamRecord, accounts: unknown): Record<string, unknown>[] => {
+  if (!Array.isArray(accounts)) {
+    throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed accounts: expected array`);
+  }
+  return accounts.map((account, index) => {
+    if (!isRecord(account)) {
+      throw new Error(`Upstream ${upstream.id} (${upstream.provider}) account[${index}] is malformed: expected object`);
+    }
+    return account;
+  });
+};
+
 const redactedConfig = (upstream: UpstreamRecord): unknown => {
-  const config = isRecord(upstream.config) ? upstream.config : {};
+  if (!isRecord(upstream.config)) {
+    throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed config: expected object`);
+  }
+  const config = upstream.config;
 
   switch (upstream.provider) {
   case 'custom':
@@ -62,15 +77,12 @@ const redactedConfig = (upstream: UpstreamRecord): unknown => {
   case 'codex':
     // refresh_token lives in state and is redacted by redactedState.
     return {
-      accounts: Array.isArray(config.accounts) ? config.accounts.map(account => {
-        const a = isRecord(account) ? account : {};
-        return {
-          ...(a.email !== undefined ? { email: clone(a.email) } : {}),
-          ...(a.chatgptAccountId !== undefined ? { chatgptAccountId: clone(a.chatgptAccountId) } : {}),
-          ...(a.chatgptUserId !== undefined ? { chatgptUserId: clone(a.chatgptUserId) } : {}),
-          ...(a.planType !== undefined ? { planType: clone(a.planType) } : {}),
-        };
-      }) : [],
+      accounts: assertAccountsArray(upstream, config.accounts).map(a => ({
+        ...(a.email !== undefined ? { email: clone(a.email) } : {}),
+        ...(a.chatgptAccountId !== undefined ? { chatgptAccountId: clone(a.chatgptAccountId) } : {}),
+        ...(a.chatgptUserId !== undefined ? { chatgptUserId: clone(a.chatgptUserId) } : {}),
+        ...(a.planType !== undefined ? { planType: clone(a.planType) } : {}),
+      })),
     };
   case 'ollama':
     return {
@@ -87,21 +99,21 @@ const redactedConfig = (upstream: UpstreamRecord): unknown => {
 
 const redactedState = (upstream: UpstreamRecord): unknown => {
   if (upstream.state === null || upstream.state === undefined) return null;
-  const state = isRecord(upstream.state) ? upstream.state : {};
+  if (!isRecord(upstream.state)) {
+    throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed state: expected object`);
+  }
+  const state = upstream.state;
 
   switch (upstream.provider) {
   case 'codex':
     return {
-      accounts: Array.isArray(state.accounts) ? state.accounts.map(account => {
-        const a = isRecord(account) ? account : {};
-        return {
-          ...(a.chatgptAccountId !== undefined ? { chatgptAccountId: clone(a.chatgptAccountId) } : {}),
-          ...(a.state !== undefined ? { state: clone(a.state) } : {}),
-          ...(a.state_message !== undefined ? { state_message: clone(a.state_message) } : {}),
-          state_updated_at: clone(a.state_updated_at),
-          refresh_token_set: hasSecret(a.refresh_token),
-        };
-      }) : [],
+      accounts: assertAccountsArray(upstream, state.accounts).map(a => ({
+        ...(a.chatgptAccountId !== undefined ? { chatgptAccountId: clone(a.chatgptAccountId) } : {}),
+        ...(a.state !== undefined ? { state: clone(a.state) } : {}),
+        ...(a.state_message !== undefined ? { state_message: clone(a.state_message) } : {}),
+        state_updated_at: clone(a.state_updated_at),
+        refresh_token_set: hasSecret(a.refresh_token),
+      })),
     };
   case 'copilot':
   case 'custom':

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { upstreamRecordToFullJson, upstreamRecordToJson } from './serialize.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
@@ -103,4 +103,50 @@ test('upstreamRecordToFullJson includes provider config secrets for export', () 
   assertEquals(result.id, 'up_custom_test');
   assertEquals(config.bearerToken, 'sk-secret-token-12345');
   assertEquals(config.bearerTokenSet, undefined);
+});
+
+// Strict-throw helpers in serialize.ts fail loud rather than silently
+// collapse shape drift into nulls. The list endpoint maps
+// serializeForResponse over every row, so a single malformed row in
+// production blocks `/api/upstreams`. These tests pin that contract.
+
+const codexBase = (overrides: { config?: unknown; state?: unknown }): UpstreamRecord => ({
+  id: 'up_cx_test',
+  provider: 'codex',
+  name: 'Codex',
+  enabled: true,
+  sortOrder: 0,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+  flagOverrides: {},
+  disabledPublicModelIds: [],
+  proxyFallbackList: [],
+  config: overrides.config ?? { accounts: [{ email: 'a@example.com' }] },
+  state: overrides.state ?? null,
+} as unknown as UpstreamRecord);
+
+test('upstreamRecordToJson throws when codex config.accounts is not an array', () => {
+  const record = codexBase({ config: { accounts: 'not-an-array' } });
+  expect(() => upstreamRecordToJson(record)).toThrow(/malformed accounts/);
+});
+
+test('upstreamRecordToJson throws when codex state.accounts is not an array', () => {
+  const record = codexBase({
+    config: { accounts: [{ email: 'a@example.com' }] },
+    state: { accounts: 'not-an-array' },
+  });
+  expect(() => upstreamRecordToJson(record)).toThrow(/malformed accounts/);
+});
+
+test('upstreamRecordToJson throws when codex config is not an object', () => {
+  const record = codexBase({ config: 'not-an-object' });
+  expect(() => upstreamRecordToJson(record)).toThrow(/malformed config/);
+});
+
+test('upstreamRecordToJson throws when codex state is not an object', () => {
+  const record = codexBase({
+    config: { accounts: [{ email: 'a@example.com' }] },
+    state: 'not-an-object',
+  });
+  expect(() => upstreamRecordToJson(record)).toThrow(/malformed state/);
 });


### PR DESCRIPTION
## Summary

Make `serialize.ts` in the upstreams control plane fail loudly when a
row's persisted `config` or `state` JSON does not match the structural
invariants the Zod write-path enforces. Previously a drifted row would
quietly render as an empty/partial entry on the dashboard, hiding the
fact that the upstream had effectively lost its credentials.

## Approach

The control-plane writes to `upstream.config` / `upstream.state` are
already gated by Zod schemas in `control-plane/schemas.ts`. The
serializer is downstream of those writes, so anything that violates the
schema at read time is a bug that should surface — not something the
serializer should mask with `isRecord(x) ? x : {}` /
`Array.isArray(x) ? x.map(...) : []`.

A single helper, `assertAccountsArray(upstream, accounts)`, replaces the
per-provider `Array.isArray` ternaries on `config.accounts` /
`state.accounts` and throws with the upstream id, provider kind, and the
index of the offending entry. The top-level `redactedConfig` /
`redactedState` switches now throw on a non-record outer value instead
of returning `{}`. The codex branches collapse to one line per field
since the array guard is gone, which makes the redaction contract
("copy this field, redact that one to a boolean") readable at a glance.

This is intentionally fail-loud at the `/api/upstreams` boundary: `list`
maps the serializer over every row, so one malformed row will 500 the
endpoint with a stack trace naming the bad row, instead of the dashboard
silently dropping its credentials.

## Scope

- `packages/gateway/src/control-plane/upstreams/serialize.ts` — strict
  throws on malformed `config` / `state`; new `assertAccountsArray`
  helper; codex branches simplified.
- `packages/gateway/src/control-plane/upstreams/serialize_test.ts` —
  regression tests covering string-in-`config`, string-in-`state`,
  string-in-`config.accounts`, and string-in-`state.accounts` through
  `upstreamRecordToJson`.

The redacted shape for well-formed rows is unchanged; dashboard
consumers see the same fields with the same names.

## Test plan

- [x] typecheck clean on touched packages
- [x] vitest passes on touched packages (with the new regression tests
      for malformed `config` / `state` / `accounts`)
- [x] lint clean
