### PR TITLE
fix(responses): treat compaction_trigger as a control signal, not a stored item

### DIFF
--- a/packages/gateway/src/data-plane/llm/responses/items/format_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/items/format_test.ts
@@ -62,6 +62,16 @@ test('throws for unknown item types instead of using a generic fallback prefix',
   assertThrows(() => createTemporaryResponsesItemId('unknown_item'), TypeError, 'Unknown Responses item type');
 });
 
+// `compaction_trigger` is intentionally absent from the prefix map. It is a
+// per-request control signal (payload-free, idless, never re-sent on later
+// turns) that is filtered out in `stageInputItem`, so no stored row is ever
+// minted for it. The throw here is the regression test: it pins the invariant
+// that nobody adds a prefix back without also re-introducing a use case.
+test('rejects compaction_trigger — a control signal that should never be stored', () => {
+  assertThrows(() => createStoredResponsesItemId('compaction_trigger'), TypeError, 'Unknown Responses item type');
+  assertThrows(() => createTemporaryResponsesItemId('compaction_trigger'), TypeError, 'Unknown Responses item type');
+});
+
 test('successive stored ids for the same item type collide-free under random body', () => {
   const seen = new Set<string>();
   for (let i = 0; i < 1024; i += 1) {

--- a/packages/gateway/src/data-plane/llm/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/llm/responses/items/store.ts
@@ -268,6 +268,15 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
   }
 
   private async stageInputItem(item: ResponsesInputItem): Promise<void> {
+    // `compaction_trigger` is a per-request control signal, not content:
+    // payload-free, idless, never persisted in codex's own rollout/history,
+    // and never re-sent on subsequent turns. A trigger-bearing generate is
+    // treated as a compaction (serve forces snapshotMode='replace') so the
+    // next snapshot is the resulting `compaction` blob alone; this row
+    // would have no reader. Skipping it also keeps `createStoredResponsesItemId`
+    // from minting a prefix for a type that never needs one.
+    if (item.type === 'compaction_trigger') return;
+
     if (item.type === 'item_reference') {
       const row = this.getItemById(item.id);
       if (row === undefined) throw new Error(`Cannot stage unresolved Responses item_reference id=${item.id}`);

--- a/packages/gateway/src/data-plane/llm/responses/serve.ts
+++ b/packages/gateway/src/data-plane/llm/responses/serve.ts
@@ -25,6 +25,15 @@ export interface ResponsesServeCompactArgs {
   readonly headers: Headers;
 }
 
+// Codex's RemoteCompactionV2 performs compaction through the generate path
+// by appending a `compaction_trigger` control item to the input. Semantically
+// this is the same operation as `/responses/compact`: the upstream replaces
+// the prior history with a single `compaction` output, and any later
+// `previous_response_id` should resolve to that blob alone — not the dropped
+// history. Treat such a request like compact at the snapshot seam.
+const containsCompactionTrigger = (input: ResponsesPayload['input']): boolean =>
+  typeof input !== 'string' && input.some(item => item.type === 'compaction_trigger');
+
 export const responsesServe = {
   generate: async (args: ResponsesServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
     const { payload, ctx, store, snapshotMode = 'append', headers } = args;
@@ -37,7 +46,10 @@ export const responsesServe = {
               : null,
     });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.generate({ payload: plan.prepared, ctx, store, candidate: plan.candidate, snapshotMode, headers });
+    const effectiveSnapshotMode: ResponsesSnapshotMode = snapshotMode !== 'none' && containsCompactionTrigger(plan.prepared.input)
+      ? 'replace'
+      : snapshotMode;
+    return await responsesAttempt.generate({ payload: plan.prepared, ctx, store, candidate: plan.candidate, snapshotMode: effectiveSnapshotMode, headers });
   },
 
   compact: async (args: ResponsesServeCompactArgs): Promise<ResponsesAttemptResult> => {

--- a/packages/gateway/src/data-plane/llm/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/serve_test.ts
@@ -559,3 +559,86 @@ test('generate reuses an existing input row when a later turn echoes the same us
   if (turn1InputId === undefined || turn2InputId === undefined) throw new Error('expected each snapshot to start with a staged input item');
   assertEquals(turn2InputId, turn1InputId);
 });
+
+test('generate treats compaction_trigger-bearing input as compaction: snapshot replaces prior history with the compaction output alone, trigger reaches the wire but never stores a row', async () => {
+  const repo = installRepo();
+
+  // Seed a prior conversation: one user message + a snapshot pointing at it.
+  // The compacting turn references that snapshot via previous_response_id, so
+  // generate without the trigger would normally append [prior items + this
+  // turn's input + output] into the new snapshot. The trigger flips that to
+  // 'replace' so the new snapshot only carries the compaction blob — the
+  // whole point of compaction is to drop the prior history.
+  const priorMessageId = createStoredResponsesItemId('message');
+  await repo.responsesItems.insertMany([{
+    id: priorMessageId,
+    apiKeyId: API_KEY_ID,
+    upstreamId: null,
+    upstreamItemId: null,
+    itemType: 'message',
+    origin: 'input',
+    contentHash: null,
+    encryptedContentHash: null,
+    payload: { item: { type: 'message', id: priorMessageId, role: 'user', content: 'old turn' } },
+    createdAt: 1_000,
+    refreshedAt: 1_000,
+  }]);
+  await repo.responsesSnapshots.insert({
+    id: 'resp_before_compact',
+    apiKeyId: API_KEY_ID,
+    itemIds: [priorMessageId],
+    createdAt: 1_000,
+    refreshedAt: 1_000,
+  });
+
+  let receivedInput: unknown = null;
+  const callResponses = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
+    receivedInput = (body as { input: unknown }).input;
+    return {
+      ok: true,
+      events: makeProtocolFrames([{
+        type: 'response.completed',
+        sequence_number: 0,
+        response: {
+          ...makeResponsesResult(),
+          output: [{ type: 'compaction', id: 'upstream_cmp_id', encrypted_content: 'ENC' }] as unknown as ResponsesResult['output'],
+        },
+      }]),
+      modelKey: 'test-model-key',
+      headers: new Headers(),
+    };
+  });
+  queueCandidates([makeCandidate({ upstream: 'up_a', callResponses })]);
+
+  const result = await responsesServe.generate({
+    payload: makePayload({
+      previous_response_id: 'resp_before_compact',
+      input: [{ type: 'compaction_trigger' }],
+    }),
+    ctx: makeGatewayCtx(),
+    store: createResponsesHttpStore(API_KEY_ID, true),
+    headers: new Headers(),
+  });
+
+  if (result.type !== 'events') throw new Error('expected events');
+  const events = await collectEvents(result.events);
+  const completed = events.find(e => e.type === 'response.completed') as Extract<ResponsesStreamEvent, { type: 'response.completed' }>;
+  const responseId = completed.response.id;
+
+  // 'replace' semantics: only the new compaction row, no item_reference to
+  // priorMessageId and no row for the trigger. (The test would also throw
+  // outright at `stageInputItem` if the trigger early-return regressed,
+  // since createStoredResponsesItemId('compaction_trigger') has no prefix.)
+  const snap = await repo.responsesSnapshots.lookup(API_KEY_ID, responseId);
+  if (snap === null) throw new Error('expected snapshot to be persisted');
+  assertEquals(snap.itemIds.length, 1);
+  const onlyItemId = snap.itemIds[0];
+  if (onlyItemId === undefined) throw new Error('unreachable');
+  assertEquals(onlyItemId.startsWith('cmp_'), true);
+
+  // The trigger still reaches the upstream — the gateway only intercepts at
+  // the storage seam, not on the wire. The expanded prefix puts item_reference
+  // first, the trigger last.
+  if (!Array.isArray(receivedInput)) throw new Error('expected the wire input to be an array');
+  assertEquals((receivedInput.at(-1) as { type?: unknown })?.type, 'compaction_trigger');
+});


### PR DESCRIPTION
## Summary

Replaces #90. The trailing `compaction_trigger` input item that codex's RemoteCompactionV2 sends is a **control signal**, not content: payload-free, idless on the wire ([the Responses API rejects an `id` field for it](https://github.com/openai/codex/blob/9f06cf1a0907f650887ca26af5cee13b4f9a13ea/codex-rs/protocol/src/models.rs#L1122-L1128)), [synthesized fresh at compact time and never persisted or echoed back](https://github.com/openai/codex/blob/9f06cf1a0907f650887ca26af5cee13b4f9a13ea/codex-rs/core/src/compact_remote_v2.rs#L236-L237).

Two symptoms come from treating it like a normal input item:

1. `stageInputItem` falls through to `createStoredResponsesItemId('compaction_trigger')`, which throws because the type has no prefix in the storage scheme — every auto-compacting `/azure-api.codex` session 500's before the upstream call.
2. Even with a prefix, the request would commit an `'append'` snapshot stitching `[prior history + this turn's input + compaction blob]`, defeating the entire point of compaction (the next `previous_response_id` would re-load the history we just paid to summarize away).

This PR addresses both at the storage seam without changing what reaches the upstream wire:

- `stageInputItem` early-returns for `compaction_trigger`. The trigger is ephemeral and content-free; persisting it would create a row no future turn ever references.
- `responsesServe.generate` detects a trigger in the prepared input and forces `snapshotMode: 'replace'` (the same mode the dedicated `/responses/compact` path already uses), unless the caller already opted out via `store: false`. The new snapshot becomes the compaction output alone, matching codex's own [rollout/history policy](https://github.com/openai/codex/blob/9f06cf1a0907f650887ca26af5cee13b4f9a13ea/codex-rs/rollout/src/policy.rs).

#90's `compaction_trigger: 'cmpt'` prefix mapping is therefore unnecessary and intentionally not introduced. A regression test in `format_test.ts` pins `createStoredResponsesItemId('compaction_trigger')` to throw so a future contributor doesn't reintroduce storage for the trigger.

## Test plan

- [x] `pnpm run test` — 2792 passed
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] Manual: continue a `/azure-api.codex` conversation past the auto-compact threshold; verify the request succeeds, the response carries a `compaction` output item, and the subsequent `previous_response_id` reference reads back only the compaction blob (not the dropped history).