### PR TITLE
fix(gateway): scrub client-IP propagation signals from inbound headers

### DIFF
--- a/packages/gateway/src/data-plane/shared/inbound-headers.ts
+++ b/packages/gateway/src/data-plane/shared/inbound-headers.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
 
 // Headers stripped from the inbound request before the data plane threads
-// the bag down to the provider boundary. Three groups, one deny-list:
+// the bag down to the provider boundary. Four groups, one deny-list:
 //
 // - Gateway-owned auth + identity. Providers pin their own credentials and
 //   content-type on the wire (Azure's `api-key`, Anthropic's `x-api-key`,
@@ -23,20 +23,35 @@ import type { Context } from 'hono';
 //   transparently decode, and SSE upstreams must stay uncompressed
 //   end-to-end so stream parsers see raw bytes.
 //
-// Non-secret propagation signals (`forwarded`, `cf-*`, `x-real-ip`,
-// `user-agent`, vendor `anthropic-*` / `openai-*` betas, and any other
-// business header the client sends) stay in the bag and reach the
-// upstream. Copilot and Codex clone the bag before merging their own
-// pinned headers, so they inherit the scrub for free.
-const SCRUBBED_INBOUND_HEADERS = [
+// - Client-IP / geo propagation signals injected by the runtime edge or by
+//   any reverse proxy in front of us: every `cf-*` header Cloudflare adds
+//   (`cf-connecting-ip`, `cf-ipcountry`, `cf-ray`, `cf-visitor`,
+//   `cf-warp-tag-id`, `cf-worker`, and a long tail of geo/ASN entries that
+//   Cloudflare extends over time — matched by prefix rather than
+//   enumeration), the RFC 7239 `forwarded` chain, the de-facto
+//   `x-forwarded-*` family, `x-real-ip`, `x-client-ip`, `true-client-ip`,
+//   and the RFC 8586 `cdn-loop` cookie. Forwarding these is both a privacy
+//   leak (the client's real IP and coarse geo reach the LLM upstream) and
+//   an availability hazard: OpenAI's Cloudflare WAF 403s Codex Responses
+//   requests when downstream `cf-*` signals disagree with our egress IP,
+//   the same shape cubercsl reported for a Node deployment behind a
+//   Cloudflare reverse proxy.
+//
+// Vendor business headers (`user-agent`, `anthropic-*` / `openai-*` betas,
+// `x-client-request-id`, and any other header the client legitimately
+// authored) still reach upstream. Providers that clone the bag before
+// merging their own pinned headers inherit the scrub for free.
+const SCRUBBED_INBOUND_HEADER_NAMES = [
   'accept-encoding',
   'api-key',
   'authorization',
+  'cdn-loop',
   'connection',
   'content-length',
   'content-type',
   'cookie',
   'expect',
+  'forwarded',
   'host',
   'keep-alive',
   'proxy-authorization',
@@ -44,11 +59,19 @@ const SCRUBBED_INBOUND_HEADERS = [
   'te',
   'trailer',
   'transfer-encoding',
+  'true-client-ip',
   'upgrade',
   'x-api-key',
+  'x-client-ip',
   'x-floway-session',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
   'x-goog-api-key',
+  'x-real-ip',
 ];
+
+const SCRUBBED_INBOUND_HEADER_PREFIXES = ['cf-'];
 
 // Build the unified inbound-headers bag the data plane threads to the
 // provider boundary. Copies the source request's headers and removes the
@@ -57,6 +80,9 @@ const SCRUBBED_INBOUND_HEADERS = [
 // it into a boundary ctx (Copilot, Codex).
 export const inboundHeadersForUpstream = (c: Context): Headers => {
   const headers = new Headers(c.req.raw.headers);
-  for (const name of SCRUBBED_INBOUND_HEADERS) headers.delete(name);
+  for (const name of SCRUBBED_INBOUND_HEADER_NAMES) headers.delete(name);
+  for (const name of [...headers.keys()]) {
+    if (SCRUBBED_INBOUND_HEADER_PREFIXES.some(prefix => name.startsWith(prefix))) headers.delete(name);
+  }
   return headers;
 };

--- a/packages/gateway/src/data-plane/shared/inbound-headers_test.ts
+++ b/packages/gateway/src/data-plane/shared/inbound-headers_test.ts
@@ -46,7 +46,7 @@ describe('inboundHeadersForUpstream', () => {
     assertEquals(headers.get('user-agent'), 'claude-sdk/1.0');
   });
 
-  test('strips HTTP/1.1 framing, hop-by-hop, and accept-encoding while preserving propagation signals', async () => {
+  test('strips HTTP/1.1 framing, hop-by-hop, accept-encoding, and client-IP propagation signals', async () => {
     const app = new Hono();
     let headers: Headers | undefined;
     app.post('/test', c => {
@@ -68,7 +68,13 @@ describe('inboundHeadersForUpstream', () => {
         'upgrade': 'websocket',
         'forwarded': 'for=192.0.2.1;proto=https',
         'x-real-ip': '192.0.2.1',
+        'x-client-ip': '192.0.2.1',
+        'true-client-ip': '192.0.2.1',
         'x-forwarded-for': '192.0.2.1',
+        'x-forwarded-host': 'gateway.example.com',
+        'x-forwarded-proto': 'https',
+        'cdn-loop': 'cloudflare',
+        'anthropic-beta': 'context-1m',
       },
       body: 'inbound-body-bytes',
     });
@@ -84,12 +90,45 @@ describe('inboundHeadersForUpstream', () => {
       'trailer',
       'transfer-encoding',
       'upgrade',
+      'forwarded',
+      'x-real-ip',
+      'x-client-ip',
+      'true-client-ip',
+      'x-forwarded-for',
+      'x-forwarded-host',
+      'x-forwarded-proto',
+      'cdn-loop',
     ]) {
       assertEquals(headers.has(name), false);
     }
-    assertEquals(headers.get('forwarded'), 'for=192.0.2.1;proto=https');
-    assertEquals(headers.get('x-real-ip'), '192.0.2.1');
-    assertEquals(headers.get('x-forwarded-for'), '192.0.2.1');
+    assertEquals(headers.get('anthropic-beta'), 'context-1m');
+  });
+
+  test('strips every cf-* header Cloudflare injects, by prefix', async () => {
+    const app = new Hono();
+    let headers: Headers | undefined;
+    app.get('/test', c => {
+      headers = inboundHeadersForUpstream(c);
+      return c.text('ok');
+    });
+    await app.request('/test', {
+      headers: {
+        'cf-connecting-ip': '203.0.113.10',
+        'cf-connecting-ipv6': '2001:db8::1',
+        'cf-ipcountry': 'US',
+        'cf-ray': 'abcdef1234567890-IAD',
+        'cf-visitor': '{"scheme":"https"}',
+        'cf-warp-tag-id': 'tag-1',
+        'cf-worker': 'gateway.example.com',
+        'cf-something-future': 'whatever',
+        'anthropic-beta': 'context-1m',
+      },
+    });
+    assertExists(headers);
+    for (const name of [...headers.keys()]) {
+      if (name.startsWith('cf-')) throw new Error(`expected cf-* to be scrubbed, saw ${name}`);
+    }
+    assertEquals(headers.get('anthropic-beta'), 'context-1m');
   });
 
   test('returns a fresh Headers each call so mutations do not leak across requests', async () => {


### PR DESCRIPTION
## Summary

- Strip `cf-*` (by prefix), `forwarded`, `x-forwarded-{for,host,proto}`, `x-real-ip`, `x-client-ip`, `true-client-ip`, and `cdn-loop` from the inbound bag the data plane threads to every provider boundary.
- Single funnel at `packages/gateway/src/data-plane/shared/inbound-headers.ts`, so Copilot, Azure, Custom, and Ollama (all passthrough) inherit the fix for free — the Codex Responses fingerprint fix in #92 is the orthogonal first defense and still needed.
- Switch the scrub structure to "exact name list + prefix list" because Cloudflare keeps extending its `cf-*` set (geo, ASN, Warp tags); enumeration would rot.

## Why

Two problems with letting these headers reach upstream:

- **Privacy**: client's real IP and coarse geo end up at the LLM upstream. We call on behalf of our users; upstream should only see our egress.
- **Availability**: OpenAI's Cloudflare WAF 403s Codex Responses when downstream `cf-*` signals disagree with our egress IP. @cubercsl reported the same 403 page (#92 (comment)) for a Node deployment behind a Cloudflare reverse proxy, resolved by stripping `cf-*` upstream of Floway. Closing the leak in the gateway funnel covers it for every operator and every provider in one place.

## Test plan

- [x] `pnpm run test` — 277 files / 3113 tests pass, including the new prefix-coverage case (`cf-something-future` exercised).
- [x] `pnpm run typecheck` — clean across all packages.
- [x] `pnpm run lint` — clean.
- [x] Existing inbound-headers test that previously asserted `forwarded`/`x-real-ip`/`x-forwarded-for` are preserved has been flipped to assert they are stripped.