### PR TITLE
fix(gateway): isolate upstream catalog failures from model routing

### DIFF
--- a/packages/gateway/src/data-plane/embeddings/serve_test.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve_test.ts
@@ -327,7 +327,11 @@ test('/v1/embeddings rejects model on custom upstream without /embeddings capabi
   );
 });
 
-test('/v1/embeddings preserves custom upstream /models HTTP errors', async () => {
+// A custom upstream whose `/v1/models` fetch rejects is treated as
+// temporarily empty: the request resolves to 404 model-missing with the
+// failing upstream's display name appended parenthetically, instead of
+// the gateway forwarding the upstream's raw HTTP status to the client.
+test('/v1/embeddings reports the failed upstream parenthetically when /v1/models rejects', async () => {
   const { apiKey, repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
   clearInProcessCopilotTokenCache();
@@ -370,15 +374,22 @@ test('/v1/embeddings preserves custom upstream /models HTTP errors', async () =>
         }),
       });
 
-      assertEquals(response.status, 403);
+      assertEquals(response.status, 404);
       assertEquals(await response.json(), {
-        error: { message: 'bad embed key' },
+        error: {
+          message: 'Model custom-embed-model is not available on any configured upstream (models from upstream(s) "Embedding Provider" failed to load).',
+          type: 'api_error',
+        },
       });
     },
   );
 });
 
-test('/v1/embeddings preserves model-load errors hidden by another provider', async () => {
+// Even when a second upstream's catalog loads successfully (and so its
+// models are routable), the rejected upstream's name still surfaces in
+// the model-missing body so the operator can tell the failure apart
+// from a genuine "no upstream has this model" miss.
+test('/v1/embeddings reports the failed upstream even when a sibling upstream\'s catalog loads', async () => {
   const { apiKey, repo } = await setupAppTest();
   clearInProcessCopilotTokenCache();
 
@@ -434,9 +445,9 @@ test('/v1/embeddings preserves model-load errors hidden by another provider', as
         }),
       });
 
-      assertEquals(response.status, 403);
+      assertEquals(response.status, 404);
       const body = await response.json();
-      assertEquals(body.error.message, 'bad embed key');
+      assertEquals(body.error.message, 'Model custom-embed-model is not available on any configured upstream (models from upstream(s) "Embedding Provider" failed to load).');
     },
   );
 });

--- a/packages/gateway/src/data-plane/llm/chat-completions/errors.ts
+++ b/packages/gateway/src/data-plane/llm/chat-completions/errors.ts
@@ -1,3 +1,4 @@
+import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { LlmServeFailure } from '../shared/errors.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
@@ -27,8 +28,8 @@ export const renderChatCompletionsFailure = (
   case 'routing-unavailable':
     return openAiErrorResult(400, failure.message, { param: 'input', code: 'responses_item_routing_unavailable' });
   case 'model-missing':
-    return openAiErrorResult(404, `Model ${failure.model} is not available on any configured upstream.`);
+    return openAiErrorResult(404, appendFailedUpstreams(`Model ${failure.model} is not available on any configured upstream.`, failure.failedUpstreams));
   case 'model-unsupported':
-    return openAiErrorResult(400, `Model ${failure.model} does not support the /chat/completions endpoint.`);
+    return openAiErrorResult(400, appendFailedUpstreams(`Model ${failure.model} does not support the /chat/completions endpoint.`, failure.failedUpstreams));
   }
 };

