### PR TITLE
fix(protocols): stop concatenating chat stable scalars

### DIFF
--- a/packages/protocols/src/chat-completions/index.ts
+++ b/packages/protocols/src/chat-completions/index.ts
@@ -84,6 +84,7 @@ export interface ChatCompletionsResult {
   choices: ChatCompletionsChoiceNonStreaming[];
   // https://platform.openai.com/docs/api-reference/chat/object
   service_tier?: 'default' | 'auto' | 'flex' | 'priority' | 'scale' | (string & {}) | null;
+  system_fingerprint?: string | null;
   usage?: ChatCompletionsUsage;
 }
 
@@ -94,6 +95,7 @@ export interface ChatCompletionsStreamEvent {
   model: string;
   choices: ChatCompletionsChoiceStreaming[];
   service_tier?: 'default' | 'auto' | 'flex' | 'priority' | 'scale' | (string & {}) | null;
+  system_fingerprint?: string | null;
   usage?: ChatCompletionsUsage;
 }
 

--- a/packages/protocols/src/chat-completions/reassemble.ts
+++ b/packages/protocols/src/chat-completions/reassemble.ts
@@ -15,19 +15,26 @@ import { captureExtras } from '../common/reassemble-extras.ts';
 //    replayed onto the assembled result.
 //
 // `reasoning_content` (the DeepSeek/Kimi dialect for reasoning text on Chat
-// Completions) is the concrete case that motivated this; the goal is that any
-// future field — `audio_prompt_tokens`, `prompt_filter_results`,
+// Completions) is the concrete case that motivated the extras path; the goal
+// is that any future field — `audio_prompt_tokens`, `prompt_filter_results`,
 // `this_is_a_non_standard_field_of_reasoning` — survives by default without a
 // gateway code change.
+//
+// Stable scalar strings that the upstream repeats unchanged on every chunk —
+// OpenAI's `system_fingerprint` and `service_tier` are the canonical examples
+// — MUST be registered as known keys; otherwise the generic extras path
+// concatenates them into a duplicated mess (`fp_xfp_xfp_x…`).
 
 const KNOWN_DELTA_KEYS = new Set(['content', 'role', 'reasoning_text', 'reasoning_opaque', 'reasoning_items', 'tool_calls']);
 const KNOWN_CHOICE_KEYS = new Set(['index', 'delta', 'finish_reason']);
-const KNOWN_CHUNK_KEYS = new Set(['id', 'object', 'created', 'model', 'choices', 'usage']);
+const KNOWN_CHUNK_KEYS = new Set(['id', 'object', 'created', 'model', 'choices', 'usage', 'system_fingerprint', 'service_tier']);
 
 export async function reassembleChatCompletionsEvents(chunks: AsyncIterable<ChatCompletionsStreamEvent>): Promise<ChatCompletionsResult> {
   let id = '';
   let model = '';
   let created = 0;
+  let systemFingerprint: string | undefined;
+  let serviceTier: ChatCompletionsResult['service_tier'];
   let content = '';
   let reasoningText = '';
   let reasoningOpaque = '';
@@ -52,6 +59,13 @@ export async function reassembleChatCompletionsEvents(chunks: AsyncIterable<Chat
       id = chunk.id as string;
       model = chunk.model as string;
       created = chunk.created as number;
+    }
+
+    if (!systemFingerprint && typeof chunk.system_fingerprint === 'string' && chunk.system_fingerprint) {
+      systemFingerprint = chunk.system_fingerprint;
+    }
+    if (!serviceTier && typeof chunk.service_tier === 'string' && chunk.service_tier) {
+      serviceTier = chunk.service_tier;
     }
 
     if (chunk.usage) {
@@ -146,6 +160,8 @@ export async function reassembleChatCompletionsEvents(chunks: AsyncIterable<Chat
         ...choiceExtras,
       },
     ],
+    ...(systemFingerprint && { system_fingerprint: systemFingerprint }),
+    ...(serviceTier && { service_tier: serviceTier }),
     ...(lastUsage && { usage: lastUsage }),
     ...chunkExtras,
   } as ChatCompletionsResult;

