### PR TITLE
feat(usage): normalize variant cache-token field names across upstreams

### DIFF
--- a/packages/gateway/src/data-plane/completions/usage.ts
+++ b/packages/gateway/src/data-plane/completions/usage.ts
@@ -1,13 +1,14 @@
 import type { TokenUsage } from '../../repo/types.ts';
-import { billableServiceTier, tokenUsage } from '../shared/telemetry/usage.ts';
+import { billableServiceTier, openAICacheTokensFromUsage, tokenUsage } from '../shared/telemetry/usage.ts';
 
 // `/v1/completions` shares OpenAI's CompletionUsage schema with
-// `/v1/chat/completions` — the same prompt-cache split lives under
-// `prompt_tokens_details` when the upstream reports it (vLLM, llama.cpp,
-// Fireworks, OpenRouter, xAI Grok all populate it; OpenAI's own text
-// models leave it absent). The bare `input` dimension subtracts cache_read
-// so the two input dimensions stay disjoint, matching what
-// tokenUsageFromChatCompletionsUsage does for chat.
+// `/v1/chat/completions`. Both routes hand off to the shared
+// `openAICacheTokensFromUsage` helper for the cache-read / cache-write
+// counts so the variant field names wild OpenAI-compatible upstreams
+// emit (DeepSeek's `prompt_cache_hit_tokens`, Moonshot's flat
+// `cached_tokens`, OpenRouter's `cache_write_tokens`, …) land in the
+// correct dimensions automatically. The bare `input` dimension subtracts
+// both cache counts so the three input dimensions stay disjoint.
 //
 // `service_tier` lives on the response root, not inside `usage`, and is
 // supplied separately by the caller. vLLM surfaces it on the
@@ -16,16 +17,16 @@ import { billableServiceTier, tokenUsage } from '../shared/telemetry/usage.ts';
 
 export const tokenUsageFromCompletionsUsage = (usage: unknown, serviceTier: string | null | undefined): TokenUsage | null => {
   if (!usage || typeof usage !== 'object') return null;
-  const { prompt_tokens: promptTokens, completion_tokens: completionTokens, prompt_tokens_details: details } = usage as {
+  const { prompt_tokens: promptTokens, completion_tokens: completionTokens } = usage as {
     prompt_tokens?: unknown;
     completion_tokens?: unknown;
-    prompt_tokens_details?: { cached_tokens?: unknown };
   };
   if (typeof promptTokens !== 'number' || typeof completionTokens !== 'number') return null;
-  const cacheRead = typeof details?.cached_tokens === 'number' ? details.cached_tokens : 0;
+  const { cacheRead, cacheWrite } = openAICacheTokensFromUsage(usage);
   return tokenUsage({
-    input: promptTokens - cacheRead,
+    input: promptTokens - cacheRead - cacheWrite,
     input_cache_read: cacheRead,
+    input_cache_write: cacheWrite,
     output: completionTokens,
     tier: billableServiceTier(serviceTier),
   });

--- a/packages/gateway/src/data-plane/completions/usage_test.ts
+++ b/packages/gateway/src/data-plane/completions/usage_test.ts
@@ -23,6 +23,29 @@ test('tokenUsageFromCompletionsUsage splits prompt_tokens into cache_read + bare
   );
 });
 
