### PR TITLE
fix(provider-codex): match CLIProxyAPI response headers

### DIFF
--- a/packages/provider-codex/src/constants.ts
+++ b/packages/provider-codex/src/constants.ts
@@ -47,3 +47,9 @@ export const CODEX_CLI_VERSION = '0.137.0';
 // constraint at the top of this file.
 export const CODEX_ORIGINATOR = 'codex_cli_rs';
 export const CODEX_USER_AGENT = `codex_cli_rs/${CODEX_CLI_VERSION}`;
+
+// CLIProxyAPI's current Codex Responses executor presents as codex-tui
+// rather than codex_cli_rs. Keep this scoped to /codex/responses: model
+// listing still depends on the codex_cli_rs client_version contract above.
+export const CODEX_RESPONSES_ORIGINATOR = 'codex-tui';
+export const CODEX_RESPONSES_USER_AGENT = 'codex-tui/0.135.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.135.0)';

--- a/packages/provider-codex/src/constants.ts
+++ b/packages/provider-codex/src/constants.ts
@@ -1,6 +1,6 @@
-// All Codex / ChatGPT upstream constants. Do NOT make these operator-
-// configurable — wrapper-identifying UA suffixes trigger selective 401s from
-// OpenAI's bot management.
+// All Codex / ChatGPT upstream constants. Keep the data-plane identity fixed
+// to the official Codex CLI shape; operator-specific products or wrapper/MCP
+// UA suffixes make the client fingerprint drift.
 
 // codex-cli's OAuth client id. Used at auth.openai.com for both authorize and
 // token-exchange. Same value across the canonical Codex CLI source and every

--- a/packages/provider-codex/src/constants.ts
+++ b/packages/provider-codex/src/constants.ts
@@ -42,13 +42,9 @@ export const CODEX_MODELS_PATH = '/codex/models';
 // the User-Agent so the upstream sees a self-consistent client.
 export const CODEX_CLI_VERSION = '0.137.0';
 
-// Identity headers for /codex/models. Keep these scoped to model listing:
-// /codex/models depends on the codex_cli_rs client_version contract above.
-export const CODEX_MODELS_ORIGINATOR = 'codex_cli_rs';
-export const CODEX_MODELS_USER_AGENT = `codex_cli_rs/${CODEX_CLI_VERSION}`;
-
-// Identity headers for /codex/responses. Responses traffic presents as
-// codex-tui rather than codex_cli_rs.
-export const CODEX_RESPONSES_ORIGINATOR = 'codex-tui';
-export const CODEX_RESPONSES_USER_AGENT =
-  `codex-tui/${CODEX_CLI_VERSION} (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; ${CODEX_CLI_VERSION})`;
+// Shared official Codex data-plane identity for /codex/models and
+// /codex/responses. Keep wrapper-specific products and MCP suffixes out of
+// this shape; OpenAI's bot management keys on the client fingerprint.
+export const CODEX_ORIGINATOR = 'codex_cli_rs';
+export const CODEX_USER_AGENT =
+  `codex_cli_rs/${CODEX_CLI_VERSION} (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`;

--- a/packages/provider-codex/src/constants.ts
+++ b/packages/provider-codex/src/constants.ts
@@ -42,14 +42,13 @@ export const CODEX_MODELS_PATH = '/codex/models';
 // the User-Agent so the upstream sees a self-consistent client.
 export const CODEX_CLI_VERSION = '0.137.0';
 
-// Identity headers for /codex/responses. Bare User-Agent — no
-// parenthetical OS/arch/terminal suffix per the bot-management
-// constraint at the top of this file.
-export const CODEX_ORIGINATOR = 'codex_cli_rs';
-export const CODEX_USER_AGENT = `codex_cli_rs/${CODEX_CLI_VERSION}`;
+// Identity headers for /codex/models. Keep these scoped to model listing:
+// /codex/models depends on the codex_cli_rs client_version contract above.
+export const CODEX_MODELS_ORIGINATOR = 'codex_cli_rs';
+export const CODEX_MODELS_USER_AGENT = `codex_cli_rs/${CODEX_CLI_VERSION}`;
 
-// CLIProxyAPI's current Codex Responses executor presents as codex-tui
-// rather than codex_cli_rs. Keep this scoped to /codex/responses: model
-// listing still depends on the codex_cli_rs client_version contract above.
+// Identity headers for /codex/responses. Responses traffic presents as
+// codex-tui rather than codex_cli_rs.
 export const CODEX_RESPONSES_ORIGINATOR = 'codex-tui';
-export const CODEX_RESPONSES_USER_AGENT = 'codex-tui/0.135.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.135.0)';
+export const CODEX_RESPONSES_USER_AGENT =
+  `codex-tui/${CODEX_CLI_VERSION} (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; ${CODEX_CLI_VERSION})`;

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -85,21 +85,21 @@ const ensureAccessToken = async (opts: CallCodexResponsesOptions): Promise<strin
   return entry.token;
 };
 
