### PR TITLE
refactor(middleware): consolidate Hono Variables into typed apiKey/user/sessionId

### DIFF
--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -4,7 +4,7 @@ import { logger } from 'hono/logger';
 
 import { controlPlaneRoutes } from './control-plane/routes.ts';
 import { mountDataPlane } from './data-plane/routes.ts';
-import { authMiddleware } from './middleware/auth.ts';
+import { type AuthVars, authMiddleware } from './middleware/auth.ts';
 import { internalErrorResponse } from './middleware/internal-error-response.ts';
 
 // `app` is built as a single chained expression so its TypeScript type carries
@@ -14,7 +14,11 @@ import { internalErrorResponse } from './middleware/internal-error-response.ts';
 // chain because apps/web does not consume data-plane routes through the RPC
 // client — it talks to /v1/chat/completions etc. via plain fetch — and the
 // data-plane router does not need its types preserved.
-export const app = new Hono()
+//
+// The `Variables: AuthVars` generic gives every handler typed c.set / c.get
+// on the three auth slots (apiKey, user, sessionId); string-key typos and
+// type mismatches now fail compile instead of producing silent `any`.
+export const app = new Hono<{ Variables: AuthVars }>()
   .onError(internalErrorResponse)
   .use('*', logger())
   .use('*', cors())

