### PR TITLE
refactor(web): UpstreamRecord discriminated union with assertNever guards

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -137,9 +137,8 @@ export interface CodexQuotaSnapshot {
   ratelimited_until?: string;
 }
 
-export interface UpstreamRecord {
+interface UpstreamRecordBase {
   id: string;
-  provider: UpstreamProviderKind;
   name: string;
   enabled: boolean;
   sort_order: number;
@@ -150,16 +149,12 @@ export interface UpstreamRecord {
   // unroutable, but their per-model metadata stays editable. May include ids no
   // longer present in the live model list.
   disabled_public_model_ids: string[];
-  config: CustomUpstreamConfig | AzureUpstreamConfig | CopilotUpstreamConfig | CodexUpstreamConfig | OllamaUpstreamConfig;
   // Ordered fallback dial-list. Each entry pins a proxy id (or the literal
   // string `'direct'` for "no proxy") and an optional `colos` whitelist that
   // scopes the entry to specific Cloudflare colos / Node RUNTIME_LOCATION
   // tags. Empty/missing whitelist means "active in all colos". Empty top-
   // level list means "always direct".
   proxy_fallback_list: ProxyFallbackEntry[];
-  // Codex is the only provider that ships gateway-managed state on the row
-  // today; the other providers serialize this as null.
-  state: CodexUpstreamState | null;
   // SWR models-cache freshness joined from the models_cache table. Both inner
   // values are null on a row that has never been warmed; lastError is set
   // when the most recent warm failed but a prior fetch still populates
@@ -168,10 +163,18 @@ export interface UpstreamRecord {
     fetchedAt: number | null;
     lastError: { message: string; at: number } | null;
   };
-  // Present only for provider === 'codex'; serialized inline so the dashboard
-  // renders the quota panel without a follow-up fetch.
-  codex_quota?: CodexQuotaSnapshot | null;
 }
+
+// Provider-keyed discriminated union: each variant pins `provider` and the
+// matching `config` / `state` shape, so `switch (record.provider)` narrows
+// both fields without an `as` cast. Codex's `codex_quota` field rides on the
+// codex variant only.
+export type UpstreamRecord =
+  | (UpstreamRecordBase & { provider: 'custom'; config: CustomUpstreamConfig; state: null })
+  | (UpstreamRecordBase & { provider: 'azure'; config: AzureUpstreamConfig; state: null })
+  | (UpstreamRecordBase & { provider: 'copilot'; config: CopilotUpstreamConfig; state: null })
+  | (UpstreamRecordBase & { provider: 'codex'; config: CodexUpstreamConfig; state: CodexUpstreamState | null; codex_quota?: CodexQuotaSnapshot | null })
+  | (UpstreamRecordBase & { provider: 'ollama'; config: OllamaUpstreamConfig; state: null });
 
 export interface FlagDef {
   id: string;

--- a/apps/web/src/components/settings/UpstreamRow.vue
+++ b/apps/web/src/components/settings/UpstreamRow.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import type { AzureUpstreamConfig, CodexUpstreamConfig, CopilotUpstreamConfig, CustomUpstreamConfig, OllamaUpstreamConfig, UpstreamProviderKind, UpstreamRecord } from '../../api/types.ts';
+import type { UpstreamProviderKind, UpstreamRecord } from '../../api/types.ts';
+import { assertNever } from '../../utils/assert-never.ts';
 
 const props = defineProps<{
   upstream: UpstreamRecord;
-  // Count of public models bound to this upstream, resolved by the parent over
-  // the control-plane /api/models response.
   modelCount: number;
   moveUpDisabled: boolean;
   moveDownDisabled: boolean;
@@ -27,37 +26,29 @@ const providerBadgeClass = (kind: UpstreamProviderKind) => {
   case 'copilot': return 'border-accent-cyan/30 bg-accent-cyan/10 text-accent-cyan';
   case 'codex': return 'border-accent-violet/30 bg-accent-violet/10 text-accent-violet';
   case 'ollama': return 'border-accent-rose/30 bg-accent-rose/10 text-accent-rose';
-  case 'custom':
-  default: return 'border-accent-amber/30 bg-accent-amber/10 text-accent-amber';
+  case 'custom': return 'border-accent-amber/30 bg-accent-amber/10 text-accent-amber';
   }
+  return assertNever(kind);
 };
 
 const modelSummary = computed(() => `${props.modelCount} model${props.modelCount === 1 ? '' : 's'}`);
 
 const subtitle = computed(() => {
-  const cfg = props.upstream.config;
-  switch (props.upstream.provider) {
-  case 'azure': {
-    const azure = cfg as AzureUpstreamConfig;
-    const models = azure.models?.length ?? 0;
-    return [azure.endpoint || 'Azure AI endpoint', `${models} model${models === 1 ? '' : 's'}`].join(' · ');
-  }
-  case 'custom': return (cfg as CustomUpstreamConfig).baseUrl ?? '';
+  const u = props.upstream;
+  switch (u.provider) {
+  case 'azure': return u.config.endpoint;
+  case 'custom': return u.config.baseUrl;
   case 'copilot': {
-    const copilot = cfg as CopilotUpstreamConfig;
-    const user = copilot.user;
-    return user?.login ? `@${user.login} · ${copilot.accountType || 'copilot'}` : 'GitHub Copilot account';
+    const user = u.config.user;
+    return user.login ? `@${user.login} · ${u.config.accountType}` : 'GitHub Copilot account';
   }
   case 'codex': {
-    const codex = cfg as CodexUpstreamConfig;
-    const account = codex.accounts?.[0];
-    return account ? [account.email, account.planType].filter(Boolean).join(' · ') : 'ChatGPT Codex account';
+    const account = u.config.accounts[0];
+    return `${account.email} · ${account.planType}`;
   }
-  case 'ollama': {
-    const ollama = cfg as OllamaUpstreamConfig;
-    return ollama.baseUrl ?? 'Ollama endpoint';
+  case 'ollama': return u.config.baseUrl ?? 'Ollama endpoint';
   }
-  }
+  return assertNever(u);
 });
 </script>
 

--- a/apps/web/src/components/settings/UpstreamsSettingsCard.vue
+++ b/apps/web/src/components/settings/UpstreamsSettingsCard.vue
@@ -24,10 +24,7 @@ const api = useApi();
 // the other providers count public models that have a binding pointing at this
 // upstream row.
 const modelCountFor = (record: UpstreamRecord): number => {
-  if (record.provider === 'azure') {
-    const cfg = record.config as { models?: unknown[] };
-    return cfg.models?.length ?? 0;
-  }
+  if (record.provider === 'azure') return record.config.models.length;
   const list = props.models ?? [];
   return list.filter(m => m.upstreams.some(b => b.id === record.id)).length;
 };

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -4,26 +4,33 @@
 
 import { computed } from 'vue';
 
-import type { CodexAccountCredentialState, CodexAccountIdentity, CodexUpstreamConfig, CodexUpstreamState, UpstreamRecord } from '../../api/types.ts';
+import type { CodexAccountCredentialState, CodexAccountIdentity, UpstreamRecord } from '../../api/types.ts';
 import { Badge, Card } from '@floway-dev/ui';
 
 const props = defineProps<{
   record: UpstreamRecord;
 }>();
 
-const account = computed<CodexAccountIdentity | null>(() => {
-  const cfg = props.record.config as CodexUpstreamConfig;
-  return cfg.accounts[0] ?? null;
+// Narrow once: this card only renders inside a codex upstream's edit page.
+// Pinning the narrow at the script-setup boundary lets every computed below
+// reach `config` / `state` / `codex_quota` without `as` casts.
+const codexRecord = computed(() => {
+  if (props.record.provider !== 'codex') {
+    throw new Error(`CodexAccountCard requires a codex upstream, got ${props.record.provider}`);
+  }
+  return props.record;
 });
 
+const account = computed<CodexAccountIdentity | null>(() => codexRecord.value.config.accounts[0] ?? null);
+
 const credential = computed<CodexAccountCredentialState | null>(() => {
-  const raw = props.record.state as CodexUpstreamState | null;
+  const raw = codexRecord.value.state;
   if (!raw || !Array.isArray(raw.accounts)) return null;
   if (!account.value) return raw.accounts[0] ?? null;
   return raw.accounts.find(a => a.chatgptAccountId === account.value!.chatgptAccountId) ?? raw.accounts[0] ?? null;
 });
 
-const quota = computed(() => props.record.codex_quota ?? null);
+const quota = computed(() => codexRecord.value.codex_quota ?? null);
 
 const formatTimestamp = (iso: string): string => {
   const d = new Date(iso);

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
 
 import AzureConfigPanel from './AzureConfigPanel.vue';
 import CodexConfigPanel from './CodexConfigPanel.vue';
@@ -12,6 +12,7 @@ import OllamaConfigPanel from './OllamaConfigPanel.vue';
 import ProviderPicker from './ProviderPicker.vue';
 import ProxyFallbackListPanel from './ProxyFallbackListPanel.vue';
 import type { CopilotQuotaSnapshot, FlagDef, ProxyFallbackEntry, UpstreamProviderKind, UpstreamRecord } from '../../api/types.ts';
+import { assertNever } from '../../utils/assert-never.ts';
 import { Input, Switch, TagCombobox } from '@floway-dev/ui';
 
 const activeProvider = defineModel<UpstreamProviderKind>('provider', { required: true });
@@ -24,7 +25,7 @@ const azureDraft = defineModel<AzureDraft>('azure', { required: true });
 const ollamaDraft = defineModel<OllamaDraft>('ollama', { required: true });
 const proxyFallbackList = defineModel<ProxyFallbackEntry[]>('proxyFallbackList', { required: true });
 
-defineProps<{
+const props = defineProps<{
   mode: 'create' | 'edit';
   record: UpstreamRecord | null;
   flags: FlagDef[];
@@ -54,15 +55,20 @@ defineEmits<{
   'codex-error': [message: string];
 }>();
 
+// Per-provider narrowed views of the record so each child panel receives the
+// matching discriminated variant without inline casts.
+const codexRecord = computed(() => props.record?.provider === 'codex' ? props.record : null);
+const copilotRecord = computed(() => props.record?.provider === 'copilot' ? props.record : null);
+
 const providerBadgeClass = (kind: UpstreamProviderKind) => {
   switch (kind) {
   case 'azure': return 'border-accent-emerald/30 bg-accent-emerald/10 text-accent-emerald';
   case 'copilot': return 'border-accent-cyan/30 bg-accent-cyan/10 text-accent-cyan';
   case 'codex': return 'border-accent-violet/30 bg-accent-violet/10 text-accent-violet';
   case 'ollama': return 'border-accent-rose/30 bg-accent-rose/10 text-accent-rose';
-  case 'custom':
-  default: return 'border-accent-amber/30 bg-accent-amber/10 text-accent-amber';
+  case 'custom': return 'border-accent-amber/30 bg-accent-amber/10 text-accent-amber';
   }
+  return assertNever(kind);
 };
 
 // Intrinsic floor for the aside: smallest height at which every
@@ -170,7 +176,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
 
       <section v-else-if="activeProvider === 'copilot'" class="shrink-0">
         <CopilotConfigPanel
-          :record="record"
+          :record="copilotRecord"
           :initial-quota="initialCopilotQuota"
           :initial-quota-error="initialCopilotQuotaError"
           :proxy-fallback-list="proxyFallbackList"
@@ -181,7 +187,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
       <section v-else-if="activeProvider === 'codex'" class="shrink-0">
         <CodexConfigPanel
           :mode="mode"
-          :record="record"
+          :record="codexRecord"
           :proxy-fallback-list="proxyFallbackList"
           @imported="u => $emit('codex-imported', u)"
           @error="m => $emit('codex-error', m)"

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -21,7 +21,7 @@ import {
 import ModelsPanel from './ModelsPanel.vue';
 import UpstreamConfigPanel from './UpstreamConfigPanel.vue';
 import { authFetch, callApi, useApi } from '../../api/client.ts';
-import type { AzureUpstreamConfig, CopilotQuotaSnapshot, CustomRawModel, CustomUpstreamConfig, FlagDef, ModelEndpoints, OllamaUpstreamConfig, ProxyFallbackEntry, UpstreamModelConfig, UpstreamProviderKind, UpstreamRecord } from '../../api/types.ts';
+import type { CopilotQuotaSnapshot, CustomRawModel, FlagDef, ModelEndpoints, OllamaUpstreamConfig, ProxyFallbackEntry, UpstreamModelConfig, UpstreamProviderKind, UpstreamRecord } from '../../api/types.ts';
 import { useRuntimeInfo } from '../../composables/useRuntimeInfo.ts';
 import { useUpstreamsStore } from '../../composables/useUpstreams.ts';
 import { Button } from '@floway-dev/ui';
@@ -97,7 +97,7 @@ const seedFromRecord = (r: UpstreamRecord) => {
   proxyFallbackList.value = r.proxy_fallback_list.map(e => ({ id: e.id, ...(e.colos ? { colos: [...e.colos] } : {}) }));
 
   if (r.provider === 'custom') {
-    const cfg = r.config as CustomUpstreamConfig;
+    const cfg = r.config;
     customDraft.value = {
       baseUrl: cfg.baseUrl,
       authStyle: cfg.authStyle,
@@ -114,14 +114,14 @@ const seedFromRecord = (r: UpstreamRecord) => {
       models: cfg.models ? (JSON.parse(JSON.stringify(cfg.models)) as UpstreamModelConfig[]) : [],
     };
   } else if (r.provider === 'azure') {
-    const cfg = r.config as AzureUpstreamConfig;
+    const cfg = r.config;
     azureDraft.value = {
       endpoint: cfg.endpoint,
       apiKey: '',
       models: cfg.models ? (JSON.parse(JSON.stringify(cfg.models)) as UpstreamModelConfig[]) : [],
     };
   } else if (r.provider === 'ollama') {
-    const cfg = r.config as OllamaUpstreamConfig;
+    const cfg = r.config;
     ollamaDraft.value = {
       baseUrl: cfg.baseUrl,
       apiKey: '',
@@ -156,12 +156,12 @@ const setActiveProvider = (next: UpstreamProviderKind) => {
 };
 
 const customBearerTokenSet = computed(() => {
-  const cfg = props.record?.config as CustomUpstreamConfig | undefined;
-  return cfg?.bearerTokenSet === true;
+  if (props.record?.provider !== 'custom') return false;
+  return props.record.config.bearerTokenSet === true;
 });
 const azureApiKeySet = computed(() => {
-  const cfg = props.record?.config as AzureUpstreamConfig | undefined;
-  return cfg?.apiKeySet === true;
+  if (props.record?.provider !== 'azure') return false;
+  return props.record.config.apiKeySet === true;
 });
 const ollamaApiKeySet = computed(() => {
   const cfg = props.record?.config as OllamaUpstreamConfig | undefined;

--- a/apps/web/src/components/upstreams/UpstreamPicker.vue
+++ b/apps/web/src/components/upstreams/UpstreamPicker.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue';
 
 import type { UpstreamProviderKind } from '../../api/types.ts';
 import type { UpstreamOption } from '../../composables/useUpstreamOptions.ts';
+import { assertNever } from '../../utils/assert-never.ts';
 import { Badge, Sortable, Switch } from '@floway-dev/ui';
 
 export interface UpstreamPickerValue {
@@ -59,12 +60,17 @@ const badgeCount = computed(() => value.value.override ? rows.value.filter(r => 
 
 interface ProviderMeta { tone: 'amber' | 'emerald' | 'cyan' | 'rose' | 'zinc'; label: string }
 const providerMeta = (provider: UpstreamProviderKind | null): ProviderMeta => {
-  if (provider === 'custom') return { tone: 'amber', label: 'Custom' };
-  if (provider === 'azure') return { tone: 'emerald', label: 'Azure' };
-  if (provider === 'copilot') return { tone: 'cyan', label: 'Copilot' };
-  if (provider === 'codex') return { tone: 'cyan', label: 'Codex' };
-  if (provider === 'ollama') return { tone: 'rose', label: 'Ollama' };
-  return { tone: 'zinc', label: 'Unknown' };
+  // The row's provider goes null when an upstream id in the saved value list
+  // no longer matches anything in `available` (e.g. a deleted upstream).
+  if (provider === null) return { tone: 'zinc', label: 'Unknown' };
+  switch (provider) {
+  case 'custom': return { tone: 'amber', label: 'Custom' };
+  case 'azure': return { tone: 'emerald', label: 'Azure' };
+  case 'copilot': return { tone: 'cyan', label: 'Copilot' };
+  case 'codex': return { tone: 'cyan', label: 'Codex' };
+  case 'ollama': return { tone: 'rose', label: 'Ollama' };
+  }
+  return assertNever(provider);
 };
 </script>
 

--- a/apps/web/src/utils/assert-never.ts
+++ b/apps/web/src/utils/assert-never.ts
@@ -1,0 +1,8 @@
+// Exhaustiveness helper for closed-union switches. Type-checks at compile
+// time that every branch of the union is handled; throws at runtime if a
+// silently-expanded union ever reaches it (e.g. a wire-shape change widening
+// the type without updating the consumer).
+
+export const assertNever = (value: never): never => {
+  throw new Error(`Unhandled union variant: ${String(value)}`);
+};


### PR DESCRIPTION
## Summary

Reshape the dashboard's `UpstreamRecord` from a single wide interface
into a provider-keyed discriminated union, drop the `as` casts every
consumer used to carry, and add an `assertNever` helper so future
provider kinds can't ship without a matching switch branch.

## Approach

`UpstreamRecord` previously paired `provider: UpstreamProviderKind`
with a wide union for `config` / `state` / `codex_quota`. The codex
quota lived on every variant despite only ever being populated for
codex, and every `switch (record.provider)` site had to re-`as`-cast
`record.config` to the matching shape. The new shape makes each
variant pin its own `config`, `state`, and (for codex) `codex_quota`,
so narrowing on `provider` does the cast for free.

`apps/web/src/utils/assert-never.ts` is the exhaustiveness lever: a
`function assertNever(x: never): never` call in the default branch
turns "missed a variant" into a `tsc` error, and into a runtime throw
if the union ever widens unexpectedly.

## Scope

- `apps/web/src/utils/assert-never.ts` — new exhaustiveness helper.
- `apps/web/src/api/types.ts` — `UpstreamRecord` becomes a
  discriminated union over `provider`; `codex_quota` moves onto the
  codex variant only.
- `components/settings/UpstreamRow.vue`,
  `settings/UpstreamsSettingsCard.vue`,
  `upstreams/UpstreamPicker.vue`,
  `upstream-edit/UpstreamConfigPanel.vue`,
  `upstream-edit/UpstreamEditPage.vue` — drop `as` casts on
  `record.config` / `record.state`; add `assertNever(provider)`
  defaults so a future variant can't ship without a matching branch.

## Test plan

- [x] typecheck clean on touched packages
- [x] lint clean
- [x] dashboard renders for each provider kind (no regression in
      switch coverage)
