### PR TITLE
fix(responses): keep WebSocket store:false snapshots session-local

### DIFF
--- a/packages/gateway/src/data-plane/codex/routes_test.ts
+++ b/packages/gateway/src/data-plane/codex/routes_test.ts
@@ -1,10 +1,139 @@
+import type { ExecutionContext } from 'hono';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
 import { mountCodexRoutes } from './routes.ts';
+import { app as gatewayApp } from '../../app.ts';
 import { type AuthVars, authMiddleware } from '../../middleware/auth.ts';
-import { copilotModels, setupAppTest } from '../../test-helpers.ts';
+import { copilotModels, setupAppTest, sseResponsesResponse } from '../../test-helpers.ts';
+import { isStoredResponseId } from '../llm/responses/items/format.ts';
 import { jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
+
+type WorkerResponseInit = ResponseInit & { readonly webSocket?: WebSocket };
+
+class TestWorkerWebSocket extends EventTarget {
+  peer?: TestWorkerWebSocket;
+  readyState: number = WebSocket.OPEN;
+
+  accept(): void {}
+
+  send(data: string): void {
+    this.peer?.dispatchEvent(new MessageEvent('message', { data }));
+  }
+
+  close(): void {
+    this.readyState = WebSocket.CLOSED;
+    if (this.peer) {
+      this.peer.readyState = WebSocket.CLOSED;
+      this.peer.dispatchEvent(new Event('close'));
+    }
+  }
+}
+
+const installWorkerWebSocketRuntime = (): {
+  readonly pairs: Array<{ readonly client: TestWorkerWebSocket; readonly server: TestWorkerWebSocket }>;
+  restore(): void;
+} => {
+  const globals = globalThis as typeof globalThis & {
+    WebSocketPair?: unknown;
+    Response: typeof Response;
+  };
+  const originalWebSocketPair = globals.WebSocketPair;
+  const OriginalResponse = globals.Response;
+  const pairs: Array<{ readonly client: TestWorkerWebSocket; readonly server: TestWorkerWebSocket }> = [];
+
+  globals.WebSocketPair = class {
+    constructor() {
+      const client = new TestWorkerWebSocket();
+      const server = new TestWorkerWebSocket();
+      client.peer = server;
+      server.peer = client;
+      pairs.push({ client, server });
+      return { 0: client, 1: server };
+    }
+  };
+
+  globals.Response = class extends OriginalResponse {
+    constructor(body?: BodyInit | null, init?: WorkerResponseInit) {
+      if (init?.status === 101) {
+        const { webSocket, status: _status, ...rest } = init;
+        super(null, { ...rest, status: 200 });
+        Object.defineProperty(this, 'status', { value: 101 });
+        Object.defineProperty(this, 'webSocket', { value: webSocket });
+        return;
+      }
+      super(body, init);
+    }
+  };
+
+  return {
+    pairs,
+    restore: () => {
+      globals.WebSocketPair = originalWebSocketPair;
+      globals.Response = OriginalResponse;
+    },
+  };
+};
+
+const waitForMessages = async (
+  socket: TestWorkerWebSocket,
+  done: (messages: readonly Record<string, unknown>[]) => boolean,
+  timeoutMs = 1_000,
+): Promise<readonly Record<string, unknown>[]> => {
+  const messages: Record<string, unknown>[] = [];
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.removeEventListener('message', onMessage);
+      reject(new Error(`Timed out waiting for WebSocket messages; received ${JSON.stringify(messages)}`));
+    }, timeoutMs);
+    const onMessage = (event: Event): void => {
+      const data = (event as MessageEvent<string>).data;
+      messages.push(JSON.parse(data) as Record<string, unknown>);
+      if (!done(messages)) return;
+      clearTimeout(timeout);
+      socket.removeEventListener('message', onMessage);
+      resolve(messages);
+    };
+    socket.addEventListener('message', onMessage);
+  });
+};
+
+const withWorkerWebSocketRuntime = async <T>(run: (runtime: ReturnType<typeof installWorkerWebSocketRuntime>) => Promise<T>): Promise<T> => {
+  const runtime = installWorkerWebSocketRuntime();
+  try {
+    return await run(runtime);
+  } finally {
+    runtime.restore();
+  }
+};
+
+const connectCodexResponsesWebSocket = async (
+  runtime: ReturnType<typeof installWorkerWebSocketRuntime>,
+  apiKey: string,
+): Promise<TestWorkerWebSocket> => {
+  const executionCtx = {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    props: {},
+  } satisfies ExecutionContext;
+  const response = await gatewayApp.fetch(new Request('https://example.test/azure-api.codex/responses', {
+    method: 'GET',
+    headers: {
+      upgrade: 'websocket',
+      authorization: `Bearer ${apiKey}`,
+    },
+  }), {}, executionCtx);
+  expect(response.status).toBe(101);
+  const pair = runtime.pairs.at(-1);
+  expect(pair).toBeDefined();
+  return pair!.client;
+};
+
+const responseDoneId = (messages: readonly Record<string, unknown>[]): string => {
+  const done = messages.find(message => message.type === 'response.done') as { response?: { id?: unknown } } | undefined;
+  expect(done?.response?.id).toEqual(expect.any(String));
+  return done!.response!.id as string;
+};
 
 const buildCodexApp = () => {
   const app = new Hono<{ Variables: AuthVars }>();
@@ -130,6 +259,75 @@ describe('codex 1p namespace', () => {
       });
       expect(response.status).toBe(426);
       expect(await response.json()).toEqual({ error: 'Expected Upgrade: websocket' });
+    });
+
+    it('chains previous_response_id on /azure-api.codex/responses WebSocket using response.done id', async () => {
+      const { apiKey } = await setupAppTest();
+      const upstreamBodies: unknown[] = [];
+      let turn = 0;
+
+      await withMockedFetch(
+        async request => {
+          const url = new URL(request.url);
+          if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+          if (url.pathname === '/copilot_internal/v2/token') {
+            return jsonResponse({ token: 'test-copilot-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+          }
+          if (url.pathname === '/models') {
+            return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+          }
+          if (url.pathname === '/responses') {
+            upstreamBodies.push(JSON.parse(await request.text()));
+            turn += 1;
+            return sseResponsesResponse({
+              id: `resp_codex_ws_${turn}`,
+              object: 'response',
+              model: 'gpt-direct-responses',
+              status: 'completed',
+              output_text: `codex ws answer ${turn}`,
+              output: [{
+                id: `assistant_codex_ws_${turn}`,
+                type: 'message',
+                role: 'assistant',
+                status: 'completed',
+                content: [{ type: 'output_text', text: `codex ws answer ${turn}` }],
+              }],
+            });
+          }
+          throw new Error(`Unhandled fetch ${request.url}`);
+        },
+        async () => await withWorkerWebSocketRuntime(async runtime => {
+          const client = await connectCodexResponsesWebSocket(runtime, apiKey.key);
+          const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+          client.send(JSON.stringify({
+            type: 'response.create',
+            response: { model: 'gpt-direct-responses', input: 'codex first', store: false },
+          }));
+          const firstResponseId = responseDoneId(await firstDone);
+          expect(isStoredResponseId(firstResponseId)).toBe(true);
+
+          const secondDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+          client.send(JSON.stringify({
+            type: 'response.create',
+            response: {
+              model: 'gpt-direct-responses',
+              previous_response_id: firstResponseId,
+              input: 'codex second',
+              store: false,
+            },
+          }));
+          const secondResponseId = responseDoneId(await secondDone);
+          expect(isStoredResponseId(secondResponseId)).toBe(true);
+        }),
+      );
+
+      const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
+      expect(secondBody.previous_response_id).toBeUndefined();
+      expect(secondBody.input.map(item => [item.type, item.role, item.content])).toEqual([
+        ['message', 'user', 'codex first'],
+        ['message', 'assistant', [{ type: 'output_text', text: 'codex ws answer 1' }]],
+        ['message', 'user', 'codex second'],
+      ]);
     });
   });
 

--- a/packages/gateway/src/data-plane/llm/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/llm/responses/websocket.ts
@@ -153,7 +153,7 @@ const handleClientMessage = async (
     const payload = responsesPayloadFromClientSource(source);
     const ctx = createGatewayCtxFromHono(c, { wantsStream: true, downstreamAbortController });
     const store = session.createStore(payload.store ?? undefined);
-    const snapshotMode = payload.store === false ? 'none' : 'append';
+    const snapshotMode = 'append';
 
     let result;
     try {

--- a/packages/gateway/src/data-plane/llm/responses/websocket_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/websocket_test.ts
@@ -101,6 +101,16 @@ const waitForMicrotasks = async (): Promise<void> => {
   for (let i = 0; i < 10; i++) await Promise.resolve();
 };
 
+const responseDoneId = (messages: readonly Record<string, unknown>[]): string => {
+  const done = messages.find(message => message.type === 'response.done') as { response?: { id?: unknown } } | undefined;
+  assertExists(done);
+  const response = done.response;
+  assertExists(response);
+  const id = response.id;
+  if (typeof id !== 'string') throw new Error(`expected response.done id to be a string, got ${typeof id}`);
+  return id;
+};
+
 const connectResponsesWebSocket = async (apiKey: string): Promise<TestWorkerWebSocket> => {
   const executionCtx = {
     waitUntil: () => {},
@@ -409,13 +419,9 @@ test('Responses WebSocket forwards HTTP failures with status_code, error.code, a
   );
 });
 
-// store=false passes snapshotMode='none' to responsesServe, so the turn
-// writes neither a snapshot nor item rows anywhere (not even the per-session
-// MemoryStatefulResponsesBacking). A follow-up message that names the
-// previous response must therefore fail verbatim with the OpenAI
-// previous_response_not_found envelope.
-test('Responses WebSocket store:false writes no items/snapshot and follow-ups cannot resolve it', async () => {
+test('Responses WebSocket store:false keeps session snapshots without durable repo writes', async () => {
   const { apiKey, repo } = await setupAppTest();
+  const upstreamBodies: unknown[] = [];
 
   await withMockedFetch(
     async request => {
@@ -428,18 +434,20 @@ test('Responses WebSocket store:false writes no items/snapshot and follow-ups ca
         return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
       }
       if (url.pathname === '/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()));
+        const turn = upstreamBodies.length;
         return sseResponsesResponse({
-          id: 'resp_ws_first',
+          id: `resp_ws_store_false_${turn}`,
           object: 'response',
           model: 'gpt-direct-responses',
           status: 'completed',
-          output_text: 'first answer',
+          output_text: `answer ${turn}`,
           output: [{
-            id: 'assistant_ws_1',
+            id: `assistant_ws_store_false_${turn}`,
             type: 'message',
             role: 'assistant',
             status: 'completed',
-            content: [{ type: 'output_text', text: 'first answer' }],
+            content: [{ type: 'output_text', text: `answer ${turn}` }],
           }],
         });
       }
@@ -457,8 +465,9 @@ test('Responses WebSocket store:false writes no items/snapshot and follow-ups ca
         },
       }));
       const firstMessages = await firstDone;
+      const firstResponseId = responseDoneId(firstMessages);
 
-      assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, 'resp_ws_first'), null);
+      assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, firstResponseId), null);
       const firstOutput = firstMessages.find(message => message.type === 'response.output_item.done') as { item?: { id?: string } } | undefined;
       assertExists(firstOutput?.item?.id);
       assertEquals(await repo.responsesItems.lookupMany(apiKey.id, [firstOutput.item.id]), []);
@@ -467,23 +476,48 @@ test('Responses WebSocket store:false writes no items/snapshot and follow-ups ca
         [],
       );
 
-      const followupError = waitForMessages(client, messages => messages.length === 1);
+      const followupDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
       client.send(JSON.stringify({
         type: 'response.create',
         event_id: 'evt_followup',
         response: {
           model: 'gpt-direct-responses',
-          previous_response_id: 'resp_ws_first',
+          previous_response_id: firstResponseId,
           input: 'follow-up',
           store: false,
         },
       }));
-      assertEquals(await followupError, [{
+      const secondMessages = await followupDone;
+      const secondResponseId = responseDoneId(secondMessages);
+      assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, secondResponseId), null);
+
+      const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
+      assertEquals(secondBody.previous_response_id, undefined);
+      assertEquals(secondBody.input.map(item => [item.type, item.role, item.content]), [
+        ['message', 'user', 'first question'],
+        ['message', 'assistant', [{ type: 'output_text', text: 'answer 1' }]],
+        ['message', 'user', 'follow-up'],
+      ]);
+
+      const sessionB = await connectResponsesWebSocket(apiKey.key);
+      const missingDone = waitForMessages(sessionB, messages => messages.length === 1);
+      sessionB.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_cross_session',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'cross-session attempt',
+          store: false,
+        },
+      }));
+
+      assertEquals(await missingDone, [{
         type: 'error',
-        event_id: 'evt_followup',
+        event_id: 'evt_cross_session',
         status_code: 400,
         error: {
-          message: "Previous response with id 'resp_ws_first' not found.",
+          message: `Previous response with id '${firstResponseId}' not found.`,
           type: 'invalid_request_error',
           param: 'previous_response_id',
           code: 'previous_response_not_found',


### PR DESCRIPTION
Replaces https://github.com/Menci/Floway/pull/91. Removed the Codex-compatible persistence part.

The README documents that store:false on a Responses WebSocket turn should disable durable persistence, but should still keep response state inside the current socket session so later messages on the same WebSocket can use previous_response_id.

Before this change, store:false could skip snapshot recording entirely, so a follow-up message in the same socket could fail to resolve a response id that Floway had just returned.

This change makes WebSocket store:false session-local instead of stateless: it does not write durable response state, but it keeps enough in-memory socket state for same-session chaining to work.

Reproduce:
Use /v1/response endpoint and turn on supports_websockets for codex.

Screenshots:
<img width="1280" height="950" alt="5028528722566384658" src="https://github.com/user-attachments/assets/e52368ea-4943-4047-b0cb-02a963c62f7b" />
