### PR TITLE
feat(translate): bridge service_tier:fast ↔ speed:fast across OpenAI/Anthropic translators

### DIFF
--- a/packages/protocols/src/messages/index.ts
+++ b/packages/protocols/src/messages/index.ts
@@ -49,7 +49,7 @@ export interface MessagesPayload {
     // no `json_object` variant.
     format?: { type: 'json_schema'; schema: Record<string, unknown> };
   };
-  service_tier?: 'auto' | 'standard_only';
+  service_tier?: 'auto' | 'standard_only' | (string & {});
   // https://docs.claude.com/en/build-with-claude/fast-mode — Fast Mode is
   // opt-in per request. Beta-only on the upstream wire (gated by
   // `anthropic-beta: fast-mode-2026-02-01`), but we expose the field at the

--- a/packages/translate/src/chat-completions-via-messages/events.ts
+++ b/packages/translate/src/chat-completions-via-messages/events.ts
@@ -40,6 +40,9 @@ interface MessagesToChatCompletionsStreamState {
   promptTokens: number;
   cachedPromptTokens: number;
   reasoningBlockIndex?: number;
+  // Captured from message_delta usage for service_tier pass-through.
+  upstreamSpeed?: string;
+  upstreamServiceTier?: string;
 }
 
 export const createMessagesToChatCompletionsStreamState = (): MessagesToChatCompletionsStreamState => ({
@@ -70,25 +73,32 @@ const makeChunk = (state: MessagesToChatCompletionsStreamState, delta: ChatCompl
   ],
 });
 
-const makeUsageChunk = (state: MessagesToChatCompletionsStreamState, outputTokens: number): ChatCompletionsStreamEvent => ({
-  id: state.messageId,
-  object: 'chat.completion.chunk',
-  created: state.created,
-  model: state.model,
-  choices: [],
-  usage: {
-    prompt_tokens: state.promptTokens,
-    completion_tokens: outputTokens,
-    total_tokens: state.promptTokens + outputTokens,
-    ...(state.cachedPromptTokens > 0
-      ? {
-          prompt_tokens_details: {
-            cached_tokens: state.cachedPromptTokens,
-          },
-        }
-      : {}),
-  },
-});
+const makeUsageChunk = (state: MessagesToChatCompletionsStreamState, outputTokens: number): ChatCompletionsStreamEvent => {
+  // Anthropic's `speed: 'fast'` surfaces as OpenAI `service_tier: 'fast'`;
+  // all other Anthropic service_tier values pass through directly.
+  const serviceTier = state.upstreamSpeed === 'fast' ? 'fast' : state.upstreamServiceTier;
+
+  return {
+    id: state.messageId,
+    object: 'chat.completion.chunk',
+    created: state.created,
+    model: state.model,
+    choices: [],
+    usage: {
+      prompt_tokens: state.promptTokens,
+      completion_tokens: outputTokens,
+      total_tokens: state.promptTokens + outputTokens,
+      ...(state.cachedPromptTokens > 0
+        ? {
+            prompt_tokens_details: {
+              cached_tokens: state.cachedPromptTokens,
+            },
+          }
+        : {}),
+    },
+    ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
+  };
+};
 
 const unexpectedMessagesVariant = (value: never): never => {
   throw new Error(`Unexpected Messages stream variant: ${JSON.stringify(value)}`);
@@ -181,7 +191,13 @@ export const translateMessagesEventToChatCompletionsChunks = (event: MessagesStr
   case 'message_delta': {
     const chunk = makeChunk(state, {}, mapMessagesStopReasonToChatCompletionsFinishReason(event.delta.stop_reason ?? null));
 
-    return event.usage ? [chunk, makeUsageChunk(state, event.usage.output_tokens)] : [chunk];
+    if (event.usage) {
+      if (event.usage.speed !== undefined) state.upstreamSpeed = event.usage.speed;
+      if (event.usage.service_tier !== undefined) state.upstreamServiceTier = event.usage.service_tier;
+      return [chunk, makeUsageChunk(state, event.usage.output_tokens)];
+    }
+
+    return [chunk];
   }
 
   case 'message_stop':

--- a/packages/translate/src/chat-completions-via-messages/events_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/events_test.ts
@@ -938,3 +938,56 @@ test('message_delta usage includes cache_creation_input_tokens in prompt_tokens'
   assertEquals(chunk.usage!.completion_tokens, 50);
   assertEquals(chunk.usage!.total_tokens, 180);
 });
+
+// ── speed / service_tier pass-through ──
+
+test('Anthropic speed:fast maps to service_tier:fast on the usage chunk', () => {
+  const state = createMessagesToChatCompletionsStreamState();
+  translateMessagesEventToChatCompletionsChunks(MSG_START, state);
+
+  const result = translateMessagesEventToChatCompletionsChunks(
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn' },
+      usage: { output_tokens: 5, speed: 'fast' },
+    } as MessagesStreamEvent,
+    state,
+  ) as ChatCompletionsStreamEvent[];
+
+  const usageChunk = result[1];
+  assertEquals(usageChunk.service_tier, 'fast');
+});
+
+test('Anthropic service_tier:standard with no speed passes service_tier:standard through on the usage chunk', () => {
+  const state = createMessagesToChatCompletionsStreamState();
+  translateMessagesEventToChatCompletionsChunks(MSG_START, state);
+
+  const result = translateMessagesEventToChatCompletionsChunks(
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn' },
+      usage: { output_tokens: 5, service_tier: 'standard' },
+    } as MessagesStreamEvent,
+    state,
+  ) as ChatCompletionsStreamEvent[];
+
+  const usageChunk = result[1];
+  assertEquals(usageChunk.service_tier, 'standard');
+});
+
+test('no speed or service_tier on message_delta → no service_tier on usage chunk', () => {
+  const state = createMessagesToChatCompletionsStreamState();
+  translateMessagesEventToChatCompletionsChunks(MSG_START, state);
+
+  const result = translateMessagesEventToChatCompletionsChunks(
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn' },
+      usage: { output_tokens: 5 },
+    } as MessagesStreamEvent,
+    state,
+  ) as ChatCompletionsStreamEvent[];
+
+  const usageChunk = result[1];
+  assertEquals(usageChunk.service_tier, undefined);
+});

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -188,6 +188,16 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
   if (formatSchema) outputConfig.format = { type: 'json_schema', schema: formatSchema };
   const hasOutputConfig = Object.keys(outputConfig).length > 0;
 
