### PR TITLE
fix(responses): preserve Codex-compatible response chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,15 +129,17 @@ the shim driving the internal multi-turn loop and replaying prior
 `/v1/responses` stores replayable Responses input and output items for API-key
 scoped HTTP requests. Clients can send `previous_response_id` to continue from
 a stored snapshot, or resend full input history; repeated full-history input is
-deduplicated by content hash instead of stored again. HTTP `store: false` does
-not create durable snapshots or input payload rows, but it keeps output item
-metadata for routing; if a later `store: true` request echoes that item with a
-full payload, the metadata row is filled in place.
+deduplicated by content hash instead of stored again. For ordinary clients, HTTP
+`store: false` does not create durable snapshots or input payload rows, but it
+keeps output item metadata for routing; if a later `store: true` request echoes
+that item with a full payload, the metadata row is filled in place.
 
 The same endpoint accepts `GET` WebSocket upgrades for streaming Responses
-events. WebSocket `store: false` keeps replay state only inside the open
-session, so same-socket `previous_response_id` works without writing those
-items or snapshots to durable storage.
+events. For ordinary clients, WebSocket `store: false` keeps replay state only
+inside the open session, so same-socket `previous_response_id` works without
+writing those items or snapshots to durable storage. Codex clients are handled
+specially on both transports: their `store: false` requests still keep durable
+Floway replay snapshots so Floway-minted response ids remain chainable.
 
 ## Development
 

--- a/packages/gateway/src/data-plane/codex/client-detection.ts
+++ b/packages/gateway/src/data-plane/codex/client-detection.ts
@@ -1,0 +1,7 @@
+import type { Context } from 'hono';
+
+const CODEX_USER_AGENT_PATTERN = /\b(?:codex_exec|codex_cli_rs)\/\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?/;
+
+export const isCodexClientRequest = (c: Context): boolean =>
+  CODEX_USER_AGENT_PATTERN.test(c.req.header('user-agent') ?? '')
+  || c.req.header('originator') === 'codex_cli_rs';

--- a/packages/gateway/src/data-plane/codex/routes_test.ts
+++ b/packages/gateway/src/data-plane/codex/routes_test.ts
@@ -1,10 +1,139 @@
+import type { ExecutionContext } from 'hono';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
 import { mountCodexRoutes } from './routes.ts';
+import { app as gatewayApp } from '../../app.ts';
 import { type AuthVars, authMiddleware } from '../../middleware/auth.ts';