--- a/packages/protocols/src/chat-completions/reassemble_test.ts
+++ b/packages/protocols/src/chat-completions/reassemble_test.ts
@@ -359,3 +359,107 @@ test('reassembleChatCompletionsEvents preserves unknown choice-level fields (con
   };
   assertEquals(result.choices[0].content_filter_results, { hate: { filtered: false, severity: 'safe' } });
 });
+
+test('reassembleChatCompletionsEvents carries system_fingerprint without concatenating its repeated chunks', async () => {
+  const body = makeEvents([
+    {
+      data: {
+        id: 'cmpl_fp',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        system_fingerprint: 'fp_abc123',
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'hi' } }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_fp',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        system_fingerprint: 'fp_abc123',
+        choices: [{ index: 0, delta: { content: ' there' } }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_fp',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        system_fingerprint: 'fp_abc123',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      },
+    },
+  ]);
+
+  const result = await reassembleChatCompletionsEvents(body);
+  assertEquals(result.system_fingerprint, 'fp_abc123');
+  assertEquals(result.choices[0].message.content, 'hi there');
+});
+
+test('reassembleChatCompletionsEvents carries service_tier without concatenating its repeated chunks', async () => {
+  const body = makeEvents([
+    {
+      data: {
+        id: 'cmpl_tier',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        service_tier: 'priority',
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' } }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_tier',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        service_tier: 'priority',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      },
+    },
+  ]);
+
+  const result = await reassembleChatCompletionsEvents(body);
+  assertEquals(result.service_tier, 'priority');
+});
+
+test('reassembleChatCompletionsEvents holds first non-empty system_fingerprint when later chunks omit it', async () => {
+  const body = makeEvents([
+    {
+      data: {
+        id: 'cmpl_fp_late',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        system_fingerprint: null,
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'a' } }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_fp_late',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        system_fingerprint: 'fp_late',
+        choices: [{ index: 0, delta: { content: 'b' } }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_fp_late',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      },
+    },
+  ]);
+
+  const result = await reassembleChatCompletionsEvents(body);
+  assertEquals(result.system_fingerprint, 'fp_late');
+});

--- a/packages/protocols/src/common/reassemble-extras.ts
+++ b/packages/protocols/src/common/reassemble-extras.ts
@@ -14,6 +14,12 @@
 //   so an unknown vendor extension that copies it survives.
 // - Plain object + plain object: shallow merge. Last write wins per key.
 // - Anything else: last non-null value wins.
+//
+// Caller contract: the string-concat default assumes any unknown string field
+// is a streaming text delta. Stable scalar string fields — the kind an
+// upstream repeats unchanged on every chunk (e.g. OpenAI's
+// `system_fingerprint`, `service_tier`) — MUST be registered as known keys
+// by the caller, otherwise this helper concatenates the same value N times.
 
 const isPlainArray = (value: unknown): value is unknown[] => Array.isArray(value);
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>


### PR DESCRIPTION
## Summary

- The Chat Completions reassembler routed every chunk-level field outside `KNOWN_CHUNK_KEYS` through the generic `captureExtras` path, whose default string rule is `existing + value`. OpenAI repeats `system_fingerprint` (and `service_tier`) unchanged on every chunk, so a non-streaming client got `fp_abc123fp_abc123fp_abc123…` instead of `fp_abc123` — the longer the response, the worse the corruption.
- The legacy `/v1/completions` reassembler already handles `system_fingerprint` correctly via a typed first-non-empty accumulator; the chat-completions one silently inherited the wrong default because nobody had spelled out the caller contract on `captureExtras`.
- Register `system_fingerprint` and `service_tier` as known chunk keys with typed first-non-empty accumulators alongside `id`/`model`/`created`, declare `system_fingerprint?: string | null` on both `ChatCompletionsStreamEvent` and `ChatCompletionsResult`, and emit them on the assembled result. Pin the hidden assumption in `reassemble-extras.ts`' header comment so the next stable-scalar field doesn't fall into the same trap.

## Test plan

- [x] `pnpm --filter @floway-dev/protocols exec vitest run src/chat-completions/reassemble_test.ts` — 3 new tests cover (1) `system_fingerprint` repeated on every chunk stays as one value, (2) `service_tier` likewise, (3) first non-empty `system_fingerprint` wins when later chunks omit it.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — clean.
- [x] `pnpm run test` — 3353/3353 across the workspace.