+test('tokenUsageFromCompletionsUsage reads DeepSeek prompt_cache_hit_tokens', () => {
+  // DeepSeek exposes a non-OpenAI shape on /v1/chat/completions (it has no
+  // /v1/completions of its own, but the helper symmetry matters): hit + miss
+  // counters at the usage root, with `prompt_tokens` equal to `hit + miss`.
+  assertEquals(
+    tokenUsageFromCompletionsUsage(
+      { prompt_tokens: 200, completion_tokens: 5, total_tokens: 205, prompt_cache_hit_tokens: 128, prompt_cache_miss_tokens: 72 },
+      undefined,
+    ),
+    { input: 72, input_cache_read: 128, output: 5 },
+  );
+});
+
+test('tokenUsageFromCompletionsUsage reads the flat top-level cached_tokens (Moonshot / Cohere v2 / Qwen Singapore legacy)', () => {
+  assertEquals(
+    tokenUsageFromCompletionsUsage(
+      { prompt_tokens: 50, completion_tokens: 3, total_tokens: 53, cached_tokens: 32 },
+      undefined,
+    ),
+    { input: 18, input_cache_read: 32, output: 3 },
+  );
+});
+
 test('tokenUsageFromCompletionsUsage runs serviceTier through billableServiceTier', () => {
   // Non-base values pass through; default / standard fold to null so they
   // aggregate with rows that have no tier; null/undefined stays null.

--- a/packages/gateway/src/data-plane/llm/chat-completions/usage.ts
+++ b/packages/gateway/src/data-plane/llm/chat-completions/usage.ts
@@ -1,14 +1,17 @@
-import { billableServiceTier, tokenUsage } from '../../shared/telemetry/usage.ts';
+import { billableServiceTier, openAICacheTokensFromUsage, tokenUsage } from '../../shared/telemetry/usage.ts';
 import type { ChatCompletionsResult } from '@floway-dev/protocols/chat-completions';
 
-// OpenAI Chat usage reports prompt_tokens inclusive of cached and
-// cache-creation tokens; subtract them to recover the disjoint bare input.
-// The top-level `service_tier` echoes the actual processing tier; surface it
-// via `billableServiceTier` so per-tier pricing overrides resolve at
-// recording time. https://developers.openai.com/api/docs/guides/priority-processing
+// OpenAI Chat usage reports prompt_tokens inclusive of cached and cache-
+// creation tokens; the shared `openAICacheTokensFromUsage` helper resolves
+// the variant cache field names (OpenAI canonical, DeepSeek hit/miss split,
+// Moonshot flat, OpenRouter cache_write_tokens) onto a single (read, write)
+// pair, which we subtract from prompt_tokens to recover the disjoint bare
+// input. The top-level `service_tier` echoes the actual processing tier;
+// surface it via `billableServiceTier` so per-tier pricing overrides resolve
+// at recording time.
+// https://developers.openai.com/api/docs/guides/priority-processing
 export const tokenUsageFromChatCompletionsUsage = (u: NonNullable<ChatCompletionsResult['usage']>, serviceTier: string | null | undefined) => {
-  const cacheRead = u.prompt_tokens_details?.cached_tokens ?? 0;
-  const cacheWrite = u.prompt_tokens_details?.cache_creation_input_tokens ?? 0;
+  const { cacheRead, cacheWrite } = openAICacheTokensFromUsage(u);
   return tokenUsage({
     input: u.prompt_tokens - cacheRead - cacheWrite,
     input_cache_read: cacheRead,

--- a/packages/gateway/src/data-plane/llm/chat-completions/usage_test.ts
+++ b/packages/gateway/src/data-plane/llm/chat-completions/usage_test.ts
@@ -17,6 +17,56 @@ test('Chat usage maps disjoint input/cache/output counts and omits tier when ser
   );
 });
 
+test('Chat usage reads DeepSeek prompt_cache_hit_tokens at the usage root', () => {
+  // DeepSeek puts the hit count at the usage root (paired with miss) instead
+  // of under prompt_tokens_details. The shared helper sniffs the variant and
+  // lands it in cache_read, leaving miss on bare input.
+  assertEquals(
+    tokenUsageFromChatCompletionsUsage(
+      // The non-standard hit/miss fields aren't on ChatCompletionsUsage; we
+      // cast through to mirror what an actual DeepSeek response would carry.
+      { prompt_tokens: 200, completion_tokens: 5, total_tokens: 205, prompt_cache_hit_tokens: 128, prompt_cache_miss_tokens: 72 } as never,
+      null,
+    ),
+    {
+      input: 72,
+      input_cache_read: 128,
+      output: 5,
+    },
+  );
+});
+
+test('Chat usage reads the flat top-level cached_tokens (Moonshot / Cohere v2 / Qwen Singapore legacy)', () => {
+  assertEquals(
+    tokenUsageFromChatCompletionsUsage(
+      { prompt_tokens: 50, completion_tokens: 3, total_tokens: 53, cached_tokens: 32 } as never,
+      null,
+    ),
+    {
+      input: 18,
+      input_cache_read: 32,
+      output: 3,
+    },
+  );
+});
+
+test('Chat usage reads OpenRouter cache_write_tokens as the write counter', () => {
+  // OpenRouter emits cache_write_tokens alongside cached_tokens under the
+  // standard wrapper when it routes to Anthropic / explicit-Gemini / Alibaba.
+  assertEquals(
+    tokenUsageFromChatCompletionsUsage(
+      { prompt_tokens: 100, completion_tokens: 4, total_tokens: 104, prompt_tokens_details: { cached_tokens: 30, cache_write_tokens: 50 } } as never,
+      null,
+    ),
+    {
+      input: 20,
+      input_cache_read: 30,
+      input_cache_write: 50,
+      output: 4,
+    },
+  );
+});
+
 test('Chat usage drops service_tier=default to no-tier', () => {
   assertEquals(
     tokenUsageFromChatCompletionsUsage(

--- a/packages/gateway/src/data-plane/shared/telemetry/usage.ts
+++ b/packages/gateway/src/data-plane/shared/telemetry/usage.ts
@@ -36,6 +36,63 @@ export const tokenUsage = (counts: TokenUsage): TokenUsage => {
   return out;
 };
 
+// Cache-read / cache-write token counts pulled from an OpenAI-shaped `usage`
+// block. The field name and nesting depth vary by upstream; this helper
+// hides the variants so the per-API extractors (chat-completions, completions)
+// see a single normalized pair regardless of which provider answered.
+//
+// Cache-read candidates, in order of preference:
+//   - `prompt_tokens_details.cached_tokens` — OpenAI canonical (vLLM, llama.cpp,
+//     SGLang, Gemini OpenAI-compat, xAI, Mistral, OpenRouter, Groq, Cerebras,
+//     Zhipu, Doubao, Qwen main, …).
+//   - `prompt_cache_hit_tokens`             — DeepSeek (paired with
+//     `prompt_cache_miss_tokens`; `prompt_tokens` is `hit + miss`).
+//   - `cached_tokens`                       — Moonshot / Kimi, Cohere v2 native,
+//     Qwen Singapore legacy (top-level, no wrapper).
+//
+// Cache-write candidates, in order of preference:
+//   - `prompt_tokens_details.cache_creation_input_tokens` — the Anthropic
+//     messages → chat-completions translation pair forwards the native
+//     Anthropic field name under OpenAI's wrapper.
+//   - `prompt_tokens_details.cache_write_tokens`           — OpenRouter
+//     (Anthropic / Gemini-explicit / Alibaba-routed).
+//
+// Each count is a subset of `prompt_tokens`, so subtracting them in the
+// caller recovers the disjoint bare-input dimension. Upstreams that report
+// no cache fields at all (Together, Perplexity, SiliconFlow, TGI, Ollama-
+// compat, plus most providers without a cache layer) fall through to zero,
+// leaving the whole prompt count on the bare input bucket.
+export interface OpenAICacheTokens {
+  readonly cacheRead: number;
+  readonly cacheWrite: number;
+}
+
+interface OpenAIUsageWithCacheVariants {
+  prompt_tokens_details?: {
+    cached_tokens?: unknown;
+    cache_creation_input_tokens?: unknown;
+    cache_write_tokens?: unknown;
+  };
+  prompt_cache_hit_tokens?: unknown;
+  cached_tokens?: unknown;
+}
+
+export const openAICacheTokensFromUsage = (usage: unknown): OpenAICacheTokens => {
+  if (!usage || typeof usage !== 'object') return { cacheRead: 0, cacheWrite: 0 };
+  const u = usage as OpenAIUsageWithCacheVariants;
+  return {
+    cacheRead: firstNumber([u.prompt_tokens_details?.cached_tokens, u.prompt_cache_hit_tokens, u.cached_tokens]),
+    cacheWrite: firstNumber([u.prompt_tokens_details?.cache_creation_input_tokens, u.prompt_tokens_details?.cache_write_tokens]),
+  };
+};
+
+const firstNumber = (candidates: readonly unknown[]): number => {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'number') return candidate;
+  }
+  return 0;
+};
+
 export const tokenUsageFromEmbeddingsBody = (body: unknown): TokenUsage | null => {
   if (!body || typeof body !== 'object') return null;
   const { usage } = body as { usage?: unknown };

--- a/packages/gateway/src/data-plane/shared/telemetry/usage_test.ts
+++ b/packages/gateway/src/data-plane/shared/telemetry/usage_test.ts
@@ -1,0 +1,79 @@
+import { test } from 'vitest';
+
+import { openAICacheTokensFromUsage } from './usage.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+test('OpenAI canonical shape — prompt_tokens_details.cached_tokens lands in cacheRead', () => {
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 100, completion_tokens: 7, prompt_tokens_details: { cached_tokens: 80 } }),
+    { cacheRead: 80, cacheWrite: 0 },
+  );
+});
+
+test('DeepSeek shape — prompt_cache_hit_tokens at usage root lands in cacheRead', () => {
+  // DeepSeek emits `prompt_cache_hit_tokens` + `prompt_cache_miss_tokens` at
+  // the usage root; prompt_tokens is hit + miss.
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 200, completion_tokens: 5, prompt_cache_hit_tokens: 128, prompt_cache_miss_tokens: 72 }),
+    { cacheRead: 128, cacheWrite: 0 },
+  );
+});
+
+test('Flat shape — top-level cached_tokens (Moonshot / Cohere v2 / Qwen Singapore legacy)', () => {
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 50, completion_tokens: 3, cached_tokens: 32 }),
+    { cacheRead: 32, cacheWrite: 0 },
+  );
+});
+
+test('OpenAI canonical wins when both nested and flat are present (the wrapped form is authoritative)', () => {
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 100, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 64 }, cached_tokens: 999 }),
+    { cacheRead: 64, cacheWrite: 0 },
+  );
+});
+
+test('Cache-write — Anthropic-style cache_creation_input_tokens under the wrapper', () => {
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 100, completion_tokens: 4, prompt_tokens_details: { cached_tokens: 30, cache_creation_input_tokens: 50 } }),
+    { cacheRead: 30, cacheWrite: 50 },
+  );
+});
+
+test('Cache-write — OpenRouter cache_write_tokens under the wrapper', () => {
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 100, completion_tokens: 4, prompt_tokens_details: { cached_tokens: 30, cache_write_tokens: 50 } }),
+    { cacheRead: 30, cacheWrite: 50 },
+  );
+});
+
+test('cache_creation_input_tokens wins over cache_write_tokens when both are present (Anthropic-native name is authoritative)', () => {
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 100, completion_tokens: 4, prompt_tokens_details: { cache_creation_input_tokens: 20, cache_write_tokens: 50 } }),
+    { cacheRead: 0, cacheWrite: 20 },
+  );
+});
+
+test('Zero on missing / malformed / fields-absent usage blocks', () => {
+  assertEquals(openAICacheTokensFromUsage(null), { cacheRead: 0, cacheWrite: 0 });
+  assertEquals(openAICacheTokensFromUsage(undefined), { cacheRead: 0, cacheWrite: 0 });
+  assertEquals(openAICacheTokensFromUsage('not an object'), { cacheRead: 0, cacheWrite: 0 });
+  assertEquals(openAICacheTokensFromUsage({}), { cacheRead: 0, cacheWrite: 0 });
+  assertEquals(openAICacheTokensFromUsage({ prompt_tokens: 10, completion_tokens: 2 }), { cacheRead: 0, cacheWrite: 0 });
+  // Gemini OpenAI-compat emits `prompt_tokens_details: null` on cache miss
+  // (not an empty object); the optional chain has to absorb that.
+  assertEquals(openAICacheTokensFromUsage({ prompt_tokens: 10, completion_tokens: 2, prompt_tokens_details: null }), { cacheRead: 0, cacheWrite: 0 });
+  // Non-numeric noise falls through.
+  assertEquals(openAICacheTokensFromUsage({ prompt_tokens_details: { cached_tokens: 'no' } }), { cacheRead: 0, cacheWrite: 0 });
+  assertEquals(openAICacheTokensFromUsage({ prompt_cache_hit_tokens: null }), { cacheRead: 0, cacheWrite: 0 });
+});
+
+test('Zero is a valid count, not a missing signal', () => {
+  // vLLM with --enable-prompt-tokens-details emits cached_tokens: 0 on a cold
+  // request after PR #44383; an honest zero must not fall through to the
+  // next candidate.
+  assertEquals(
+    openAICacheTokensFromUsage({ prompt_tokens: 10, completion_tokens: 2, prompt_tokens_details: { cached_tokens: 0 }, cached_tokens: 999 }),
+    { cacheRead: 0, cacheWrite: 0 },
+  );
+});


