### PR TITLE
fix(responses): recognize compaction trigger items

### DIFF
--- a/packages/gateway/src/data-plane/llm/responses/items/format.ts
+++ b/packages/gateway/src/data-plane/llm/responses/items/format.ts
@@ -22,6 +22,7 @@ const itemTypePrefixes = {
   tool_search_call: 'ts',
   tool_search_output: 'tso',
   compaction: 'cmp',
+  compaction_trigger: 'cmpt',
   image_generation_call: 'ig',
   code_interpreter_call: 'ci',
   local_shell_call: 'lsh',

--- a/packages/gateway/src/data-plane/llm/responses/items/format_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/items/format_test.ts
@@ -22,6 +22,7 @@ const explicitPrefixes = [
   ['tool_search_call', 'ts'],
   ['tool_search_output', 'tso'],
   ['compaction', 'cmp'],
+  ['compaction_trigger', 'cmpt'],
   ['image_generation_call', 'ig'],
   ['code_interpreter_call', 'ci'],
   ['local_shell_call', 'lsh'],


### PR DESCRIPTION
## Summary

Recognize `compaction_trigger` as a first-class Responses item type when formatting stored response item ids.

Without this prefix mapping, responses that include compaction trigger items can hit the generic unknown-item path instead of receiving a stable item id prefix. This adds the `cmpt` prefix and covers it in the item formatting tests.

## Reproduction

Use the `/azure-api.codex` endpoint and continue a conversation until automatic compaction is triggered.

Observed behavior: once auto compaction is triggered, the request fails instead of continuing normally.

Screenshot: 

<img width="1468" height="114" alt="IMG_6491" src="https://github.com/user-attachments/assets/18ce4b40-b79e-4f93-835d-eab90e3fa76d" />