--- a/packages/gateway/src/data-plane/llm/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/llm/chat-completions/serve.ts
@@ -18,7 +18,7 @@ export interface ChatCompletionsServeGenerateArgs {
 export const chatCompletionsServe = {
   generate: async (args: ChatCompletionsServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
     const { payload, ctx, store, headers } = args;
-    const { candidates, sawModel } = await enumerateProviderCandidates({
+    const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
       pickTarget: endpoints =>
@@ -40,8 +40,8 @@ export const chatCompletionsServe = {
     if (candidate === undefined) {
       return renderChatCompletionsFailure(
         sawModel
-          ? { kind: 'model-unsupported', model: payload.model }
-          : { kind: 'model-missing', model: payload.model },
+          ? { kind: 'model-unsupported', model: payload.model, failedUpstreams }
+          : { kind: 'model-missing', model: payload.model, failedUpstreams },
       );
     }
     return await chatCompletionsAttempt.generate({ payload, ctx, store, candidate, headers });

--- a/packages/gateway/src/data-plane/llm/gemini/errors.ts
+++ b/packages/gateway/src/data-plane/llm/gemini/errors.ts
@@ -1,3 +1,4 @@
+import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { LlmServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiStreamEvent } from '@floway-dev/protocols/gemini';
@@ -48,8 +49,8 @@ export const renderGeminiFailure = (
   case 'routing-unavailable':
     return geminiRpcErrorResult(400, failure.message);
   case 'model-missing':
-    return geminiRpcErrorResult(404, `Model ${failure.model} is not available on any configured upstream.`);
+    return geminiRpcErrorResult(404, appendFailedUpstreams(`Model ${failure.model} is not available on any configured upstream.`, failure.failedUpstreams));
   case 'model-unsupported':
-    return geminiRpcErrorResult(400, `Model ${failure.model} does not support ${endpoint === 'countTokens' ? 'countTokens' : 'the Gemini generateContent endpoint'}.`);
+    return geminiRpcErrorResult(400, appendFailedUpstreams(`Model ${failure.model} does not support ${endpoint === 'countTokens' ? 'countTokens' : 'the Gemini generateContent endpoint'}.`, failure.failedUpstreams));
   }
 };

--- a/packages/gateway/src/data-plane/llm/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/llm/gemini/serve.ts
@@ -30,7 +30,7 @@ export interface GeminiServeCountTokensArgs {
 export const geminiServe = {
   generate: async (args: GeminiServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> => {
     const { payload, ctx, store, model, headers } = args;
-    const { candidates, sawModel } = await enumerateProviderCandidates({
+    const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
       // Gemini has no native upstream target in the provider API; prefer
@@ -50,8 +50,8 @@ export const geminiServe = {
     if (candidate === undefined) {
       return renderGeminiFailure(
         sawModel
-          ? { kind: 'model-unsupported', model }
-          : { kind: 'model-missing', model },
+          ? { kind: 'model-unsupported', model, failedUpstreams }
+          : { kind: 'model-missing', model, failedUpstreams },
         'generate',
       );
     }
@@ -60,7 +60,7 @@ export const geminiServe = {
 
   countTokens: async (args: GeminiServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | PlainResult> => {
     const { payload, ctx, store, model, headers } = args;
-    const { candidates, sawModel } = await enumerateProviderCandidates({
+    const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
       // Gemini countTokens has no native upstream support; only providers
@@ -80,8 +80,8 @@ export const geminiServe = {
     if (candidate === undefined) {
       return renderGeminiFailure(
         sawModel
-          ? { kind: 'model-unsupported', model }
-          : { kind: 'model-missing', model },
+          ? { kind: 'model-unsupported', model, failedUpstreams }
+          : { kind: 'model-missing', model, failedUpstreams },
         'countTokens',
       );
     }

--- a/packages/gateway/src/data-plane/llm/messages/errors.ts
+++ b/packages/gateway/src/data-plane/llm/messages/errors.ts
@@ -1,3 +1,4 @@
+import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { LlmServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -32,8 +33,8 @@ export const renderMessagesFailure = (
   case 'routing-unavailable':
     return anthropicErrorResult(400, 'invalid_request_error', failure.message);
   case 'model-missing':
-    return anthropicErrorResult(404, 'not_found_error', `Model ${failure.model} is not available on any configured upstream.`);
+    return anthropicErrorResult(404, 'not_found_error', appendFailedUpstreams(`Model ${failure.model} is not available on any configured upstream.`, failure.failedUpstreams));
   case 'model-unsupported':
-    return anthropicErrorResult(400, 'invalid_request_error', `Model ${failure.model} does not support the ${endpointPath} endpoint.`);
+    return anthropicErrorResult(400, 'invalid_request_error', appendFailedUpstreams(`Model ${failure.model} does not support the ${endpointPath} endpoint.`, failure.failedUpstreams));
   }
 };

--- a/packages/gateway/src/data-plane/llm/messages/serve.ts
+++ b/packages/gateway/src/data-plane/llm/messages/serve.ts
@@ -25,7 +25,7 @@ export interface MessagesServeCountTokensArgs {
 export const messagesServe = {
   generate: async (args: MessagesServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => {
     const { payload, ctx, store, headers } = args;
-    const { candidates, sawModel } = await enumerateProviderCandidates({
+    const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
       pickTarget: endpoints =>
@@ -47,8 +47,8 @@ export const messagesServe = {
     if (candidate === undefined) {
       return renderMessagesFailure(
         sawModel
-          ? { kind: 'model-unsupported', model: payload.model }
-          : { kind: 'model-missing', model: payload.model },
+          ? { kind: 'model-unsupported', model: payload.model, failedUpstreams }
+          : { kind: 'model-missing', model: payload.model, failedUpstreams },
         'generate',
       );
     }
@@ -57,7 +57,7 @@ export const messagesServe = {
 
   countTokens: async (args: MessagesServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | PlainResult> => {
     const { payload, ctx, store, headers } = args;
-    const { candidates, sawModel } = await enumerateProviderCandidates({
+    const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
       pickTarget: endpoints => endpoints.messages ? 'messages' : null,
@@ -74,8 +74,8 @@ export const messagesServe = {
     if (candidate === undefined) {
       return renderMessagesFailure(
         sawModel
-          ? { kind: 'model-unsupported', model: payload.model }
-          : { kind: 'model-missing', model: payload.model },
+          ? { kind: 'model-unsupported', model: payload.model, failedUpstreams }
+          : { kind: 'model-missing', model: payload.model, failedUpstreams },
         'countTokens',
       );
     }

--- a/packages/gateway/src/data-plane/llm/responses/errors.ts
+++ b/packages/gateway/src/data-plane/llm/responses/errors.ts
@@ -1,3 +1,4 @@
+import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { LlmServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -28,8 +29,8 @@ export const renderResponsesFailure = (
   case 'routing-unavailable':
     return openAiErrorResult(400, failure.message, { param: 'input', code: 'responses_item_routing_unavailable' });
   case 'model-missing':
-    return openAiErrorResult(404, `Model ${failure.model} is not available on any configured upstream.`);
+    return openAiErrorResult(404, appendFailedUpstreams(`Model ${failure.model} is not available on any configured upstream.`, failure.failedUpstreams));
   case 'model-unsupported':
-    return openAiErrorResult(400, `Model ${failure.model} does not support the /responses endpoint.`);
+    return openAiErrorResult(400, appendFailedUpstreams(`Model ${failure.model} does not support the /responses endpoint.`, failure.failedUpstreams));
   }
 };

--- a/packages/gateway/src/data-plane/llm/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/llm/responses/interceptors/server-tools/image-generation.ts
@@ -1,6 +1,7 @@
 import { createPerRequestFetcher } from '../../../../../dial/per-request.ts';
 import { sleep } from '../../../../../shared/sleep.ts';
 import { resolveModelForRequest } from '../../../../providers/registry.ts';
+import { appendFailedUpstreams } from '../../../../shared/failed-upstreams.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency } from '../../../../shared/telemetry/performance.ts';
 import { recordTokenUsage, tokenUsageFromImagesResponse } from '../../../../shared/telemetry/usage.ts';
 import type { GatewayCtx } from '../../../shared/gateway-ctx.ts';
@@ -545,7 +546,7 @@ const resolveImageBinding = async (
       ok: false,
       error: {
         type: 'image_generation_error',
-        message: `No upstream provides model '${state.config.model}' for the ${endpointPath} endpoint.`,
+        message: appendFailedUpstreams(`No upstream provides model '${state.config.model}' for the ${endpointPath} endpoint.`, resolution.failedUpstreams),
         code: 'model_not_found',
         retryable: false,
       },

--- a/packages/gateway/src/data-plane/llm/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/llm/responses/serve-prep.ts
@@ -88,7 +88,7 @@ export const prepareResponsesServePlan = async (args: {
 }): Promise<ResponsesServePlan> => {
   const { payload, ctx, store, pickTarget } = args;
   const prepared = await expandPreviousResponseId(payload, store);
-  const { candidates, sawModel } = await enumerateProviderCandidates({
+  const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
     upstreamIds: ctx.upstreamIds,
     model: prepared.model,
     pickTarget,
@@ -114,8 +114,8 @@ export const prepareResponsesServePlan = async (args: {
       kind: 'failure',
       result: renderResponsesFailure(
         sawModel
-          ? { kind: 'model-unsupported', model: prepared.model }
-          : { kind: 'model-missing', model: prepared.model },
+          ? { kind: 'model-unsupported', model: prepared.model, failedUpstreams }
+          : { kind: 'model-missing', model: prepared.model, failedUpstreams },
       ),
     };
   }

--- a/packages/gateway/src/data-plane/llm/shared/candidates.ts
+++ b/packages/gateway/src/data-plane/llm/shared/candidates.ts
@@ -9,7 +9,9 @@ export type { ProviderCandidate };
 // Returns the candidates that satisfy both the model resolution and the
 // target-endpoint pick, plus a `sawModel` flag that distinguishes the
 // "model is missing entirely" failure from "model exists but does not
-// expose the endpoint this source needs".
+// expose the endpoint this source needs", plus the names of upstreams
+// whose catalog fetch rejected this round so the caller's failure
+// renderer can surface them parenthetically.
 export const enumerateProviderCandidates = async ({
   upstreamIds, model, pickTarget, scheduler, currentColo,
 }: {
@@ -25,23 +27,46 @@ export const enumerateProviderCandidates = async ({
   // Threaded into the per-request fetcher so colo-scoped fallback entries
   // can be honoured at dial time.
   currentColo: string | null;
-}): Promise<{ readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }> => {
+}): Promise<{ readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }> => {
   const fetcherForUpstream = await createPerRequestFetcher(currentColo);
   const providers = await listModelProviders(upstreamIds);
+
+  // Fan out per-upstream and recover each rejection as a "this upstream
+  // has no models for this request" result rather than propagating the
+  // first failure: one upstream past HARD whose force re-fetch fails
+  // must not poison routing for other upstreams. The cache layer
+  // already memoizes in-flight fetches per upstream so the parallel
+  // walk does not multiply upstream round trips. Results are kept in
+  // input order so candidate priority (first viable candidate wins)
+  // matches the configured provider order.
+  const settled = await Promise.allSettled(providers.map(provider =>
+    resolveModelForProvider(provider, model, fetcherForUpstream(provider.upstream), scheduler)
+      .then(resolved => ({ provider, resolved }))));
+
   const candidates: ProviderCandidate[] = [];
+  const failedUpstreams: string[] = [];
   let sawModel = false;
 
-  for (const provider of providers) {
-    const fetcher = fetcherForUpstream(provider.upstream);
-    const resolved = await resolveModelForProvider(provider, model, fetcher, scheduler);
+  for (const [index, result] of settled.entries()) {
+    const provider = providers[index];
+    if (result.status === 'rejected') {
+      const error = result.reason;
+      // Caller-driven cancellation must propagate; see the matching
+      // guard in `collectProviderModels`.
+      if (error instanceof Error && error.name === 'AbortError') throw error;
+      failedUpstreams.push(provider.name);
+      continue;
+    }
+
+    const { resolved } = result.value;
     if (!resolved) continue;
     sawModel = true;
 
     const targetApi = pickTarget(resolved.binding.upstreamModel.endpoints);
     if (!targetApi) continue;
 
-    candidates.push({ provider, binding: resolved.binding, targetApi, fetcher });
+    candidates.push({ provider, binding: resolved.binding, targetApi, fetcher: fetcherForUpstream(provider.upstream) });
   }
 
-  return { candidates, sawModel };
+  return { candidates, sawModel, failedUpstreams };
 };

--- a/packages/gateway/src/data-plane/llm/shared/candidates_test.ts
+++ b/packages/gateway/src/data-plane/llm/shared/candidates_test.ts
@@ -1,10 +1,11 @@
 import { describe, test } from 'vitest';
 
 import { enumerateProviderCandidates } from './candidates.ts';
-import { setupAppTest } from '../../../test-helpers.ts';
+import { buildCustomUpstreamRecord, setupAppTest } from '../../../test-helpers.ts';
+import { clearInFlightForTesting } from '../../providers/models-cache.ts';
 import type { ModelEndpoints } from '@floway-dev/protocols/common';
 import type { LlmTargetApi, UpstreamRecord } from '@floway-dev/provider';
-import { assertEquals } from '@floway-dev/test-utils';
+import { assertEquals, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
 // Drains SWR background revalidate so a rejection surfaces in the runner
 // instead of being swallowed.
@@ -214,5 +215,88 @@ describe('enumerateProviderCandidates', () => {
     assertEquals(msgCandidates.length, 0);
     // pickTarget filtered out, but the model exists — sawModel stays true.
     assertEquals(sawModel, true);
+  });
+
+  // Regression: a single upstream whose catalog fetch rejects must not poison
+  // the loop. The healthy upstreams still produce candidates and the broken
+  // upstream's display name surfaces via failedUpstreams so the eventual
+  // serve-side error renderer can mention it.
+  test('a single rejecting upstream does not block candidates from healthy upstreams', async () => {
+    clearInFlightForTesting();
+    const { repo } = await setupAppTest();
+    await repo.upstreams.deleteAll();
+    await repo.upstreams.save(buildCustomUpstreamRecord({
+      id: 'up_broken',
+      name: 'Broken upstream',
+      sortOrder: 1,
+      config: { baseUrl: 'https://broken.example.com', bearerToken: 'sk-x', endpoints: { messages: {} } },
+    }));
+    await repo.upstreams.save(azureUpstream('up_ok', 2, ['test-model'], { messages: {} }));
+
+    await withMockedFetch(
+      request => {
+        const url = new URL(request.url);
+        if (url.hostname === 'broken.example.com' && url.pathname === '/v1/models') {
+          return jsonResponse({ error: 'upstream went down' }, 502);
+        }
+        throw new Error(`Unhandled fetch ${request.url}`);
+      },
+      async () => {
+        const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
+          upstreamIds: null,
+          model: 'test-model',
+          pickTarget: pickMessages,
+          scheduler: testScheduler,
+          currentColo: null,
+        });
+
+        assertEquals(candidates.length, 1);
+        assertEquals(candidates[0].provider.upstream, 'up_ok');
+        assertEquals(sawModel, true);
+        assertEquals(failedUpstreams, ['Broken upstream']);
+      },
+    );
+  });
+
+  // When every upstream's catalog rejects, the request gets an empty candidate
+  // list and sawModel=false — the LLM serve sites turn that into model-missing
+  // with the failed-upstream parenthetical attached.
+  test('all upstreams rejecting yields no candidates, sawModel=false, and every name in failedUpstreams', async () => {
+    clearInFlightForTesting();
+    const { repo } = await setupAppTest();
+    await repo.upstreams.deleteAll();
+    await repo.upstreams.save(buildCustomUpstreamRecord({
+      id: 'up_a',
+      name: 'A',
+      sortOrder: 1,
+      config: { baseUrl: 'https://a.example.com', bearerToken: 'sk-x', endpoints: { messages: {} } },
+    }));
+    await repo.upstreams.save(buildCustomUpstreamRecord({
+      id: 'up_b',
+      name: 'B',
+      sortOrder: 2,
+      config: { baseUrl: 'https://b.example.com', bearerToken: 'sk-x', endpoints: { messages: {} } },
+    }));
+
+    await withMockedFetch(
+      request => {
+        const url = new URL(request.url);
+        if (url.pathname === '/v1/models') return jsonResponse({ error: 'down' }, 502);
+        throw new Error(`Unhandled fetch ${request.url}`);
+      },
+      async () => {
+        const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
+          upstreamIds: null,
+          model: 'test-model',
+          pickTarget: pickMessages,
+          scheduler: testScheduler,
+          currentColo: null,
+        });
+
+        assertEquals(candidates.length, 0);
+        assertEquals(sawModel, false);
+        assertEquals(failedUpstreams, ['A', 'B']);
+      },
+    );
   });
 });

--- a/packages/gateway/src/data-plane/llm/shared/errors.ts
+++ b/packages/gateway/src/data-plane/llm/shared/errors.ts
@@ -1,8 +1,13 @@
 // Failures a protocol can render before reaching an upstream; unexpected
-// throws bubble as-is.
+// throws bubble as-is. `failedUpstreams` on model-{missing,unsupported}
+// carries the upstream names whose catalog fetch threw during this
+// resolution — surfaced parenthetically so the caller can tell a genuine
+// "no upstream has this model" miss from a transient outage where the
+// upstream that owns the model is currently unreachable. Empty / absent
+// means every consulted upstream returned a catalog.
 export type LlmServeFailure =
-  | { readonly kind: 'model-missing'; readonly model: string }
-  | { readonly kind: 'model-unsupported'; readonly model: string }
+  | { readonly kind: 'model-missing'; readonly model: string; readonly failedUpstreams?: readonly string[] }
+  | { readonly kind: 'model-unsupported'; readonly model: string; readonly failedUpstreams?: readonly string[] }
   | { readonly kind: 'item-not-found'; readonly itemId: string }
   | { readonly kind: 'routing-unavailable'; readonly message: string };
 

--- a/packages/gateway/src/data-plane/llm/shared/errors_test.ts
+++ b/packages/gateway/src/data-plane/llm/shared/errors_test.ts
@@ -5,13 +5,18 @@ import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 const cases: readonly LlmServeFailure[] = [
   { kind: 'model-missing', model: 'gpt-9' },
+  { kind: 'model-missing', model: 'gpt-9', failedUpstreams: ['Azure prod'] },
   { kind: 'model-unsupported', model: 'gpt-9' },
+  { kind: 'model-unsupported', model: 'gpt-9', failedUpstreams: ['Azure prod', 'Custom'] },
   { kind: 'item-not-found', itemId: 'msg_abc' },
   { kind: 'routing-unavailable', message: 'no upstream can serve this' },
 ];
 
 for (const failure of cases) {
-  test(`round-trips ${failure.kind} through throw/catch`, () => {
+  const label = 'failedUpstreams' in failure && failure.failedUpstreams?.length
+    ? `${failure.kind} (with ${failure.failedUpstreams.length} failed upstream(s))`
+    : failure.kind;
+  test(`round-trips ${label} through throw/catch`, () => {
     const error = assertThrows(() => throwLlmServeFailure(failure));
     assertEquals(tryCatchLlmServeFailure(error), failure);
   });

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -13,6 +13,10 @@ interface ProviderModelsResult {
   models: ResolvedModel[];
   sawSuccess: boolean;
   lastError: unknown;
+  // Upstream names whose catalog fetch rejected this round, in the same
+  // order as the input `providers` list so the model-missing renderer can
+  // surface a stable, dashboard-aligned list.
+  failedUpstreams: string[];
 }
 
 const NO_UPSTREAM_CONFIGURED_MESSAGE = 'No upstream provider configured — connect GitHub Copilot or add a Custom/Azure upstream in the dashboard';
@@ -102,6 +106,7 @@ const collectProviderModels = async (
   const byId = new Map<string, ResolvedModel>();
   let sawSuccess = false;
   let lastError: unknown = null;
+  const failedUpstreams: string[] = [];
 
   // Fan out per-upstream so a slow provider does not stall the rest. The SWR
   // cache layer dedupes concurrent in-flight fetches per upstream and serves
@@ -116,7 +121,7 @@ const collectProviderModels = async (
 
   const settled = await Promise.allSettled(providers.map(fetchOne));
 
-  for (const result of settled) {
+  for (const [index, result] of settled.entries()) {
     if (result.status === 'rejected') {
       // Caller-driven cancellation must propagate. Burying it in lastError
       // and letting an earlier sawSuccess return a partially-populated
@@ -125,6 +130,7 @@ const collectProviderModels = async (
       const error = result.reason;
       if (error instanceof Error && error.name === 'AbortError') throw error;
       lastError = error;
+      failedUpstreams.push(providers[index].name);
       continue;
     }
     sawSuccess = true;
@@ -159,7 +165,7 @@ const collectProviderModels = async (
     }
   }
 
-  return { models: [...byId.values()], sawSuccess, lastError };
+  return { models: [...byId.values()], sawSuccess, lastError, failedUpstreams };
 };
 
 const modelWithProviderInstances = (model: ResolvedModel, providers: ReadonlySet<ModelProviderInstance>): ResolvedModel => {
@@ -238,6 +244,12 @@ export const getInternalModels = async (
 interface ModelResolution {
   id: string;
   model?: ResolvedModel;
+  // Upstream names whose catalog fetch rejected during this resolution.
+  // Threaded out so the caller's failure renderer can mention them
+  // parenthetically — same data the dashboard's `modelsCache.lastError`
+  // surfaces, but inlined into the per-request 404/400 so a client sees
+  // why their model might be temporarily missing.
+  failedUpstreams: readonly string[];
 }
 
 interface ProviderModelResolution {
@@ -280,18 +292,20 @@ export const resolveModelForRequest = async (
     throw new Error(NO_UPSTREAM_CONFIGURED_MESSAGE);
   }
 
-  const { models, lastError } = await collectProviderModels(providers, fetcherForUpstream, scheduler);
+  const { models, failedUpstreams } = await collectProviderModels(providers, fetcherForUpstream, scheduler);
   const byId = new Map(models.map(model => [model.id, model]));
 
   const exact = byId.get(modelId);
-  if (exact) return { id: exact.id, model: exact };
+  if (exact) return { id: exact.id, model: exact, failedUpstreams };
 
   const alias = resolveProviderAlias(providers, byId, modelId);
-  if (alias) return { id: alias.id, model: alias };
+  if (alias) return { id: alias.id, model: alias, failedUpstreams };
 
-  if (lastError) throw lastError;
-
-  return { id: modelId };
+  // Treat a failing upstream as "no models from that upstream right now"
+  // rather than rethrowing its catalog error — other upstreams still
+  // route, and the failed list is handed back so the caller's failure
+  // body can name the affected upstreams.
+  return { id: modelId, failedUpstreams };
 };
 
 const providerModelRecord = (instance: ModelProviderInstance, upstreamModel: UpstreamModel): ProviderModelRecord => ({

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -524,3 +524,54 @@ test('getInternalModels: a rejected provider does not block other providers', as
     },
   );
 });
+
+// Regression: when an upstream's force re-fetch rejects past HARD, the call
+// site asking for a model belonging to one of the *healthy* upstreams must
+// still resolve. The broken upstream's display name flows back via
+// `failedUpstreams` so the eventual error renderer can mention it.
+test('resolveModelForRequest: healthy upstream still resolves alongside a rejecting one, with failedUpstreams reported', async () => {
+  clearInFlightForTesting();
+  const { repo } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+
+  await repo.upstreams.save(buildCustomUpstreamRecord({
+    id: 'up_broken',
+    name: 'Broken upstream',
+    sortOrder: 1,
+    config: { baseUrl: 'https://broken.example.com', bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+  }));
+  await repo.upstreams.save(buildCustomUpstreamRecord({
+    id: 'up_ok',
+    name: 'Healthy upstream',
+    sortOrder: 2,
+    config: { baseUrl: 'https://ok.example.com', bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+  }));
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'broken.example.com' && url.pathname === '/v1/models') {
+        return jsonResponse({ error: 'upstream went down' }, 502);
+      }
+      if (url.hostname === 'ok.example.com' && url.pathname === '/v1/models') {
+        return jsonResponse({ object: 'list', data: [{ id: 'ok-model', supported_endpoints: ['/chat/completions'] }] });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const resolvedExisting = await resolveModelForRequest('ok-model', null, () => directFetcher, testScheduler);
+      assertEquals(resolvedExisting.id, 'ok-model');
+      assertEquals(resolvedExisting.model?.providers.map(({ upstream }) => upstream), ['up_ok']);
+      assertEquals(resolvedExisting.failedUpstreams, ['Broken upstream']);
+
+      // A model nobody currently knows about must NOT rethrow the broken
+      // upstream's catalog error — the caller's failure renderer is the right
+      // place to surface that, parenthetically, alongside the model-missing
+      // body.
+      const resolvedMissing = await resolveModelForRequest('unknown-model', null, () => directFetcher, testScheduler);
+      assertEquals(resolvedMissing.id, 'unknown-model');
+      assertEquals(resolvedMissing.model, undefined);
+      assertEquals(resolvedMissing.failedUpstreams, ['Broken upstream']);
+    },
+  );
+});

--- a/packages/gateway/src/data-plane/shared/failed-upstreams.ts
+++ b/packages/gateway/src/data-plane/shared/failed-upstreams.ts
@@ -1,0 +1,19 @@
+// Append a parenthetical clause to a "model not found / unsupported"
+// error body when one or more upstreams' catalog fetches rejected
+// during the request. Surfaced inline alongside the per-request 4xx
+// so a client can tell a genuine miss from a transient outage where
+// the upstream that owns the model is currently unreachable. The same
+// data is independently visible to operators on the dashboard via
+// `modelsCache.lastError`.
+//
+// The suffix is inserted *before* a trailing `.` so the final message
+// reads "Model X is not available on any configured upstream (models
+// from upstream(s) "a" failed to load).", not "endpoint. (...load).".
+//
+// Returns the message unchanged when no upstream failed.
+export const appendFailedUpstreams = (message: string, failedUpstreams: readonly string[] | undefined): string => {
+  if (!failedUpstreams || failedUpstreams.length === 0) return message;
+  const names = failedUpstreams.map(name => `"${name}"`).join(', ');
+  const suffix = ` (models from upstream(s) ${names} failed to load)`;
+  return message.endsWith('.') ? `${message.slice(0, -1)}${suffix}.` : `${message}${suffix}`;
+};

--- a/packages/gateway/src/data-plane/shared/failed-upstreams_test.ts
+++ b/packages/gateway/src/data-plane/shared/failed-upstreams_test.ts
@@ -1,0 +1,30 @@
+import { test } from 'vitest';
+
+import { appendFailedUpstreams } from './failed-upstreams.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+test('returns the message unchanged when no upstream failed', () => {
+  assertEquals(appendFailedUpstreams('Model X is not available.', undefined), 'Model X is not available.');
+  assertEquals(appendFailedUpstreams('Model X is not available.', []), 'Model X is not available.');
+});
+
+test('inserts the parenthetical before a trailing period', () => {
+  assertEquals(
+    appendFailedUpstreams('Model X is not available.', ['Azure prod']),
+    'Model X is not available (models from upstream(s) "Azure prod" failed to load).',
+  );
+});
+
+test('joins multiple names with commas in the supplied order', () => {
+  assertEquals(
+    appendFailedUpstreams('Model X is not available.', ['a', 'b', 'c']),
+    'Model X is not available (models from upstream(s) "a", "b", "c" failed to load).',
+  );
+});
+
+test('appends without inserting when the message has no trailing period', () => {
+  assertEquals(
+    appendFailedUpstreams('Model X is not available', ['a']),
+    'Model X is not available (models from upstream(s) "a" failed to load)',
+  );
+});

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -16,6 +16,7 @@ import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import type { NonLlmServeApiName } from './api-names.ts';
+import { appendFailedUpstreams } from './failed-upstreams.ts';
 import { inboundHeadersForUpstream } from './inbound-headers.ts';
 import type { PerformanceTelemetryContext } from './telemetry/performance.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, recordRequestPerformance, runtimeLocationFromRequest } from './telemetry/performance.ts';
@@ -121,9 +122,9 @@ export const passthroughServe = async (ctx: PassthroughServeContext): Promise<Re
 
   try {
     const fetcherForUpstream = await createPerRequestFetcher(getCurrentColo(c.req.raw));
-    const { id: modelId, model: resolved } = await resolveModelForRequest(model, effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundScheduler);
+    const { id: modelId, model: resolved, failedUpstreams } = await resolveModelForRequest(model, effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundScheduler);
     if (!resolved) {
-      return passthroughApiError(c, `Model ${modelId} is not available on any configured upstream.`, 404);
+      return passthroughApiError(c, appendFailedUpstreams(`Model ${modelId} is not available on any configured upstream.`, failedUpstreams), 404);
     }
 
     for (const binding of resolved.providers) {
@@ -176,7 +177,7 @@ export const passthroughServe = async (ctx: PassthroughServeContext): Promise<Re
       return forwardUpstreamResponse(response);
     }
 
-    return passthroughApiError(c, noBindingMessage(modelId), 400);
+    return passthroughApiError(c, appendFailedUpstreams(noBindingMessage(modelId), failedUpstreams), 400);
   } catch (e) {
     if (e instanceof ProviderModelsUnavailableError) {
       const forwarded = httpResponseToResponse(e.httpResponse);


### PR DESCRIPTION
## Summary

- An upstream past the SWR HARD window whose forced re-fetch threw used to bubble its rejection out of both `enumerateProviderCandidates` and `resolveModelForRequest`, failing every LLM data-plane request — including ones for models served entirely by other, healthy upstreams.
- Both call sites now treat a rejecting upstream as "no models from that upstream right now": `enumerateProviderCandidates` walks providers in parallel via `Promise.allSettled` (input order preserved); `resolveModelForRequest` drops its trailing `throw lastError`. The SWR cache layer is untouched — past HARD + force fail still throws, just absorbed by callers.
- The rejected upstream's display name flows back via a new optional `failedUpstreams` field on `LlmServeFailure.model-{missing,unsupported}` and a shared `appendFailedUpstreams(message, failed)` helper that inlines a `(models from upstream(s) "a", "b" failed to load)` clause before the trailing period. Plumbed through chat-completions, messages, gemini, responses, passthrough (embeddings + images), and the image-generation server tool. Operators still see the underlying error per-upstream via `modelsCache.lastError` on the dashboard.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm run test` — 2790 passed (added: `failed-upstreams_test.ts`, two `candidates_test` regressions, one `registry_test` regression, an `errors_test` round-trip case; rewrote the two `/v1/embeddings` tests that previously asserted the misbehavior this fix targets)
- [x] `pnpm run lint`