### PR DESCRIPTION
## Summary

The OpenAI-shape `usage.prompt_tokens_details.cached_tokens` convention is dominant but not universal among the "wild" OpenAI-compatible upstreams Floway routes to. Several providers emit cache-hit counts under different field names, and our extractors silently miscounted those rows as zero cache activity (the entire prompt landed on the bare `input` dimension).

A short cross-provider survey:

| Cache-read shape | Upstreams emitting it | Covered before? |
|---|---|---|
| `usage.prompt_tokens_details.cached_tokens` (OpenAI canonical) | OpenAI, Gemini OpenAI-compat, xAI, Mistral, OpenRouter, Groq, Cerebras, Zhipu, Doubao, Qwen main, llama.cpp, vLLM, SGLang | ✓ |
| `usage.prompt_cache_hit_tokens` + `usage.prompt_cache_miss_tokens` (root level, `prompt_tokens` is the sum) | **DeepSeek** | ✗ |
| `usage.cached_tokens` (flat, no wrapper) | Moonshot / Kimi, Cohere v2 native, Qwen Singapore legacy | ✗ |
| HTTP header `fireworks-cached-prompt-tokens` + `perf_metrics["cached-prompt-tokens"]` (outside `usage`) | Fireworks AI | irreducible at this layer |
| Not reported | Anthropic OpenAI-compat, Together, Perplexity, SiliconFlow, TGI, Ollama-compat | n/a |

