### PR TITLE
refactor(gateway): type-narrow Hono auth-middleware-stamped vars

### DIFF
--- a/packages/gateway/src/data-plane/llm/shared/gateway-ctx.ts
+++ b/packages/gateway/src/data-plane/llm/shared/gateway-ctx.ts
@@ -23,8 +23,20 @@ export interface GatewayCtx {
   readonly currentColo: string | null;
 }
 
-export const createGatewayCtxFromHono = (c: Context, wantsStream: boolean): GatewayCtx => {
-  const apiKeyId = c.get('apiKeyId') as string;
+// Names the auth-middleware-stamped Hono variables this builder reads. Hono
+// gives no compile-time guarantee that a middleware ran; the alias is the
+// local declaration of what `auth.ts` is contracted to set so the lookup
+// sheds its inline cast.
+export interface GatewayCtxAuthVars {
+  apiKeyId: string;
+  apiKeyUpstreamIds: readonly string[] | null;
+  userUpstreamIds: readonly string[] | null;
+}
+
+type AuthedContext = Context<{ Variables: GatewayCtxAuthVars }>;
+
+export const createGatewayCtxFromHono = (c: AuthedContext, wantsStream: boolean): GatewayCtx => {
+  const apiKeyId = c.get('apiKeyId');
   const upstreamIds = effectiveUpstreamIdsFromContext(c);
   const downstreamAbortController = wantsStream ? new AbortController() : undefined;
   return {
@@ -40,10 +52,10 @@ export const createGatewayCtxFromHono = (c: Context, wantsStream: boolean): Gate
 };
 
 export const createGatewayCtxForWs = (
-  c: Context,
+  c: AuthedContext,
   downstreamAbortController: AbortController,
 ): GatewayCtx => {
-  const apiKeyId = c.get('apiKeyId') as string;
+  const apiKeyId = c.get('apiKeyId');
   const upstreamIds = effectiveUpstreamIdsFromContext(c);
   return {
     apiKeyId,

--- a/packages/gateway/src/data-plane/llm/shared/gateway-ctx_test.ts
+++ b/packages/gateway/src/data-plane/llm/shared/gateway-ctx_test.ts
@@ -1,21 +1,15 @@
 import { Hono } from 'hono';
 import { describe, test } from 'vitest';
 
-import { createGatewayCtxFromHono, createGatewayCtxForWs } from './gateway-ctx.ts';
+import { createGatewayCtxFromHono, createGatewayCtxForWs, type GatewayCtxAuthVars } from './gateway-ctx.ts';
 import { assertEquals, assertExists } from '@floway-dev/test-utils';
-
-interface AuthVars {
-  apiKeyId: string;
-  apiKeyUpstreamIds: readonly string[] | null;
-  userUpstreamIds: readonly string[] | null;
-}
 
 // Mirrors the production guarantee: by the time a data-plane handler runs,
 // auth middleware has stamped all three vars on the context. Tests that want
 // to model an unrestricted key on an uncapped user can rely on the defaults;
 // tests that want to model a capped key or user override at the handler.
-const makeApp = (): Hono<{ Variables: AuthVars }> => {
-  const app = new Hono<{ Variables: AuthVars }>();
+const makeApp = (): Hono<{ Variables: GatewayCtxAuthVars }> => {
+  const app = new Hono<{ Variables: GatewayCtxAuthVars }>();
   app.use('*', async (c, next) => {
     c.set('apiKeyId', 'test-key');
     c.set('apiKeyUpstreamIds', null);


### PR DESCRIPTION
## Summary

Replaces the inline `as string` cast in `createGatewayCtxFromHono` with a typed `AuthedContext` that names the three variables the auth middleware is contracted to stamp on every gateway request. Downstream readers get `string` directly from `c.get('apiKeyId')`, and any future route wired up without auth in front fails at compile time rather than handing `undefined`-as-`string` to consumers.

## Approach

`gateway-ctx.ts` now exports a `GatewayCtxAuthVars` interface describing the three middleware-stamped variables (`apiKeyId`, `apiKeyUpstreamIds`, `userUpstreamIds`) and an `AuthedContext = Context<{ Variables: GatewayCtxAuthVars }>` alias. The factory accepts `AuthedContext` in place of the bare `Context`, so `c.get('apiKeyId')` resolves to `string` natively and `effectiveUpstreamIdsFromContext` reads `userUpstreamIds` through the same narrowed typing. The interface is exported so future post-auth helpers can type-import it instead of inventing duplicates.

The companion test drops its local `AuthVars` interface and uses the exported `GatewayCtxAuthVars` for the mock middleware, so any drift between middleware and factory contract fails to compile in the test before it would fail in production.

## Scope

- `packages/gateway/src/data-plane/llm/shared/gateway-ctx.ts` — add `GatewayCtxAuthVars` + `AuthedContext`, drop the inline cast.
- `packages/gateway/src/data-plane/llm/shared/gateway-ctx_test.ts` — replace the local `AuthVars` shape with the exported interface in the mock middleware.

## Test plan

- [x] typecheck clean on touched packages
- [x] vitest passes on touched packages
- [x] lint clean