--- a/packages/gateway/src/control-plane/api-keys/routes.ts
+++ b/packages/gateway/src/control-plane/api-keys/routes.ts
@@ -1,6 +1,4 @@
-import type { Context } from 'hono';
-
-import { userUpstreamIdsFromContext } from '../../middleware/auth.ts';
+import { type AuthedContext, userFromContext, userUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import { type CtxWithJson } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { ApiKey } from '../../repo/types.ts';
@@ -17,7 +15,7 @@ const apiKeyToJson = (key: ApiKey) => ({
 });
 
 const validateUpstreamIdsAgainstUserCap = async (
-  c: Context,
+  c: AuthedContext,
   proposed: readonly string[] | null,
 ): Promise<string | null> => {
   if (proposed === null) return null;
@@ -35,8 +33,8 @@ const validateUpstreamIdsAgainstUserCap = async (
     : null;
 };
 
-const ownedKeyOr404 = async (c: Context, id: string): Promise<ApiKey | Response> => {
-  const userId = c.get('userId') as number;
+const ownedKeyOr404 = async (c: AuthedContext, id: string): Promise<ApiKey | Response> => {
+  const userId = userFromContext(c).id;
   const key = await getRepo().apiKeys.getById(id);
   // Returning 404 on foreign keys (rather than 403) avoids leaking the
   // existence of another user's key id to the actor.
@@ -44,14 +42,14 @@ const ownedKeyOr404 = async (c: Context, id: string): Promise<ApiKey | Response>
   return key;
 };
 
-export const listKeys = async (c: Context) => {
-  const userId = c.get('userId') as number;
+export const listKeys = async (c: AuthedContext) => {
+  const userId = userFromContext(c).id;
   const keys = await getRepo().apiKeys.listByUserId(userId);
   return c.json(keys.map(apiKeyToJson));
 };
 
 export const createKey = async (c: CtxWithJson<typeof createKeyBody>) => {
-  const userId = c.get('userId') as number;
+  const userId = userFromContext(c).id;
   const body = c.req.valid('json');
 
   const upstreamErr = await validateUpstreamIdsAgainstUserCap(c, body.upstream_ids ?? null);
@@ -70,7 +68,7 @@ export const createKey = async (c: CtxWithJson<typeof createKeyBody>) => {
   return c.json(apiKeyToJson(key), 201);
 };
 
-export const deleteKey = async (c: Context) => {
+export const deleteKey = async (c: AuthedContext) => {
   const id = c.req.param('id')!;
   const owned = await ownedKeyOr404(c, id);
   if (owned instanceof Response) return owned;
@@ -78,7 +76,7 @@ export const deleteKey = async (c: Context) => {
   return c.json({ ok: true });
 };
 
-export const rotateKey = async (c: Context) => {
+export const rotateKey = async (c: AuthedContext) => {
   const id = c.req.param('id')!;
   const owned = await ownedKeyOr404(c, id);
   if (owned instanceof Response) return owned;

--- a/packages/gateway/src/control-plane/auth/routes.ts
+++ b/packages/gateway/src/control-plane/auth/routes.ts
@@ -1,5 +1,4 @@
-import type { Context } from 'hono';
-
+import { type AuthedContext, sessionIdFromContext, userFromContext } from '../../middleware/auth.ts';
 import { type CtxWithJson } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { User } from '../../repo/types.ts';
@@ -39,29 +38,19 @@ export const authLogin = async (c: CtxWithJson<typeof authLoginBody>) => {
   return c.json({ token: session.id, user: userToEffectiveWire(user) });
 };
 
-export const authLogout = async (c: Context) => {
-  const sessionId = c.get('sessionId') as string | undefined;
+export const authLogout = async (c: AuthedContext) => {
+  const sessionId = sessionIdFromContext(c);
   if (sessionId) await getRepo().sessions.deleteById(sessionId);
   return c.json({ ok: true });
 };
 
-export const authMe = async (c: Context) => {
-  const userId = c.get('userId') as number;
-  const sessionId = c.get('sessionId') as string | undefined;
-  const apiKeyId = c.get('apiKeyId') as string | undefined;
-  const repo = getRepo();
-  const user = await repo.users.getById(userId);
-  if (!user) throw new Error(`authMiddleware loaded userId ${userId} but it is now missing`);
-
-  let apiKey: { id: string; name: string } | null = null;
-  if (apiKeyId) {
-    const key = await repo.apiKeys.getById(apiKeyId);
-    if (!key) throw new Error(`authMiddleware accepted apiKeyId ${apiKeyId} but it is now missing`);
-    apiKey = { id: key.id, name: key.name };
-  }
+export const authMe = async (c: AuthedContext) => {
+  const user = userFromContext(c);
+  const sessionId = sessionIdFromContext(c);
+  const apiKey = c.get('apiKey');
   return c.json({
     user: userToEffectiveWire(user),
     viaApiKey: !sessionId,
-    apiKey,
+    apiKey: apiKey ? { id: apiKey.id, name: apiKey.name } : null,
   });
 };

--- a/packages/gateway/src/control-plane/routes.ts
+++ b/packages/gateway/src/control-plane/routes.ts
@@ -1,4 +1,4 @@
-import { type Context, Hono, type Next } from 'hono';
+import { Hono, type Next } from 'hono';
 
 import { createKey, deleteKey, listKeys, rotateKey, updateKey } from './api-keys/routes.ts';
 import { authLogin, authLogout, authMe } from './auth/routes.ts';
@@ -13,11 +13,12 @@ import { searchUsage } from './search-usage/routes.ts';
 import { tokenUsage } from './token-usage/routes.ts';
 import { codexImport, codexPkceStart, codexRefreshNow, codexReimport, copilotAuthPoll, copilotAuthStart, createUpstream, deleteUpstream, fetchModels, listOptionalFlags, listUpstreamModels, listUpstreamOptions, listUpstreams, updateUpstream } from './upstreams/routes.ts';
 import { changeOwnPassword, createUser, deleteUser, listUsers, updateUser } from './users/routes.ts';
+import { type AuthedContext, type AuthVars, userFromContext } from '../middleware/auth.ts';
 import { zValidator } from '../middleware/zod-validator.ts';
 import { getRuntimeInfo } from '../runtime/runtime-info.ts';
 
-const adminOnlyMiddleware = async (c: Context, next: Next) => {
-  if (!c.get('isAdmin')) {
+const adminOnlyMiddleware = async (c: AuthedContext, next: Next) => {
+  if (!userFromContext(c).isAdmin) {
     return c.json({ error: 'Admin privileges required' }, 403);
   }
   await next();
@@ -25,8 +26,10 @@ const adminOnlyMiddleware = async (c: Context, next: Next) => {
 
 // Chained route registration is required so Hono flows per-path types into
 // the exported `controlPlaneRoutes` type; RPC clients consume it for path/
-// method autocomplete and request/response inference.
-export const controlPlaneRoutes = new Hono()
+// method autocomplete and request/response inference. The `Variables` generic
+// mirrors `app.ts` so c.set / c.get stay type-checked inside every handler
+// registered here (and inside the inner admin-gated sub-app).
+export const controlPlaneRoutes = new Hono<{ Variables: AuthVars }>()
   .get('/api/health', c => c.json({ status: 'ok', service: 'floway' }))
   // Quiet 204 to suppress 404 noise from favicon probes; the path is
   // already in PUBLIC_PATHS so auth lets it through.
@@ -55,7 +58,7 @@ export const controlPlaneRoutes = new Hono()
   // pairs with a logged-in dashboard session); admins reset other users'
   // passwords through PATCH /api/users/:id below, which is admin-gated.
   .patch('/api/users/me/password', zValidator('json', changeOwnPasswordBody), changeOwnPassword)
-  .route('/api', new Hono()
+  .route('/api', new Hono<{ Variables: AuthVars }>()
     .use('*', adminOnlyMiddleware)
     .get('/users', listUsers)
     .post('/users', zValidator('json', createUserBody), createUser)

--- a/packages/gateway/src/control-plane/telemetry-view.ts
+++ b/packages/gateway/src/control-plane/telemetry-view.ts
@@ -1,4 +1,4 @@
-import type { Context } from 'hono';
+import { type AuthedContext, canViewGlobalTelemetry, userFromContext } from '../middleware/auth.ts';
 
 export type TelemetryView = 'all-by-user' | 'self-by-key';
 
@@ -8,12 +8,12 @@ export type ResolvedTelemetryView =
   | { view: 'all-by-user' };
 
 export const resolveTelemetryView = (
-  c: Context,
+  c: AuthedContext,
   rawView: TelemetryView | undefined,
   rawKeyId: string | undefined,
 ): ResolvedTelemetryView | { error: 'forbidden' | 'bad_request'; message: string } => {
-  const userId = c.get('userId') as number;
-  const canViewGlobal = c.get('canViewGlobalTelemetry') === true;
+  const user = userFromContext(c);
+  const canViewGlobal = canViewGlobalTelemetry(user);
 
   const view = rawView ?? (canViewGlobal ? 'all-by-user' : 'self-by-key');
 
@@ -31,6 +31,6 @@ export const resolveTelemetryView = (
   }
 
   return view === 'self-by-key'
-    ? { view: 'self-by-key', scopeUserId: userId }
+    ? { view: 'self-by-key', scopeUserId: user.id }
     : { view: 'all-by-user' };
 };

--- a/packages/gateway/src/control-plane/users/routes.ts
+++ b/packages/gateway/src/control-plane/users/routes.ts
@@ -1,6 +1,5 @@
-import type { Context } from 'hono';
-
 import { userToRawWire } from './wire.ts';
+import { type AuthedContext, sessionIdFromContext, userFromContext } from '../../middleware/auth.ts';
 import { type CtxWithJson } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { ApiKey, User } from '../../repo/types.ts';
@@ -21,7 +20,7 @@ const parseUserId = (raw: string): number | null => {
   return Number.isInteger(n) && n >= 1 ? n : null;
 };
 
-export const listUsers = async (c: Context) => {
+export const listUsers = async (c: AuthedContext) => {
   const users = await getRepo().users.list();
   return c.json(users.map(userToRawWire));
 };
@@ -66,7 +65,7 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
   const id = parseUserId(c.req.param('id')!);
   if (id === null) return c.json({ error: 'invalid user id' }, 400);
   const body = c.req.valid('json');
-  const actorId = c.get('userId') as number;
+  const actorId = userFromContext(c).id;
   const repo = getRepo();
 
   const existing = await repo.users.getById(id);
@@ -95,7 +94,7 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
   await repo.users.save(next);
 
   if (body.password !== undefined) {
-    const sessionId = c.get('sessionId') as string | undefined;
+    const sessionId = sessionIdFromContext(c);
     if (sessionId) await repo.sessions.deleteByUserIdExcept(id, sessionId);
     else await repo.sessions.deleteByUserId(id);
   }
@@ -103,10 +102,10 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
   return c.json(userToRawWire(next));
 };
 
-export const deleteUser = async (c: Context) => {
+export const deleteUser = async (c: AuthedContext) => {
   const id = parseUserId(c.req.param('id')!);
   if (id === null) return c.json({ error: 'invalid user id' }, 400);
-  const actorId = c.get('userId') as number;
+  const actorId = userFromContext(c).id;
   if (id === 1) return c.json({ error: 'user 1 cannot be deleted' }, 400);
   if (id === actorId) return c.json({ error: 'cannot delete yourself' }, 400);
 
@@ -120,16 +119,14 @@ export const deleteUser = async (c: Context) => {
 };
 
 export const changeOwnPassword = async (c: CtxWithJson<typeof changeOwnPasswordBody>) => {
-  const sessionId = c.get('sessionId') as string | undefined;
+  const sessionId = sessionIdFromContext(c);
   if (!sessionId) {
     return c.json({ error: 'Self-service password change requires a logged-in dashboard session' }, 401);
   }
-  const userId = c.get('userId') as number;
+  const user = userFromContext(c);
   const { currentPassword, newPassword } = c.req.valid('json');
   const repo = getRepo();
 
-  const user = await repo.users.getById(userId);
-  if (!user) throw new Error(`authMiddleware loaded userId ${userId} but it is now missing`);
   // 400, not 401: these are domain validation errors on the request payload,
   // not authentication failures. The dashboard's auth client treats 401 as
   // "session expired" and silently signs the user out, which is wrong here —
@@ -142,6 +139,6 @@ export const changeOwnPassword = async (c: CtxWithJson<typeof changeOwnPasswordB
   }
 
   await repo.users.save({ ...user, passwordHash: await hashPassword(newPassword) });
-  await repo.sessions.deleteByUserIdExcept(userId, sessionId);
+  await repo.sessions.deleteByUserIdExcept(user.id, sessionId);
   return c.json({ ok: true });
 };

--- a/packages/gateway/src/data-plane/codex/routes.ts
+++ b/packages/gateway/src/data-plane/codex/routes.ts
@@ -57,12 +57,13 @@ import {
   codexWhamAgentIdentitiesJwks,
 } from './chatgpt-backend.ts';
 import { codexModels } from './models.ts';
+import type { AuthVars } from '../../middleware/auth.ts';
 import { responsesHttp } from '../llm/responses/http.ts';
 import { responsesWebSocket } from '../llm/responses/websocket.ts';
 
 const CODEX_BASE_PATH = '/azure-api.codex';
 
-export const mountCodexRoutes = (app: Hono) => {
+export const mountCodexRoutes = (app: Hono<{ Variables: AuthVars }>) => {
   app.post(`${CODEX_BASE_PATH}/responses`, responsesHttp.generate);
   app.post(`${CODEX_BASE_PATH}/responses/compact`, responsesHttp.compact);
   app.get(`${CODEX_BASE_PATH}/responses`, responsesWebSocket);

--- a/packages/gateway/src/data-plane/codex/routes_test.ts
+++ b/packages/gateway/src/data-plane/codex/routes_test.ts
@@ -2,12 +2,12 @@ import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
 import { mountCodexRoutes } from './routes.ts';
-import { authMiddleware } from '../../middleware/auth.ts';
+import { type AuthVars, authMiddleware } from '../../middleware/auth.ts';
 import { copilotModels, setupAppTest } from '../../test-helpers.ts';
 import { jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
 const buildCodexApp = () => {
-  const app = new Hono();
+  const app = new Hono<{ Variables: AuthVars }>();
   app.use('*', authMiddleware);
   mountCodexRoutes(app);
   return app;

--- a/packages/gateway/src/data-plane/llm/chat-completions/http_test.ts
+++ b/packages/gateway/src/data-plane/llm/chat-completions/http_test.ts
@@ -1,8 +1,10 @@
 import { type Context, Hono } from 'hono';
 import { test, vi } from 'vitest';
 
+import type { AuthVars } from '../../../middleware/auth.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import type { ApiKey, User } from '../../../repo/types.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
@@ -36,18 +38,34 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-interface AuthVars {
-  apiKeyId: string;
-  apiKeyUpstreamIds: readonly string[] | null;
-  userUpstreamIds: readonly string[] | null;
-}
+const buildApiKey = (overrides: Partial<ApiKey> = {}): ApiKey => ({
+  id: API_KEY_ID,
+  userId: 1,
+  name: 'http_test',
+  key: 'sk-http-test',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  upstreamIds: null,
+  deletedAt: null,
+  ...overrides,
+});
+
+const buildUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  username: 'http_test',
+  passwordHash: null,
+  isAdmin: false,
+  upstreamIds: null,
+  canViewGlobalTelemetry: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  deletedAt: null,
+  ...overrides,
+});
 
 const makeApp = (middleware?: (c: Context) => void): Hono<{ Variables: AuthVars }> => {
   const app = new Hono<{ Variables: AuthVars }>();
   app.use('*', async (c, next) => {
-    c.set('apiKeyId', API_KEY_ID);
-    c.set('apiKeyUpstreamIds', null);
-    c.set('userUpstreamIds', null);
+    c.set('apiKey', buildApiKey());
+    c.set('user', buildUser());
     middleware?.(c);
     await next();
   });
@@ -198,7 +216,7 @@ test('POST /v1/chat/completions does not write any non-auth Hono context slot', 
   }));
   queueCandidates([makeCandidate({ callChatCompletions })]);
 
-  const knownAuthKeys = new Set(['apiKeyId', 'apiKeyUpstreamIds']);
+  const knownAuthKeys = new Set(['apiKey', 'user']);
   const observedKeys: string[] = [];
 
   const app = makeApp(c => {

--- a/packages/gateway/src/data-plane/llm/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/llm/gemini/http_test.ts
@@ -1,8 +1,10 @@
 import { Hono } from 'hono';
 import { test, vi } from 'vitest';
 
+import type { AuthVars } from '../../../middleware/auth.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import type { ApiKey, User } from '../../../repo/types.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
@@ -37,12 +39,34 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-const makeApp = (): Hono<{ Variables: { apiKeyId: string; apiKeyUpstreamIds: readonly string[] | null; userUpstreamIds: readonly string[] | null } }> => {
-  const app = new Hono<{ Variables: { apiKeyId: string; apiKeyUpstreamIds: readonly string[] | null; userUpstreamIds: readonly string[] | null } }>();
+const buildApiKey = (overrides: Partial<ApiKey> = {}): ApiKey => ({
+  id: API_KEY_ID,
+  userId: 1,
+  name: 'http_test',
+  key: 'sk-http-test',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  upstreamIds: null,
+  deletedAt: null,
+  ...overrides,
+});
+
+const buildUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  username: 'http_test',
+  passwordHash: null,
+  isAdmin: false,
+  upstreamIds: null,
+  canViewGlobalTelemetry: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  deletedAt: null,
+  ...overrides,
+});
+
+const makeApp = (): Hono<{ Variables: AuthVars }> => {
+  const app = new Hono<{ Variables: AuthVars }>();
   app.use('*', async (c, next) => {
-    c.set('apiKeyId', API_KEY_ID);
-    c.set('apiKeyUpstreamIds', null);
-    c.set('userUpstreamIds', null);
+    c.set('apiKey', buildApiKey());
+    c.set('user', buildUser());
     await next();
   });
   app.post('/v1beta/models/:modelAction{.+}', geminiHttp);

--- a/packages/gateway/src/data-plane/llm/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/llm/messages/http_test.ts
@@ -1,8 +1,10 @@
 import { Hono } from 'hono';
 import { test, vi } from 'vitest';
 
+import type { AuthVars } from '../../../middleware/auth.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import type { ApiKey, User } from '../../../repo/types.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -36,12 +38,34 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-const makeApp = (): Hono<{ Variables: { apiKeyId: string; apiKeyUpstreamIds: readonly string[] | null; userUpstreamIds: readonly string[] | null } }> => {
-  const app = new Hono<{ Variables: { apiKeyId: string; apiKeyUpstreamIds: readonly string[] | null; userUpstreamIds: readonly string[] | null } }>();
+const buildApiKey = (overrides: Partial<ApiKey> = {}): ApiKey => ({
+  id: API_KEY_ID,
+  userId: 1,
+  name: 'http_test',
+  key: 'sk-http-test',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  upstreamIds: null,
+  deletedAt: null,
+  ...overrides,
+});
+
+const buildUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  username: 'http_test',
+  passwordHash: null,
+  isAdmin: false,
+  upstreamIds: null,
+  canViewGlobalTelemetry: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  deletedAt: null,
+  ...overrides,
+});
+
+const makeApp = (): Hono<{ Variables: AuthVars }> => {
+  const app = new Hono<{ Variables: AuthVars }>();
   app.use('*', async (c, next) => {
-    c.set('apiKeyId', API_KEY_ID);
-    c.set('apiKeyUpstreamIds', null);
-    c.set('userUpstreamIds', null);
+    c.set('apiKey', buildApiKey());
+    c.set('user', buildUser());
     await next();
   });
   app.post('/v1/messages', messagesHttp.generate);

--- a/packages/gateway/src/data-plane/llm/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/http_test.ts
@@ -2,9 +2,10 @@ import { Hono } from 'hono';
 import { test, vi } from 'vitest';
 
 import { createStoredResponsesItemId, isStoredResponseId } from './items/format.ts';
+import type { AuthVars } from '../../../middleware/auth.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
-import type { StoredResponsesItem } from '../../../repo/types.ts';
+import type { ApiKey, StoredResponsesItem, User } from '../../../repo/types.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -42,14 +43,36 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-const makeApp = (): Hono<{ Variables: { apiKeyId: string; apiKeyUpstreamIds: readonly string[] | null; userUpstreamIds: readonly string[] | null } }> => {
-  const app = new Hono<{ Variables: { apiKeyId: string; apiKeyUpstreamIds: readonly string[] | null; userUpstreamIds: readonly string[] | null } }>();
+const buildApiKey = (overrides: Partial<ApiKey> = {}): ApiKey => ({
+  id: API_KEY_ID,
+  userId: 1,
+  name: 'http_test',
+  key: 'sk-http-test',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  upstreamIds: null,
+  deletedAt: null,
+  ...overrides,
+});
+
+const buildUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  username: 'http_test',
+  passwordHash: null,
+  isAdmin: false,
+  upstreamIds: null,
+  canViewGlobalTelemetry: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  deletedAt: null,
+  ...overrides,
+});
+
+const makeApp = (): Hono<{ Variables: AuthVars }> => {
+  const app = new Hono<{ Variables: AuthVars }>();
   // Stamp the authenticated key onto every request so the http entry sees the
   // same value the real auth middleware would set.
   app.use('*', async (c, next) => {
-    c.set('apiKeyId', API_KEY_ID);
-    c.set('apiKeyUpstreamIds', null);
-    c.set('userUpstreamIds', null);
+    c.set('apiKey', buildApiKey());
+    c.set('user', buildUser());
     await next();
   });
   app.post('/v1/responses', responsesHttp.generate);

--- a/packages/gateway/src/data-plane/llm/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/llm/responses/websocket.ts
@@ -5,6 +5,7 @@ import { createResponsesWsSession } from './items/store.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
+import { apiKeyFromContext, type AuthedContext } from '../../../middleware/auth.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { SourceStreamState, eventResultMetadata, recordPerformance, recordUsage } from '../shared/respond.ts';
@@ -63,7 +64,7 @@ interface ResponsesWebSocketClientEvent {
   [key: string]: unknown;
 }
 
-export const responsesWebSocket = async (c: Context): Promise<Response> => {
+export const responsesWebSocket = async (c: AuthedContext): Promise<Response> => {
   if (c.req.header('upgrade')?.toLowerCase() !== 'websocket') {
     return Response.json({ error: 'Expected Upgrade: websocket' }, { status: 426 });
   }
@@ -85,8 +86,8 @@ export const responsesWebSocket = async (c: Context): Promise<Response> => {
   return new Response(null, { status: 101, webSocket: client } as ResponseInit & { readonly webSocket: WebSocket });
 };
 
-const createResponsesWebSocketEvents = (c: Context): ResponsesWebSocketHandlers => {
-  const session = createResponsesWsSession(c.get('apiKeyId') as string);
+const createResponsesWebSocketEvents = (c: AuthedContext): ResponsesWebSocketHandlers => {
+  const session = createResponsesWsSession(apiKeyFromContext(c).id);
   let closed = false;
   let activeAbortController: AbortController | undefined;
   let queue = Promise.resolve();
@@ -122,7 +123,7 @@ const createResponsesWebSocketEvents = (c: Context): ResponsesWebSocketHandlers 
 };
 
 const handleClientMessage = async (
-  c: Context,
+  c: AuthedContext,
   socket: ResponsesWebSocketSocket,
   session: ReturnType<typeof createResponsesWsSession>,
   data: unknown,

--- a/packages/gateway/src/data-plane/llm/routes.ts
+++ b/packages/gateway/src/data-plane/llm/routes.ts
@@ -5,8 +5,9 @@ import { geminiHttp } from './gemini/http.ts';
 import { messagesHttp } from './messages/http.ts';
 import { responsesHttp } from './responses/http.ts';
 import { responsesWebSocket } from './responses/websocket.ts';
+import type { AuthVars } from '../../middleware/auth.ts';
 
-export const mountLlmRoutes = (app: Hono) => {
+export const mountLlmRoutes = (app: Hono<{ Variables: AuthVars }>) => {
   app.post('/v1/chat/completions', chatCompletionsHttp.generate);
   app.post('/chat/completions', chatCompletionsHttp.generate);
   app.post('/v1/responses', responsesHttp.generate);

--- a/packages/gateway/src/data-plane/llm/shared/gateway-ctx.ts
+++ b/packages/gateway/src/data-plane/llm/shared/gateway-ctx.ts
@@ -1,6 +1,4 @@
-import type { Context } from 'hono';
-
-import { effectiveUpstreamIdsFromContext } from '../../../middleware/auth.ts';
+import { apiKeyFromContext, type AuthedContext, effectiveUpstreamIdsFromContext } from '../../../middleware/auth.ts';
 import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { getCurrentColo } from '../../../runtime/runtime-info.ts';
 import { runtimeLocationFromRequest } from '../../shared/telemetry/performance.ts';
@@ -23,18 +21,6 @@ export interface GatewayCtx {
   readonly currentColo: string | null;
 }
 
-// Names the auth-middleware-stamped Hono variables this builder reads. Hono
-// gives no compile-time guarantee that a middleware ran; the alias is the
-// local declaration of what `auth.ts` is contracted to set so the lookup
-// sheds its inline cast.
-export interface GatewayCtxAuthVars {
-  apiKeyId: string;
-  apiKeyUpstreamIds: readonly string[] | null;
-  userUpstreamIds: readonly string[] | null;
-}
-
-type AuthedContext = Context<{ Variables: GatewayCtxAuthVars }>;
-
 export interface CreateGatewayCtxOptions {
   wantsStream: boolean;
   // WebSocket-style call sites own the AbortController (so the upgrade
@@ -45,7 +31,7 @@ export interface CreateGatewayCtxOptions {
 
 export const createGatewayCtxFromHono = (c: AuthedContext, opts: CreateGatewayCtxOptions): GatewayCtx => {
   const controller = opts.downstreamAbortController ?? (opts.wantsStream ? new AbortController() : undefined);
-  const apiKeyId = c.get('apiKeyId');
+  const apiKeyId = apiKeyFromContext(c).id;
   const upstreamIds = effectiveUpstreamIdsFromContext(c);
   return {
     apiKeyId,

--- a/packages/gateway/src/data-plane/llm/shared/gateway-ctx_test.ts
+++ b/packages/gateway/src/data-plane/llm/shared/gateway-ctx_test.ts
@@ -1,19 +1,43 @@
 import { Hono } from 'hono';
 import { describe, test } from 'vitest';
 
-import { createGatewayCtxFromHono, type GatewayCtxAuthVars } from './gateway-ctx.ts';
+import { createGatewayCtxFromHono } from './gateway-ctx.ts';
+import type { AuthVars } from '../../../middleware/auth.ts';
+import type { ApiKey, User } from '../../../repo/types.ts';
 import { assertEquals, assertExists } from '@floway-dev/test-utils';
 
+const buildApiKey = (overrides: Partial<ApiKey> = {}): ApiKey => ({
+  id: 'test-key',
+  userId: 1,
+  name: 'test',
+  key: 'sk-test',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  upstreamIds: null,
+  deletedAt: null,
+  ...overrides,
+});
+
+const buildUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  username: 'tester',
+  passwordHash: null,
+  isAdmin: false,
+  upstreamIds: null,
+  canViewGlobalTelemetry: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  deletedAt: null,
+  ...overrides,
+});
+
 // Mirrors the production guarantee: by the time a data-plane handler runs,
-// auth middleware has stamped all three vars on the context. Tests that want
-// to model an unrestricted key on an uncapped user can rely on the defaults;
+// auth middleware has stamped apiKey + user on the context. Tests that want to
+// model an unrestricted key on an uncapped user can rely on the defaults;
 // tests that want to model a capped key or user override at the handler.
-const makeApp = (): Hono<{ Variables: GatewayCtxAuthVars }> => {
-  const app = new Hono<{ Variables: GatewayCtxAuthVars }>();
+const makeApp = (): Hono<{ Variables: AuthVars }> => {
+  const app = new Hono<{ Variables: AuthVars }>();
   app.use('*', async (c, next) => {
-    c.set('apiKeyId', 'test-key');
-    c.set('apiKeyUpstreamIds', null);
-    c.set('userUpstreamIds', null);
+    c.set('apiKey', buildApiKey());
+    c.set('user', buildUser());
     await next();
   });
   return app;
@@ -24,8 +48,7 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     let ctx: ReturnType<typeof createGatewayCtxFromHono> | undefined;
     app.get('/test', c => {
-      c.set('apiKeyId', 'key-1');
-      c.set('apiKeyUpstreamIds', ['up-1', 'up-2']);
+      c.set('apiKey', buildApiKey({ id: 'key-1', upstreamIds: ['up-1', 'up-2'] }));
       ctx = createGatewayCtxFromHono(c, { wantsStream: true });
       return c.text('ok');
     });
@@ -134,18 +157,22 @@ describe('createGatewayCtxFromHono', () => {
     const app = makeApp();
     const collected: { capOnly?: readonly string[] | null; both?: readonly string[] | null; keyOnly?: readonly string[] | null } = {};
     app.get('/cap-only', c => {
-      c.set('userUpstreamIds', ['up-a']);
+      // Unrestricted key (apiKey.upstreamIds null) under a capped user.
+      c.set('user', buildUser({ upstreamIds: ['up-a'] }));
       collected.capOnly = createGatewayCtxFromHono(c, { wantsStream: false }).upstreamIds;
       return c.text('ok');
     });
     app.get('/both', c => {
-      c.set('userUpstreamIds', ['up-a', 'up-b']);
-      c.set('apiKeyUpstreamIds', ['up-b', 'up-c']);
+      // Per-key whitelist further narrows the user cap and preserves per-key order.
+      c.set('user', buildUser({ upstreamIds: ['up-a', 'up-b'] }));
+      c.set('apiKey', buildApiKey({ upstreamIds: ['up-b', 'up-c'] }));
       collected.both = createGatewayCtxFromHono(c, { wantsStream: false }).upstreamIds;
       return c.text('ok');
     });
     app.get('/key-only', c => {
-      c.set('apiKeyUpstreamIds', ['up-x']);
+      // Uncapped user with a per-key whitelist falls through to the per-key
+      // list verbatim.
+      c.set('apiKey', buildApiKey({ upstreamIds: ['up-x'] }));
       collected.keyOnly = createGatewayCtxFromHono(c, { wantsStream: false }).upstreamIds;
       return c.text('ok');
     });

--- a/packages/gateway/src/data-plane/routes.ts
+++ b/packages/gateway/src/data-plane/routes.ts
@@ -6,8 +6,9 @@ import { imagesEdits, imagesGenerations } from './images/serve.ts';
 import { mountLlmRoutes } from './llm/routes.ts';
 import { serveGeminiModelInfo, serveGeminiModels } from './models/gemini.ts';
 import { models } from './models/serve.ts';
+import type { AuthVars } from '../middleware/auth.ts';
 
-export const mountDataPlane = (app: Hono) => {
+export const mountDataPlane = (app: Hono<{ Variables: AuthVars }>) => {
   mountLlmRoutes(app);
   mountCodexRoutes(app);
 

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -21,7 +21,7 @@ import type { PerformanceTelemetryContext } from './telemetry/performance.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, recordRequestPerformance, runtimeLocationFromRequest } from './telemetry/performance.ts';
 import { recordTokenUsage } from './telemetry/usage.ts';
 import { createPerRequestFetcher } from '../../dial/per-request.ts';
-import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
+import { apiKeyFromContext, type AuthedContext, effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import type { TokenUsage } from '../../repo/types.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getCurrentColo } from '../../runtime/runtime-info.ts';
@@ -87,7 +87,7 @@ const safeJsonClone = async (resp: Response, sourceApi: NonLlmServeApiName): Pro
 };
 
 export interface PassthroughServeContext {
-  readonly c: Context;
+  readonly c: AuthedContext;
   readonly sourceApi: NonLlmServeApiName;
   // Already-validated public model id the client requested. The helper
   // resolves it against the provider registry; if no upstream serves the
@@ -114,7 +114,7 @@ export interface PassthroughServeContext {
 export const passthroughServe = async (ctx: PassthroughServeContext): Promise<Response> => {
   const { c, sourceApi, model, bindingServesEndpoint, call, extractUsage, noBindingMessage } = ctx;
   const requestStartedAt = performance.now();
-  const apiKeyId = c.get('apiKeyId') as string;
+  const apiKeyId = apiKeyFromContext(c).id;
   const runtimeLocation = runtimeLocationFromRequest(c.req.raw);
   const backgroundScheduler = backgroundSchedulerFromContext(c);
   let lastPerformance: PerformanceTelemetryContext | undefined;

--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -1,14 +1,27 @@
 import type { Context, Next } from 'hono';
 
 import { getRepo } from '../repo/index.ts';
-import type { User } from '../repo/types.ts';
+import type { ApiKey, User } from '../repo/types.ts';
 import { timingSafeEqual } from '../shared/passwords.ts';
 import { getEnv } from '@floway-dev/platform';
 
 const PUBLIC_PATHS = new Set(['/api/health', '/favicon.ico']);
 const AUTH_VALIDATE_PATHS = new Set(['/auth/login']);
 
-export const authMiddleware = async (c: Context, next: Next) => {
+// The three slots auth middleware stamps on every authenticated request. All
+// optional because public / login routes carry none; handlers that require
+// one assert via the typed accessors below rather than reading c.get raw.
+// Hono's `Variables` generic makes c.set / c.get type-checked at the key
+// level once the app is built as `new Hono<{ Variables: AuthVars }>()`.
+export interface AuthVars {
+  apiKey: ApiKey | undefined;
+  user: User | undefined;
+  sessionId: string | undefined;
+}
+
+export type AuthedContext = Context<{ Variables: AuthVars }>;
+
+export const authMiddleware = async (c: AuthedContext, next: Next) => {
   const path = c.req.path;
   if (PUBLIC_PATHS.has(path) && c.req.method === 'GET') return await next();
   if (AUTH_VALIDATE_PATHS.has(path) && c.req.method === 'POST') return await next();
@@ -25,7 +38,7 @@ export const authMiddleware = async (c: Context, next: Next) => {
       await getRepo().sessions.deleteById(sessionToken);
       return c.json({ error: 'Invalid session' }, 401);
     }
-    setUserContext(c, user);
+    c.set('user', user);
     c.set('sessionId', sessionToken);
     return await next();
   }
@@ -46,23 +59,9 @@ export const authMiddleware = async (c: Context, next: Next) => {
   const user = await getRepo().users.getById(apiKey.userId);
   if (!user) return c.json({ error: 'Unauthorized' }, 401);
 
-  setUserContext(c, user);
-  c.set('apiKeyId', apiKey.id);
-  c.set('apiKeyUpstreamIds', apiKey.upstreamIds);
+  c.set('apiKey', apiKey);
+  c.set('user', user);
   await next();
-};
-
-const setUserContext = (c: Context, user: User) => {
-  c.set('userId', user.id);
-  c.set('isAdmin', user.isAdmin);
-  c.set('userUpstreamIds', user.upstreamIds);
-  // Baseline the key-level whitelist to "no key restriction". Session requests
-  // (dashboard) carry no API key and never reach the override below, so without
-  // this `effectiveUpstreamIdsFromContext` would read an unset `undefined` and
-  // slip past its `=== null` guards. The API-key path overwrites this with the
-  // key's actual whitelist.
-  c.set('apiKeyUpstreamIds', null);
-  c.set('canViewGlobalTelemetry', user.isAdmin || user.canViewGlobalTelemetry);
 };
 
 const extractApiKey = (c: Context): string | null => {
@@ -74,12 +73,41 @@ const extractApiKey = (c: Context): string | null => {
     ?? null;
 };
 
-export const userUpstreamIdsFromContext = (c: Context): readonly string[] | null =>
-  c.get('userUpstreamIds') as readonly string[] | null;
+// Authenticated-route accessors. Each throws when the requested slot is
+// unset so misuse surfaces immediately instead of reading silently as
+// undefined. Use these instead of raw c.get so every reader goes through
+// the same assertion (and the bare-Context handler signatures don't have to
+// thread AuthVars typing manually).
+export const apiKeyFromContext = (c: AuthedContext): ApiKey => {
+  const apiKey = c.get('apiKey');
+  if (!apiKey) throw new Error('apiKeyFromContext: no API key on this request; this route must be reached via API-key auth');
+  return apiKey;
+};
 
-export const effectiveUpstreamIdsFromContext = (c: Context): readonly string[] | null => {
-  const userIds = userUpstreamIdsFromContext(c);
-  const keyIds = c.get('apiKeyUpstreamIds') as readonly string[] | null;
+export const userFromContext = (c: AuthedContext): User => {
+  const user = c.get('user');
+  if (!user) throw new Error('userFromContext: no authenticated user on this request');
+  return user;
+};
+
+export const sessionIdFromContext = (c: AuthedContext): string | undefined => c.get('sessionId');
+
+// Pure derivation off the User row — admins inherit global-telemetry
+// access, regular users carry the explicit flag. Lives next to the auth
+// helpers so the rule has one home.
+export const canViewGlobalTelemetry = (user: User): boolean => user.isAdmin || user.canViewGlobalTelemetry;
+
+// Per-user upstream cap. null = unrestricted at the user level.
+export const userUpstreamIdsFromContext = (c: AuthedContext): readonly string[] | null =>
+  c.get('user')?.upstreamIds ?? null;
+
+// Effective upstream whitelist for this request: intersect the per-user cap
+// with the per-key whitelist. null = unrestricted. Session-only requests
+// resolve to the per-user cap alone (apiKey is absent). Data-plane reads
+// this to constrain provider/binding selection.
+export const effectiveUpstreamIdsFromContext = (c: AuthedContext): readonly string[] | null => {
+  const userIds = c.get('user')?.upstreamIds ?? null;
+  const keyIds = c.get('apiKey')?.upstreamIds ?? null;
   if (userIds === null && keyIds === null) return null;
   if (userIds === null) return keyIds;
   if (keyIds === null) return userIds;

--- a/packages/gateway/src/middleware/zod-validator.ts
+++ b/packages/gateway/src/middleware/zod-validator.ts
@@ -2,6 +2,8 @@ import { zValidator as zValidatorBase } from '@hono/zod-validator';
 import type { Context, ValidationTargets } from 'hono';
 import type { z, ZodType } from 'zod';
 
+import type { AuthVars } from './auth.ts';
+
 // Wrap @hono/zod-validator so validation failures return our canonical
 // `{ error: msg }` 400 shape — matching what the hand-written control-plane
 // validators returned before this change. Without the wrapper, zValidator's
@@ -26,6 +28,7 @@ export const zValidator = <T extends ZodType, Target extends keyof ValidationTar
 // Handler context aliases for routes whose request shape is declared via
 // zValidator middleware. Handlers in separate files import these to type
 // `c.req.valid('json' | 'query')` precisely without restating the env / path
-// generics every time.
-export type CtxWithJson<S extends ZodType> = Context<{ Variables: Record<string, unknown> }, string, { in: { json: z.infer<S> }; out: { json: z.infer<S> } }>;
-export type CtxWithQuery<S extends ZodType> = Context<{ Variables: Record<string, unknown> }, string, { in: { query: z.infer<S> }; out: { query: z.infer<S> } }>;
+// generics every time. The Variables generic mirrors app.ts so handlers can
+// still call apiKeyFromContext / userFromContext on the same Context.
+export type CtxWithJson<S extends ZodType> = Context<{ Variables: AuthVars }, string, { in: { json: z.infer<S> }; out: { json: z.infer<S> } }>;
+export type CtxWithQuery<S extends ZodType> = Context<{ Variables: AuthVars }, string, { in: { query: z.infer<S> }; out: { query: z.infer<S> } }>;


### PR DESCRIPTION
## Summary
- Auth middleware previously stamped 8 string-keyed slots (`apiKeyId`, `apiKeyUpstreamIds`, `userId`, `isAdmin`, `userUpstreamIds`, `canViewGlobalTelemetry`, `apiKey`, `sessionId`) on a bare `Hono` context, and every reader did `c.get('key') as T` with no type-checking on either the key or the cast.
- Replace them with three typed slots — `apiKey: ApiKey`, `user: User`, `sessionId: string` — declared on a single `AuthVars` interface and threaded through every Hono instance as `Hono<{ Variables: AuthVars }>`. A typo on the key name now fails compile, and the value type is inferred.
- All readers go through `apiKeyFromContext` / `userFromContext` / `sessionIdFromContext` (plus pure derivations `canViewGlobalTelemetry` and `effectiveUpstreamIdsFromContext`); no production file still does `c.get('xxx') as ...`.

## Notes
- `mountLlmRoutes` / `mountCodexRoutes` / `mountDataPlane` thread the typed Hono so handler types propagate through registration.
- `zod-validator`'s `CtxWithJson` / `CtxWithQuery` aliases pin `AuthVars` as their Variables generic so a validated handler can still call the auth helpers.
- `createGatewayCtxFromHono` and `passthroughServe` accept `AuthedContext` and read apiKey via the helper.
- Per-protocol `http_test.ts` fixtures replace ad-hoc per-slot mocks with `c.set('apiKey', buildApiKey())` + `c.set('user', buildUser())`.
- No runtime behavior change: the same data flows through the same code paths, just with strong typing on the auth boundary.

## Test plan
- [x] \`pnpm run typecheck\` across all packages
- [x] \`pnpm run lint\`
- [x] \`pnpm --filter @floway-dev/gateway exec vitest run\` — 1279 / 1279 passing