### PR TITLE
refactor(copilot): derive data-plane host from token-exchange endpoints.api

### DIFF
--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -2,21 +2,24 @@ import { serve, upgradeWebSocket } from '@hono/node-server';
 import { Agent, Pool, setGlobalDispatcher } from 'undici';
 import { WebSocketServer } from 'ws';
 
-// api.{individual,business,enterprise}.githubcopilot.com closes its keep-alive
-// socket right after each response; reusing it surfaces as UND_ERR_SOCKET or
+// Copilot data-plane hosts close their keep-alive socket right after each
+// response; reusing it surfaces as UND_ERR_SOCKET or
 // RequestContentLengthMismatchError. `pipelining: 0` disables keep-alive.
+//
+// The host list is decided by GitHub (returned in /copilot_internal/v2/token
+// `endpoints.api`, never enumerated locally), so we match the
+// `*.githubcopilot.com` family rather than enumerate today's three
+// (individual, business, enterprise) and silently miss any new tier GitHub
+// adds.
 //
 // Refs: https://github.com/nodejs/undici/blob/v6.21.0/docs/docs/api/Client.md#parameter-clientoptions
 //       https://github.com/Menci/Floway/pull/78#issuecomment-4765475966
-const COPILOT_HOSTS = new Set([
-  'api.individual.githubcopilot.com',
-  'api.business.githubcopilot.com',
-  'api.enterprise.githubcopilot.com',
-]);
+const isCopilotDataPlaneHost = (hostname: string): boolean =>
+  hostname === 'githubcopilot.com' || hostname.endsWith('.githubcopilot.com');
 setGlobalDispatcher(new Agent({
   factory: (origin, opts) => {
     const hostname = typeof origin === 'string' ? new URL(origin).hostname : origin.hostname;
-    return new Pool(origin, COPILOT_HOSTS.has(hostname) ? { ...opts, pipelining: 0 } : opts);
+    return new Pool(origin, isCopilotDataPlaneHost(hostname) ? { ...opts, pipelining: 0 } : opts);
   },
 }));
 

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -70,9 +70,18 @@ export interface CopilotUser {
 }
 
 export interface CopilotUpstreamConfig {
-  accountType: 'individual' | 'business' | 'enterprise';
   user: CopilotUser;
   githubTokenSet?: boolean;
+}
+
+// Per-tier data-plane host GitHub last routed our PAT to. Populated on the
+// first successful token exchange and refreshed alongside the bearer token
+// (matches vscode-copilot-chat domainServiceImpl.ts). Null on a freshly-
+// imported upstream that hasn't completed a token exchange — but the import
+// path mints one synchronously, so a null here in steady state means
+// something is wrong (PAT revoked, network blocked).
+export interface CopilotUpstreamState {
+  copilotToken: { baseUrl: string } | null;
 }
 
 // Account-pool identities derived from the id_token at codex import. v1