-import { copilotModels, setupAppTest } from '../../test-helpers.ts';
+import { copilotModels, setupAppTest, sseResponsesResponse } from '../../test-helpers.ts';
+import { isStoredResponseId } from '../llm/responses/items/format.ts';
 import { jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
+
+type WorkerResponseInit = ResponseInit & { readonly webSocket?: WebSocket };
+
+class TestWorkerWebSocket extends EventTarget {
+  peer?: TestWorkerWebSocket;
+  readyState: number = WebSocket.OPEN;
+
+  accept(): void {}
+
+  send(data: string): void {
+    this.peer?.dispatchEvent(new MessageEvent('message', { data }));
+  }
+
+  close(): void {
+    this.readyState = WebSocket.CLOSED;
+    if (this.peer) {
+      this.peer.readyState = WebSocket.CLOSED;
+      this.peer.dispatchEvent(new Event('close'));
+    }
+  }
+}
+
+const installWorkerWebSocketRuntime = (): {
+  readonly pairs: Array<{ readonly client: TestWorkerWebSocket; readonly server: TestWorkerWebSocket }>;
+  restore(): void;
+} => {
+  const globals = globalThis as typeof globalThis & {
+    WebSocketPair?: unknown;
+    Response: typeof Response;
+  };
+  const originalWebSocketPair = globals.WebSocketPair;
+  const OriginalResponse = globals.Response;
+  const pairs: Array<{ readonly client: TestWorkerWebSocket; readonly server: TestWorkerWebSocket }> = [];
+
+  globals.WebSocketPair = class {
+    constructor() {
+      const client = new TestWorkerWebSocket();
+      const server = new TestWorkerWebSocket();
+      client.peer = server;
+      server.peer = client;
+      pairs.push({ client, server });
+      return { 0: client, 1: server };
+    }
+  };
+
+  globals.Response = class extends OriginalResponse {
+    constructor(body?: BodyInit | null, init?: WorkerResponseInit) {
+      if (init?.status === 101) {
+        const { webSocket, status: _status, ...rest } = init;
+        super(null, { ...rest, status: 200 });
+        Object.defineProperty(this, 'status', { value: 101 });
+        Object.defineProperty(this, 'webSocket', { value: webSocket });
+        return;
+      }
+      super(body, init);
+    }
+  };
+
+  return {
+    pairs,
+    restore: () => {
+      globals.WebSocketPair = originalWebSocketPair;
+      globals.Response = OriginalResponse;
+    },
+  };
+};
+
+const waitForMessages = async (
+  socket: TestWorkerWebSocket,
+  done: (messages: readonly Record<string, unknown>[]) => boolean,
+  timeoutMs = 1_000,
+): Promise<readonly Record<string, unknown>[]> => {
+  const messages: Record<string, unknown>[] = [];
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.removeEventListener('message', onMessage);
+      reject(new Error(`Timed out waiting for WebSocket messages; received ${JSON.stringify(messages)}`));
+    }, timeoutMs);
+    const onMessage = (event: Event): void => {
+      const data = (event as MessageEvent<string>).data;
+      messages.push(JSON.parse(data) as Record<string, unknown>);
+      if (!done(messages)) return;
+      clearTimeout(timeout);
+      socket.removeEventListener('message', onMessage);
+      resolve(messages);
+    };
+    socket.addEventListener('message', onMessage);
+  });
+};
+
+const withWorkerWebSocketRuntime = async <T>(run: (runtime: ReturnType<typeof installWorkerWebSocketRuntime>) => Promise<T>): Promise<T> => {
+  const runtime = installWorkerWebSocketRuntime();
+  try {
+    return await run(runtime);
+  } finally {
+    runtime.restore();
+  }
+};
+
+const connectCodexResponsesWebSocket = async (
+  runtime: ReturnType<typeof installWorkerWebSocketRuntime>,
+  apiKey: string,
+): Promise<TestWorkerWebSocket> => {
+  const executionCtx = {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    props: {},
+  } satisfies ExecutionContext;
+  const response = await gatewayApp.fetch(new Request('https://example.test/azure-api.codex/responses', {
+    method: 'GET',
+    headers: {
+      upgrade: 'websocket',
+      authorization: `Bearer ${apiKey}`,
+    },
+  }), {}, executionCtx);
+  expect(response.status).toBe(101);
+  const pair = runtime.pairs.at(-1);
+  expect(pair).toBeDefined();
+  return pair!.client;
+};
+
+const responseDoneId = (messages: readonly Record<string, unknown>[]): string => {
+  const done = messages.find(message => message.type === 'response.done') as { response?: { id?: unknown } } | undefined;
+  expect(done?.response?.id).toEqual(expect.any(String));
+  return done!.response!.id as string;
+};
 
 const buildCodexApp = () => {
   const app = new Hono<{ Variables: AuthVars }>();
@@ -130,6 +259,146 @@ describe('codex 1p namespace', () => {
       });
       expect(response.status).toBe(426);
       expect(await response.json()).toEqual({ error: 'Expected Upgrade: websocket' });
+    });
+
+    it('chains previous_response_id on /azure-api.codex/responses WebSocket using response.done id', async () => {
+      const { apiKey } = await setupAppTest();
+      const upstreamBodies: unknown[] = [];
+      let turn = 0;
+
+      await withMockedFetch(
+        async request => {
+          const url = new URL(request.url);
+          if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+          if (url.pathname === '/copilot_internal/v2/token') {
+            return jsonResponse({ token: 'test-copilot-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+          }
+          if (url.pathname === '/models') {
+            return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+          }
+          if (url.pathname === '/responses') {
+            upstreamBodies.push(JSON.parse(await request.text()));
+            turn += 1;
+            return sseResponsesResponse({
+              id: `resp_codex_ws_${turn}`,
+              object: 'response',
+              model: 'gpt-direct-responses',
+              status: 'completed',
+              output_text: `codex ws answer ${turn}`,
+              output: [{
+                id: `assistant_codex_ws_${turn}`,
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [{ type: 'output_text', text: `codex ws answer ${turn}` }],
+              }],
+            });
+          }
+          throw new Error(`Unhandled fetch ${request.url}`);
+        },
+        async () => await withWorkerWebSocketRuntime(async runtime => {
+          const client = await connectCodexResponsesWebSocket(runtime, apiKey.key);
+          const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+          client.send(JSON.stringify({
+            type: 'response.create',
+            response: { model: 'gpt-direct-responses', input: 'codex first' },
+          }));
+          const firstResponseId = responseDoneId(await firstDone);
+          expect(isStoredResponseId(firstResponseId)).toBe(true);
+
+          const secondDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+          client.send(JSON.stringify({
+            type: 'response.create',
+            response: {
+              model: 'gpt-direct-responses',
+              previous_response_id: firstResponseId,
+              input: 'codex second',
+            },
+          }));
+          const secondResponseId = responseDoneId(await secondDone);
+          expect(isStoredResponseId(secondResponseId)).toBe(true);
+        }),
+      );
+
+      const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
+      expect(secondBody.previous_response_id).toBeUndefined();
+      expect(secondBody.input.map(item => [item.type, item.role, item.content])).toEqual([
+        ['message', 'user', 'codex first'],
+        ['message', 'assistant', [{ type: 'output_text', text: 'codex ws answer 1' }]],
+        ['message', 'user', 'codex second'],
+      ]);
+    });
+  });
+
+  describe('responses HTTP mounts', () => {
+    it('lets /v1/responses resolve previous_response_id minted by /azure-api.codex/responses', async () => {
+      const { apiKey } = await setupAppTest();
+      const upstreamBodies: unknown[] = [];
+      let turn = 0;
+      let firstResponseId: string | undefined;
+
+      await withMockedFetch(
+        async request => {
+          const url = new URL(request.url);
+          if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+          if (url.pathname === '/copilot_internal/v2/token') {
+            return jsonResponse({ token: 'test-copilot-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+          }
+          if (url.pathname === '/models') {
+            return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+          }
+          if (url.pathname === '/responses') {
+            upstreamBodies.push(JSON.parse(await request.text()));
+            turn += 1;
+            return sseResponsesResponse({
+              id: `resp_codex_http_${turn}`,
+              object: 'response',
+              model: 'gpt-direct-responses',
+              status: 'completed',
+              output_text: `codex http answer ${turn}`,
+              output: [{
+                id: `assistant_codex_http_${turn}`,
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [{ type: 'output_text', text: `codex http answer ${turn}` }],
+              }],
+            });
+          }
+          throw new Error(`Unhandled fetch ${request.url}`);
+        },
+        async () => {
+          const first = await gatewayApp.request('/azure-api.codex/responses', {
+            method: 'POST',
+            headers: { authorization: `Bearer ${apiKey.key}`, 'content-type': 'application/json' },
+            body: JSON.stringify({ model: 'gpt-direct-responses', input: 'codex http first' }),
+          });
+          expect(first.status).toBe(200);
+          const firstBody = await first.json() as { id: string };
+          firstResponseId = firstBody.id;
+          expect(isStoredResponseId(firstResponseId)).toBe(true);
+
+          const second = await gatewayApp.request('/v1/responses', {
+            method: 'POST',
+            headers: { 'x-api-key': apiKey.key, 'content-type': 'application/json' },
+            body: JSON.stringify({
+              model: 'gpt-direct-responses',
+              previous_response_id: firstResponseId,
+              input: 'v1 http second',
+            }),
+          });
+          expect(second.status).toBe(200);
+        },
+      );
+
+      expect(firstResponseId).toBeDefined();
+      const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
+      expect(secondBody.previous_response_id).toBeUndefined();
+      expect(secondBody.input.map(item => [item.type, item.role, item.content])).toEqual([
+        ['message', 'user', 'codex http first'],
+        ['message', 'assistant', [{ type: 'output_text', text: 'codex http answer 1' }]],
+        ['message', 'user', 'v1 http second'],
+      ]);
     });
   });
 

--- a/packages/gateway/src/data-plane/llm/responses/http.ts
+++ b/packages/gateway/src/data-plane/llm/responses/http.ts
@@ -5,6 +5,7 @@ import { respondResponses } from './respond.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
 import { CODEX_AUTO_REVIEW_ALIAS, CODEX_AUTO_REVIEW_TARGET } from '../../codex/auto-review-alias.ts';
+import { isCodexClientRequest } from '../../codex/client-detection.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createGatewayCtxFromHono } from '../shared/gateway-ctx.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
@@ -25,6 +26,9 @@ const rewriteResponsesEntryModelAlias = (payload: ResponsesPayload, stampReasoni
     reasoning: { ...(payload.reasoning ?? {}), effort: 'low' },
   };
 };
+
+const shouldPreserveCodexStoreFalse = (c: Context, payload: ResponsesPayload): boolean =>
+  payload.store === false && isCodexClientRequest(c);
 
 // OpenAI's verbatim previous_response_not_found envelope. Codex compares this
 // body byte-for-byte against upstream — see the cross-references on
@@ -62,8 +66,19 @@ export const responsesHttp = {
       const payload = rewriteResponsesEntryModelAlias(await c.req.json<ResponsesPayload>(), true);
       const wantsStream = payload.stream === true;
       const ctx = createGatewayCtxFromHono(c, { wantsStream });
-      const store = createResponsesHttpStore(ctx.apiKeyId, payload.store ?? undefined);
-      const result = await responsesServe.generate({ payload, ctx, store, snapshotMode: payload.store === false ? 'none' : 'append', headers: inboundHeadersForUpstream(c) });
+      // Codex sends `store:false` when it fails to classify the endpoint as
+      // Azure-style, but still chains turns through Floway-minted
+      // `previous_response_id`. Preserve gateway replay state for that client
+      // without rewriting the upstream wire body.
+      const preserveCodexStoreFalse = shouldPreserveCodexStoreFalse(c, payload);
+      const store = createResponsesHttpStore(ctx.apiKeyId, preserveCodexStoreFalse ? true : payload.store ?? undefined);
+      const result = await responsesServe.generate({
+        payload,
+        ctx,
+        store,
+        snapshotMode: payload.store === false && !preserveCodexStoreFalse ? 'none' : 'append',
+        headers: inboundHeadersForUpstream(c),
+      });
       const { response } = await respondResponses(c, result, wantsStream, ctx);
       return response;
     } catch (error) {

--- a/packages/gateway/src/data-plane/llm/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/http_test.ts
@@ -10,7 +10,7 @@ import type { ProviderCandidate } from '../shared/candidates.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { directFetcher, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
-import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
+import { assert, assertEquals, assertExists, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 // Mock the candidates seam so each test hands the http entry exactly the
 // provider candidates it wants. Mirrors the pattern from serve_test.ts.
@@ -192,6 +192,91 @@ test('POST /v1/responses returns a single JSON body when stream is omitted', asy
   const body = await response.json() as ResponsesResult;
   assert(isStoredResponseId(body.id), `expected floway-minted resp_ id, got ${body.id}`);
   assertEquals(body.status, 'completed');
+});
+
+test('POST /v1/responses with store:false keeps the response non-addressable for ordinary clients', async () => {
+  const repo = installRepo();
+  const callResponses = vi.fn(async (): Promise<ProviderStreamResult<ResponsesStreamEvent>> => ({
+    ok: true,
+    events: makeProviderEvents([completedEvent('resp_no_store')]),
+    modelKey: 'test-model-key',
+    headers: new Headers(),
+  }));
+  queueCandidates([makeCandidate({ callResponses })]);
+  const app = makeApp();
+
+  const response = await app.request('/v1/responses', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'test-model', input: 'do not store', store: false }),
+  });
+
+  assertEquals(response.status, 200);
+  const body = await response.json() as ResponsesResult;
+  assertEquals(await repo.responsesSnapshots.lookup(API_KEY_ID, body.id), null);
+
+  const followup = await app.request('/v1/responses', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: 'test-model',
+      previous_response_id: body.id,
+      input: 'follow up',
+    }),
+  });
+
+  assertEquals(followup.status, 400);
+  const followupBody = await followup.json() as { error: { code: string } };
+  assertEquals(followupBody.error.code, 'previous_response_not_found');
+});
+
+test('POST /v1/responses preserves gateway snapshots for Codex store:false requests without rewriting the provider body', async () => {
+  const repo = installRepo();
+  const observedBodies: Array<{ store?: unknown; previous_response_id?: unknown; input?: unknown }> = [];
+  const callResponses = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
+    observedBodies.push(body as { store?: unknown; previous_response_id?: unknown; input?: unknown });
+    return {
+      ok: true,
+      events: makeProviderEvents([completedEvent()]),
+      modelKey: 'test-model-key',
+      headers: new Headers(),
+    };
+  });
+  queueCandidates([makeCandidate({ callResponses })]);
+  queueCandidates([makeCandidate({ callResponses })]);
+  const app = makeApp();
+  const codexHeaders = { 'content-type': 'application/json', 'user-agent': 'codex_exec/0.999.0 (test)' };
+
+  const first = await app.request('/v1/responses', {
+    method: 'POST',
+    headers: codexHeaders,
+    body: JSON.stringify({ model: 'test-model', input: 'codex first', store: false }),
+  });
+
+  assertEquals(first.status, 200);
+  const firstBody = await first.json() as ResponsesResult;
+  assertExists(await repo.responsesSnapshots.lookup(API_KEY_ID, firstBody.id));
+
+  const second = await app.request('/v1/responses', {
+    method: 'POST',
+    headers: codexHeaders,
+    body: JSON.stringify({
+      model: 'test-model',
+      previous_response_id: firstBody.id,
+      input: 'codex second',
+      store: false,
+    }),
+  });
+
+  assertEquals(second.status, 200);
+  assertEquals(observedBodies.map(body => body.store), [false, false]);
+  assertEquals(observedBodies[1]?.previous_response_id, undefined);
+  const secondInput = observedBodies[1]?.input as Array<{ type: string; role?: string; content?: unknown }>;
+  assertEquals(secondInput.map(item => [item.type, item.role, item.content]), [
+    ['message', 'user', 'codex first'],
+    ['item_reference', undefined, undefined],
+    ['message', 'user', 'codex second'],
+  ]);
 });
 
 test('POST /v1/responses/compact returns a non-streaming compaction envelope', async () => {

--- a/packages/gateway/src/data-plane/llm/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/llm/responses/items/store.ts
@@ -580,12 +580,13 @@ export const createResponsesHttpStore = (apiKeyId: string | null, store: boolean
 
 // For Responses WebSocket entry — session-scoped layered store.
 //
-// `store=false` on a WS message disables the durable backing for that turn but
-// still records full items and snapshots in the session-scoped in-memory layer,
-// so subsequent messages on the same socket can resolve `previous_response_id`
-// against them. The session's lifetime bounds the data — nothing persists beyond
-// the socket. `store=true` (or omitted) layers durable repo writes on top of the
-// in-memory layer, so the turn is also addressable from later sessions.
+// Effective `store=false` disables the durable backing for that turn but still
+// records full items and snapshots in the session-scoped in-memory layer, so
+// subsequent messages on the same socket can resolve `previous_response_id`
+// against them. The session's lifetime bounds the data — nothing persists
+// beyond the socket. Effective `store=true` (or omitted) layers durable repo
+// writes on top of the in-memory layer, so the turn is also addressable from
+// later sessions.
 export const createResponsesWsSession = (apiKeyId: string | null): {
   createStore(store: boolean | undefined): StatefulResponsesStore;
 } => {

--- a/packages/gateway/src/data-plane/llm/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/llm/responses/websocket.ts
@@ -6,6 +6,7 @@ import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
 import { apiKeyFromContext, type AuthedContext } from '../../../middleware/auth.ts';
+import { isCodexClientRequest } from '../../codex/client-detection.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { SourceStreamState, eventResultMetadata, recordPerformance, recordUsage } from '../shared/respond.ts';
@@ -152,8 +153,13 @@ const handleClientMessage = async (
       : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
     const payload = responsesPayloadFromClientSource(source);
     const ctx = createGatewayCtxFromHono(c, { wantsStream: true, downstreamAbortController });
-    const store = session.createStore(payload.store ?? undefined);
-    const snapshotMode = payload.store === false ? 'none' : 'append';
+    // Codex may send `store:false` on /v1 WebSockets when the provider URL is
+    // not Azure-marked, while still expecting Floway response ids to chain.
+    // Preserve durable gateway replay state for Codex without rewriting the
+    // provider wire body; ordinary WS `store:false` stays session-local.
+    const preserveCodexStoreFalse = payload.store === false && isCodexClientRequest(c);
+    const store = session.createStore(preserveCodexStoreFalse ? true : payload.store ?? undefined);
+    const snapshotMode = 'append';
 
     let result;
     try {

--- a/packages/gateway/src/data-plane/llm/responses/websocket_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/websocket_test.ts
@@ -101,17 +101,32 @@ const waitForMicrotasks = async (): Promise<void> => {
   for (let i = 0; i < 10; i++) await Promise.resolve();
 };
 
-const connectResponsesWebSocket = async (apiKey: string): Promise<TestWorkerWebSocket> => {
+const responseDoneId = (messages: readonly Record<string, unknown>[]): string => {
+  const done = messages.find(message => message.type === 'response.done') as { response?: { id?: unknown } } | undefined;
+  assertExists(done);
+  const response = done.response;
+  assertExists(response);
+  const id = response.id;
+  if (typeof id !== 'string') throw new Error(`expected response.done id to be a string, got ${typeof id}`);
+  return id;
+};
+
+const connectResponsesWebSocket = async (
+  apiKey: string,
+  path = '/v1/responses',
+  extraHeaders: Record<string, string> = {},
+): Promise<TestWorkerWebSocket> => {
   const executionCtx = {
     waitUntil: () => {},
     passThroughOnException: () => {},
     props: {},
   } satisfies ExecutionContext;
-  const response = await app.fetch(new Request('https://example.test/v1/responses', {
+  const response = await app.fetch(new Request(`https://example.test${path}`, {
     method: 'GET',
     headers: {
       upgrade: 'websocket',
       'x-api-key': apiKey,
+      ...extraHeaders,
     },
   }), {}, executionCtx);
   assertEquals(response.status, 101);
@@ -409,13 +424,9 @@ test('Responses WebSocket forwards HTTP failures with status_code, error.code, a
   );
 });
 
-// store=false passes snapshotMode='none' to responsesServe, so the turn
-// writes neither a snapshot nor item rows anywhere (not even the per-session
-// MemoryStatefulResponsesBacking). A follow-up message that names the
-// previous response must therefore fail verbatim with the OpenAI
-// previous_response_not_found envelope.
-test('Responses WebSocket store:false writes no items/snapshot and follow-ups cannot resolve it', async () => {
+test('Responses WebSocket store:false keeps session snapshots without durable repo writes', async () => {
   const { apiKey, repo } = await setupAppTest();
+  const upstreamBodies: unknown[] = [];
 
   await withMockedFetch(
     async request => {
@@ -428,18 +439,20 @@ test('Responses WebSocket store:false writes no items/snapshot and follow-ups ca
         return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
       }
       if (url.pathname === '/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()));
+        const turn = upstreamBodies.length;
         return sseResponsesResponse({
-          id: 'resp_ws_first',
+          id: `resp_ws_store_false_${turn}`,
           object: 'response',
           model: 'gpt-direct-responses',
           status: 'completed',
-          output_text: 'first answer',
+          output_text: `answer ${turn}`,
           output: [{
-            id: 'assistant_ws_1',
+            id: `assistant_ws_store_false_${turn}`,
             type: 'message',
             role: 'assistant',
             status: 'completed',
-            content: [{ type: 'output_text', text: 'first answer' }],
+            content: [{ type: 'output_text', text: `answer ${turn}` }],
           }],
         });
       }
@@ -457,8 +470,9 @@ test('Responses WebSocket store:false writes no items/snapshot and follow-ups ca
         },
       }));
       const firstMessages = await firstDone;
+      const firstResponseId = responseDoneId(firstMessages);
 
-      assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_first'), null);
+      assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, firstResponseId), null);
       const firstOutput = firstMessages.find(message => message.type === 'response.output_item.done') as { item?: { id?: string } } | undefined;
       assertExists(firstOutput?.item?.id);
       assertEquals(await repo.responsesItems.lookupMany(apiKey.id, [firstOutput.item.id]), []);
@@ -467,28 +481,151 @@ test('Responses WebSocket store:false writes no items/snapshot and follow-ups ca
         [],
       );
 
-      const followupError = waitForMessages(client, messages => messages.length === 1);
+      const followupDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
       client.send(JSON.stringify({
         type: 'response.create',
         event_id: 'evt_followup',
         response: {
           model: 'gpt-direct-responses',
-          previous_response_id: 'resp_ws_first',
+          previous_response_id: firstResponseId,
           input: 'follow-up',
           store: false,
         },
       }));
-      assertEquals(await followupError, [{
+      const secondMessages = await followupDone;
+      const secondResponseId = responseDoneId(secondMessages);
+      assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, secondResponseId), null);
+
+      const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
+      assertEquals(secondBody.previous_response_id, undefined);
+      assertEquals(secondBody.input.map(item => [item.type, item.role, item.content]), [
+        ['message', 'user', 'first question'],
+        ['message', 'assistant', [{ type: 'output_text', text: 'answer 1' }]],
+        ['message', 'user', 'follow-up'],
+      ]);
+
+      const sessionB = await connectResponsesWebSocket(apiKey.key);
+      const missingDone = waitForMessages(sessionB, messages => messages.length === 1);
+      sessionB.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_cross_session',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'cross-session attempt',
+          store: false,
+        },
+      }));
+
+      assertEquals(await missingDone, [{
         type: 'error',
-        event_id: 'evt_followup',
+        event_id: 'evt_cross_session',
         status_code: 400,
         error: {
-          message: "Previous response with id 'resp_ws_first' not found.",
+          message: `Previous response with id '${firstResponseId}' not found.`,
           type: 'invalid_request_error',
           param: 'previous_response_id',
           code: 'previous_response_not_found',
         },
       }]);
+    }),
+  );
+});
+
+test('Responses WebSocket writes durable snapshots for Codex store:false requests without rewriting the provider body', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const upstreamBodies: unknown[] = [];
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()));
+        const turn = upstreamBodies.length;
+        return sseResponsesResponse({
+          id: `resp_ws_codex_store_false_${turn}`,
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output_text: `codex answer ${turn}`,
+          output: [{
+            id: `assistant_ws_codex_store_false_${turn}`,
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: `codex answer ${turn}` }],
+          }],
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key, '/v1/responses', { 'user-agent': 'codex_exec/0.999.0 (test)' });
+      const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        response: {
+          model: 'gpt-direct-responses',
+          input: 'codex first',
+          store: false,
+        },
+      }));
+      const firstMessages = await firstDone;
+      const firstResponseId = responseDoneId(firstMessages);
+      assertExists(await repo.responsesSnapshots.lookup(apiKey.id, firstResponseId));
+
+      const followupDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_followup',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'codex second',
+          store: false,
+        },
+      }));
+      const secondMessages = await followupDone;
+      assertExists(await repo.responsesSnapshots.lookup(apiKey.id, responseDoneId(secondMessages)));
+
+      const sessionB = await connectResponsesWebSocket(apiKey.key, '/v1/responses', { 'user-agent': 'codex_exec/0.999.0 (test)' });
+      const crossSessionDone = waitForMessages(sessionB, messages => messages.some(message => message.type === 'response.done'));
+      sessionB.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_cross_session',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'codex cross-session',
+          store: false,
+        },
+      }));
+      const crossSessionMessages = await crossSessionDone;
+      assertExists(await repo.responsesSnapshots.lookup(apiKey.id, responseDoneId(crossSessionMessages)));
+
+      const [firstBody, secondBody, crossSessionBody] = upstreamBodies as Array<{ store?: unknown; previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> }>;
+      assertEquals(firstBody?.store, false);
+      assertEquals(secondBody?.store, false);
+      assertEquals(crossSessionBody?.store, false);
+      assertEquals(secondBody?.previous_response_id, undefined);
+      assertEquals(secondBody?.input.map(item => [item.type, item.role, item.content]), [
+        ['message', 'user', 'codex first'],
+        ['message', 'assistant', [{ type: 'output_text', text: 'codex answer 1' }]],
+        ['message', 'user', 'codex second'],
+      ]);
+      assertEquals(crossSessionBody?.previous_response_id, undefined);
+      assertEquals(crossSessionBody?.input.map(item => [item.type, item.role, item.content]), [
+        ['message', 'user', 'codex first'],
+        ['message', 'assistant', [{ type: 'output_text', text: 'codex answer 1' }]],
+        ['message', 'user', 'codex cross-session'],
+      ]);
     }),
   );
 });


