### PR TITLE
feat(web-search): add Jina as a third provider

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -325,9 +325,10 @@ export interface ControlPlaneModel extends PublicModel {
 }
 
 export interface SearchConfig {
-  provider: 'disabled' | 'tavily' | 'microsoft-grounding';
+  provider: 'disabled' | 'tavily' | 'microsoft-grounding' | 'jina';
   tavily: { apiKey: string };
   microsoftGrounding: { apiKey: string };
+  jina: { apiKey: string };
 }
 
 export interface CopilotQuotaSnapshot {

--- a/apps/web/src/components/settings/SearchConfigSection.vue
+++ b/apps/web/src/components/settings/SearchConfigSection.vue
@@ -5,7 +5,7 @@ import { callApi, useApi } from '../../api/client.ts';
 import type { SearchConfig } from '../../api/types.ts';
 import { useAuthStore } from '../../stores/auth.ts';
 import SecretInput from '../shared/SecretInput.vue';
-import { Button, Input } from '@floway-dev/ui';
+import { Button, Input, Select } from '@floway-dev/ui';
 
 interface SearchTestResult {
   ok: boolean;
@@ -15,43 +15,45 @@ interface SearchTestResult {
   error?: { code: string; message: string };
 }
 
-// Single source of truth for the provider list. Each entry knows its
-// human label, the per-provider config slot, and a `set` writer that
-// returns a fresh SearchConfig with that slot's apiKey replaced.
+// Single source of truth for the provider list. `apiKey` reads the
+// per-provider config slot; `set` writes a new apiKey back into that slot.
+// Both are absent for the `disabled` option, which has no credential field.
 interface ProviderOption {
-  id: SearchConfig['provider'];
+  value: SearchConfig['provider'];
   label: string;
   description: string;
-  // `apiKey` reads from the config slot; `set` writes a new apiKey back
-  // into the right slot. Both ignored for the `disabled` option.
   apiKey?: (config: SearchConfig) => string;
   set?: (config: SearchConfig, apiKey: string) => SearchConfig;
 }
 
+// Presented as a dropdown rather than radio cards so adding a fifth
+// provider stays a one-line entry; the existing per-option description
+// slot in the shared Select also keeps the explanation inside the
+// popover instead of permanently consuming vertical space.
 const PROVIDER_OPTIONS: ProviderOption[] = [
   {
-    id: 'disabled',
+    value: 'disabled',
     label: 'Disabled',
-    description: 'No upstream web search provider',
+    description: 'No upstream web search provider.',
   },
   {
-    id: 'tavily',
+    value: 'tavily',
     label: 'Tavily',
-    description: 'Gateway-managed Tavily API key',
+    description: 'Gateway-managed Tavily API key.',
     apiKey: config => config.tavily.apiKey,
     set: (config, apiKey) => ({ ...config, tavily: { apiKey } }),
   },
   {
-    id: 'microsoft-grounding',
+    value: 'microsoft-grounding',
     label: 'Microsoft Grounding',
-    description: 'Gateway-managed Microsoft Grounding key',
+    description: 'Gateway-managed Microsoft Grounding key.',
     apiKey: config => config.microsoftGrounding.apiKey,
     set: (config, apiKey) => ({ ...config, microsoftGrounding: { apiKey } }),
   },
   {
-    id: 'jina',
+    value: 'jina',
     label: 'Jina',
-    description: 'Gateway-managed Jina API key (s.jina.ai + r.jina.ai)',
+    description: 'Gateway-managed Jina API key (s.jina.ai + r.jina.ai).',
     apiKey: config => config.jina.apiKey,
     set: (config, apiKey) => ({ ...config, jina: { apiKey } }),
   },
@@ -71,7 +73,7 @@ const saving = ref(false);
 const testing = ref(false);
 const testResult = ref<SearchTestResult | null>(null);
 
-const activeOption = computed(() => PROVIDER_OPTIONS.find(option => option.id === draft.value.provider) ?? PROVIDER_OPTIONS[0]);
+const activeOption = computed(() => PROVIDER_OPTIONS.find(option => option.value === draft.value.provider) ?? PROVIDER_OPTIONS[0]);
 
 const setProvider = (provider: SearchConfig['provider']) => {
   draft.value = { ...draft.value, provider };
@@ -136,34 +138,21 @@ const test = async () => {
 
     <p v-if="error" class="mb-4 rounded-md border border-accent-rose/40 bg-accent-rose/10 px-3 py-2 text-xs text-accent-rose">{{ error }}</p>
 
-    <div class="space-y-5">
+    <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
       <div>
-        <p class="text-xs font-medium text-gray-500 uppercase tracking-widest mb-3">Search Provider</p>
-        <div class="grid grid-cols-1 gap-3">
-          <label
-            v-for="option in PROVIDER_OPTIONS"
-            :key="option.id"
-            class="flex items-center gap-3 rounded-xl border p-4 transition-all cursor-pointer"
-            :class="draft.provider === option.id ? 'border-accent-cyan/50 bg-accent-cyan/5' : 'border-white/10 hover:border-white/20'"
-          >
-            <input
-              type="radio"
-              name="search-provider"
-              :value="option.id"
-              class="accent-accent-cyan"
-              :checked="draft.provider === option.id"
-              @change="setProvider(option.id)"
-            >
-            <div>
-              <p class="text-sm font-medium text-white">{{ option.label }}</p>
-              <p class="text-xs text-gray-500">{{ option.description }}</p>
-            </div>
-          </label>
-        </div>
+        <label class="mb-1.5 block text-xs font-medium text-gray-500">Search Provider</label>
+        <Select
+          :model-value="draft.provider"
+          :options="PROVIDER_OPTIONS"
+          @update:model-value="v => v !== undefined && setProvider(v)"
+        >
+          <template #description="{ option }">
+            <p class="text-[11px] text-gray-500">{{ option.description }}</p>
+          </template>
+        </Select>
       </div>
-
       <div>
-        <label class="block text-xs font-medium text-gray-500 uppercase tracking-widest mb-2">{{ searchCredentialLabel }}</label>
+        <label class="mb-1.5 block text-xs font-medium text-gray-500">{{ searchCredentialLabel }}</label>
         <SecretInput
           v-if="activeOption.apiKey"
           :placeholder="`${activeOption.label} API key`"
@@ -179,46 +168,46 @@ const test = async () => {
           class="w-full"
         />
       </div>
+    </div>
 
-      <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-        <Button :loading="saving" @click="save">Save Search Config</Button>
-        <Button variant="secondary" :loading="testing" :disabled="draft.provider === 'disabled'" @click="test">Test Search</Button>
-        <p v-if="draft.provider === 'disabled'" class="text-xs text-gray-500">Search testing is disabled until a provider is selected.</p>
+    <div class="mt-5 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+      <Button :loading="saving" @click="save">Save Search Config</Button>
+      <Button variant="secondary" :loading="testing" :disabled="draft.provider === 'disabled'" @click="test">Test Search</Button>
+      <p v-if="draft.provider === 'disabled'" class="text-xs text-gray-500">Search testing is disabled until a provider is selected.</p>
+    </div>
+
+    <div v-if="testResult" class="mt-5 bg-surface-900 rounded-xl border border-white/5 p-4">
+      <div class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0">
+          <p class="text-sm font-medium text-white">Search Test Result</p>
+          <p class="text-xs text-gray-500">Provider: <span>{{ testResult.provider }}</span> · Query: <span>{{ testResult.query }}</span></p>
+        </div>
+        <span
+          class="text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-full"
+          :class="testResult.ok ? 'bg-accent-emerald/10 text-accent-emerald' : 'bg-red-500/10 text-red-400'"
+        >{{ testResult.ok ? 'OK' : 'Error' }}</span>
       </div>
 
-      <div v-if="testResult" class="bg-surface-900 rounded-xl border border-white/5 p-4">
-        <div class="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
-          <div class="min-w-0">
-            <p class="text-sm font-medium text-white">Search Test Result</p>
-            <p class="text-xs text-gray-500">Provider: <span>{{ testResult.provider }}</span> · Query: <span>{{ testResult.query }}</span></p>
-          </div>
-          <span
-            class="text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded-full"
-            :class="testResult.ok ? 'bg-accent-emerald/10 text-accent-emerald' : 'bg-red-500/10 text-red-400'"
-          >{{ testResult.ok ? 'OK' : 'Error' }}</span>
-        </div>
-
-        <div v-if="testResult.ok" class="space-y-3">
-          <div
-            v-for="result in testResult.results ?? []"
-            :key="result.url + result.title"
-            class="rounded-lg border border-white/5 bg-surface-800 p-3"
-          >
-            <div class="flex items-start justify-between gap-3 mb-1">
-              <div>
-                <a :href="result.url" target="_blank" class="text-sm font-medium text-accent-cyan hover:underline break-words">{{ result.title }}</a>
-                <p class="text-[11px] text-gray-500 break-all">{{ result.url }}</p>
-              </div>
-              <span v-if="result.pageAge" class="text-[10px] text-gray-600 uppercase tracking-widest">{{ result.pageAge }}</span>
+      <div v-if="testResult.ok" class="space-y-3">
+        <div
+          v-for="result in testResult.results ?? []"
+          :key="result.url + result.title"
+          class="rounded-lg border border-white/5 bg-surface-800 p-3"
+        >
+          <div class="flex items-start justify-between gap-3 mb-1">
+            <div>
+              <a :href="result.url" target="_blank" class="text-sm font-medium text-accent-cyan hover:underline break-words">{{ result.title }}</a>
+              <p class="text-[11px] text-gray-500 break-all">{{ result.url }}</p>
             </div>
-            <p class="text-sm text-gray-300 leading-relaxed">{{ result.previewText }}</p>
+            <span v-if="result.pageAge" class="text-[10px] text-gray-600 uppercase tracking-widest">{{ result.pageAge }}</span>
           </div>
+          <p class="text-sm text-gray-300 leading-relaxed">{{ result.previewText }}</p>
         </div>
+      </div>
 
-        <div v-else class="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-          <p class="text-sm text-red-300 font-medium">{{ testResult.error?.code }}</p>
-          <p class="text-sm text-gray-300 mt-1">{{ testResult.error?.message }}</p>
-        </div>
+      <div v-else class="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+        <p class="text-sm text-red-300 font-medium">{{ testResult.error?.code }}</p>
+        <p class="text-sm text-gray-300 mt-1">{{ testResult.error?.message }}</p>
       </div>
     </div>
   </div>

--- a/apps/web/src/components/settings/SearchConfigSection.vue
+++ b/apps/web/src/components/settings/SearchConfigSection.vue
@@ -15,6 +15,48 @@ interface SearchTestResult {
   error?: { code: string; message: string };
 }
 
+// Single source of truth for the provider list. Each entry knows its
+// human label, the per-provider config slot, and a `set` writer that
+// returns a fresh SearchConfig with that slot's apiKey replaced.
+interface ProviderOption {
+  id: SearchConfig['provider'];
+  label: string;
+  description: string;
+  // `apiKey` reads from the config slot; `set` writes a new apiKey back
+  // into the right slot. Both ignored for the `disabled` option.
+  apiKey?: (config: SearchConfig) => string;
+  set?: (config: SearchConfig, apiKey: string) => SearchConfig;
+}
+
+const PROVIDER_OPTIONS: ProviderOption[] = [
+  {
+    id: 'disabled',
+    label: 'Disabled',
+    description: 'No upstream web search provider',
+  },
+  {
+    id: 'tavily',
+    label: 'Tavily',
+    description: 'Gateway-managed Tavily API key',
+    apiKey: config => config.tavily.apiKey,
+    set: (config, apiKey) => ({ ...config, tavily: { apiKey } }),
+  },
+  {
+    id: 'microsoft-grounding',
+    label: 'Microsoft Grounding',
+    description: 'Gateway-managed Microsoft Grounding key',
+    apiKey: config => config.microsoftGrounding.apiKey,
+    set: (config, apiKey) => ({ ...config, microsoftGrounding: { apiKey } }),
+  },
+  {
+    id: 'jina',
+    label: 'Jina',
+    description: 'Gateway-managed Jina API key (s.jina.ai + r.jina.ai)',
+    apiKey: config => config.jina.apiKey,
+    set: (config, apiKey) => ({ ...config, jina: { apiKey } }),
+  },
+];
+
 const props = defineProps<{
   initialConfig: SearchConfig;
   initialError?: string | null;
@@ -29,32 +71,20 @@ const saving = ref(false);
 const testing = ref(false);
 const testResult = ref<SearchTestResult | null>(null);
 
+const activeOption = computed(() => PROVIDER_OPTIONS.find(option => option.id === draft.value.provider) ?? PROVIDER_OPTIONS[0]);
+
 const setProvider = (provider: SearchConfig['provider']) => {
   draft.value = { ...draft.value, provider };
 };
 
-const searchCredentialLabel = computed(() => {
-  switch (draft.value.provider) {
-  case 'tavily': return 'Tavily API key';
-  case 'microsoft-grounding': return 'Microsoft Grounding API key';
-  case 'disabled':
-  default: return 'Credential';
-  }
-});
+const searchCredentialLabel = computed(() => activeOption.value.apiKey ? `${activeOption.value.label} API key` : 'Credential');
 
-const searchCredentialValue = computed(() => {
-  switch (draft.value.provider) {
-  case 'tavily': return draft.value.tavily.apiKey;
-  case 'microsoft-grounding': return draft.value.microsoftGrounding.apiKey;
-  default: return '';
-  }
-});
+const searchCredentialValue = computed(() => activeOption.value.apiKey?.(draft.value) ?? '');
 
 const setSearchCredentialValue = (v: string) => {
-  if (draft.value.provider === 'tavily') {
-    draft.value = { ...draft.value, tavily: { apiKey: v } };
-  } else if (draft.value.provider === 'microsoft-grounding') {
-    draft.value = { ...draft.value, microsoftGrounding: { apiKey: v } };
+  const option = activeOption.value;
+  if (option.set) {
+    draft.value = option.set(draft.value, v);
   }
 };
 
@@ -111,56 +141,22 @@ const test = async () => {
         <p class="text-xs font-medium text-gray-500 uppercase tracking-widest mb-3">Search Provider</p>
         <div class="grid grid-cols-1 gap-3">
           <label
+            v-for="option in PROVIDER_OPTIONS"
+            :key="option.id"
             class="flex items-center gap-3 rounded-xl border p-4 transition-all cursor-pointer"
-            :class="draft.provider === 'disabled' ? 'border-accent-cyan/50 bg-accent-cyan/5' : 'border-white/10 hover:border-white/20'"
+            :class="draft.provider === option.id ? 'border-accent-cyan/50 bg-accent-cyan/5' : 'border-white/10 hover:border-white/20'"
           >
             <input
               type="radio"
               name="search-provider"
-              value="disabled"
+              :value="option.id"
               class="accent-accent-cyan"
-              :checked="draft.provider === 'disabled'"
-              @change="setProvider('disabled')"
+              :checked="draft.provider === option.id"
+              @change="setProvider(option.id)"
             >
             <div>
-              <p class="text-sm font-medium text-white">Disabled</p>
-              <p class="text-xs text-gray-500">No upstream web search provider</p>
-            </div>
-          </label>
-
-          <label
-            class="flex items-center gap-3 rounded-xl border p-4 transition-all cursor-pointer"
-            :class="draft.provider === 'tavily' ? 'border-accent-cyan/50 bg-accent-cyan/5' : 'border-white/10 hover:border-white/20'"
-          >
-            <input
-              type="radio"
-              name="search-provider"
-              value="tavily"
-              class="accent-accent-cyan"
-              :checked="draft.provider === 'tavily'"
-              @change="setProvider('tavily')"
-            >
-            <div>
-              <p class="text-sm font-medium text-white">Tavily</p>
-              <p class="text-xs text-gray-500">Gateway-managed Tavily API key</p>
-            </div>
-          </label>
-
-          <label
-            class="flex items-center gap-3 rounded-xl border p-4 transition-all cursor-pointer"
-            :class="draft.provider === 'microsoft-grounding' ? 'border-accent-cyan/50 bg-accent-cyan/5' : 'border-white/10 hover:border-white/20'"
-          >
-            <input
-              type="radio"
-              name="search-provider"
-              value="microsoft-grounding"
-              class="accent-accent-cyan"
-              :checked="draft.provider === 'microsoft-grounding'"
-              @change="setProvider('microsoft-grounding')"
-            >
-            <div>
-              <p class="text-sm font-medium text-white">Microsoft Grounding</p>
-              <p class="text-xs text-gray-500">Gateway-managed Microsoft Grounding key</p>
+              <p class="text-sm font-medium text-white">{{ option.label }}</p>
+              <p class="text-xs text-gray-500">{{ option.description }}</p>
             </div>
           </label>
         </div>
@@ -169,8 +165,8 @@ const test = async () => {
       <div>
         <label class="block text-xs font-medium text-gray-500 uppercase tracking-widest mb-2">{{ searchCredentialLabel }}</label>
         <SecretInput
-          v-if="draft.provider !== 'disabled'"
-          :placeholder="draft.provider === 'tavily' ? 'Tavily API key' : 'Microsoft Grounding API key'"
+          v-if="activeOption.apiKey"
+          :placeholder="`${activeOption.label} API key`"
           :model-value="searchCredentialValue"
           class="w-full"
           @update:model-value="setSearchCredentialValue"

--- a/apps/web/src/pages/dashboard/settings.vue
+++ b/apps/web/src/pages/dashboard/settings.vue
@@ -21,6 +21,7 @@ const defaultSearchConfig: SearchConfig = {
   provider: 'disabled',
   tavily: { apiKey: '' },
   microsoftGrounding: { apiKey: '' },
+  jina: { apiKey: '' },
 };
 
 export const useSettingsPageData = defineBasicLoader(async () => {

--- a/packages/gateway/migrations/0043_jina_provider.sql
+++ b/packages/gateway/migrations/0043_jina_provider.sql
@@ -1,0 +1,28 @@
+-- Extend `search_config` and `search_usage` to accept the Jina provider.
+--
+-- `search_config.jina_api_key` is a plain ADD COLUMN with empty default so the
+-- singleton row keeps working untouched until the operator configures Jina via
+-- the dashboard.
+--
+-- `search_usage.provider` carries a CHECK constraint listing the allowed names;
+-- D1/SQLite cannot alter a CHECK constraint in place, so we rebuild the table
+-- via swap (same pattern as 0017 — see the comment there).
+
+ALTER TABLE search_config ADD COLUMN jina_api_key TEXT NOT NULL DEFAULT '';
+
+CREATE TABLE search_usage_new (
+  provider TEXT NOT NULL CHECK (provider IN ('tavily', 'microsoft-grounding', 'jina')),
+  key_id TEXT NOT NULL,
+  action TEXT NOT NULL DEFAULT 'search' CHECK (action IN ('search', 'fetch_page')),
+  hour TEXT NOT NULL,
+  requests INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (provider, key_id, action, hour)
+);
+
+INSERT INTO search_usage_new (provider, key_id, action, hour, requests)
+SELECT provider, key_id, action, hour, requests FROM search_usage;
+
+DROP INDEX IF EXISTS idx_search_usage_hour;
+DROP TABLE search_usage;
+ALTER TABLE search_usage_new RENAME TO search_usage;
+CREATE INDEX idx_search_usage_hour ON search_usage (hour);

--- a/packages/gateway/src/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes_test.ts
@@ -324,7 +324,7 @@ test('export includes full upstream configs and omits performance by default', a
   await repo.usage.set(USAGE_1);
   await repo.searchUsage.set(SEARCH_USAGE_1);
   await repo.performance.set(PERFORMANCE_1);
-  await repo.searchConfig.save({ provider: 'tavily', tavily: { apiKey: 'tvly-test' }, microsoftGrounding: { apiKey: 'ms-test' } });
+  await repo.searchConfig.save({ provider: 'tavily', tavily: { apiKey: 'tvly-test' }, microsoftGrounding: { apiKey: 'ms-test' }, jina: { apiKey: '' } });
 
   const result = await doExport(app);
 
@@ -386,7 +386,7 @@ test('import replace writes upstreams and clears replaced collections', async ()
   await repo.usage.set(USAGE_1);
   await repo.searchUsage.set(SEARCH_USAGE_1);
   await repo.responsesItems.insertMany([STORED_RESPONSES_ITEM]);
-  await repo.searchConfig.save({ provider: 'tavily', tavily: { apiKey: 'old' }, microsoftGrounding: { apiKey: '' } });
+  await repo.searchConfig.save({ provider: 'tavily', tavily: { apiKey: 'old' }, microsoftGrounding: { apiKey: '' }, jina: { apiKey: '' } });
 
   const result = await doImport(app, 'replace', {
     users: [SEED_ADMIN],
@@ -395,7 +395,7 @@ test('import replace writes upstreams and clears replaced collections', async ()
     usage: [USAGE_2],
     searchUsage: [SEARCH_USAGE_2],
     performanceIncluded: false,
-    searchConfig: { provider: 'microsoft-grounding', tavily: { apiKey: '' }, microsoftGrounding: { apiKey: 'ms-new' } },
+    searchConfig: { provider: 'microsoft-grounding', tavily: { apiKey: '' }, microsoftGrounding: { apiKey: 'ms-new' }, jina: { apiKey: '' } },
   });
 
   assertEquals(result.status, 200);
@@ -405,7 +405,7 @@ test('import replace writes upstreams and clears replaced collections', async ()
   assertEquals(await repo.usage.listAll(), [USAGE_2]);
   assertEquals(await repo.searchUsage.listAll(), [SEARCH_USAGE_2]);
   assertEquals(await repo.responsesItems.lookupMany('key-a', [STORED_RESPONSES_ITEM.id]), []);
-  assertEquals(await repo.searchConfig.get(), { provider: 'microsoft-grounding', tavily: { apiKey: '' }, microsoftGrounding: { apiKey: 'ms-new' } });
+  assertEquals(await repo.searchConfig.get(), { provider: 'microsoft-grounding', tavily: { apiKey: '' }, microsoftGrounding: { apiKey: 'ms-new' }, jina: { apiKey: '' } });
 });
 
 test('import merge upserts by repository key without clearing unrelated rows', async () => {
@@ -1056,7 +1056,7 @@ test('a full v6 export re-imports verbatim — the export→import round trip is
   await repo.searchUsage.set(SEARCH_USAGE_2);
   await repo.performance.set(PERFORMANCE_1);
   await repo.performance.set(PERFORMANCE_2);
-  const config = { provider: 'tavily' as const, tavily: { apiKey: 'tk' }, microsoftGrounding: { apiKey: '' } };
+  const config = { provider: 'tavily' as const, tavily: { apiKey: 'tk' }, microsoftGrounding: { apiKey: '' }, jina: { apiKey: '' } };
   await repo.searchConfig.save(config);
 
   const exported = await doExport(app, true);

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -518,9 +518,10 @@ export const resetBackoffBody = z.object({
 // --- search config ---
 
 export const searchConfigSchema = z.object({
-  provider: z.enum(['disabled', 'tavily', 'microsoft-grounding']),
+  provider: z.enum(['disabled', 'tavily', 'microsoft-grounding', 'jina']),
   tavily: z.object({ apiKey: z.string() }),
   microsoftGrounding: z.object({ apiKey: z.string() }),
+  jina: z.object({ apiKey: z.string() }),
 });
 
 // --- data transfer ---

--- a/packages/gateway/src/control-plane/search-config/routes_test.ts
+++ b/packages/gateway/src/control-plane/search-config/routes_test.ts
@@ -54,6 +54,7 @@ test('/api/search-config PUT persists config and POST /test returns preview', as
         provider: 'tavily',
         tavily: { apiKey: 'tvly-test' },
         microsoftGrounding: { apiKey: 'ms-test' },
+        jina: { apiKey: 'jina-test' },
       };
 
       const putResponse = await requestApp('/api/search-config', {

--- a/packages/gateway/src/control-plane/search-usage/routes_test.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes_test.ts
@@ -48,6 +48,7 @@ test('/api/search-usage in self-by-key mode includes per-key metadata for the ac
     provider: 'microsoft-grounding',
     tavily: { apiKey: 'tvly-test' },
     microsoftGrounding: { apiKey: 'ms-test' },
+    jina: { apiKey: '' },
   });
 
   const response = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&include_key_metadata=1', {

--- a/packages/gateway/src/data-plane/llm/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/interceptors/server-tool-shim_test.ts
@@ -282,6 +282,7 @@ beforeEach(() => {
     provider: 'tavily',
     tavily: { apiKey: 'test-key' },
     microsoftGrounding: { apiKey: '' },
+    jina: { apiKey: '' },
   } satisfies SearchConfig);
 });
 

--- a/packages/gateway/src/data-plane/tools/web-search/provider.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/provider.ts
@@ -1,7 +1,8 @@
+import { createJinaWebSearchProvider } from './providers/jina.ts';
 import { createMicrosoftGroundingWebSearchProvider } from './providers/microsoft-grounding.ts';
 import { createTavilyWebSearchProvider } from './providers/tavily.ts';
 import { FIXED_SEARCH_CONFIG_TEST_QUERY } from './search-config.ts';
-import type { ConfiguredWebSearchProvider, SearchConfig, SearchConfigConnectionTestResult } from './types.ts';
+import type { ConfiguredWebSearchProvider, SearchConfig, SearchConfigConnectionTestResult, WebSearchProvider, WebSearchProviderName } from './types.ts';
 
 const toPreviewText = (content: Array<{ type: 'text'; text: string }>): string =>
   content
@@ -9,28 +10,31 @@ const toPreviewText = (content: Array<{ type: 'text'; text: string }>): string =
     .join('\n')
     .slice(0, 280);
 
+// Per-provider lookup: pulls the credential out of the config slot for
+// that provider and constructs the impl. Keeps `resolveConfiguredWeb...`
+// data-driven so adding a fourth provider is one entry, not another
+// if-branch.
+const PROVIDER_FACTORIES: { [N in WebSearchProviderName]: (config: SearchConfig) => { apiKey: string; build: (apiKey: string) => WebSearchProvider } } = {
+  tavily: config => ({ apiKey: config.tavily.apiKey, build: createTavilyWebSearchProvider }),
+  'microsoft-grounding': config => ({ apiKey: config.microsoftGrounding.apiKey, build: createMicrosoftGroundingWebSearchProvider }),
+  jina: config => ({ apiKey: config.jina.apiKey, build: createJinaWebSearchProvider }),
+};
+
 export const resolveConfiguredWebSearchProvider = (config: SearchConfig): ConfiguredWebSearchProvider => {
   if (config.provider === 'disabled') {
     return { type: 'disabled' };
   }
 
-  if (config.provider === 'tavily') {
-    return config.tavily.apiKey
-      ? {
-          type: 'enabled',
-          provider: 'tavily',
-          impl: createTavilyWebSearchProvider(config.tavily.apiKey),
-        }
-      : { type: 'missing-credential', provider: 'tavily' };
+  const factory = PROVIDER_FACTORIES[config.provider](config);
+  if (!factory.apiKey) {
+    return { type: 'missing-credential', provider: config.provider };
   }
 
-  return config.microsoftGrounding.apiKey
-    ? {
-        type: 'enabled',
-        provider: 'microsoft-grounding',
-        impl: createMicrosoftGroundingWebSearchProvider(config.microsoftGrounding.apiKey),
-      }
-    : { type: 'missing-credential', provider: 'microsoft-grounding' };
+  return {
+    type: 'enabled',
+    provider: config.provider,
+    impl: factory.build(factory.apiKey),
+  };
 };
 
 export const testSearchConfigConnection = async (config: SearchConfig): Promise<SearchConfigConnectionTestResult> => {

--- a/packages/gateway/src/data-plane/tools/web-search/provider_test.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/provider_test.ts
@@ -16,6 +16,7 @@ test('resolveConfiguredWebSearchProvider returns disabled, missing-credential, o
       provider: 'tavily',
       tavily: { apiKey: '' },
       microsoftGrounding: { apiKey: 'ms-test' },
+      jina: { apiKey: '' },
     }),
     {
       type: 'missing-credential',
@@ -27,6 +28,7 @@ test('resolveConfiguredWebSearchProvider returns disabled, missing-credential, o
     provider: 'microsoft-grounding',
     tavily: { apiKey: 'tvly-test' },
     microsoftGrounding: { apiKey: 'ms-test' },
+    jina: { apiKey: '' },
   });
 
   assertEquals(resolved.type, 'enabled');
@@ -52,6 +54,7 @@ test('testSearchConfigConnection returns structured disabled and missing-credent
       provider: 'tavily',
       tavily: { apiKey: '' },
       microsoftGrounding: { apiKey: 'ms-test' },
+      jina: { apiKey: '' },
     }),
     {
       ok: false,
@@ -98,6 +101,7 @@ test('testSearchConfigConnection previews at most three normalized results', asy
         provider: 'tavily',
         tavily: { apiKey: 'tvly-test' },
         microsoftGrounding: { apiKey: 'ms-test' },
+        jina: { apiKey: '' },
       });
 
       assertEquals(result.ok, true);
@@ -126,6 +130,7 @@ test('testSearchConfigConnection returns no_results when the provider returns no
           provider: 'tavily',
           tavily: { apiKey: 'tvly-test' },
           microsoftGrounding: { apiKey: 'ms-test' },
+          jina: { apiKey: '' },
         }),
         {
           ok: false,
@@ -159,6 +164,7 @@ test('testSearchConfigConnection returns preview results for Microsoft Grounding
         provider: 'microsoft-grounding',
         tavily: { apiKey: 'tvly-test' },
         microsoftGrounding: { apiKey: 'ms-test' },
+        jina: { apiKey: '' },
       });
 
       assertEquals(result.ok, true);
@@ -200,6 +206,7 @@ test('testSearchConfigConnection does not record search usage', async () => {
         provider: 'tavily',
         tavily: { apiKey: 'tvly-test' },
         microsoftGrounding: { apiKey: '' },
+        jina: { apiKey: '' },
       });
 
       assertEquals(result.ok, true);

--- a/packages/gateway/src/data-plane/tools/web-search/providers/jina.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/providers/jina.ts
@@ -1,0 +1,309 @@
+import { extractWebSearchProviderErrorMessage, toWebSearchTextBlocks, validateWebSearchQuery } from './shared.ts';
+import { truncateUtf8 } from './truncate.ts';
+import { isJsonObject } from '../../../../shared/json-helpers.ts';
+import { sleep } from '../../../../shared/sleep.ts';
+import { normalizeDomainList } from '../domain-normalize.ts';
+import {
+  DEFAULT_WEB_SEARCH_RESULT_COUNT,
+  MAX_FETCH_PAGE_BYTES,
+  type WebSearchFetchPageRequest,
+  type WebSearchFetchPageResult,
+  type WebSearchProvider,
+  type WebSearchProviderErrorCode,
+  type WebSearchProviderRequest,
+  type WebSearchProviderResult,
+} from '../types.ts';
+
+const JINA_SEARCH_URL = 'https://s.jina.ai/';
+const JINA_READER_URL = 'https://r.jina.ai/';
+
+// Per-result content cap (cl100k_base tokens) clipped server-side by
+// `X-Max-Tokens` on s.jina.ai. Jina's default scrapes the full readability
+// markdown of each result page, which can run into double-digit KB; capping
+// to 500 tokens (~2 KB markdown) keeps each Jina result in the same size
+// ballpark as Microsoft Grounding's `passage` mode (~300-400 tokens) and
+// Tavily's `basic` mode (~100 tokens / ~400 chars). 500 is also Jina's
+// documented minimum — values below trigger `Rejected by validator (v) =>
+// v >= 500`. Verified against jina-ai/reader's `tokenTrim` call sites in
+// `src/services/snapshot-formatter.ts`; `X-Token-Budget` is the header that's
+// silently ignored on search — `X-Max-Tokens` is not.
+const JINA_SEARCH_MAX_TOKENS_PER_RESULT = 500;
+
+// Hard cap on Jina's `count` query param (validated server-side as 0..20).
+const JINA_SEARCH_MAX_COUNT = 20;
+
+// Per-URL retry policy for the Reader endpoint. Matches the Microsoft
+// Grounding browse retry shape because the failure modes are the same —
+// 429 / 5xx are transient, everything else is structural. Each URL retries
+// independently, so the worst-case wall clock for a 5-URL batch is still
+// `sum(delays)` ≈ 15s, not 5× that.
+const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000] as const;
+const RETRYABLE_HTTP_STATUS: ReadonlySet<number> = new Set([429, 500, 502, 503, 504]);
+
+interface JinaEnvelope {
+  code: number;
+  status?: number;
+  data?: unknown;
+  name?: string;
+  message?: string;
+}
+
+interface JinaSearchEntry {
+  url: string;
+  title: string;
+  content?: string;
+  description?: string;
+  publishedTime?: string;
+}
+
+const parseEnvelope = (payload: unknown): JinaEnvelope | null => {
+  if (!isJsonObject(payload)) return null;
+  if (typeof payload.code !== 'number') return null;
+  return {
+    code: payload.code,
+    status: typeof payload.status === 'number' ? payload.status : undefined,
+    data: payload.data,
+    name: typeof payload.name === 'string' ? payload.name : undefined,
+    message: typeof payload.message === 'string' ? payload.message : undefined,
+  };
+};
+
+const isAssertionEmptyResults = (envelope: JinaEnvelope): boolean =>
+  envelope.name === 'AssertionFailureError'
+  && typeof envelope.message === 'string'
+  && /no search results/i.test(envelope.message);
+
+const httpStatusToErrorCode = (status: number): WebSearchProviderErrorCode => {
+  if (status === 429) return 'too_many_requests';
+  if (status === 413) return 'request_too_large';
+  if (status === 400) return 'invalid_tool_input';
+  return 'unavailable';
+};
+
+const fetchWithRetry = async (doFetch: () => Promise<Response>, signal?: AbortSignal): Promise<Response> => {
+  let attempt = 0;
+  while (true) {
+    const response = await doFetch();
+    if (!RETRYABLE_HTTP_STATUS.has(response.status)) return response;
+    if (attempt >= RETRY_DELAYS_MS.length) return response;
+    await sleep(RETRY_DELAYS_MS[attempt], signal);
+    attempt += 1;
+  }
+};
+
+// Jina accepts a single hostname per `X-Site` header, or multiple via the
+// literal `", "` separator (comma + space). Anything else collapses to a
+// single bogus hostname server-side; see `serper-search.ts:209` in
+// jina-ai/reader.
+const buildSiteHeader = (allowedDomains?: string[]): string | undefined => {
+  const normalized = normalizeDomainList(allowedDomains);
+  return normalized.length > 0 ? normalized.join(', ') : undefined;
+};
+
+const normalizeSearchResult = (value: unknown): Extract<WebSearchProviderResult, { type: 'ok' }>['results'][number] | null => {
+  if (!isJsonObject(value) || typeof value.title !== 'string' || typeof value.url !== 'string') {
+    return null;
+  }
+  const entry = value as unknown as JinaSearchEntry;
+  // `content` is the readability-extracted markdown (when present, capped to
+  // JINA_SEARCH_MAX_TOKENS_PER_RESULT by `X-Max-Tokens`); `description` is
+  // the SERP-level snippet that Jina always returns. Prefer the former, fall
+  // back to the latter — matches what Tavily and Microsoft Grounding hand
+  // back as result-level `content`.
+  const text = entry.content ?? entry.description ?? '';
+  return {
+    source: entry.url,
+    title: entry.title,
+    pageAge: typeof entry.publishedTime === 'string' && entry.publishedTime.trim().length > 0 ? entry.publishedTime : undefined,
+    content: toWebSearchTextBlocks(text),
+  };
+};
+
+// Reader returns 200 with a single `data` object (or the wrapped envelope
+// shape) — pull out the markdown content and the canonical post-redirect URL.
+const extractReaderPage = (envelope: JinaEnvelope, requestedUrl: string): { url: string; title?: string; content: string } | null => {
+  if (envelope.code !== 200 || !isJsonObject(envelope.data)) return null;
+  const data = envelope.data;
+  const url = typeof data.url === 'string' ? data.url : requestedUrl;
+  const content = typeof data.content === 'string' ? data.content : '';
+  if (typeof data.title === 'string' && data.title.length > 0) {
+    return { url, title: data.title, content };
+  }
+  return { url, content };
+};
+
+type ReadOutcome =
+  | { kind: 'ok'; url: string; title?: string; content: string }
+  | { kind: 'fail'; url: string; httpStatus: number; message: string };
+
+const readOneUrl = async (httpFetch: typeof fetch, apiKey: string, url: string, signal?: AbortSignal): Promise<ReadOutcome> => {
+  try {
+    const response = await fetchWithRetry(
+      () => httpFetch(JINA_READER_URL, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ url }),
+        ...(signal !== undefined ? { signal } : {}),
+      }),
+      signal,
+    );
+
+    if (!response.ok) {
+      const message = (await extractWebSearchProviderErrorMessage(response)) ?? `HTTP ${response.status}`;
+      return { kind: 'fail', url, httpStatus: response.status, message };
+    }
+
+    const payload = await response.json();
+    const envelope = parseEnvelope(payload);
+    if (envelope === null) {
+      return { kind: 'fail', url, httpStatus: response.status, message: 'Jina reader returned an unexpected payload shape.' };
+    }
+
+    const page = extractReaderPage(envelope, url);
+    if (page === null) {
+      return { kind: 'fail', url, httpStatus: response.status, message: envelope.message ?? 'Jina reader returned no content.' };
+    }
+
+    return { kind: 'ok', ...page };
+  } catch (error) {
+    // httpStatus=0 signals a transport-level failure (network, abort, etc.)
+    // so the batch collapsing rule downstream can distinguish "Jina is
+    // unreachable" from "one URL was rejected".
+    return { kind: 'fail', url, httpStatus: 0, message: error instanceof Error ? error.message : String(error) };
+  }
+};
+
+export const createJinaWebSearchProvider = (apiKey: string, deps?: { fetch?: typeof fetch }): WebSearchProvider => {
+  const httpFetch = deps?.fetch ?? fetch;
+
+  const search = async (request: WebSearchProviderRequest): Promise<WebSearchProviderResult> => {
+    const validatedQuery = validateWebSearchQuery(request.query);
+    if (validatedQuery.type === 'error') {
+      return validatedQuery.result;
+    }
+
+    const limit = Math.min(request.maxResults ?? DEFAULT_WEB_SEARCH_RESULT_COUNT, JINA_SEARCH_MAX_COUNT);
+    const params = new URLSearchParams({
+      q: validatedQuery.query,
+      count: String(limit),
+    });
+    // Jina takes Google's `gl` (geographic location) as a lowercase
+    // ISO-3166-1 alpha-2 code. There is no equivalent `X-Country` header
+    // despite the name suggesting one — confirmed by grepping the
+    // open-source jina-ai/reader codebase.
+    const country = request.userLocation?.country?.trim();
+    if (country && /^[a-z]{2}$/i.test(country)) {
+      params.set('gl', country.toLowerCase());
+    }
+
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${apiKey}`,
+      accept: 'application/json',
+      'x-max-tokens': String(JINA_SEARCH_MAX_TOKENS_PER_RESULT),
+    };
+    const siteHeader = buildSiteHeader(request.allowedDomains);
+    if (siteHeader !== undefined) {
+      headers['x-site'] = siteHeader;
+    }
+    // Jina has no exclude-domains operator (no `-site:` builder, no
+    // counterpart to Tavily's `exclude_domains`). Silently drop
+    // `blockedDomains` rather than reject the search — giving the agent
+    // more results, even ones it might filter post-hoc, beats failing a
+    // call it could have used.
+
+    try {
+      const response = await httpFetch(`${JINA_SEARCH_URL}?${params.toString()}`, {
+        method: 'GET',
+        headers,
+        ...(request.signal !== undefined ? { signal: request.signal } : {}),
+      });
+
+      const payload = await response.json().catch(() => null);
+      const envelope = parseEnvelope(payload);
+
+      if (!response.ok) {
+        // Jina returns "no results" as an HTTP 4xx with
+        // `AssertionFailureError`. Surface that as an empty result list
+        // instead of a hard error, matching how Tavily and Grounding
+        // hand back an empty `results` array on no hits.
+        if (envelope !== null && isAssertionEmptyResults(envelope)) {
+          return { type: 'ok', results: [] };
+        }
+        return {
+          type: 'error',
+          errorCode: httpStatusToErrorCode(response.status),
+          message: envelope?.message ?? `Jina search failed (HTTP ${response.status}).`,
+        };
+      }
+
+      if (envelope === null || !Array.isArray(envelope.data)) {
+        return {
+          type: 'error',
+          errorCode: 'unavailable',
+          message: 'Jina search returned an unexpected payload shape; check provider status.',
+        };
+      }
+
+      const results = envelope.data
+        .map(normalizeSearchResult)
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+        .slice(0, limit);
+
+      return { type: 'ok', results };
+    } catch (error) {
+      return {
+        type: 'error',
+        errorCode: 'unavailable',
+        message: error instanceof Error ? error.message : 'Jina search failed.',
+      };
+    }
+  };
+
+  const fetchPage = async (request: WebSearchFetchPageRequest): Promise<WebSearchFetchPageResult> => {
+    if (request.urls.length === 0) {
+      return { type: 'ok', pages: [], failures: [] };
+    }
+
+    const outcomes = await Promise.all(request.urls.map(url => readOneUrl(httpFetch, apiKey, url, request.signal)));
+
+    // Whole-batch transport / 5xx failure collapses into one envelope —
+    // mirrors Microsoft Grounding's policy. Per-URL 4xx stays granular so
+    // a single bad target doesn't poison the rest of the batch.
+    const allHardFail = outcomes.every(outcome => outcome.kind === 'fail' && (outcome.httpStatus === 0 || outcome.httpStatus >= 500));
+    if (allHardFail) {
+      const first = outcomes[0] as Extract<ReadOutcome, { kind: 'fail' }>;
+      return { type: 'error', errorCode: 'unavailable', message: first.message };
+    }
+
+    const pages: Extract<WebSearchFetchPageResult, { type: 'ok' }>['pages'] = [];
+    const failures: Extract<WebSearchFetchPageResult, { type: 'ok' }>['failures'] = [];
+
+    for (const outcome of outcomes) {
+      if (outcome.kind === 'ok') {
+        const truncated = truncateUtf8(outcome.content, MAX_FETCH_PAGE_BYTES);
+        pages.push({
+          url: outcome.url,
+          ...(outcome.title !== undefined ? { title: outcome.title } : {}),
+          content: truncated.content,
+          truncated: truncated.truncated,
+          fullContentBytes: truncated.fullContentBytes,
+        });
+        continue;
+      }
+
+      failures.push({
+        url: outcome.url,
+        errorCode: httpStatusToErrorCode(outcome.httpStatus),
+        message: outcome.message,
+      });
+    }
+
+    return { type: 'ok', pages, failures };
+  };
+
+  return { search, fetchPage };
+};

--- a/packages/gateway/src/data-plane/tools/web-search/providers/jina_test.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/providers/jina_test.ts
@@ -1,0 +1,430 @@
+import { test } from 'vitest';
+
+import { createJinaWebSearchProvider } from './jina.ts';
+import { FakeTime } from '../../../../test-time.ts';
+import { assertEquals, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
+
+const okEnvelope = (data: unknown) => jsonResponse({ code: 200, status: 20000, data, meta: { usage: { tokens: 1 } } });
+
+const errorEnvelope = (httpStatus: number, name: string, message: string, status?: number) => jsonResponse(
+  { code: httpStatus, status: status ?? httpStatus * 100, name, message, data: null },
+  httpStatus,
+);
+
+test('createJinaWebSearchProvider sends bearer auth, X-Max-Tokens, X-Site, and gl', async () => {
+  let request: Request | undefined;
+
+  await withMockedFetch(
+    incoming => {
+      request = incoming;
+      return okEnvelope([
+        {
+          title: 'React',
+          url: 'https://react.dev',
+          content: 'Official React documentation',
+          publishedTime: 'Fri, 19 Jun 2026 18:46:03 GMT',
+        },
+      ]);
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.search({
+        query: 'React documentation',
+        allowedDomains: ['react.dev', 'reactjs.org'],
+        blockedDomains: ['example.com'],
+        userLocation: { country: 'US' },
+      });
+
+      const url = new URL(request!.url);
+      assertEquals(url.origin + url.pathname, 'https://s.jina.ai/');
+      assertEquals(url.searchParams.get('q'), 'React documentation');
+      assertEquals(url.searchParams.get('count'), '10');
+      assertEquals(url.searchParams.get('gl'), 'us');
+      assertEquals(request?.method, 'GET');
+      assertEquals(request?.headers.get('authorization'), 'Bearer jina-test');
+      assertEquals(request?.headers.get('accept'), 'application/json');
+      assertEquals(request?.headers.get('x-max-tokens'), '500');
+      assertEquals(request?.headers.get('x-site'), 'react.dev, reactjs.org');
+      assertEquals(result.type, 'ok');
+      if (result.type !== 'ok') throw new Error('expected ok');
+      assertEquals(result.results[0].source, 'https://react.dev');
+      assertEquals(result.results[0].title, 'React');
+      assertEquals(result.results[0].pageAge, 'Fri, 19 Jun 2026 18:46:03 GMT');
+      assertEquals(result.results[0].content, [{ type: 'text', text: 'Official React documentation' }]);
+    },
+  );
+});
+
+test('createJinaWebSearchProvider omits X-Site when no allowed domains', async () => {
+  let request: Request | undefined;
+  await withMockedFetch(
+    incoming => {
+      request = incoming;
+      return okEnvelope([]);
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      await provider.search({ query: 'React' });
+      assertEquals(request?.headers.has('x-site'), false);
+    },
+  );
+});
+
+test('createJinaWebSearchProvider falls back to SERP description when content is absent', async () => {
+  await withMockedFetch(
+    () => okEnvelope([{ title: 'React', url: 'https://react.dev', description: 'short snippet' }]),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.search({ query: 'React' });
+      if (result.type !== 'ok') throw new Error('expected ok');
+      assertEquals(result.results[0].content, [{ type: 'text', text: 'short snippet' }]);
+    },
+  );
+});
+
+test('createJinaWebSearchProvider clamps maxResults to Jina cap of 20', async () => {
+  let request: Request | undefined;
+  await withMockedFetch(
+    incoming => {
+      request = incoming;
+      return okEnvelope([]);
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      await provider.search({ query: 'React', maxResults: 50 });
+      const url = new URL(request!.url);
+      assertEquals(url.searchParams.get('count'), '20');
+    },
+  );
+});
+
+test('createJinaWebSearchProvider forwards explicit maxResults below the cap', async () => {
+  let request: Request | undefined;
+  await withMockedFetch(
+    incoming => {
+      request = incoming;
+      return okEnvelope([]);
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      await provider.search({ query: 'React', maxResults: 3 });
+      const url = new URL(request!.url);
+      assertEquals(url.searchParams.get('count'), '3');
+    },
+  );
+});
+
+test('createJinaWebSearchProvider rejects blank and overlong queries before fetch', async () => {
+  let called = false;
+  await withMockedFetch(
+    () => {
+      called = true;
+      return okEnvelope([]);
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      assertEquals(await provider.search({ query: '   ' }), {
+        type: 'error',
+        errorCode: 'invalid_tool_input',
+        message: 'Search query must not be empty.',
+      });
+      assertEquals(await provider.search({ query: 'x'.repeat(1001) }), {
+        type: 'error',
+        errorCode: 'query_too_long',
+        message: 'Search query must be at most 1000 characters.',
+      });
+    },
+  );
+  assertEquals(called, false);
+});
+
+test('createJinaWebSearchProvider maps 429 to too_many_requests', async () => {
+  await withMockedFetch(
+    () => errorEnvelope(429, 'RateLimitError', 'rate limited'),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      assertEquals(await provider.search({ query: 'React' }), {
+        type: 'error',
+        errorCode: 'too_many_requests',
+        message: 'rate limited',
+      });
+    },
+  );
+});
+
+test('createJinaWebSearchProvider maps 400 ParamValidationError to invalid_tool_input', async () => {
+  await withMockedFetch(
+    () => errorEnvelope(400, 'ParamValidationError', 'bad gl'),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      assertEquals(await provider.search({ query: 'React' }), {
+        type: 'error',
+        errorCode: 'invalid_tool_input',
+        message: 'bad gl',
+      });
+    },
+  );
+});
+
+test('createJinaWebSearchProvider maps 401 AuthenticationFailedError to unavailable', async () => {
+  await withMockedFetch(
+    () => errorEnvelope(401, 'AuthenticationFailedError', 'Invalid API key'),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.search({ query: 'React' });
+      assertEquals(result.type, 'error');
+      if (result.type !== 'error') throw new Error('expected error');
+      assertEquals(result.errorCode, 'unavailable');
+      assertEquals(result.message, 'Invalid API key');
+    },
+  );
+});
+
+test('createJinaWebSearchProvider normalizes AssertionFailureError "no search results" to ok empty', async () => {
+  await withMockedFetch(
+    () => errorEnvelope(404, 'AssertionFailureError', 'No search results available for query "asdfqwerty"'),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      assertEquals(await provider.search({ query: 'asdfqwerty' }), { type: 'ok', results: [] });
+    },
+  );
+});
+
+test('createJinaWebSearchProvider surfaces other AssertionFailureError as unavailable', async () => {
+  await withMockedFetch(
+    () => errorEnvelope(404, 'AssertionFailureError', 'Engine selection failed'),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.search({ query: 'React' });
+      assertEquals(result.type, 'error');
+      if (result.type !== 'error') throw new Error('expected error');
+      assertEquals(result.errorCode, 'unavailable');
+    },
+  );
+});
+
+test('createJinaWebSearchProvider treats malformed envelope as unavailable', async () => {
+  await withMockedFetch(
+    () => jsonResponse({ message: 'unexpected' }),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.search({ query: 'React' });
+      assertEquals(result.type, 'error');
+      if (result.type !== 'error') throw new Error('expected error');
+      assertEquals(result.errorCode, 'unavailable');
+    },
+  );
+});
+
+test('createJinaWebSearchProvider drops entries missing title or url', async () => {
+  await withMockedFetch(
+    () => okEnvelope([
+      { url: 'https://a', content: 'no title' },
+      { title: 'B', url: 'https://b', content: 'ok' },
+    ]),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.search({ query: 'x' });
+      if (result.type !== 'ok') throw new Error('expected ok');
+      assertEquals(result.results.length, 1);
+      assertEquals(result.results[0].source, 'https://b');
+    },
+  );
+});
+
+test('createJinaWebSearchProvider forwards an AbortSignal to the underlying fetch', async () => {
+  let captured: AbortSignal | undefined;
+  await withMockedFetch(
+    incoming => {
+      captured = incoming.signal;
+      return okEnvelope([]);
+    },
+    async () => {
+      const controller = new AbortController();
+      const provider = createJinaWebSearchProvider('jina-test');
+      await provider.search({ query: 'x', signal: controller.signal });
+      if (captured === undefined) throw new Error('signal was not forwarded');
+      controller.abort();
+      assertEquals(captured.aborted, true);
+    },
+  );
+});
+
+test('Jina fetchPage fans out one POST per URL and parses the envelope', async () => {
+  const captured: Request[] = [];
+  await withMockedFetch(
+    async incoming => {
+      const clone = incoming.clone();
+      captured.push(incoming);
+      const body = JSON.parse(await clone.text());
+      return okEnvelope({ url: body.url as string, title: `Title ${body.url as string}`, content: `body of ${body.url as string}` });
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.fetchPage({ urls: ['https://a.com', 'https://b.com'] });
+
+      assertEquals(captured.length, 2);
+      assertEquals(captured[0].url, 'https://r.jina.ai/');
+      assertEquals(captured[0].method, 'POST');
+      assertEquals(captured[0].headers.get('authorization'), 'Bearer jina-test');
+      assertEquals(captured[0].headers.get('accept'), 'application/json');
+      assertEquals(result, {
+        type: 'ok',
+        pages: [
+          { url: 'https://a.com', title: 'Title https://a.com', content: 'body of https://a.com', truncated: false, fullContentBytes: 21 },
+          { url: 'https://b.com', title: 'Title https://b.com', content: 'body of https://b.com', truncated: false, fullContentBytes: 21 },
+        ],
+        failures: [],
+      });
+    },
+  );
+});
+
+test('Jina fetchPage returns empty ok envelope for no URLs', async () => {
+  let called = false;
+  await withMockedFetch(
+    () => {
+      called = true;
+      return okEnvelope({});
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.fetchPage({ urls: [] });
+      assertEquals(result, { type: 'ok', pages: [], failures: [] });
+      assertEquals(called, false);
+    },
+  );
+});
+
+test('Jina fetchPage truncates a long page to MAX_FETCH_PAGE_BYTES', async () => {
+  const longText = 'x'.repeat(20_000);
+  await withMockedFetch(
+    () => okEnvelope({ url: 'https://a.com', content: longText }),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.fetchPage({ urls: ['https://a.com'] });
+      if (result.type !== 'ok') throw new Error('expected ok');
+      assertEquals(result.pages[0].truncated, true);
+      assertEquals(result.pages[0].fullContentBytes, 20_000);
+      assertEquals(result.pages[0].content.length, 10_240);
+    },
+  );
+});
+
+test('Jina fetchPage routes a 4xx URL to failures while keeping the rest', async () => {
+  await withMockedFetch(
+    async incoming => {
+      const body = JSON.parse(await incoming.clone().text());
+      if (body.url === 'https://broken.com') {
+        return errorEnvelope(400, 'ParamValidationError', 'unreachable');
+      }
+      return okEnvelope({ url: body.url as string, content: 'ok body' });
+    },
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.fetchPage({ urls: ['https://a.com', 'https://broken.com'] });
+      if (result.type !== 'ok') throw new Error('expected ok');
+      assertEquals(result.pages.length, 1);
+      assertEquals(result.pages[0].url, 'https://a.com');
+      assertEquals(result.failures, [
+        { url: 'https://broken.com', errorCode: 'invalid_tool_input', message: 'unreachable' },
+      ]);
+    },
+  );
+});
+
+test('Jina fetchPage retries 429 with 1s/2s/4s/8s backoff and succeeds on the fifth try', async () => {
+  const fakeTime = new FakeTime();
+  let attempts = 0;
+  try {
+    await withMockedFetch(
+      () => {
+        attempts += 1;
+        if (attempts < 5) return errorEnvelope(429, 'RateLimitError', 'rate limited');
+        return okEnvelope({ url: 'https://a.com', content: 'finally' });
+      },
+      async () => {
+        const provider = createJinaWebSearchProvider('jina-test');
+        const promise = provider.fetchPage({ urls: ['https://a.com'] });
+
+        fakeTime.runMicrotasks();
+        assertEquals(attempts, 1);
+        await fakeTime.tickAsync(1000);
+        assertEquals(attempts, 2);
+        await fakeTime.tickAsync(2000);
+        assertEquals(attempts, 3);
+        await fakeTime.tickAsync(4000);
+        assertEquals(attempts, 4);
+        await fakeTime.tickAsync(8000);
+
+        const result = await promise;
+        if (result.type !== 'ok') throw new Error('expected ok');
+        assertEquals(result.pages[0].content, 'finally');
+      },
+    );
+  } finally {
+    fakeTime.restore();
+  }
+});
+
+test('Jina fetchPage surfaces a per-URL 429 failure after exhausting retries', async () => {
+  const fakeTime = new FakeTime();
+  try {
+    await withMockedFetch(
+      // First URL keeps 429ing; second succeeds — verifies retry exhaustion
+      // routes to failures[] while keeping the rest of the batch intact.
+      async incoming => {
+        const body = JSON.parse(await incoming.clone().text());
+        if (body.url === 'https://hot.com') return errorEnvelope(429, 'RateLimitError', 'rate limited');
+        return okEnvelope({ url: body.url as string, content: 'cool body' });
+      },
+      async () => {
+        const provider = createJinaWebSearchProvider('jina-test');
+        const promise = provider.fetchPage({ urls: ['https://hot.com', 'https://cool.com'] });
+        // Drain the retry timeline (1+2+4+8 = 15s).
+        await fakeTime.tickAsync(15_000);
+        const result = await promise;
+        if (result.type !== 'ok') throw new Error('expected ok');
+        assertEquals(result.pages.length, 1);
+        assertEquals(result.pages[0].url, 'https://cool.com');
+        assertEquals(result.failures, [
+          { url: 'https://hot.com', errorCode: 'too_many_requests', message: 'rate limited' },
+        ]);
+      },
+    );
+  } finally {
+    fakeTime.restore();
+  }
+});
+
+test('Jina fetchPage collapses to whole-batch error when every URL transport-fails', async () => {
+  await withMockedFetch(
+    () => Promise.reject(new Error('network down')),
+    async () => {
+      const provider = createJinaWebSearchProvider('jina-test');
+      const result = await provider.fetchPage({ urls: ['https://a.com', 'https://b.com'] });
+      assertEquals(result.type, 'error');
+      if (result.type !== 'error') throw new Error('expected error');
+      assertEquals(result.errorCode, 'unavailable');
+      assertEquals(result.message, 'network down');
+    },
+  );
+});
+
+test('Jina fetchPage forwards an AbortSignal to each per-URL fetch', async () => {
+  const captured: AbortSignal[] = [];
+  await withMockedFetch(
+    incoming => {
+      captured.push(incoming.signal);
+      return okEnvelope({ url: 'https://x', content: 'ok' });
+    },
+    async () => {
+      const controller = new AbortController();
+      const provider = createJinaWebSearchProvider('jina-test');
+      await provider.fetchPage({ urls: ['https://a', 'https://b'], signal: controller.signal });
+      assertEquals(captured.length, 2);
+      controller.abort();
+      assertEquals(captured.every(s => s.aborted), true);
+    },
+  );
+});

--- a/packages/gateway/src/data-plane/tools/web-search/search-config.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/search-config.ts
@@ -1,11 +1,13 @@
 import type { SearchConfig } from './types.ts';
 import { getRepo } from '../../../repo/index.ts';
 import { isJsonObject } from '../../../shared/json-helpers.ts';
+import { WEB_SEARCH_PROVIDER_NAMES, isWebSearchProviderName } from '../../../shared/web-search-providers.ts';
 
 export const DEFAULT_SEARCH_CONFIG: SearchConfig = {
   provider: 'disabled',
   tavily: { apiKey: '' },
   microsoftGrounding: { apiKey: '' },
+  jina: { apiKey: '' },
 };
 
 export const FIXED_SEARCH_CONFIG_TEST_QUERY = 'React documentation';
@@ -20,12 +22,9 @@ export const parseSearchConfigStrict = (input: unknown): SearchConfig => {
   if (!isJsonObject(input)) {
     throw new Error('search config must be a JSON object');
   }
-  if (
-    input.provider !== 'disabled'
-    && input.provider !== 'tavily'
-    && input.provider !== 'microsoft-grounding'
-  ) {
-    throw new Error(`search config provider must be 'disabled', 'tavily', or 'microsoft-grounding', got ${JSON.stringify(input.provider)}`);
+  if (input.provider !== 'disabled' && !isWebSearchProviderName(input.provider)) {
+    const allowed = ['disabled', ...WEB_SEARCH_PROVIDER_NAMES].map(name => `'${name}'`).join(', ');
+    throw new Error(`search config provider must be one of ${allowed}, got ${JSON.stringify(input.provider)}`);
   }
   if (!isJsonObject(input.tavily)) {
     throw new Error('search config tavily must be an object');
@@ -39,10 +38,17 @@ export const parseSearchConfigStrict = (input: unknown): SearchConfig => {
   if (typeof input.microsoftGrounding.apiKey !== 'string') {
     throw new Error('search config microsoftGrounding.apiKey must be a string');
   }
+  if (!isJsonObject(input.jina)) {
+    throw new Error('search config jina must be an object');
+  }
+  if (typeof input.jina.apiKey !== 'string') {
+    throw new Error('search config jina.apiKey must be a string');
+  }
   return {
     provider: input.provider,
     tavily: { apiKey: input.tavily.apiKey.trim() },
     microsoftGrounding: { apiKey: input.microsoftGrounding.apiKey.trim() },
+    jina: { apiKey: input.jina.apiKey.trim() },
   };
 };
 
@@ -55,11 +61,13 @@ export const normalizeSearchConfig = (input: unknown): SearchConfig => {
   const record = isJsonObject(input) ? input : {};
   const tavily = isJsonObject(record.tavily) ? record.tavily : {};
   const microsoftGrounding = isJsonObject(record.microsoftGrounding) ? record.microsoftGrounding : {};
+  const jina = isJsonObject(record.jina) ? record.jina : {};
 
   return {
-    provider: record.provider === 'tavily' || record.provider === 'microsoft-grounding' ? record.provider : 'disabled',
+    provider: isWebSearchProviderName(record.provider) ? record.provider : 'disabled',
     tavily: { apiKey: typeof tavily.apiKey === 'string' ? tavily.apiKey.trim() : '' },
     microsoftGrounding: { apiKey: typeof microsoftGrounding.apiKey === 'string' ? microsoftGrounding.apiKey.trim() : '' },
+    jina: { apiKey: typeof jina.apiKey === 'string' ? jina.apiKey.trim() : '' },
   };
 };
 

--- a/packages/gateway/src/data-plane/tools/web-search/search-config_test.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/search-config_test.ts
@@ -11,15 +11,17 @@ interface SearchConfigRow {
   provider: string;
   tavily_api_key: string;
   microsoft_grounding_api_key: string;
+  jina_api_key: string;
 }
 
-const SELECT_SQL = 'SELECT provider, tavily_api_key, microsoft_grounding_api_key FROM search_config WHERE id = 1';
-const UPSERT_SQL = `INSERT INTO search_config (id, provider, tavily_api_key, microsoft_grounding_api_key, updated_at)
-         VALUES (1, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+const SELECT_SQL = 'SELECT provider, tavily_api_key, microsoft_grounding_api_key, jina_api_key FROM search_config WHERE id = 1';
+const UPSERT_SQL = `INSERT INTO search_config (id, provider, tavily_api_key, microsoft_grounding_api_key, jina_api_key, updated_at)
+         VALUES (1, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
          ON CONFLICT (id) DO UPDATE SET
            provider = excluded.provider,
            tavily_api_key = excluded.tavily_api_key,
            microsoft_grounding_api_key = excluded.microsoft_grounding_api_key,
+           jina_api_key = excluded.jina_api_key,
            updated_at = excluded.updated_at`;
 
 class FakeSqlPreparedStatement {
@@ -50,6 +52,7 @@ class FakeSqlPreparedStatement {
         provider: String(this.binds[0]),
         tavily_api_key: String(this.binds[1]),
         microsoft_grounding_api_key: String(this.binds[2]),
+        jina_api_key: String(this.binds[3]),
       };
       return Promise.resolve({ results: [], success: true, meta: {} });
     }
@@ -78,12 +81,14 @@ test('search config repo defaults to disabled and round-trips provider keys', as
     provider: 'tavily',
     tavily: { apiKey: 'tvly-test' },
     microsoftGrounding: { apiKey: 'ms-test' },
+    jina: { apiKey: 'jina-test' },
   });
 
   assertEquals(await loadSearchConfig(), {
     provider: 'tavily',
     tavily: { apiKey: 'tvly-test' },
     microsoftGrounding: { apiKey: 'ms-test' },
+    jina: { apiKey: 'jina-test' },
   });
   assertEquals(FIXED_SEARCH_CONFIG_TEST_QUERY, 'React documentation');
 });
@@ -96,6 +101,7 @@ test('loadSearchConfig strict-parses a stored row and rejects unknown provider v
     provider: 'unknown-provider',
     tavily: { apiKey: '  tvly-test  ' },
     microsoftGrounding: { apiKey: '  ms-test  ' },
+    jina: { apiKey: '' },
   });
 
   await assertRejects(() => loadSearchConfig(), Error, 'provider');
@@ -106,15 +112,17 @@ test('loadSearchConfig strict-parses a stored row and trims valid api keys', asy
   initRepo(repo);
 
   await repo.searchConfig.save({
-    provider: 'tavily',
+    provider: 'jina',
     tavily: { apiKey: '  tvly-trim  ' },
     microsoftGrounding: { apiKey: '  ms-trim  ' },
+    jina: { apiKey: '  jina-trim  ' },
   });
 
   assertEquals(await loadSearchConfig(), {
-    provider: 'tavily',
+    provider: 'jina',
     tavily: { apiKey: 'tvly-trim' },
     microsoftGrounding: { apiKey: 'ms-trim' },
+    jina: { apiKey: 'jina-trim' },
   });
 });
 
@@ -135,9 +143,14 @@ test('parseSearchConfigStrict throws on missing required fields', () => {
     'microsoftGrounding',
   );
   assertThrows(
-    () => parseSearchConfigStrict({ provider: 'disabled', tavily: {}, microsoftGrounding: { apiKey: '' } }),
+    () => parseSearchConfigStrict({ provider: 'disabled', tavily: {}, microsoftGrounding: { apiKey: '' }, jina: { apiKey: '' } }),
     Error,
     'tavily.apiKey',
+  );
+  assertThrows(
+    () => parseSearchConfigStrict({ provider: 'disabled', tavily: { apiKey: '' }, microsoftGrounding: { apiKey: '' } }),
+    Error,
+    'jina',
   );
 });
 
@@ -149,21 +162,25 @@ test('saveSearchConfig writes the typed columns and round-trips through the same
     provider: 'disabled',
     tavily: { apiKey: '  tvly-test  ' },
     microsoftGrounding: { apiKey: '  ms-test  ' },
+    jina: { apiKey: '  jina-test  ' },
   });
 
   assertEquals(saved, {
     provider: 'disabled',
     tavily: { apiKey: 'tvly-test' },
     microsoftGrounding: { apiKey: 'ms-test' },
+    jina: { apiKey: 'jina-test' },
   });
   assertEquals(db.searchConfig, {
     provider: 'disabled',
     tavily_api_key: 'tvly-test',
     microsoft_grounding_api_key: 'ms-test',
+    jina_api_key: 'jina-test',
   });
   assertEquals(await loadSearchConfig(), {
     provider: 'disabled',
     tavily: { apiKey: 'tvly-test' },
     microsoftGrounding: { apiKey: 'ms-test' },
+    jina: { apiKey: 'jina-test' },
   });
 });

--- a/packages/gateway/src/data-plane/tools/web-search/types.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/types.ts
@@ -7,6 +7,7 @@ export interface SearchConfig {
   provider: 'disabled' | WebSearchProviderName;
   tavily: { apiKey: string };
   microsoftGrounding: { apiKey: string };
+  jina: { apiKey: string };
 }
 
 export const DEFAULT_WEB_SEARCH_RESULT_COUNT = 10;

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -1092,33 +1092,36 @@ class SqlSearchConfigRepo implements SearchConfigRepo {
 
   async get(): Promise<unknown | null> {
     const row = await this.db
-      .prepare('SELECT provider, tavily_api_key, microsoft_grounding_api_key FROM search_config WHERE id = 1')
-      .first<{ provider: string; tavily_api_key: string; microsoft_grounding_api_key: string }>();
+      .prepare('SELECT provider, tavily_api_key, microsoft_grounding_api_key, jina_api_key FROM search_config WHERE id = 1')
+      .first<{ provider: string; tavily_api_key: string; microsoft_grounding_api_key: string; jina_api_key: string }>();
     if (!row) throw new Error('search_config singleton row missing');
     return {
       provider: row.provider,
       tavily: { apiKey: row.tavily_api_key },
       microsoftGrounding: { apiKey: row.microsoft_grounding_api_key },
+      jina: { apiKey: row.jina_api_key },
     };
   }
 
   async save(config: unknown): Promise<void> {
-    const { provider, tavily, microsoftGrounding } = config as {
+    const { provider, tavily, microsoftGrounding, jina } = config as {
       provider: string;
       tavily: { apiKey: string };
       microsoftGrounding: { apiKey: string };
+      jina: { apiKey: string };
     };
     await this.db
       .prepare(
-        `INSERT INTO search_config (id, provider, tavily_api_key, microsoft_grounding_api_key, updated_at)
-         VALUES (1, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        `INSERT INTO search_config (id, provider, tavily_api_key, microsoft_grounding_api_key, jina_api_key, updated_at)
+         VALUES (1, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
          ON CONFLICT (id) DO UPDATE SET
            provider = excluded.provider,
            tavily_api_key = excluded.tavily_api_key,
            microsoft_grounding_api_key = excluded.microsoft_grounding_api_key,
+           jina_api_key = excluded.jina_api_key,
            updated_at = excluded.updated_at`,
       )
-      .bind(provider, tavily.apiKey, microsoftGrounding.apiKey)
+      .bind(provider, tavily.apiKey, microsoftGrounding.apiKey, jina.apiKey)
       .run();
   }
 }

--- a/packages/gateway/src/shared/web-search-providers.ts
+++ b/packages/gateway/src/shared/web-search-providers.ts
@@ -1,4 +1,4 @@
-export const WEB_SEARCH_PROVIDER_NAMES = ['tavily', 'microsoft-grounding'] as const;
+export const WEB_SEARCH_PROVIDER_NAMES = ['tavily', 'microsoft-grounding', 'jina'] as const;
 
 export type WebSearchProviderName = (typeof WEB_SEARCH_PROVIDER_NAMES)[number];
 


### PR DESCRIPTION
## Summary

Adds `jina` as a third web-search provider alongside `tavily` and `microsoft-grounding`. Search calls `s.jina.ai`; `fetchPage` calls `r.jina.ai` once per URL in parallel with 1s/2s/4s/8s backoff on 429/5xx. The dashboard provider picker becomes a dropdown driven by a single `PROVIDER_OPTIONS` list, matching the pattern PR #101 introduced for the custom-upstream Auth Style.

## Key design calls (with the research that drove them)

- **`apiKey` is required** — anonymous on `s.jina.ai` now returns 401 (verified live; the README is stale). Reader still accepts anonymous, but a single Bearer token covers both endpoints, so we treat Jina as one global credential.
- **Search sends `X-Max-Tokens: 500`** to clip each per-result `content` to ~2 KB markdown server-side. Without it Jina scrapes and bills the full readability page per result (10–20 KB × 10 = 100 KB+ per query). Verified in `jina-ai/reader` (`snapshot-formatter.ts` calls `tokenTrim(content, maxTokens)` on every output shape). 500 is also Jina's documented minimum — lower rejects with `Rejected by validator (v) => v >= 500`. The related `X-Token-Budget` *is* silently ignored on search; `X-Max-Tokens` is not.
- **Sized 500 tokens against the other providers**: Tavily `basic` (no caller cap) returns ~400-char NLP summaries (~100 tokens), and MS Grounding `passage` returns ~300–400 tokens. 500 tokens puts Jina in the same ballpark — neither drowning the context with full pages nor starving it on raw SERP descriptions.
- **Domain filters**: `allowedDomains` becomes `X-Site` (Jina splits on the literal `", "` per `serper-search.ts:209`, so we join with that separator). `blockedDomains` is silently dropped because Jina has no exclude operator — surfacing more results, even ones the agent might filter post-hoc, beats failing the call.
- **`userLocation.country` maps to `gl`** (lowercase ISO-3166-1 alpha-2). There is no `X-Country` header despite the name suggesting one — confirmed by grepping the open-source codebase.
- **No-results normalization**: Jina returns HTTP 4xx + `AssertionFailureError` with a recognizable message when a query has no hits. We normalize that to `type: 'ok', results: []` so the agent doesn't see a hard error for an empty SERP.

## Along the way

- `resolveConfiguredWebSearchProvider` becomes a one-line table lookup keyed by `WebSearchProviderName`.
- The dashboard provider picker becomes a dropdown (`@floway-dev/ui` `Select`) driven by a single `PROVIDER_OPTIONS` list, matching the pattern PR #101 introduced for custom Auth Style. Adding a fourth provider is one entry, the per-option description lives in the popover instead of permanently consuming vertical space, and the credential field collapses next to the dropdown on sm+ widths.

## Migration

`0043_jina_provider.sql` does two things:
- `ALTER TABLE search_config ADD COLUMN jina_api_key TEXT NOT NULL DEFAULT ''` — plain add, the singleton row keeps working untouched.
- Rebuilds `search_usage` via swap to extend the provider CHECK constraint to accept `'jina'` (same pattern as 0017, since D1/SQLite can't alter a CHECK in place). All existing rows survive.

Numbered `0043` rather than `0042` because main's PR #101 landed `0042_custom_apikey_rename.sql` during this branch's rebase.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 3236/3237 pass; the single failure is the well-known flaky timing assertion in `packages/http/src/tls_test.ts` that's load-sensitive in the full parallel suite, passes 12/12 standalone, unrelated to web search
- [x] **Live verification** against a real Jina key, on a local instance pointed at the dev D1 (the live Copilot upstream is what drove the model):
  - **Dashboard Test Search** — `POST /api/search-config/test` returns three preview hits for `React documentation`, confirming the auth + envelope parse + previewText pipeline.
  - **OpenAI Responses (`/v1/responses`)** — prompt: "Find the Vue.js 3 docs homepage, then open it and quote the tagline." Trace: 1× `web_search_call` (action=search), 1× `web_search_call` (action=open_page, url=https://vuejs.org/), final `message` correctly quoting Vue's real tagline ("An approachable, performant and versatile framework…"). Both `s.jina.ai` and `r.jina.ai` round-trips exercised.
  - **Anthropic Messages (`/v1/messages`)** — prompt: "Search for the latest stable Node.js LTS version, briefly state version + source URL." Trace: turn 1 search → `pause_turn` (correct per Anthropic's hosted-search contract); turn 2 search (`site:nodejs.org/en/download`) → `pause_turn`; turn 3 → `end_turn` with the final answer `v24.17.0` + source URL. Multi-turn server-tool loop healthy, `X-Max-Tokens: 500` snippet size let the model decide when it needed a second query.