### PR TITLE
feat(custom): three auth modes (bearer/anthropic/none) with dropdown UI

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -48,12 +48,12 @@ export interface CustomRawModel {
 
 export interface CustomUpstreamConfig {
   baseUrl: string;
-  authStyle: 'bearer' | 'anthropic';
+  authStyle: 'bearer' | 'anthropic' | 'none';
   endpoints: ModelEndpoints;
   pathOverrides?: Record<string, string>;
   modelsFetch: CustomModelsFetch;
   models: UpstreamModelConfig[];
-  bearerTokenSet?: boolean;
+  apiKeySet?: boolean;
 }
 
 export interface AzureUpstreamConfig {
@@ -102,7 +102,7 @@ export interface CodexUpstreamConfig {
 
 export interface OllamaUpstreamConfig {
   baseUrl: string;
-  // apiKeySet mirrors customConfig.bearerTokenSet — the wire never carries the
+  // apiKeySet mirrors customConfig.apiKeySet — the wire never carries the
   // real secret, only a flag the dashboard uses to render the "leave blank to
   // keep" hint and the "••••••••" placeholder.
   apiKeySet?: boolean;

--- a/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
@@ -3,16 +3,16 @@
 // /models toggle, path overrides). The model list is owned by a separate
 // panel — this panel only carries the connection-shaped config.
 
-import type { CustomDraft } from './customConfig.ts';
+import type { CustomAuthStyle, CustomDraft } from './customConfig.ts';
 import { PATH_KEYS } from './customConfig.ts';
 import EndpointsField from './EndpointsField.vue';
 import SecretInput from '../shared/SecretInput.vue';
-import { Button, Input, Switch } from '@floway-dev/ui';
+import { Button, Input, Select, Switch } from '@floway-dev/ui';
 
 const draft = defineModel<CustomDraft>({ required: true });
 
 defineProps<{
-  bearerTokenSet: boolean;
+  apiKeySet: boolean;
   editMode: boolean;
   fetchLoading: boolean;
   fetchError: string | null;
@@ -21,74 +21,84 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{ 'fetch-models': [] }>();
+
+// Auth styles are presented as a dropdown rather than a radio grid because
+// the radio cards crowded the panel even at two options and would have run
+// out of space at three. The dropdown also carries a per-option description
+// slot, which lets the actual HTTP header live next to the human label
+// inside the popover rather than as a permanently-visible block.
+interface AuthOption {
+  value: CustomAuthStyle;
+  label: string;
+  explanation: string;
+  headerExample?: string;
+}
+
+const authOptions: AuthOption[] = [
+  {
+    value: 'bearer',
+    label: 'Bearer',
+    explanation: 'Most OpenAI-compatible APIs. Sends the key in the Authorization header.',
+    headerExample: 'Authorization: Bearer <key>',
+  },
+  {
+    value: 'anthropic',
+    label: 'Anthropic',
+    explanation: 'Anthropic-compatible APIs. Sends the key in a custom header plus an API version.',
+    headerExample: 'x-api-key: <key>\nanthropic-version: 2023-06-01',
+  },
+  {
+    value: 'none',
+    label: 'None',
+    explanation: 'No authentication. Use for local or internal upstreams that accept anonymous requests.',
+  },
+];
+
+const setAuthStyle = (style: CustomAuthStyle) => {
+  // Switching to 'none' strips any in-flight apiKey; switching away leaves
+  // the field blank so the user explicitly re-enters it.
+  draft.value = style === 'none'
+    ? { ...draft.value, authStyle: 'none', apiKey: '' }
+    : { ...draft.value, authStyle: style };
+};
 </script>
 
 <template>
   <div class="space-y-5">
-    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-      <div>
-        <label class="mb-1.5 block text-xs font-medium text-gray-500">Base URL</label>
-        <Input
-          :model-value="draft.baseUrl"
-          placeholder="e.g. https://api.openai.com"
-          class="font-mono"
-          @update:model-value="v => draft = { ...draft, baseUrl: v }"
-        />
-      </div>
-      <div>
-        <label class="mb-1.5 block text-xs font-medium text-gray-500">
-          {{ draft.authStyle === 'anthropic' ? 'API Key' : 'Bearer Token' }}<span v-if="editMode && bearerTokenSet" class="text-gray-500"> (leave blank to keep)</span>
-        </label>
-        <SecretInput
-          :model-value="draft.bearerToken"
-          :placeholder="bearerTokenSet ? '••••••••' : (draft.authStyle === 'anthropic' ? 'sk-ant-xxxxx' : 'sk-xxxxx')"
-          class="font-mono"
-          @update:model-value="v => draft = { ...draft, bearerToken: v }"
-        />
-      </div>
+    <div>
+      <label class="mb-1.5 block text-xs font-medium text-gray-500">Base URL</label>
+      <Input
+        :model-value="draft.baseUrl"
+        placeholder="e.g. https://api.openai.com"
+        class="font-mono"
+        @update:model-value="v => draft = { ...draft, baseUrl: v }"
+      />
     </div>
 
-    <div>
-      <p class="mb-2 text-xs font-medium text-gray-500">Auth Style</p>
-      <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <label
-          class="flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-xs text-gray-300 transition-colors"
-          :class="draft.authStyle === 'bearer'
-            ? 'border-accent-cyan/40 bg-accent-cyan/5'
-            : 'border-white/10 bg-surface-800/50 hover:border-white/20'"
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div>
+        <label class="mb-1.5 block text-xs font-medium text-gray-500">Auth Style</label>
+        <Select
+          :model-value="draft.authStyle"
+          :options="authOptions"
+          @update:model-value="v => v !== undefined && setAuthStyle(v)"
         >
-          <input
-            type="radio"
-            name="customAuthStyle"
-            value="bearer"
-            class="mt-0.5 accent-accent-cyan"
-            :checked="draft.authStyle === 'bearer'"
-            @change="draft = { ...draft, authStyle: 'bearer' }"
-          >
-          <span class="flex flex-col gap-0.5">
-            <span class="font-medium">Bearer</span>
-            <span class="font-mono text-[10px] text-gray-600">Authorization: Bearer &lt;token&gt;</span>
-          </span>
+          <template #description="{ option }">
+            <p class="text-[11px] text-gray-500">{{ option.explanation }}</p>
+            <code v-if="option.headerExample" class="mt-1 block whitespace-pre font-mono text-[10px] text-gray-600">{{ option.headerExample }}</code>
+          </template>
+        </Select>
+      </div>
+      <div v-if="draft.authStyle !== 'none'">
+        <label class="mb-1.5 block text-xs font-medium text-gray-500">
+          API Key<span v-if="editMode && apiKeySet" class="text-gray-500"> (leave blank to keep)</span>
         </label>
-        <label
-          class="flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-xs text-gray-300 transition-colors"
-          :class="draft.authStyle === 'anthropic'
-            ? 'border-accent-cyan/40 bg-accent-cyan/5'
-            : 'border-white/10 bg-surface-800/50 hover:border-white/20'"
-        >
-          <input
-            type="radio"
-            name="customAuthStyle"
-            value="anthropic"
-            class="mt-0.5 accent-accent-cyan"
-            :checked="draft.authStyle === 'anthropic'"
-            @change="draft = { ...draft, authStyle: 'anthropic' }"
-          >
-          <span class="flex flex-col gap-0.5">
-            <span class="font-medium">Anthropic</span>
-            <span class="font-mono text-[10px] text-gray-600">x-api-key + anthropic-version</span>
-          </span>
-        </label>
+        <SecretInput
+          :model-value="draft.apiKey"
+          :placeholder="apiKeySet ? '••••••••' : (draft.authStyle === 'anthropic' ? 'sk-ant-xxxxx' : 'sk-xxxxx')"
+          class="font-mono"
+          @update:model-value="v => draft = { ...draft, apiKey: v }"
+        />
       </div>
     </div>
 

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -27,7 +27,7 @@ const proxyFallbackList = defineModel<ProxyFallbackEntry[]>('proxyFallbackList',
 type CommonConfigPanelProps = {
   provider: UpstreamProviderKind;
   flags: FlagDef[];
-  customBearerTokenSet: boolean;
+  customApiKeySet: boolean;
   azureApiKeySet: boolean;
   ollamaApiKeySet: boolean;
   fetchLoading: boolean;
@@ -164,7 +164,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
       <section v-if="provider === 'custom'" class="shrink-0">
         <CustomConfigPanel
           v-model="customDraft"
-          :bearer-token-set="customBearerTokenSet"
+          :api-key-set="customApiKeySet"
           :edit-mode="mode === 'edit'"
           :fetch-loading="fetchLoading"
           :fetch-error="fetchError"

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -117,7 +117,7 @@ const seedFromRecord = (r: UpstreamRecord) => {
       baseUrl: cfg.baseUrl,
       authStyle: cfg.authStyle,
       endpoints: { ...cfg.endpoints },
-      bearerToken: '',
+      apiKey: '',
       pathOverrides: seedPathOverrides(cfg.pathOverrides),
       modelsFetch: cfg.modelsFetch
         ? { enabled: cfg.modelsFetch.enabled, endpoint: cfg.modelsFetch.endpoint ?? '' }
@@ -160,9 +160,9 @@ const seedFresh = () => {
 if (props.mode === 'edit') seedFromRecord(props.record);
 else seedFresh();
 
-const customBearerTokenSet = computed(() => {
+const customApiKeySet = computed(() => {
   if (props.record?.provider !== 'custom') return false;
-  return props.record.config.bearerTokenSet === true;
+  return props.record.config.apiKeySet === true;
 });
 const azureApiKeySet = computed(() => {
   if (props.record?.provider !== 'azure') return false;
@@ -548,7 +548,7 @@ const workbenchStyle = computed(() => ({ '--right-pane-h': `${Math.ceil(rightCon
         :flags="flags"
         :colo-aware="coloAware"
         :current-colo="currentColo"
-        :custom-bearer-token-set="customBearerTokenSet"
+        :custom-api-key-set="customApiKeySet"
         :azure-api-key-set="azureApiKeySet"
         :ollama-api-key-set="ollamaApiKeySet"
         :fetch-loading="fetchLoading"

--- a/apps/web/src/components/upstream-edit/customConfig.ts
+++ b/apps/web/src/components/upstream-edit/customConfig.ts
@@ -22,11 +22,20 @@ export const seedPathOverrides = (saved: Record<string, string> | null | undefin
   return out;
 };
 
+export type CustomAuthStyle = 'bearer' | 'anthropic' | 'none';
+
+// Form state is kept flat (apiKey is always a string slot, even when
+// authStyle === 'none' parks it as ''). This keeps two-way binding simple
+// across the SecretInput and lets the user toggle between styles without
+// the field disappearing from the underlying object. buildCustomConfigCore
+// projects this onto the discriminated wire shape: it omits apiKey entirely
+// when 'none', and otherwise sends a trimmed key (or omits it for the
+// edit-mode "keep stored secret" path).
 export interface CustomDraft {
   baseUrl: string;
-  authStyle: 'bearer' | 'anthropic';
+  authStyle: CustomAuthStyle;
   endpoints: ModelEndpoints;
-  bearerToken: string;
+  apiKey: string;
   pathOverrides: Record<PathKey, string>;
   // Live /models browse toggle and its endpoint override; an empty endpoint
   // means "use the OpenAI default", stripped to undefined on save.
@@ -48,37 +57,45 @@ export interface OllamaDraft {
   models: UpstreamModelConfig[];
 }
 
-export interface CustomConfigCore {
+interface CustomConfigCoreBase {
   baseUrl: string;
-  authStyle: 'bearer' | 'anthropic';
   endpoints: ModelEndpoints;
-  bearerToken?: string;
   modelsFetch: { enabled: boolean; endpoint?: string };
 }
 
+// Wire-shape projection of CustomDraft. Discriminated on authStyle so the
+// 'none' branch can't carry an apiKey field at all.
+export type CustomConfigCore =
+  | (CustomConfigCoreBase & { authStyle: 'none' })
+  | (CustomConfigCoreBase & { authStyle: 'bearer' | 'anthropic'; apiKey?: string });
+
 // The fields shared by the persisted config and the /models browse preview.
 // Keeping a single builder guarantees the browse request can never drift from
-// what save() would write. An empty token or models endpoint is omitted so the
-// backend keeps the secret and resolves the OpenAI default respectively.
+// what save() would write. For non-'none' styles, an empty apiKey is omitted
+// so the backend keeps the stored secret; for 'none', apiKey is dropped
+// entirely.
 export const buildCustomConfigCore = (draft: CustomDraft): CustomConfigCore => {
-  const core: CustomConfigCore = {
+  const base: CustomConfigCoreBase = {
     baseUrl: draft.baseUrl.trim(),
-    authStyle: draft.authStyle,
     endpoints: draft.endpoints,
     modelsFetch: {
       enabled: draft.modelsFetch.enabled,
       ...(draft.modelsFetch.endpoint.trim() ? { endpoint: draft.modelsFetch.endpoint.trim() } : {}),
     },
   };
-  if (draft.bearerToken.trim()) core.bearerToken = draft.bearerToken.trim();
-  return core;
+  if (draft.authStyle === 'none') return { ...base, authStyle: 'none' };
+
+  const trimmed = draft.apiKey.trim();
+  return trimmed
+    ? { ...base, authStyle: draft.authStyle, apiKey: trimmed }
+    : { ...base, authStyle: draft.authStyle };
 };
 
 export const blankCustomDraft = (): CustomDraft => ({
   baseUrl: '',
   authStyle: 'bearer',
   endpoints: { chatCompletions: {} },
-  bearerToken: '',
+  apiKey: '',
   pathOverrides: emptyPathOverrides(),
   modelsFetch: { enabled: true, endpoint: '' },
   models: [],

--- a/packages/gateway/migrations/0042_custom_apikey_rename.sql
+++ b/packages/gateway/migrations/0042_custom_apikey_rename.sql
@@ -1,0 +1,24 @@
+-- Rename the credential field on every `custom` upstream from `bearerToken`
+-- to `apiKey`. The name was misleading even before the third auth mode:
+-- with authStyle = 'anthropic' the value is sent as `x-api-key`, not as a
+-- bearer token. Adding `authStyle = 'none'` makes the old name actively
+-- wrong, so we collapse both inconsistencies in one pass.
+--
+-- json_type returns NULL only when the path is absent, so it covers JSON-null
+-- values as well — using `json_extract(...) IS NOT NULL` would have skipped
+-- rows whose bearerToken happened to be stored as JSON null.
+UPDATE upstreams
+SET config_json = json_patch(
+  json_remove(config_json, '$.bearerToken'),
+  json_object('apiKey', json_extract(config_json, '$.bearerToken'))
+)
+WHERE provider = 'custom'
+  AND json_type(config_json, '$.bearerToken') IS NOT NULL;
+
+-- The runtime parser used to default an absent authStyle to 'bearer'. The
+-- new parser is strict and requires the field. Backfill the legacy rows
+-- here so the strict parse path stays clean.
+UPDATE upstreams
+SET config_json = json_patch(config_json, json_object('authStyle', 'bearer'))
+WHERE provider = 'custom'
+  AND json_type(config_json, '$.authStyle') IS NULL;

--- a/packages/gateway/src/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes_test.ts
@@ -84,7 +84,8 @@ const CUSTOM_UPSTREAM: UpstreamRecord = {
   proxyFallbackList: [],
   config: {
     baseUrl: 'https://custom.example.com',
-    bearerToken: 'sk-custom',
+    authStyle: 'bearer',
+    apiKey: 'sk-custom',
     endpoints: { chatCompletions: {}, responses: {} },
     modelsFetch: { enabled: true, endpoint: '/models' },
   },
@@ -329,7 +330,7 @@ test('export includes full upstream configs and omits performance by default', a
 
   assertEquals(result.data.apiKeys, [KEY_A]);
   assertEquals(result.data.upstreams.map((upstream: any) => upstream.id), ['up_copilot_a', 'up_custom_a', 'up_azure_a']);
-  assertEquals(result.data.upstreams.find((upstream: any) => upstream.id === 'up_custom_a').config.bearerToken, 'sk-custom');
+  assertEquals(result.data.upstreams.find((upstream: any) => upstream.id === 'up_custom_a').config.apiKey, 'sk-custom');
   assertEquals(result.data.upstreams.find((upstream: any) => upstream.id === 'up_copilot_a').config.githubToken, 'ghu-alice');
   assertEquals(result.data.upstreams.find((upstream: any) => upstream.id === 'up_azure_a').config.apiKey, 'az-key');
   assertEquals(result.data.usage, [USAGE_1]);
@@ -559,7 +560,7 @@ test('import rejects invalid records before clearing existing data', async () =>
   const badUpstream = await doImport(app, 'replace', {
     users: [SEED_ADMIN],
     apiKeys: [],
-    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), config: { baseUrl: 'https://custom.example.com', bearerToken: 'sk', endpoints: { bogus: {} } } }],
+    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), config: { baseUrl: 'https://custom.example.com', authStyle: 'bearer', apiKey: 'sk', endpoints: { bogus: {} } } }],
     usage: [],
     searchUsage: [],
     performanceIncluded: false,

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -105,13 +105,13 @@ const upstreamModelSchema = z.object({
 
 const customConfigSchema = z.object({
   baseUrl: z.string().min(1),
-  // authStyle is optional; the runtime parser defaults omitted values to
-  // bearer, so the schema accepts the same.
-  authStyle: z.enum(['bearer', 'anthropic']).optional(),
+  authStyle: z.enum(['bearer', 'anthropic', 'none']),
   // Structured capability map — the runtime parser permits an empty map for
   // an upstream serving only kind-derived models.
   endpoints: modelEndpointsSchema,
-  bearerToken: z.string().optional(),
+  // Optional because edit-mode PATCH omits it to keep the stored secret;
+  // the runtime parser enforces presence vs. authStyle invariants.
+  apiKey: z.string().optional(),
   // PATCH passes `null` to explicitly clear pathOverrides; nullable() keeps
   // that escape hatch.
   pathOverrides: z.record(z.string(), z.string()).nullable().optional(),

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -145,7 +145,15 @@ const mergeConfigPatch = (provider: UpstreamProviderKind, existing: unknown, pat
     ...structuredClone(patch),
   };
 
-  if (provider === 'custom' && patch.pathOverrides === null) delete next.pathOverrides;
+  if (provider === 'custom') {
+    if (patch.pathOverrides === null) delete next.pathOverrides;
+    // Dead-field guard: a 'none' upstream must not carry a stale apiKey
+    // from a previous authStyle. Always strip apiKey when the merged style
+    // is 'none' so the persisted shape stays one branch of the discriminated
+    // union. The reverse (switching away from 'none') is left to the
+    // runtime parser, which rejects a missing apiKey when one is required.
+    if (next.authStyle === 'none') delete next.apiKey;
+  }
   return { ok: true, value: next };
 };
 

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -7,7 +7,8 @@ type JsonObject = Record<string, any>;
 
 const customConfig = {
   baseUrl: 'https://custom.example.com',
-  bearerToken: 'sk-test',
+  authStyle: 'bearer',
+  apiKey: 'sk-test',
   endpoints: { chatCompletions: {} },
 };
 
@@ -59,17 +60,17 @@ test('POST /api/upstreams creates custom upstreams and redacts bearer tokens', a
   assertEquals(resp.status, 201);
   const created = (await resp.json()) as JsonObject;
   assertEquals(created.provider, 'custom');
-  assertEquals(created.config.bearerToken, undefined);
-  assertEquals(created.config.bearerTokenSet, true);
+  assertEquals(created.config.apiKey, undefined);
+  assertEquals(created.config.apiKeySet, true);
   assertEquals(created.config.baseUrl, 'https://custom.example.com');
   assertEquals(created.flag_overrides, { 'vendor-kimi': true });
 
   const stored = await repo.upstreams.getById(created.id);
-  assertEquals((stored?.config as Record<string, unknown>).bearerToken, 'sk-test');
+  assertEquals((stored?.config as Record<string, unknown>).apiKey, 'sk-test');
 
   const list = await requestApp('/api/upstreams', { headers: { 'x-floway-session': adminSession } });
   const items = (await list.json()) as JsonObject[];
-  assertEquals(items[0].config.bearerToken, undefined);
+  assertEquals(items[0].config.apiKey, undefined);
 });
 
 test('POST /api/upstreams validates Azure models and redacts API keys', async () => {
@@ -174,7 +175,7 @@ test('PATCH /api/upstreams preserves omitted secrets and re-warms the models cac
   );
 
   const updated = await repo.upstreams.getById(created.id);
-  assertEquals((updated?.config as Record<string, unknown>).bearerToken, 'sk-test');
+  assertEquals((updated?.config as Record<string, unknown>).apiKey, 'sk-test');
   assertEquals((updated?.config as Record<string, unknown>).endpoints, { responses: {} });
 
   const cached = await repo.modelsCache.get(created.id);
@@ -241,7 +242,7 @@ test('GET /api/upstreams attaches models-cache freshness to every row', async ()
     flagOverrides: {},
     disabledPublicModelIds: [],
     proxyFallbackList: [],
-    config: { baseUrl: 'https://a.example.com', bearerToken: 'x', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://a.example.com', authStyle: 'bearer', apiKey: 'x', endpoints: { chatCompletions: {} } },
     state: null,
   };
   await repo.upstreams.save({ ...baseRow, id: 'up_fresh', name: 'Fresh', sortOrder: 0 });
@@ -300,7 +301,7 @@ test('GET /api/upstream-options returns the minimal picker shape to admin and no
     flagOverrides: {},
     disabledPublicModelIds: [],
     proxyFallbackList: [],
-    config: { baseUrl: 'https://custom.example.com', bearerToken: 'sk-secret', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://custom.example.com', authStyle: 'bearer', apiKey: 'sk-secret', endpoints: { chatCompletions: {} } },
     state: null,
   });
 
@@ -359,7 +360,7 @@ test('POST /api/upstreams/fetch-models rejects calls that supply a saved upstrea
     flagOverrides: {},
     disabledPublicModelIds: [],
     proxyFallbackList: [],
-    config: { ...customConfig, bearerToken: 'sk-stored-secret' },
+    config: { ...customConfig, apiKey: 'sk-stored-secret' },
     state: null,
   });
 
@@ -367,7 +368,7 @@ test('POST /api/upstreams/fetch-models rejects calls that supply a saved upstrea
   // (the SWR-cached path); fetch-models stays draft-only.
   const resp = await requestApp(
     '/api/upstreams/fetch-models',
-    authed(adminSession, { provider: 'custom', id: 'up_stored_secret', config: { ...customConfig, bearerToken: '' } }),
+    authed(adminSession, { provider: 'custom', id: 'up_stored_secret', config: { ...customConfig, apiKey: '' } }),
   );
   assertEquals(resp.status, 400);
   const body = (await resp.json()) as { error: { message: string; type: string } };
@@ -469,11 +470,11 @@ test('POST /api/upstreams/fetch-models rejects a malformed draft config with 400
   const { adminSession } = await setupAppTest();
 
   // Blank token with no id and no stored secret to substitute: the runtime
-  // assert rejects the empty bearerToken, surfaced as a 400 validation error.
-  const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { provider: 'custom', config: { ...customConfig, bearerToken: '' } }));
+  // assert rejects the empty apiKey, surfaced as a 400 validation error.
+  const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { provider: 'custom', config: { ...customConfig, apiKey: '' } }));
   assertEquals(resp.status, 400);
   const body = (await resp.json()) as { error: string };
-  assertEquals(body.error.includes('bearerToken'), true);
+  assertEquals(body.error.includes('apiKey'), true);
 });
 
 test('GET /api/upstreams/:id/models?refresh=true forces a fresh upstream fetch', async () => {
@@ -490,7 +491,7 @@ test('GET /api/upstreams/:id/models?refresh=true forces a fresh upstream fetch',
     flagOverrides: {},
     disabledPublicModelIds: [],
     proxyFallbackList: [],
-    config: { ...customConfig, bearerToken: 'sk-refresh' },
+    config: { ...customConfig, apiKey: 'sk-refresh' },
     state: null,
   });
   // SOFT-fresh row: without ?refresh=true the cache returns it verbatim.

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -68,7 +68,7 @@ const redactedConfig = (upstream: UpstreamRecord): unknown => {
       ...(config.pathOverrides !== undefined ? { pathOverrides: clone(config.pathOverrides) } : {}),
       ...(config.modelsFetch !== undefined ? { modelsFetch: clone(config.modelsFetch) } : {}),
       ...(config.models !== undefined ? { models: clone(config.models) } : {}),
-      bearerTokenSet: hasSecret(config.bearerToken),
+      apiKeySet: hasSecret(config.apiKey),
     };
   case 'azure':
     return {

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -19,7 +19,8 @@ const custom: UpstreamRecord = {
   proxyFallbackList: [],
   config: {
     baseUrl: 'https://api.example.com',
-    bearerToken: 'sk-secret-token-12345',
+    authStyle: 'bearer',
+    apiKey: 'sk-secret-token-12345',
     endpoints: { chatCompletions: {}, responses: {} },
     modelsFetch: { enabled: true, endpoint: '/models' },
     models: [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }],
@@ -39,8 +40,8 @@ test('upstreamRecordToJson redacts custom bearer token inside config', () => {
   assertEquals(result.flag_overrides, { 'vendor-deepseek': true });
   assertEquals(result.state, null);
   assertEquals(config.baseUrl, 'https://api.example.com');
-  assertEquals(config.bearerToken, undefined);
-  assertEquals(config.bearerTokenSet, true);
+  assertEquals(config.apiKey, undefined);
+  assertEquals(config.apiKeySet, true);
   assertEquals(config.endpoints, { chatCompletions: {}, responses: {} });
   assertEquals(config.modelsFetch, { enabled: true, endpoint: '/models' });
   assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }]);
@@ -140,8 +141,8 @@ test('upstreamRecordToFullJson includes provider config secrets for export', () 
   const config = result.config as Record<string, unknown>;
 
   assertEquals(result.id, 'up_custom_test');
-  assertEquals(config.bearerToken, 'sk-secret-token-12345');
-  assertEquals(config.bearerTokenSet, undefined);
+  assertEquals(config.apiKey, 'sk-secret-token-12345');
+  assertEquals(config.apiKeySet, undefined);
 });
 
 // Strict-throw helpers in serialize.ts fail loud rather than silently

--- a/packages/gateway/src/data-plane/embeddings/serve_test.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve_test.ts
@@ -217,7 +217,8 @@ test('/v1/embeddings routes to custom upstream when model is only declared there
     disabledPublicModelIds: [],
     config: {
       baseUrl: 'https://embed.example.com',
-      bearerToken: 'sk-embed',
+      authStyle: 'bearer',
+      apiKey: 'sk-embed',
       endpoints: {},
     },
   }));
@@ -289,7 +290,8 @@ test('/v1/embeddings rejects model on custom upstream without /embeddings capabi
     disabledPublicModelIds: [],
     config: {
       baseUrl: 'https://chat.example.com',
-      bearerToken: 'sk-chat',
+      authStyle: 'bearer',
+      apiKey: 'sk-chat',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -346,7 +348,8 @@ test('/v1/embeddings reports the failed upstream parenthetically when /v1/models
     disabledPublicModelIds: [],
     config: {
       baseUrl: 'https://embed.example.com',
-      bearerToken: 'sk-embed',
+      authStyle: 'bearer',
+      apiKey: 'sk-embed',
       endpoints: {},
     },
   }));
@@ -403,7 +406,8 @@ test('/v1/embeddings reports the failed upstream even when a sibling upstream\'s
     disabledPublicModelIds: [],
     config: {
       baseUrl: 'https://embed.example.com',
-      bearerToken: 'sk-embed',
+      authStyle: 'bearer',
+      apiKey: 'sk-embed',
       endpoints: {},
     },
   }));

--- a/packages/gateway/src/data-plane/images/serve_test.ts
+++ b/packages/gateway/src/data-plane/images/serve_test.ts
@@ -86,7 +86,8 @@ test('/v1/images/generations rejects model on custom upstream without /images/ge
     sortOrder: 100,
     config: {
       baseUrl: 'https://chat.example.com',
-      bearerToken: 'sk-chat',
+      authStyle: 'bearer',
+      apiKey: 'sk-chat',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -121,7 +122,8 @@ test('/v1/images/generations forwards a JSON request through a custom upstream a
     sortOrder: 100,
     config: {
       baseUrl: 'https://images.example.com',
-      bearerToken: 'sk-images',
+      authStyle: 'bearer',
+      apiKey: 'sk-images',
       endpoints: {},
     },
   }));

--- a/packages/gateway/src/data-plane/llm/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/llm/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -170,7 +170,8 @@ beforeEach(async () => {
     proxyFallbackList: [],
     config: {
       baseUrl: 'https://unused.example.com',
-      bearerToken: 'unused',
+      authStyle: 'bearer',
+      apiKey: 'unused',
       endpoints: { imagesGenerations: {}, imagesEdits: {} },
       modelsFetch: { enabled: false, endpoint: '/models' },
       models: [],

--- a/packages/gateway/src/data-plane/llm/shared/candidates_test.ts
+++ b/packages/gateway/src/data-plane/llm/shared/candidates_test.ts
@@ -229,7 +229,7 @@ describe('enumerateProviderCandidates', () => {
       id: 'up_broken',
       name: 'Broken upstream',
       sortOrder: 1,
-      config: { baseUrl: 'https://broken.example.com', bearerToken: 'sk-x', endpoints: { messages: {} } },
+      config: { baseUrl: 'https://broken.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { messages: {} } },
     }));
     await repo.upstreams.save(azureUpstream('up_ok', 2, ['test-model'], { messages: {} }));
 
@@ -269,13 +269,13 @@ describe('enumerateProviderCandidates', () => {
       id: 'up_a',
       name: 'A',
       sortOrder: 1,
-      config: { baseUrl: 'https://a.example.com', bearerToken: 'sk-x', endpoints: { messages: {} } },
+      config: { baseUrl: 'https://a.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { messages: {} } },
     }));
     await repo.upstreams.save(buildCustomUpstreamRecord({
       id: 'up_b',
       name: 'B',
       sortOrder: 2,
-      config: { baseUrl: 'https://b.example.com', bearerToken: 'sk-x', endpoints: { messages: {} } },
+      config: { baseUrl: 'https://b.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { messages: {} } },
     }));
 
     await withMockedFetch(

--- a/packages/gateway/src/data-plane/models/gemini_test.ts
+++ b/packages/gateway/src/data-plane/models/gemini_test.ts
@@ -145,7 +145,8 @@ test('/v1beta/models includes custom upstream LLM models', async () => {
     createdAt: '2026-05-01T00:00:00.000Z',
     config: {
       baseUrl: 'https://custom.example.com',
-      bearerToken: 'sk-custom',
+      authStyle: 'bearer',
+      apiKey: 'sk-custom',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -196,7 +197,8 @@ test('/v1beta/models excludes custom upstream embedding-only models', async () =
     createdAt: '2026-05-01T00:00:00.000Z',
     config: {
       baseUrl: 'https://embed.example.com',
-      bearerToken: 'sk-embed',
+      authStyle: 'bearer',
+      apiKey: 'sk-embed',
       endpoints: {},
     },
   }));
@@ -237,7 +239,8 @@ test('/v1beta/models hides upstream identity when a provider returns an invalid 
     createdAt: '2026-05-01T00:00:00.000Z',
     config: {
       baseUrl: 'https://gemini-secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -280,7 +283,8 @@ test('/v1beta/models hides upstream HTTP error bodies', async () => {
     createdAt: '2026-05-01T00:00:00.000Z',
     config: {
       baseUrl: 'https://gemini-http-secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -326,7 +330,8 @@ test('/v1beta/models hides thrown upstream request errors', async () => {
     createdAt: '2026-05-01T00:00:00.000Z',
     config: {
       baseUrl: 'https://gemini-throw-secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -369,7 +374,8 @@ test('/v1beta/models hides malformed upstream response bodies', async () => {
     createdAt: '2026-05-01T00:00:00.000Z',
     config: {
       baseUrl: 'https://gemini-malformed-secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));

--- a/packages/gateway/src/data-plane/models/serve_test.ts
+++ b/packages/gateway/src/data-plane/models/serve_test.ts
@@ -23,7 +23,8 @@ test('/v1/models returns merged model list from Copilot and custom upstreams', a
     sortOrder: 100,
     config: {
       baseUrl: 'https://oai.example.com',
-      bearerToken: 'sk-test',
+      authStyle: 'bearer',
+      apiKey: 'sk-test',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -188,7 +189,8 @@ test('/models returns the same superset payload as /v1/models', async () => {
     sortOrder: 100,
     config: {
       baseUrl: 'https://images-proj.example.com',
-      bearerToken: 'sk-images-proj',
+      authStyle: 'bearer',
+      apiKey: 'sk-images-proj',
       endpoints: {  },
     },
   }));
@@ -282,7 +284,8 @@ test('/v1/models hides upstream identity when a provider returns an invalid mode
     sortOrder: 100,
     config: {
       baseUrl: 'https://secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -317,7 +320,8 @@ test('public model list endpoints hide upstream HTTP error bodies and headers', 
     sortOrder: 100,
     config: {
       baseUrl: 'https://http-secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -364,7 +368,8 @@ test('public model list endpoints hide thrown upstream request errors', async ()
     sortOrder: 100,
     config: {
       baseUrl: 'https://throw-secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));
@@ -404,7 +409,8 @@ test('public model list endpoints hide malformed upstream response bodies', asyn
     sortOrder: 100,
     config: {
       baseUrl: 'https://malformed-secret.example.com',
-      bearerToken: 'sk-secret',
+      authStyle: 'bearer',
+      apiKey: 'sk-secret',
       endpoints: { chatCompletions: {} },
     },
   }));

--- a/packages/gateway/src/data-plane/providers/custom/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/custom/provider_test.ts
@@ -19,7 +19,8 @@ const baseRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => 
   proxyFallbackList: [],
   config: {
     baseUrl: 'https://custom.example.com',
-    bearerToken: 'sk-test',
+    authStyle: 'bearer',
+    apiKey: 'sk-test',
     endpoints: { chatCompletions: {}, responses: {}, messages: {} },
   },
   state: null,
@@ -97,7 +98,8 @@ test('Custom provider uses configured endpoints regardless of per-model hints in
         id: 'up_custom_endpoints',
         config: {
           baseUrl: 'https://custom.example.com',
-          bearerToken: 'sk-test',
+          authStyle: 'bearer',
+          apiKey: 'sk-test',
           endpoints: { chatCompletions: {} },
         },
       })).provider;
@@ -158,7 +160,7 @@ test('Custom provider falls back to `name` when display_name is missing (loose O
 test('Custom provider projects gpt-image-* models with kind=image and both image endpoints', async () => {
   await setupAppTest();
   const record = buildCustomUpstreamRecord({
-    config: { baseUrl: 'https://custom.example.com', bearerToken: 'sk-custom', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://custom.example.com', authStyle: 'bearer', apiKey: 'sk-custom', endpoints: { chatCompletions: {} } },
   });
   await withMockedFetch(
     request => {
@@ -182,7 +184,7 @@ test('Custom provider projects gpt-image-* models with kind=image and both image
 test('Custom provider callImagesGenerations posts JSON with model re-injected', async () => {
   await setupAppTest();
   const record = buildCustomUpstreamRecord({
-    config: { baseUrl: 'https://custom.example.com', bearerToken: 'sk-custom', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://custom.example.com', authStyle: 'bearer', apiKey: 'sk-custom', endpoints: { chatCompletions: {} } },
   });
   let forwarded: { url: string; body: { model?: unknown; prompt?: unknown } } | undefined;
   await withMockedFetch(
@@ -211,7 +213,7 @@ test('Custom provider callImagesGenerations posts JSON with model re-injected', 
 test('Custom provider callImagesEdits forwards multipart body with model field appended', async () => {
   await setupAppTest();
   const record = buildCustomUpstreamRecord({
-    config: { baseUrl: 'https://custom.example.com', bearerToken: 'sk-custom', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://custom.example.com', authStyle: 'bearer', apiKey: 'sk-custom', endpoints: { chatCompletions: {} } },
   });
   let forwarded: { url: string; form: FormData } | undefined;
   await withMockedFetch(
@@ -251,7 +253,8 @@ test('Custom provider with modelsFetch disabled serves only manual models and ne
         id: 'up_custom_manual_only',
         config: {
           baseUrl: 'https://custom.example.com',
-          bearerToken: 'sk-test',
+          authStyle: 'bearer',
+          apiKey: 'sk-test',
           endpoints: { chatCompletions: {} },
           modelsFetch: { enabled: false },
           models: [
@@ -305,7 +308,8 @@ test('Custom provider with a manual override sharing an upstream id wins over th
         id: 'up_custom_override',
         config: {
           baseUrl: 'https://custom.example.com',
-          bearerToken: 'sk-test',
+          authStyle: 'bearer',
+          apiKey: 'sk-test',
           endpoints: { chatCompletions: {} },
           modelsFetch: { enabled: true },
           models: [

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -205,7 +205,8 @@ test('resolveModelForRequest applies provider-owned aliases only to that provide
     buildCustomUpstreamRecord({
       config: {
         baseUrl: 'https://custom.example.com',
-        bearerToken: 'sk-custom',
+        authStyle: 'bearer',
+        apiKey: 'sk-custom',
         endpoints: { messages: {} },
       },
     }),
@@ -258,13 +259,13 @@ test('resolveModelForProvider only loads the selected provider catalog', async (
     id: 'up_first',
     name: 'First',
     sortOrder: 0,
-    config: { baseUrl: 'https://first.example.com', bearerToken: 'sk-first', endpoints: { responses: {} } },
+    config: { baseUrl: 'https://first.example.com', authStyle: 'bearer', apiKey: 'sk-first', endpoints: { responses: {} } },
   }));
   await repo.upstreams.save(buildCustomUpstreamRecord({
     id: 'up_second',
     name: 'Second',
     sortOrder: 100,
-    config: { baseUrl: 'https://second.example.com', bearerToken: 'sk-second', endpoints: { responses: {} } },
+    config: { baseUrl: 'https://second.example.com', authStyle: 'bearer', apiKey: 'sk-second', endpoints: { responses: {} } },
   }));
 
   const providers = await listModelProviders(null);
@@ -446,7 +447,7 @@ test('getInternalModels fans out per-upstream catalog fetches in parallel', asyn
       id: u.id,
       name: u.id,
       sortOrder: index,
-      config: { baseUrl: `https://${u.host}`, bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+      config: { baseUrl: `https://${u.host}`, authStyle: 'bearer', apiKey: 'sk-x', endpoints: { chatCompletions: {} } },
     }));
   }
 
@@ -489,19 +490,19 @@ test('getInternalModels: a rejected provider does not block other providers', as
     id: 'up_ok_1',
     name: 'OK 1',
     sortOrder: 1,
-    config: { baseUrl: 'https://ok1.example.com', bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://ok1.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { chatCompletions: {} } },
   }));
   await repo.upstreams.save(buildCustomUpstreamRecord({
     id: 'up_broken',
     name: 'Broken',
     sortOrder: 2,
-    config: { baseUrl: 'https://broken.example.com', bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://broken.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { chatCompletions: {} } },
   }));
   await repo.upstreams.save(buildCustomUpstreamRecord({
     id: 'up_ok_2',
     name: 'OK 2',
     sortOrder: 3,
-    config: { baseUrl: 'https://ok2.example.com', bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://ok2.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { chatCompletions: {} } },
   }));
 
   await withMockedFetch(
@@ -538,13 +539,13 @@ test('resolveModelForRequest: healthy upstream still resolves alongside a reject
     id: 'up_broken',
     name: 'Broken upstream',
     sortOrder: 1,
-    config: { baseUrl: 'https://broken.example.com', bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://broken.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { chatCompletions: {} } },
   }));
   await repo.upstreams.save(buildCustomUpstreamRecord({
     id: 'up_ok',
     name: 'Healthy upstream',
     sortOrder: 2,
-    config: { baseUrl: 'https://ok.example.com', bearerToken: 'sk-x', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://ok.example.com', authStyle: 'bearer', apiKey: 'sk-x', endpoints: { chatCompletions: {} } },
   }));
 
   await withMockedFetch(

--- a/packages/gateway/src/data-plane/shared/passthrough-serve_test.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve_test.ts
@@ -29,7 +29,8 @@ const registerEmbeddingsUpstream = async (repo: Awaited<ReturnType<typeof setupA
     sortOrder: 100,
     config: {
       baseUrl: 'https://passthrough.example.com',
-      bearerToken: 'sk-passthrough',
+      authStyle: 'bearer',
+      apiKey: 'sk-passthrough',
       endpoints: {},
     },
   }));

--- a/packages/gateway/src/repo/proxies_test.ts
+++ b/packages/gateway/src/repo/proxies_test.ts
@@ -25,7 +25,7 @@ const upstreamFixture = (id: string, proxyFallbackList: ProxyFallbackEntry[]): U
   sortOrder: 0,
   createdAt: '2026-06-01T00:00:00.000Z',
   updatedAt: '2026-06-01T00:00:00.000Z',
-  config: { baseUrl: 'https://example.test', bearerToken: 'sk', endpoints: { chatCompletions: {} } },
+  config: { baseUrl: 'https://example.test', authStyle: 'bearer', apiKey: 'sk', endpoints: { chatCompletions: {} } },
   state: null,
   flagOverrides: {},
   disabledPublicModelIds: [],

--- a/packages/gateway/src/repo/upstreams_test.ts
+++ b/packages/gateway/src/repo/upstreams_test.ts
@@ -161,7 +161,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     sortOrder: 2,
     createdAt: '2026-05-21T10:00:02.000Z',
     updatedAt: '2026-05-21T10:00:02.000Z',
-    config: { baseUrl: 'https://custom.example/v1', bearerToken: 'sk-custom', endpoints: { chatCompletions: {} } },
+    config: { baseUrl: 'https://custom.example/v1', authStyle: 'bearer', apiKey: 'sk-custom', endpoints: { chatCompletions: {} } },
     flagOverrides: { 'z-fix': true, 'a-fix': true },
     disabledPublicModelIds: [],
   });
@@ -202,7 +202,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     sortOrder: 0,
     createdAt: '2099-01-01T00:00:00.000Z',
     updatedAt: '2026-05-21T10:00:04.000Z',
-    config: { baseUrl: 'https://updated.example/v1', bearerToken: 'sk-updated', endpoints: { responses: {} } },
+    config: { baseUrl: 'https://updated.example/v1', authStyle: 'bearer', apiKey: 'sk-updated', endpoints: { responses: {} } },
     flagOverrides: { 'm-fix': true, 'a-fix': true },
     disabledPublicModelIds: [],
   });
@@ -415,6 +415,48 @@ test('migration 0010 creates unified upstreams and rewrites legacy upstream iden
     ]);
     assertEquals(sqlJsRows<{ key: string }>(db, 'SELECT key FROM config ORDER BY key'), [{ key: 'keep_me' }]);
     assertEquals(sqlJsRows<{ name: string }>(db, "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('github_accounts', 'upstream_configs') ORDER BY name"), []);
+  } finally {
+    db.close();
+  }
+});
+
+test('migration 0042 renames bearerToken to apiKey and backfills authStyle on legacy rows', async () => {
+  const db = await createMigratedSqlJsDatabase();
+  try {
+    for (const filename of [...migrationSqlByFilename.keys()].filter(f => f >= '0010_unified_upstreams.sql' && f < '0042_custom_apikey_rename.sql').toSorted()) {
+      applySqlJsFile(db, filename);
+    }
+
+    // Seed two custom rows mirroring real legacy shapes:
+    //   - up_legacy:     post-0010 row with bearerToken and no authStyle
+    //   - up_anthropic:  later row with bearerToken AND authStyle: 'anthropic'
+    // and a non-custom (azure) row that the migration must leave untouched.
+    db.run(`INSERT INTO upstreams (id, provider, name, enabled, sort_order, created_at, updated_at, config_json, flag_overrides, disabled_public_model_ids, proxy_fallback_list_json)
+            VALUES
+              ('up_legacy', 'custom', 'Legacy', 1, 0, '2026-05-21T00:00:00.000Z', '2026-05-21T00:00:00.000Z', json_object('baseUrl', 'https://a.example/v1', 'bearerToken', 'sk-legacy'), '[]', '[]', '[]'),
+              ('up_anthropic', 'custom', 'Anthropic', 1, 1, '2026-05-21T00:00:00.000Z', '2026-05-21T00:00:00.000Z', json_object('baseUrl', 'https://b.example/v1', 'bearerToken', 'sk-ant', 'authStyle', 'anthropic'), '[]', '[]', '[]'),
+              ('up_azure', 'azure', 'Azure', 1, 2, '2026-05-21T00:00:00.000Z', '2026-05-21T00:00:00.000Z', json_object('endpoint', 'https://az.example', 'apiKey', 'az-key'), '[]', '[]', '[]')`);
+
+    applySqlJsFile(db, '0042_custom_apikey_rename.sql');
+
+    const rows = sqlJsRows<{ id: string; bearerToken: unknown; apiKey: string; authStyle: string }>(
+      db,
+      `SELECT
+        id,
+        json_extract(config_json, '$.bearerToken') AS bearerToken,
+        json_extract(config_json, '$.apiKey') AS apiKey,
+        json_extract(config_json, '$.authStyle') AS authStyle
+       FROM upstreams
+       ORDER BY id`,
+    );
+
+    assertEquals(rows.find(r => r.id === 'up_legacy'), { id: 'up_legacy', bearerToken: null, apiKey: 'sk-legacy', authStyle: 'bearer' });
+    assertEquals(rows.find(r => r.id === 'up_anthropic'), { id: 'up_anthropic', bearerToken: null, apiKey: 'sk-ant', authStyle: 'anthropic' });
+    // Non-custom rows are untouched.
+    const azure = rows.find(r => r.id === 'up_azure');
+    assertEquals(azure?.bearerToken, null);
+    assertEquals(azure?.apiKey, 'az-key');
+    assertEquals(azure?.authStyle, null);
   } finally {
     db.close();
   }

--- a/packages/gateway/src/test-helpers.ts
+++ b/packages/gateway/src/test-helpers.ts
@@ -71,7 +71,8 @@ export const buildCopilotUpstreamRecord = (githubAccount: CopilotAccountFixture,
 export const buildCustomUpstreamRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => {
   const config = {
     baseUrl: 'https://custom.example.com',
-    bearerToken: 'sk-custom',
+    authStyle: 'bearer',
+    apiKey: 'sk-custom',
     endpoints: { chatCompletions: {} },
   };
   const { config: overrideConfig, ...rest } = overrides;

--- a/packages/provider-custom/src/config.ts
+++ b/packages/provider-custom/src/config.ts
@@ -1,9 +1,11 @@
 // Generic custom upstream — any third-party LLM provider that speaks an
 // OpenAI-shaped or Anthropic-shaped HTTP API under a single base URL with a
 // static credential. `authStyle` decides the credential header:
-//   - 'bearer'    -> Authorization: Bearer <token>   (OpenAI, OpenRouter, ...)
-//   - 'anthropic' -> x-api-key: <token> + anthropic-version: 2023-06-01
+//   - 'bearer'    -> Authorization: Bearer <key>     (OpenAI, OpenRouter, ...)
+//   - 'anthropic' -> x-api-key: <key> + anthropic-version: 2023-06-01
 //                                                    (api.anthropic.com)
+//   - 'none'      -> no auth header (local or internal upstreams that
+//                                                    accept anonymous requests)
 //
 // The base URL is stored without an API prefix (admin enters e.g.
 // https://api.openai.com); we join it to a per-endpoint path. Default paths
@@ -22,7 +24,7 @@ import type { ModelEndpoints } from '@floway-dev/protocols/common';
 import type { UpstreamModelConfig, UpstreamRecord } from '@floway-dev/provider';
 import { endpointsField, modelsField, validateUpstreamPath } from '@floway-dev/provider';
 
-export type CustomAuthStyle = 'bearer' | 'anthropic';
+export type CustomAuthStyle = 'bearer' | 'anthropic' | 'none';
 
 // Logical endpoints the admin may override. Sub-paths (messages_count_tokens,
 // responses_compact) and the catalog (models — owned by modelsFetch.endpoint)
@@ -37,29 +39,31 @@ export interface CustomModelsFetch {
   endpoint?: string;
 }
 
-export interface CustomUpstreamConfig {
+// Fields shared by every auth style. The discriminated branches below add
+// `apiKey` only on the styles that actually send one, so consumers cannot
+// reach for `config.apiKey` on a 'none' upstream.
+interface CustomUpstreamConfigBase {
   baseUrl: string;
-  bearerToken: string;
-  authStyle: CustomAuthStyle;
   endpoints: ModelEndpoints;
   pathOverrides?: Partial<Record<CustomPathOverrideKey, string>>;
   modelsFetch: CustomModelsFetch;
   models: UpstreamModelConfig[];
 }
 
+export type CustomUpstreamConfig =
+  | (CustomUpstreamConfigBase & { authStyle: 'none' })
+  | (CustomUpstreamConfigBase & { authStyle: 'bearer' | 'anthropic'; apiKey: string });
+
 export type CustomUpstreamRecord = UpstreamRecord & {
   provider: 'custom';
   config: CustomUpstreamConfig;
 };
 
-const AUTH_STYLES: ReadonlySet<CustomAuthStyle> = new Set<CustomAuthStyle>(['bearer', 'anthropic']);
+const AUTH_STYLES: ReadonlySet<CustomAuthStyle> = new Set<CustomAuthStyle>(['bearer', 'anthropic', 'none']);
 
 const authStyleField = (value: unknown): CustomAuthStyle => {
-  // Records written before authStyle existed default to bearer, matching the
-  // previous fixed behavior.
-  if (value === undefined) return 'bearer';
   if (typeof value !== 'string' || !AUTH_STYLES.has(value as CustomAuthStyle)) {
-    throw new Error('Malformed custom upstream config: authStyle must be "bearer" or "anthropic"');
+    throw new Error('Malformed custom upstream config: authStyle must be "bearer", "anthropic", or "none"');
   }
   return value as CustomAuthStyle;
 };
@@ -86,11 +90,11 @@ const baseUrlField = (value: unknown): string => {
 
 const PATH_OVERRIDE_KEYS = new Set<CustomPathOverrideKey>(['chat_completions', 'responses', 'messages', 'embeddings', 'images_generations', 'images_edits']);
 
-const pathOverridesField = (value: unknown): CustomUpstreamConfig['pathOverrides'] => {
+const pathOverridesField = (value: unknown): CustomUpstreamConfigBase['pathOverrides'] => {
   if (value === undefined) return undefined;
   if (!isRecord(value)) throw new Error('Malformed custom upstream config: pathOverrides must be an object');
 
-  const pathOverrides: NonNullable<CustomUpstreamConfig['pathOverrides']> = {};
+  const pathOverrides: NonNullable<CustomUpstreamConfigBase['pathOverrides']> = {};
   for (const [key, path] of Object.entries(value)) {
     if (!PATH_OVERRIDE_KEYS.has(key as CustomPathOverrideKey)) {
       throw new Error(`Malformed custom upstream config: unsupported pathOverrides key ${key}`);
@@ -124,17 +128,27 @@ export const assertCustomUpstreamRecord = (record: UpstreamRecord): CustomUpstre
   if (record.provider !== 'custom') throw new Error(`Expected custom upstream record, got ${record.provider}`);
   if (!isRecord(record.config)) throw new Error('Malformed custom upstream config: config must be an object');
 
-  return {
-    ...record,
-    provider: 'custom',
-    config: {
-      baseUrl: baseUrlField(record.config.baseUrl),
-      bearerToken: nonEmptyStringField(record.config.bearerToken, 'bearerToken'),
-      authStyle: authStyleField(record.config.authStyle),
-      endpoints: endpointsField(record.config.endpoints, 'custom upstream config: endpoints', { allowEmpty: true }),
-      ...(record.config.pathOverrides !== undefined ? { pathOverrides: pathOverridesField(record.config.pathOverrides) } : {}),
-      modelsFetch: modelsFetchField(record.config.modelsFetch),
-      models: modelsField(record.config.models ?? [], 'custom'),
-    },
+  const raw = record.config;
+  const authStyle = authStyleField(raw.authStyle);
+  const base = {
+    baseUrl: baseUrlField(raw.baseUrl),
+    endpoints: endpointsField(raw.endpoints, 'custom upstream config: endpoints', { allowEmpty: true }),
+    ...(raw.pathOverrides !== undefined ? { pathOverrides: pathOverridesField(raw.pathOverrides) } : {}),
+    modelsFetch: modelsFetchField(raw.modelsFetch),
+    models: modelsField(raw.models ?? [], 'custom'),
   };
+
+  if (authStyle === 'none') {
+    // Reject dead fields: a stored 'none' row must not carry a stale apiKey
+    // from an earlier auth style. mergeConfigPatch enforces this on PATCH
+    // and the migration leaves no such rows, so any presence here signals
+    // bad input.
+    if (raw.apiKey !== undefined) {
+      throw new Error('Malformed custom upstream config: apiKey must not be present when authStyle is "none"');
+    }
+    return { ...record, provider: 'custom', config: { ...base, authStyle } };
+  }
+
+  const apiKey = nonEmptyStringField(raw.apiKey, 'apiKey');
+  return { ...record, provider: 'custom', config: { ...base, authStyle, apiKey } };
 };

--- a/packages/provider-custom/src/config_test.ts
+++ b/packages/provider-custom/src/config_test.ts
@@ -14,7 +14,8 @@ const baseRecord: UpstreamRecord = {
   updatedAt: '2026-04-29T00:00:00.000Z',
   config: {
     baseUrl: 'https://custom.example.com',
-    bearerToken: 'sk-test',
+    authStyle: 'bearer',
+    apiKey: 'sk-test',
     endpoints: { chatCompletions: {} },
   },
   state: null,
@@ -104,10 +105,57 @@ test('assertCustomUpstreamRecord rejects malformed opaque config instead of drop
         ...baseRecord,
         config: {
           ...(baseRecord.config as Record<string, unknown>),
-          authStyle: 'apiKey',
+          authStyle: 'oauth',
         },
       }),
     Error,
-    'authStyle must be "bearer" or "anthropic"',
+    'authStyle must be "bearer", "anthropic", or "none"',
+  );
+});
+
+test('assertCustomUpstreamRecord accepts authStyle "none" with no apiKey', () => {
+  const { config } = assertCustomUpstreamRecord({
+    ...baseRecord,
+    config: {
+      baseUrl: 'https://internal.example.com',
+      authStyle: 'none',
+      endpoints: { chatCompletions: {} },
+    },
+  });
+  assertEquals(config.authStyle, 'none');
+  // The discriminated union narrows: apiKey is statically absent on the
+  // 'none' branch, so reading it requires the cast.
+  assertEquals((config as unknown as Record<string, unknown>).apiKey, undefined);
+});
+
+test('assertCustomUpstreamRecord rejects authStyle "none" with a stale apiKey', () => {
+  assertThrows(
+    () =>
+      assertCustomUpstreamRecord({
+        ...baseRecord,
+        config: {
+          ...(baseRecord.config as Record<string, unknown>),
+          authStyle: 'none',
+          apiKey: 'sk-leftover',
+        },
+      }),
+    Error,
+    'apiKey must not be present when authStyle is "none"',
+  );
+});
+
+test('assertCustomUpstreamRecord rejects authStyle "bearer" with no apiKey', () => {
+  assertThrows(
+    () =>
+      assertCustomUpstreamRecord({
+        ...baseRecord,
+        config: {
+          baseUrl: 'https://custom.example.com',
+          authStyle: 'bearer',
+          endpoints: { chatCompletions: {} },
+        },
+      }),
+    Error,
+    'apiKey must be a non-empty string',
   );
 });

--- a/packages/provider-custom/src/fetch-models_test.ts
+++ b/packages/provider-custom/src/fetch-models_test.ts
@@ -17,7 +17,8 @@ const upstreamRecord = () => ({
   proxyFallbackList: [],
   config: {
     baseUrl: 'https://custom.example.com',
-    bearerToken: 'token',
+    authStyle: 'bearer',
+    apiKey: 'token',
     endpoints: { chatCompletions: {} },
   },
   state: null,

--- a/packages/provider-custom/src/fetch.ts
+++ b/packages/provider-custom/src/fetch.ts
@@ -26,11 +26,14 @@ const customFetchInternal = async (
 ): Promise<Response> => {
   const headers = new Headers(init.headers);
   if (config.authStyle === 'anthropic') {
-    headers.set('x-api-key', config.bearerToken);
+    headers.set('x-api-key', config.apiKey);
     if (!headers.has('anthropic-version')) headers.set('anthropic-version', ANTHROPIC_VERSION);
-  } else {
-    headers.set('Authorization', `Bearer ${config.bearerToken}`);
+  } else if (config.authStyle === 'bearer') {
+    headers.set('Authorization', `Bearer ${config.apiKey}`);
   }
+  // authStyle === 'none' falls through with no auth header. The same goes
+  // for the /models fetch — Models Fetch shares this code path, so a 'none'
+  // upstream is queried anonymously end-to-end.
   if (init.body && !headers.has('Content-Type') && !(init.body instanceof FormData)) {
     headers.set('Content-Type', 'application/json');
   }

--- a/packages/provider-custom/src/fetch_test.ts
+++ b/packages/provider-custom/src/fetch_test.ts
@@ -24,7 +24,8 @@ const baseRecord: UpstreamRecord = {
   updatedAt: '2026-04-29T00:00:00.000Z',
   config: {
     baseUrl: 'https://custom.example.com',
-    bearerToken: 'sk-test',
+    authStyle: 'bearer',
+    apiKey: 'sk-test',
     endpoints: { chatCompletions: {} },
   },
   state: null,
@@ -214,4 +215,33 @@ test('authStyle "anthropic" preserves a caller-supplied anthropic-version', asyn
   );
 
   assertEquals(anthropicVersion, '2024-01-01');
+});
+
+test('authStyle "none" sends neither Authorization nor x-api-key', async () => {
+  const { config } = assertCustomUpstreamRecord({
+    ...baseRecord,
+    config: {
+      baseUrl: 'https://internal.example.com',
+      authStyle: 'none',
+      endpoints: { chatCompletions: {} },
+    },
+  });
+  let authHeader: string | null = null;
+  let xApiKey: string | null = null;
+  let anthropicVersion: string | null = null;
+  await withMockedFetch(
+    request => {
+      authHeader = request.headers.get('authorization');
+      xApiKey = request.headers.get('x-api-key');
+      anthropicVersion = request.headers.get('anthropic-version');
+      return new Response('{}', { status: 200 });
+    },
+    async () => {
+      await customFetchChatCompletions(config, { method: 'POST', body: '{}' }, { fetcher: directFetcher });
+    },
+  );
+
+  assertEquals(authHeader, null);
+  assertEquals(xApiKey, null);
+  assertEquals(anthropicVersion, null);
 });

--- a/packages/provider-custom/src/provider_test.ts
+++ b/packages/provider-custom/src/provider_test.ts
@@ -25,7 +25,8 @@ const buildCustomUpstream = (options: BuildOptions = {}): UpstreamRecord => ({
   proxyFallbackList: [],
   config: {
     baseUrl: 'https://custom.example.com',
-    bearerToken: 'sk-test',
+    authStyle: 'bearer',
+    apiKey: 'sk-test',
     endpoints: { chatCompletions: {} },
     modelsFetch: { enabled: options.modelsFetchEnabled ?? true },
     models: options.models ?? [],

--- a/packages/ui/src/Select.vue
+++ b/packages/ui/src/Select.vue
@@ -1,23 +1,26 @@
-<script setup lang="ts" generic="T extends string | number">
+<script setup lang="ts" generic="T extends string | number, O extends { value: T; label: string; disabled?: boolean } = { value: T; label: string; disabled?: boolean }">
 import { SelectContent, SelectIcon, SelectItem, SelectItemIndicator, SelectItemText, SelectPortal, SelectRoot, SelectTrigger, SelectValue, SelectViewport } from 'reka-ui';
 import { computed } from 'vue';
 
 import { cn } from './utils/cn.ts';
 
-interface Option {
-  value: T;
-  label: string;
-  disabled?: boolean;
-}
-
 const value = defineModel<T>();
 
 const props = withDefaults(defineProps<{
-  options: Option[];
+  options: O[];
   placeholder?: string;
   disabled?: boolean;
   size?: 'sm' | 'md';
 }>(), { size: 'md' });
+
+// Per-option scoped slot for a second-line description under the label.
+// Consumers attach arbitrary metadata to their option objects and the slot
+// receives the full option so it can render whatever shape it needs (an
+// explanation, a code snippet, badges, ...). Slot absence keeps the
+// previous single-line behavior.
+defineSlots<{
+  description?: (props: { option: O }) => unknown;
+}>();
 
 const triggerClass = computed(() => cn(
   'inline-flex w-full items-center justify-between rounded-[10px] border border-white/[0.14] bg-surface-700 text-white',
@@ -57,14 +60,17 @@ const onUpdate = (raw: string | number | undefined) => {
             :key="String(opt.value)"
             :value="opt.value"
             :disabled="opt.disabled"
-            class="relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-7 pr-2 text-sm text-white outline-none data-[highlighted]:bg-accent-cyan/10 data-[highlighted]:text-accent-cyan data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed"
+            class="relative flex w-full cursor-pointer select-none flex-col items-stretch rounded-sm py-1.5 pl-7 pr-2 text-sm text-white outline-none data-[highlighted]:bg-accent-cyan/10 data-[highlighted]:text-accent-cyan data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed"
           >
-            <span class="absolute left-2 flex size-3.5 items-center justify-center">
+            <span class="absolute left-2 top-2 flex size-3.5 items-center justify-center">
               <SelectItemIndicator>
                 <i class="i-lucide-check size-3.5 text-accent-cyan" />
               </SelectItemIndicator>
             </span>
             <SelectItemText>{{ opt.label }}</SelectItemText>
+            <div v-if="$slots.description" class="mt-0.5">
+              <slot name="description" :option="opt" />
+            </div>
           </SelectItem>
         </SelectViewport>
       </SelectContent>


### PR DESCRIPTION
Add a third `none` auth style to the `custom` provider — for upstreams that accept anonymous requests (local Ollama, internal proxies, mock servers) — and replace the cramped horizontal radio grid in the dashboard editor with a dropdown that carries a per-option description. The same change renames the stored credential field from `bearerToken` to `apiKey`: the old name had been misleading since `authStyle: 'anthropic'` was introduced (the value is sent as `x-api-key`, not as a bearer token), and a third style would have made the misnomer worse.

## Auth modes

`CustomAuthStyle` becomes `'bearer' | 'anthropic' | 'none'`, and the config type is a discriminated union — only the `bearer` and `anthropic` branches carry an `apiKey` field, so consumers cannot reach for `config.apiKey` on a `'none'` upstream. At fetch time the new branch sends no `Authorization` and no `x-api-key`, including for the live `/models` fetch (Models Fetch shares the same code path).

The runtime parser is strict on the invariant: a stored row with `authStyle: 'none'` carrying a residual `apiKey`, or with `authStyle: 'bearer' | 'anthropic'` and no `apiKey`, is rejected with a specific error. The invariant is enforced by the parser, not by defensive checks scattered across read sites.

## Migration

`0042_custom_apikey_rename.sql` is one file with two updates. The first uses `json_patch + json_remove + json_object` to rename `$.bearerToken` → `$.apiKey` on every custom row. The `WHERE` clause uses `json_type(config_json, '$.bearerToken') IS NOT NULL` rather than `json_extract(...) IS NOT NULL` so the rename also covers rows whose stored value happens to be JSON null (the path exists but the value is null) — the strict parser would otherwise reject those after rename. The second update backfills `authStyle: 'bearer'` on legacy rows that predate the field, which lets the runtime parser drop its absent-`authStyle` default and become strict.

Post-migration invariants on every `provider = 'custom'` row: `bearerToken` is gone, `authStyle` is one of the three enum values, and `apiKey` exists iff `authStyle !== 'none'`.

## Control plane

`customConfigSchema` (Zod) stays flat: `authStyle: z.enum([...])` is now required, and `apiKey: z.string().optional()` keeps the edit-mode "leave blank to keep stored secret" path working. The discriminated invariant is enforced one layer in, in `assertCustomUpstreamRecord`, where the canonical error messages already live.

`mergeConfigPatch` gains a single rule for the custom provider: when the merged `authStyle` is `'none'`, drop `apiKey` from the next-state before validation runs. The reverse direction (`none` → `bearer`/`anthropic`) is left to the parser, which rejects a missing `apiKey` on the two branches that require one.

The serialized response renames `bearerTokenSet` → `apiKeySet`; no other wire-shape change.

## Dashboard UI

The two-column horizontal radio grid in `CustomConfigPanel.vue` is replaced with the shared `Select`. Each option carries a one-line explanation and an optional `headerExample`; the new `#description` scoped slot renders both inside the dropdown panel (the trigger stays compact, label-only). The `none` option carries no `headerExample`, so the slot's `v-if` leaves just the one-line explanation rather than inventing a fake header string.

The API Key input hides entirely when `authStyle === 'none'`; switching away from `'none'` makes it reappear empty. No disabled-but-visible state, no remember-previous-value across switches. The input label collapses to "API Key" across the two modes that send one — the dropdown's per-option description already tells the user the precise header the value lands in, so a per-style label variant adds noise without information.

## UI library

`@floway-dev/ui`'s `Select` becomes generic over the option type via a second type parameter constrained to the existing `{ value; label; disabled? }` shape, with that shape as the default so existing call sites stay typed unchanged. The new `#description` scoped slot is typed against the consumer's full option type, so the slot inside the custom panel reads `option.explanation` / `option.headerExample` with real types rather than `unknown`. When no `#description` slot is provided, the component renders identically to before.

## Verification

`pnpm run typecheck` clean across all 19 projects; `pnpm run lint` clean; `pnpm run test` passes (290 files / 3220 tests, up one for the new migration `0042` test against three seeded rows — a legacy `bearerToken` row, an `authStyle: 'anthropic'` row, and a non-custom row that must remain untouched); `pnpm run build:web` succeeds.

Manual smoke on `dev:node` + Vite SPA against the live HTTP path: created custom upstreams in each of the three modes and confirmed the payloads round-trip with the right redaction (`apiKeySet: false` for `none`, `apiKeySet: true` for the other two); PATCH from `anthropic` → `none` stripped `apiKey`; the reverse without supplying `apiKey` returned `400 Malformed custom upstream config: apiKey must be a non-empty string`; the reverse with a fresh key succeeded.