### PR DESCRIPTION
## Summary

Preserve response chaining for Codex-compatible clients across Floway's Responses surfaces.

The README documents that `store:false` on a Responses WebSocket turn should disable durable persistence, but should still keep response state inside the current socket session so later messages on the same WebSocket can use `previous_response_id`.

Before this change, `store:false` could skip snapshot recording entirely, so a follow-up message in the same socket could fail to resolve a response id that Floway had just returned.

This change makes WebSocket `store:false` session-local instead of stateless: it does not write durable response state, but it keeps enough in-memory socket state for same-session chaining to work.

## Codex Compatibility

Codex under `/azure-api.codex` normally sends `store:true`, but users may also point Codex-compatible clients at `/v1/responses`. In that path, strict handling of `store:false` can make chaining brittle even though Floway has enough local context to preserve the expected client behavior.

Floway returns its own response ids, so this change preserves replay state for Codex-style requests where needed.
That keeps follow-up turns usable across `/azure-api.codex` and `/v1/responses` without changing the upstream wire body.

## What Changed

- Keep WebSocket `store:false` snapshots in the socket-local session store.
- Preserve durable persistence for `store:true` and omitted `store`.
- Add Codex client detection for `/v1/responses` chaining.

## Tests

- `corepack pnpm vitest run --project @floway-dev/gateway packages/gateway/src/data-plane/codex/routes_test.ts packages/gateway/src/data-plane/llm/responses/http_test.ts packages/gateway/src/data-plane/llm/responses/websocket_test.ts`
- `corepack pnpm --filter @floway-dev/gateway run typecheck`
- `corepack pnpm eslint packages/gateway/src/data-plane/codex/client-detection.ts packages/gateway/src/data-plane/codex/routes_test.ts packages/gateway/src/data-plane/llm/responses/http.ts packages/gateway/src/data-plane/llm/responses/http_test.ts packages/gateway/src/data-plane/llm/responses/items/store.ts packages/gateway/src/data-plane/llm/responses/websocket.ts packages/gateway/src/data-plane/llm/responses/websocket_test.ts`