### PR TITLE
fix(gateway): scrub HTTP framing + hop-by-hop from inbound headers

### DIFF
--- a/packages/gateway/src/data-plane/shared/inbound-headers.ts
+++ b/packages/gateway/src/data-plane/shared/inbound-headers.ts
@@ -1,27 +1,50 @@
 import type { Context } from 'hono';
 
-// Headers that authenticate the client to the gateway, plus per-hop
-// headers the inbound request sets for the gateway-side connection.
-// Azure and custom upstreams pass `opts.headers` straight to the wire
-// after setting their own pinned auth (`api-key` on Azure's OpenAI
-// surface, `x-api-key` on the Anthropic surface, `Authorization: Bearer`
-// on custom), so an inbound copy of any of these would override the
-// pinned value and either leak a gateway-private credential or hand the
-// upstream a value the client controls. `content-type` is stripped for
-// the same reason: each provider sets it from the wire-body shape it
-// builds, and a FormData passthrough additionally needs the runtime to
-// derive a fresh multipart boundary on the outbound request.
-// Forwarded-* / `cf-*` / `x-real-ip` and similar non-secret diagnostic
-// signals stay in the bag — they identify the client at the upstream and
-// have no clobber risk. Copilot and Codex clone before they merge, so
-// they inherit the scrub for free.
-const GATEWAY_PRIVATE_INBOUND_HEADERS = [
+// Headers stripped from the inbound request before the data plane threads
+// the bag down to the provider boundary. Three groups, one deny-list:
+//
+// - Gateway-owned auth + identity. Providers pin their own credentials and
+//   content-type on the wire (Azure's `api-key`, Anthropic's `x-api-key`,
+//   `Authorization: Bearer`, each provider's body-derived `content-type`,
+//   the runtime's freshly-derived multipart boundary for FormData
+//   passthrough). Letting any of these survive would clobber a pinned
+//   value or leak a private one.
+//
+// - HTTP/1.1 framing + hop-by-hop (RFC 9110 §7.6.1). `content-length` and
+//   `transfer-encoding` describe the inbound body and would mis-frame the
+//   re-serialized outbound body — on Node this surfaces as undici's
+//   `RequestContentLengthMismatchError`; Workers' `fetch` silently rewrites
+//   the framing. `connection`, `keep-alive`, `proxy-connection`, `te`,
+//   `trailer`, `upgrade`, `expect` are end-to-end meaningless; the runtime
+//   fetch refuses most of them outright.
+//
+// - `accept-encoding`. End-to-end in spec terms, transport-level in
+//   practice: the runtime fetch advertises the encodings it can
+//   transparently decode, and SSE upstreams must stay uncompressed
+//   end-to-end so stream parsers see raw bytes.
+//
+// Non-secret propagation signals (`forwarded`, `cf-*`, `x-real-ip`,
+// `user-agent`, vendor `anthropic-*` / `openai-*` betas, and any other
+// business header the client sends) stay in the bag and reach the
+// upstream. Copilot and Codex clone the bag before merging their own
+// pinned headers, so they inherit the scrub for free.
+const SCRUBBED_INBOUND_HEADERS = [
+  'accept-encoding',
   'api-key',
   'authorization',
+  'connection',
+  'content-length',
   'content-type',
   'cookie',
+  'expect',
   'host',
+  'keep-alive',
   'proxy-authorization',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
   'x-api-key',
   'x-floway-session',
   'x-goog-api-key',
@@ -29,11 +52,11 @@ const GATEWAY_PRIVATE_INBOUND_HEADERS = [
 
 // Build the unified inbound-headers bag the data plane threads to the
 // provider boundary. Copies the source request's headers and removes the
-// gateway's own auth + per-hop signals before the provider can observe
-// them, regardless of whether the provider passes the bag through (Azure,
-// custom) or clones it into a boundary ctx (Copilot, Codex).
+// scrub set before the provider can observe them, regardless of whether
+// the provider passes the bag through (Azure, custom, Ollama) or clones
+// it into a boundary ctx (Copilot, Codex).
 export const inboundHeadersForUpstream = (c: Context): Headers => {
   const headers = new Headers(c.req.raw.headers);
-  for (const name of GATEWAY_PRIVATE_INBOUND_HEADERS) headers.delete(name);
+  for (const name of SCRUBBED_INBOUND_HEADERS) headers.delete(name);
   return headers;
 };

--- a/packages/gateway/src/data-plane/shared/inbound-headers_test.ts
+++ b/packages/gateway/src/data-plane/shared/inbound-headers_test.ts
@@ -46,6 +46,52 @@ describe('inboundHeadersForUpstream', () => {
     assertEquals(headers.get('user-agent'), 'claude-sdk/1.0');
   });
 
+  test('strips HTTP/1.1 framing, hop-by-hop, and accept-encoding while preserving propagation signals', async () => {
+    const app = new Hono();
+    let headers: Headers | undefined;
+    app.post('/test', c => {
+      headers = inboundHeadersForUpstream(c);
+      return c.text('ok');
+    });
+    await app.request('/test', {
+      method: 'POST',
+      headers: {
+        'accept-encoding': 'gzip, br',
+        'connection': 'keep-alive',
+        'content-length': '17',
+        'expect': '100-continue',
+        'keep-alive': 'timeout=5',
+        'proxy-connection': 'keep-alive',
+        'te': 'trailers',
+        'trailer': 'X-After',
+        'transfer-encoding': 'chunked',
+        'upgrade': 'websocket',
+        'forwarded': 'for=192.0.2.1;proto=https',
+        'x-real-ip': '192.0.2.1',
+        'x-forwarded-for': '192.0.2.1',
+      },
+      body: 'inbound-body-bytes',
+    });
+    assertExists(headers);
+    for (const name of [
+      'accept-encoding',
+      'connection',
+      'content-length',
+      'expect',
+      'keep-alive',
+      'proxy-connection',
+      'te',
+      'trailer',
+      'transfer-encoding',
+      'upgrade',
+    ]) {
+      assertEquals(headers.has(name), false);
+    }
+    assertEquals(headers.get('forwarded'), 'for=192.0.2.1;proto=https');
+    assertEquals(headers.get('x-real-ip'), '192.0.2.1');
+    assertEquals(headers.get('x-forwarded-for'), '192.0.2.1');
+  });
+
   test('returns a fresh Headers each call so mutations do not leak across requests', async () => {
     const app = new Hono();
     let first: Headers | undefined;


### PR DESCRIPTION
## Summary

After we collapsed the provider-boundary header conduits into a single `opts.headers: Headers`, the inbound-headers scrub only removed nine gateway-private auth/identity entries before threading the bag to every upstream `fetch`. Everything else — including HTTP/1.1 framing and hop-by-hop headers — survived.

On Cloudflare Workers this was invisible: the runtime silently rewrites Fetch-spec forbidden request headers. On the self-hosted Node target, undici refuses to forward `content-length` / `transfer-encoding` / `connection` / `keep-alive` / `te` / `upgrade` / `expect`; the inbound `content-length` additionally never matches the body each provider re-serializes via `JSON.stringify(...)`, surfacing as undici's `RequestContentLengthMismatchError`. Every protocol entry maps that throw to `internalErrorResult(502, …)` — so every request becomes a 502.

Extend the scrub list to cover:

- **HTTP/1.1 framing + hop-by-hop (RFC 9110 §7.6.1)**: `content-length`, `transfer-encoding`, `connection`, `keep-alive`, `proxy-connection`, `te`, `trailer`, `upgrade`, `expect`.
- **`accept-encoding`**: end-to-end in spec, transport-level in practice. The runtime fetch advertises encodings it can transparently decode, and SSE upstreams must stay uncompressed end-to-end so stream parsers see raw bytes.

Stays a deny-list — arbitrary business headers (`forwarded`, `cf-*`, `x-real-ip`, `user-agent`, vendor `anthropic-*` / `openai-*` betas, any custom client header) keep propagating to the upstream untouched.

Closes #77

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm exec vitest run packages/gateway/src/data-plane/shared/inbound-headers_test.ts` (3 / 3, including the new framing/hop-by-hop case)
- [x] `pnpm --filter @floway-dev/gateway run test` (2781 / 2781)
- [x] `pnpm exec eslint --cache packages/gateway`