### PR TITLE
fix(provider-ollama): iterate extraHeaders as a Headers instance

### DIFF
--- a/packages/provider-ollama/src/fetch.ts
+++ b/packages/provider-ollama/src/fetch.ts
@@ -31,7 +31,7 @@ const ollamaFetchInternal = async (
     headers.set('Content-Type', 'application/json');
   }
   if (options.extraHeaders) {
-    for (const [k, v] of Object.entries(options.extraHeaders)) headers.set(k, v);
+    for (const [k, v] of options.extraHeaders) headers.set(k, v);
   }
   return await options.fetcher(joinBaseAndPath(config.baseUrl, path), { ...init, headers }, options.recordUpstreamLatency);
 };

--- a/packages/provider-ollama/src/fetch_test.ts
+++ b/packages/provider-ollama/src/fetch_test.ts
@@ -109,3 +109,33 @@ test('Content-Type defaults to application/json for JSON bodies', async () => {
   );
   assertEquals(contentType, 'application/json');
 });
+
+test('extraHeaders is a Headers instance and every entry reaches the wire', async () => {
+  const { config } = assertOllamaUpstreamRecord(baseRecord);
+  let userAgent: string | null = null;
+  let forwarded: string | null = null;
+  let anthropicBeta: string | null = null;
+  await withMockedFetch(
+    request => {
+      userAgent = request.headers.get('User-Agent');
+      forwarded = request.headers.get('Forwarded');
+      anthropicBeta = request.headers.get('anthropic-beta');
+      return new Response('{}', { status: 200 });
+    },
+    async () => {
+      const extraHeaders = new Headers({
+        'User-Agent': 'claude-sdk/1.0',
+        'Forwarded': 'for=192.0.2.1;proto=https',
+        'anthropic-beta': 'context-1m',
+      });
+      await ollamaFetchChatCompletions(
+        config,
+        { method: 'POST', body: '{}' },
+        { fetcher: directFetcher, extraHeaders },
+      );
+    },
+  );
+  assertEquals(userAgent, 'claude-sdk/1.0');
+  assertEquals(forwarded, 'for=192.0.2.1;proto=https');
+  assertEquals(anthropicBeta, 'context-1m');
+});


### PR DESCRIPTION
## Summary

`UpstreamFetchOptions.extraHeaders` is typed `Headers` (see `packages/provider/src/options.ts`), but the Ollama transport unwrapped it with `Object.entries(options.extraHeaders)`. `Object.entries` on a `Headers` instance returns `[]` — so every inbound header (`user-agent`, `forwarded`, vendor betas, anything an interceptor stamped on for the downstream) was silently dropped on the Ollama path.

The other providers (`provider-azure`, `provider-custom`, `provider-copilot`, `provider-codex`) iterate `Headers` directly with `for (const [k, v] of headers)`. Align Ollama with them.

## Test plan

- [x] `pnpm --filter @floway-dev/provider-ollama run typecheck`
- [x] `pnpm --filter @floway-dev/provider-ollama run test` (21 / 21, including the new `extraHeaders` reach-the-wire case)
- [x] `pnpm exec eslint --cache packages/provider-ollama`