-const CODEX_RESPONSE_PASSTHROUGH_HEADERS = [
+const CODEX_RESPONSES_PASSTHROUGH_HEADERS = [
   'version',
   'x-codex-beta-features',
   'x-codex-turn-metadata',
   'x-client-request-id',
 ] as const;
 
-const CODEX_RESPONSE_SESSION_HEADERS = ['session_id', 'session-id'] as const;
+const trimHeader = (headers: Headers, name: string): string | null => {
+  const value = headers.get(name)?.trim();
+  return value || null;
+};
 
-const nonEmptyHeader = (headers: Headers, names: readonly string[]): string | null => {
-  for (const name of names) {
-    const value = headers.get(name)?.trim();
-    if (value) return value;
-  }
-  return null;
+const setCodexSessionHeaders = (headers: Headers, source: Headers): void => {
+  const sessionId = trimHeader(source, 'session-id') ?? trimHeader(source, 'session_id') ?? crypto.randomUUID();
+  headers.set('session-id', sessionId);
 };
 
 const buildCodexResponsesHeaders = (opts: CallCodexResponsesOptions, accessToken: string): Headers => {
@@ -110,9 +110,9 @@ const buildCodexResponsesHeaders = (opts: CallCodexResponsesOptions, accessToken
   headers.set('user-agent', CODEX_RESPONSES_USER_AGENT);
   headers.set('accept', 'text/event-stream');
   headers.set('content-type', 'application/json');
-  headers.set('session_id', nonEmptyHeader(opts.headers, CODEX_RESPONSE_SESSION_HEADERS) ?? crypto.randomUUID());
+  setCodexSessionHeaders(headers, opts.headers);
 
-  for (const name of CODEX_RESPONSE_PASSTHROUGH_HEADERS) {
+  for (const name of CODEX_RESPONSES_PASSTHROUGH_HEADERS) {
     const value = opts.headers.get(name)?.trim();
     if (value) headers.set(name, value);
   }

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -2,9 +2,10 @@ import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToke
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import {
   CODEX_BACKEND_BASE,
-  CODEX_RESPONSES_ORIGINATOR,
+  CODEX_CLI_VERSION,
+  CODEX_ORIGINATOR,
   CODEX_RESPONSES_PATH,
-  CODEX_RESPONSES_USER_AGENT,
+  CODEX_USER_AGENT,
 } from './constants.ts';
 import {
   getCodexQuota,
@@ -85,39 +86,63 @@ const ensureAccessToken = async (opts: CallCodexResponsesOptions): Promise<strin
   return entry.token;
 };
 
-const CODEX_RESPONSES_PASSTHROUGH_HEADERS = [
-  'version',
-  'x-codex-beta-features',
-  'x-codex-turn-metadata',
-  'x-client-request-id',
-] as const;
+interface CodexRequestIdentity {
+  installationId: string;
+  sessionId: string;
+  threadId: string;
+  windowId: string;
+}
 
 const trimHeader = (headers: Headers, name: string): string | null => {
   const value = headers.get(name)?.trim();
   return value || null;
 };
 
-const setCodexSessionHeaders = (headers: Headers, source: Headers): void => {
-  const sessionId = trimHeader(source, 'session-id') ?? trimHeader(source, 'session_id') ?? crypto.randomUUID();
-  headers.set('session-id', sessionId);
+const buildCodexRequestIdentity = async (opts: CallCodexResponsesOptions): Promise<CodexRequestIdentity> => {
+  const sessionId = trimHeader(opts.headers, 'session-id') ?? trimHeader(opts.headers, 'session_id') ?? crypto.randomUUID();
+  const installationId = await sha256Uuid(`codex-installation:${opts.upstreamId}:${opts.account.chatgptAccountId}`);
+  const windowId = await sha256Uuid(`codex-window:${opts.upstreamId}:${opts.account.chatgptAccountId}:${sessionId}`);
+  return { installationId, sessionId, threadId: sessionId, windowId };
 };
 
-const buildCodexResponsesHeaders = (opts: CallCodexResponsesOptions, accessToken: string): Headers => {
+const buildCodexResponsesHeaders = (opts: CallCodexResponsesOptions, accessToken: string, identity: CodexRequestIdentity): Headers => {
   const headers = new Headers();
   headers.set('authorization', `Bearer ${accessToken}`);
   headers.set('chatgpt-account-id', opts.account.chatgptAccountId);
-  headers.set('originator', CODEX_RESPONSES_ORIGINATOR);
-  headers.set('user-agent', CODEX_RESPONSES_USER_AGENT);
+  headers.set('originator', CODEX_ORIGINATOR);
+  headers.set('user-agent', CODEX_USER_AGENT);
   headers.set('accept', 'text/event-stream');
   headers.set('content-type', 'application/json');
-  setCodexSessionHeaders(headers, opts.headers);
-
-  for (const name of CODEX_RESPONSES_PASSTHROUGH_HEADERS) {
-    const value = opts.headers.get(name)?.trim();
-    if (value) headers.set(name, value);
-  }
+  headers.set('session-id', identity.sessionId);
+  headers.set('thread-id', identity.threadId);
+  headers.set('version', CODEX_CLI_VERSION);
+  headers.set('x-client-request-id', identity.threadId);
+  headers.set('x-codex-window-id', identity.windowId);
+  headers.set('x-codex-turn-metadata', JSON.stringify({
+    installation_id: identity.installationId,
+    session_id: identity.sessionId,
+    thread_id: identity.threadId,
+    window_id: identity.windowId,
+  }));
 
   return headers;
+};
+
+const buildCodexResponsesBody = (
+  opts: CallCodexResponsesOptions,
+  identity: CodexRequestIdentity,
+): Record<string, unknown> => {
+  const body: Record<string, unknown> = {
+    ...(opts.body as unknown as Record<string, unknown>),
+    model: opts.model.id,
+    store: false,
+    stream: true,
+    client_metadata: {
+      'x-codex-installation-id': identity.installationId,
+    },
+  };
+  if (body.prompt_cache_key === undefined) body.prompt_cache_key = identity.threadId;
+  return body;
 };
 
 const performUpstreamCall = async (
@@ -125,12 +150,14 @@ const performUpstreamCall = async (
   accessToken: string,
   alreadyRetried: boolean,
 ): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
-  const headers = buildCodexResponsesHeaders(opts, accessToken);
+  const identity = await buildCodexRequestIdentity(opts);
+  const headers = buildCodexResponsesHeaders(opts, accessToken, identity);
+  const body = buildCodexResponsesBody(opts, identity);
 
   const upstreamFetch = opts.call.fetcher(`${CODEX_BACKEND_BASE}${CODEX_RESPONSES_PATH}`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ ...opts.body, model: opts.model.id, store: false, stream: true }),
+    body: JSON.stringify(body),
     signal: opts.signal,
   }, opts.call.recordUpstreamLatency).then(async response => {
     if (response.ok) {
@@ -203,6 +230,16 @@ const parseUpstreamError = (rawText: string): { code: string | null; message: st
   } catch {
     return { code: null, message: rawText.slice(0, 256) };
   }
+};
+
+// Format the SHA-256 hex digest as a UUIDv4-shaped opaque identifier. The
+// upstream treats these values opaquely, but UUID shape keeps logs and tools
+// that validate ids happy.
+const sha256Uuid = async (input: string): Promise<string> => {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  const hex = Array.from(new Uint8Array(buf), b => b.toString(16).padStart(2, '0')).join('');
+  const variantNibble = ((parseInt(hex[16], 16) & 0x3) | 0x8).toString(16);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-${variantNibble}${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
 };
 
 const synthetic503 = (message: string): Response => new Response(JSON.stringify({ error: { type: 'codex_upstream_unavailable', message } }), {

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -2,9 +2,9 @@ import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToke
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import {
   CODEX_BACKEND_BASE,
-  CODEX_ORIGINATOR,
+  CODEX_RESPONSES_ORIGINATOR,
   CODEX_RESPONSES_PATH,
-  CODEX_USER_AGENT,
+  CODEX_RESPONSES_USER_AGENT,
 } from './constants.ts';
 import {
   getCodexQuota,
@@ -85,21 +85,47 @@ const ensureAccessToken = async (opts: CallCodexResponsesOptions): Promise<strin
   return entry.token;
 };
 
+const CODEX_RESPONSE_PASSTHROUGH_HEADERS = [
+  'version',
+  'x-codex-beta-features',
+  'x-codex-turn-metadata',
+  'x-client-request-id',
+] as const;
+
+const CODEX_RESPONSE_SESSION_HEADERS = ['session_id', 'session-id'] as const;
+
+const nonEmptyHeader = (headers: Headers, names: readonly string[]): string | null => {
+  for (const name of names) {
+    const value = headers.get(name)?.trim();
+    if (value) return value;
+  }
+  return null;
+};
+
+const buildCodexResponsesHeaders = (opts: CallCodexResponsesOptions, accessToken: string): Headers => {
+  const headers = new Headers();
+  headers.set('authorization', `Bearer ${accessToken}`);
+  headers.set('chatgpt-account-id', opts.account.chatgptAccountId);
+  headers.set('originator', CODEX_RESPONSES_ORIGINATOR);
+  headers.set('user-agent', CODEX_RESPONSES_USER_AGENT);
+  headers.set('accept', 'text/event-stream');
+  headers.set('content-type', 'application/json');
+  headers.set('session_id', nonEmptyHeader(opts.headers, CODEX_RESPONSE_SESSION_HEADERS) ?? crypto.randomUUID());
+
+  for (const name of CODEX_RESPONSE_PASSTHROUGH_HEADERS) {
+    const value = opts.headers.get(name)?.trim();
+    if (value) headers.set(name, value);
+  }
+
+  return headers;
+};
+
 const performUpstreamCall = async (
   opts: CallCodexResponsesOptions,
   accessToken: string,
   alreadyRetried: boolean,
 ): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
-  // `opts.headers` is the provider's private boundary-ctx clone; mutate
-  // directly. Every header below uses `set`, so retry passes overwrite
-  // rather than accumulate.
-  const headers = opts.headers;
-  headers.set('authorization', `Bearer ${accessToken}`);
-  headers.set('chatgpt-account-id', opts.account.chatgptAccountId);
-  headers.set('originator', CODEX_ORIGINATOR);
-  headers.set('user-agent', CODEX_USER_AGENT);
-  headers.set('accept', 'text/event-stream');
-  headers.set('content-type', 'application/json');
+  const headers = buildCodexResponsesHeaders(opts, accessToken);
 
   const upstreamFetch = opts.call.fetcher(`${CODEX_BACKEND_BASE}${CODEX_RESPONSES_PATH}`, {
     method: 'POST',

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { CODEX_RESPONSES_ORIGINATOR, CODEX_RESPONSES_USER_AGENT } from './constants.ts';
+import { CODEX_CLI_VERSION, CODEX_ORIGINATOR, CODEX_USER_AGENT } from './constants.ts';
 import { callCodexResponses, type CodexCallEffects } from './fetch.ts';
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotEntry, CodexUpstreamState } from './state.ts';
 import { initProviderRepo, type Fetcher, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
@@ -17,6 +17,7 @@ const model: UpstreamModel = {
 };
 
 const upstreamId = 'up_a';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 const farFutureAccessToken: CodexAccessTokenEntry = {
   token: 'at_kv',
@@ -199,13 +200,17 @@ describe('callCodexResponses — upstream classification', () => {
     expect(body.stream).toBe(true);
   });
 
-  test('builds Codex responses headers from a clean set', async () => {
+  test('builds Codex responses headers and metadata from a clean set', async () => {
     seedFreshAccessToken();
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model,
-      body: { input: [], stream: true },
+      body: {
+        input: [],
+        stream: true,
+        client_metadata: { 'x-codex-installation-id': 'downstream-installation' },
+      } as unknown as Parameters<typeof callCodexResponses>[0]['body'],
       headers: new Headers({
         'cf-connecting-ip': '203.0.113.10',
         forwarded: 'for=203.0.113.10',
@@ -217,6 +222,7 @@ describe('callCodexResponses — upstream classification', () => {
         'x-client-request-id': 'req-123',
         'x-codex-beta-features': 'responses_websockets=2026-02-06',
         'x-codex-turn-metadata': 'turn-meta',
+        'x-codex-window-id': 'downstream-window',
         'x-real-ip': '203.0.113.10',
       }),
       effects: makeEffects(),
@@ -226,20 +232,120 @@ describe('callCodexResponses — upstream classification', () => {
     const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
     expect(headers.get('authorization')).toBe('Bearer at_kv');
     expect(headers.get('chatgpt-account-id')).toBe('acc');
-    expect(headers.get('originator')).toBe(CODEX_RESPONSES_ORIGINATOR);
-    expect(headers.get('user-agent')).toBe(CODEX_RESPONSES_USER_AGENT);
+    expect(headers.get('originator')).toBe(CODEX_ORIGINATOR);
+    expect(headers.get('user-agent')).toBe(CODEX_USER_AGENT);
     expect(headers.get('accept')).toBe('text/event-stream');
     expect(headers.get('content-type')).toBe('application/json');
     expect(headers.get('session-id')).toBe('downstream-session');
     expect(headers.get('session_id')).toBeNull();
-    expect(headers.get('version')).toBe('1');
-    expect(headers.get('x-client-request-id')).toBe('req-123');
-    expect(headers.get('x-codex-beta-features')).toBe('responses_websockets=2026-02-06');
-    expect(headers.get('x-codex-turn-metadata')).toBe('turn-meta');
+    expect(headers.get('version')).toBe(CODEX_CLI_VERSION);
+    expect(headers.get('x-client-request-id')).toBe('downstream-session');
+    expect(headers.get('thread-id')).toBe('downstream-session');
+    expect(headers.get('x-codex-beta-features')).toBeNull();
+    expect(headers.get('x-codex-window-id')).toMatch(UUID_RE);
+    expect(headers.get('x-codex-window-id')).not.toBe('downstream-window');
+    const turnMetadata = JSON.parse(headers.get('x-codex-turn-metadata') ?? 'null') as Record<string, unknown>;
+    expect(turnMetadata).toEqual({
+      installation_id: expect.stringMatching(UUID_RE),
+      session_id: 'downstream-session',
+      thread_id: 'downstream-session',
+      window_id: headers.get('x-codex-window-id'),
+    });
+    expect(headers.get('x-codex-turn-metadata')).not.toBe('turn-meta');
     expect(headers.get('cf-connecting-ip')).toBeNull();
     expect(headers.get('forwarded')).toBeNull();
     expect(headers.get('openai-beta')).toBeNull();
     expect(headers.get('x-real-ip')).toBeNull();
+
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.prompt_cache_key).toBe('downstream-session');
+    expect(body.client_metadata).toEqual({ 'x-codex-installation-id': turnMetadata.installation_id });
+  });
+
+  test('synthesized Codex identity is deterministic for the same session and account', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
+    const request = {
+      upstreamId, account: activeAccount, model,
+      body: { input: [], stream: true },
+      headers: new Headers({ 'session-id': 'stable-session' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    } satisfies Parameters<typeof callCodexResponses>[0];
+
+    await callCodexResponses(request);
+    await callCodexResponses({ ...request, headers: new Headers({ 'session-id': 'stable-session' }) });
+
+    const firstHeaders = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    const secondHeaders = new Headers((fetchSpy.mock.calls[1][1] as RequestInit).headers);
+    expect(firstHeaders.get('x-codex-window-id')).toBe(secondHeaders.get('x-codex-window-id'));
+    expect(firstHeaders.get('x-codex-turn-metadata')).toBe(secondHeaders.get('x-codex-turn-metadata'));
+    expect(firstHeaders.get('x-client-request-id')).toBe('stable-session');
+    expect(secondHeaders.get('x-client-request-id')).toBe('stable-session');
+  });
+
+  test('different sessions produce different synthesized window and turn metadata', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
+
+    await callCodexResponses({
+      upstreamId, account: activeAccount, model,
+      body: { input: [], stream: true },
+      headers: new Headers({ 'session-id': 'session-a' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    await callCodexResponses({
+      upstreamId, account: activeAccount, model,
+      body: { input: [], stream: true },
+      headers: new Headers({ 'session-id': 'session-b' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const firstHeaders = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    const secondHeaders = new Headers((fetchSpy.mock.calls[1][1] as RequestInit).headers);
+    expect(firstHeaders.get('x-codex-window-id')).not.toBe(secondHeaders.get('x-codex-window-id'));
+    expect(firstHeaders.get('x-codex-turn-metadata')).not.toBe(secondHeaders.get('x-codex-turn-metadata'));
+    const firstMetadata = JSON.parse(firstHeaders.get('x-codex-turn-metadata') ?? 'null') as Record<string, unknown>;
+    const secondMetadata = JSON.parse(secondHeaders.get('x-codex-turn-metadata') ?? 'null') as Record<string, unknown>;
+    expect(firstMetadata.installation_id).toBe(secondMetadata.installation_id);
+    expect(firstMetadata.session_id).toBe('session-a');
+    expect(secondMetadata.session_id).toBe('session-b');
+  });
+
+  test('injects prompt_cache_key only when caller leaves it absent', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
+
+    await callCodexResponses({
+      upstreamId, account: activeAccount, model,
+      body: { input: [], stream: true },
+      headers: new Headers({ 'session-id': 'cache-session' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    await callCodexResponses({
+      upstreamId, account: activeAccount, model,
+      body: { input: [], stream: true, prompt_cache_key: 'caller-cache-key' },
+      headers: new Headers({ 'session-id': 'cache-session' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    await callCodexResponses({
+      upstreamId, account: activeAccount, model,
+      body: { input: [], stream: true, prompt_cache_key: null },
+      headers: new Headers({ 'session-id': 'cache-session' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const injectedBody = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    const preservedStringBody = JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string) as Record<string, unknown>;
+    const preservedNullBody = JSON.parse((fetchSpy.mock.calls[2][1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(injectedBody.prompt_cache_key).toBe('cache-session');
+    expect(preservedStringBody.prompt_cache_key).toBe('caller-cache-key');
+    expect(preservedNullBody).toHaveProperty('prompt_cache_key', null);
   });
 
   test('preserves a hyphenated Codex session id for prompt cache', async () => {

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -199,7 +199,7 @@ describe('callCodexResponses — upstream classification', () => {
     expect(body.stream).toBe(true);
   });
 
-  test('builds CLIProxyAPI-style Codex responses headers from a clean set', async () => {
+  test('builds Codex responses headers from a clean set', async () => {
     seedFreshAccessToken();
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
     await callCodexResponses({
@@ -211,7 +211,7 @@ describe('callCodexResponses — upstream classification', () => {
         forwarded: 'for=203.0.113.10',
         'openai-beta': 'responses=experimental',
         originator: 'downstream-originator',
-        session_id: 'downstream-session',
+        'session-id': 'downstream-session',
         'user-agent': 'curl/8.7.1',
         version: '1',
         'x-client-request-id': 'req-123',
@@ -230,7 +230,8 @@ describe('callCodexResponses — upstream classification', () => {
     expect(headers.get('user-agent')).toBe(CODEX_RESPONSES_USER_AGENT);
     expect(headers.get('accept')).toBe('text/event-stream');
     expect(headers.get('content-type')).toBe('application/json');
-    expect(headers.get('session_id')).toBe('downstream-session');
+    expect(headers.get('session-id')).toBe('downstream-session');
+    expect(headers.get('session_id')).toBeNull();
     expect(headers.get('version')).toBe('1');
     expect(headers.get('x-client-request-id')).toBe('req-123');
     expect(headers.get('x-codex-beta-features')).toBe('responses_websockets=2026-02-06');
@@ -239,6 +240,57 @@ describe('callCodexResponses — upstream classification', () => {
     expect(headers.get('forwarded')).toBeNull();
     expect(headers.get('openai-beta')).toBeNull();
     expect(headers.get('x-real-ip')).toBeNull();
+  });
+
+  test('preserves a hyphenated Codex session id for prompt cache', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    await callCodexResponses({
+      upstreamId, account: activeAccount,
+      model,
+      body: { input: [], stream: true },
+      headers: new Headers({ 'session-id': 'cache-session' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get('session-id')).toBe('cache-session');
+    expect(headers.get('session_id')).toBeNull();
+  });
+
+  test('canonicalizes downstream session_id to the Codex session-id header', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    await callCodexResponses({
+      upstreamId, account: activeAccount,
+      model,
+      body: { input: [], stream: true },
+      headers: new Headers({ session_id: 'alias-session' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get('session-id')).toBe('alias-session');
+    expect(headers.get('session_id')).toBeNull();
+  });
+
+  test('prefers downstream session-id over session_id when both are provided', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    await callCodexResponses({
+      upstreamId, account: activeAccount,
+      model,
+      body: { input: [], stream: true },
+      headers: new Headers({ 'session-id': 'canonical-session', session_id: 'alias-session' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get('session-id')).toBe('canonical-session');
+    expect(headers.get('session_id')).toBeNull();
   });
 
   test('generates a Codex session id when the downstream request has none', async () => {
@@ -250,7 +302,8 @@ describe('callCodexResponses — upstream classification', () => {
     });
 
     const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
-    expect(headers.get('session_id')).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(headers.get('session-id')).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(headers.get('session_id')).toBeNull();
   });
 
   test('401 token_invalidated → persistTerminalState session_terminated, return 503', async () => {

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { CODEX_RESPONSES_ORIGINATOR, CODEX_RESPONSES_USER_AGENT } from './constants.ts';
 import { callCodexResponses, type CodexCallEffects } from './fetch.ts';
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotEntry, CodexUpstreamState } from './state.ts';
 import { initProviderRepo, type Fetcher, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
@@ -196,6 +197,60 @@ describe('callCodexResponses — upstream classification', () => {
     expect(body.model).toBe('gpt-5.4');
     expect(body.store).toBe(false);
     expect(body.stream).toBe(true);
+  });
+
+  test('builds CLIProxyAPI-style Codex responses headers from a clean set', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    await callCodexResponses({
+      upstreamId, account: activeAccount,
+      model,
+      body: { input: [], stream: true },
+      headers: new Headers({
+        'cf-connecting-ip': '203.0.113.10',
+        forwarded: 'for=203.0.113.10',
+        'openai-beta': 'responses=experimental',
+        originator: 'downstream-originator',
+        session_id: 'downstream-session',
+        'user-agent': 'curl/8.7.1',
+        version: '1',
+        'x-client-request-id': 'req-123',
+        'x-codex-beta-features': 'responses_websockets=2026-02-06',
+        'x-codex-turn-metadata': 'turn-meta',
+        'x-real-ip': '203.0.113.10',
+      }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get('authorization')).toBe('Bearer at_kv');
+    expect(headers.get('chatgpt-account-id')).toBe('acc');
+    expect(headers.get('originator')).toBe(CODEX_RESPONSES_ORIGINATOR);
+    expect(headers.get('user-agent')).toBe(CODEX_RESPONSES_USER_AGENT);
+    expect(headers.get('accept')).toBe('text/event-stream');
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get('session_id')).toBe('downstream-session');
+    expect(headers.get('version')).toBe('1');
+    expect(headers.get('x-client-request-id')).toBe('req-123');
+    expect(headers.get('x-codex-beta-features')).toBe('responses_websockets=2026-02-06');
+    expect(headers.get('x-codex-turn-metadata')).toBe('turn-meta');
+    expect(headers.get('cf-connecting-ip')).toBeNull();
+    expect(headers.get('forwarded')).toBeNull();
+    expect(headers.get('openai-beta')).toBeNull();
+    expect(headers.get('x-real-ip')).toBeNull();
+  });
+
+  test('generates a Codex session id when the downstream request has none', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    await callCodexResponses({
+      upstreamId, account: activeAccount,
+      model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
+    });
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get('session_id')).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 
   test('401 token_invalidated → persistTerminalState session_terminated, return 503', async () => {

--- a/packages/provider-codex/src/interceptors/responses/inject-session-id.ts
+++ b/packages/provider-codex/src/interceptors/responses/inject-session-id.ts
@@ -1,10 +1,9 @@
 import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 
-// Codex backend's prompt cache keys on the `session-id` header. Empirically:
-// with a stable `session-id` repeated across turns of the same conversation,
-// ~88% of input tokens hit the cache (e.g. 1792/2031 on a 2k-token prompt).
-// Without it, cache hits are sporadic at best.
+// Codex backend's prompt cache keys on the `session-id` header. Keeping it
+// stable across turns of the same conversation gives upstream a consistent
+// cache key; omitting it leaves cache affinity to upstream defaults.
 //
 // Strategy: derive a stable id from `(instructions + first user-message text)`
 // so the same conversation prefix produces the same session-id across turns,

--- a/packages/provider-codex/src/interceptors/responses/inject-session-id.ts
+++ b/packages/provider-codex/src/interceptors/responses/inject-session-id.ts
@@ -1,11 +1,10 @@
 import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 
-// Codex backend's prompt cache keys on the `session-id` header (hyphen form;
-// underscore form is silently ignored). Empirically: with a stable hyphen
-// `session-id` repeated across turns of the same conversation, ~88% of input
-// tokens hit the cache (e.g. 1792/2031 on a 2k-token prompt). Without it,
-// cache hits are sporadic at best.
+// Codex backend's prompt cache keys on the `session-id` header. Empirically:
+// with a stable `session-id` repeated across turns of the same conversation,
+// ~88% of input tokens hit the cache (e.g. 1792/2031 on a 2k-token prompt).
+// Without it, cache hits are sporadic at best.
 //
 // Strategy: derive a stable id from `(instructions + first user-message text)`
 // so the same conversation prefix produces the same session-id across turns,
@@ -13,16 +12,21 @@ import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 // (different system prompt or different opening user message) get different
 // ids and don't poison each other's cache.
 //
-// Honor a client-supplied `session-id` (or underscore variant) verbatim — the
-// client may already track its own session boundary; we only inject when both
-// header forms are absent.
+// Honor a client-supplied `session-id` verbatim. A downstream `session_id` is
+// accepted only as a compatibility alias when the canonical header is absent;
+// upstream still receives only `session-id`.
 
 export const injectSessionId = async <TResult>(
   ctx: ResponsesBoundaryCtx,
   _request: object,
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
-  if (ctx.headers.get('session-id') || ctx.headers.get('session_id')) return await run();
+  const suppliedSessionId = trimHeader(ctx.headers, 'session-id') ?? trimHeader(ctx.headers, 'session_id');
+  if (suppliedSessionId) {
+    ctx.headers.set('session-id', suppliedSessionId);
+    ctx.headers.delete('session_id');
+    return await run();
+  }
 
   const instructions = typeof ctx.payload.instructions === 'string' ? ctx.payload.instructions : '';
   const firstUser = firstUserMessageText(ctx.payload.input);
@@ -30,6 +34,11 @@ export const injectSessionId = async <TResult>(
   // collide with an empty first-user-message via prefix concatenation.
   ctx.headers.set('session-id', await sha256Uuid(`${instructions}${firstUser}`));
   return await run();
+};
+
+const trimHeader = (headers: Headers, name: string): string | null => {
+  const value = headers.get(name)?.trim();
+  return value || null;
 };
 
 const firstUserMessageText = (input: unknown): string => {

--- a/packages/provider-codex/src/interceptors/responses/inject-session-id_test.ts
+++ b/packages/provider-codex/src/interceptors/responses/inject-session-id_test.ts
@@ -74,13 +74,25 @@ test('honors a client-supplied session-id (hyphen form) without overwriting', as
   assertEquals(ctx.headers.get('session-id'), 'client-supplied');
 });
 
-test('honors a client-supplied session_id (underscore form) without injecting hyphen variant', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hi' }, new Headers({ 'session_id': 'client-supplied' }));
+test('canonicalizes a client-supplied session_id alias when session-id is absent', async () => {
+  const ctx = invocation({ model: 'gpt-test', input: 'hi' }, new Headers({ session_id: 'client-supplied' }));
 
   await injectSessionId(ctx, stubRequest, okEvents);
 
-  assertEquals(ctx.headers.get('session_id'), 'client-supplied');
-  assertEquals(ctx.headers.get('session-id'), null);
+  assertEquals(ctx.headers.get('session-id'), 'client-supplied');
+  assertEquals(ctx.headers.get('session_id'), null);
+});
+
+test('prefers session-id over a client-supplied session_id alias', async () => {
+  const ctx = invocation({ model: 'gpt-test', input: 'hi' }, new Headers({
+    'session-id': 'canonical',
+    session_id: 'alias',
+  }));
+
+  await injectSessionId(ctx, stubRequest, okEvents);
+
+  assertEquals(ctx.headers.get('session-id'), 'canonical');
+  assertEquals(ctx.headers.get('session_id'), null);
 });
 
 test('handles array input by reading the first role:"user" item', async () => {

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -1,9 +1,9 @@
 import {
   CODEX_BACKEND_BASE,
   CODEX_CLI_VERSION,
+  CODEX_MODELS_ORIGINATOR,
   CODEX_MODELS_PATH,
-  CODEX_ORIGINATOR,
-  CODEX_USER_AGENT,
+  CODEX_MODELS_USER_AGENT,
 } from './constants.ts';
 import { pricingForCodexModelKey } from './pricing.ts';
 import { type Fetcher, type UpstreamModel } from '@floway-dev/provider';
@@ -26,8 +26,8 @@ export const fetchCodexCatalog = async (opts: { accessToken: string; accountId: 
     headers: {
       authorization: `Bearer ${opts.accessToken}`,
       'chatgpt-account-id': opts.accountId,
-      originator: CODEX_ORIGINATOR,
-      'user-agent': CODEX_USER_AGENT,
+      originator: CODEX_MODELS_ORIGINATOR,
+      'user-agent': CODEX_MODELS_USER_AGENT,
       accept: 'application/json',
     },
     signal: opts.signal,

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -1,9 +1,9 @@
 import {
   CODEX_BACKEND_BASE,
   CODEX_CLI_VERSION,
-  CODEX_MODELS_ORIGINATOR,
   CODEX_MODELS_PATH,
-  CODEX_MODELS_USER_AGENT,
+  CODEX_ORIGINATOR,
+  CODEX_USER_AGENT,
 } from './constants.ts';
 import { pricingForCodexModelKey } from './pricing.ts';
 import { type Fetcher, type UpstreamModel } from '@floway-dev/provider';
@@ -26,8 +26,8 @@ export const fetchCodexCatalog = async (opts: { accessToken: string; accountId: 
     headers: {
       authorization: `Bearer ${opts.accessToken}`,
       'chatgpt-account-id': opts.accountId,
-      originator: CODEX_MODELS_ORIGINATOR,
-      'user-agent': CODEX_MODELS_USER_AGENT,
+      originator: CODEX_ORIGINATOR,
+      'user-agent': CODEX_USER_AGENT,
       accept: 'application/json',
     },
     signal: opts.signal,

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -30,7 +30,7 @@ describe('fetchCodexCatalog', () => {
     expect(headers.get('chatgpt-account-id')).toBe('acc');
     expect(headers.get('originator')).toBe(CODEX_ORIGINATOR);
     expect(headers.get('user-agent')).toBe(CODEX_USER_AGENT);
-    expect(headers.get('user-agent')).toBe('codex_cli_rs/0.137.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10');
+    expect(headers.get('user-agent')).toBe(`codex_cli_rs/${CODEX_CLI_VERSION} (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`);
     expect(headers.get('openai-beta')).toBeNull();
   });
 

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { CODEX_CLI_VERSION } from './constants.ts';
+import { CODEX_CLI_VERSION, CODEX_ORIGINATOR, CODEX_USER_AGENT } from './constants.ts';
 import { codexRawToUpstreamModel, fetchCodexCatalog } from './models.ts';
 import { resolveEffectivePricing } from '@floway-dev/protocols/common';
 import { directFetcher } from '@floway-dev/provider';
@@ -28,8 +28,9 @@ describe('fetchCodexCatalog', () => {
     const headers = new Headers((init as RequestInit | undefined)?.headers);
     expect(headers.get('authorization')).toBe('Bearer at');
     expect(headers.get('chatgpt-account-id')).toBe('acc');
-    expect(headers.get('originator')).toBe('codex_cli_rs');
-    expect(headers.get('user-agent')).toBe(`codex_cli_rs/${CODEX_CLI_VERSION}`);
+    expect(headers.get('originator')).toBe(CODEX_ORIGINATOR);
+    expect(headers.get('user-agent')).toBe(CODEX_USER_AGENT);
+    expect(headers.get('user-agent')).toBe('codex_cli_rs/0.137.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10');
     expect(headers.get('openai-beta')).toBeNull();
   });
 


### PR DESCRIPTION
Match the Codex Responses request headers used by CLIProxyAPI for `/backend-api/codex/responses`.

We hit a case where the same upstream account and same proxy egress IP behaved differently depending on the client shape:

- `/codex/models` could fetch and list models normally.
- Codex CLI worked normally from a machine using the same egress IP.
- Floway requests to `/backend-api/codex/responses` still returned upstream `403`.

That pointed away from account validity, token refresh, or proxy reachability, and toward request fingerprint differences on the Responses data-plane call.

The captured 403 body starts with a normal HTML document:
```html
<html>
  <head>
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <style global>body{font-family:Arial,Helvetica,sans-serif}.container{align-items:center;display:flex;flex-direction:column;height:100%;justify-content:center;width:100%}@keyframes enlarge-appear{0%{opacity:0;transform:scale(75%) rotate(-90deg)}to{opacity:1;transform:scale(100%) rotate(0deg)}}.logo{color:#8e8ea0;padding-bottom:1.5rem}.scale-appear{animation:enlarge-appear .4s ease-out}@media (min-width:768px){.scale-appear{height:48px;width:48px}}.data:empty{display:none}.data{border-radius:5px;color:#8e8ea0;max-width:420px;text-align:center;width:100%}.data ul{list-style:none;padding:0}.blocked-icon{color:#ef4444}.message{align-items:center;display:flex;font-size:1.5rem;gap:1rem;justify-content:center}.explanation{font-size:.9rem;line-height:1.5;max-width:420px;opacity:50%;text-align:center;width:100%}.explanation a{color:#000}@media (prefers-color-scheme:dark){body{background-color:#343541;color:#eee}.logo{color:#acacbe}.explanation a{color:#fff}}</style>
  </head>
  <body>
    <div class="container">
      <div class="logo">
        <svg
          width="41"
          height="41"
          viewBox="0 0 41 41"
          fill="none"
          xmlns="http://www.w3.org/2000/svg"
          strokeWidth="2"
          class="scale-appear"
        >
          <path
            d="M37.5324 16.8707C37.9808 15.5241 38.1363 14.0974 37.9886 12.6859C37.8409 11.2744 37.3934 9.91076 36.676 8.68622C35.6126 6.83404 33.9882 5.3676 32.0373 4.4985C30.0864 3.62941 27.9098 3.40259 25.8215 3.85078C24.8796 2.7893 23.7219 1.94125 22.4257 1.36341C21.1295 0.785575 19.7249 0.491269 18.3058 0.500197C16.1708 0.495044 14.0893 1.16803 12.3614 2.42214C10.6335 3.67624 9.34853 5.44666 8.6917 7.47815C7.30085 7.76286 5.98686 8.3414 4.8377 9.17505C3.68854 10.0087 2.73073 11.0782 2.02839 12.312C0.956464 14.1591 0.498905 16.2988 0.721698 18.4228C0.944492 20.5467 1.83612 22.5449 3.268 24.1293C2.81966 25.4759 2.66413 26.9026 2.81182 28.3141C2.95951 29.7256 3.40701 31.0892 4.12437 32.3138C5.18791 34.1659 6.8123 35.6322 8.76321 36.5013C10.7141 37.3704 12.8907 37.5973 14.9789 37.1492C15.9208 38.2107 17.0786 39.0587 18.3747 39.6366C19.6709 40.2144 21.0755 40.5087 22.4946 40.4998C24.6307 40.5054 26.7133 39.8321 28.4418 38.5772C30.1704 37.3223 31.4556 35.5506 32.1119 33.5179C33.5027 33.2332 34.8167 32.6547 35.9659 31.821C37.115 30.9874 38.0728 29.9178 38.7752 28.684C39.8458 26.8371 40.3023 24.6979 40.0789 22.5748C39.8556 20.4517 38.9639 18.4544 37.5324 16.8707ZM22.4978 37.8849C20.7443 37.8874 19.0459 37.2733 17.6994 36.1501C17.7601 36.117 17.8666 36.0586 17.936 36.0161L25.9004 31.4156C26.1003 31.3019 26.2663 31.137 26.3813 30.9378C26.4964 30.7386 26.5563 30.5124 26.5549 30.2825V19.0542L29.9213 20.998C29.9389 21.0068 29.9541 21.0198 29.9656 21.0359C29.977 21.052 29.9842 21.0707 29.9867 21.0902V30.3889C29.9842 32.375 29.1946 34.2791 27.7909 35.6841C26.3872 37.0892 24.4838 37.8806 22.4978 37.8849ZM6.39227 31.0064C5.51397 29.4888 5.19742 27.7107 5.49804 25.9832C5.55718 26.0187 5.66048 26.0818 5.73461 26.1244L13.699 30.7248C13.8975 30.8408 14.1233 30.902 14.3532 30.902C14.583 30.902 14.8088 30.8408 15.0073 30.7248L24.731 25.1103V28.9979C24.7321 29.0177 24.7283 29.0376 24.7199 29.0556C24.7115 29.0736 24.6988 29.0893 24.6829 29.1012L16.6317 33.7497C14.9096 34.7416 12.8643 35.0097 10.9447 34.4954C9.02506 33.9811 7.38785 32.7263 6.39227 31.0064ZM4.29707 13.6194C5.17156 12.0998 6.55279 10.9364 8.19885 10.3327C8.19885 10.4013 8.19491 10.5228 8.19491 10.6071V19.808C8.19351 20.0378 8.25334 20.2638 8.36823 20.4629C8.48312 20.6619 8.64893 20.8267 8.84863 20.9404L18.5723 26.5542L15.206 28.4979C15.1894 28.5089 15.1703 28.5155 15.1505 28.5173C15.1307 28.5191 15.1107 28.516 15.0924 28.5082L7.04046 23.8557C5.32135 22.8601 4.06716 21.2235 3.55289 19.3046C3.03862 17.3858 3.30624 15.3413 4.29707 13.6194ZM31.955 20.0556L22.2312 14.4411L25.5976 12.4981C25.6142 12.4872 25.6333 12.4805 25.6531 12.4787C25.67
```