@@ -162,7 +171,7 @@ interface UpstreamRecordBase {
 export type UpstreamRecord =
   | (UpstreamRecordBase & { provider: 'custom'; config: CustomUpstreamConfig; state: null })
   | (UpstreamRecordBase & { provider: 'azure'; config: AzureUpstreamConfig; state: null })
-  | (UpstreamRecordBase & { provider: 'copilot'; config: CopilotUpstreamConfig; state: null })
+  | (UpstreamRecordBase & { provider: 'copilot'; config: CopilotUpstreamConfig; state: CopilotUpstreamState | null })
   | (UpstreamRecordBase & { provider: 'codex'; config: CodexUpstreamConfig; state: CodexUpstreamState | null; codex_quota?: CodexQuotaSnapshot | null })
   | (UpstreamRecordBase & { provider: 'ollama'; config: OllamaUpstreamConfig; state: null });
 

--- a/apps/web/src/components/settings/UpstreamRow.vue
+++ b/apps/web/src/components/settings/UpstreamRow.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue';
 
 import type { UpstreamProviderKind, UpstreamRecord } from '../../api/types.ts';
 import { assertNever } from '../../utils/assert-never.ts';
+import { copilotAccountTypeLabel } from '../../utils/copilot.ts';
 
 const props = defineProps<{
   upstream: UpstreamRecord;
@@ -40,7 +41,8 @@ const subtitle = computed(() => {
   case 'custom': return u.config.baseUrl;
   case 'copilot': {
     const user = u.config.user;
-    return user.login ? `@${user.login} · ${u.config.accountType}` : 'GitHub Copilot account';
+    const accountType = copilotAccountTypeLabel(u.state);
+    return user.login ? `@${user.login} · ${accountType ?? 'copilot'}` : 'GitHub Copilot account';
   }
   case 'codex': {
     const account = u.config.accounts[0];

--- a/apps/web/src/components/settings/UpstreamRow.vue
+++ b/apps/web/src/components/settings/UpstreamRow.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 
 import type { UpstreamProviderKind, UpstreamRecord } from '../../api/types.ts';
 import { assertNever } from '../../utils/assert-never.ts';
-import { copilotAccountTypeLabel } from '../../utils/copilot.ts';
+import { copilotAccountTypeDisplay } from '../../utils/copilot.ts';
 
 const props = defineProps<{
   upstream: UpstreamRecord;
@@ -41,8 +41,9 @@ const subtitle = computed(() => {
   case 'custom': return u.config.baseUrl;
   case 'copilot': {
     const user = u.config.user;
-    const accountType = copilotAccountTypeLabel(u.state);
-    return user.login ? `@${user.login} · ${accountType ?? 'copilot'}` : 'GitHub Copilot account';
+    return user.login
+      ? `@${user.login} · ${copilotAccountTypeDisplay(u.state)}`
+      : 'GitHub Copilot account';
   }
   case 'codex': {
     const account = u.config.accounts[0];

--- a/apps/web/src/components/upstream-edit/CopilotConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CopilotConfigPanel.vue
@@ -2,7 +2,7 @@
 
 import CopilotDeviceFlow from './CopilotDeviceFlow.vue';
 import CopilotInfo from './CopilotInfo.vue';
-import type { CopilotQuotaSnapshot, CopilotUpstreamConfig, ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
+import type { CopilotQuotaSnapshot, CopilotUpstreamConfig, CopilotUpstreamState, ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 
 defineProps<{
   record: UpstreamRecord | null;
@@ -19,6 +19,7 @@ defineEmits<{ completed: [upstream: UpstreamRecord | undefined] }>();
     v-if="record"
     :upstream-id="record.id"
     :config="record.config as CopilotUpstreamConfig"
+    :state="record.state as CopilotUpstreamState | null"
     :initial-quota="initialQuota"
     :initial-quota-error="initialQuotaError"
   />

--- a/apps/web/src/components/upstream-edit/CopilotInfo.vue
+++ b/apps/web/src/components/upstream-edit/CopilotInfo.vue
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue';
 
 import { callApi, useApi } from '../../api/client.ts';
 import type { CopilotQuotaSnapshot, CopilotUpstreamConfig, CopilotUpstreamState } from '../../api/types.ts';
-import { copilotAccountTypeLabel } from '../../utils/copilot.ts';
+import { copilotAccountTypeDisplay } from '../../utils/copilot.ts';
 import { Card } from '@floway-dev/ui';
 
 const props = defineProps<{
@@ -14,7 +14,7 @@ const props = defineProps<{
   initialQuotaError?: string | null;
 }>();
 
-const accountType = computed(() => copilotAccountTypeLabel(props.state));
+const accountTypeDisplay = computed(() => copilotAccountTypeDisplay(props.state));
 
 const api = useApi();
 const quota = ref<CopilotQuotaSnapshot | null>(props.initialQuota ?? null);
@@ -57,7 +57,7 @@ const usedPercent = computed(() => {
         >
         <div>
           <p class="text-sm font-medium text-white">{{ config.user.name ?? config.user.login }}</p>
-          <p class="text-xs text-gray-400">@{{ config.user.login }} · {{ accountType ?? 'copilot' }}</p>
+          <p class="text-xs text-gray-400">@{{ config.user.login }} · {{ accountTypeDisplay }}</p>
         </div>
       </div>
     </Card>

--- a/apps/web/src/components/upstream-edit/CopilotInfo.vue
+++ b/apps/web/src/components/upstream-edit/CopilotInfo.vue
@@ -2,15 +2,19 @@
 import { computed, ref } from 'vue';
 
 import { callApi, useApi } from '../../api/client.ts';
-import type { CopilotQuotaSnapshot, CopilotUpstreamConfig } from '../../api/types.ts';
+import type { CopilotQuotaSnapshot, CopilotUpstreamConfig, CopilotUpstreamState } from '../../api/types.ts';
+import { copilotAccountTypeLabel } from '../../utils/copilot.ts';
 import { Card } from '@floway-dev/ui';
 
 const props = defineProps<{
   upstreamId: string;
   config: CopilotUpstreamConfig;
+  state: CopilotUpstreamState | null;
   initialQuota?: CopilotQuotaSnapshot | null;
   initialQuotaError?: string | null;
 }>();
+
+const accountType = computed(() => copilotAccountTypeLabel(props.state));
 
 const api = useApi();
 const quota = ref<CopilotQuotaSnapshot | null>(props.initialQuota ?? null);
@@ -53,7 +57,7 @@ const usedPercent = computed(() => {
         >
         <div>
           <p class="text-sm font-medium text-white">{{ config.user.name ?? config.user.login }}</p>
-          <p class="text-xs text-gray-400">@{{ config.user.login }} · {{ config.accountType }}</p>
+          <p class="text-xs text-gray-400">@{{ config.user.login }} · {{ accountType ?? 'copilot' }}</p>
         </div>
       </div>
     </Card>

--- a/apps/web/src/utils/copilot.ts
+++ b/apps/web/src/utils/copilot.ts
@@ -1,0 +1,19 @@
+import type { CopilotUpstreamState } from '../api/types.ts';
+
+// Map the per-tier baseUrl GitHub returns from /copilot_internal/v2/token's
+// `endpoints.api` to the marketing label the dashboard renders. Null when
+// state has never been seeded (freshly imported and not yet usable) or when
+// GitHub routes us to a host we don't have a label for yet — the latter is
+// fine to surface as "Copilot" without breaking the page.
+export type CopilotAccountTypeLabel = 'individual' | 'business' | 'enterprise';
+
+const BASE_URL_TO_LABEL: Record<string, CopilotAccountTypeLabel> = {
+  'https://api.individual.githubcopilot.com': 'individual',
+  'https://api.business.githubcopilot.com': 'business',
+  'https://api.enterprise.githubcopilot.com': 'enterprise',
+};
+
+export const copilotAccountTypeLabel = (state: CopilotUpstreamState | null | undefined): CopilotAccountTypeLabel | null => {
+  const baseUrl = state?.copilotToken?.baseUrl;
+  return baseUrl ? BASE_URL_TO_LABEL[baseUrl] ?? null : null;
+};

--- a/apps/web/src/utils/copilot.ts
+++ b/apps/web/src/utils/copilot.ts
@@ -1,11 +1,13 @@
 import type { CopilotUpstreamState } from '../api/types.ts';
 
 // Map the per-tier baseUrl GitHub returns from /copilot_internal/v2/token's
-// `endpoints.api` to the marketing label the dashboard renders. Null when
-// state has never been seeded (freshly imported and not yet usable) or when
-// GitHub routes us to a host we don't have a label for yet — the latter is
-// fine to surface as "Copilot" without breaking the page.
+// `endpoints.api` to the marketing label the dashboard renders. Returns
+// null when state has never been seeded (freshly imported and not yet
+// usable) or when GitHub routes us to a host we don't have a label for
+// yet — callers fall back to `COPILOT_GENERIC_LABEL` for display.
 export type CopilotAccountTypeLabel = 'individual' | 'business' | 'enterprise';
+
+export const COPILOT_GENERIC_LABEL = 'copilot';
 
 const BASE_URL_TO_LABEL: Record<string, CopilotAccountTypeLabel> = {
   'https://api.individual.githubcopilot.com': 'individual',
@@ -17,3 +19,8 @@ export const copilotAccountTypeLabel = (state: CopilotUpstreamState | null | und
   const baseUrl = state?.copilotToken?.baseUrl;
   return baseUrl ? BASE_URL_TO_LABEL[baseUrl] ?? null : null;
 };
+
+// Display label with the generic-fallback applied for callers that render
+// a non-empty string unconditionally (badge text, settings-row subtitle).
+export const copilotAccountTypeDisplay = (state: CopilotUpstreamState | null | undefined): string =>
+  copilotAccountTypeLabel(state) ?? COPILOT_GENERIC_LABEL;

--- a/apps/web/src/utils/copilot_test.ts
+++ b/apps/web/src/utils/copilot_test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest';
+
+import { copilotAccountTypeDisplay, copilotAccountTypeLabel } from './copilot.ts';
+
+test('copilotAccountTypeLabel maps the three known per-tier hosts', () => {
+  expect(copilotAccountTypeLabel({ copilotToken: { baseUrl: 'https://api.individual.githubcopilot.com' } })).toBe('individual');
+  expect(copilotAccountTypeLabel({ copilotToken: { baseUrl: 'https://api.business.githubcopilot.com' } })).toBe('business');
+  expect(copilotAccountTypeLabel({ copilotToken: { baseUrl: 'https://api.enterprise.githubcopilot.com' } })).toBe('enterprise');
+});
+
+test('copilotAccountTypeLabel returns null when state is missing or unhydrated', () => {
+  expect(copilotAccountTypeLabel(null)).toBe(null);
+  expect(copilotAccountTypeLabel(undefined)).toBe(null);
+  expect(copilotAccountTypeLabel({ copilotToken: null })).toBe(null);
+});
+
+test('copilotAccountTypeLabel returns null for a host GitHub may add that we have not labeled yet', () => {
+  expect(copilotAccountTypeLabel({ copilotToken: { baseUrl: 'https://api.education.githubcopilot.com' } })).toBe(null);
+});
+
+test('copilotAccountTypeDisplay falls back to the generic label for null/unknown cases', () => {
+  expect(copilotAccountTypeDisplay(null)).toBe('copilot');
+  expect(copilotAccountTypeDisplay({ copilotToken: null })).toBe('copilot');
+  expect(copilotAccountTypeDisplay({ copilotToken: { baseUrl: 'https://api.education.githubcopilot.com' } })).toBe('copilot');
+  expect(copilotAccountTypeDisplay({ copilotToken: { baseUrl: 'https://api.enterprise.githubcopilot.com' } })).toBe('enterprise');
+});

--- a/packages/gateway/migrations/0037_copilot_drop_legacy_state_shape.sql
+++ b/packages/gateway/migrations/0037_copilot_drop_legacy_state_shape.sql
@@ -1,0 +1,24 @@
+-- The Copilot refactor that moved per-tier data-plane host routing from
+-- a static config.accountType enum to a state.copilotToken.baseUrl field
+-- changed two on-disk shapes; this migration cleans them up.
+--
+-- 1. config_json.accountType is no longer read by the gateway. The per-tier
+--    host comes from /copilot_internal/v2/token's `endpoints.api` instead.
+--    Strip the field so the source of truth does not drift.
+UPDATE upstreams
+SET config_json = json_remove(config_json, '$.accountType')
+WHERE provider = 'copilot'
+  AND json_extract(config_json, '$.accountType') IS NOT NULL;
+
+-- 2. state_json.copilotToken gained a required `baseUrl` field. Pre-
+--    refactor entries persisted only `{token, expiresAt}` — without baseUrl
+--    the runtime cannot route the data-plane call. SQL cannot backfill
+--    baseUrl (it lives in a live response from /copilot_internal/v2/token),
+--    so strip the partial entry; the next data-plane request mints a fresh
+--    {token, expiresAt, baseUrl} via exchangeCopilotToken().
+UPDATE upstreams
+SET state_json = json_remove(state_json, '$.copilotToken')
+WHERE provider = 'copilot'
+  AND state_json IS NOT NULL
+  AND json_extract(state_json, '$.copilotToken') IS NOT NULL
+  AND json_extract(state_json, '$.copilotToken.baseUrl') IS NULL;

--- a/packages/gateway/src/control-plane/auth/github-device-flow.ts
+++ b/packages/gateway/src/control-plane/auth/github-device-flow.ts
@@ -1,5 +1,4 @@
 import { directFetcher, type Fetcher } from '@floway-dev/provider';
-import { copilotPlanToAccountType, githubHeaders, type CopilotAccountType } from '@floway-dev/provider-copilot';
 
 export interface GitHubUser {
   login: string;
@@ -78,14 +77,4 @@ export const fetchGitHubUser = async (githubToken: string, fetcher: Fetcher = di
 
   if (!userResp.ok) throw new Error(`GitHub user lookup failed: ${userResp.status} ${await userResp.text()}`);
   return (await userResp.json()) as GitHubUser;
-};
-
-export const detectAccountType = async (githubToken: string, fetcher: Fetcher = directFetcher): Promise<CopilotAccountType> => {
-  const resp = await fetcher('https://api.github.com/copilot_internal/user', {
-    headers: githubHeaders(githubToken),
-  });
-  if (!resp.ok) throw new Error(`GitHub Copilot account type detection failed: ${resp.status} ${await resp.text()}`);
-
-  const data = (await resp.json()) as { copilot_plan?: unknown };
-  return copilotPlanToAccountType(data.copilot_plan);
 };

--- a/packages/gateway/src/control-plane/auth/routes_test.ts
+++ b/packages/gateway/src/control-plane/auth/routes_test.ts
@@ -218,7 +218,7 @@ test('/api/upstreams/copilot/auth/start starts GitHub device flow', async () => 
   );
 });
 
-test('/api/upstreams/copilot/auth/poll creates a Copilot upstream row', async () => {
+test('/api/upstreams/copilot/auth/poll creates a Copilot upstream row and seeds state from the token exchange', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
 
@@ -227,8 +227,17 @@ test('/api/upstreams/copilot/auth/poll creates a Copilot upstream row', async ()
       const url = new URL(request.url);
       if (url.hostname === 'github.com' && url.pathname === '/login/oauth/access_token') return jsonResponse({ access_token: 'ghu_new' });
       if (url.hostname === 'api.github.com' && url.pathname === '/user') return jsonResponse(githubUser);
-      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
-      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/user') return jsonResponse({ copilot_plan: 'enterprise' });
+      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({
+          token: 'ct_new',
+          expires_at: Math.floor(Date.now() / 1000) + 1500,
+          refresh_in: 1200,
+          endpoints: { api: 'https://api.enterprise.githubcopilot.com' },
+        });
+      }
+      // Warmup probes /models on the per-tier host — return an empty catalog
+      // so the import handler completes without waiting on a real fetch.
+      if (url.hostname === 'api.enterprise.githubcopilot.com') return jsonResponse({ data: [] });
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
@@ -249,6 +258,9 @@ test('/api/upstreams/copilot/auth/poll creates a Copilot upstream row', async ()
       assertEquals(body.upstream.provider, 'copilot');
       assertEquals(body.upstream.config.githubToken, undefined);
       assertEquals(body.upstream.config.githubTokenSet, true);
+      // The serialized state exposes only the per-tier baseUrl; the bearer
+      // token and its expiry stay server-side.
+      assertEquals(body.upstream.state, { copilotToken: { baseUrl: 'https://api.enterprise.githubcopilot.com' } });
     },
   );
 
@@ -256,8 +268,11 @@ test('/api/upstreams/copilot/auth/poll creates a Copilot upstream row', async ()
   assertEquals(rows.length, 1);
   assertEquals(rows[0].provider, 'copilot');
   assertEquals((rows[0].config as Record<string, any>).githubToken, 'ghu_new');
-  assertEquals((rows[0].config as Record<string, any>).accountType, 'enterprise');
+  assertEquals((rows[0].config as Record<string, any>).accountType, undefined);
   assertEquals((rows[0].config as Record<string, any>).user.id, 777);
+  const persistedState = rows[0].state as { copilotToken: { token: string; baseUrl: string } | null } | null;
+  assertEquals(persistedState?.copilotToken?.token, 'ct_new');
+  assertEquals(persistedState?.copilotToken?.baseUrl, 'https://api.enterprise.githubcopilot.com');
 });
 
 test('/api/upstreams/copilot/auth/poll rejects failed GitHub user lookup without saving an upstream', async () => {
@@ -291,17 +306,16 @@ test('/api/upstreams/copilot/auth/poll rejects failed GitHub user lookup without
   assertEquals(await repo.upstreams.list(), []);
 });
 
-test('/api/upstreams/copilot/auth/poll rejects failed Copilot account type lookup without saving an upstream', async () => {
+test('/api/upstreams/copilot/auth/poll rejects a failed token exchange without saving an upstream', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
 
   await withMockedFetch(
     request => {
       const url = new URL(request.url);
-      if (url.hostname === 'github.com' && url.pathname === '/login/oauth/access_token') return jsonResponse({ access_token: 'ghu_no_plan' });
+      if (url.hostname === 'github.com' && url.pathname === '/login/oauth/access_token') return jsonResponse({ access_token: 'ghu_no_seat' });
       if (url.hostname === 'api.github.com' && url.pathname === '/user') return jsonResponse(githubUser);
-      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
-      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/user') return jsonResponse({ message: 'no copilot seat' }, 403);
+      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/v2/token') return jsonResponse({ message: 'no copilot seat' }, 403);
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
@@ -316,7 +330,7 @@ test('/api/upstreams/copilot/auth/poll rejects failed Copilot account type looku
 
       assertEquals(response.status, 502);
       const body = (await response.json()) as { error: string };
-      assertStringIncludes(body.error, 'GitHub Copilot account type detection failed: 403');
+      assertStringIncludes(body.error, 'Copilot token fetch failed: 403');
       assertStringIncludes(body.error, 'no copilot seat');
     },
   );
@@ -324,17 +338,18 @@ test('/api/upstreams/copilot/auth/poll rejects failed Copilot account type looku
   assertEquals(await repo.upstreams.list(), []);
 });
 
-test('/api/upstreams/copilot/auth/poll rejects unknown Copilot account type without saving an upstream', async () => {
+test('/api/upstreams/copilot/auth/poll rejects a token-exchange response missing endpoints.api without saving an upstream', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
 
   await withMockedFetch(
     request => {
       const url = new URL(request.url);
-      if (url.hostname === 'github.com' && url.pathname === '/login/oauth/access_token') return jsonResponse({ access_token: 'ghu_unknown_plan' });
+      if (url.hostname === 'github.com' && url.pathname === '/login/oauth/access_token') return jsonResponse({ access_token: 'ghu_no_endpoint' });
       if (url.hostname === 'api.github.com' && url.pathname === '/user') return jsonResponse(githubUser);
-      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
-      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/user') return jsonResponse({ copilot_plan: 'free' });
+      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'ct_no_endpoint', expires_at: Math.floor(Date.now() / 1000) + 1500, refresh_in: 1200 });
+      }
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
@@ -348,7 +363,7 @@ test('/api/upstreams/copilot/auth/poll rejects unknown Copilot account type with
       });
 
       assertEquals(response.status, 502);
-      assertEquals((await response.json()) as Record<string, unknown>, { error: 'Unknown GitHub Copilot plan: "free"' });
+      assertEquals((await response.json()) as Record<string, unknown>, { error: 'Copilot token exchange response missing endpoints.api' });
     },
   );
 
@@ -359,7 +374,6 @@ test('/api/upstreams/copilot/auth/poll updates an existing row for the same GitH
   const { repo, adminSession, githubAccount } = await setupAppTest({
     githubAccount: {
       token: 'ghu_old',
-      accountType: 'individual',
       user: githubUser,
     },
   });
@@ -372,8 +386,15 @@ test('/api/upstreams/copilot/auth/poll updates an existing row for the same GitH
       const url = new URL(request.url);
       if (url.hostname === 'github.com' && url.pathname === '/login/oauth/access_token') return jsonResponse({ access_token: 'ghu_refreshed' });
       if (url.hostname === 'api.github.com' && url.pathname === '/user') return jsonResponse(githubUser);
-      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
-      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/user') return jsonResponse({ copilot_plan: 'business' });
+      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({
+          token: 'ct_refreshed',
+          expires_at: Math.floor(Date.now() / 1000) + 1500,
+          refresh_in: 1200,
+          endpoints: { api: 'https://api.business.githubcopilot.com' },
+        });
+      }
+      if (url.hostname === 'api.business.githubcopilot.com') return jsonResponse({ data: [] });
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
@@ -396,5 +417,6 @@ test('/api/upstreams/copilot/auth/poll updates an existing row for the same GitH
   assertEquals(rows[0].name, 'Pinned Copilot');
   assertEquals(rows[0].sortOrder, 9);
   assertEquals((rows[0].config as Record<string, any>).githubToken, 'ghu_refreshed');
-  assertEquals((rows[0].config as Record<string, any>).accountType, 'business');
+  const persistedState = rows[0].state as { copilotToken: { baseUrl: string } | null } | null;
+  assertEquals(persistedState?.copilotToken?.baseUrl, 'https://api.business.githubcopilot.com');
 });

--- a/packages/gateway/src/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes_test.ts
@@ -100,7 +100,6 @@ const COPILOT_UPSTREAM: UpstreamRecord = {
   proxyFallbackList: [],
   config: {
     githubToken: 'ghu-alice',
-    accountType: 'individual',
     user: {
       id: 100,
       login: 'alice',

--- a/packages/gateway/src/control-plane/models/routes_test.ts
+++ b/packages/gateway/src/control-plane/models/routes_test.ts
@@ -39,7 +39,7 @@ test('/api/models exposes each binding as { kind, id } so multi-provider models 
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'claude-sonnet-4', display_name: 'Claude Sonnet 4', supported_endpoints: ['/v1/messages'] }]));
@@ -71,7 +71,7 @@ const modelsFetchHandler = (request: Request): Response => {
   const url = new URL(request.url);
   if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
   if (url.pathname === '/copilot_internal/v2/token') {
-    return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+    return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
   }
   if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
     return jsonResponse(copilotModels([{ id: 'claude-sonnet-4', display_name: 'Claude Sonnet 4', supported_endpoints: ['/v1/messages'] }]));

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -129,7 +129,6 @@ const azureConfigSchema = z.object({
 
 const copilotConfigSchema = z.object({
   githubToken: z.string().min(1),
-  accountType: z.enum(['individual', 'business', 'enterprise']),
   user: z.object({
     login: z.string(),
     avatar_url: z.string(),

--- a/packages/gateway/src/control-plane/shared/field-validators.ts
+++ b/packages/gateway/src/control-plane/shared/field-validators.ts
@@ -1,4 +1,4 @@
-import { isCopilotAccountType, type CopilotUpstreamConfig, type CopilotUpstreamUser } from '@floway-dev/provider-copilot';
+import type { CopilotUpstreamConfig, CopilotUpstreamUser } from '@floway-dev/provider-copilot';
 
 export type { CopilotUpstreamConfig, CopilotUpstreamUser };
 
@@ -40,12 +40,8 @@ const copilotUserField = (value: unknown, err: FieldErrorBuilder): CopilotUpstre
 
 export const copilotConfigField = (value: unknown, err: FieldErrorBuilder): CopilotUpstreamConfig => {
   if (!isRecord(value)) throw err('config', 'an object');
-  if (!isCopilotAccountType(value.accountType)) {
-    throw err('config.accountType', 'one of individual, business, enterprise');
-  }
   return {
     githubToken: nonEmptyStringField(value.githubToken, 'githubToken', err),
-    accountType: value.accountType,
     user: copilotUserField(value.user, err),
   };
 };

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -12,7 +12,7 @@ import { getRepo } from '../../repo/index.ts';
 import { DIRECT_PROXY_ID, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { shortId } from '../../shared/short-id.ts';
-import { detectAccountType, fetchGitHubUser, pollGitHubDeviceFlow, startGitHubDeviceFlow } from '../auth/github-device-flow.ts';
+import { fetchGitHubUser, pollGitHubDeviceFlow, startGitHubDeviceFlow } from '../auth/github-device-flow.ts';
 import type { codexImportBody, codexPkceStartBody, codexRefreshNowBody, codexReimportBody, copilotAuthPollBody, createUpstreamBody, fetchModelsBody, updateUpstreamBody } from '../schemas.ts';
 import { copilotConfigField, type CopilotUpstreamConfig, isRecord } from '../shared/field-validators.ts';
 import {
@@ -43,7 +43,7 @@ import {
   importCodexFromCallback,
   refreshCodexAccessToken,
 } from '@floway-dev/provider-codex';
-import { clearCopilotTokenCache } from '@floway-dev/provider-copilot';
+import { clearInProcessCopilotTokenCache, exchangeCopilotToken, readCopilotUpstreamState, type CopilotUpstreamState } from '@floway-dev/provider-copilot';
 import { assertCustomUpstreamRecord, fetchCustomModels } from '@floway-dev/provider-custom';
 import { assertOllamaUpstreamRecord, createOllamaProvider } from '@floway-dev/provider-ollama';
 
@@ -408,7 +408,10 @@ export const copilotAuthPoll = async (c: CtxWithJson<typeof copilotAuthPollBody>
     if (!data.access_token) return c.json({ status: 'error', error: 'Unknown response' }, 500);
 
     const user = await fetchGitHubUser(data.access_token, fetcher);
-    const accountType = await detectAccountType(data.access_token, fetcher);
+    // Seed state with a token now so the upstream is immediately usable and
+    // dashboard knows the per-tier `endpoints.api` GitHub routes this PAT to.
+    // Also validates the PAT — a bad token throws before we touch the repo.
+    const tokenEntry = await exchangeCopilotToken(data.access_token, fetcher);
 
     const repo = getRepo().upstreams;
     const upstreams = await repo.list();
@@ -416,8 +419,12 @@ export const copilotAuthPoll = async (c: CtxWithJson<typeof copilotAuthPollBody>
     const now = new Date().toISOString();
     const config: CopilotUpstreamConfig = {
       githubToken: data.access_token,
-      accountType,
       user,
+    };
+    const prevState = existing ? readCopilotUpstreamState(existing.state) : { knownModels: null, copilotToken: null };
+    const nextState: CopilotUpstreamState = {
+      ...prevState,
+      copilotToken: tokenEntry,
     };
 
     const record: UpstreamRecord = existing
@@ -425,6 +432,7 @@ export const copilotAuthPoll = async (c: CtxWithJson<typeof copilotAuthPollBody>
           ...existing,
           config,
           updatedAt: now,
+          state: nextState,
         }
       : {
           id: newId(),
@@ -442,11 +450,15 @@ export const copilotAuthPoll = async (c: CtxWithJson<typeof copilotAuthPollBody>
           // correctly without clobbering a prior persisted choice.
           proxyFallbackList: proxyFallbackList !== undefined ? normalizeProxyFallbackList(proxyFallbackList) : [],
           config,
-          state: null,
+          state: nextState,
         };
 
     await repo.save(record);
-    await clearCopilotTokenCache(record.id);
+    // Drop the in-process memo so any isolate that already held a token entry
+    // for this upstream id (from a prior rotation) re-hydrates from the fresh
+    // state we just wrote, rather than serving up to 60s of stale auth.
+    // Persisted state stays — we just put a freshly minted token there.
+    clearInProcessCopilotTokenCache();
     await warmModelsCache(record, c);
     return c.json({ status: 'complete', user, upstream: await serializeForResponse(record) });
   } catch (e: unknown) {

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -23,7 +23,6 @@ const azureConfig = {
 
 const copilotConfig = {
   githubToken: 'ghu_secret',
-  accountType: 'individual',
   user: {
     id: 12345,
     login: 'octo',
@@ -1053,10 +1052,11 @@ test('POST /api/upstreams/copilot/auth/poll persists the override on the freshly
   await repo.proxies.insert({ id: 'p_real', name: 'Real', url: 'socks5://198.51.100.10:1080', dialTimeoutSeconds: null });
 
   // Drive the device-flow poll deterministically: every GitHub-side call
-  // the handler makes (oauth token exchange, /user, /copilot_internal/user,
-  // and the post-save warmup's /copilot_internal/v2/token mint) must
-  // resolve, otherwise the warmup falls into copilot auth's withRetry
-  // backoff and the test stalls for ~7s before passing.
+  // the handler makes (oauth token exchange, /user, and the import-time
+  // /copilot_internal/v2/token mint that seeds state.copilotToken with the
+  // per-tier endpoints.api) must resolve, otherwise the token exchange falls
+  // into copilot auth's withRetry backoff and the test stalls for ~7s before
+  // passing.
   await withMockedFetch(
     async (request: Request) => {
       const url = new URL(request.url);
@@ -1065,9 +1065,6 @@ test('POST /api/upstreams/copilot/auth/poll persists the override on the freshly
       }
       if (url.hostname === 'api.github.com' && url.pathname === '/user') {
         return jsonResponse({ login: 'octo', avatar_url: 'https://example.com/a.png', name: 'Octo', id: 99 });
-      }
-      if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/user') {
-        return jsonResponse({ copilot_plan: 'individual' });
       }
       if (url.hostname === 'api.github.com' && url.pathname === '/copilot_internal/v2/token') {
         return jsonResponse({ token: 'ct_test', expires_at: Math.floor(Date.now() / 1000) + 1500, refresh_in: 1200, endpoints: { api: 'https://api.individual.githubcopilot.com' } });

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -70,7 +70,6 @@ const redactedConfig = (upstream: UpstreamRecord): unknown => {
     };
   case 'copilot':
     return {
-      ...(config.accountType !== undefined ? { accountType: clone(config.accountType) } : {}),
       ...(config.user !== undefined ? { user: clone(config.user) } : {}),
       githubTokenSet: hasSecret(config.githubToken),
     };
@@ -115,7 +114,14 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
         refresh_token_set: hasSecret(a.refresh_token),
       })),
     };
-  case 'copilot':
+  case 'copilot': {
+    // Expose only the per-tier baseUrl the dashboard renders an account-type
+    // badge from. Bearer token + expiry stay server-side: short-lived auth
+    // material has no presentation use.
+    const token = isRecord(state.copilotToken) ? state.copilotToken : null;
+    const baseUrl = typeof token?.baseUrl === 'string' ? token.baseUrl : null;
+    return { copilotToken: baseUrl !== null ? { baseUrl } : null };
+  }
   case 'custom':
   case 'azure':
   case 'ollama':

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -101,6 +101,40 @@ test('upstreamRecordToJson redacts Copilot GitHub token inside config and expose
   assertEquals(state.copilotToken, { baseUrl: 'https://api.enterprise.githubcopilot.com' });
 });
 
+test('upstreamRecordToJson serializes a Copilot row with state=null without throwing', () => {
+  const result = upstreamRecordToJson({
+    ...custom,
+    id: 'up_copilot_fresh',
+    provider: 'copilot',
+    config: {
+      githubToken: 'ghu_secret',
+      user: { id: 200, login: 'fresh', name: null, avatar_url: 'https://example.com/fresh.png' },
+    },
+    state: null,
+  });
+
+  assertEquals(result.provider, 'copilot');
+  // A freshly imported Copilot row that hasn't completed its first token
+  // exchange yet has no state at all — the dashboard renders the generic
+  // 'copilot' badge in that case rather than a per-tier label.
+  assertEquals(result.state, null);
+});
+
+test('upstreamRecordToJson serializes a Copilot row whose state lacks copilotToken as { copilotToken: null }', () => {
+  const result = upstreamRecordToJson({
+    ...custom,
+    id: 'up_copilot_no_token',
+    provider: 'copilot',
+    config: {
+      githubToken: 'ghu_secret',
+      user: { id: 201, login: 'no-token', name: null, avatar_url: 'https://example.com/n.png' },
+    },
+    state: { knownModels: null, copilotToken: null },
+  });
+  const state = result.state as Record<string, unknown>;
+  assertEquals(state.copilotToken, null);
+});
+
 test('upstreamRecordToFullJson includes provider config secrets for export', () => {
   const result = upstreamRecordToFullJson(custom);
   const config = result.config as Record<string, unknown>;

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -66,14 +66,13 @@ test('upstreamRecordToJson redacts Azure API keys inside config', () => {
   assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }]);
 });
 
-test('upstreamRecordToJson redacts Copilot GitHub token inside config', () => {
+test('upstreamRecordToJson redacts Copilot GitHub token inside config and exposes the state baseUrl', () => {
   const result = upstreamRecordToJson({
     ...custom,
     id: 'up_copilot_test',
     provider: 'copilot',
     config: {
       githubToken: 'ghu_secret',
-      accountType: 'individual',
       user: {
         id: 100,
         login: 'octo',
@@ -81,19 +80,25 @@ test('upstreamRecordToJson redacts Copilot GitHub token inside config', () => {
         avatar_url: 'https://example.com/avatar.png',
       },
     },
+    state: {
+      copilotToken: { token: 'tok-secret', expiresAt: 4102444800, baseUrl: 'https://api.enterprise.githubcopilot.com' },
+    },
   });
   const config = result.config as Record<string, unknown>;
+  const state = result.state as Record<string, unknown>;
 
   assertEquals(result.provider, 'copilot');
   assertEquals(config.githubToken, undefined);
   assertEquals(config.githubTokenSet, true);
-  assertEquals(config.accountType, 'individual');
+  assertEquals(config.accountType, undefined);
   assertEquals(config.user, {
     id: 100,
     login: 'octo',
     name: null,
     avatar_url: 'https://example.com/avatar.png',
   });
+  // baseUrl surfaces; bearer token and expiry stay server-side.
+  assertEquals(state.copilotToken, { baseUrl: 'https://api.enterprise.githubcopilot.com' });
 });
 
 test('upstreamRecordToFullJson includes provider config secrets for export', () => {

--- a/packages/gateway/src/data-plane/codex/routes_test.ts
+++ b/packages/gateway/src/data-plane/codex/routes_test.ts
@@ -24,7 +24,7 @@ const copilotFetch = (models: Array<{ id: string; maxContextWindowTokens?: numbe
       return jsonResponse(['1.110.1']);
     }
     if (url.pathname === '/copilot_internal/v2/token') {
-      return jsonResponse({ token: 'test-copilot-token', expires_at: 4102444800, refresh_in: 3600 });
+      return jsonResponse({ token: 'test-copilot-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
     }
     if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
       return jsonResponse(copilotModels(models));

--- a/packages/gateway/src/data-plane/embeddings/serve_test.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve_test.ts
@@ -26,6 +26,7 @@ test('/v1/embeddings wraps scalar string input for Copilot upstream', async () =
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -83,6 +84,7 @@ test('/v1/embeddings records usage under request model when upstream omits model
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -151,6 +153,7 @@ test('/v1/embeddings records request and upstream performance', async () => {
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -406,6 +409,7 @@ test('/v1/embeddings preserves model-load errors hidden by another provider', as
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
@@ -452,6 +456,7 @@ test('/v1/embeddings rejects malformed body at the provider-independent boundary
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {

--- a/packages/gateway/src/data-plane/images/serve_test.ts
+++ b/packages/gateway/src/data-plane/images/serve_test.ts
@@ -32,7 +32,7 @@ test('/v1/images/generations 404s when no upstream provides the model', async ()
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'copilot-chat', supported_endpoints: ['/chat/completions'] }]));
@@ -132,7 +132,7 @@ test('/v1/images/generations forwards a JSON request through a custom upstream a
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'copilot-chat', supported_endpoints: ['/chat/completions'] }]));
@@ -197,7 +197,7 @@ test('/v1/images/edits forwards a multipart request through an Azure model and r
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'copilot-chat', supported_endpoints: ['/chat/completions'] }]));

--- a/packages/gateway/src/data-plane/llm/responses/websocket_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/websocket_test.ts
@@ -147,7 +147,7 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
@@ -225,7 +225,7 @@ test('Responses WebSocket keepalive during an in-flight request does not drop th
         const url = new URL(request.url);
         if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
         if (url.pathname === '/copilot_internal/v2/token') {
-          return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+          return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
         }
         if (url.pathname === '/models') {
           return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
@@ -377,7 +377,7 @@ test('Responses WebSocket forwards HTTP failures with status_code, error.code, a
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') return jsonResponse(copilotModels([]));
       throw new Error(`Unhandled fetch ${request.url}`);
@@ -422,7 +422,7 @@ test('Responses WebSocket store:false writes no items/snapshot and follow-ups ca
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
@@ -504,7 +504,7 @@ test('Responses WebSocket store:true durable snapshots can chain through local s
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
@@ -568,7 +568,7 @@ test('Responses WebSocket session-level store: second message resolves prior ite
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
@@ -680,7 +680,7 @@ test('Responses WebSocket aborts the in-flight Responses request when the client
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));

--- a/packages/gateway/src/data-plane/models/gemini_test.ts
+++ b/packages/gateway/src/data-plane/models/gemini_test.ts
@@ -19,6 +19,7 @@ test('/v1beta/models lists Copilot LLM models in Gemini model shape', async () =
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -99,6 +100,7 @@ test('/v1beta/models/:modelId returns one Gemini model or Google RPC 404', async
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {

--- a/packages/gateway/src/data-plane/models/serve_test.ts
+++ b/packages/gateway/src/data-plane/models/serve_test.ts
@@ -6,7 +6,6 @@ import { jsonResponse, withMockedFetch, assertEquals } from '@floway-dev/test-ut
 
 const SECOND_ACCOUNT = {
   token: 'ghu_second',
-  accountType: 'individual',
   user: {
     id: 2002,
     login: 'second',
@@ -41,6 +40,7 @@ test('/v1/models returns merged model list from Copilot and custom upstreams', a
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models' && url.hostname === 'api.individual.githubcopilot.com') {
@@ -205,6 +205,7 @@ test('/models returns the same superset payload as /v1/models', async () => {
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models' && url.hostname === 'api.individual.githubcopilot.com') {
@@ -477,6 +478,7 @@ test('/v1/models returns the id-sorted union of every connected GitHub account',
           token: tokenForGithubToken.get(githubToken),
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
 
@@ -542,6 +544,7 @@ test('/v1/models returns the last real error when every account model load fails
           token: 'copilot-invalid-models',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
 

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -150,6 +150,7 @@ test('getInternalModels returns the catalog projection without execution binding
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
@@ -222,6 +223,7 @@ test('resolveModelForRequest applies provider-owned aliases only to that provide
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {

--- a/packages/gateway/src/dial/per-request_test.ts
+++ b/packages/gateway/src/dial/per-request_test.ts
@@ -14,7 +14,6 @@ const stubSocketDial: SocketDial = {
 
 const COPILOT_CONFIG = {
   githubToken: 'tok',
-  accountType: 'individual' as const,
   user: { login: 'u', avatar_url: '', name: null, id: 1 },
 };
 

--- a/packages/gateway/src/repo/upstreams_test.ts
+++ b/packages/gateway/src/repo/upstreams_test.ts
@@ -172,7 +172,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     sortOrder: 1,
     createdAt: '2026-05-21T10:00:03.000Z',
     updatedAt: '2026-05-21T10:00:03.000Z',
-    config: { githubToken: 'gho_d1', accountType: 'individual', user: { id: 1, login: 'copilot', name: null, avatar_url: 'https://avatars.test/1.png' } },
+    config: { githubToken: 'gho_d1', user: { id: 1, login: 'copilot', name: null, avatar_url: 'https://avatars.test/1.png' } },
   });
   const azure = upstream({
     id: 'up_azure_sql',

--- a/packages/gateway/src/test-helpers.ts
+++ b/packages/gateway/src/test-helpers.ts
@@ -28,7 +28,6 @@ interface AppTestContext {
 
 interface CopilotAccountFixture {
   token: string;
-  accountType: string;
   user: {
     login: string;
     avatar_url: string;
@@ -47,7 +46,6 @@ const TEST_UPSTREAM_TIMESTAMP = '2026-03-15T00:00:00.000Z';
 export const buildCopilotUpstreamRecord = (githubAccount: CopilotAccountFixture, overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => {
   const config = {
     githubToken: githubAccount.token,
-    accountType: githubAccount.accountType,
     user: githubAccount.user,
   };
   const { config: overrideConfig, ...rest } = overrides;
@@ -136,7 +134,6 @@ export async function setupAppTest(options: SetupOptions = {}): Promise<AppTestC
 
   const githubAccount = options.githubAccount ?? {
     token: `ghu_${crypto.randomUUID().replace(/-/g, '')}`,
-    accountType: 'individual',
     user: {
       id: Math.floor(Math.random() * 1000000) + 1,
       login: 'tester',

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -1,40 +1,6 @@
 import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
 import { getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
 
-const COPILOT_BASE_URLS = {
-  individual: 'https://api.individual.githubcopilot.com',
-  business: 'https://api.business.githubcopilot.com',
-  enterprise: 'https://api.enterprise.githubcopilot.com',
-} as const;
-
-export type CopilotAccountType = keyof typeof COPILOT_BASE_URLS;
-
-const COPILOT_ACCOUNT_TYPES = Object.keys(COPILOT_BASE_URLS) as readonly CopilotAccountType[];
-
-// Pro+, Max, and EDU all share the individual data-plane host. Full plan list:
-// https://github.com/microsoft/vscode/blob/9fc5f412c92925bd5b2e41e2029006847432bde6/src/vs/workbench/services/chat/common/chatEntitlementService.ts
-const COPILOT_PLAN_TO_ACCOUNT_TYPE: Record<string, CopilotAccountType> = {
-  individual: 'individual',
-  individual_pro: 'individual',
-  individual_max: 'individual',
-  individual_edu: 'individual',
-  business: 'business',
-  enterprise: 'enterprise',
-};
-
-// For already-normalized data-plane values; wire-side `copilot_plan` needs
-// copilotPlanToAccountType() to collapse aliases first.
-export const isCopilotAccountType = (value: unknown): value is CopilotAccountType =>
-  typeof value === 'string' && COPILOT_ACCOUNT_TYPES.includes(value as CopilotAccountType);
-
-// GitHub may grow new `copilot_plan` strings without notice, so unknown values
-// throw rather than mapping to a default.
-export const copilotPlanToAccountType = (plan: unknown): CopilotAccountType => {
-  const accountType = typeof plan === 'string' ? COPILOT_PLAN_TO_ACCOUNT_TYPE[plan] : undefined;
-  if (!accountType) throw new Error(`Unknown GitHub Copilot plan: ${JSON.stringify(plan)}`);
-  return accountType;
-};
-
 // Version constants pinned to a known-good set. GitHub Copilot rejects too-new
 // editor-plugin-version values (caozhiyuan/copilot-api@80e17dfd downgraded
 // 0.48.0 → 0.47.1 after upstream broke on the newer one); dynamically tracking
@@ -169,11 +135,11 @@ function isTokenValid(token: string | null, expiresAt: number): boolean {
   return expiresAt > now + 60;
 }
 
-async function getCopilotToken(upstreamId: string, githubToken: string, fetcher: Fetcher, signal: AbortSignal | undefined): Promise<string> {
+async function getCopilotToken(upstreamId: string, githubToken: string, fetcher: Fetcher, signal: AbortSignal | undefined): Promise<CopilotTokenEntry> {
   const now = Date.now();
   const cached = inProcessTokenCache.get(upstreamId);
   if (cached && isTokenValid(cached.entry.token, cached.entry.expiresAt) && now - cached.cachedAt < IN_PROCESS_TTL_MS) {
-    return cached.entry.token;
+    return cached.entry;
   }
 
   const fresh = await getRepo().upstreams.getById(upstreamId);
@@ -182,7 +148,7 @@ async function getCopilotToken(upstreamId: string, githubToken: string, fetcher:
   const persisted = state.copilotToken;
   if (persisted && isTokenValid(persisted.token, persisted.expiresAt)) {
     inProcessTokenCache.set(upstreamId, { entry: persisted, cachedAt: now });
-    return persisted.token;
+    return persisted;
   }
 
   // Routed through the upstream's Fetcher so deployments behind a network
@@ -191,32 +157,7 @@ async function getCopilotToken(upstreamId: string, githubToken: string, fetcher:
   // Copilot proxy would still see periodic auth-refresh failures every
   // ~25 minutes per process.
   return await withRetry(async () => {
-    // Token exchange is a GET against api.github.com (not POST); matches
-    // VSCode Copilot Chat and caozhiyuan/copilot-api. A POST returns 404.
-    // Forward the data-plane request's signal so a client disconnect
-    // during refresh tears the call down instead of burning the per-proxy
-    // dial deadline before unwinding.
-    const resp = await fetcher('https://api.github.com/copilot_internal/v2/token', {
-      method: 'GET',
-      headers: githubHeaders(githubToken),
-      signal,
-    });
-
-    if (!resp.ok) {
-      const text = await resp.text();
-      throw new CopilotTokenFetchError(resp.status, text, new Headers(resp.headers));
-    }
-
-    const data = (await resp.json()) as {
-      token: string;
-      expires_at: number;
-      refresh_in: number;
-    };
-
-    const entry: CopilotTokenEntry = {
-      token: data.token,
-      expiresAt: data.expires_at,
-    };
+    const entry = await exchangeCopilotToken(githubToken, fetcher, signal);
     inProcessTokenCache.set(upstreamId, { entry, cachedAt: Date.now() });
     // Best-effort persistence: a losing CAS or transient DB error must not
     // invalidate the freshly fetched token, which the caller is about to use
@@ -230,9 +171,48 @@ async function getCopilotToken(upstreamId: string, githubToken: string, fetcher:
     } catch (err) {
       console.warn(`Failed to persist Copilot token for ${upstreamId}:`, err);
     }
-
-    return data.token;
+    return entry;
   }, signal);
+}
+
+// Pure exchange against /copilot_internal/v2/token — no caching, no
+// persistence, no retry. Callers that want those wrap it (getCopilotToken
+// adds all three; the control-plane import path calls it once to validate
+// the PAT and seed initial state). Method is GET, not POST — POST returns
+// 404 from this endpoint (matches VSCode Copilot Chat and caozhiyuan/copilot-
+// api). `endpoints.api` is the per-tier data-plane host GitHub routes this
+// PAT to — it travels with the token because they share a lifetime
+// (vscode-copilot-chat 5863f5a7 domainServiceImpl.ts L55, refreshes on
+// every onDidStoreUpdate; all four reference implementations agree).
+export async function exchangeCopilotToken(githubToken: string, fetcher: Fetcher, signal?: AbortSignal): Promise<CopilotTokenEntry> {
+  const resp = await fetcher('https://api.github.com/copilot_internal/v2/token', {
+    method: 'GET',
+    headers: githubHeaders(githubToken),
+    signal,
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new CopilotTokenFetchError(resp.status, text, new Headers(resp.headers));
+  }
+
+  const data = (await resp.json()) as {
+    token: string;
+    expires_at: number;
+    refresh_in: number;
+    endpoints?: { api?: string };
+  };
+
+  const baseUrl = data.endpoints?.api;
+  if (typeof baseUrl !== 'string' || baseUrl === '') {
+    throw new Error('Copilot token exchange response missing endpoints.api');
+  }
+
+  return {
+    token: data.token,
+    expiresAt: data.expires_at,
+    baseUrl,
+  };
 }
 
 export interface CopilotFetchOptions {
@@ -250,19 +230,17 @@ export interface CopilotFetchOptions {
 export interface CopilotAuth {
   id: string;
   githubToken: string;
-  accountType: CopilotAccountType;
 }
 
 export async function copilotAuthedFetch(path: string, init: RequestInit, auth: CopilotAuth, options: CopilotFetchOptions): Promise<Response> {
-  const token = await getCopilotToken(auth.id, auth.githubToken, options.fetcher, init.signal ?? undefined);
-  const baseUrl = COPILOT_BASE_URLS[auth.accountType];
+  const entry = await getCopilotToken(auth.id, auth.githubToken, options.fetcher, init.signal ?? undefined);
 
   // x-request-id and x-agent-task-id share a single per-call UUID, mirroring
   // VSCode Copilot Chat's "one id ties the request to its background task" pattern.
   const requestId = crypto.randomUUID();
 
   const headers = new Headers(init.headers);
-  headers.set('Authorization', `Bearer ${token}`);
+  headers.set('Authorization', `Bearer ${entry.token}`);
   headers.set('Content-Type', 'application/json');
   headers.set('editor-version', EDITOR_VERSION);
   headers.set('editor-plugin-version', EDITOR_PLUGIN_VERSION);
@@ -294,7 +272,7 @@ export async function copilotAuthedFetch(path: string, init: RequestInit, auth: 
     }
   }
 
-  return await options.fetcher(`${baseUrl}${path}`, { ...init, headers }, options.recordUpstreamLatency);
+  return await options.fetcher(`${entry.baseUrl}${path}`, { ...init, headers }, options.recordUpstreamLatency);
 }
 
 // Headers for api.github.com calls — token exchange and /copilot_internal/user.

--- a/packages/provider-copilot/src/auth_test.ts
+++ b/packages/provider-copilot/src/auth_test.ts
@@ -7,6 +7,7 @@ import { initProviderRepo, directFetcher, type UpstreamRecord } from '@floway-de
 import { assertEquals, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
 const UPSTREAM_ID = 'up_copilot_test';
+const TOKEN_BASE_URL = 'https://api.individual.githubcopilot.com';
 
 const installRepoAndClearCache = async () => {
   let state: unknown = null;
@@ -22,7 +23,7 @@ const installRepoAndClearCache = async () => {
     flagOverrides: {},
     disabledPublicModelIds: [],
     proxyFallbackList: [],
-    config: { githubToken: 'ghu_test', accountType: 'individual', user: { id: 1, login: 't', name: null, avatar_url: '' } },
+    config: { githubToken: 'ghu_test', user: { id: 1, login: 't', name: null, avatar_url: '' } },
   };
   initProviderRepo(() => ({
     upstreams: {
@@ -50,7 +51,12 @@ const mockTokenAndCapture = async (
     async request => {
       const url = new URL(request.url);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'tok-test', expires_at: Math.floor(Date.now() / 1000) + 3600, refresh_in: 1800 });
+        return jsonResponse({
+          token: 'tok-test',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          refresh_in: 1800,
+          endpoints: { api: TOKEN_BASE_URL },
+        });
       }
       captured = new Headers(request.headers);
       return new Response('{}', { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
@@ -59,7 +65,7 @@ const mockTokenAndCapture = async (
       await copilotAuthedFetch(
         '/v1/messages',
         { method: 'POST', body: '{}' },
-        { id: UPSTREAM_ID, githubToken: 'ghu_test', accountType: 'individual' },
+        { id: UPSTREAM_ID, githubToken: 'ghu_test' },
         extraHeaders ? { headers: extraHeaders, fetcher: directFetcher } : { fetcher: directFetcher },
       );
     },
@@ -86,7 +92,7 @@ test('copilotAuthedFetch deletes a base header when the interceptor passes an em
   });
 });
 
-test('copilotAuthedFetch persists the minted Copilot token into state_json.copilotToken', async () => {
+test('copilotAuthedFetch persists the minted Copilot token (with baseUrl) into state_json.copilotToken', async () => {
   const harness = await installRepoAndClearCache();
   const expiresAt = Math.floor(Date.now() / 1000) + 3600;
 
@@ -94,7 +100,12 @@ test('copilotAuthedFetch persists the minted Copilot token into state_json.copil
     async request => {
       const url = new URL(request.url);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'tok-persisted', expires_at: expiresAt, refresh_in: 1800 });
+        return jsonResponse({
+          token: 'tok-persisted',
+          expires_at: expiresAt,
+          refresh_in: 1800,
+          endpoints: { api: TOKEN_BASE_URL },
+        });
       }
       return new Response('{}', { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
     },
@@ -102,7 +113,7 @@ test('copilotAuthedFetch persists the minted Copilot token into state_json.copil
       await copilotAuthedFetch(
         '/v1/messages',
         { method: 'POST', body: '{}' },
-        { id: UPSTREAM_ID, githubToken: 'ghu_test', accountType: 'individual' },
+        { id: UPSTREAM_ID, githubToken: 'ghu_test' },
         { fetcher: directFetcher },
       );
     },
@@ -112,6 +123,36 @@ test('copilotAuthedFetch persists the minted Copilot token into state_json.copil
   if (!persisted) throw new Error('expected state_json to be written');
   assertEquals(persisted.copilotToken?.token, 'tok-persisted');
   assertEquals(persisted.copilotToken?.expiresAt, expiresAt);
+  assertEquals(persisted.copilotToken?.baseUrl, TOKEN_BASE_URL);
+});
+
+test('copilotAuthedFetch routes the data-plane call through the baseUrl GitHub stamped on the token', async () => {
+  await installRepoAndClearCache();
+  let observedUrl: string | null = null;
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({
+          token: 'tok-test',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          refresh_in: 1800,
+          endpoints: { api: 'https://api.enterprise.githubcopilot.com' },
+        });
+      }
+      observedUrl = request.url;
+      return new Response('{}', { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
+    },
+    async () => {
+      await copilotAuthedFetch(
+        '/v1/messages',
+        { method: 'POST', body: '{}' },
+        { id: UPSTREAM_ID, githubToken: 'ghu_test' },
+        { fetcher: directFetcher },
+      );
+    },
+  );
+  assertEquals(observedUrl, 'https://api.enterprise.githubcopilot.com/v1/messages');
 });
 
 test('copilotAuthedFetch reads a still-valid Copilot token from state_json instead of refreshing', async () => {
@@ -124,7 +165,12 @@ test('copilotAuthedFetch reads a still-valid Copilot token from state_json inste
       const url = new URL(request.url);
       if (url.pathname === '/copilot_internal/v2/token') {
         tokenFetches++;
-        return jsonResponse({ token: 'tok-persisted', expires_at: Math.floor(Date.now() / 1000) + 3600, refresh_in: 1800 });
+        return jsonResponse({
+          token: 'tok-persisted',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          refresh_in: 1800,
+          endpoints: { api: TOKEN_BASE_URL },
+        });
       }
       upstreamFetches++;
       authHeader = request.headers.get('authorization');
@@ -134,7 +180,7 @@ test('copilotAuthedFetch reads a still-valid Copilot token from state_json inste
       const args = [
         '/v1/messages',
         { method: 'POST' as const, body: '{}' },
-        { id: UPSTREAM_ID, githubToken: 'ghu_test', accountType: 'individual' as const },
+        { id: UPSTREAM_ID, githubToken: 'ghu_test' },
         { fetcher: directFetcher },
       ] as const;
       await copilotAuthedFetch(...args);

--- a/packages/provider-copilot/src/config.ts
+++ b/packages/provider-copilot/src/config.ts
@@ -44,11 +44,6 @@ const copilotUserField = (value: unknown): CopilotUpstreamUser => {
   };
 };
 
-// Tolerates an unread `accountType` field surviving in legacy config_json
-// rows: that field used to drive the per-tier base URL, but the data-plane
-// host now travels with the bearer token (state.copilotToken.baseUrl) per
-// vscode-copilot-chat 5863f5a7 domainServiceImpl.ts. New writes never emit
-// it; a follow-up data migration will strip it from existing rows.
 export const assertCopilotUpstreamRecord = (record: UpstreamRecord): CopilotUpstreamRecord => {
   if (record.provider !== 'copilot') throw new Error(`Expected copilot upstream record, got ${record.provider}`);
   if (!isRecord(record.config)) throw new Error('Malformed copilot upstream config: config must be an object');

--- a/packages/provider-copilot/src/config.ts
+++ b/packages/provider-copilot/src/config.ts
@@ -1,4 +1,3 @@
-import { isCopilotAccountType, type CopilotAccountType } from './auth.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
 
 export interface CopilotUpstreamUser {
@@ -10,7 +9,6 @@ export interface CopilotUpstreamUser {
 
 export interface CopilotUpstreamConfig {
   githubToken: string;
-  accountType: CopilotAccountType;
   user: CopilotUpstreamUser;
 }
 
@@ -23,13 +21,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> => typeof va
 
 const stringField = (value: unknown, field: string): string => {
   if (typeof value !== 'string') throw new Error(`Malformed copilot upstream config: ${field} must be a string`);
-  return value;
-};
-
-const accountTypeField = (value: unknown): CopilotAccountType => {
-  if (!isCopilotAccountType(value)) {
-    throw new Error('Malformed copilot upstream config: accountType must be one of individual, business, enterprise');
-  }
   return value;
 };
 
@@ -53,6 +44,11 @@ const copilotUserField = (value: unknown): CopilotUpstreamUser => {
   };
 };
 
+// Tolerates an unread `accountType` field surviving in legacy config_json
+// rows: that field used to drive the per-tier base URL, but the data-plane
+// host now travels with the bearer token (state.copilotToken.baseUrl) per
+// vscode-copilot-chat 5863f5a7 domainServiceImpl.ts. New writes never emit
+// it; a follow-up data migration will strip it from existing rows.
 export const assertCopilotUpstreamRecord = (record: UpstreamRecord): CopilotUpstreamRecord => {
   if (record.provider !== 'copilot') throw new Error(`Expected copilot upstream record, got ${record.provider}`);
   if (!isRecord(record.config)) throw new Error('Malformed copilot upstream config: config must be an object');
@@ -61,7 +57,6 @@ export const assertCopilotUpstreamRecord = (record: UpstreamRecord): CopilotUpst
     provider: 'copilot',
     config: {
       githubToken: stringField(record.config.githubToken, 'githubToken'),
-      accountType: accountTypeField(record.config.accountType),
       user: copilotUserField(record.config.user),
     },
   };

--- a/packages/provider-copilot/src/fetch-models_test.ts
+++ b/packages/provider-copilot/src/fetch-models_test.ts
@@ -20,7 +20,7 @@ const installRepoAndConfig = async () => {
     flagOverrides: {},
     disabledPublicModelIds: [],
     proxyFallbackList: [],
-    config: { githubToken, accountType: 'individual', user: { id: 1, login: 't', name: null, avatar_url: '' } },
+    config: { githubToken, user: { id: 1, login: 't', name: null, avatar_url: '' } },
   };
   initProviderRepo(() => ({
     upstreams: {
@@ -29,14 +29,14 @@ const installRepoAndConfig = async () => {
     },
   }));
   clearInProcessCopilotTokenCache();
-  return { id, githubToken, accountType: 'individual' as const };
+  return { id, githubToken };
 };
 
 const copilotTokenResponse = (request: Request): Response | null => {
   const url = new URL(request.url);
   if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
   if (url.pathname === '/copilot_internal/v2/token') {
-    return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+    return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
   }
   return null;
 };

--- a/packages/provider-copilot/src/index.ts
+++ b/packages/provider-copilot/src/index.ts
@@ -2,10 +2,8 @@ export { createCopilotProvider } from './provider.ts';
 export {
   clearCopilotTokenCache,
   clearInProcessCopilotTokenCache,
-  copilotPlanToAccountType,
+  exchangeCopilotToken,
   githubHeaders,
-  isCopilotAccountType,
-  type CopilotAccountType,
 } from './auth.ts';
 export {
   assertCopilotUpstreamRecord,

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -160,7 +160,7 @@ const finalizeCopilotModels = (rawModels: CopilotRawModel[], enabledFlags: Reado
 
 export const createCopilotProvider = async (record: UpstreamRecord): Promise<ModelProviderInstance> => {
   const copilot = assertCopilotUpstreamRecord(record);
-  const upstreamConfig = { id: copilot.id, githubToken: copilot.config.githubToken, accountType: copilot.config.accountType };
+  const upstreamConfig = { id: copilot.id, githubToken: copilot.config.githubToken };
   // Computed once: only the upstream layer applies for this provider kind
   // (no per-model override layer).
   const upstreamFlags = resolveEffectiveFlags(defaultsForProvider('copilot'), [copilot.flagOverrides]);

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -27,7 +27,6 @@ const buildCopilotUpstream = (overrides: Partial<UpstreamRecord> = {}): Upstream
     ...rest,
     config: overrideConfig ?? {
       githubToken: `ghu_${crypto.randomUUID().replace(/-/g, '')}`,
-      accountType: 'individual',
       user: { id: 1, login: 'tester', name: 'Test User', avatar_url: 'https://example.com/avatar.png' },
     },
   };
@@ -139,6 +138,7 @@ test('Copilot provider exposes the highest-priority non-Claude endpoint', async 
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -183,6 +183,7 @@ test('Copilot provider exposes only Responses for Claude when available', async 
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -232,6 +233,7 @@ test('Copilot provider owns the claude-* Messages capability workaround', async 
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -285,6 +287,7 @@ test('Copilot provider selects raw variants that support the target endpoint', a
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -343,7 +346,7 @@ test('Copilot provider runs the Responses boundary chain on the compact path', a
 
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'gpt-resp', supported_endpoints: ['/responses'] }]));
@@ -419,6 +422,7 @@ test('Copilot provider exposes its default flag set via UpstreamModel.enabledFla
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -433,23 +437,6 @@ test('Copilot provider exposes its default flag set via UpstreamModel.enabledFla
       assertEquals(model.enabledFlags.has('retry-cyber-policy'), true);
       assertEquals(model.enabledFlags.has('messages-web-search-shim'), true);
     },
-  );
-});
-
-test('Copilot provider rejects malformed account type instead of falling back', async () => {
-  const { copilotUpstream } = await setupCopilotTest();
-
-  await assertRejects(
-    () =>
-      createCopilotProvider({
-        ...copilotUpstream,
-        config: {
-          ...(copilotUpstream.config as Record<string, unknown>),
-          accountType: 'toString',
-        },
-      }),
-    Error,
-    'accountType must be one of individual, business, enterprise',
   );
 });
 
@@ -471,6 +458,7 @@ test('Copilot provider forces stream=true for streaming endpoints and leaves cou
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -542,6 +530,7 @@ test('Copilot provider sets copilot-vision-request when an image is nested insid
           token: 'copilot-access-token',
           expires_at: 4102444800,
           refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
         });
       }
       if (url.pathname === '/models') {
@@ -617,7 +606,7 @@ test('Copilot Messages boundary chain does NOT fire on the Chat Completions wire
       const url = new URL(request.url);
       if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
       if (url.pathname === '/copilot_internal/v2/token') {
-        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
       }
       if (url.pathname === '/models') {
         return jsonResponse(copilotModels([{ id: 'gpt-chat', supported_endpoints: ['/chat/completions'] }]));
@@ -652,7 +641,7 @@ const copilotPreflight = (request: Request): Response | null => {
   const url = new URL(request.url);
   if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
   if (url.pathname === '/copilot_internal/v2/token') {
-    return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600 });
+    return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
   }
   return null;
 };
@@ -851,7 +840,7 @@ test('readCopilotUpstreamState round-trips a persisted state with both knownMode
       { object: 'list', data: [{ id: 'm1', name: 'm1', version: '1', supported_endpoints: [], capabilities: { type: 'chat', limits: {} } }] },
       1_000_000,
     ),
-    copilotToken: { token: 'tok', expiresAt: 2_000_000 },
+    copilotToken: { token: 'tok', expiresAt: 2_000_000, baseUrl: 'https://api.individual.githubcopilot.com' },
   };
   const round = readCopilotUpstreamState(JSON.parse(JSON.stringify(seeded)));
   assertEquals(round.copilotToken?.token, 'tok');

--- a/packages/provider-copilot/src/state.ts
+++ b/packages/provider-copilot/src/state.ts
@@ -6,11 +6,15 @@ import type { CopilotKnownModels } from './known-models.ts';
 
 // Short-lived Copilot session token minted by exchanging the operator-supplied
 // GitHub PAT against /copilot_internal/v2/token. The PAT itself lives in
-// CopilotUpstreamConfig; only the minted token (and its expiry) belong in
-// state.
+// CopilotUpstreamConfig; everything that comes back from the exchange — the
+// bearer token, its expiry, and the per-tier `endpoints.api` GitHub routes us
+// to — belongs in state. The base URL travels with the token because they
+// share a lifetime: a seat upgraded to a different tier yields a new bearer
+// and a new endpoints.api in the same response.
 export interface CopilotTokenEntry {
   token: string;
   expiresAt: number;
+  baseUrl: string;
 }
 
 export interface CopilotUpstreamState {
@@ -26,6 +30,7 @@ const ALLOWED_STATE_KEYS_MAP: Record<keyof CopilotUpstreamState, true> = {
 const ALLOWED_TOKEN_KEYS_MAP: Record<keyof CopilotTokenEntry, true> = {
   token: true,
   expiresAt: true,
+  baseUrl: true,
 };
 
 const assertCopilotTokenEntry = (value: unknown, where: string): void => {
@@ -43,6 +48,9 @@ const assertCopilotTokenEntry = (value: unknown, where: string): void => {
   }
   if (typeof obj.expiresAt !== 'number' || !Number.isFinite(obj.expiresAt)) {
     throw new TypeError(`${where}.expiresAt must be a finite number`);
+  }
+  if (typeof obj.baseUrl !== 'string' || obj.baseUrl === '') {
+    throw new TypeError(`${where}.baseUrl must be a non-empty string`);
   }
 };
 

--- a/packages/provider-copilot/src/state_test.ts
+++ b/packages/provider-copilot/src/state_test.ts
@@ -1,0 +1,65 @@
+import { test } from 'vitest';
+
+import { assertCopilotUpstreamState, readCopilotUpstreamState, type CopilotUpstreamState } from './state.ts';
+import { assertEquals, assertThrows } from '@floway-dev/test-utils';
+
+test('readCopilotUpstreamState passes through a complete new-shape entry verbatim', () => {
+  const seeded = {
+    knownModels: null,
+    copilotToken: { token: 'tok', expiresAt: 2_000_000, baseUrl: 'https://api.individual.githubcopilot.com' },
+  } satisfies CopilotUpstreamState;
+  const round = readCopilotUpstreamState(JSON.parse(JSON.stringify(seeded)));
+  assertEquals(round.copilotToken, seeded.copilotToken);
+});
+
+// Regression: pre-refactor rows persisted `{token, expiresAt}` without
+// baseUrl. The strict asserter must throw on read so the data-plane call
+// fails loudly until migration 0037_copilot_drop_legacy_state_shape strips
+// the partial entry; treating the legacy shape as "stale token, refresh
+// silently" would have hidden a real data-shape drift behind a refresh
+// loop, and CLAUDE.md disallows code-level compat for old data shapes.
+test('readCopilotUpstreamState throws on a legacy copilotToken entry that lacks baseUrl', () => {
+  const legacy = {
+    knownModels: null,
+    copilotToken: { token: 'tok', expiresAt: 2_000_000 },
+  };
+  assertThrows(
+    () => readCopilotUpstreamState(legacy),
+    TypeError,
+    'CopilotUpstreamState.copilotToken.baseUrl must be a non-empty string',
+  );
+});
+
+test('readCopilotUpstreamState treats a copilotToken:null state as valid', () => {
+  const round = readCopilotUpstreamState({ knownModels: null, copilotToken: null });
+  assertEquals(round.copilotToken, null);
+});
+
+test('readCopilotUpstreamState treats a state without copilotToken key as valid', () => {
+  const round = readCopilotUpstreamState({ knownModels: null });
+  assertEquals(round.copilotToken, null);
+});
+
+test('readCopilotUpstreamState collapses null/undefined raw to empty state', () => {
+  assertEquals(readCopilotUpstreamState(null), { knownModels: null, copilotToken: null });
+  assertEquals(readCopilotUpstreamState(undefined), { knownModels: null, copilotToken: null });
+});
+
+test('assertCopilotUpstreamState rejects an unknown top-level key', () => {
+  assertThrows(
+    () => assertCopilotUpstreamState({ knownModels: null, copilotToken: null, unexpected: 1 }),
+    TypeError,
+    "CopilotUpstreamState has unexpected key 'unexpected'",
+  );
+});
+
+test('assertCopilotUpstreamState rejects an unknown key inside copilotToken', () => {
+  assertThrows(
+    () => assertCopilotUpstreamState({
+      knownModels: null,
+      copilotToken: { token: 'tok', expiresAt: 1, baseUrl: 'https://api.individual.githubcopilot.com', unexpected: true },
+    }),
+    TypeError,
+    "CopilotUpstreamState.copilotToken has unexpected key 'unexpected'",
+  );
+});


### PR DESCRIPTION
## Summary

- **`refactor`**: Copilot per-tier data-plane host comes from `/copilot_internal/v2/token`'s `endpoints.api` (matches VSCode), not a static `accountType` enum.
- **`fix`**: migration 0037 strips legacy `config.accountType` and `state.copilotToken` entries that lack `baseUrl`; adds regression tests; consolidates dashboard display fallback; widens Node undici-pool match to `*.githubcopilot.com`.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `test` green (2780 tests, +13 regression)
- [x] Local D1 migration chain applies cleanly
- [x] Deployed to prod from this branch; both Copilot rows self-healed to correct enterprise host