A parallel divergence for cache-write under the OpenAI wrapper:

| Cache-write shape | Source | Covered before? |
|---|---|---|
| `prompt_tokens_details.cache_creation_input_tokens` | the gateway's Anthropic messages → chat-completions translation pair (Anthropic-native name forwarded under OpenAI's wrapper) | ✓ |
| `prompt_tokens_details.cache_write_tokens` | OpenRouter (Anthropic / explicit-Gemini / Alibaba-routed) | ✗ |

## Change

- New `openAICacheTokensFromUsage(usage: unknown): { cacheRead, cacheWrite }` helper in `shared/telemetry/usage.ts`. It sniffs the variants in explicit precedence order:
  - cache-read: `prompt_tokens_details.cached_tokens` → `prompt_cache_hit_tokens` → flat `cached_tokens`
  - cache-write: `prompt_tokens_details.cache_creation_input_tokens` → `prompt_tokens_details.cache_write_tokens`
- Both per-API extractors (`tokenUsageFromChatCompletionsUsage`, `tokenUsageFromCompletionsUsage`) now call the helper instead of reading the fields directly. The chat extractor keeps its strict `ChatCompletionsUsage` parameter type — the variant sniff lives at the extraction boundary and the protocol type stays clean of non-standard fields.
- Completions also gains cache-write subtraction so its three input dimensions stay disjoint when an upstream that emits cache-write happens to answer there (no-op when cache-write is 0).
- Tests cover each variant shape on the helper and on both per-API extractors, plus the precedence behavior when multiple candidates are present, the `null prompt_tokens_details` case (Gemini cache miss), and that a real `cached_tokens: 0` is honored rather than falling through to the next candidate.

## Out of scope

- **Fireworks**: HTTP-header + `perf_metrics` sibling, completely outside the `usage` block. Capturing it needs provider-specific extraction at the transport layer, deferred to a separate change.
- **vLLM streaming `/v1/completions` bug** ([vllm-project/vllm#44961](https://github.com/vllm-project/vllm/issues/44961), fixed by [#44383](https://github.com/vllm-project/vllm/pull/44383) on `main`): pure upstream-side, no gateway code change can recover the omitted field. The Zhipu/GLM fork we observed predates that fix.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 3364 / 3364 pass (was 3295 on `main`; +16 new test cases across `shared/telemetry/usage_test.ts`, `completions/usage_test.ts`, `chat-completions/usage_test.ts`)
- [ ] Manual end-to-end against a DeepSeek upstream once configured, to confirm a cache-hit request lands `input_cache_read > 0` in the usage row