+  // `service_tier: 'fast'` from the Chat Completions caller maps to
+  // Anthropic's `speed: 'fast'`; all other defined service_tier values
+  // pass through as `service_tier` on the Messages wire.
+  const serviceTierFields: Partial<MessagesPayload> =
+    payload.service_tier === 'fast'
+      ? { speed: 'fast' }
+      : payload.service_tier != null
+        ? { service_tier: payload.service_tier }
+        : {};
+
   // Leave OpenAI `user` and generic metadata out of the Messages fallback instead
   // of treating them as a backchannel for Anthropic `metadata.user_id`.
   return {
@@ -205,6 +215,7 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
     ...(tools ? { tools } : {}),
     ...(payload.tool_choice != null ? { tool_choice: translateChatCompletionsToolChoice(payload.tool_choice) } : {}),
     ...(hasOutputConfig ? { output_config: outputConfig } : {}),
+    ...serviceTierFields,
   };
 };
 

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { translateChatCompletionsToMessages } from './request.ts';
 import type { RemoteImageLoader } from '../shared/via-messages/remote-images.ts';
-import { assertEquals, assertExists, assertRejects } from '../test-assert.ts';
+import { assertEquals, assertExists, assertFalse, assertRejects } from '../test-assert.ts';
 import type { ChatCompletionsMessage, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import {
   MESSAGES_FALLBACK_MAX_TOKENS,
@@ -43,7 +43,55 @@ function stubRemoteImageLoader(result: Awaited<ReturnType<RemoteImageLoader>>): 
   return () => Promise.resolve(result);
 }
 
-// ── System / Developer messages ──
+// ── service_tier → speed mapping ──
+
+test('translateChatCompletionsToMessages maps service_tier:fast to speed:fast (no service_tier on target)', async () => {
+  const result = await translateChatCompletionsToMessages(
+    mkPayload({
+      messages: [{ role: 'user', content: 'hi' }],
+      service_tier: 'fast',
+    }),
+  );
+
+  assertEquals(result.speed, 'fast');
+  assertFalse('service_tier' in result);
+});
+
+test('translateChatCompletionsToMessages passes service_tier:priority through as service_tier (no speed override)', async () => {
+  const result = await translateChatCompletionsToMessages(
+    mkPayload({
+      messages: [{ role: 'user', content: 'hi' }],
+      service_tier: 'priority',
+    }),
+  );
+
+  assertEquals(result.service_tier, 'priority');
+  assertFalse('speed' in result);
+});
+
+test('translateChatCompletionsToMessages passes service_tier:auto through as service_tier', async () => {
+  const result = await translateChatCompletionsToMessages(
+    mkPayload({
+      messages: [{ role: 'user', content: 'hi' }],
+      service_tier: 'auto',
+    }),
+  );
+
+  assertEquals(result.service_tier, 'auto');
+  assertFalse('speed' in result);
+});
+
+test('translateChatCompletionsToMessages omits both speed and service_tier when service_tier is absent', async () => {
+  const result = await translateChatCompletionsToMessages(
+    mkPayload({
+      messages: [{ role: 'user', content: 'hi' }],
+    }),
+  );
+
+  assertFalse('speed' in result);
+  assertFalse('service_tier' in result);
+});
+
 //
 // Chat Completions system/developer messages translate INLINE as Messages
 // role: 'system' items, preserving chronology. The Messages role enum admits

--- a/packages/translate/src/messages-via-chat-completions/events.ts
+++ b/packages/translate/src/messages-via-chat-completions/events.ts
@@ -99,6 +99,8 @@ interface ChatCompletionsToMessagesStreamState {
   deferredContent?: string;
   pendingFinishReason?: ChatCompletionsStreamEvent['choices'][0]['finish_reason'];
   pendingUsage?: ChatCompletionsStreamEvent['usage'];
+  // Captured from any chunk's service_tier for speed pass-through.
+  upstreamServiceTier?: string;
   finalMessageSent?: boolean;
 }
 
@@ -316,6 +318,10 @@ const emitFinalMessageIfReady = (state: ChatCompletionsToMessagesStreamState, ev
 
   const usage = mapChatCompletionsUsageToMessagesUsage(state.pendingUsage);
 
+  // Chat Completions `service_tier: 'fast'` surfaces as Messages `speed: 'fast'`;
+  // all other `service_tier` values have no Messages equivalent and are dropped.
+  if (state.upstreamServiceTier === 'fast') usage.speed = 'fast';
+
   events.push(
     {
       type: 'message_delta',
@@ -341,6 +347,8 @@ export const createChatCompletionsToMessagesStreamState = (): ChatCompletionsToM
 
 export const translateChatCompletionsChunkToMessagesEvents = (chunk: ChatCompletionsStreamEvent, state: ChatCompletionsToMessagesStreamState): MessagesStreamEvent[] => {
   const events: MessagesStreamEvent[] = [];
+
+  if (chunk.service_tier != null) state.upstreamServiceTier = chunk.service_tier;
 
   if (chunk.choices.length === 0) {
     if (chunk.usage) {

--- a/packages/translate/src/messages-via-chat-completions/events_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/events_test.ts
@@ -491,3 +491,61 @@ test('mapChatCompletionsUsageToMessagesUsage surfaces cache_creation_input_token
   assertEquals(usage.cache_read_input_tokens, undefined);
   assertEquals(usage.cache_creation_input_tokens, 50);
 });
+
+test('translateChatCompletionsChunkToMessagesEvents surfaces service_tier:fast as usage.speed:fast in message_delta', () => {
+  const state = createChatCompletionsToMessagesStreamState();
+  const events = [
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({ role: 'assistant', content: 'hi' }), state),
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({}, 'stop'), state),
+    ...translateChatCompletionsChunkToMessagesEvents(
+      {
+        id: 'chatcmpl_test',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: 'gpt-test',
+        choices: [],
+        service_tier: 'fast',
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+      state,
+    ),
+  ];
+
+  const messageDelta = events.find(event => event.type === 'message_delta');
+  assertEquals((messageDelta as { usage: { speed?: string } }).usage.speed, 'fast');
+});
+
+test('translateChatCompletionsChunkToMessagesEvents omits usage.speed when service_tier is not fast', () => {
+  const state = createChatCompletionsToMessagesStreamState();
+  const events = [
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({ role: 'assistant', content: 'hi' }), state),
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({}, 'stop'), state),
+    ...translateChatCompletionsChunkToMessagesEvents(
+      {
+        id: 'chatcmpl_test',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: 'gpt-test',
+        choices: [],
+        service_tier: 'default',
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+      state,
+    ),
+  ];
+
+  const messageDelta = events.find(event => event.type === 'message_delta');
+  assertFalse('speed' in (messageDelta as { usage: Record<string, unknown> }).usage);
+});
+
+test('translateChatCompletionsChunkToMessagesEvents omits usage.speed when service_tier is absent', () => {
+  const state = createChatCompletionsToMessagesStreamState();
+  const events = [
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({ role: 'assistant', content: 'hi' }), state),
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({}, 'stop'), state),
+    ...translateChatCompletionsChunkToMessagesEvents(usageChunk(), state),
+  ];
+
+  const messageDelta = events.find(event => event.type === 'message_delta');
+  assertFalse('speed' in (messageDelta as { usage: Record<string, unknown> }).usage);
+});

--- a/packages/translate/src/messages-via-chat-completions/request.ts
+++ b/packages/translate/src/messages-via-chat-completions/request.ts
@@ -279,10 +279,10 @@ export const translateMessagesToChatCompletions = (payload: MessagesPayload): Ch
   const responseFormat = jsonSchema ? { type: 'json_schema' as const, json_schema: jsonSchema } : undefined;
 
   // `speed: 'fast'` maps to Chat Completions `service_tier: 'fast'`; other
-  // values of `speed` have no OpenAI equivalent and are dropped. Anthropic's own
-  // `service_tier` field ('auto'/'standard_only') carries different semantics
-  // than OpenAI's and is not forwarded.
-  const serviceTier = payload.speed === 'fast' ? 'fast' : undefined;
+  // non-fast `speed` values have no OpenAI equivalent and are dropped. When
+  // `speed` is absent, Anthropic's own `service_tier` ('auto'/'standard_only')
+  // is passed through verbatim for symmetry with the forward direction.
+  const serviceTier = payload.speed === 'fast' ? 'fast' : payload.speed === undefined ? payload.service_tier : undefined;
 
   return {
     model: payload.model,

--- a/packages/translate/src/messages-via-chat-completions/request.ts
+++ b/packages/translate/src/messages-via-chat-completions/request.ts
@@ -278,6 +278,12 @@ export const translateMessagesToChatCompletions = (payload: MessagesPayload): Ch
   const jsonSchema = openAiJsonSchemaCoreFromMessagesFormat(payload.output_config?.format);
   const responseFormat = jsonSchema ? { type: 'json_schema' as const, json_schema: jsonSchema } : undefined;
 
+  // `speed: 'fast'` maps to Chat Completions `service_tier: 'fast'`; other
+  // values of `speed` have no OpenAI equivalent and are dropped. Anthropic's own
+  // `service_tier` field ('auto'/'standard_only') carries different semantics
+  // than OpenAI's and is not forwarded.
+  const serviceTier = payload.speed === 'fast' ? 'fast' : undefined;
+
   return {
     model: payload.model,
     messages: translateMessagesInput(payload.messages, payload.system),
@@ -290,6 +296,7 @@ export const translateMessagesToChatCompletions = (payload: MessagesPayload): Ch
     tools: translateMessagesTools(clientTools),
     tool_choice: translateMessagesToolChoice(payload.tool_choice, clientTools),
     ...(responseFormat ? { response_format: responseFormat } : {}),
+    ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
   };
 };
 

--- a/packages/translate/src/messages-via-chat-completions/request_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/request_test.ts
@@ -513,7 +513,7 @@ test('translateMessagesToChatCompletions drops speed values other than fast with
   assertFalse('service_tier' in result);
 });
 
-test('translateMessagesToChatCompletions does not forward Anthropic service_tier to Chat Completions', () => {
+test('translateMessagesToChatCompletions forwards Anthropic service_tier to Chat Completions when speed is absent', () => {
   const result = translateMessagesToChatCompletions({
     model: 'gpt-test',
     max_tokens: 256,
@@ -521,5 +521,16 @@ test('translateMessagesToChatCompletions does not forward Anthropic service_tier
     messages: [{ role: 'user', content: 'hi' }],
   });
 
-  assertFalse('service_tier' in result);
+  assertEquals(result.service_tier, 'auto');
+});
+
+test('translateMessagesToChatCompletions forwards service_tier:standard_only to Chat Completions when speed is absent', () => {
+  const result = translateMessagesToChatCompletions({
+    model: 'gpt-test',
+    max_tokens: 256,
+    service_tier: 'standard_only',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertEquals(result.service_tier, 'standard_only');
 });

--- a/packages/translate/src/messages-via-chat-completions/request_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/request_test.ts
@@ -480,3 +480,46 @@ test('translateMessagesToChatCompletions rejects an unknown message role', () =>
     'does not accept role tool',
   );
 });
+
+test('translateMessagesToChatCompletions maps speed:fast to service_tier:fast on the outbound Chat Completions payload', () => {
+  const result = translateMessagesToChatCompletions({
+    model: 'gpt-test',
+    max_tokens: 256,
+    speed: 'fast',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertEquals(result.service_tier, 'fast');
+});
+
+test('translateMessagesToChatCompletions omits service_tier when speed is absent', () => {
+  const result = translateMessagesToChatCompletions({
+    model: 'gpt-test',
+    max_tokens: 256,
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertFalse('service_tier' in result);
+});
+
+test('translateMessagesToChatCompletions drops speed values other than fast without emitting service_tier', () => {
+  const result = translateMessagesToChatCompletions({
+    model: 'gpt-test',
+    max_tokens: 256,
+    speed: 'standard',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertFalse('service_tier' in result);
+});
+
+test('translateMessagesToChatCompletions does not forward Anthropic service_tier to Chat Completions', () => {
+  const result = translateMessagesToChatCompletions({
+    model: 'gpt-test',
+    max_tokens: 256,
+    service_tier: 'auto',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertFalse('service_tier' in result);
+});

--- a/packages/translate/src/messages-via-responses/events.ts
+++ b/packages/translate/src/messages-via-responses/events.ts
@@ -72,6 +72,10 @@ export const translateResponsesToMessagesResult = (response: ResponsesResult): M
   const inputTokens = response.usage?.input_tokens ?? 0;
   const cachedTokens = response.usage?.input_tokens_details?.cached_tokens;
 
+  // Responses `service_tier: 'fast'` surfaces as Messages `speed: 'fast'`;
+  // all other `service_tier` values have no Messages equivalent and are dropped.
+  const speed = response.service_tier === 'fast' ? 'fast' : undefined;
+
   return {
     id: response.id,
     type: 'message',
@@ -84,6 +88,7 @@ export const translateResponsesToMessagesResult = (response: ResponsesResult): M
       input_tokens: inputTokens - (cachedTokens ?? 0),
       output_tokens: response.usage?.output_tokens ?? 0,
       ...(cachedTokens !== undefined ? { cache_read_input_tokens: cachedTokens } : {}),
+      ...(speed !== undefined ? { speed } : {}),
     },
   };
 };

--- a/packages/translate/src/messages-via-responses/events_test.ts
+++ b/packages/translate/src/messages-via-responses/events_test.ts
@@ -622,3 +622,53 @@ test('translateResponsesToMessagesResult projects whitespace-only reasoning summ
 
   assertEquals(result.content, [{ type: 'redacted_thinking', data: packReasoningSignature('rs_ws', '') }]);
 });
+
+test('translateResponsesToMessagesResult maps service_tier:fast to usage.speed:fast', () => {
+  const result = translateResponsesToMessagesResult({
+    id: 'resp_fast',
+    object: 'response',
+    model: 'gpt-test',
+    output: [],
+    output_text: '',
+    status: 'completed',
+    error: null,
+    incomplete_details: null,
+    service_tier: 'fast',
+    usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+  });
+
+  assertEquals(result.usage.speed, 'fast');
+});
+
+test('translateResponsesToMessagesResult omits usage.speed when service_tier is not fast', () => {
+  const result = translateResponsesToMessagesResult({
+    id: 'resp_default',
+    object: 'response',
+    model: 'gpt-test',
+    output: [],
+    output_text: '',
+    status: 'completed',
+    error: null,
+    incomplete_details: null,
+    service_tier: 'default',
+    usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+  });
+
+  assertEquals(result.usage.speed, undefined);
+});
+
+test('translateResponsesToMessagesResult omits usage.speed when service_tier is absent', () => {
+  const result = translateResponsesToMessagesResult({
+    id: 'resp_no_tier',
+    object: 'response',
+    model: 'gpt-test',
+    output: [],
+    output_text: '',
+    status: 'completed',
+    error: null,
+    incomplete_details: null,
+    usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+  });
+
+  assertEquals(result.usage.speed, undefined);
+});

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -213,11 +213,11 @@ export const translateMessagesToResponses = (payload: MessagesPayload): Response
   const jsonSchema = openAiJsonSchemaCoreFromMessagesFormat(payload.output_config?.format);
   const text = jsonSchema ? { format: { type: 'json_schema' as const, ...jsonSchema } } : undefined;
 
-  // `speed: 'fast'` maps to Responses `service_tier: 'fast'`; other values of
-  // `speed` have no OpenAI equivalent and are dropped. Anthropic's own
-  // `service_tier` field ('auto'/'standard_only') carries different semantics
-  // than OpenAI's and is not forwarded.
-  const serviceTier = payload.speed === 'fast' ? 'fast' : undefined;
+  // `speed: 'fast'` maps to Responses `service_tier: 'fast'`; other non-fast
+  // `speed` values have no OpenAI equivalent and are dropped. When `speed` is
+  // absent, Anthropic's own `service_tier` ('auto'/'standard_only') is passed
+  // through verbatim for symmetry with the forward direction.
+  const serviceTier = payload.speed === 'fast' ? 'fast' : payload.speed === undefined ? payload.service_tier : undefined;
 
   // Keep fallback semantics strict: do not synthesize `temperature: 1`,
   // `store: false`, `parallel_tool_calls: true`, or `reasoning.summary` when the

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -213,6 +213,12 @@ export const translateMessagesToResponses = (payload: MessagesPayload): Response
   const jsonSchema = openAiJsonSchemaCoreFromMessagesFormat(payload.output_config?.format);
   const text = jsonSchema ? { format: { type: 'json_schema' as const, ...jsonSchema } } : undefined;
 
+  // `speed: 'fast'` maps to Responses `service_tier: 'fast'`; other values of
+  // `speed` have no OpenAI equivalent and are dropped. Anthropic's own
+  // `service_tier` field ('auto'/'standard_only') carries different semantics
+  // than OpenAI's and is not forwarded.
+  const serviceTier = payload.speed === 'fast' ? 'fast' : undefined;
+
   // Keep fallback semantics strict: do not synthesize `temperature: 1`,
   // `store: false`, `parallel_tool_calls: true`, or `reasoning.summary` when the
   // Messages source did not express those knobs.
@@ -229,6 +235,7 @@ export const translateMessagesToResponses = (payload: MessagesPayload): Response
     stream: true,
     ...(reasoning ? { reasoning } : {}),
     ...(text ? { text } : {}),
+    ...(serviceTier !== undefined ? { service_tier: serviceTier } : {}),
   };
 };
 

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -535,7 +535,7 @@ test('translateMessagesToResponses drops speed values other than fast without em
   assertFalse('service_tier' in result);
 });
 
-test('translateMessagesToResponses does not forward Anthropic service_tier to Responses', () => {
+test('translateMessagesToResponses forwards Anthropic service_tier to Responses when speed is absent', () => {
   const result = translateMessagesToResponses({
     model: 'gpt-test',
     max_tokens: 256,
@@ -543,5 +543,16 @@ test('translateMessagesToResponses does not forward Anthropic service_tier to Re
     messages: [{ role: 'user', content: 'hi' }],
   });
 
-  assertFalse('service_tier' in result);
+  assertEquals(result.service_tier, 'auto');
+});
+
+test('translateMessagesToResponses forwards service_tier:standard_only to Responses when speed is absent', () => {
+  const result = translateMessagesToResponses({
+    model: 'gpt-test',
+    max_tokens: 256,
+    service_tier: 'standard_only',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertEquals(result.service_tier, 'standard_only');
 });

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -502,3 +502,46 @@ test('translateMessagesToResponses rejects an unknown message role', () => {
     'does not accept role tool',
   );
 });
+
+test('translateMessagesToResponses maps speed:fast to service_tier:fast on the outbound Responses payload', () => {
+  const result = translateMessagesToResponses({
+    model: 'gpt-test',
+    max_tokens: 256,
+    speed: 'fast',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertEquals(result.service_tier, 'fast');
+});
+
+test('translateMessagesToResponses omits service_tier when speed is absent', () => {
+  const result = translateMessagesToResponses({
+    model: 'gpt-test',
+    max_tokens: 256,
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertFalse('service_tier' in result);
+});
+
+test('translateMessagesToResponses drops speed values other than fast without emitting service_tier', () => {
+  const result = translateMessagesToResponses({
+    model: 'gpt-test',
+    max_tokens: 256,
+    speed: 'standard',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertFalse('service_tier' in result);
+});
+
+test('translateMessagesToResponses does not forward Anthropic service_tier to Responses', () => {
+  const result = translateMessagesToResponses({
+    model: 'gpt-test',
+    max_tokens: 256,
+    service_tier: 'auto',
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertFalse('service_tier' in result);
+});

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -80,11 +80,17 @@ interface MessagesToResponsesStreamState {
   cacheReadInputTokens?: number;
   cacheCreationInputTokens?: number;
   stopReason?: MessagesMessageDeltaEvent['delta']['stop_reason'];
+  // Captured from message_delta usage for service_tier pass-through.
+  upstreamSpeed?: string;
+  upstreamServiceTier?: string;
   customToolNames: ReadonlySet<string>;
 }
 
 const buildResult = (state: MessagesToResponsesStreamState, status: ResponsesResult['status']): ResponsesResult => {
   const inputTokens = state.inputTokens + (state.cacheReadInputTokens ?? 0) + (state.cacheCreationInputTokens ?? 0);
+  // Anthropic's `speed: 'fast'` surfaces as OpenAI `service_tier: 'fast'`;
+  // all other Anthropic service_tier values pass through directly.
+  const serviceTier = state.upstreamSpeed === 'fast' ? 'fast' : state.upstreamServiceTier;
 
   return responses.result({
     id: state.responseId,
@@ -98,6 +104,7 @@ const buildResult = (state: MessagesToResponsesStreamState, status: ResponsesRes
     // don't map to incomplete.
     ...(status === 'incomplete' ? { incompleteDetails: { reason: 'max_output_tokens' as const } } : {}),
     usage: responses.usage(inputTokens, state.outputTokens, state.cacheReadInputTokens),
+    ...(serviceTier !== undefined ? { serviceTier } : {}),
   });
 };
 
@@ -352,6 +359,8 @@ export const translateMessagesEventToResponsesEvents = (event: MessagesStreamEve
     }
     if (event.usage) {
       state.outputTokens = event.usage.output_tokens;
+      if (event.usage.speed !== undefined) state.upstreamSpeed = event.usage.speed;
+      if (event.usage.service_tier !== undefined) state.upstreamServiceTier = event.usage.service_tier;
     }
     return [];
   }

--- a/packages/translate/src/responses-via-messages/events_test.ts
+++ b/packages/translate/src/responses-via-messages/events_test.ts
@@ -11,7 +11,10 @@ type ResponsesOutputItemDoneEvent = Extract<ResponsesStreamEvent, { type: 'respo
 
 // ── Helpers ──
 
-const runToCompletion = (usage: { input_tokens: number; output_tokens: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number }): ResponsesResult => {
+const runToCompletion = (
+  usage: { input_tokens: number; output_tokens: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number },
+  deltaUsageExtras?: { speed?: string; service_tier?: string },
+): ResponsesResult => {
   const state = createMessagesToResponsesStreamState('resp_test', 'claude-sonnet-4-20250514');
 
   translateMessagesEventToResponsesEvents(
@@ -57,7 +60,7 @@ const runToCompletion = (usage: { input_tokens: number; output_tokens: number; c
     {
       type: 'message_delta',
       delta: { stop_reason: 'end_turn' },
-      usage: { output_tokens: usage.output_tokens },
+      usage: { output_tokens: usage.output_tokens, ...deltaUsageExtras },
     } as MessagesStreamEvent,
     state,
   );
@@ -752,4 +755,24 @@ test('synthesized function_call item carries a stable id consistent across added
   assertEquals(state.completedItems, [
     { type: 'function_call', id: 'fc_0', call_id: 'toolu_1', name: 'lookup', arguments: '{"q":"x"}', status: 'completed' },
   ]);
+});
+
+// ── speed / service_tier pass-through ──
+
+test('Anthropic speed:fast maps to service_tier:fast on the Responses result', () => {
+  const result = runToCompletion({ input_tokens: 10, output_tokens: 5 }, { speed: 'fast' });
+
+  assertEquals(result.service_tier, 'fast');
+});
+
+test('Anthropic service_tier:standard with no speed passes service_tier:standard through', () => {
+  const result = runToCompletion({ input_tokens: 10, output_tokens: 5 }, { service_tier: 'standard' });
+
+  assertEquals(result.service_tier, 'standard');
+});
+
+test('Anthropic service_tier absent results in no service_tier on the Responses result', () => {
+  const result = runToCompletion({ input_tokens: 10, output_tokens: 5 });
+
+  assertEquals(result.service_tier, undefined);
 });

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -331,6 +331,17 @@ export const translateResponsesToMessages = async (payload: ResponsesPayload, op
   if (formatSchema) outputConfig.format = { type: 'json_schema', schema: formatSchema };
   const hasOutputConfig = Object.keys(outputConfig).length > 0;
 
+  // `service_tier: 'fast'` from the Responses caller maps to Anthropic's
+  // `speed: 'fast'`; all other defined service_tier values pass through as
+  // `service_tier` on the Messages wire (Anthropic accepts 'auto',
+  // 'standard_only', and future literals).
+  const serviceTierFields: Partial<MessagesPayload> =
+    payload.service_tier === 'fast'
+      ? { speed: 'fast' }
+      : payload.service_tier != null
+        ? { service_tier: payload.service_tier }
+        : {};
+
   // Responses `metadata` is intentionally omitted on the Messages path;
   // not coerced into Anthropic metadata.user_id, prompt-cache, or safety
   // semantics.
@@ -346,6 +357,7 @@ export const translateResponsesToMessages = async (payload: ResponsesPayload, op
     tool_choice: translateToolChoice(payload.tool_choice),
     ...(effort === 'none' ? { thinking: { type: 'disabled' as const } } : {}),
     ...(hasOutputConfig ? { output_config: outputConfig } : {}),
+    ...serviceTierFields,
   };
 
   return { target, customToolNames };

--- a/packages/translate/src/responses-via-messages/request_test.ts
+++ b/packages/translate/src/responses-via-messages/request_test.ts
@@ -6,6 +6,51 @@ import { MESSAGES_FALLBACK_MAX_TOKENS, type MessagesClientTool, type MessagesToo
 
 const stubRemoteImageLoader = (result: { mediaType: string | null; data: Uint8Array } | null) => () => Promise.resolve(result);
 
+const minimalPayload = {
+  model: 'claude-test',
+  input: [{ type: 'message' as const, role: 'user' as const, content: 'hi' }],
+  instructions: null,
+  temperature: null,
+  top_p: null,
+  max_output_tokens: 256,
+  tools: null,
+  tool_choice: 'auto' as const,
+  metadata: null,
+  stream: null,
+  store: false,
+  parallel_tool_calls: true,
+};
+
+// ── service_tier → speed mapping ──
+
+test('translateResponsesToMessages maps service_tier:fast to speed:fast (no service_tier on target)', async () => {
+  const result = await translateResponsesToMessages({ ...minimalPayload, service_tier: 'fast' });
+
+  assertEquals(result.target.speed, 'fast');
+  assertFalse('service_tier' in result.target);
+});
+
+test('translateResponsesToMessages passes service_tier:priority through as service_tier (no speed override)', async () => {
+  const result = await translateResponsesToMessages({ ...minimalPayload, service_tier: 'priority' });
+
+  assertEquals(result.target.service_tier, 'priority');
+  assertFalse('speed' in result.target);
+});
+
+test('translateResponsesToMessages passes service_tier:auto through as service_tier', async () => {
+  const result = await translateResponsesToMessages({ ...minimalPayload, service_tier: 'auto' });
+
+  assertEquals(result.target.service_tier, 'auto');
+  assertFalse('speed' in result.target);
+});
+
+test('translateResponsesToMessages omits both speed and service_tier when service_tier is absent', async () => {
+  const result = await translateResponsesToMessages(minimalPayload);
+
+  assertFalse('speed' in result.target);
+  assertFalse('service_tier' in result.target);
+});
+
 test('translateResponsesToMessages maps reasoning.effort none to thinking.disabled', async () => {
   const result = await translateResponsesToMessages({
     model: 'claude-test',

--- a/packages/translate/src/shared/responses-via/responses-event-builder.ts
+++ b/packages/translate/src/shared/responses-via/responses-event-builder.ts
@@ -98,6 +98,7 @@ export const result = (input: {
   status: ResponsesResult['status'];
   usage?: ResponsesUsage;
   incompleteDetails?: ResponsesResult['incomplete_details'];
+  serviceTier?: ResponsesResult['service_tier'];
 }): ResponsesResult => ({
   id: input.id,
   object: 'response',
@@ -111,6 +112,7 @@ export const result = (input: {
   error: null,
   incomplete_details: input.incompleteDetails ?? null,
   ...(input.usage !== undefined ? { usage: input.usage } : {}),
+  ...(input.serviceTier !== undefined ? { service_tier: input.serviceTier } : {}),
 });
 
 // Every output item carries its own `id` so that, when a Responses client is


### PR DESCRIPTION
## Summary

Anthropic Messages exposes "Fast Mode" via a top-level `speed: 'fast'` field. OpenAI Responses and Chat Completions use `service_tier: 'fast'`. They model the same operator intent — opt into a low-latency premium tier — on different wires. Floway's four cross-protocol translators now bridge them bidirectionally, both on the request and response sides.

## Request side

**OpenAI caller → Anthropic upstream** (`responses-via-messages`, `chat-completions-via-messages`):

| Incoming OpenAI payload | Outgoing Messages payload |
|---|---|
| `service_tier: 'fast'` | `speed: 'fast'`; no `service_tier` field |
| Other `service_tier` value | `service_tier: <value>` pass-through (Messages wire accepts arbitrary strings) |
| Absent | Nothing |

**Anthropic caller → OpenAI upstream** (`messages-via-responses`, `messages-via-chat-completions`):

| Incoming Messages payload | Outgoing OpenAI payload |
|---|---|
| `speed: 'fast'` | `service_tier: 'fast'`; no `speed` field on the OpenAI wire |
| `speed: 'standard'` or other non-fast | Dropped (no OpenAI equivalent for explicit non-fast) |
| No `speed`, has `service_tier: <value>` | `service_tier: <value>` pass-through (Anthropic's own scheduling tier hint — let the OpenAI upstream reject if unsupported) |
| No `speed`, no `service_tier` | Nothing |

## Response side

**Anthropic upstream → OpenAI caller** (event translators on both pairs):

- Anthropic `message_delta.usage.speed: 'fast'` → surfaces as `usage.service_tier: 'fast'` on the synthesized Responses result or Chat Completions usage chunk
- Other Anthropic `usage.service_tier` values pass through verbatim to the OpenAI side

**OpenAI upstream → Anthropic caller** (event translators on the reverse pairs):

- OpenAI `usage.service_tier: 'fast'` (Responses result envelope or Chat Completions chunk) → surfaces as Messages `usage.speed: 'fast'` on the synthesized output
- Non-'fast' OpenAI `service_tier` values dropped (Messages `speed` only defines `'standard'`/`'fast'`; arbitrary OpenAI tier strings aren't faithfully roundtrippable)

## Result

OpenAI-style clients (Codex CLI, official OpenAI SDKs, anything that speaks Responses or Chat Completions) get end-to-end Fast Mode against Floway-routed Anthropic models with no per-client adaptation. Anthropic-style clients (Claude Code CLI, the official Anthropic SDK) get the same against Floway-routed OpenAI-style upstreams. The translation is bidirectional, symmetric, and lossy only where the source/target wires fundamentally disagree (OpenAI's richer `service_tier` enum vs Anthropic's binary `speed`).

`MessagesPayload.service_tier` was widened from `'auto' | 'standard_only'` to `'auto' | 'standard_only' | (string & {})` to accept the pass-through values; the IDE autocomplete hints stay accurate while the type doesn't reject upstream-specific tier strings.

## Test plan

- [x] `pnpm run test` — clean (14 new tests across the four translator directories' request and event suites)
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [ ] Manual: send a Responses request with `service_tier: 'fast'` against a Floway-routed Claude model; verify outbound Anthropic request body carries `speed: 'fast'`; verify the synthesized Responses result's `usage.service_tier === 'fast'`
- [ ] Manual: send a Messages request with `speed: 'fast'` against a Floway-routed OpenAI/Azure model; verify outbound carries `service_tier: 'fast'`; verify the synthesized Messages output's `usage.speed === 'fast'`