### PR TITLE
feat(provider): per-model chat metadata (modalities + reasoning) as first-class field

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -22,8 +22,6 @@ export interface ProxyFallbackEntry {
 // Mutable variant of @floway-dev/protocols/common ChatModelInfo. The editor
 // mutates these arrays in place during reasoning-level/modality edits, so
 // dropping `readonly` here is intentional — the wire shape stays readonly.
-// TODO (Task 18): Redesign the editor UI to handle all four reasoning sub-blocks
-// (effort, budget_tokens, adaptive, mandatory). For now only effort is surfaced.
 export interface UpstreamChatConfig {
   modalities?: { input: ('text' | 'image')[]; output: ('text' | 'image')[] };
   reasoning?: {

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -27,8 +27,8 @@ export interface UpstreamChatConfig {
   reasoning?: {
     effort?: { supported: string[]; default: string };
     budget_tokens?: { min?: number; max?: number };
-    adaptive?: boolean;
-    mandatory?: boolean;
+    adaptive?: true;
+    mandatory?: true;
   };
 }
 

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -19,6 +19,21 @@ export interface ProxyFallbackEntry {
   colos?: string[];
 }
 
+// Mutable variant of @floway-dev/protocols/common ChatModelInfo. The editor
+// mutates these arrays in place during reasoning-level/modality edits, so
+// dropping `readonly` here is intentional — the wire shape stays readonly.
+// TODO (Task 18): Redesign the editor UI to handle all four reasoning sub-blocks
+// (effort, budget_tokens, adaptive, mandatory). For now only effort is surfaced.
+export interface UpstreamChatConfig {
+  modalities?: { input: ('text' | 'image')[]; output: ('text' | 'image')[] };
+  reasoning?: {
+    effort?: { supported: string[]; default: string };
+    budget_tokens?: { min?: number; max?: number };
+    adaptive?: boolean;
+    mandatory?: boolean;
+  };
+}
+
 export interface UpstreamModelConfig {
   upstreamModelId: string;
   publicModelId?: string;
@@ -28,6 +43,7 @@ export interface UpstreamModelConfig {
   limits?: ModelLimits;
   cost?: ModelPricing;
   flagOverrides?: { enabled: boolean; values: Record<string, boolean> };
+  chat?: UpstreamChatConfig;
 }
 
 export interface CustomModelsFetch {

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -287,6 +287,7 @@ const isReasoningValid = computed<boolean>(() => {
   if (!reasoning.effort) return true;
   return reasoning.effort.default !== '' && reasoning.effort.supported.includes(reasoning.effort.default);
 });
+});
 
 watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediate: true });
 

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -306,7 +306,6 @@ const isReasoningValid = computed<boolean>(() => {
 
   return true;
 });
-});
 
 watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediate: true });
 

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -286,11 +286,11 @@ const mandatoryEnabled = computed(() => config.value?.chat?.reasoning?.mandatory
 const anyControlledEnabled = computed(() => effortEnabled.value || budgetTokensEnabled.value || adaptiveEnabled.value);
 const controlledDisabled = computed(() => !editable.value || mandatoryEnabled.value);
 const mandatoryDisabled = computed(() => !editable.value || anyControlledEnabled.value);
-const presetEffortLevels = computed(() => REASONING_LEVELS.filter(level => !supportedEfforts.value.includes(level)));
 
 const supportedEfforts = computed<string[]>(
   () => config.value?.chat?.reasoning?.effort?.supported ?? [],
 );
+const presetEffortLevels = computed(() => REASONING_LEVELS.filter(level => !supportedEfforts.value.includes(level)));
 
 // ── Validity ───────────────────────────────────────────────────────────────
 
@@ -343,8 +343,8 @@ const buildNextReasoning = (
   // Drop keys explicitly set to undefined.
   const cleaned = Object.fromEntries(
     Object.entries(merged).filter(([, v]) => v !== undefined),
-  ) as UpstreamChatConfig['reasoning'];
-  return cleaned && Object.keys(cleaned).length > 0 ? cleaned : undefined;
+  ) as NonNullable<UpstreamChatConfig['reasoning']>;
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
 };
 
 const toggleImageInput = (on: boolean) => {

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -280,6 +280,14 @@ const budgetTokensEnabled = computed(() => config.value?.chat?.reasoning?.budget
 const adaptiveEnabled = computed(() => config.value?.chat?.reasoning?.adaptive === true);
 const mandatoryEnabled = computed(() => config.value?.chat?.reasoning?.mandatory === true);
 
+// Mandatory is exclusive: when enabled it dominates and the three operator-
+// controlled toggles disappear. When any of those is on, Mandatory is locked
+// off. UI-only constraint (the schema would technically accept any subset).
+const anyControlledEnabled = computed(() => effortEnabled.value || budgetTokensEnabled.value || adaptiveEnabled.value);
+const controlledDisabled = computed(() => !editable.value || mandatoryEnabled.value);
+const mandatoryDisabled = computed(() => !editable.value || anyControlledEnabled.value);
+const presetEffortLevels = computed(() => REASONING_LEVELS.filter(level => !supportedEfforts.value.includes(level)));
+
 const supportedEfforts = computed<string[]>(
   () => config.value?.chat?.reasoning?.effort?.supported ?? [],
 );
@@ -349,7 +357,7 @@ const toggleImageInput = (on: boolean) => {
 const toggleEffort = (on: boolean) => {
   if (!editable.value) return;
   const reasoning = on
-    ? buildNextReasoning({ effort: { supported: [], default: '' } })
+    ? buildNextReasoning({ effort: { supported: ['low', 'medium', 'high'], default: 'medium' } })
     : buildNextReasoning({ effort: undefined });
   patch({ chat: buildNextChat({ reasoning }) });
 };
@@ -370,7 +378,10 @@ const removeReasoningLevel = (level: string) => {
   const updated = supportedEfforts.value.filter(e => e !== level);
   const existingEffort = config.value.chat?.reasoning?.effort;
   const nextDefault = existingEffort?.default === level ? '' : (existingEffort?.default ?? '');
-  const nextEffort = updated.length > 0 ? { supported: updated, default: nextDefault } : undefined;
+  // Keep the effort sub-block even when no levels remain — the empty-list
+  // warning replaces the tag row in-place so the user sees what's needed
+  // without the toggle silently flipping off.
+  const nextEffort = { supported: updated, default: nextDefault };
   patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ effort: nextEffort }) }) });
 };
 

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -375,9 +375,20 @@ const addReasoningLevel = (level: string) => {
 
 const removeReasoningLevel = (level: string) => {
   if (!editable.value || !config.value) return;
-  const updated = supportedEfforts.value.filter(e => e !== level);
+  const current = supportedEfforts.value;
+  const removedIndex = current.indexOf(level);
+  const updated = current.filter(e => e !== level);
   const existingEffort = config.value.chat?.reasoning?.effort;
-  const nextDefault = existingEffort?.default === level ? '' : (existingEffort?.default ?? '');
+  // The default must always be one of the supported levels (or empty when the
+  // list itself is empty). When the operator deletes the current default, pick
+  // the neighbor that slides into the same index slot — falling back to the
+  // new tail when the removed entry was the last one.
+  let nextDefault = existingEffort?.default ?? '';
+  if (existingEffort?.default === level) {
+    if (updated.length === 0) nextDefault = '';
+    else if (removedIndex < updated.length) nextDefault = updated[removedIndex]!;
+    else nextDefault = updated[updated.length - 1]!;
+  }
   // Keep the effort sub-block even when no levels remain — the empty-list
   // warning replaces the tag row in-place so the user sees what's needed
   // without the toggle silently flipping off.
@@ -771,6 +782,7 @@ const toggleMandatory = (on: boolean) => {
           <div v-if="effortEnabled" class="mt-3 space-y-1.5 border-l-2 border-white/[0.08] pl-3">
             <div class="flex min-h-[1.625rem] flex-wrap items-center gap-x-3 gap-y-1.5">
               <span class="text-xs font-semibold text-gray-300">Effort levels</span>
+              <span class="text-[11px] text-gray-500">(click to set default)</span>
               <template v-if="supportedEfforts.length > 0">
                 <button
                   v-for="level in supportedEfforts"
@@ -806,7 +818,6 @@ const toggleMandatory = (on: boolean) => {
               <p v-else class="whitespace-nowrap text-[11px] text-accent-amber">Add at least one effort level — click a preset on the right.</p>
             </div>
             <div v-if="editable" class="flex flex-wrap items-center gap-1.5">
-              <span class="text-[11px] text-gray-500">add:</span>
               <button
                 v-for="level in presetEffortLevels"
                 :key="level"
@@ -836,7 +847,7 @@ const toggleMandatory = (on: boolean) => {
                 :model-value="config.chat?.reasoning?.budget_tokens?.min"
                 :readonly="!editable"
                 placeholder="—"
-                class="!w-24 font-mono"
+                class="!h-6 !w-24 !py-0 !text-[11px] font-mono"
                 @update:model-value="v => updateBudgetTokensMin(v)"
               />
             </label>
@@ -849,7 +860,7 @@ const toggleMandatory = (on: boolean) => {
                 :model-value="config.chat?.reasoning?.budget_tokens?.max"
                 :readonly="!editable"
                 placeholder="—"
-                class="!w-24 font-mono"
+                class="!h-6 !w-24 !py-0 !text-[11px] font-mono"
                 @update:model-value="v => updateBudgetTokensMax(v)"
               />
             </label>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -259,7 +259,7 @@ const updateFlagOverrides = (values: Record<string, boolean>) => {
 // (ReasoningEffort::Custom(String)) so any string is accepted upstream;
 // these are just the convenient quick-adds. See:
 // https://github.com/openai/codex/blob/main/codex-rs/protocol/src/openai_models.rs
-const REASONING_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'ultra'] as const;
+const REASONING_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 
 // Free-typing input for adding a custom reasoning level not in the quick-add list.
 const reasoningLevelInput = ref('');

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -727,128 +727,129 @@ const toggleMandatory = (on: boolean) => {
         </section>
 
         <section v-if="rowKind === 'chat'">
-          <div class="mb-3 flex items-baseline gap-3">
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
             <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Modalities</h3>
-            <span class="text-[11px] text-gray-500">text is always supported; toggle additional inputs</span>
+            <span class="text-[11px] text-gray-500">text always supported</span>
+            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
+              <Switch
+                :model-value="chatImageInput"
+                :disabled="!editable"
+                @update:model-value="v => toggleImageInput(v === true)"
+              />
+              <span class="text-xs" :class="chatImageInput ? 'text-white' : 'text-gray-500'">Image input</span>
+            </label>
           </div>
-          <label class="flex w-fit items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
-            <Switch
-              :model-value="chatImageInput"
-              :disabled="!editable"
-              @update:model-value="v => toggleImageInput(v === true)"
-            />
-            <span class="text-xs" :class="chatImageInput ? 'text-white' : 'text-gray-500'">Image input</span>
-          </label>
         </section>
 
         <section v-if="rowKind === 'chat'">
           <div class="mb-3 flex items-baseline gap-3">
             <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Reasoning</h3>
-            <span class="text-[11px] text-gray-500">enable any subset; details expand under each toggle</span>
+            <span class="text-[11px] text-gray-500">Mandatory is exclusive; the other three may combine freely</span>
           </div>
 
           <div class="flex flex-wrap gap-x-6 gap-y-2">
-            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
-              <Switch :model-value="effortEnabled" :disabled="!editable" @update:model-value="v => toggleEffort(v === true)" />
+            <label class="flex items-center gap-2" :class="controlledDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'">
+              <Switch :model-value="effortEnabled" :disabled="controlledDisabled" @update:model-value="v => toggleEffort(v === true)" />
               <span class="text-xs" :class="effortEnabled ? 'text-white' : 'text-gray-500'">Effort levels</span>
             </label>
-            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
-              <Switch :model-value="budgetTokensEnabled" :disabled="!editable" @update:model-value="v => toggleBudgetTokens(v === true)" />
+            <label class="flex items-center gap-2" :class="controlledDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'">
+              <Switch :model-value="budgetTokensEnabled" :disabled="controlledDisabled" @update:model-value="v => toggleBudgetTokens(v === true)" />
               <span class="text-xs" :class="budgetTokensEnabled ? 'text-white' : 'text-gray-500'">Budget tokens</span>
             </label>
-            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
-              <Switch :model-value="adaptiveEnabled" :disabled="!editable" @update:model-value="v => toggleAdaptive(v === true)" />
+            <label class="flex items-center gap-2" :class="controlledDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'">
+              <Switch :model-value="adaptiveEnabled" :disabled="controlledDisabled" @update:model-value="v => toggleAdaptive(v === true)" />
               <span class="text-xs" :class="adaptiveEnabled ? 'text-white' : 'text-gray-500'">Adaptive</span>
               <Tooltip content="Model self-selects reasoning effort"><span class="text-[10px] text-gray-600">?</span></Tooltip>
             </label>
-            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
-              <Switch :model-value="mandatoryEnabled" :disabled="!editable" @update:model-value="v => toggleMandatory(v === true)" />
+            <label class="flex items-center gap-2" :class="mandatoryDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'">
+              <Switch :model-value="mandatoryEnabled" :disabled="mandatoryDisabled" @update:model-value="v => toggleMandatory(v === true)" />
               <span class="text-xs" :class="mandatoryEnabled ? 'text-white' : 'text-gray-500'">Mandatory</span>
               <Tooltip content="Reasoning is always applied; caller cannot opt out"><span class="text-[10px] text-gray-600">?</span></Tooltip>
             </label>
           </div>
 
-          <div v-if="effortEnabled" class="mt-3 space-y-2 border-l-2 border-white/[0.08] pl-3">
-            <div v-if="supportedEfforts.length > 0" class="flex flex-wrap gap-1.5">
-              <span
-                v-for="level in supportedEfforts"
-                :key="level"
-                class="inline-flex items-center gap-1 rounded border border-white/15 bg-white/[0.07] px-2 py-0.5 font-mono text-[11px] text-gray-300"
-              >
-                {{ level }}
+          <div v-if="effortEnabled" class="mt-3 space-y-1.5 border-l-2 border-white/[0.08] pl-3">
+            <div class="flex min-h-[1.625rem] flex-wrap items-center gap-x-3 gap-y-1.5">
+              <span class="text-xs font-semibold text-gray-300">Effort levels</span>
+              <template v-if="supportedEfforts.length > 0">
                 <button
-                  v-if="editable"
+                  v-for="level in supportedEfforts"
+                  :key="level"
                   type="button"
-                  class="ml-0.5 text-gray-500 transition-colors hover:text-accent-rose"
-                  :aria-label="`Remove ${level}`"
-                  @click="removeReasoningLevel(level)"
+                  class="inline-flex items-center gap-1 rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
+                  :class="[
+                    config.chat?.reasoning?.effort?.default === level
+                      ? 'border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan font-semibold'
+                      : 'border-white/15 bg-white/[0.07] text-gray-300 hover:border-white/30 hover:text-white',
+                    editable ? 'cursor-pointer' : 'cursor-not-allowed',
+                  ]"
+                  :disabled="!editable"
+                  :title="config.chat?.reasoning?.effort?.default === level ? 'Default — click another to switch' : 'Click to set as default'"
+                  @click="setDefaultEffort(level)"
                 >
-                  <svg class="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M9 3 3 9M3 3l6 6" />
-                  </svg>
+                  {{ level }}
+                  <span
+                    v-if="editable"
+                    role="button"
+                    tabindex="0"
+                    class="ml-0.5 cursor-pointer text-gray-500 transition-colors hover:text-accent-rose"
+                    :aria-label="`Remove ${level}`"
+                    @click.stop="removeReasoningLevel(level)"
+                    @keydown.enter.stop.prevent="removeReasoningLevel(level)"
+                  >
+                    <svg class="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M9 3 3 9M3 3l6 6" />
+                    </svg>
+                  </span>
                 </button>
-              </span>
+              </template>
+              <p v-else class="whitespace-nowrap text-[11px] text-accent-amber">Add at least one effort level — click a preset on the right.</p>
             </div>
             <div v-if="editable" class="flex flex-wrap items-center gap-1.5">
+              <span class="text-[11px] text-gray-500">add:</span>
               <button
-                v-for="level in REASONING_LEVELS"
+                v-for="level in presetEffortLevels"
                 :key="level"
                 type="button"
-                class="rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
-                :class="supportedEfforts.includes(level)
-                  ? 'border-white/10 text-gray-600 cursor-default'
-                  : 'border-white/15 text-gray-400 hover:border-accent-cyan/40 hover:text-accent-cyan'"
-                :disabled="supportedEfforts.includes(level)"
+                class="rounded border border-white/15 px-2 py-0.5 font-mono text-[11px] text-gray-400 transition-colors hover:border-accent-cyan/40 hover:text-accent-cyan"
                 @click="addReasoningLevel(level)"
               >+ {{ level }}</button>
               <Input
                 v-model="reasoningLevelInput"
+                size="sm"
                 placeholder="custom…"
-                class="!w-32 font-mono"
+                class="!h-6 !w-28 !py-0 !text-[11px] font-mono"
                 @keydown.enter.prevent="commitReasoningInput"
               />
-              <Button variant="secondary" size="sm" @click="commitReasoningInput">Add</Button>
-            </div>
-            <p v-if="supportedEfforts.length === 0" class="text-[11px] text-accent-rose">Add at least one effort level.</p>
-            <div class="flex items-center gap-2">
-              <span class="text-xs text-gray-500">Default:</span>
-              <Select
-                v-if="editable"
-                class="!w-32"
-                :model-value="config.chat?.reasoning?.effort?.default ?? ''"
-                :options="[{ value: '', label: '— none —' }, ...supportedEfforts.map(e => ({ value: e, label: e }))]"
-                :disabled="supportedEfforts.length === 0"
-                @update:model-value="v => setDefaultEffort(v as string)"
-              />
-              <span v-else class="font-mono text-xs text-gray-400">{{ config.chat?.reasoning?.effort?.default || '—' }}</span>
-              <p v-if="config.chat?.reasoning?.effort && !config.chat.reasoning.effort.default && supportedEfforts.length > 0" class="text-[11px] text-accent-rose">
-                Default cleared — pick a level.
-              </p>
+              <Button variant="secondary" size="sm" class="!h-6 !px-2 !py-0 !text-[11px]" @click="commitReasoningInput">Add</Button>
             </div>
           </div>
 
           <div v-if="budgetTokensEnabled" class="mt-3 flex flex-wrap items-center gap-3 border-l-2 border-white/[0.08] pl-3">
-            <label class="flex items-center gap-2">
-              <span class="text-xs text-gray-500">Min</span>
+            <span class="text-xs font-semibold text-gray-300">Budget tokens</span>
+            <label class="flex items-center gap-1.5">
+              <span class="text-[11px] text-gray-500">Min</span>
               <Input
                 type="number"
                 min="0"
+                size="sm"
                 :model-value="config.chat?.reasoning?.budget_tokens?.min"
                 :readonly="!editable"
                 placeholder="—"
-                class="!w-28 font-mono"
+                class="!w-24 font-mono"
                 @update:model-value="v => updateBudgetTokensMin(v)"
               />
             </label>
-            <label class="flex items-center gap-2">
-              <span class="text-xs text-gray-500">Max</span>
+            <label class="flex items-center gap-1.5">
+              <span class="text-[11px] text-gray-500">Max</span>
               <Input
                 type="number"
                 min="0"
+                size="sm"
                 :model-value="config.chat?.reasoning?.budget_tokens?.max"
                 :readonly="!editable"
                 placeholder="—"
-                class="!w-28 font-mono"
+                class="!w-24 font-mono"
                 @update:model-value="v => updateBudgetTokensMax(v)"
               />
             </label>
@@ -856,7 +857,7 @@ const toggleMandatory = (on: boolean) => {
               v-if="config.chat?.reasoning?.budget_tokens?.min !== undefined
                 && config.chat?.reasoning?.budget_tokens?.max !== undefined
                 && config.chat.reasoning.budget_tokens.max < config.chat.reasoning.budget_tokens.min"
-              class="text-[11px] text-accent-rose"
+              class="text-[11px] text-accent-amber"
             >
               Max must be ≥ min.
             </p>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -409,6 +409,55 @@ const setDefaultEffort = (value: string) => {
   patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ effort: { supported: current, default: value } }) }) });
 };
 
+// ── Effort tag drag-to-reorder ─────────────────────────────────────────────
+//
+// HTML5 DnD distinguishes drag from click via a built-in pointer-distance
+// threshold: a mousedown+mouseup with no movement still fires `click` (and
+// sets the default), while a mousedown+drag+drop suppresses click entirely.
+// So the two affordances coexist on the same button element.
+const draggedEffortIndex = ref<number | null>(null);
+const dragOverEffortIndex = ref<number | null>(null);
+
+const onEffortDragStart = (index: number, e: DragEvent) => {
+  if (!editable.value) return;
+  draggedEffortIndex.value = index;
+  if (e.dataTransfer) {
+    e.dataTransfer.effectAllowed = 'move';
+    // Firefox requires setData to actually initiate the drag.
+    e.dataTransfer.setData('text/plain', String(index));
+  }
+};
+
+const onEffortDragOver = (index: number, e: DragEvent) => {
+  if (draggedEffortIndex.value === null) return;
+  e.preventDefault();
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+  dragOverEffortIndex.value = index;
+};
+
+const onEffortDragLeave = (index: number) => {
+  if (dragOverEffortIndex.value === index) dragOverEffortIndex.value = null;
+};
+
+const onEffortDrop = (index: number, e: DragEvent) => {
+  e.preventDefault();
+  const from = draggedEffortIndex.value;
+  draggedEffortIndex.value = null;
+  dragOverEffortIndex.value = null;
+  if (from === null || from === index || !config.value) return;
+  const current = [...supportedEfforts.value];
+  const [moved] = current.splice(from, 1);
+  if (moved === undefined) return;
+  current.splice(index, 0, moved);
+  const existing = config.value.chat?.reasoning?.effort;
+  patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ effort: { supported: current, default: existing?.default ?? '' } }) }) });
+};
+
+const onEffortDragEnd = () => {
+  draggedEffortIndex.value = null;
+  dragOverEffortIndex.value = null;
+};
+
 // ── Budget tokens sub-block ────────────────────────────────────────────────
 
 const toggleBudgetTokens = (on: boolean) => {
@@ -785,7 +834,7 @@ const toggleMandatory = (on: boolean) => {
               <span class="text-[11px] text-gray-500">(click to set default)</span>
               <template v-if="supportedEfforts.length > 0">
                 <button
-                  v-for="level in supportedEfforts"
+                  v-for="(level, index) in supportedEfforts"
                   :key="level"
                   type="button"
                   class="inline-flex items-center gap-1 rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
@@ -793,11 +842,19 @@ const toggleMandatory = (on: boolean) => {
                     config.chat?.reasoning?.effort?.default === level
                       ? 'border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan font-semibold'
                       : 'border-white/15 bg-white/[0.07] text-gray-300 hover:border-white/30 hover:text-white',
-                    editable ? 'cursor-pointer' : 'cursor-not-allowed',
+                    editable ? 'cursor-grab active:cursor-grabbing' : 'cursor-not-allowed',
+                    draggedEffortIndex === index && 'opacity-40',
+                    dragOverEffortIndex === index && draggedEffortIndex !== index && 'ring-1 ring-accent-cyan',
                   ]"
                   :disabled="!editable"
-                  :title="config.chat?.reasoning?.effort?.default === level ? 'Default — click another to switch' : 'Click to set as default'"
+                  :draggable="editable"
+                  :title="config.chat?.reasoning?.effort?.default === level ? 'Default — click another to switch, drag to reorder' : 'Click to set as default, drag to reorder'"
                   @click="setDefaultEffort(level)"
+                  @dragstart="e => onEffortDragStart(index, e)"
+                  @dragover="e => onEffortDragOver(index, e)"
+                  @dragleave="onEffortDragLeave(index)"
+                  @drop="e => onEffortDrop(index, e)"
+                  @dragend="onEffortDragEnd"
                 >
                   {{ level }}
                   <span

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -748,12 +748,12 @@ const toggleMandatory = (on: boolean) => {
             <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
               <Switch :model-value="adaptiveEnabled" :disabled="!editable" @update:model-value="v => toggleAdaptive(v === true)" />
               <span class="text-xs" :class="adaptiveEnabled ? 'text-white' : 'text-gray-500'">Adaptive</span>
-              <Tooltip text="Model self-selects reasoning effort"><span class="text-[10px] text-gray-600">?</span></Tooltip>
+              <Tooltip content="Model self-selects reasoning effort"><span class="text-[10px] text-gray-600">?</span></Tooltip>
             </label>
             <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
               <Switch :model-value="mandatoryEnabled" :disabled="!editable" @update:model-value="v => toggleMandatory(v === true)" />
               <span class="text-xs" :class="mandatoryEnabled ? 'text-white' : 'text-gray-500'">Mandatory</span>
-              <Tooltip text="Reasoning is always applied; caller cannot opt out"><span class="text-[10px] text-gray-600">?</span></Tooltip>
+              <Tooltip content="Reasoning is always applied; caller cannot opt out"><span class="text-[10px] text-gray-600">?</span></Tooltip>
             </label>
           </div>
 

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -4,7 +4,7 @@ import { computed, ref, watch } from 'vue';
 import EndpointsField from './EndpointsField.vue';
 import FlagOverridesEditor from './FlagOverridesEditor.vue';
 import { configOf, defaultEndpointsForKind, publicIdOf, titleFor, type Row } from './modelRows.ts';
-import type { BillingDimension, FlagDef, ModelKind, ModelPricing, UpstreamModelConfig, UpstreamProviderKind } from '../../api/types.ts';
+import type { BillingDimension, FlagDef, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig, UpstreamProviderKind } from '../../api/types.ts';
 import { Button, Input, Select, Switch, Tooltip } from '@floway-dev/ui';
 
 const props = defineProps<{
@@ -26,6 +26,7 @@ const emit = defineEmits<{
   'patch-config': [patch: Partial<UpstreamModelConfig>];
   'set-mode': [next: 'auto' | 'manual'];
   remove: [];
+  'validity-change': [valid: boolean];
 }>();
 
 const kindOptions: { value: ModelKind; label: string }[] = [
@@ -250,6 +251,102 @@ const toggleFlagOverridesEnabled = () => {
 
 const updateFlagOverrides = (values: Record<string, boolean>) => {
   patch({ flagOverrides: { enabled: true, values } });
+};
+
+// ── Chat metadata ──────────────────────────────────────────────────────────
+
+// Known Codex CLI effort presets as of v0.137. Codex's wire type is open
+// (ReasoningEffort::Custom(String)) so any string is accepted upstream;
+// these are just the convenient quick-adds. See:
+// https://github.com/openai/codex/blob/main/codex-rs/protocol/src/openai_models.rs
+const REASONING_LEVELS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'ultra'] as const;
+
+// Free-typing input for adding a custom reasoning level not in the quick-add list.
+const reasoningLevelInput = ref('');
+
+// Resync input buffer when the active row changes.
+watch(() => props.row?.uiId, () => {
+  reasoningLevelInput.value = '';
+});
+
+const chatImageInput = computed<boolean>(
+  () => config.value?.chat?.modalities?.input.includes('image') ?? false,
+);
+
+// TODO (Task 18): Redesign this section to surface all four reasoning sub-blocks
+// (effort, budget_tokens, adaptive, mandatory). Currently only effort is editable.
+const supportedEfforts = computed<string[]>(
+  () => config.value?.chat?.reasoning?.effort?.supported ?? [],
+);
+
+// A chat row is invalid when effort reasoning exists but default is empty or not
+// in effort.supported. The save button must be blocked in that state.
+const isReasoningValid = computed<boolean>(() => {
+  const reasoning = config.value?.chat?.reasoning;
+  if (!reasoning) return true;
+  if (!reasoning.effort) return true;
+  return reasoning.effort.default !== '' && reasoning.effort.supported.includes(reasoning.effort.default);
+});
+
+watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediate: true });
+
+const buildNextChat = (partial: Partial<UpstreamChatConfig>): UpstreamChatConfig | undefined => {
+  const base = config.value?.chat ?? {};
+  const next: UpstreamChatConfig = { ...base, ...partial };
+
+  // Normalise: omit modalities when it would only carry the default (text-only) shape.
+  const hasImageInput = next.modalities?.input.includes('image') === true;
+  next.modalities = hasImageInput
+    ? { input: ['text', 'image'], output: ['text'] }
+    : undefined;
+
+  // Omit reasoning when the effort list is empty (other sub-blocks preserved by Task 18 redesign).
+  if (!next.reasoning?.effort || next.reasoning.effort.supported.length === 0) {
+    const { effort: _effort, ...rest } = next.reasoning ?? {};
+    next.reasoning = Object.keys(rest).length > 0 ? rest : undefined;
+  }
+
+  // Return undefined (omit chat key entirely) when nothing is configured.
+  if (!next.modalities && !next.reasoning) return undefined;
+  return next;
+};
+
+const toggleImageInput = (on: boolean) => {
+  if (!editable.value) return;
+  patch({ chat: buildNextChat({ modalities: on ? { input: ['text', 'image'], output: ['text'] } : undefined }) });
+};
+
+const addReasoningLevel = (level: string) => {
+  if (!editable.value || !config.value) return;
+  const trimmed = level.trim();
+  if (!trimmed) return;
+  const current = supportedEfforts.value;
+  if (current.includes(trimmed)) return;
+  const updated = [...current, trimmed];
+  const existing = config.value.chat?.reasoning?.effort;
+  patch({ chat: buildNextChat({ reasoning: { ...config.value.chat?.reasoning, effort: { supported: updated, default: existing?.default ?? '' } } }) });
+};
+
+const removeReasoningLevel = (level: string) => {
+  if (!editable.value || !config.value) return;
+  const updated = supportedEfforts.value.filter(e => e !== level);
+  const existingEffort = config.value.chat?.reasoning?.effort;
+  const nextDefault = existingEffort?.default === level ? '' : (existingEffort?.default ?? '');
+  const nextEffort = updated.length > 0 ? { supported: updated, default: nextDefault } : undefined;
+  patch({ chat: buildNextChat({ reasoning: nextEffort !== undefined ? { ...config.value.chat?.reasoning, effort: nextEffort } : (({ effort: _e, ...rest }) => Object.keys(rest).length > 0 ? rest : undefined)(config.value.chat?.reasoning ?? {}) }) });
+};
+
+const commitReasoningInput = () => {
+  const trimmed = reasoningLevelInput.value.trim();
+  if (!trimmed) return;
+  addReasoningLevel(trimmed);
+  reasoningLevelInput.value = '';
+};
+
+const setDefaultEffort = (value: string) => {
+  if (!editable.value || !config.value) return;
+  const current = supportedEfforts.value;
+  patch({ chat: buildNextChat({ reasoning: { ...config.value.chat?.reasoning, effort: { supported: current, default: value } } }) });
 };
 </script>
 
@@ -529,6 +626,104 @@ const updateFlagOverrides = (values: Record<string, boolean>) => {
                     />
                   </label>
                 </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section v-if="rowKind === 'chat'">
+          <div class="mb-3 flex items-baseline gap-3">
+            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Chat</h3>
+            <span class="text-[11px] text-gray-500">modalities and reasoning capabilities</span>
+          </div>
+
+          <!-- Image input toggle -->
+          <div class="mb-4 space-y-2">
+            <span class="block text-xs font-medium text-gray-500">Input Modalities</span>
+            <div class="flex flex-wrap items-center gap-4">
+              <label class="flex cursor-not-allowed items-center gap-2">
+                <input type="checkbox" class="sr-only" checked disabled />
+                <span class="inline-flex h-4 w-4 items-center justify-center rounded border border-white/20 bg-white/10">
+                  <svg class="h-2.5 w-2.5 text-gray-400" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M2 6l3 3 5-5" />
+                  </svg>
+                </span>
+                <span class="text-xs text-gray-500">Text (always on)</span>
+              </label>
+              <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
+                <Switch
+                  :model-value="chatImageInput"
+                  :disabled="!editable"
+                  @update:model-value="v => toggleImageInput(v === true)"
+                />
+                <span class="text-xs" :class="chatImageInput ? 'text-white' : 'text-gray-500'">Image</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Reasoning levels tag input -->
+          <div class="mb-4 space-y-2">
+            <span class="block text-xs font-medium text-gray-500">Supported Reasoning Levels</span>
+            <div v-if="supportedEfforts.length > 0" class="mb-2 flex flex-wrap gap-1.5">
+              <span
+                v-for="level in supportedEfforts"
+                :key="level"
+                class="inline-flex items-center gap-1 rounded border border-white/15 bg-white/[0.07] px-2 py-0.5 font-mono text-[11px] text-gray-300"
+              >
+                {{ level }}
+                <button
+                  v-if="editable"
+                  type="button"
+                  class="ml-0.5 text-gray-500 transition-colors hover:text-accent-rose"
+                  :aria-label="`Remove ${level}`"
+                  @click="removeReasoningLevel(level)"
+                >
+                  <svg class="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M9 3 3 9M3 3l6 6" />
+                  </svg>
+                </button>
+              </span>
+            </div>
+            <div v-if="editable" class="flex flex-wrap gap-1.5">
+              <button
+                v-for="level in REASONING_LEVELS"
+                :key="level"
+                type="button"
+                class="rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
+                :class="supportedEfforts.includes(level)
+                  ? 'border-white/10 text-gray-600 cursor-default'
+                  : 'border-white/15 text-gray-400 hover:border-accent-cyan/40 hover:text-accent-cyan'"
+                :disabled="supportedEfforts.includes(level)"
+                @click="addReasoningLevel(level)"
+              >+ {{ level }}</button>
+            </div>
+            <div v-if="editable" class="flex max-w-xs gap-2">
+              <Input
+                v-model="reasoningLevelInput"
+                placeholder="custom level…"
+                class="font-mono"
+                @keydown.enter.prevent="commitReasoningInput"
+              />
+              <Button variant="secondary" size="sm" @click="commitReasoningInput">Add</Button>
+            </div>
+          </div>
+
+          <!-- Default reasoning level -->
+          <div class="space-y-2">
+            <span class="block text-xs font-medium text-gray-500">Default Reasoning Level</span>
+            <p v-if="rowKind === 'chat' && config.chat?.reasoning?.effort && !config.chat.reasoning.effort.default" class="text-[11px] text-accent-rose">
+              Default cleared — selected level is no longer in the list.
+            </p>
+            <div class="max-w-xs">
+              <Select
+                v-if="editable"
+                :model-value="config.chat?.reasoning?.effort?.default ?? ''"
+                :options="[{ value: '', label: '— none —' }, ...supportedEfforts.map(e => ({ value: e, label: e }))]"
+                :disabled="supportedEfforts.length === 0"
+                @update:model-value="v => setDefaultEffort(v as string)"
+              />
+              <div v-else class="text-xs text-gray-500">
+                {{ config.chat?.reasoning?.effort?.default || '—' }}
               </div>
             </div>
           </div>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -717,193 +717,138 @@ const toggleMandatory = (on: boolean) => {
 
         <section v-if="rowKind === 'chat'">
           <div class="mb-3 flex items-baseline gap-3">
-            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Chat</h3>
-            <span class="text-[11px] text-gray-500">modalities and reasoning capabilities</span>
+            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Modalities</h3>
+            <span class="text-[11px] text-gray-500">text is always supported; toggle additional inputs</span>
+          </div>
+          <label class="flex w-fit items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
+            <Switch
+              :model-value="chatImageInput"
+              :disabled="!editable"
+              @update:model-value="v => toggleImageInput(v === true)"
+            />
+            <span class="text-xs" :class="chatImageInput ? 'text-white' : 'text-gray-500'">Image input</span>
+          </label>
+        </section>
+
+        <section v-if="rowKind === 'chat'">
+          <div class="mb-3 flex items-baseline gap-3">
+            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Reasoning</h3>
+            <span class="text-[11px] text-gray-500">enable any subset; details expand under each toggle</span>
           </div>
 
-          <!-- Input Modalities -->
-          <div class="mb-6 space-y-2">
-            <span class="block text-xs font-medium text-gray-500">Input Modalities</span>
-            <div class="flex flex-wrap items-center gap-4">
-              <label class="flex cursor-not-allowed items-center gap-2">
-                <input type="checkbox" class="sr-only" checked disabled />
-                <span class="inline-flex h-4 w-4 items-center justify-center rounded border border-white/20 bg-white/10">
-                  <svg class="h-2.5 w-2.5 text-gray-400" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M2 6l3 3 5-5" />
-                  </svg>
-                </span>
-                <span class="text-xs text-gray-500">Text (always on)</span>
-              </label>
-              <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
-                <Switch
-                  :model-value="chatImageInput"
-                  :disabled="!editable"
-                  @update:model-value="v => toggleImageInput(v === true)"
-                />
-                <span class="text-xs" :class="chatImageInput ? 'text-white' : 'text-gray-500'">Image</span>
-              </label>
-            </div>
+          <div class="flex flex-wrap gap-x-6 gap-y-2">
+            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
+              <Switch :model-value="effortEnabled" :disabled="!editable" @update:model-value="v => toggleEffort(v === true)" />
+              <span class="text-xs" :class="effortEnabled ? 'text-white' : 'text-gray-500'">Effort levels</span>
+            </label>
+            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
+              <Switch :model-value="budgetTokensEnabled" :disabled="!editable" @update:model-value="v => toggleBudgetTokens(v === true)" />
+              <span class="text-xs" :class="budgetTokensEnabled ? 'text-white' : 'text-gray-500'">Budget tokens</span>
+            </label>
+            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
+              <Switch :model-value="adaptiveEnabled" :disabled="!editable" @update:model-value="v => toggleAdaptive(v === true)" />
+              <span class="text-xs" :class="adaptiveEnabled ? 'text-white' : 'text-gray-500'">Adaptive</span>
+              <Tooltip text="Model self-selects reasoning effort"><span class="text-[10px] text-gray-600">?</span></Tooltip>
+            </label>
+            <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
+              <Switch :model-value="mandatoryEnabled" :disabled="!editable" @update:model-value="v => toggleMandatory(v === true)" />
+              <span class="text-xs" :class="mandatoryEnabled ? 'text-white' : 'text-gray-500'">Mandatory</span>
+              <Tooltip text="Reasoning is always applied; caller cannot opt out"><span class="text-[10px] text-gray-600">?</span></Tooltip>
+            </label>
           </div>
 
-          <!-- Reasoning group -->
-          <div class="space-y-4">
-            <span class="block text-xs font-medium text-gray-500">Reasoning</span>
-
-            <!-- Effort levels sub-block -->
-            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
-              <div class="mb-3 flex items-center gap-3">
-                <Switch
-                  :model-value="effortEnabled"
-                  :disabled="!editable"
-                  @update:model-value="v => toggleEffort(v === true)"
-                />
-                <span class="text-xs font-medium" :class="effortEnabled ? 'text-white' : 'text-gray-500'">Effort levels</span>
-              </div>
-              <template v-if="effortEnabled">
-                <!-- Tag list -->
-                <div v-if="supportedEfforts.length > 0" class="mb-2 flex flex-wrap gap-1.5">
-                  <span
-                    v-for="level in supportedEfforts"
-                    :key="level"
-                    class="inline-flex items-center gap-1 rounded border border-white/15 bg-white/[0.07] px-2 py-0.5 font-mono text-[11px] text-gray-300"
-                  >
-                    {{ level }}
-                    <button
-                      v-if="editable"
-                      type="button"
-                      class="ml-0.5 text-gray-500 transition-colors hover:text-accent-rose"
-                      :aria-label="`Remove ${level}`"
-                      @click="removeReasoningLevel(level)"
-                    >
-                      <svg class="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M9 3 3 9M3 3l6 6" />
-                      </svg>
-                    </button>
-                  </span>
-                </div>
-                <!-- Quick-add buttons -->
-                <div v-if="editable" class="mb-2 flex flex-wrap gap-1.5">
-                  <button
-                    v-for="level in REASONING_LEVELS"
-                    :key="level"
-                    type="button"
-                    class="rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
-                    :class="supportedEfforts.includes(level)
-                      ? 'border-white/10 text-gray-600 cursor-default'
-                      : 'border-white/15 text-gray-400 hover:border-accent-cyan/40 hover:text-accent-cyan'"
-                    :disabled="supportedEfforts.includes(level)"
-                    @click="addReasoningLevel(level)"
-                  >+ {{ level }}</button>
-                </div>
-                <!-- Custom level input -->
-                <div v-if="editable" class="mb-4 flex max-w-xs gap-2">
-                  <Input
-                    v-model="reasoningLevelInput"
-                    placeholder="custom level…"
-                    class="font-mono"
-                    @keydown.enter.prevent="commitReasoningInput"
-                  />
-                  <Button variant="secondary" size="sm" @click="commitReasoningInput">Add</Button>
-                </div>
-                <!-- Validation message -->
-                <p v-if="effortEnabled && supportedEfforts.length === 0" class="mb-3 text-[11px] text-accent-rose">
-                  Add at least one effort level.
-                </p>
-                <!-- Default level -->
-                <div class="space-y-1.5">
-                  <span class="block text-xs font-medium text-gray-500">Default level</span>
-                  <p v-if="config.chat?.reasoning?.effort && !config.chat.reasoning.effort.default && supportedEfforts.length > 0" class="text-[11px] text-accent-rose">
-                    Default cleared — select a level from the list.
-                  </p>
-                  <div class="max-w-xs">
-                    <Select
-                      v-if="editable"
-                      :model-value="config.chat?.reasoning?.effort?.default ?? ''"
-                      :options="[{ value: '', label: '— none —' }, ...supportedEfforts.map(e => ({ value: e, label: e }))]"
-                      :disabled="supportedEfforts.length === 0"
-                      @update:model-value="v => setDefaultEffort(v as string)"
-                    />
-                    <div v-else class="text-xs text-gray-500">
-                      {{ config.chat?.reasoning?.effort?.default || '—' }}
-                    </div>
-                  </div>
-                </div>
-              </template>
-            </div>
-
-            <!-- Budget tokens sub-block -->
-            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
-              <div class="mb-3 flex items-center gap-3">
-                <Switch
-                  :model-value="budgetTokensEnabled"
-                  :disabled="!editable"
-                  @update:model-value="v => toggleBudgetTokens(v === true)"
-                />
-                <span class="text-xs font-medium" :class="budgetTokensEnabled ? 'text-white' : 'text-gray-500'">Budget tokens</span>
-              </div>
-              <template v-if="budgetTokensEnabled">
-                <div class="grid gap-3 sm:grid-cols-2">
-                  <label class="block space-y-1.5">
-                    <span class="block text-xs font-medium text-gray-500">Min tokens</span>
-                    <Input
-                      type="number"
-                      min="0"
-                      :model-value="config.chat?.reasoning?.budget_tokens?.min"
-                      :readonly="!editable"
-                      placeholder="no minimum"
-                      class="font-mono"
-                      @update:model-value="v => updateBudgetTokensMin(v)"
-                    />
-                  </label>
-                  <label class="block space-y-1.5">
-                    <span class="block text-xs font-medium text-gray-500">Max tokens</span>
-                    <Input
-                      type="number"
-                      min="0"
-                      :model-value="config.chat?.reasoning?.budget_tokens?.max"
-                      :readonly="!editable"
-                      placeholder="no maximum"
-                      class="font-mono"
-                      @update:model-value="v => updateBudgetTokensMax(v)"
-                    />
-                  </label>
-                </div>
-                <p
-                  v-if="config.chat?.reasoning?.budget_tokens?.min !== undefined
-                    && config.chat?.reasoning?.budget_tokens?.max !== undefined
-                    && config.chat.reasoning.budget_tokens.max < config.chat.reasoning.budget_tokens.min"
-                  class="mt-2 text-[11px] text-accent-rose"
+          <div v-if="effortEnabled" class="mt-3 space-y-2 border-l-2 border-white/[0.08] pl-3">
+            <div v-if="supportedEfforts.length > 0" class="flex flex-wrap gap-1.5">
+              <span
+                v-for="level in supportedEfforts"
+                :key="level"
+                class="inline-flex items-center gap-1 rounded border border-white/15 bg-white/[0.07] px-2 py-0.5 font-mono text-[11px] text-gray-300"
+              >
+                {{ level }}
+                <button
+                  v-if="editable"
+                  type="button"
+                  class="ml-0.5 text-gray-500 transition-colors hover:text-accent-rose"
+                  :aria-label="`Remove ${level}`"
+                  @click="removeReasoningLevel(level)"
                 >
-                  Max must be greater than or equal to min.
-                </p>
-              </template>
+                  <svg class="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M9 3 3 9M3 3l6 6" />
+                  </svg>
+                </button>
+              </span>
             </div>
+            <div v-if="editable" class="flex flex-wrap items-center gap-1.5">
+              <button
+                v-for="level in REASONING_LEVELS"
+                :key="level"
+                type="button"
+                class="rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
+                :class="supportedEfforts.includes(level)
+                  ? 'border-white/10 text-gray-600 cursor-default'
+                  : 'border-white/15 text-gray-400 hover:border-accent-cyan/40 hover:text-accent-cyan'"
+                :disabled="supportedEfforts.includes(level)"
+                @click="addReasoningLevel(level)"
+              >+ {{ level }}</button>
+              <Input
+                v-model="reasoningLevelInput"
+                placeholder="custom…"
+                class="!w-32 font-mono"
+                @keydown.enter.prevent="commitReasoningInput"
+              />
+              <Button variant="secondary" size="sm" @click="commitReasoningInput">Add</Button>
+            </div>
+            <p v-if="supportedEfforts.length === 0" class="text-[11px] text-accent-rose">Add at least one effort level.</p>
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-gray-500">Default:</span>
+              <Select
+                v-if="editable"
+                class="!w-32"
+                :model-value="config.chat?.reasoning?.effort?.default ?? ''"
+                :options="[{ value: '', label: '— none —' }, ...supportedEfforts.map(e => ({ value: e, label: e }))]"
+                :disabled="supportedEfforts.length === 0"
+                @update:model-value="v => setDefaultEffort(v as string)"
+              />
+              <span v-else class="font-mono text-xs text-gray-400">{{ config.chat?.reasoning?.effort?.default || '—' }}</span>
+              <p v-if="config.chat?.reasoning?.effort && !config.chat.reasoning.effort.default && supportedEfforts.length > 0" class="text-[11px] text-accent-rose">
+                Default cleared — pick a level.
+              </p>
+            </div>
+          </div>
 
-            <!-- Adaptive toggle -->
-            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
-              <div class="flex items-center gap-3">
-                <Switch
-                  :model-value="adaptiveEnabled"
-                  :disabled="!editable"
-                  @update:model-value="v => toggleAdaptive(v === true)"
-                />
-                <span class="text-xs font-medium" :class="adaptiveEnabled ? 'text-white' : 'text-gray-500'">Adaptive</span>
-                <span class="text-[11px] text-gray-600">model may self-select reasoning effort</span>
-              </div>
-            </div>
-
-            <!-- Mandatory toggle -->
-            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
-              <div class="flex items-center gap-3">
-                <Switch
-                  :model-value="mandatoryEnabled"
-                  :disabled="!editable"
-                  @update:model-value="v => toggleMandatory(v === true)"
-                />
-                <span class="text-xs font-medium" :class="mandatoryEnabled ? 'text-white' : 'text-gray-500'">Mandatory</span>
-                <span class="text-[11px] text-gray-600">reasoning is always applied, ignoring caller opt-out</span>
-              </div>
-            </div>
+          <div v-if="budgetTokensEnabled" class="mt-3 flex flex-wrap items-center gap-3 border-l-2 border-white/[0.08] pl-3">
+            <label class="flex items-center gap-2">
+              <span class="text-xs text-gray-500">Min</span>
+              <Input
+                type="number"
+                min="0"
+                :model-value="config.chat?.reasoning?.budget_tokens?.min"
+                :readonly="!editable"
+                placeholder="—"
+                class="!w-28 font-mono"
+                @update:model-value="v => updateBudgetTokensMin(v)"
+              />
+            </label>
+            <label class="flex items-center gap-2">
+              <span class="text-xs text-gray-500">Max</span>
+              <Input
+                type="number"
+                min="0"
+                :model-value="config.chat?.reasoning?.budget_tokens?.max"
+                :readonly="!editable"
+                placeholder="—"
+                class="!w-28 font-mono"
+                @update:model-value="v => updateBudgetTokensMax(v)"
+              />
+            </label>
+            <p
+              v-if="config.chat?.reasoning?.budget_tokens?.min !== undefined
+                && config.chat?.reasoning?.budget_tokens?.max !== undefined
+                && config.chat.reasoning.budget_tokens.max < config.chat.reasoning.budget_tokens.min"
+              class="text-[11px] text-accent-rose"
+            >
+              Max must be ≥ min.
+            </p>
           </div>
         </section>
 

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -273,23 +273,56 @@ const chatImageInput = computed<boolean>(
   () => config.value?.chat?.modalities?.input.includes('image') ?? false,
 );
 
-// TODO (Task 18): Redesign this section to surface all four reasoning sub-blocks
-// (effort, budget_tokens, adaptive, mandatory). Currently only effort is editable.
+// ── Reasoning sub-block enabled states ────────────────────────────────────
+
+const effortEnabled = computed(() => config.value?.chat?.reasoning?.effort !== undefined);
+const budgetTokensEnabled = computed(() => config.value?.chat?.reasoning?.budget_tokens !== undefined);
+const adaptiveEnabled = computed(() => config.value?.chat?.reasoning?.adaptive === true);
+const mandatoryEnabled = computed(() => config.value?.chat?.reasoning?.mandatory === true);
+
+// Auto-show the reasoning group header when any sub-block is enabled.
+const reasoningExpanded = computed(
+  () => effortEnabled.value || budgetTokensEnabled.value || adaptiveEnabled.value || mandatoryEnabled.value,
+);
+
 const supportedEfforts = computed<string[]>(
   () => config.value?.chat?.reasoning?.effort?.supported ?? [],
 );
 
-// A chat row is invalid when effort reasoning exists but default is empty or not
-// in effort.supported. The save button must be blocked in that state.
+// ── Validity ───────────────────────────────────────────────────────────────
+
+// A chat row is invalid when:
+// - effort is enabled but supported list is empty
+// - effort is enabled but default is empty or not in supported
+// - budget_tokens is enabled but max < min (when both are set)
+// - reasoning block is "on" (at least one toggle) but produces empty {}
 const isReasoningValid = computed<boolean>(() => {
   const reasoning = config.value?.chat?.reasoning;
-  if (!reasoning) return true;
-  if (!reasoning.effort) return true;
-  return reasoning.effort.default !== '' && reasoning.effort.supported.includes(reasoning.effort.default);
+
+  if (effortEnabled.value) {
+    const effort = reasoning?.effort;
+    if (!effort || effort.supported.length === 0) return false;
+    if (effort.default === '' || !effort.supported.includes(effort.default)) return false;
+  }
+
+  if (budgetTokensEnabled.value) {
+    const bt = reasoning?.budget_tokens;
+    if (bt?.min !== undefined && bt?.max !== undefined && bt.max < bt.min) return false;
+  }
+
+  // If at least one toggle is on but reasoning reduces to empty object → invalid.
+  if (reasoningExpanded.value && reasoning !== undefined) {
+    const hasAnyKey = Object.keys(reasoning).some(k => reasoning[k as keyof typeof reasoning] !== undefined);
+    if (!hasAnyKey) return false;
+  }
+
+  return true;
 });
 });
 
 watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediate: true });
+
+// ── Chat state builder ─────────────────────────────────────────────────────
 
 const buildNextChat = (partial: Partial<UpstreamChatConfig>): UpstreamChatConfig | undefined => {
   const base = config.value?.chat ?? {};
@@ -301,20 +334,37 @@ const buildNextChat = (partial: Partial<UpstreamChatConfig>): UpstreamChatConfig
     ? { input: ['text', 'image'], output: ['text'] }
     : undefined;
 
-  // Omit reasoning when the effort list is empty (other sub-blocks preserved by Task 18 redesign).
-  if (!next.reasoning?.effort || next.reasoning.effort.supported.length === 0) {
-    const { effort: _effort, ...rest } = next.reasoning ?? {};
-    next.reasoning = Object.keys(rest).length > 0 ? rest : undefined;
-  }
-
   // Return undefined (omit chat key entirely) when nothing is configured.
   if (!next.modalities && !next.reasoning) return undefined;
   return next;
 };
 
+// Build a reasoning object with a single key updated, dropping undefined keys.
+const buildNextReasoning = (
+  update: Partial<NonNullable<UpstreamChatConfig['reasoning']>>,
+): UpstreamChatConfig['reasoning'] => {
+  const base = config.value?.chat?.reasoning ?? {};
+  const merged = { ...base, ...update };
+  // Drop keys explicitly set to undefined.
+  const cleaned = Object.fromEntries(
+    Object.entries(merged).filter(([, v]) => v !== undefined),
+  ) as UpstreamChatConfig['reasoning'];
+  return cleaned && Object.keys(cleaned).length > 0 ? cleaned : undefined;
+};
+
 const toggleImageInput = (on: boolean) => {
   if (!editable.value) return;
   patch({ chat: buildNextChat({ modalities: on ? { input: ['text', 'image'], output: ['text'] } : undefined }) });
+};
+
+// ── Effort sub-block ───────────────────────────────────────────────────────
+
+const toggleEffort = (on: boolean) => {
+  if (!editable.value) return;
+  const reasoning = on
+    ? buildNextReasoning({ effort: { supported: [], default: '' } })
+    : buildNextReasoning({ effort: undefined });
+  patch({ chat: buildNextChat({ reasoning }) });
 };
 
 const addReasoningLevel = (level: string) => {
@@ -325,7 +375,7 @@ const addReasoningLevel = (level: string) => {
   if (current.includes(trimmed)) return;
   const updated = [...current, trimmed];
   const existing = config.value.chat?.reasoning?.effort;
-  patch({ chat: buildNextChat({ reasoning: { ...config.value.chat?.reasoning, effort: { supported: updated, default: existing?.default ?? '' } } }) });
+  patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ effort: { supported: updated, default: existing?.default ?? '' } }) }) });
 };
 
 const removeReasoningLevel = (level: string) => {
@@ -334,7 +384,7 @@ const removeReasoningLevel = (level: string) => {
   const existingEffort = config.value.chat?.reasoning?.effort;
   const nextDefault = existingEffort?.default === level ? '' : (existingEffort?.default ?? '');
   const nextEffort = updated.length > 0 ? { supported: updated, default: nextDefault } : undefined;
-  patch({ chat: buildNextChat({ reasoning: nextEffort !== undefined ? { ...config.value.chat?.reasoning, effort: nextEffort } : (({ effort: _e, ...rest }) => Object.keys(rest).length > 0 ? rest : undefined)(config.value.chat?.reasoning ?? {}) }) });
+  patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ effort: nextEffort }) }) });
 };
 
 const commitReasoningInput = () => {
@@ -347,7 +397,53 @@ const commitReasoningInput = () => {
 const setDefaultEffort = (value: string) => {
   if (!editable.value || !config.value) return;
   const current = supportedEfforts.value;
-  patch({ chat: buildNextChat({ reasoning: { ...config.value.chat?.reasoning, effort: { supported: current, default: value } } }) });
+  patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ effort: { supported: current, default: value } }) }) });
+};
+
+// ── Budget tokens sub-block ────────────────────────────────────────────────
+
+const toggleBudgetTokens = (on: boolean) => {
+  if (!editable.value) return;
+  const reasoning = on
+    ? buildNextReasoning({ budget_tokens: {} })
+    : buildNextReasoning({ budget_tokens: undefined });
+  patch({ chat: buildNextChat({ reasoning }) });
+};
+
+const updateBudgetTokensMin = (raw: string | number | null | undefined) => {
+  if (!editable.value || !config.value) return;
+  const num = parseOptionalNumber(raw);
+  const current = config.value.chat?.reasoning?.budget_tokens ?? {};
+  const next = { ...current };
+  if (num === undefined) delete next.min; else next.min = num;
+  patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ budget_tokens: next }) }) });
+};
+
+const updateBudgetTokensMax = (raw: string | number | null | undefined) => {
+  if (!editable.value || !config.value) return;
+  const num = parseOptionalNumber(raw);
+  const current = config.value.chat?.reasoning?.budget_tokens ?? {};
+  const next = { ...current };
+  if (num === undefined) delete next.max; else next.max = num;
+  patch({ chat: buildNextChat({ reasoning: buildNextReasoning({ budget_tokens: next }) }) });
+};
+
+// ── Adaptive / Mandatory toggles ───────────────────────────────────────────
+
+const toggleAdaptive = (on: boolean) => {
+  if (!editable.value) return;
+  const reasoning = on
+    ? buildNextReasoning({ adaptive: true })
+    : buildNextReasoning({ adaptive: undefined });
+  patch({ chat: buildNextChat({ reasoning }) });
+};
+
+const toggleMandatory = (on: boolean) => {
+  if (!editable.value) return;
+  const reasoning = on
+    ? buildNextReasoning({ mandatory: true })
+    : buildNextReasoning({ mandatory: undefined });
+  patch({ chat: buildNextChat({ reasoning }) });
 };
 </script>
 
@@ -638,8 +734,8 @@ const setDefaultEffort = (value: string) => {
             <span class="text-[11px] text-gray-500">modalities and reasoning capabilities</span>
           </div>
 
-          <!-- Image input toggle -->
-          <div class="mb-4 space-y-2">
+          <!-- Input Modalities -->
+          <div class="mb-6 space-y-2">
             <span class="block text-xs font-medium text-gray-500">Input Modalities</span>
             <div class="flex flex-wrap items-center gap-4">
               <label class="flex cursor-not-allowed items-center gap-2">
@@ -662,69 +758,163 @@ const setDefaultEffort = (value: string) => {
             </div>
           </div>
 
-          <!-- Reasoning levels tag input -->
-          <div class="mb-4 space-y-2">
-            <span class="block text-xs font-medium text-gray-500">Supported Reasoning Levels</span>
-            <div v-if="supportedEfforts.length > 0" class="mb-2 flex flex-wrap gap-1.5">
-              <span
-                v-for="level in supportedEfforts"
-                :key="level"
-                class="inline-flex items-center gap-1 rounded border border-white/15 bg-white/[0.07] px-2 py-0.5 font-mono text-[11px] text-gray-300"
-              >
-                {{ level }}
-                <button
-                  v-if="editable"
-                  type="button"
-                  class="ml-0.5 text-gray-500 transition-colors hover:text-accent-rose"
-                  :aria-label="`Remove ${level}`"
-                  @click="removeReasoningLevel(level)"
-                >
-                  <svg class="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M9 3 3 9M3 3l6 6" />
-                  </svg>
-                </button>
-              </span>
-            </div>
-            <div v-if="editable" class="flex flex-wrap gap-1.5">
-              <button
-                v-for="level in REASONING_LEVELS"
-                :key="level"
-                type="button"
-                class="rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
-                :class="supportedEfforts.includes(level)
-                  ? 'border-white/10 text-gray-600 cursor-default'
-                  : 'border-white/15 text-gray-400 hover:border-accent-cyan/40 hover:text-accent-cyan'"
-                :disabled="supportedEfforts.includes(level)"
-                @click="addReasoningLevel(level)"
-              >+ {{ level }}</button>
-            </div>
-            <div v-if="editable" class="flex max-w-xs gap-2">
-              <Input
-                v-model="reasoningLevelInput"
-                placeholder="custom level…"
-                class="font-mono"
-                @keydown.enter.prevent="commitReasoningInput"
-              />
-              <Button variant="secondary" size="sm" @click="commitReasoningInput">Add</Button>
-            </div>
-          </div>
+          <!-- Reasoning group -->
+          <div class="space-y-4">
+            <span class="block text-xs font-medium text-gray-500">Reasoning</span>
 
-          <!-- Default reasoning level -->
-          <div class="space-y-2">
-            <span class="block text-xs font-medium text-gray-500">Default Reasoning Level</span>
-            <p v-if="rowKind === 'chat' && config.chat?.reasoning?.effort && !config.chat.reasoning.effort.default" class="text-[11px] text-accent-rose">
-              Default cleared — selected level is no longer in the list.
-            </p>
-            <div class="max-w-xs">
-              <Select
-                v-if="editable"
-                :model-value="config.chat?.reasoning?.effort?.default ?? ''"
-                :options="[{ value: '', label: '— none —' }, ...supportedEfforts.map(e => ({ value: e, label: e }))]"
-                :disabled="supportedEfforts.length === 0"
-                @update:model-value="v => setDefaultEffort(v as string)"
-              />
-              <div v-else class="text-xs text-gray-500">
-                {{ config.chat?.reasoning?.effort?.default || '—' }}
+            <!-- Effort levels sub-block -->
+            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
+              <div class="mb-3 flex items-center gap-3">
+                <Switch
+                  :model-value="effortEnabled"
+                  :disabled="!editable"
+                  @update:model-value="v => toggleEffort(v === true)"
+                />
+                <span class="text-xs font-medium" :class="effortEnabled ? 'text-white' : 'text-gray-500'">Effort levels</span>
+              </div>
+              <template v-if="effortEnabled">
+                <!-- Tag list -->
+                <div v-if="supportedEfforts.length > 0" class="mb-2 flex flex-wrap gap-1.5">
+                  <span
+                    v-for="level in supportedEfforts"
+                    :key="level"
+                    class="inline-flex items-center gap-1 rounded border border-white/15 bg-white/[0.07] px-2 py-0.5 font-mono text-[11px] text-gray-300"
+                  >
+                    {{ level }}
+                    <button
+                      v-if="editable"
+                      type="button"
+                      class="ml-0.5 text-gray-500 transition-colors hover:text-accent-rose"
+                      :aria-label="`Remove ${level}`"
+                      @click="removeReasoningLevel(level)"
+                    >
+                      <svg class="h-2.5 w-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M9 3 3 9M3 3l6 6" />
+                      </svg>
+                    </button>
+                  </span>
+                </div>
+                <!-- Quick-add buttons -->
+                <div v-if="editable" class="mb-2 flex flex-wrap gap-1.5">
+                  <button
+                    v-for="level in REASONING_LEVELS"
+                    :key="level"
+                    type="button"
+                    class="rounded border px-2 py-0.5 font-mono text-[11px] transition-colors"
+                    :class="supportedEfforts.includes(level)
+                      ? 'border-white/10 text-gray-600 cursor-default'
+                      : 'border-white/15 text-gray-400 hover:border-accent-cyan/40 hover:text-accent-cyan'"
+                    :disabled="supportedEfforts.includes(level)"
+                    @click="addReasoningLevel(level)"
+                  >+ {{ level }}</button>
+                </div>
+                <!-- Custom level input -->
+                <div v-if="editable" class="mb-4 flex max-w-xs gap-2">
+                  <Input
+                    v-model="reasoningLevelInput"
+                    placeholder="custom level…"
+                    class="font-mono"
+                    @keydown.enter.prevent="commitReasoningInput"
+                  />
+                  <Button variant="secondary" size="sm" @click="commitReasoningInput">Add</Button>
+                </div>
+                <!-- Validation message -->
+                <p v-if="effortEnabled && supportedEfforts.length === 0" class="mb-3 text-[11px] text-accent-rose">
+                  Add at least one effort level.
+                </p>
+                <!-- Default level -->
+                <div class="space-y-1.5">
+                  <span class="block text-xs font-medium text-gray-500">Default level</span>
+                  <p v-if="config.chat?.reasoning?.effort && !config.chat.reasoning.effort.default && supportedEfforts.length > 0" class="text-[11px] text-accent-rose">
+                    Default cleared — select a level from the list.
+                  </p>
+                  <div class="max-w-xs">
+                    <Select
+                      v-if="editable"
+                      :model-value="config.chat?.reasoning?.effort?.default ?? ''"
+                      :options="[{ value: '', label: '— none —' }, ...supportedEfforts.map(e => ({ value: e, label: e }))]"
+                      :disabled="supportedEfforts.length === 0"
+                      @update:model-value="v => setDefaultEffort(v as string)"
+                    />
+                    <div v-else class="text-xs text-gray-500">
+                      {{ config.chat?.reasoning?.effort?.default || '—' }}
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </div>
+
+            <!-- Budget tokens sub-block -->
+            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
+              <div class="mb-3 flex items-center gap-3">
+                <Switch
+                  :model-value="budgetTokensEnabled"
+                  :disabled="!editable"
+                  @update:model-value="v => toggleBudgetTokens(v === true)"
+                />
+                <span class="text-xs font-medium" :class="budgetTokensEnabled ? 'text-white' : 'text-gray-500'">Budget tokens</span>
+              </div>
+              <template v-if="budgetTokensEnabled">
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <label class="block space-y-1.5">
+                    <span class="block text-xs font-medium text-gray-500">Min tokens</span>
+                    <Input
+                      type="number"
+                      min="0"
+                      :model-value="config.chat?.reasoning?.budget_tokens?.min"
+                      :readonly="!editable"
+                      placeholder="no minimum"
+                      class="font-mono"
+                      @update:model-value="v => updateBudgetTokensMin(v)"
+                    />
+                  </label>
+                  <label class="block space-y-1.5">
+                    <span class="block text-xs font-medium text-gray-500">Max tokens</span>
+                    <Input
+                      type="number"
+                      min="0"
+                      :model-value="config.chat?.reasoning?.budget_tokens?.max"
+                      :readonly="!editable"
+                      placeholder="no maximum"
+                      class="font-mono"
+                      @update:model-value="v => updateBudgetTokensMax(v)"
+                    />
+                  </label>
+                </div>
+                <p
+                  v-if="config.chat?.reasoning?.budget_tokens?.min !== undefined
+                    && config.chat?.reasoning?.budget_tokens?.max !== undefined
+                    && config.chat.reasoning.budget_tokens.max < config.chat.reasoning.budget_tokens.min"
+                  class="mt-2 text-[11px] text-accent-rose"
+                >
+                  Max must be greater than or equal to min.
+                </p>
+              </template>
+            </div>
+
+            <!-- Adaptive toggle -->
+            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
+              <div class="flex items-center gap-3">
+                <Switch
+                  :model-value="adaptiveEnabled"
+                  :disabled="!editable"
+                  @update:model-value="v => toggleAdaptive(v === true)"
+                />
+                <span class="text-xs font-medium" :class="adaptiveEnabled ? 'text-white' : 'text-gray-500'">Adaptive</span>
+                <span class="text-[11px] text-gray-600">model may self-select reasoning effort</span>
+              </div>
+            </div>
+
+            <!-- Mandatory toggle -->
+            <div class="rounded-md border border-white/[0.06] bg-white/[0.02] p-4">
+              <div class="flex items-center gap-3">
+                <Switch
+                  :model-value="mandatoryEnabled"
+                  :disabled="!editable"
+                  @update:model-value="v => toggleMandatory(v === true)"
+                />
+                <span class="text-xs font-medium" :class="mandatoryEnabled ? 'text-white' : 'text-gray-500'">Mandatory</span>
+                <span class="text-[11px] text-gray-600">reasoning is always applied, ignoring caller opt-out</span>
               </div>
             </div>
           </div>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -789,7 +789,6 @@ const toggleMandatory = (on: boolean) => {
         <section v-if="rowKind === 'chat'">
           <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
             <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Modalities</h3>
-            <span class="text-[11px] text-gray-500">text always supported</span>
             <label class="flex items-center gap-2" :class="editable ? 'cursor-pointer' : 'cursor-not-allowed'">
               <Switch
                 :model-value="chatImageInput"
@@ -802,12 +801,8 @@ const toggleMandatory = (on: boolean) => {
         </section>
 
         <section v-if="rowKind === 'chat'">
-          <div class="mb-3 flex items-baseline gap-3">
+          <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
             <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Reasoning</h3>
-            <span class="text-[11px] text-gray-500">Mandatory is exclusive; the other three may combine freely</span>
-          </div>
-
-          <div class="flex flex-wrap gap-x-6 gap-y-2">
             <label class="flex items-center gap-2" :class="controlledDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'">
               <Switch :model-value="effortEnabled" :disabled="controlledDisabled" @update:model-value="v => toggleEffort(v === true)" />
               <span class="text-xs" :class="effortEnabled ? 'text-white' : 'text-gray-500'">Effort levels</span>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -280,11 +280,6 @@ const budgetTokensEnabled = computed(() => config.value?.chat?.reasoning?.budget
 const adaptiveEnabled = computed(() => config.value?.chat?.reasoning?.adaptive === true);
 const mandatoryEnabled = computed(() => config.value?.chat?.reasoning?.mandatory === true);
 
-// Auto-show the reasoning group header when any sub-block is enabled.
-const reasoningExpanded = computed(
-  () => effortEnabled.value || budgetTokensEnabled.value || adaptiveEnabled.value || mandatoryEnabled.value,
-);
-
 const supportedEfforts = computed<string[]>(
   () => config.value?.chat?.reasoning?.effort?.supported ?? [],
 );
@@ -295,7 +290,6 @@ const supportedEfforts = computed<string[]>(
 // - effort is enabled but supported list is empty
 // - effort is enabled but default is empty or not in supported
 // - budget_tokens is enabled but max < min (when both are set)
-// - reasoning block is "on" (at least one toggle) but produces empty {}
 const isReasoningValid = computed<boolean>(() => {
   const reasoning = config.value?.chat?.reasoning;
 
@@ -308,12 +302,6 @@ const isReasoningValid = computed<boolean>(() => {
   if (budgetTokensEnabled.value) {
     const bt = reasoning?.budget_tokens;
     if (bt?.min !== undefined && bt?.max !== undefined && bt.max < bt.min) return false;
-  }
-
-  // If at least one toggle is on but reasoning reduces to empty object → invalid.
-  if (reasoningExpanded.value && reasoning !== undefined) {
-    const hasAnyKey = Object.keys(reasoning).some(k => reasoning[k as keyof typeof reasoning] !== undefined);
-    if (!hasAnyKey) return false;
   }
 
   return true;

--- a/apps/web/src/components/upstream-edit/ModelsPanel.vue
+++ b/apps/web/src/components/upstream-edit/ModelsPanel.vue
@@ -39,9 +39,9 @@ const selectedUiId = ref<string | null>(null);
 // and must keep shadowing it). Pure-manual rows have no such constraint.
 const lockedUpstreamId = reactive(new Set<string>());
 
-// Per-row validity reported by ModelEditor. Only the selected row is ever
-// mounted, so we track a single slot — when the selection changes the
-// previous row's validity is no longer observable and is removed.
+// Validity entries persist across row selection changes — switching away
+// from an invalid row keeps it in the map so save stays blocked. Entries
+// are dropped only when the row itself is removed.
 const rowValidity = reactive(new Map<string, boolean>());
 
 const onRowValidityChange = (uiId: string, valid: boolean) => {

--- a/apps/web/src/components/upstream-edit/ModelsPanel.vue
+++ b/apps/web/src/components/upstream-edit/ModelsPanel.vue
@@ -13,6 +13,10 @@ import { Button } from '@floway-dev/ui';
 const manualModels = defineModel<UpstreamModelConfig[]>({ required: true });
 const disabledIds = defineModel<string[]>('disabledIds', { required: true });
 
+const emit = defineEmits<{
+  'update:invalid': [invalid: boolean];
+}>();
+
 const props = withDefaults(defineProps<{
   autoModels?: UpstreamModelConfig[];
   flags: FlagDef[];
@@ -34,6 +38,25 @@ const selectedUiId = ref<string | null>(null);
 // uiIds whose upstreamModelId is fixed (they were seeded from an auto twin
 // and must keep shadowing it). Pure-manual rows have no such constraint.
 const lockedUpstreamId = reactive(new Set<string>());
+
+// Per-row validity reported by ModelEditor. Only the selected row is ever
+// mounted, so we track a single slot — when the selection changes the
+// previous row's validity is no longer observable and is removed.
+const rowValidity = reactive(new Map<string, boolean>());
+
+const onRowValidityChange = (uiId: string, valid: boolean) => {
+  rowValidity.set(uiId, valid);
+  emit('update:invalid', Array.from(rowValidity.values()).some(v => !v));
+};
+
+// Drop validity state for rows that are removed so stale entries do not block save.
+watch(rows, next => {
+  const live = new Set(next.map(r => r.uiId));
+  for (const id of rowValidity.keys()) {
+    if (!live.has(id)) rowValidity.delete(id);
+  }
+  emit('update:invalid', Array.from(rowValidity.values()).some(v => !v));
+}, { deep: false });
 
 // Reconcile the unified row list from the persisted manual models and the
 // live auto list. Existing rows keep their position and uiId when their
@@ -292,6 +315,7 @@ watch(manualModels, () => {
         @patch-config="patchConfig"
         @set-mode="next => selectedRow && setMode(selectedRow.uiId, next)"
         @remove="selectedRow && removeRow(selectedRow.uiId)"
+        @validity-change="valid => selectedRow && onRowValidityChange(selectedRow.uiId, valid)"
       />
     </div>
   </div>

--- a/apps/web/src/components/upstream-edit/ModelsPanel.vue
+++ b/apps/web/src/components/upstream-edit/ModelsPanel.vue
@@ -44,9 +44,11 @@ const lockedUpstreamId = reactive(new Set<string>());
 // are dropped only when the row itself is removed.
 const rowValidity = reactive(new Map<string, boolean>());
 
+const anyInvalid = computed(() => Array.from(rowValidity.values()).some(v => !v));
+watch(anyInvalid, v => emit('update:invalid', v), { immediate: true });
+
 const onRowValidityChange = (uiId: string, valid: boolean) => {
   rowValidity.set(uiId, valid);
-  emit('update:invalid', Array.from(rowValidity.values()).some(v => !v));
 };
 
 // Drop validity state for rows that are removed so stale entries do not block save.
@@ -55,7 +57,6 @@ watch(rows, next => {
   for (const id of rowValidity.keys()) {
     if (!live.has(id)) rowValidity.delete(id);
   }
-  emit('update:invalid', Array.from(rowValidity.values()).some(v => !v));
 }, { deep: false });
 
 // Reconcile the unified row list from the persisted manual models and the

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -363,7 +363,7 @@ const save = async () => {
   const trimmedName = name.value.trim();
   if (!trimmedName) { saveError.value = 'Name is required'; return; }
   if (modelPrefixInvalid.value) { saveError.value = 'Model name prefix is invalid'; return; }
-  if (modelsPanelInvalid.value) { saveError.value = 'One or more models have invalid configuration — check the Default Reasoning Level'; return; }
+  if (modelsPanelInvalid.value) { saveError.value = 'One or more models have invalid configuration — check model reasoning settings'; return; }
 
   saving.value = true;
   try {

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -313,6 +313,7 @@ const refreshCachedModels = async () => {
 
 const saving = ref(false);
 const saveError = ref<string | null>(null);
+const modelsPanelInvalid = ref(false);
 
 const buildCustomConfig = (): Extract<CreateBody, { provider: 'custom' }>['config'] => {
   const config: Extract<CreateBody, { provider: 'custom' }>['config'] = {
@@ -362,6 +363,7 @@ const save = async () => {
   const trimmedName = name.value.trim();
   if (!trimmedName) { saveError.value = 'Name is required'; return; }
   if (modelPrefixInvalid.value) { saveError.value = 'Model name prefix is invalid'; return; }
+  if (modelsPanelInvalid.value) { saveError.value = 'One or more models have invalid configuration — check the Default Reasoning Level'; return; }
 
   saving.value = true;
   try {
@@ -590,6 +592,7 @@ const workbenchStyle = computed(() => ({ '--right-pane-h': `${Math.ceil(rightCon
         :upstream-id-label="upstreamIdLabelForActive"
         :read-only="activeProvider === 'copilot' || activeProvider === 'codex' || activeProvider === 'claude-code'"
         :all-manual="activeProvider === 'azure'"
+        @update:invalid="v => modelsPanelInvalid = v"
       />
     </div>
   </div>

--- a/apps/web/src/components/upstream-edit/modelRows.ts
+++ b/apps/web/src/components/upstream-edit/modelRows.ts
@@ -37,6 +37,7 @@ export const seedFromAuto = (auto: UpstreamModelConfig): UpstreamModelConfig => 
     ...(auto.display_name ? { display_name: auto.display_name } : {}),
     ...(auto.limits ? { limits: { ...auto.limits } } : {}),
     ...(auto.cost ? { cost: { ...auto.cost } } : {}),
+    ...(auto.chat ? { chat: auto.chat } : {}),
   };
 };
 

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -89,14 +89,32 @@ const modalitiesSchema = z.object({
   output: modalityArraySchema,
 });
 
-const reasoningSchema = z.object({
-  supported_efforts: z.array(z.string().min(1))
+const effortSchema = z.object({
+  supported: z.array(z.string().min(1))
     .min(1)
     .transform(arr => Array.from(new Set(arr))),
-  default_effort: z.string().min(1),
+  default: z.string().min(1),
 }).refine(
-  r => r.supported_efforts.includes(r.default_effort),
-  { message: 'default_effort must appear in supported_efforts' },
+  r => r.supported.includes(r.default),
+  { message: 'effort.default must appear in effort.supported' },
+);
+
+const budgetTokensSchema = z.object({
+  min: z.number().int().nonnegative().optional(),
+  max: z.number().int().nonnegative().optional(),
+}).refine(
+  r => r.min === undefined || r.max === undefined || r.max >= r.min,
+  { message: 'budget_tokens.max must be >= budget_tokens.min' },
+);
+
+const reasoningSchema = z.object({
+  effort: effortSchema.optional(),
+  budget_tokens: budgetTokensSchema.optional(),
+  adaptive: z.boolean().optional(),
+  mandatory: z.boolean().optional(),
+}).refine(
+  r => r.effort !== undefined || r.budget_tokens !== undefined || r.adaptive !== undefined || r.mandatory !== undefined,
+  { message: 'reasoning must have at least one of effort, budget_tokens, adaptive, mandatory' },
 );
 
 const chatSchema = z.object({

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -73,6 +73,37 @@ const pricingDimensionShape = {
   output_image: z.number().nonnegative().optional(),
 };
 
+// Modality arrays: both input and output require at least one entry and
+// deduplicate via transform. Input additionally requires 'text' to be present
+// (a multimodal model must accept text); output has no such constraint (an
+// image-generation model may emit only images).
+const modalityArraySchema = z.array(z.enum(['text', 'image']))
+  .min(1)
+  .transform(arr => Array.from(new Set(arr)));
+
+const inputModalityArraySchema = modalityArraySchema
+  .refine(arr => arr.includes('text'), { message: "must include 'text'" });
+
+const modalitiesSchema = z.object({
+  input: inputModalityArraySchema,
+  output: modalityArraySchema,
+});
+
+const reasoningSchema = z.object({
+  supported_efforts: z.array(z.string().min(1))
+    .min(1)
+    .transform(arr => Array.from(new Set(arr))),
+  default_effort: z.string().min(1),
+}).refine(
+  r => r.supported_efforts.includes(r.default_effort),
+  { message: 'default_effort must appear in supported_efforts' },
+);
+
+const chatSchema = z.object({
+  modalities: modalitiesSchema.optional(),
+  reasoning: reasoningSchema.optional(),
+});
+
 // Mirrors the runtime UpstreamModelConfig in @floway-dev/provider.
 // Azure and custom upstreams share this per-model entry; the canonical
 // per-model endpoint validation lives in the runtime validator.
@@ -102,7 +133,11 @@ const upstreamModelSchema = z.object({
     max_prompt_tokens: z.number().optional(),
     max_output_tokens: z.number().optional(),
   }).optional(),
-});
+  chat: chatSchema.optional(),
+}).refine(
+  m => m.chat === undefined || m.kind === undefined || m.kind === 'chat',
+  { message: "chat metadata only allowed when kind === 'chat'", path: ['chat'] },
+);
 
 const customConfigSchema = z.object({
   baseUrl: z.string().min(1),

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -110,8 +110,8 @@ const budgetTokensSchema = z.object({
 const reasoningSchema = z.object({
   effort: effortSchema.optional(),
   budget_tokens: budgetTokensSchema.optional(),
-  adaptive: z.boolean().optional(),
-  mandatory: z.boolean().optional(),
+  adaptive: z.literal(true).optional(),
+  mandatory: z.literal(true).optional(),
 }).refine(
   r => r.effort !== undefined || r.budget_tokens !== undefined || r.adaptive !== undefined || r.mandatory !== undefined,
   { message: 'reasoning must have at least one of effort, budget_tokens, adaptive, mandatory' },

--- a/packages/gateway/src/control-plane/schemas_test.ts
+++ b/packages/gateway/src/control-plane/schemas_test.ts
@@ -57,13 +57,20 @@ describe('upstreamModelSchema chat', () => {
     expect(createUpstreamBody.safeParse(body).success).toBe(true);
   });
 
-  test('accepts reasoning with adaptive: false alongside mandatory: true', () => {
+  test('rejects reasoning with adaptive: false', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { adaptive: false },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(false);
+  });
+
+  test('rejects reasoning with adaptive: false even alongside mandatory: true', () => {
     const body = structuredClone(baseAzure);
     (body.config.models[0] as Record<string, unknown>).chat = {
       reasoning: { adaptive: false, mandatory: true },
     };
-    // The control-plane schema accepts false booleans; the runtime parser strips them.
-    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+    expect(createUpstreamBody.safeParse(body).success).toBe(false);
   });
 
   test('rejects empty reasoning (no sub-block)', () => {

--- a/packages/gateway/src/control-plane/schemas_test.ts
+++ b/packages/gateway/src/control-plane/schemas_test.ts
@@ -16,13 +16,62 @@ const baseAzure = {
 };
 
 describe('upstreamModelSchema chat', () => {
-  test('accepts a valid chat block', () => {
+  test('accepts a valid chat block with effort', () => {
     const body = structuredClone(baseAzure);
     (body.config.models[0] as Record<string, unknown>).chat = {
       modalities: { input: ['text', 'image'], output: ['text'] },
-      reasoning: { supported_efforts: ['low', 'medium'], default_effort: 'low' },
+      reasoning: { effort: { supported: ['low', 'medium'], default: 'low' } },
     };
     expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('accepts chat with budget_tokens only', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { budget_tokens: { min: 100, max: 5000 } },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('accepts chat with empty budget_tokens', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { budget_tokens: {} },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('accepts chat with adaptive: true', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { adaptive: true },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('accepts chat with mandatory: true', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { mandatory: true },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('accepts reasoning with adaptive: false alongside mandatory: true', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { adaptive: false, mandatory: true },
+    };
+    // The control-plane schema accepts false booleans; the runtime parser strips them.
+    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('rejects empty reasoning (no sub-block)', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: {},
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(false);
   });
 
   test('rejects chat on non-chat kind', () => {
@@ -34,10 +83,18 @@ describe('upstreamModelSchema chat', () => {
     expect(createUpstreamBody.safeParse(body).success).toBe(false);
   });
 
-  test('rejects default_effort not in supported_efforts', () => {
+  test('rejects effort.default not in effort.supported', () => {
     const body = structuredClone(baseAzure);
     (body.config.models[0] as Record<string, unknown>).chat = {
-      reasoning: { supported_efforts: ['low', 'high'], default_effort: 'medium' },
+      reasoning: { effort: { supported: ['low', 'high'], default: 'medium' } },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(false);
+  });
+
+  test('rejects budget_tokens.max < budget_tokens.min', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { budget_tokens: { min: 500, max: 100 } },
     };
     expect(createUpstreamBody.safeParse(body).success).toBe(false);
   });

--- a/packages/gateway/src/control-plane/schemas_test.ts
+++ b/packages/gateway/src/control-plane/schemas_test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import { createUpstreamBody } from './schemas.ts';
+
+const baseAzure = {
+  provider: 'azure' as const,
+  name: 'azure',
+  config: {
+    endpoint: 'https://a.example.com',
+    apiKey: 'k',
+    models: [{
+      upstreamModelId: 'm',
+      kind: 'chat' as const,
+      endpoints: { chatCompletions: {} },
+    }],
+  },
+};
+
+describe('upstreamModelSchema chat', () => {
+  test('accepts a valid chat block', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      reasoning: { supported_efforts: ['low', 'medium'], default_effort: 'low' },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('rejects chat on non-chat kind', () => {
+    const body = structuredClone(baseAzure);
+    const model = body.config.models[0] as Record<string, unknown>;
+    model.kind = 'embedding';
+    model.endpoints = { embeddings: {} };
+    model.chat = { modalities: { input: ['text'], output: ['text'] } };
+    expect(createUpstreamBody.safeParse(body).success).toBe(false);
+  });
+
+  test('rejects default_effort not in supported_efforts', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      reasoning: { supported_efforts: ['low', 'high'], default_effort: 'medium' },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(false);
+  });
+
+  test('accepts output modalities without text', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      modalities: { input: ['text'], output: ['image'] },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(true);
+  });
+
+  test('rejects empty output modalities array', () => {
+    const body = structuredClone(baseAzure);
+    (body.config.models[0] as Record<string, unknown>).chat = {
+      modalities: { input: ['text'], output: [] },
+    };
+    expect(createUpstreamBody.safeParse(body).success).toBe(false);
+  });
+});

--- a/packages/gateway/src/control-plane/schemas_test.ts
+++ b/packages/gateway/src/control-plane/schemas_test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+
 import { createUpstreamBody } from './schemas.ts';
 
 const baseAzure = {

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -446,6 +446,7 @@ export const listUpstreamModels = async (c: AuthedContext<'/:id'>) => {
       ...(model.display_name !== undefined ? { display_name: model.display_name } : {}),
       ...(model.limits ? { limits: model.limits } : {}),
       ...(model.cost ? { cost: model.cost } : {}),
+      ...(model.chat ? { chat: model.chat } : {}),
     }));
     return c.json({ data });
   } catch (e) {

--- a/packages/gateway/src/data-plane/models/load.ts
+++ b/packages/gateway/src/data-plane/models/load.ts
@@ -18,6 +18,7 @@ export const toPublicModel = (model: InternalModel): PublicModel => {
     info.created_at = new Date(model.created * 1000).toISOString();
   }
   if (model.cost) info.cost = model.cost;
+  if (model.chat) info.chat = model.chat;
   return info;
 };
 

--- a/packages/gateway/src/data-plane/models/load_test.ts
+++ b/packages/gateway/src/data-plane/models/load_test.ts
@@ -17,7 +17,7 @@ describe('toPublicModel', () => {
   test('propagates chat metadata verbatim', () => {
     const chat = {
       modalities: { input: ['text', 'image'] as const, output: ['text'] as const },
-      reasoning: { supported_efforts: ['low', 'high'] as const, default_effort: 'low' },
+      reasoning: { effort: { supported: ['low', 'high'] as const, default: 'low' } },
     };
     expect(toPublicModel({ ...base, chat }).chat).toEqual(chat);
   });

--- a/packages/gateway/src/data-plane/models/load_test.ts
+++ b/packages/gateway/src/data-plane/models/load_test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { toPublicModel } from './load.ts';
+import type { InternalModel } from '@floway-dev/provider';
+
+const base: InternalModel = {
+  id: 'm1',
+  kind: 'chat',
+  limits: { max_context_window_tokens: 100000 },
+};
+
+describe('toPublicModel', () => {
+  test('omits chat when not set', () => {
+    expect(toPublicModel(base).chat).toBeUndefined();
+  });
+
+  test('propagates chat metadata verbatim', () => {
+    const chat = {
+      modalities: { input: ['text', 'image'] as const, output: ['text'] as const },
+      reasoning: { supported_efforts: ['low', 'high'] as const, default_effort: 'low' },
+    };
+    expect(toPublicModel({ ...base, chat }).chat).toEqual(chat);
+  });
+});

--- a/packages/protocols/src/common/models.ts
+++ b/packages/protocols/src/common/models.ts
@@ -91,18 +91,24 @@ export type ModelKind = 'chat' | 'embedding' | 'image';
 
 export type Modality = 'text' | 'image';
 
-// Wire-level chat metadata, mirrored from UpstreamChatModelConfig in
-// @floway-dev/provider. Lives here so PublicModel stays self-contained.
-// Field names and semantics are intentionally identical to the provider type.
+// Operator-configured chat capability metadata. Lives in protocols because it
+// flows verbatim onto PublicModel.chat (the wire DTO) and is also re-exported
+// by @floway-dev/provider as UpstreamChatModelConfig for the catalog side; one
+// definition serves both surfaces.
 export interface ChatModelInfo {
   modalities?: {
     input: readonly Modality[];
     output: readonly Modality[];
   };
   reasoning?: {
+    // Discrete effort levels — a closed set of named presets (e.g. low/medium/high).
     effort?: { supported: readonly string[]; default: string };
+    // Operator-supplied token budget. Bounds are optional; absent bounds mean
+    // "operator can supply a budget, but legal range is unknown".
     budget_tokens?: { min?: number; max?: number };
+    // Model-controlled adaptive depth — the model decides how much reasoning to do.
     adaptive?: boolean;
+    // Always-on reasoning — the model cannot be instructed to skip it.
     mandatory?: boolean;
   };
 }

--- a/packages/protocols/src/common/models.ts
+++ b/packages/protocols/src/common/models.ts
@@ -93,14 +93,17 @@ export type Modality = 'text' | 'image';
 
 // Wire-level chat metadata, mirrored from UpstreamChatModelConfig in
 // @floway-dev/provider. Lives here so PublicModel stays self-contained.
+// Field names and semantics are intentionally identical to the provider type.
 export interface ChatModelInfo {
   modalities?: {
     input: readonly Modality[];
     output: readonly Modality[];
   };
   reasoning?: {
-    supported_efforts: readonly string[];
-    default_effort: string;
+    effort?: { supported: readonly string[]; default: string };
+    budget_tokens?: { min?: number; max?: number };
+    adaptive?: boolean;
+    mandatory?: boolean;
   };
 }
 

--- a/packages/protocols/src/common/models.ts
+++ b/packages/protocols/src/common/models.ts
@@ -89,6 +89,21 @@ export const resolveEffectivePricing = (pricing: ModelPricing | null, tier: stri
 // not pre-declare for future capabilities.
 export type ModelKind = 'chat' | 'embedding' | 'image';
 
+export type Modality = 'text' | 'image';
+
+// Wire-level chat metadata, mirrored from UpstreamChatModelConfig in
+// @floway-dev/provider. Lives here so PublicModel stays self-contained.
+export interface ChatModelInfo {
+  modalities?: {
+    input: readonly Modality[];
+    output: readonly Modality[];
+  };
+  reasoning?: {
+    supported_efforts: readonly string[];
+    default_effort: string;
+  };
+}
+
 // Public DTO served at /v1/models and /models. Single superset shape — OpenAI's
 // and Anthropic's /models field names do not overlap, so one payload satisfies
 // both client shapes.
@@ -110,6 +125,7 @@ export interface PublicModel {
   };
   kind: ModelKind;
   cost?: ModelPricing;
+  chat?: ChatModelInfo;
 }
 
 export interface PublicModelsResponse {

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -52,6 +52,7 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
           limits: { ...(model.limits ?? {}) },
           ...(model.display_name !== undefined ? { display_name: model.display_name } : {}),
           ...(model.cost ? { cost: model.cost } : {}),
+          ...(model.chat ? { chat: model.chat } : {}),
           kind: kindForEndpoints(endpoints),
           endpoints,
           providerData: { upstreamModelId: model.upstreamModelId },

--- a/packages/provider-claude-code/src/models.ts
+++ b/packages/provider-claude-code/src/models.ts
@@ -74,14 +74,14 @@ const assertApiModel = (value: unknown): ClaudeCodeApiModel => {
     id,
     display_name,
     max_input_tokens,
-    ...(capabilities !== undefined ? { capabilities: parseCapabilities(capabilities, id) } : {}),
+    ...(capabilities !== undefined ? { capabilities: parseCapabilities(capabilities) } : {}),
   };
 };
 
 // Parses the `capabilities` block from the Anthropic /v1/models response.
 // Unknown sub-fields are silently skipped — Anthropic adds capabilities
 // forward-compatibly, and we'd rather miss a future field than fail the catalog refresh.
-const parseCapabilities = (raw: unknown, _modelId: string): ClaudeCodeApiModel['capabilities'] => {
+const parseCapabilities = (raw: unknown): ClaudeCodeApiModel['capabilities'] => {
   if (typeof raw !== 'object' || raw === null) return undefined;
   const cap = raw as Record<string, unknown>;
   const out: NonNullable<ClaudeCodeApiModel['capabilities']> = {};
@@ -110,6 +110,7 @@ const parseCapabilities = (raw: unknown, _modelId: string): ClaudeCodeApiModel['
     if (thinking.types !== undefined) out.thinking = thinking;
   }
 
+  // `effort.supported` is required to interpret the block; skip otherwise.
   if (typeof cap.effort === 'object' && cap.effort !== null) {
     const eff = cap.effort as Record<string, unknown>;
     if (typeof eff.supported === 'boolean') {
@@ -122,8 +123,6 @@ const parseCapabilities = (raw: unknown, _modelId: string): ClaudeCodeApiModel['
         }
       }
       out.effort = effort;
-    } else if (typeof eff.supported !== 'boolean') {
-      // `effort.supported` is required to interpret the block; skip if absent.
     }
   }
 
@@ -148,12 +147,10 @@ export const chatFromCapabilities = (
 
   const chat: UpstreamChatModelConfig = {};
 
-  // Modalities — image input maps to text+image in / text out.
   if (capabilities.image_input?.supported === true) {
     chat.modalities = { input: ['text', 'image'], output: ['text'] };
   }
 
-  // Reasoning capabilities.
   const reasoning: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
 
   const eff = capabilities.effort;

--- a/packages/provider-claude-code/src/models.ts
+++ b/packages/provider-claude-code/src/models.ts
@@ -162,7 +162,7 @@ export const chatFromCapabilities = (
       .filter(([key, val]) => key !== 'supported' && typeof val === 'object' && val !== null && (val as { supported: boolean }).supported === true)
       .map(([key]) => key);
     if (supportedLevels.length > 0) {
-      const defaultLevel = supportedLevels.includes('high') ? 'high' : supportedLevels[0]!;
+      const defaultLevel = supportedLevels.includes('medium') ? 'medium' : supportedLevels[0]!;
       reasoning.effort = { supported: supportedLevels, default: defaultLevel };
     }
   }

--- a/packages/provider-claude-code/src/models.ts
+++ b/packages/provider-claude-code/src/models.ts
@@ -16,7 +16,7 @@
 import { CLAUDE_CODE_HEADERS_SONNET_OPUS } from './headers.ts';
 import { pricingForClaudeCodeModelKey } from './pricing.ts';
 import type { ClaudeCodeProviderData } from './types.ts';
-import type { Fetcher, UpstreamModel } from '@floway-dev/provider';
+import type { Fetcher, UpstreamModel, UpstreamChatModelConfig } from '@floway-dev/provider';
 
 const ANTHROPIC_MODELS_ENDPOINT = 'https://api.anthropic.com/v1/models?limit=100';
 
@@ -29,6 +29,22 @@ export interface ClaudeCodeApiModel {
   id: string;
   display_name: string;
   max_input_tokens: number;
+  capabilities?: {
+    image_input?: { supported: boolean };
+    thinking?: {
+      supported?: boolean;
+      types?: {
+        enabled?: { supported: boolean };
+        adaptive?: { supported: boolean };
+      };
+    };
+    // `supported` is the top-level boolean; other keys are named level
+    // sub-objects `{ supported: boolean }`. The union type captures both.
+    effort?: {
+      supported: boolean;
+      [level: string]: { supported: boolean } | boolean;
+    };
+  };
 }
 
 export const fetchClaudeCodeModelsList = async (
@@ -51,11 +67,72 @@ export const fetchClaudeCodeModelsList = async (
 
 const assertApiModel = (value: unknown): ClaudeCodeApiModel => {
   if (typeof value !== 'object' || value === null) throw new TypeError('Claude Code /v1/models entry is not an object');
-  const { id, display_name, max_input_tokens } = value as Record<string, unknown>;
+  const { id, display_name, max_input_tokens, capabilities } = value as Record<string, unknown>;
   if (typeof id !== 'string') throw new TypeError(`Claude Code /v1/models entry missing id: ${JSON.stringify(value).slice(0, 200)}`);
   if (typeof display_name !== 'string') throw new TypeError(`Claude Code /v1/models entry ${id} missing display_name`);
   if (typeof max_input_tokens !== 'number') throw new TypeError(`Claude Code /v1/models entry ${id} missing max_input_tokens`);
-  return { id, display_name, max_input_tokens };
+  return {
+    id,
+    display_name,
+    max_input_tokens,
+    ...(capabilities !== undefined ? { capabilities: parseCapabilities(capabilities, id) } : {}),
+  };
+};
+
+// Parses the `capabilities` block from the Anthropic /v1/models response.
+// Unknown or malformed sub-fields are skipped so that additions to the
+// upstream schema do not break the refresh. We only throw on clearly invalid
+// shapes for fields we actually consume.
+const parseCapabilities = (raw: unknown, modelId: string): ClaudeCodeApiModel['capabilities'] => {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const cap = raw as Record<string, unknown>;
+  const out: NonNullable<ClaudeCodeApiModel['capabilities']> = {};
+
+  if (typeof cap.image_input === 'object' && cap.image_input !== null) {
+    const ii = cap.image_input as Record<string, unknown>;
+    if (typeof ii.supported === 'boolean') out.image_input = { supported: ii.supported };
+  }
+
+  if (typeof cap.thinking === 'object' && cap.thinking !== null) {
+    const th = cap.thinking as Record<string, unknown>;
+    const thinking: NonNullable<ClaudeCodeApiModel['capabilities']>['thinking'] = {};
+    if (typeof th.supported === 'boolean') thinking.supported = th.supported;
+    if (typeof th.types === 'object' && th.types !== null) {
+      const types = th.types as Record<string, unknown>;
+      const parsedTypes: NonNullable<typeof thinking.types> = {};
+      if (typeof types.enabled === 'object' && types.enabled !== null) {
+        const en = types.enabled as Record<string, unknown>;
+        if (typeof en.supported === 'boolean') parsedTypes.enabled = { supported: en.supported };
+      }
+      if (typeof types.adaptive === 'object' && types.adaptive !== null) {
+        const ad = types.adaptive as Record<string, unknown>;
+        if (typeof ad.supported === 'boolean') parsedTypes.adaptive = { supported: ad.supported };
+      }
+      if (parsedTypes.enabled !== undefined || parsedTypes.adaptive !== undefined) thinking.types = parsedTypes;
+    }
+    if (thinking.supported !== undefined || thinking.types !== undefined) out.thinking = thinking;
+  }
+
+  if (typeof cap.effort === 'object' && cap.effort !== null) {
+    const eff = cap.effort as Record<string, unknown>;
+    if (typeof eff.supported === 'boolean') {
+      const effort: NonNullable<ClaudeCodeApiModel['capabilities']>['effort'] = { supported: eff.supported };
+      for (const [level, levelVal] of Object.entries(eff)) {
+        if (level === 'supported') continue;
+        if (typeof levelVal === 'object' && levelVal !== null) {
+          const lv = levelVal as Record<string, unknown>;
+          if (typeof lv.supported === 'boolean') effort[level] = { supported: lv.supported };
+        }
+      }
+      out.effort = effort;
+    } else {
+      // `effort.supported` is required to interpret the block; skip if absent.
+      // Log the anomaly so it shows up in the refresh trace.
+      console.warn(`Claude Code /v1/models entry ${modelId}: effort block missing top-level supported boolean, skipping`);
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
 };
 
 // Pre-4.6 models return as `claude-<family>-<digits>-<digits>-YYYYMMDD`;
@@ -66,6 +143,50 @@ const assertApiModel = (value: unknown): ClaudeCodeApiModel => {
 // upstream exposes before we hard-code its name.
 export const aliasFromApiId = (apiId: string): string => apiId.replace(/-\d{8}$/, '');
 
+// Derives the `chat` metadata from a model's capabilities block.
+// Returns undefined when no relevant capability is present so the
+// caller can omit the key entirely and keep the UpstreamModel lean.
+export const chatFromCapabilities = (
+  capabilities: ClaudeCodeApiModel['capabilities'],
+): UpstreamChatModelConfig | undefined => {
+  if (capabilities === undefined) return undefined;
+
+  const chat: UpstreamChatModelConfig = {};
+
+  // Modalities — image input maps to text+image in / text out.
+  if (capabilities.image_input?.supported === true) {
+    chat.modalities = { input: ['text', 'image'], output: ['text'] };
+  }
+
+  // Reasoning capabilities.
+  const reasoning: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
+
+  const eff = capabilities.effort;
+  if (eff?.supported === true) {
+    const supportedLevels = Object.entries(eff)
+      .filter(([key, val]) => key !== 'supported' && typeof val === 'object' && val !== null && (val as { supported: boolean }).supported === true)
+      .map(([key]) => key);
+    if (supportedLevels.length > 0) {
+      const defaultLevel = supportedLevels.includes('high') ? 'high' : supportedLevels[0]!;
+      reasoning.effort = { supported: supportedLevels, default: defaultLevel };
+    }
+  }
+
+  if (capabilities.thinking?.types?.enabled?.supported === true) {
+    reasoning.budget_tokens = {};
+  }
+
+  if (capabilities.thinking?.types?.adaptive?.supported === true) {
+    reasoning.adaptive = true;
+  }
+
+  if (reasoning.effort !== undefined || reasoning.budget_tokens !== undefined || reasoning.adaptive !== undefined) {
+    chat.reasoning = reasoning;
+  }
+
+  return (chat.modalities !== undefined || chat.reasoning !== undefined) ? chat : undefined;
+};
+
 export const buildClaudeCodeCatalog = (
   apiModels: readonly ClaudeCodeApiModel[],
   enabledFlags: ReadonlySet<string>,
@@ -73,6 +194,7 @@ export const buildClaudeCodeCatalog = (
   const alias = aliasFromApiId(api.id);
   const cost = pricingForClaudeCodeModelKey(api.id);
   const providerData: ClaudeCodeProviderData = { upstreamModelId: api.id };
+  const chat = chatFromCapabilities(api.capabilities);
   return {
     id: alias,
     display_name: api.display_name,
@@ -83,6 +205,7 @@ export const buildClaudeCodeCatalog = (
     limits: { max_context_window_tokens: api.max_input_tokens },
     providerData,
     ...(cost ? { cost } : {}),
+    ...(chat ? { chat } : {}),
   };
 });
 

--- a/packages/provider-claude-code/src/models.ts
+++ b/packages/provider-claude-code/src/models.ts
@@ -32,7 +32,6 @@ export interface ClaudeCodeApiModel {
   capabilities?: {
     image_input?: { supported: boolean };
     thinking?: {
-      supported?: boolean;
       types?: {
         enabled?: { supported: boolean };
         adaptive?: { supported: boolean };
@@ -80,9 +79,8 @@ const assertApiModel = (value: unknown): ClaudeCodeApiModel => {
 };
 
 // Parses the `capabilities` block from the Anthropic /v1/models response.
-// Unknown or malformed sub-fields are skipped so that additions to the
-// upstream schema do not break the refresh. We only throw on clearly invalid
-// shapes for fields we actually consume.
+// Unknown sub-fields are silently skipped — Anthropic adds capabilities
+// forward-compatibly, and we'd rather miss a future field than fail the catalog refresh.
 const parseCapabilities = (raw: unknown, modelId: string): ClaudeCodeApiModel['capabilities'] => {
   if (typeof raw !== 'object' || raw === null) return undefined;
   const cap = raw as Record<string, unknown>;
@@ -96,7 +94,6 @@ const parseCapabilities = (raw: unknown, modelId: string): ClaudeCodeApiModel['c
   if (typeof cap.thinking === 'object' && cap.thinking !== null) {
     const th = cap.thinking as Record<string, unknown>;
     const thinking: NonNullable<ClaudeCodeApiModel['capabilities']>['thinking'] = {};
-    if (typeof th.supported === 'boolean') thinking.supported = th.supported;
     if (typeof th.types === 'object' && th.types !== null) {
       const types = th.types as Record<string, unknown>;
       const parsedTypes: NonNullable<typeof thinking.types> = {};
@@ -110,7 +107,7 @@ const parseCapabilities = (raw: unknown, modelId: string): ClaudeCodeApiModel['c
       }
       if (parsedTypes.enabled !== undefined || parsedTypes.adaptive !== undefined) thinking.types = parsedTypes;
     }
-    if (thinking.supported !== undefined || thinking.types !== undefined) out.thinking = thinking;
+    if (thinking.types !== undefined) out.thinking = thinking;
   }
 
   if (typeof cap.effort === 'object' && cap.effort !== null) {
@@ -125,10 +122,8 @@ const parseCapabilities = (raw: unknown, modelId: string): ClaudeCodeApiModel['c
         }
       }
       out.effort = effort;
-    } else {
+    } else if (typeof eff.supported !== 'boolean') {
       // `effort.supported` is required to interpret the block; skip if absent.
-      // Log the anomaly so it shows up in the refresh trace.
-      console.warn(`Claude Code /v1/models entry ${modelId}: effort block missing top-level supported boolean, skipping`);
     }
   }
 

--- a/packages/provider-claude-code/src/models.ts
+++ b/packages/provider-claude-code/src/models.ts
@@ -81,7 +81,7 @@ const assertApiModel = (value: unknown): ClaudeCodeApiModel => {
 // Parses the `capabilities` block from the Anthropic /v1/models response.
 // Unknown sub-fields are silently skipped — Anthropic adds capabilities
 // forward-compatibly, and we'd rather miss a future field than fail the catalog refresh.
-const parseCapabilities = (raw: unknown, modelId: string): ClaudeCodeApiModel['capabilities'] => {
+const parseCapabilities = (raw: unknown, _modelId: string): ClaudeCodeApiModel['capabilities'] => {
   if (typeof raw !== 'object' || raw === null) return undefined;
   const cap = raw as Record<string, unknown>;
   const out: NonNullable<ClaudeCodeApiModel['capabilities']> = {};

--- a/packages/provider-claude-code/src/models_test.ts
+++ b/packages/provider-claude-code/src/models_test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
   aliasFromApiId,
   buildClaudeCodeCatalog,
+  chatFromCapabilities,
   claudeCodeResolveRequestedModelId,
   type ClaudeCodeApiModel,
 } from './models.ts';
@@ -29,6 +30,128 @@ describe('aliasFromApiId', () => {
     expect(aliasFromApiId('claude-opus-4-7')).toBe('claude-opus-4-7');
     expect(aliasFromApiId('claude-fable-5')).toBe('claude-fable-5');
     expect(aliasFromApiId('claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+  });
+});
+
+describe('chatFromCapabilities', () => {
+  // Case 1: effort.supported=false, thinking.types.enabled.supported=true only (mirrors Sonnet 4.5)
+  test('effort disabled + enabled thinking → only budget_tokens in reasoning', () => {
+    const chat = chatFromCapabilities({
+      effort: { supported: false },
+      thinking: { types: { enabled: { supported: true } } },
+    });
+    expect(chat).toEqual({ reasoning: { budget_tokens: {} } });
+  });
+
+  // Case 2: effort with 4 levels + xhigh=false + max=true, both thinking types (mirrors Opus 4.6)
+  test('effort with low/medium/high/max + both thinking types → full reasoning', () => {
+    const chat = chatFromCapabilities({
+      effort: {
+        supported: true,
+        low: { supported: true },
+        medium: { supported: true },
+        high: { supported: true },
+        xhigh: { supported: false },
+        max: { supported: true },
+      },
+      thinking: { types: { enabled: { supported: true }, adaptive: { supported: true } } },
+    });
+    expect(chat).toEqual({
+      reasoning: {
+        effort: { supported: ['low', 'medium', 'high', 'max'], default: 'high' },
+        budget_tokens: {},
+        adaptive: true,
+      },
+    });
+  });
+
+  // Case 3: effort with all 5 levels true, only adaptive thinking (mirrors Opus 4.7)
+  test('effort with low/medium/high/xhigh/max + only adaptive thinking → effort + adaptive', () => {
+    const chat = chatFromCapabilities({
+      effort: {
+        supported: true,
+        low: { supported: true },
+        medium: { supported: true },
+        high: { supported: true },
+        xhigh: { supported: true },
+        max: { supported: true },
+      },
+      thinking: { types: { adaptive: { supported: true } } },
+    });
+    expect(chat).toEqual({
+      reasoning: {
+        effort: { supported: ['low', 'medium', 'high', 'xhigh', 'max'], default: 'high' },
+        adaptive: true,
+      },
+    });
+  });
+
+  // Case 4: no image_input → no modalities
+  test('no image_input → no modalities key', () => {
+    const chat = chatFromCapabilities({ effort: { supported: false } });
+    expect(chat).toBeUndefined();
+  });
+
+  // Case 5: image_input + effort + enabled + adaptive → full chat object
+  test('image_input=true + effort + both thinking types → full chat', () => {
+    const chat = chatFromCapabilities({
+      image_input: { supported: true },
+      effort: {
+        supported: true,
+        low: { supported: true },
+        medium: { supported: true },
+        high: { supported: true },
+      },
+      thinking: { types: { enabled: { supported: true }, adaptive: { supported: true } } },
+    });
+    expect(chat).toEqual({
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      reasoning: {
+        effort: { supported: ['low', 'medium', 'high'], default: 'high' },
+        budget_tokens: {},
+        adaptive: true,
+      },
+    });
+  });
+
+  // Case 6: no capabilities field → no chat key
+  test('undefined capabilities → undefined', () => {
+    expect(chatFromCapabilities(undefined)).toBeUndefined();
+  });
+
+  // Case 7: image_input.supported = false → no modalities
+  test('image_input.supported=false → no modalities', () => {
+    const chat = chatFromCapabilities({
+      image_input: { supported: false },
+      thinking: { types: { enabled: { supported: true } } },
+    });
+    expect(chat).toEqual({ reasoning: { budget_tokens: {} } });
+  });
+
+  // Case 8: default selection — 'high' preferred; fallback to first
+  test('effort default: high when in supported list', () => {
+    const chat = chatFromCapabilities({
+      effort: {
+        supported: true,
+        low: { supported: true },
+        medium: { supported: true },
+        high: { supported: true },
+      },
+      thinking: { types: { enabled: { supported: true } } },
+    });
+    expect(chat!.reasoning!.effort!.default).toBe('high');
+  });
+
+  test('effort default: first item when high is not supported', () => {
+    const chat = chatFromCapabilities({
+      effort: {
+        supported: true,
+        low: { supported: true },
+        medium: { supported: true },
+      },
+      thinking: { types: { enabled: { supported: true } } },
+    });
+    expect(chat!.reasoning!.effort!.default).toBe('low');
   });
 });
 
@@ -83,6 +206,43 @@ describe('buildClaudeCodeCatalog', () => {
     const built = buildClaudeCodeCatalog(SAMPLE_API_MODELS, flags);
     for (const m of built) {
       expect(m.enabledFlags).toBe(flags);
+    }
+  });
+
+  test('populates chat from capabilities when present', () => {
+    const withCaps: ClaudeCodeApiModel[] = [
+      {
+        id: 'claude-opus-4-6-20251201',
+        display_name: 'Claude Opus 4.6',
+        max_input_tokens: 200_000,
+        capabilities: {
+          image_input: { supported: true },
+          effort: {
+            supported: true,
+            low: { supported: true },
+            medium: { supported: true },
+            high: { supported: true },
+            max: { supported: true },
+          },
+          thinking: { types: { enabled: { supported: true }, adaptive: { supported: true } } },
+        },
+      },
+    ];
+    const built = buildClaudeCodeCatalog(withCaps, new Set());
+    expect(built[0]!.chat).toEqual({
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      reasoning: {
+        effort: { supported: ['low', 'medium', 'high', 'max'], default: 'high' },
+        budget_tokens: {},
+        adaptive: true,
+      },
+    });
+  });
+
+  test('omits chat key when capabilities absent', () => {
+    const built = buildClaudeCodeCatalog(SAMPLE_API_MODELS, new Set());
+    for (const m of built) {
+      expect(m.chat).toBeUndefined();
     }
   });
 });

--- a/packages/provider-claude-code/src/models_test.ts
+++ b/packages/provider-claude-code/src/models_test.ts
@@ -58,7 +58,7 @@ describe('chatFromCapabilities', () => {
     });
     expect(chat).toEqual({
       reasoning: {
-        effort: { supported: ['low', 'medium', 'high', 'max'], default: 'high' },
+        effort: { supported: ['low', 'medium', 'high', 'max'], default: 'medium' },
         budget_tokens: {},
         adaptive: true,
       },
@@ -80,7 +80,7 @@ describe('chatFromCapabilities', () => {
     });
     expect(chat).toEqual({
       reasoning: {
-        effort: { supported: ['low', 'medium', 'high', 'xhigh', 'max'], default: 'high' },
+        effort: { supported: ['low', 'medium', 'high', 'xhigh', 'max'], default: 'medium' },
         adaptive: true,
       },
     });
@@ -107,7 +107,7 @@ describe('chatFromCapabilities', () => {
     expect(chat).toEqual({
       modalities: { input: ['text', 'image'], output: ['text'] },
       reasoning: {
-        effort: { supported: ['low', 'medium', 'high'], default: 'high' },
+        effort: { supported: ['low', 'medium', 'high'], default: 'medium' },
         budget_tokens: {},
         adaptive: true,
       },
@@ -128,8 +128,8 @@ describe('chatFromCapabilities', () => {
     expect(chat).toEqual({ reasoning: { budget_tokens: {} } });
   });
 
-  // Case 8: default selection — 'high' preferred; fallback to first
-  test('effort default: high when in supported list', () => {
+  // Case 8: default selection — 'medium' preferred; fallback to first
+  test('effort default: medium when in supported list', () => {
     const chat = chatFromCapabilities({
       effort: {
         supported: true,
@@ -139,15 +139,15 @@ describe('chatFromCapabilities', () => {
       },
       thinking: { types: { enabled: { supported: true } } },
     });
-    expect(chat!.reasoning!.effort!.default).toBe('high');
+    expect(chat!.reasoning!.effort!.default).toBe('medium');
   });
 
-  test('effort default: first item when high is not supported', () => {
+  test('effort default: first item when medium is not supported', () => {
     const chat = chatFromCapabilities({
       effort: {
         supported: true,
         low: { supported: true },
-        medium: { supported: true },
+        high: { supported: true },
       },
       thinking: { types: { enabled: { supported: true } } },
     });
@@ -232,7 +232,7 @@ describe('buildClaudeCodeCatalog', () => {
     expect(built[0]!.chat).toEqual({
       modalities: { input: ['text', 'image'], output: ['text'] },
       reasoning: {
-        effort: { supported: ['low', 'medium', 'high', 'max'], default: 'high' },
+        effort: { supported: ['low', 'medium', 'high', 'max'], default: 'medium' },
         budget_tokens: {},
         adaptive: true,
       },

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -107,11 +107,17 @@ export const codexRawToUpstreamModel = (raw: CodexRawModel, enabledFlags: Readon
   if (raw.input_modalities && raw.input_modalities.length > 0) {
     chat.modalities = { input: raw.input_modalities, output: ['text'] };
   }
-  if (raw.reasoning_efforts && raw.reasoning_efforts.length > 0 && raw.default_reasoning_effort !== undefined) {
-    if (!raw.reasoning_efforts.includes(raw.default_reasoning_effort)) {
-      throw new Error(`Codex model ${raw.id}: default_reasoning_level not in supported_reasoning_levels`);
+  if (raw.reasoning_efforts && raw.reasoning_efforts.length > 0) {
+    let effortDefault: string;
+    if (raw.default_reasoning_effort !== undefined) {
+      if (!raw.reasoning_efforts.includes(raw.default_reasoning_effort)) {
+        throw new Error(`Codex model ${raw.id}: default_reasoning_level not in supported_reasoning_levels`);
+      }
+      effortDefault = raw.default_reasoning_effort;
+    } else {
+      effortDefault = raw.reasoning_efforts.includes('medium') ? 'medium' : raw.reasoning_efforts[0]!;
     }
-    chat.reasoning = { effort: { supported: raw.reasoning_efforts, default: raw.default_reasoning_effort } };
+    chat.reasoning = { effort: { supported: raw.reasoning_efforts, default: effortDefault } };
   }
   return {
     id: raw.id,

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -111,7 +111,7 @@ export const codexRawToUpstreamModel = (raw: CodexRawModel, enabledFlags: Readon
     if (!raw.reasoning_efforts.includes(raw.default_reasoning_effort)) {
       throw new Error(`Codex model ${raw.id}: default_reasoning_level not in supported_reasoning_levels`);
     }
-    chat.reasoning = { supported_efforts: raw.reasoning_efforts, default_effort: raw.default_reasoning_effort };
+    chat.reasoning = { effort: { supported: raw.reasoning_efforts, default: raw.default_reasoning_effort } };
   }
   return {
     id: raw.id,

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -6,7 +6,7 @@ import {
   CODEX_USER_AGENT,
 } from './constants.ts';
 import { pricingForCodexModelKey } from './pricing.ts';
-import { type Fetcher, type UpstreamModel } from '@floway-dev/provider';
+import { type Fetcher, type UpstreamChatModelConfig, type UpstreamModel } from '@floway-dev/provider';
 
 export interface CodexRawModel {
   id: string;
@@ -16,6 +16,9 @@ export interface CodexRawModel {
   // (https://github.com/openai/codex/blob/d66708232299bdbf373ec55b0d6b938c246cfa60/codex-rs/protocol/src/openai_models.rs#L383-L386);
   // Floway has no override path, so only the operational value is kept.
   context_window: number;
+  input_modalities?: readonly ('text' | 'image')[];
+  reasoning_efforts?: readonly string[];
+  default_reasoning_effort?: string;
 }
 
 // `fetcher` is required so the catalog refresh traverses the same proxy/
@@ -44,7 +47,10 @@ export const fetchCodexCatalog = async (opts: { accessToken: string; accountId: 
 const isPlainRecord = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null;
 
 // Fail loud on malformed upstream catalog responses: a missing field
-// signals an upstream contract change we need to notice.
+// signals an upstream contract change we need to notice. New optional
+// fields (`input_modalities`, `supported_reasoning_levels`,
+// `default_reasoning_level`) are tolerated when absent for backwards
+// compatibility with older catalog snapshots, but throw on type drift.
 const assertRawModel = (value: unknown): CodexRawModel => {
   if (!isPlainRecord(value)) throw new TypeError('Codex model entry is not an object');
   const slug = value.slug;
@@ -53,7 +59,39 @@ const assertRawModel = (value: unknown): CodexRawModel => {
   if (typeof display_name !== 'string') throw new TypeError(`Codex model entry ${slug} missing display_name`);
   const context_window = value.context_window;
   if (typeof context_window !== 'number') throw new TypeError(`Codex model entry ${slug} missing context_window`);
-  return { id: slug, display_name, context_window };
+
+  const raw: CodexRawModel = { id: slug, display_name, context_window };
+
+  if (value.input_modalities !== undefined) {
+    if (!Array.isArray(value.input_modalities)) throw new TypeError(`Codex model entry ${slug} input_modalities not an array`);
+    const out: ('text' | 'image')[] = [];
+    for (const m of value.input_modalities) {
+      if (m !== 'text' && m !== 'image') throw new TypeError(`Codex model entry ${slug} unknown modality ${JSON.stringify(m)}`);
+      if (!out.includes(m)) out.push(m);
+    }
+    raw.input_modalities = out;
+  }
+
+  if (value.supported_reasoning_levels !== undefined) {
+    if (!Array.isArray(value.supported_reasoning_levels)) throw new TypeError(`Codex model entry ${slug} supported_reasoning_levels not an array`);
+    const efforts: string[] = [];
+    for (const entry of value.supported_reasoning_levels) {
+      if (!isPlainRecord(entry) || typeof entry.effort !== 'string' || entry.effort.length === 0) {
+        throw new TypeError(`Codex model entry ${slug} reasoning level entry malformed`);
+      }
+      if (!efforts.includes(entry.effort)) efforts.push(entry.effort);
+    }
+    raw.reasoning_efforts = efforts;
+  }
+
+  if (value.default_reasoning_level !== undefined) {
+    if (typeof value.default_reasoning_level !== 'string' || value.default_reasoning_level.length === 0) {
+      throw new TypeError(`Codex model entry ${slug} default_reasoning_level malformed`);
+    }
+    raw.default_reasoning_effort = value.default_reasoning_level;
+  }
+
+  return raw;
 };
 
 // Codex exposes only the Responses endpoint. Pricing is looked up from the
@@ -65,6 +103,16 @@ const assertRawModel = (value: unknown): CodexRawModel => {
 // downstream interceptors can read the effective set without re-resolving.
 export const codexRawToUpstreamModel = (raw: CodexRawModel, enabledFlags: ReadonlySet<string>): UpstreamModel => {
   const cost = pricingForCodexModelKey(raw.id);
+  const chat: UpstreamChatModelConfig = {};
+  if (raw.input_modalities && raw.input_modalities.length > 0) {
+    chat.modalities = { input: raw.input_modalities, output: ['text'] };
+  }
+  if (raw.reasoning_efforts && raw.reasoning_efforts.length > 0 && raw.default_reasoning_effort !== undefined) {
+    if (!raw.reasoning_efforts.includes(raw.default_reasoning_effort)) {
+      throw new Error(`Codex model ${raw.id}: default_reasoning_level not in supported_reasoning_levels`);
+    }
+    chat.reasoning = { supported_efforts: raw.reasoning_efforts, default_effort: raw.default_reasoning_effort };
+  }
   return {
     id: raw.id,
     display_name: raw.display_name,
@@ -76,5 +124,6 @@ export const codexRawToUpstreamModel = (raw: CodexRawModel, enabledFlags: Readon
     endpoints: { responses: {} },
     enabledFlags,
     ...(cost ? { cost } : {}),
+    ...(Object.keys(chat).length > 0 ? { chat } : {}),
   };
 };

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -212,13 +212,32 @@ describe('codexRawToUpstreamModel', () => {
     expect(m.chat?.reasoning).toBeUndefined();
   });
 
-  test('omits chat.reasoning when supported_reasoning_levels present but default_reasoning_level absent (both-or-nothing)', () => {
+  test('derives default = medium when supported includes medium and default_reasoning_level absent', () => {
     const m = codexRawToUpstreamModel({
       id: 'gpt-5.5',
       display_name: 'GPT-5.5',
       context_window: 272000,
-      reasoning_efforts: ['low', 'medium'],
-      // default_reasoning_effort intentionally absent
+      reasoning_efforts: ['low', 'medium', 'high'],
+    }, noFlags);
+    expect(m.chat?.reasoning).toEqual({ effort: { supported: ['low', 'medium', 'high'], default: 'medium' } });
+  });
+
+  test('derives default = first when medium absent and default_reasoning_level absent', () => {
+    const m = codexRawToUpstreamModel({
+      id: 'gpt-5.5',
+      display_name: 'GPT-5.5',
+      context_window: 272000,
+      reasoning_efforts: ['low', 'high'],
+    }, noFlags);
+    expect(m.chat?.reasoning).toEqual({ effort: { supported: ['low', 'high'], default: 'low' } });
+  });
+
+  test('drops reasoning entirely when default_reasoning_level present but supported_reasoning_levels absent', () => {
+    const m = codexRawToUpstreamModel({
+      id: 'gpt-5.5',
+      display_name: 'GPT-5.5',
+      context_window: 272000,
+      default_reasoning_effort: 'medium',
     }, noFlags);
     expect(m.chat?.reasoning).toBeUndefined();
   });

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -190,7 +190,7 @@ describe('codexRawToUpstreamModel', () => {
     }, noFlags);
     expect(m.chat).toEqual({
       modalities: { input: ['text', 'image'], output: ['text'] },
-      reasoning: { supported_efforts: ['low', 'medium', 'high', 'xhigh'], default_effort: 'medium' },
+      reasoning: { effort: { supported: ['low', 'medium', 'high', 'xhigh'], default: 'medium' } },
     });
   });
 

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -57,6 +57,58 @@ describe('fetchCodexCatalog', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({ models: [{ slug: 'gpt-x', display_name: 'GPT-X' }] }));
     await expect(fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher })).rejects.toThrow(/context_window/);
   });
+
+  test('carries input_modalities, supported_reasoning_levels, default_reasoning_level through to CodexRawModel', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({
+      models: [{
+        slug: 'gpt-5.5',
+        display_name: 'GPT-5.5',
+        context_window: 272000,
+        input_modalities: ['text', 'image'],
+        supported_reasoning_levels: [
+          { effort: 'low', description: 'Fast' },
+          { effort: 'medium', description: 'Balanced' },
+          { effort: 'high', description: 'Thorough' },
+        ],
+        default_reasoning_level: 'medium',
+      }],
+    }));
+    const catalog = await fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher });
+    expect(catalog).toHaveLength(1);
+    expect(catalog[0]).toEqual({
+      id: 'gpt-5.5',
+      display_name: 'GPT-5.5',
+      context_window: 272000,
+      input_modalities: ['text', 'image'],
+      reasoning_efforts: ['low', 'medium', 'high'],
+      default_reasoning_effort: 'medium',
+    });
+  });
+
+  test('tolerates entries missing the new optional fields (pre-catalog backwards compat)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({
+      models: [{ slug: 'gpt-old', display_name: 'GPT-Old', context_window: 100000 }],
+    }));
+    const catalog = await fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher });
+    expect(catalog[0]).toEqual({ id: 'gpt-old', display_name: 'GPT-Old', context_window: 100000 });
+    expect(catalog[0].input_modalities).toBeUndefined();
+    expect(catalog[0].reasoning_efforts).toBeUndefined();
+    expect(catalog[0].default_reasoning_effort).toBeUndefined();
+  });
+
+  test('throws on malformed input_modalities entry (unknown modality)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({
+      models: [{ slug: 'gpt-x', display_name: 'GPT-X', context_window: 1, input_modalities: ['video'] }],
+    }));
+    await expect(fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher })).rejects.toThrow(/modality/);
+  });
+
+  test('throws on malformed supported_reasoning_levels entry (missing effort)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({
+      models: [{ slug: 'gpt-x', display_name: 'GPT-X', context_window: 1, supported_reasoning_levels: [{ description: 'no effort field' }] }],
+    }));
+    await expect(fetchCodexCatalog({ accessToken: 'at', accountId: 'acc', fetcher: directFetcher })).rejects.toThrow(/reasoning level entry malformed/);
+  });
 });
 
 describe('codexRawToUpstreamModel', () => {
@@ -125,5 +177,59 @@ describe('codexRawToUpstreamModel', () => {
     const flags: ReadonlySet<string> = new Set(['responses-web-search-shim']);
     const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 }, flags);
     expect(m.enabledFlags).toBe(flags);
+  });
+
+  test('populates chat when raw advertises both modalities and reasoning', () => {
+    const m = codexRawToUpstreamModel({
+      id: 'gpt-5.5',
+      display_name: 'GPT-5.5',
+      context_window: 272000,
+      input_modalities: ['text', 'image'],
+      reasoning_efforts: ['low', 'medium', 'high', 'xhigh'],
+      default_reasoning_effort: 'medium',
+    }, noFlags);
+    expect(m.chat).toEqual({
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      reasoning: { supported_efforts: ['low', 'medium', 'high', 'xhigh'], default_effort: 'medium' },
+    });
+  });
+
+  test('omits chat when raw has no modalities or reasoning metadata', () => {
+    const m = codexRawToUpstreamModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 }, noFlags);
+    expect(m.chat).toBeUndefined();
+  });
+
+  test('sets chat.modalities but omits chat.reasoning when only modalities are present', () => {
+    const m = codexRawToUpstreamModel({
+      id: 'gpt-5.5',
+      display_name: 'GPT-5.5',
+      context_window: 272000,
+      input_modalities: ['text'],
+    }, noFlags);
+    expect(m.chat).toEqual({
+      modalities: { input: ['text'], output: ['text'] },
+    });
+    expect(m.chat?.reasoning).toBeUndefined();
+  });
+
+  test('omits chat.reasoning when supported_reasoning_levels present but default_reasoning_level absent (both-or-nothing)', () => {
+    const m = codexRawToUpstreamModel({
+      id: 'gpt-5.5',
+      display_name: 'GPT-5.5',
+      context_window: 272000,
+      reasoning_efforts: ['low', 'medium'],
+      // default_reasoning_effort intentionally absent
+    }, noFlags);
+    expect(m.chat?.reasoning).toBeUndefined();
+  });
+
+  test('throws when default_reasoning_effort is not in reasoning_efforts', () => {
+    expect(() => codexRawToUpstreamModel({
+      id: 'gpt-5.5',
+      display_name: 'GPT-5.5',
+      context_window: 272000,
+      reasoning_efforts: ['low', 'medium'],
+      default_reasoning_effort: 'high',
+    }, noFlags)).toThrow(/default_reasoning_level not in supported_reasoning_levels/);
   });
 });

--- a/packages/provider-copilot/src/chat-from-raw.ts
+++ b/packages/provider-copilot/src/chat-from-raw.ts
@@ -1,0 +1,37 @@
+import type { CopilotRawModel } from './types.ts';
+import type { UpstreamChatModelConfig } from '@floway-dev/provider';
+
+export const chatFromCopilotRaw = (raw: CopilotRawModel): UpstreamChatModelConfig | undefined => {
+  const supports = raw.capabilities?.supports;
+  if (!supports) return undefined;
+
+  const chat: UpstreamChatModelConfig = {};
+
+  if (supports.vision === true) {
+    chat.modalities = { input: ['text', 'image'], output: ['text'] };
+  }
+
+  const reasoning: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
+  const efforts = supports.reasoning_effort;
+  if (efforts && efforts.length > 0) {
+    // Default to 'medium' if supported, else the first available — mirrors
+    // the OpenRouter convention for reasoning-effort defaults.
+    const def = efforts.includes('medium') ? 'medium' : efforts[0];
+    reasoning.effort = { supported: efforts, default: def };
+  }
+  const minBudget = supports.min_thinking_budget;
+  const maxBudget = supports.max_thinking_budget;
+  if (minBudget !== undefined || maxBudget !== undefined) {
+    reasoning.budget_tokens = {
+      ...(minBudget !== undefined ? { min: minBudget } : {}),
+      ...(maxBudget !== undefined ? { max: maxBudget } : {}),
+    };
+  }
+  if (supports.adaptive_thinking === true) {
+    reasoning.adaptive = true;
+  }
+
+  if (Object.keys(reasoning).length > 0) chat.reasoning = reasoning;
+
+  return Object.keys(chat).length > 0 ? chat : undefined;
+};

--- a/packages/provider-copilot/src/chat-from-raw.ts
+++ b/packages/provider-copilot/src/chat-from-raw.ts
@@ -14,8 +14,7 @@ export const chatFromCopilotRaw = (raw: CopilotRawModel): UpstreamChatModelConfi
   const reasoning: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
   const efforts = supports.reasoning_effort;
   if (efforts && efforts.length > 0) {
-    // Default to 'medium' if supported, else the first available — mirrors
-    // the OpenRouter convention for reasoning-effort defaults.
+    // Default to 'medium' if supported, else the first available.
     const def = efforts.includes('medium') ? 'medium' : efforts[0];
     reasoning.effort = { supported: efforts, default: def };
   }

--- a/packages/provider-copilot/src/chat-from-raw.ts
+++ b/packages/provider-copilot/src/chat-from-raw.ts
@@ -14,7 +14,6 @@ export const chatFromCopilotRaw = (raw: CopilotRawModel): UpstreamChatModelConfi
   const reasoning: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
   const efforts = supports.reasoning_effort;
   if (efforts && efforts.length > 0) {
-    // Default to 'medium' if supported, else the first available.
     const def = efforts.includes('medium') ? 'medium' : efforts[0];
     reasoning.effort = { supported: efforts, default: def };
   }

--- a/packages/provider-copilot/src/chat-from-raw_test.ts
+++ b/packages/provider-copilot/src/chat-from-raw_test.ts
@@ -1,0 +1,95 @@
+import { test } from 'vitest';
+
+import { chatFromCopilotRaw } from './chat-from-raw.ts';
+import type { CopilotRawModel } from './types.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+const rawModel = (supports: NonNullable<NonNullable<CopilotRawModel['capabilities']>['supports']>): CopilotRawModel => ({
+  id: 'test-model',
+  capabilities: { supports },
+});
+
+test('chatFromCopilotRaw returns undefined when capabilities.supports is absent', () => {
+  assertEquals(chatFromCopilotRaw({ id: 'test-model' }), undefined);
+  assertEquals(chatFromCopilotRaw({ id: 'test-model', capabilities: {} }), undefined);
+  assertEquals(chatFromCopilotRaw({ id: 'test-model', capabilities: { type: 'chat' } }), undefined);
+});
+
+test('chatFromCopilotRaw returns undefined when supports has no recognized fields', () => {
+  assertEquals(chatFromCopilotRaw(rawModel({})), undefined);
+});
+
+test('chatFromCopilotRaw vision-only → modalities with image input', () => {
+  const chat = chatFromCopilotRaw(rawModel({ vision: true }));
+  assertEquals(chat, { modalities: { input: ['text', 'image'], output: ['text'] } });
+});
+
+test('chatFromCopilotRaw vision: false → no modalities', () => {
+  assertEquals(chatFromCopilotRaw(rawModel({ vision: false })), undefined);
+});
+
+test('chatFromCopilotRaw reasoning_effort with medium → default is medium', () => {
+  const chat = chatFromCopilotRaw(rawModel({ reasoning_effort: ['low', 'medium', 'high'] }));
+  assertEquals(chat, {
+    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+  });
+});
+
+test('chatFromCopilotRaw reasoning_effort full GPT-5 set → default is medium', () => {
+  const efforts = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+  const chat = chatFromCopilotRaw(rawModel({ reasoning_effort: efforts }));
+  assertEquals(chat, {
+    reasoning: { effort: { supported: efforts, default: 'medium' } },
+  });
+});
+
+test('chatFromCopilotRaw reasoning_effort without medium → default is first', () => {
+  const chat = chatFromCopilotRaw(rawModel({ reasoning_effort: ['minimal', 'xhigh'] }));
+  assertEquals(chat, {
+    reasoning: { effort: { supported: ['minimal', 'xhigh'], default: 'minimal' } },
+  });
+});
+
+test('chatFromCopilotRaw min+max_thinking_budget → budget_tokens', () => {
+  const chat = chatFromCopilotRaw(rawModel({ min_thinking_budget: 1024, max_thinking_budget: 16384 }));
+  assertEquals(chat, {
+    reasoning: { budget_tokens: { min: 1024, max: 16384 } },
+  });
+});
+
+test('chatFromCopilotRaw min_thinking_budget only → budget_tokens.min', () => {
+  const chat = chatFromCopilotRaw(rawModel({ min_thinking_budget: 512 }));
+  assertEquals(chat, { reasoning: { budget_tokens: { min: 512 } } });
+});
+
+test('chatFromCopilotRaw max_thinking_budget only → budget_tokens.max', () => {
+  const chat = chatFromCopilotRaw(rawModel({ max_thinking_budget: 8192 }));
+  assertEquals(chat, { reasoning: { budget_tokens: { max: 8192 } } });
+});
+
+test('chatFromCopilotRaw adaptive_thinking: true → reasoning.adaptive', () => {
+  const chat = chatFromCopilotRaw(rawModel({ adaptive_thinking: true }));
+  assertEquals(chat, { reasoning: { adaptive: true } });
+});
+
+test('chatFromCopilotRaw adaptive_thinking: false → no chat', () => {
+  assertEquals(chatFromCopilotRaw(rawModel({ adaptive_thinking: false })), undefined);
+});
+
+test('chatFromCopilotRaw combined: vision + reasoning_effort + adaptive_thinking → full chat', () => {
+  const chat = chatFromCopilotRaw(rawModel({
+    vision: true,
+    reasoning_effort: ['low', 'medium', 'high', 'xhigh'],
+    min_thinking_budget: 1024,
+    max_thinking_budget: 32768,
+    adaptive_thinking: true,
+  }));
+  assertEquals(chat, {
+    modalities: { input: ['text', 'image'], output: ['text'] },
+    reasoning: {
+      effort: { supported: ['low', 'medium', 'high', 'xhigh'], default: 'medium' },
+      budget_tokens: { min: 1024, max: 32768 },
+      adaptive: true,
+    },
+  });
+});

--- a/packages/provider-copilot/src/merge-claude-variants_test.ts
+++ b/packages/provider-copilot/src/merge-claude-variants_test.ts
@@ -176,3 +176,46 @@ test('mergeClaudeVariants preserves order across mixed claude/non-claude models'
     ['claude-opus-4-7', 'gpt-5.5', 'claude-sonnet-4-6'],
   );
 });
+
+test('mergeClaudeVariants preserves vision/adaptive_thinking/budget from base variant', () => {
+  // These fields are uniform per family (every variant shares the same base
+  // capability), so the merge just keeps the base's value via the ...supports spread.
+  const input: CopilotModelsResponse = {
+    object: 'list',
+    data: [
+      {
+        ...claudeVariant('claude-opus-4.7', { reasoningEfforts: ['medium'] }),
+        capabilities: {
+          type: 'chat',
+          limits: { max_context_window_tokens: 200_000 },
+          supports: {
+            vision: true,
+            reasoning_effort: ['medium'],
+            min_thinking_budget: 1024,
+            max_thinking_budget: 32768,
+            adaptive_thinking: true,
+          },
+        },
+      },
+      {
+        ...claudeVariant('claude-opus-4.7-xhigh', { reasoningEfforts: ['xhigh'] }),
+        capabilities: {
+          type: 'chat',
+          limits: { max_context_window_tokens: 200_000 },
+          supports: { vision: true, reasoning_effort: ['xhigh'] },
+        },
+      },
+    ],
+  };
+
+  const merged = mergeClaudeVariants(input);
+  assertEquals(merged.data.length, 1);
+  const supports = merged.data[0].capabilities?.supports;
+  // vision and budget fields come from the base via spread
+  assertEquals(supports?.vision, true);
+  assertEquals(supports?.min_thinking_budget, 1024);
+  assertEquals(supports?.max_thinking_budget, 32768);
+  assertEquals(supports?.adaptive_thinking, true);
+  // reasoning_effort is the union
+  assertSameSet(supports?.reasoning_effort, ['medium', 'xhigh']);
+});

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -1,3 +1,4 @@
+import { chatFromCopilotRaw } from './chat-from-raw.ts';
 import { assertCopilotUpstreamRecord } from './config.ts';
 import { fetchCopilotModels } from './fetch-models.ts';
 import { copilotFetchChatCompletions, copilotFetchEmbeddings, copilotFetchMessages, copilotFetchMessagesCountTokens, copilotFetchResponses } from './fetch.ts';
@@ -43,6 +44,8 @@ const copilotInternalModel = (model: CopilotRawModel): Omit<UpstreamModel, 'kind
   if (model.created !== undefined) internal.created = model.created;
   const displayName = model.display_name ?? model.name;
   if (displayName !== undefined) internal.display_name = displayName;
+  const chat = chatFromCopilotRaw(model);
+  if (chat !== undefined) internal.chat = chat;
   return internal;
 };
 

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -1039,3 +1039,134 @@ test('Copilot provider passes unknown speed values to the upstream verbatim so t
 
   assertEquals(upstreamBody?.speed, 'priority');
 });
+
+// ---------------------------------------------------------------------------
+// chat? auto-population from upstream /models capabilities
+// ---------------------------------------------------------------------------
+
+interface CopilotModelCapabilityFixture {
+  id: string;
+  supported_endpoints?: string[];
+  supports?: {
+    vision?: boolean;
+    reasoning_effort?: string[];
+    min_thinking_budget?: number;
+    max_thinking_budget?: number;
+    adaptive_thinking?: boolean;
+  };
+}
+
+const copilotModelsWithCapabilities = (models: CopilotModelCapabilityFixture[]) => ({
+  object: 'list',
+  data: models.map(model => ({
+    id: model.id,
+    name: model.id,
+    version: '1',
+    supported_endpoints: model.supported_endpoints ?? ['/chat/completions'],
+    capabilities: {
+      type: 'chat',
+      limits: {},
+      ...(model.supports !== undefined ? { supports: model.supports } : {}),
+    },
+  })),
+});
+
+const getModelsWithCapabilities = async (fixtures: CopilotModelCapabilityFixture[]) => {
+  const { copilotUpstream } = await setupCopilotTest();
+  const instance = await createCopilotProvider(copilotUpstream);
+  let models: Awaited<ReturnType<typeof instance.provider.getProvidedModels>> = [];
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') return jsonResponse(copilotModelsWithCapabilities(fixtures));
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => { models = await instance.provider.getProvidedModels(directFetcher); },
+  );
+
+  return models;
+};
+
+test('Copilot chat field: vision-only → modalities with image input', async () => {
+  const [model] = await getModelsWithCapabilities([
+    { id: 'gpt-vision', supports: { vision: true } },
+  ]);
+  assertEquals(model.chat, { modalities: { input: ['text', 'image'], output: ['text'] } });
+});
+
+test('Copilot chat field: reasoning_effort with medium → effort with default medium', async () => {
+  const [model] = await getModelsWithCapabilities([
+    { id: 'o3-mini', supports: { reasoning_effort: ['low', 'medium', 'high'] } },
+  ]);
+  assertEquals(model.chat, {
+    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+  });
+});
+
+test('Copilot chat field: reasoning_effort full GPT-5 set → default is medium', async () => {
+  const [model] = await getModelsWithCapabilities([
+    { id: 'gpt-5', supports: { reasoning_effort: ['minimal', 'low', 'medium', 'high', 'xhigh'] } },
+  ]);
+  assertEquals(model.chat, {
+    reasoning: { effort: { supported: ['minimal', 'low', 'medium', 'high', 'xhigh'], default: 'medium' } },
+  });
+});
+
+test('Copilot chat field: reasoning_effort without medium → default is first', async () => {
+  const [model] = await getModelsWithCapabilities([
+    { id: 'o-nomedium', supports: { reasoning_effort: ['minimal', 'xhigh'] } },
+  ]);
+  assertEquals(model.chat, {
+    reasoning: { effort: { supported: ['minimal', 'xhigh'], default: 'minimal' } },
+  });
+});
+
+test('Copilot chat field: min+max_thinking_budget → budget_tokens', async () => {
+  const [model] = await getModelsWithCapabilities([
+    { id: 'claude-think', supported_endpoints: ['/v1/messages'], supports: { min_thinking_budget: 1024, max_thinking_budget: 16384 } },
+  ]);
+  assertEquals(model.chat, { reasoning: { budget_tokens: { min: 1024, max: 16384 } } });
+});
+
+test('Copilot chat field: adaptive_thinking: true → reasoning.adaptive', async () => {
+  const [model] = await getModelsWithCapabilities([
+    { id: 'claude-adaptive', supported_endpoints: ['/v1/messages'], supports: { adaptive_thinking: true } },
+  ]);
+  assertEquals(model.chat, { reasoning: { adaptive: true } });
+});
+
+test('Copilot chat field: combined vision + reasoning_effort + adaptive_thinking → full chat', async () => {
+  const [model] = await getModelsWithCapabilities([
+    {
+      id: 'claude-opus-4.7',
+      supported_endpoints: ['/v1/messages'],
+      supports: {
+        vision: true,
+        reasoning_effort: ['low', 'medium', 'high', 'xhigh'],
+        min_thinking_budget: 1024,
+        max_thinking_budget: 32768,
+        adaptive_thinking: true,
+      },
+    },
+  ]);
+  assertEquals(model.chat, {
+    modalities: { input: ['text', 'image'], output: ['text'] },
+    reasoning: {
+      effort: { supported: ['low', 'medium', 'high', 'xhigh'], default: 'medium' },
+      budget_tokens: { min: 1024, max: 32768 },
+      adaptive: true,
+    },
+  });
+});
+
+test('Copilot chat field: no capabilities → no chat field', async () => {
+  const [model] = await getModelsWithCapabilities([
+    { id: 'basic-model' },
+  ]);
+  assertEquals(model.chat, undefined);
+});

--- a/packages/provider-copilot/src/types.ts
+++ b/packages/provider-copilot/src/types.ts
@@ -1,7 +1,8 @@
 // Copilot's `/models` wire shape. Lives here (not in the provider-neutral
 // layer) because no other provider consumes these fields — `capabilities.type`
-// and `supports.reasoning_effort` are read by Copilot's raw variant selector,
-// the rest is upstream metadata we ignore.
+// is read by the endpoint-routing logic; `supports.*` fields are consumed by
+// both the raw variant selector (reasoning_effort) and the chat capability
+// mapper (vision, min/max_thinking_budget, adaptive_thinking).
 
 export interface CopilotRawModel {
   id: string;
@@ -19,7 +20,11 @@ export interface CopilotRawModel {
       max_output_tokens?: number;
     };
     supports?: {
+      vision?: boolean;
       reasoning_effort?: string[];
+      min_thinking_budget?: number;
+      max_thinking_budget?: number;
+      adaptive_thinking?: boolean;
     };
   };
 }

--- a/packages/provider-custom/src/fetch-models.ts
+++ b/packages/provider-custom/src/fetch-models.ts
@@ -12,7 +12,7 @@
 import type { CustomUpstreamConfig } from './config.ts';
 import { customFetchModels } from './fetch.ts';
 import { BILLING_DIMENSIONS, type ModelKind, type ModelPricing } from '@floway-dev/protocols/common';
-import { fetchUpstreamModels, type Fetcher } from '@floway-dev/provider';
+import { chatField, fetchUpstreamModels, type Fetcher, type UpstreamChatModelConfig } from '@floway-dev/provider';
 
 export interface CustomRawModel {
   id: string;
@@ -78,124 +78,6 @@ const parseKind = (value: unknown): ModelKind | undefined => {
   return undefined;
 };
 
-// Chat metadata types and parsing. Mirrored from the provider package's model-config.ts.
-// These are defined locally here because custom provider is permissive about chat fields,
-// treating them as best-effort metadata rather than structured configuration.
-
-type Modality = 'text' | 'image';
-
-interface UpstreamChatModelConfig {
-  modalities?: {
-    input: readonly Modality[];
-    output: readonly Modality[];
-  };
-  reasoning?: {
-    effort?: { supported: readonly string[]; default: string };
-    budget_tokens?: { min?: number; max?: number };
-    adaptive?: boolean;
-    mandatory?: boolean;
-  };
-}
-
-const MODALITY_VALUES: ReadonlySet<Modality> = new Set(['text', 'image']);
-
-const modalityArrayField = (value: unknown): readonly Modality[] => {
-  if (!Array.isArray(value)) throw new Error('must be an array');
-  const out: Modality[] = [];
-  for (const entry of value) {
-    if (typeof entry !== 'string' || !MODALITY_VALUES.has(entry as Modality)) {
-      throw new Error(`unknown modality ${JSON.stringify(entry)}`);
-    }
-    if (!out.includes(entry as Modality)) out.push(entry as Modality);
-  }
-  if (out.length === 0) throw new Error('must have at least one modality');
-  return out;
-};
-
-const inputModalitiesField = (value: unknown): readonly Modality[] => {
-  const modalities = modalityArrayField(value);
-  if (!modalities.includes('text')) throw new Error('must include text');
-  return modalities;
-};
-
-const parseChat = (value: unknown): UpstreamChatModelConfig | undefined => {
-  if (value === undefined) return undefined;
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error('must be an object');
-  const record = value as Record<string, unknown>;
-  const out: UpstreamChatModelConfig = {};
-
-  if (record.modalities !== undefined) {
-    if (typeof record.modalities !== 'object' || record.modalities === null || Array.isArray(record.modalities)) {
-      throw new Error('modalities must be an object');
-    }
-    const mod = record.modalities as Record<string, unknown>;
-    out.modalities = {
-      input: inputModalitiesField(mod.input),
-      output: modalityArrayField(mod.output),
-    };
-  }
-
-  if (record.reasoning !== undefined) {
-    if (typeof record.reasoning !== 'object' || record.reasoning === null || Array.isArray(record.reasoning)) {
-      throw new Error('reasoning must be an object');
-    }
-    const reasoning = record.reasoning as Record<string, unknown>;
-    const result: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
-
-    if (reasoning.effort !== undefined) {
-      if (typeof reasoning.effort !== 'object' || reasoning.effort === null || Array.isArray(reasoning.effort)) {
-        throw new Error('effort must be an object');
-      }
-      const effort = reasoning.effort as Record<string, unknown>;
-      if (!Array.isArray(effort.supported)) throw new Error('effort.supported must be an array');
-      const supported: string[] = [];
-      for (const eff of effort.supported) {
-        if (typeof eff !== 'string' || eff.length === 0) throw new Error('effort.supported must contain non-empty strings');
-        if (!supported.includes(eff)) supported.push(eff);
-      }
-      if (supported.length === 0) throw new Error('effort.supported must have at least one entry');
-      if (typeof effort.default !== 'string' || effort.default.length === 0) {
-        throw new Error('effort.default must be a non-empty string');
-      }
-      if (!supported.includes(effort.default)) {
-        throw new Error(`effort.default not in effort.supported`);
-      }
-      result.effort = { supported, default: effort.default };
-    }
-
-    if (reasoning.budget_tokens !== undefined) {
-      if (typeof reasoning.budget_tokens !== 'object' || reasoning.budget_tokens === null || Array.isArray(reasoning.budget_tokens)) {
-        throw new Error('budget_tokens must be an object');
-      }
-      const bt = reasoning.budget_tokens as Record<string, unknown>;
-      const min = (typeof bt.min === 'number' && Number.isInteger(bt.min) && bt.min >= 0) ? bt.min : undefined;
-      const max = (typeof bt.max === 'number' && Number.isInteger(bt.max) && bt.max >= 0) ? bt.max : undefined;
-      if (min !== undefined && max !== undefined && max < min) {
-        throw new Error('budget_tokens.max must be >= min');
-      }
-      result.budget_tokens = { ...(min !== undefined ? { min } : {}), ...(max !== undefined ? { max } : {}) };
-    }
-
-    if (reasoning.adaptive !== undefined) {
-      if (typeof reasoning.adaptive !== 'boolean') throw new Error('adaptive must be a boolean');
-      if (reasoning.adaptive) result.adaptive = true;
-    }
-
-    if (reasoning.mandatory !== undefined) {
-      if (typeof reasoning.mandatory !== 'boolean') throw new Error('mandatory must be a boolean');
-      if (reasoning.mandatory) result.mandatory = true;
-    }
-
-    if (!result.effort && !result.budget_tokens && !result.adaptive && !result.mandatory) {
-      throw new Error('reasoning must have at least one of effort, budget_tokens, adaptive, mandatory');
-    }
-
-    out.reasoning = result;
-  }
-
-  return Object.keys(out).length > 0 ? out : undefined;
-};
-
 const parseRawModel = (value: unknown): CustomRawModel | null => {
   if (!isRecord(value)) return null;
   if (typeof value.id !== 'string' || value.id === '') return null;
@@ -218,7 +100,7 @@ const parseRawModel = (value: unknown): CustomRawModel | null => {
   if (kind !== undefined) model.kind = kind;
   // Attempt to parse chat metadata; silently skip on malformed data.
   try {
-    const chat = parseChat(value.chat);
+    const chat = chatField(value.chat, `${value.id}.chat`);
     if (chat !== undefined) model.chat = chat;
   } catch {
     // Permissive: if chat field is malformed, skip it and continue.

--- a/packages/provider-custom/src/fetch-models.ts
+++ b/packages/provider-custom/src/fetch-models.ts
@@ -34,6 +34,9 @@ export interface CustomRawModel {
   // Optional ModelKind published by Floway upstreams; absent on plain
   // OpenAI-compat upstreams.
   kind?: ModelKind;
+  // Optional chat metadata from Floway-shaped upstreams; absent on plain
+  // OpenAI-compat upstreams.
+  chat?: UpstreamChatModelConfig;
 }
 
 export interface CustomModelsResponse {
@@ -75,6 +78,124 @@ const parseKind = (value: unknown): ModelKind | undefined => {
   return undefined;
 };
 
+// Chat metadata types and parsing. Mirrored from the provider package's model-config.ts.
+// These are defined locally here because custom provider is permissive about chat fields,
+// treating them as best-effort metadata rather than structured configuration.
+
+type Modality = 'text' | 'image';
+
+interface UpstreamChatModelConfig {
+  modalities?: {
+    input: readonly Modality[];
+    output: readonly Modality[];
+  };
+  reasoning?: {
+    effort?: { supported: readonly string[]; default: string };
+    budget_tokens?: { min?: number; max?: number };
+    adaptive?: boolean;
+    mandatory?: boolean;
+  };
+}
+
+const MODALITY_VALUES: ReadonlySet<Modality> = new Set(['text', 'image']);
+
+const modalityArrayField = (value: unknown): readonly Modality[] => {
+  if (!Array.isArray(value)) throw new Error('must be an array');
+  const out: Modality[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !MODALITY_VALUES.has(entry as Modality)) {
+      throw new Error(`unknown modality ${JSON.stringify(entry)}`);
+    }
+    if (!out.includes(entry as Modality)) out.push(entry as Modality);
+  }
+  if (out.length === 0) throw new Error('must have at least one modality');
+  return out;
+};
+
+const inputModalitiesField = (value: unknown): readonly Modality[] => {
+  const modalities = modalityArrayField(value);
+  if (!modalities.includes('text')) throw new Error('must include text');
+  return modalities;
+};
+
+const parseChat = (value: unknown): UpstreamChatModelConfig | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error('must be an object');
+  const record = value as Record<string, unknown>;
+  const out: UpstreamChatModelConfig = {};
+
+  if (record.modalities !== undefined) {
+    if (typeof record.modalities !== 'object' || record.modalities === null || Array.isArray(record.modalities)) {
+      throw new Error('modalities must be an object');
+    }
+    const mod = record.modalities as Record<string, unknown>;
+    out.modalities = {
+      input: inputModalitiesField(mod.input),
+      output: modalityArrayField(mod.output),
+    };
+  }
+
+  if (record.reasoning !== undefined) {
+    if (typeof record.reasoning !== 'object' || record.reasoning === null || Array.isArray(record.reasoning)) {
+      throw new Error('reasoning must be an object');
+    }
+    const reasoning = record.reasoning as Record<string, unknown>;
+    const result: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
+
+    if (reasoning.effort !== undefined) {
+      if (typeof reasoning.effort !== 'object' || reasoning.effort === null || Array.isArray(reasoning.effort)) {
+        throw new Error('effort must be an object');
+      }
+      const effort = reasoning.effort as Record<string, unknown>;
+      if (!Array.isArray(effort.supported)) throw new Error('effort.supported must be an array');
+      const supported: string[] = [];
+      for (const eff of effort.supported) {
+        if (typeof eff !== 'string' || eff.length === 0) throw new Error('effort.supported must contain non-empty strings');
+        if (!supported.includes(eff)) supported.push(eff);
+      }
+      if (supported.length === 0) throw new Error('effort.supported must have at least one entry');
+      if (typeof effort.default !== 'string' || effort.default.length === 0) {
+        throw new Error('effort.default must be a non-empty string');
+      }
+      if (!supported.includes(effort.default)) {
+        throw new Error(`effort.default not in effort.supported`);
+      }
+      result.effort = { supported, default: effort.default };
+    }
+
+    if (reasoning.budget_tokens !== undefined) {
+      if (typeof reasoning.budget_tokens !== 'object' || reasoning.budget_tokens === null || Array.isArray(reasoning.budget_tokens)) {
+        throw new Error('budget_tokens must be an object');
+      }
+      const bt = reasoning.budget_tokens as Record<string, unknown>;
+      const min = (typeof bt.min === 'number' && Number.isInteger(bt.min) && bt.min >= 0) ? bt.min : undefined;
+      const max = (typeof bt.max === 'number' && Number.isInteger(bt.max) && bt.max >= 0) ? bt.max : undefined;
+      if (min !== undefined && max !== undefined && max < min) {
+        throw new Error('budget_tokens.max must be >= min');
+      }
+      result.budget_tokens = { ...(min !== undefined ? { min } : {}), ...(max !== undefined ? { max } : {}) };
+    }
+
+    if (reasoning.adaptive !== undefined) {
+      if (typeof reasoning.adaptive !== 'boolean') throw new Error('adaptive must be a boolean');
+      if (reasoning.adaptive) result.adaptive = true;
+    }
+
+    if (reasoning.mandatory !== undefined) {
+      if (typeof reasoning.mandatory !== 'boolean') throw new Error('mandatory must be a boolean');
+      if (reasoning.mandatory) result.mandatory = true;
+    }
+
+    if (!result.effort && !result.budget_tokens && !result.adaptive && !result.mandatory) {
+      throw new Error('reasoning must have at least one of effort, budget_tokens, adaptive, mandatory');
+    }
+
+    out.reasoning = result;
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+
 const parseRawModel = (value: unknown): CustomRawModel | null => {
   if (!isRecord(value)) return null;
   if (typeof value.id !== 'string' || value.id === '') return null;
@@ -95,6 +216,13 @@ const parseRawModel = (value: unknown): CustomRawModel | null => {
   if (cost !== undefined) model.cost = cost;
   const kind = parseKind(value.kind);
   if (kind !== undefined) model.kind = kind;
+  // Attempt to parse chat metadata; silently skip on malformed data.
+  try {
+    const chat = parseChat(value.chat);
+    if (chat !== undefined) model.chat = chat;
+  } catch {
+    // Permissive: if chat field is malformed, skip it and continue.
+  }
   return model;
 };
 

--- a/packages/provider-custom/src/fetch-models.ts
+++ b/packages/provider-custom/src/fetch-models.ts
@@ -102,9 +102,7 @@ const parseRawModel = (value: unknown): CustomRawModel | null => {
   try {
     const chat = chatField(value.chat, `${value.id}.chat`);
     if (chat !== undefined) model.chat = chat;
-  } catch {
-    // Permissive: if chat field is malformed, skip it and continue.
-  }
+  } catch { /* skip */ }
   return model;
 };
 

--- a/packages/provider-custom/src/fetch-models_test.ts
+++ b/packages/provider-custom/src/fetch-models_test.ts
@@ -187,3 +187,71 @@ test('fetchCustomModels routes the catalog GET through the injected fetcher, not
   assertEquals(calls[0].authorization, 'Bearer token');
   assertEquals(result.data[0].id, 'injected-model');
 });
+
+test('fetchCustomModels reads chat metadata from Floway-shaped upstreams', async () => {
+  const { config } = assertCustomUpstreamRecord(upstreamRecord());
+  await withMockedFetch(
+    () => jsonResponse({
+      object: 'list',
+      data: [{
+        id: 'm-1',
+        chat: {
+          modalities: {
+            input: ['text', 'image'],
+            output: ['text'],
+          },
+          reasoning: {
+            effort: {
+              supported: ['low', 'medium', 'high'],
+              default: 'medium',
+            },
+          },
+        },
+      }],
+    }),
+    async () => {
+      const result = await fetchCustomModels(config, directFetcher);
+      const model = result.data[0];
+      assertEquals(model.id, 'm-1');
+      assertEquals(model.chat?.modalities?.input, ['text', 'image']);
+      assertEquals(model.chat?.modalities?.output, ['text']);
+      assertEquals(model.chat?.reasoning?.effort?.supported, ['low', 'medium', 'high']);
+      assertEquals(model.chat?.reasoning?.effort?.default, 'medium');
+    },
+  );
+});
+
+test('fetchCustomModels skips malformed chat field without error', async () => {
+  const { config } = assertCustomUpstreamRecord(upstreamRecord());
+  await withMockedFetch(
+    () => jsonResponse({
+      object: 'list',
+      data: [{
+        id: 'm-1',
+        chat: 'malformed',
+      }],
+    }),
+    async () => {
+      const result = await fetchCustomModels(config, directFetcher);
+      const model = result.data[0];
+      assertEquals(model.id, 'm-1');
+      assertEquals(model.chat, undefined);
+    },
+  );
+});
+
+test('fetchCustomModels skips missing chat field', async () => {
+  const { config } = assertCustomUpstreamRecord(upstreamRecord());
+  await withMockedFetch(
+    () => jsonResponse({
+      object: 'list',
+      data: [{ id: 'm-1' }],
+    }),
+    async () => {
+      const result = await fetchCustomModels(config, directFetcher);
+      const model = result.data[0];
+      assertEquals(model.id, 'm-1');
+      assertEquals(model.chat, undefined);
+    },
+  );
+});

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -91,6 +91,7 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     };
     if (model.display_name !== undefined) internal.display_name = model.display_name;
     if (model.cost) internal.cost = model.cost;
+    if (model.chat) internal.chat = model.chat;
     return internal;
   });
   const manualPricingByUpstreamId = new Map<string, ModelPricing>(

--- a/packages/provider-ollama/src/chat-from-raw.ts
+++ b/packages/provider-ollama/src/chat-from-raw.ts
@@ -1,0 +1,29 @@
+import type { OllamaRawModel } from './fetch-models.ts';
+import type { UpstreamChatModelConfig } from '@floway-dev/provider';
+
+// `^gpt-oss[:_-]` matches `gpt-oss:20b` (tag-suffixed) and any future
+// `gpt-oss-*` or `gpt-oss_*` family member. The gpt-oss (harmony) family
+// is the only Ollama family whose chat template renders `.ThinkLevel` literally
+// (as `Reasoning: {{ .ThinkLevel }}`), so effort strings low/medium/high have
+// differential effect. The server downgrades `max → high` for this family
+// (ollama/server/routes.go:440-450). All other thinking-capable families
+// (qwen3, deepseek-r1, glm-4, …) only read a boolean `.Think` from the
+// template, so effort strings produce no differential output — `adaptive: true`
+// is the honest catalog representation for those.
+const GPT_OSS_FAMILY = /^gpt-oss[:_-]/i;
+
+export const chatFromOllamaRaw = (raw: OllamaRawModel): UpstreamChatModelConfig | undefined => {
+  const chat: UpstreamChatModelConfig = {};
+
+  if (raw.capabilities.has('vision')) {
+    chat.modalities = { input: ['text', 'image'], output: ['text'] };
+  }
+
+  if (raw.capabilities.has('thinking')) {
+    chat.reasoning = GPT_OSS_FAMILY.test(raw.id)
+      ? { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } }
+      : { adaptive: true };
+  }
+
+  return Object.keys(chat).length > 0 ? chat : undefined;
+};

--- a/packages/provider-ollama/src/chat-from-raw.ts
+++ b/packages/provider-ollama/src/chat-from-raw.ts
@@ -1,17 +1,15 @@
 import type { OllamaRawModel } from './fetch-models.ts';
 import type { UpstreamChatModelConfig } from '@floway-dev/provider';
 
-// `^gpt-oss[:_-]` matches `gpt-oss:20b` (tag-suffixed) and any future
-// `gpt-oss-*` or `gpt-oss_*` family member. The gpt-oss (harmony) family
-// is the only Ollama family whose chat template renders `.ThinkLevel` literally
-// (as `Reasoning: {{ .ThinkLevel }}`), so effort strings low/medium/high have
-// differential effect. The server downgrades `max → high` for this family
-// (ollama/server/routes.go:440-450). All other thinking-capable families
-// (qwen3, deepseek-r1, glm-4, …) only read a boolean `.Think` from the
-// template, so effort strings produce no differential output — `adaptive: true`
-// is the honest catalog representation for those.
-const GPT_OSS_FAMILY = /^gpt-oss[:_-]/i;
-
+// Across Ollama's thinking-capable families, only gpt-oss (harmony) renders
+// `.ThinkLevel` literally in its chat template — every other family (qwen3,
+// deepseek-r1, glm-4, …) reads a boolean `.Think` and ignores the effort
+// string. We surface effort uniformly anyway: the gateway has no reliable
+// per-family signal to discriminate without baking in a family allowlist that
+// drifts as the catalog grows, and an honest `adaptive: true` would force
+// operators of effort-respecting families to opt out of the standard preset.
+// Operators who need stricter behavior can override `chat.reasoning` in the
+// manual row.
 export const chatFromOllamaRaw = (raw: OllamaRawModel): UpstreamChatModelConfig | undefined => {
   const chat: UpstreamChatModelConfig = {};
 
@@ -20,9 +18,7 @@ export const chatFromOllamaRaw = (raw: OllamaRawModel): UpstreamChatModelConfig 
   }
 
   if (raw.capabilities.has('thinking')) {
-    chat.reasoning = GPT_OSS_FAMILY.test(raw.id)
-      ? { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } }
-      : { adaptive: true };
+    chat.reasoning = { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } };
   }
 
   return Object.keys(chat).length > 0 ? chat : undefined;

--- a/packages/provider-ollama/src/chat-from-raw_test.ts
+++ b/packages/provider-ollama/src/chat-from-raw_test.ts
@@ -1,0 +1,58 @@
+import { test } from 'vitest';
+
+import { chatFromOllamaRaw } from './chat-from-raw.ts';
+import type { OllamaRawModel } from './fetch-models.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+const rawModel = (id: string, capabilities: string[]): OllamaRawModel => ({
+  id,
+  capabilities: new Set(capabilities),
+});
+
+test('chatFromOllamaRaw gpt-oss:20b with thinking → effort branch low/medium/high', () => {
+  const chat = chatFromOllamaRaw(rawModel('gpt-oss:20b', ['completion', 'tools', 'thinking']));
+  assertEquals(chat, {
+    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+  });
+});
+
+test('chatFromOllamaRaw gpt-oss-coder (dash suffix) → effort branch', () => {
+  const chat = chatFromOllamaRaw(rawModel('gpt-oss-coder', ['thinking']));
+  assertEquals(chat, {
+    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+  });
+});
+
+test('chatFromOllamaRaw deepseek-r1:32b with thinking → adaptive: true', () => {
+  const chat = chatFromOllamaRaw(rawModel('deepseek-r1:32b', ['completion', 'thinking']));
+  assertEquals(chat, { reasoning: { adaptive: true } });
+});
+
+test('chatFromOllamaRaw qwen3:32b with thinking → adaptive: true', () => {
+  const chat = chatFromOllamaRaw(rawModel('qwen3:32b', ['thinking']));
+  assertEquals(chat, { reasoning: { adaptive: true } });
+});
+
+test('chatFromOllamaRaw vision-only → modalities only, no reasoning', () => {
+  const chat = chatFromOllamaRaw(rawModel('llava:13b', ['completion', 'vision']));
+  assertEquals(chat, { modalities: { input: ['text', 'image'], output: ['text'] } });
+});
+
+test('chatFromOllamaRaw vision + thinking (gpt-oss) → both modalities and effort reasoning', () => {
+  const chat = chatFromOllamaRaw(rawModel('gpt-oss:120b', ['vision', 'thinking']));
+  assertEquals(chat, {
+    modalities: { input: ['text', 'image'], output: ['text'] },
+    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+  });
+});
+
+test('chatFromOllamaRaw neither vision nor thinking → undefined', () => {
+  assertEquals(chatFromOllamaRaw(rawModel('mistral:7b', ['completion', 'tools'])), undefined);
+});
+
+test('chatFromOllamaRaw GPT-OSS:20b uppercase → effort branch (case-insensitive)', () => {
+  const chat = chatFromOllamaRaw(rawModel('GPT-OSS:20b', ['thinking']));
+  assertEquals(chat, {
+    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+  });
+});

--- a/packages/provider-ollama/src/chat-from-raw_test.ts
+++ b/packages/provider-ollama/src/chat-from-raw_test.ts
@@ -9,28 +9,21 @@ const rawModel = (id: string, capabilities: string[]): OllamaRawModel => ({
   capabilities: new Set(capabilities),
 });
 
-test('chatFromOllamaRaw gpt-oss:20b with thinking → effort branch low/medium/high', () => {
+const EFFORT_PRESET = { supported: ['low', 'medium', 'high'], default: 'medium' };
+
+test('chatFromOllamaRaw thinking-capable model → uniform effort preset', () => {
   const chat = chatFromOllamaRaw(rawModel('gpt-oss:20b', ['completion', 'tools', 'thinking']));
-  assertEquals(chat, {
-    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
-  });
+  assertEquals(chat, { reasoning: { effort: EFFORT_PRESET } });
 });
 
-test('chatFromOllamaRaw gpt-oss-coder (dash suffix) → effort branch', () => {
-  const chat = chatFromOllamaRaw(rawModel('gpt-oss-coder', ['thinking']));
-  assertEquals(chat, {
-    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
-  });
-});
-
-test('chatFromOllamaRaw deepseek-r1:32b with thinking → adaptive: true', () => {
+test('chatFromOllamaRaw deepseek-r1 thinking → same effort preset', () => {
   const chat = chatFromOllamaRaw(rawModel('deepseek-r1:32b', ['completion', 'thinking']));
-  assertEquals(chat, { reasoning: { adaptive: true } });
+  assertEquals(chat, { reasoning: { effort: EFFORT_PRESET } });
 });
 
-test('chatFromOllamaRaw qwen3:32b with thinking → adaptive: true', () => {
+test('chatFromOllamaRaw qwen3 thinking → same effort preset', () => {
   const chat = chatFromOllamaRaw(rawModel('qwen3:32b', ['thinking']));
-  assertEquals(chat, { reasoning: { adaptive: true } });
+  assertEquals(chat, { reasoning: { effort: EFFORT_PRESET } });
 });
 
 test('chatFromOllamaRaw vision-only → modalities only, no reasoning', () => {
@@ -38,21 +31,14 @@ test('chatFromOllamaRaw vision-only → modalities only, no reasoning', () => {
   assertEquals(chat, { modalities: { input: ['text', 'image'], output: ['text'] } });
 });
 
-test('chatFromOllamaRaw vision + thinking (gpt-oss) → both modalities and effort reasoning', () => {
+test('chatFromOllamaRaw vision + thinking → both modalities and effort reasoning', () => {
   const chat = chatFromOllamaRaw(rawModel('gpt-oss:120b', ['vision', 'thinking']));
   assertEquals(chat, {
     modalities: { input: ['text', 'image'], output: ['text'] },
-    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+    reasoning: { effort: EFFORT_PRESET },
   });
 });
 
 test('chatFromOllamaRaw neither vision nor thinking → undefined', () => {
   assertEquals(chatFromOllamaRaw(rawModel('mistral:7b', ['completion', 'tools'])), undefined);
-});
-
-test('chatFromOllamaRaw GPT-OSS:20b uppercase → effort branch (case-insensitive)', () => {
-  const chat = chatFromOllamaRaw(rawModel('GPT-OSS:20b', ['thinking']));
-  assertEquals(chat, {
-    reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
-  });
 });

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -92,6 +92,7 @@ export const createOllamaProvider = (record: UpstreamRecord): ModelProviderInsta
     };
     if (model.display_name !== undefined) internal.display_name = model.display_name;
     if (model.cost) internal.cost = model.cost;
+    if (model.chat) internal.chat = model.chat;
     return internal;
   });
   const manualPricingByUpstreamId = new Map<string, ModelPricing>(

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -18,6 +18,7 @@
 // Manual config.models[] entries override auto-fetched models with the same
 // upstreamModelId, mirroring the custom provider's pinning behavior.
 
+import { chatFromOllamaRaw } from './chat-from-raw.ts';
 import { assertOllamaUpstreamRecord, type OllamaUpstreamConfig } from './config.ts';
 import { fetchOllamaCatalog, type OllamaCatalog } from './fetch-models.ts';
 import { ollamaFetchChatCompletions, ollamaFetchCompletions, ollamaFetchEmbeddings, ollamaFetchMessages, ollamaFetchMessagesCountTokens, ollamaFetchResponses, ollamaFetchResponsesCompact } from './fetch.ts';
@@ -63,6 +64,8 @@ const finalizeOllamaModels = (
     if (raw.modifiedAt !== undefined) model.created = raw.modifiedAt;
     const cost = pricingForOllamaModelKey(raw.id);
     if (cost) model.cost = cost;
+    const chat = chatFromOllamaRaw(raw);
+    if (chat) model.chat = chat;
     models.push(model);
   }
   return models;

--- a/packages/provider-ollama/src/provider_test.ts
+++ b/packages/provider-ollama/src/provider_test.ts
@@ -170,3 +170,17 @@ test('call* methods POST to /v1/<endpoint> with the upstream model id and Bearer
   assertEquals(body.model, 'gpt-oss:120b');
   assertEquals(body.stream, true);
 });
+
+test('getProvidedModels populates chat from capabilities: gpt-oss thinking → effort, vision → modalities', async () => {
+  const instance = createOllamaProvider(buildRecord());
+  await withMockedFetch(tagsAndShow, async () => {
+    const models = await instance.provider.getProvidedModels(directFetcher);
+    const gptoss = models.find(m => m.id === 'gpt-oss:120b')!;
+    assertEquals(gptoss.chat, {
+      reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
+    });
+    // Embedding model has no thinking/vision → no chat field.
+    const embed = models.find(m => m.id === 'nomic-embed-text:latest')!;
+    assertEquals(embed.chat, undefined);
+  });
+});

--- a/packages/provider-ollama/src/provider_test.ts
+++ b/packages/provider-ollama/src/provider_test.ts
@@ -59,7 +59,7 @@ test('getProvidedModels surfaces chat models with all three OpenAI/Anthropic-com
     const models = await instance.provider.getProvidedModels(directFetcher);
     const gptoss = models.find(m => m.id === 'gpt-oss:120b')!;
     assertEquals(gptoss.kind, 'chat');
-    assertEquals(Object.keys(gptoss.endpoints).sort(), ['chatCompletions', 'messages', 'responses']);
+    assertEquals(Object.keys(gptoss.endpoints).sort(), ['chatCompletions', 'completions', 'messages', 'responses']);
     assertEquals(gptoss.owned_by, 'ollama');
     assertEquals(gptoss.limits.max_context_window_tokens, 131072);
     // OLLAMA_MODEL_PRICING covers gpt-oss:120b, so cost flows through into

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -76,8 +76,11 @@ export type {
   UpstreamModelConfig,
   UpstreamModelFlagOverrides,
   UpstreamModelLimits,
+  Modality,
+  UpstreamChatModelConfig,
 } from './model-config.ts';
 export {
+  chatField,
   endpointsField,
   flagOverridesField,
   isRecord,

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -21,8 +21,15 @@ export interface UpstreamChatModelConfig {
     output: readonly Modality[];
   };
   reasoning?: {
-    supported_efforts: readonly string[];
-    default_effort: string;
+    // Discrete effort levels — a closed set of named presets (e.g. low/medium/high).
+    effort?: { supported: readonly string[]; default: string };
+    // Operator-supplied token budget. Bounds are optional; absent bounds mean
+    // "operator can supply a budget, but legal range is unknown".
+    budget_tokens?: { min?: number; max?: number };
+    // Model-controlled adaptive depth — the model decides how much reasoning to do.
+    adaptive?: boolean;
+    // Always-on reasoning — the model cannot be instructed to skip it.
+    mandatory?: boolean;
   };
 }
 
@@ -181,21 +188,64 @@ const inputModalitiesField = (value: unknown, label: string): readonly Modality[
   return modalities;
 };
 
+const optionalNonNegativeIntField = (value: unknown, label: string): number | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error(`Malformed ${label}: must be a non-negative integer`);
+  }
+  return value;
+};
+
 const reasoningField = (value: unknown, label: string): UpstreamChatModelConfig['reasoning'] => {
   if (!isRecord(value)) throw new Error(`Malformed ${label}: must be an object`);
-  if (!Array.isArray(value.supported_efforts)) throw new Error(`Malformed ${label}.supported_efforts: must be an array`);
-  const supported: string[] = [];
-  for (const eff of value.supported_efforts) {
-    if (typeof eff !== 'string' || eff.length === 0) throw new Error(`Malformed ${label}.supported_efforts: every entry must be a non-empty string`);
-    if (!supported.includes(eff)) supported.push(eff);
+
+  const result: NonNullable<UpstreamChatModelConfig['reasoning']> = {};
+
+  if (value.effort !== undefined) {
+    if (!isRecord(value.effort)) throw new Error(`Malformed ${label}.effort: must be an object`);
+    if (!Array.isArray(value.effort.supported)) throw new Error(`Malformed ${label}.effort.supported: must be an array`);
+    const supported: string[] = [];
+    for (const eff of value.effort.supported) {
+      if (typeof eff !== 'string' || eff.length === 0) throw new Error(`Malformed ${label}.effort.supported: every entry must be a non-empty string`);
+      if (!supported.includes(eff)) supported.push(eff);
+    }
+    if (supported.length === 0) throw new Error(`Malformed ${label}.effort.supported: must have at least one entry`);
+    if (typeof value.effort.default !== 'string' || value.effort.default.length === 0) {
+      throw new Error(`Malformed ${label}.effort.default: must be a non-empty string`);
+    }
+    if (!supported.includes(value.effort.default)) {
+      throw new Error(`Malformed ${label}.effort.default: ${JSON.stringify(value.effort.default)} not in effort.supported`);
+    }
+    result.effort = { supported, default: value.effort.default };
   }
-  if (typeof value.default_effort !== 'string' || value.default_effort.length === 0) {
-    throw new Error(`Malformed ${label}.default_effort: must be a non-empty string`);
+
+  if (value.budget_tokens !== undefined) {
+    if (!isRecord(value.budget_tokens)) throw new Error(`Malformed ${label}.budget_tokens: must be an object`);
+    const min = optionalNonNegativeIntField(value.budget_tokens.min, `${label}.budget_tokens.min`);
+    const max = optionalNonNegativeIntField(value.budget_tokens.max, `${label}.budget_tokens.max`);
+    if (min !== undefined && max !== undefined && max < min) {
+      throw new Error(`Malformed ${label}.budget_tokens: max must be >= min`);
+    }
+    result.budget_tokens = { ...(min !== undefined ? { min } : {}), ...(max !== undefined ? { max } : {}) };
   }
-  if (!supported.includes(value.default_effort)) {
-    throw new Error(`Malformed ${label}.default_effort: ${JSON.stringify(value.default_effort)} not in supported_efforts`);
+
+  if (value.adaptive !== undefined) {
+    if (typeof value.adaptive !== 'boolean') throw new Error(`Malformed ${label}.adaptive: must be a boolean`);
+    // Strip false — semantically equivalent to absent.
+    if (value.adaptive) result.adaptive = true;
   }
-  return { supported_efforts: supported, default_effort: value.default_effort };
+
+  if (value.mandatory !== undefined) {
+    if (typeof value.mandatory !== 'boolean') throw new Error(`Malformed ${label}.mandatory: must be a boolean`);
+    // Strip false — semantically equivalent to absent.
+    if (value.mandatory) result.mandatory = true;
+  }
+
+  if (result.effort === undefined && result.budget_tokens === undefined && result.adaptive === undefined && result.mandatory === undefined) {
+    throw new Error(`Malformed ${label}: must have at least one of effort, budget_tokens, adaptive, mandatory`);
+  }
+
+  return result;
 };
 
 export const chatField = (value: unknown, label: string): UpstreamChatModelConfig | undefined => {

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -171,8 +171,14 @@ const modalityArrayField = (value: unknown, label: string): readonly Modality[] 
     }
     if (!out.includes(entry as Modality)) out.push(entry as Modality);
   }
-  if (!out.includes('text')) throw new Error(`Malformed ${label}: must include 'text'`);
+  if (out.length === 0) throw new Error(`Malformed ${label}: must have at least one modality`);
   return out;
+};
+
+const inputModalitiesField = (value: unknown, label: string): readonly Modality[] => {
+  const modalities = modalityArrayField(value, label);
+  if (!modalities.includes('text')) throw new Error(`Malformed ${label}: must include 'text'`);
+  return modalities;
 };
 
 const reasoningField = (value: unknown, label: string): UpstreamChatModelConfig['reasoning'] => {
@@ -199,7 +205,7 @@ export const chatField = (value: unknown, label: string): UpstreamChatModelConfi
   if (value.modalities !== undefined) {
     if (!isRecord(value.modalities)) throw new Error(`Malformed ${label}.modalities: must be an object`);
     out.modalities = {
-      input: modalityArrayField(value.modalities.input, `${label}.modalities.input`),
+      input: inputModalitiesField(value.modalities.input, `${label}.modalities.input`),
       output: modalityArrayField(value.modalities.output, `${label}.modalities.output`),
     };
   }

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -260,6 +260,7 @@ export const chatField = (value: unknown, label: string): UpstreamChatModelConfi
     };
   }
   if (value.reasoning !== undefined) out.reasoning = reasoningField(value.reasoning, `${label}.reasoning`);
+  if (out.modalities === undefined && out.reasoning === undefined) return undefined;
   return out;
 };
 

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -1,6 +1,8 @@
 import { isKnownFlagId } from './flags.ts';
-import { BILLING_DIMENSIONS, type BillingDimension, type ModelEndpointKey, type ModelEndpoints, type ModelKind, type ModelPricing } from '@floway-dev/protocols/common';
+import { BILLING_DIMENSIONS, type BillingDimension, type ChatModelInfo, type ModelEndpointKey, type ModelEndpoints, type ModelKind, type Modality, type ModelPricing } from '@floway-dev/protocols/common';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
+
+export type { Modality } from '@floway-dev/protocols/common';
 
 export interface UpstreamModelLimits {
   max_context_window_tokens?: number;
@@ -13,25 +15,10 @@ export interface UpstreamModelFlagOverrides {
   values: Record<string, boolean>;
 }
 
-export type Modality = 'text' | 'image';
-
-export interface UpstreamChatModelConfig {
-  modalities?: {
-    input: readonly Modality[];
-    output: readonly Modality[];
-  };
-  reasoning?: {
-    // Discrete effort levels — a closed set of named presets (e.g. low/medium/high).
-    effort?: { supported: readonly string[]; default: string };
-    // Operator-supplied token budget. Bounds are optional; absent bounds mean
-    // "operator can supply a budget, but legal range is unknown".
-    budget_tokens?: { min?: number; max?: number };
-    // Model-controlled adaptive depth — the model decides how much reasoning to do.
-    adaptive?: boolean;
-    // Always-on reasoning — the model cannot be instructed to skip it.
-    mandatory?: boolean;
-  };
-}
+// The catalog-side name for the wire chat metadata. Shape lives in
+// @floway-dev/protocols/common so PublicModel.chat and the upstream catalog
+// share a single declaration.
+export type UpstreamChatModelConfig = ChatModelInfo;
 
 export interface UpstreamModelConfig {
   // Mirrors of fields that flow through to PublicModel (snake_case for parity).

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -13,18 +13,30 @@ export interface UpstreamModelFlagOverrides {
   values: Record<string, boolean>;
 }
 
+export type Modality = 'text' | 'image';
+
+export interface UpstreamChatModelConfig {
+  modalities?: {
+    input: readonly Modality[];
+    output: readonly Modality[];
+  };
+  reasoning?: {
+    supported_efforts: readonly string[];
+    default_effort: string;
+  };
+}
+
 export interface UpstreamModelConfig {
-  upstreamModelId: string;
-  publicModelId?: string;
-  // Required metadata mirroring our public model definition. Routing is driven
-  // by `endpoints` (the structured capability map: a present key means the model
-  // is served by that endpoint); `kind` decides which fields the dashboard form
-  // surfaces and is derived from `endpoints` when an entry omits it.
+  // Mirrors of fields that flow through to PublicModel (snake_case for parity).
   kind: ModelKind;
   endpoints: ModelEndpoints;
   display_name?: string;
   limits?: UpstreamModelLimits;
   cost?: ModelPricing;
+  chat?: UpstreamChatModelConfig;
+  // Floway-internal (camelCase, not surfaced on PublicModel).
+  upstreamModelId: string;
+  publicModelId?: string;
   flagOverrides?: UpstreamModelFlagOverrides;
 }
 
@@ -148,6 +160,53 @@ export const pricingField = (value: unknown, label: string): ModelPricing | unde
 
 const MODEL_KINDS: ReadonlySet<ModelKind> = new Set<ModelKind>(['chat', 'embedding', 'image']);
 
+const MODALITY_VALUES: ReadonlySet<Modality> = new Set<Modality>(['text', 'image']);
+
+const modalityArrayField = (value: unknown, label: string): readonly Modality[] => {
+  if (!Array.isArray(value)) throw new Error(`Malformed ${label}: must be an array`);
+  const out: Modality[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !MODALITY_VALUES.has(entry as Modality)) {
+      throw new Error(`Malformed ${label}: unknown modality ${JSON.stringify(entry)}`);
+    }
+    if (!out.includes(entry as Modality)) out.push(entry as Modality);
+  }
+  if (!out.includes('text')) throw new Error(`Malformed ${label}: must include 'text'`);
+  return out;
+};
+
+const reasoningField = (value: unknown, label: string): UpstreamChatModelConfig['reasoning'] => {
+  if (!isRecord(value)) throw new Error(`Malformed ${label}: must be an object`);
+  if (!Array.isArray(value.supported_efforts)) throw new Error(`Malformed ${label}.supported_efforts: must be an array`);
+  const supported: string[] = [];
+  for (const eff of value.supported_efforts) {
+    if (typeof eff !== 'string' || eff.length === 0) throw new Error(`Malformed ${label}.supported_efforts: every entry must be a non-empty string`);
+    if (!supported.includes(eff)) supported.push(eff);
+  }
+  if (typeof value.default_effort !== 'string' || value.default_effort.length === 0) {
+    throw new Error(`Malformed ${label}.default_effort: must be a non-empty string`);
+  }
+  if (!supported.includes(value.default_effort)) {
+    throw new Error(`Malformed ${label}.default_effort: ${JSON.stringify(value.default_effort)} not in supported_efforts`);
+  }
+  return { supported_efforts: supported, default_effort: value.default_effort };
+};
+
+export const chatField = (value: unknown, label: string): UpstreamChatModelConfig | undefined => {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error(`Malformed ${label}: must be an object`);
+  const out: UpstreamChatModelConfig = {};
+  if (value.modalities !== undefined) {
+    if (!isRecord(value.modalities)) throw new Error(`Malformed ${label}.modalities: must be an object`);
+    out.modalities = {
+      input: modalityArrayField(value.modalities.input, `${label}.modalities.input`),
+      output: modalityArrayField(value.modalities.output, `${label}.modalities.output`),
+    };
+  }
+  if (value.reasoning !== undefined) out.reasoning = reasoningField(value.reasoning, `${label}.reasoning`);
+  return out;
+};
+
 // kind is a pure function of the routing endpoints, so an entry that omits it
 // (an import, or hand-edited JSON) derives one rather than failing. The editor
 // always writes an explicit kind, keeping it consistent with the endpoints.
@@ -163,14 +222,20 @@ const modelField = (value: unknown, label: string): UpstreamModelConfig => {
   if (!isRecord(value)) throw new Error(`Malformed ${label}: must be an object`);
   const cost = pricingField(value.cost, `${label}.cost`);
   const endpoints = endpointsField(value.endpoints, `${label}.endpoints`);
+  const kind = kindField(value.kind, endpoints, `${label}.kind`);
+  const chat = chatField(value.chat, `${label}.chat`);
+  if (chat !== undefined && kind !== 'chat') {
+    throw new Error(`Malformed ${label}: chat field is only allowed when kind === 'chat'`);
+  }
   return {
-    upstreamModelId: nonEmptyStringField(value.upstreamModelId, `${label}.upstreamModelId`),
-    ...(value.publicModelId !== undefined ? { publicModelId: optionalStringField(value.publicModelId, `${label}.publicModelId`) } : {}),
-    kind: kindField(value.kind, endpoints, `${label}.kind`),
+    kind,
     endpoints,
     ...(value.display_name !== undefined ? { display_name: optionalStringField(value.display_name, `${label}.display_name`) } : {}),
     ...(value.limits !== undefined ? { limits: limitsField(value.limits, `${label}.limits`) } : {}),
     ...(cost ? { cost } : {}),
+    ...(chat ? { chat } : {}),
+    upstreamModelId: nonEmptyStringField(value.upstreamModelId, `${label}.upstreamModelId`),
+    ...(value.publicModelId !== undefined ? { publicModelId: optionalStringField(value.publicModelId, `${label}.publicModelId`) } : {}),
     ...(value.flagOverrides !== undefined ? { flagOverrides: flagOverridesField(value.flagOverrides, `${label}.flagOverrides`) } : {}),
   };
 };

--- a/packages/provider/src/model-config_test.ts
+++ b/packages/provider/src/model-config_test.ts
@@ -1,6 +1,6 @@
-import { test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
-import { pricingField } from './model-config.ts';
+import { chatField, modelsField, pricingField } from './model-config.ts';
 import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 test('pricingField parses bare dimensions and drops empty objects', () => {
@@ -53,4 +53,72 @@ test('pricingField rejects non-object tiers, empty names, and negative rates', (
   assertThrows(() => pricingField({ tiers: { '': { input: 5 } } }, 'cost'), Error, 'tier name');
   assertThrows(() => pricingField({ tiers: { fast: 1 } }, 'cost'), Error, 'tiers.fast');
   assertThrows(() => pricingField({ tiers: { fast: { input: -1 } } }, 'cost'), Error, 'non-negative');
+});
+
+describe('chatField', () => {
+  test('returns undefined when value is undefined', () => {
+    expect(chatField(undefined, 'm.chat')).toBeUndefined();
+  });
+
+  test('parses a full chat block', () => {
+    const chat = chatField({
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      reasoning: { supported_efforts: ['low', 'medium', 'high'], default_effort: 'medium' },
+    }, 'm.chat');
+    expect(chat).toEqual({
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      reasoning: { supported_efforts: ['low', 'medium', 'high'], default_effort: 'medium' },
+    });
+  });
+
+  test('rejects unknown modality value', () => {
+    expect(() => chatField({ modalities: { input: ['video'], output: ['text'] } }, 'm.chat'))
+      .toThrow(/modalities\.input/);
+  });
+
+  test('rejects modalities missing text', () => {
+    expect(() => chatField({ modalities: { input: ['image'], output: ['text'] } }, 'm.chat'))
+      .toThrow(/must include 'text'/);
+  });
+
+  test('deduplicates modality entries', () => {
+    const chat = chatField({ modalities: { input: ['text', 'text', 'image'], output: ['text'] } }, 'm.chat');
+    expect(chat?.modalities?.input).toEqual(['text', 'image']);
+  });
+
+  test('rejects empty reasoning effort string', () => {
+    expect(() => chatField({ reasoning: { supported_efforts: ['low', ''], default_effort: 'low' } }, 'm.chat'))
+      .toThrow(/supported_efforts/);
+  });
+
+  test('rejects default_effort not in supported_efforts', () => {
+    expect(() => chatField({ reasoning: { supported_efforts: ['low', 'high'], default_effort: 'medium' } }, 'm.chat'))
+      .toThrow(/default_effort/);
+  });
+
+  test('rejects reasoning without default_effort', () => {
+    expect(() => chatField({ reasoning: { supported_efforts: ['low'] } }, 'm.chat'))
+      .toThrow(/default_effort/);
+  });
+});
+
+describe('modelsField chat integration', () => {
+  test('rejects chat on non-chat kind', () => {
+    expect(() => modelsField([{
+      upstreamModelId: 'm',
+      kind: 'embedding',
+      endpoints: { embeddings: {} },
+      chat: { modalities: { input: ['text'], output: ['text'] } },
+    }], 'p')).toThrow(/chat .* only allowed when kind/);
+  });
+
+  test('accepts chat on chat kind', () => {
+    const [m] = modelsField([{
+      upstreamModelId: 'm',
+      kind: 'chat',
+      endpoints: { chatCompletions: {} },
+      chat: { modalities: { input: ['text'], output: ['text'] } },
+    }], 'p');
+    expect(m.chat?.modalities?.input).toEqual(['text']);
+  });
 });

--- a/packages/provider/src/model-config_test.ts
+++ b/packages/provider/src/model-config_test.ts
@@ -60,15 +60,132 @@ describe('chatField', () => {
     expect(chatField(undefined, 'm.chat')).toBeUndefined();
   });
 
-  test('parses a full chat block', () => {
+  test('parses a full chat block with effort sub-block', () => {
     const chat = chatField({
       modalities: { input: ['text', 'image'], output: ['text'] },
-      reasoning: { supported_efforts: ['low', 'medium', 'high'], default_effort: 'medium' },
+      reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
     }, 'm.chat');
     expect(chat).toEqual({
       modalities: { input: ['text', 'image'], output: ['text'] },
-      reasoning: { supported_efforts: ['low', 'medium', 'high'], default_effort: 'medium' },
+      reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },
     });
+  });
+
+  test('parses reasoning with budget_tokens only', () => {
+    const chat = chatField({ reasoning: { budget_tokens: { min: 100, max: 5000 } } }, 'm.chat');
+    expect(chat?.reasoning).toEqual({ budget_tokens: { min: 100, max: 5000 } });
+  });
+
+  test('parses reasoning with empty budget_tokens (bounds unknown)', () => {
+    const chat = chatField({ reasoning: { budget_tokens: {} } }, 'm.chat');
+    expect(chat?.reasoning).toEqual({ budget_tokens: {} });
+  });
+
+  test('parses reasoning with adaptive: true', () => {
+    const chat = chatField({ reasoning: { adaptive: true } }, 'm.chat');
+    expect(chat?.reasoning).toEqual({ adaptive: true });
+  });
+
+  test('strips adaptive: false to absent', () => {
+    const chat = chatField({ reasoning: { adaptive: false, mandatory: true } }, 'm.chat');
+    expect(chat?.reasoning).toEqual({ mandatory: true });
+    expect(chat?.reasoning?.adaptive).toBeUndefined();
+  });
+
+  test('parses reasoning with mandatory: true', () => {
+    const chat = chatField({ reasoning: { mandatory: true } }, 'm.chat');
+    expect(chat?.reasoning).toEqual({ mandatory: true });
+  });
+
+  test('strips mandatory: false to absent', () => {
+    const chat = chatField({ reasoning: { mandatory: false, adaptive: true } }, 'm.chat');
+    expect(chat?.reasoning).toEqual({ adaptive: true });
+    expect(chat?.reasoning?.mandatory).toBeUndefined();
+  });
+
+  test('parses all four sub-blocks together', () => {
+    const chat = chatField({
+      reasoning: {
+        effort: { supported: ['low', 'high'], default: 'low' },
+        budget_tokens: { min: 0, max: 1000 },
+        adaptive: true,
+        mandatory: false,
+      },
+    }, 'm.chat');
+    expect(chat?.reasoning).toEqual({
+      effort: { supported: ['low', 'high'], default: 'low' },
+      budget_tokens: { min: 0, max: 1000 },
+      adaptive: true,
+    });
+  });
+
+  test('rejects empty reasoning (no sub-block)', () => {
+    expect(() => chatField({ reasoning: {} }, 'm.chat'))
+      .toThrow(/at least one of effort, budget_tokens, adaptive, mandatory/);
+  });
+
+  test('rejects reasoning with only adaptive: false and mandatory: false', () => {
+    expect(() => chatField({ reasoning: { adaptive: false, mandatory: false } }, 'm.chat'))
+      .toThrow(/at least one of effort, budget_tokens, adaptive, mandatory/);
+  });
+
+  test('rejects non-boolean adaptive', () => {
+    expect(() => chatField({ reasoning: { adaptive: 'yes' } }, 'm.chat'))
+      .toThrow(/adaptive.*boolean/);
+  });
+
+  test('rejects non-boolean mandatory', () => {
+    expect(() => chatField({ reasoning: { mandatory: 1 } }, 'm.chat'))
+      .toThrow(/mandatory.*boolean/);
+  });
+
+  test('rejects effort.default not in effort.supported', () => {
+    expect(() => chatField({ reasoning: { effort: { supported: ['low', 'high'], default: 'medium' } } }, 'm.chat'))
+      .toThrow(/effort\.default/);
+  });
+
+  test('rejects empty effort.supported', () => {
+    expect(() => chatField({ reasoning: { effort: { supported: [], default: '' } } }, 'm.chat'))
+      .toThrow(/effort\.supported/);
+  });
+
+  test('rejects empty string in effort.supported', () => {
+    expect(() => chatField({ reasoning: { effort: { supported: ['low', ''], default: 'low' } } }, 'm.chat'))
+      .toThrow(/effort\.supported/);
+  });
+
+  test('deduplicates effort.supported entries', () => {
+    const chat = chatField({ reasoning: { effort: { supported: ['low', 'low', 'high'], default: 'low' } } }, 'm.chat');
+    expect(chat?.reasoning?.effort?.supported).toEqual(['low', 'high']);
+  });
+
+  test('rejects budget_tokens.max < budget_tokens.min', () => {
+    expect(() => chatField({ reasoning: { budget_tokens: { min: 500, max: 100 } } }, 'm.chat'))
+      .toThrow(/max must be >= min/);
+  });
+
+  test('rejects negative budget_tokens.min', () => {
+    expect(() => chatField({ reasoning: { budget_tokens: { min: -1 } } }, 'm.chat'))
+      .toThrow(/non-negative integer/);
+  });
+
+  test('rejects non-integer budget_tokens.max', () => {
+    expect(() => chatField({ reasoning: { budget_tokens: { max: 1.5 } } }, 'm.chat'))
+      .toThrow(/non-negative integer/);
+  });
+
+  test('rejects reasoning without effort.default', () => {
+    expect(() => chatField({ reasoning: { effort: { supported: ['low'] } } }, 'm.chat'))
+      .toThrow(/effort\.default/);
+  });
+
+  test('returns undefined when chat block is empty', () => {
+    expect(chatField({}, 'm.chat')).toBeUndefined();
+  });
+
+  test('accepts image-only output modalities', () => {
+    const chat = chatField({ modalities: { input: ['text'], output: ['image'] } }, 'm.chat');
+    expect(chat?.modalities?.output).toEqual(['image']);
   });
 
   test('rejects unknown modality value', () => {
@@ -84,30 +201,6 @@ describe('chatField', () => {
   test('deduplicates modality entries', () => {
     const chat = chatField({ modalities: { input: ['text', 'text', 'image'], output: ['text'] } }, 'm.chat');
     expect(chat?.modalities?.input).toEqual(['text', 'image']);
-  });
-
-  test('rejects empty reasoning effort string', () => {
-    expect(() => chatField({ reasoning: { supported_efforts: ['low', ''], default_effort: 'low' } }, 'm.chat'))
-      .toThrow(/supported_efforts/);
-  });
-
-  test('rejects default_effort not in supported_efforts', () => {
-    expect(() => chatField({ reasoning: { supported_efforts: ['low', 'high'], default_effort: 'medium' } }, 'm.chat'))
-      .toThrow(/default_effort/);
-  });
-
-  test('rejects reasoning without default_effort', () => {
-    expect(() => chatField({ reasoning: { supported_efforts: ['low'] } }, 'm.chat'))
-      .toThrow(/default_effort/);
-  });
-
-  test('returns empty object (not undefined) for empty chat block', () => {
-    expect(chatField({}, 'm.chat')).toEqual({});
-  });
-
-  test('accepts image-only output modalities', () => {
-    const chat = chatField({ modalities: { input: ['text'], output: ['image'] } }, 'm.chat');
-    expect(chat?.modalities?.output).toEqual(['image']);
   });
 
   test('rejects empty output modalities array', () => {

--- a/packages/provider/src/model-config_test.ts
+++ b/packages/provider/src/model-config_test.ts
@@ -100,6 +100,20 @@ describe('chatField', () => {
     expect(() => chatField({ reasoning: { supported_efforts: ['low'] } }, 'm.chat'))
       .toThrow(/default_effort/);
   });
+
+  test('returns empty object (not undefined) for empty chat block', () => {
+    expect(chatField({}, 'm.chat')).toEqual({});
+  });
+
+  test('accepts image-only output modalities', () => {
+    const chat = chatField({ modalities: { input: ['text'], output: ['image'] } }, 'm.chat');
+    expect(chat?.modalities?.output).toEqual(['image']);
+  });
+
+  test('rejects empty output modalities array', () => {
+    expect(() => chatField({ modalities: { input: ['text'], output: [] } }, 'm.chat'))
+      .toThrow(/at least one modality/);
+  });
 });
 
 describe('modelsField chat integration', () => {

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -1,5 +1,6 @@
 import type { ModelPrefixConfig } from './model-prefix.ts';
 import type { ModelKind, ModelEndpoints, ModelPricing } from '@floway-dev/protocols/common';
+import type { UpstreamChatModelConfig } from './model-config.ts';
 
 export const ALL_PROVIDER_KINDS = ['copilot', 'custom', 'azure', 'codex', 'claude-code', 'ollama'] as const;
 export type UpstreamProviderKind = typeof ALL_PROVIDER_KINDS[number];
@@ -84,6 +85,7 @@ export interface InternalModel {
   };
   kind: ModelKind;
   cost?: ModelPricing;
+  chat?: UpstreamChatModelConfig;
 }
 
 export interface UpstreamModel extends InternalModel {

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -1,6 +1,6 @@
+import type { UpstreamChatModelConfig } from './model-config.ts';
 import type { ModelPrefixConfig } from './model-prefix.ts';
 import type { ModelKind, ModelEndpoints, ModelPricing } from '@floway-dev/protocols/common';
-import type { UpstreamChatModelConfig } from './model-config.ts';
 
 export const ALL_PROVIDER_KINDS = ['copilot', 'custom', 'azure', 'codex', 'claude-code', 'ollama'] as const;
 export type UpstreamProviderKind = typeof ALL_PROVIDER_KINDS[number];


### PR DESCRIPTION
## Summary

Adds optional per-model `chat` metadata — modalities + a discriminated reasoning capability block — as a first-class field on `UpstreamModelConfig`, `InternalModel`, and `PublicModel`. Five provider plugins auto-derive it from their upstream catalogs; the dashboard editor lets operators tune it per-model. The field surfaces at `/v1/models` so downstream clients can adapt UI to per-model capabilities without hard-coding vendor knowledge.

## Schema

```ts
chat?: {
  modalities?: { input: ('text'|'image')[]; output: ('text'|'image')[] };
  reasoning?: {
    effort?: { supported: string[]; default: string };
    budget_tokens?: { min?: number; max?: number };
    adaptive?: boolean;
    mandatory?: boolean;
  };
};
```

The reasoning block carries any subset of the four sub-fields with at least one present; `mandatory` is mutually exclusive with the other three (Mandatory means reasoning is always on, callers cannot opt out). Wire validation rejects `adaptive: false` / `mandatory: false` (semantically equivalent to absent) and requires `modalities.input` to include `'text'`.

`ChatModelInfo` lives in `@floway-dev/protocols/common`; `@floway-dev/provider` re-exports it as `UpstreamChatModelConfig`, so the catalog input and the `/v1/models` output share a single declaration.

## Per-provider auto-fill

| Provider | Modalities | Reasoning |
|---|---|---|
| codex | `input_modalities` | `supported_reasoning_levels` → `effort.supported`; `default_reasoning_level` → `effort.default` (derived as `medium` if supported, else first, when upstream omits it) |
| copilot | `capabilities.supports.vision` | `reasoning_effort` array → `effort` (default `medium`); `min/max_thinking_budget` → `budget_tokens`; `adaptive_thinking` → `adaptive` |
| claude-code | `capabilities.image_input.supported` | `capabilities.effort` open enum → `effort` (default `medium`); `thinking.types.enabled` → `budget_tokens: {}`; `thinking.types.adaptive` → `adaptive` |
| ollama | `capabilities` includes `vision` | `thinking` capability → effort `[low, medium, high]` with `medium` default (uniform across families) |
| custom | reuses `chatField` parser | reuses `chatField` parser |
| azure | dashboard-only | dashboard-only |

Custom / Ollama / Azure also forward the operator-configured `chat` block from the row's manual model config. `GET /api/upstreams/:id/models` propagates `chat` for auto-resolved models so dashboard auto rows render the capability the provider already populates.

## Dashboard

`ModelEditor.vue` gains a chat sub-section (chat kind only). Modalities collapses to a single inline row (Image input toggle, text always implied). Reasoning puts the four toggles (Effort / Budget tokens / Adaptive / Mandatory) inline with the section heading; selecting Mandatory disables the other three and vice versa.

When Effort is on, the operator picks levels from a tag list. Quick-add presets cover `none / minimal / low / medium / high / xhigh / max`; a custom input adds any free-form level. Tags drag horizontally to reorder and click to set as the default (the default tag highlights in accent cyan). Budget tokens exposes optional min / max numeric inputs at the same compact size as the custom effort input. Validation warnings render in amber and reserve their slot so the layout does not jump.

## Test plan

- [x] `pnpm run test` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run typecheck` clean
- [x] Dashboard ModelEditor sanity check — toggle Image input, Effort / Budget / Adaptive / Mandatory (verify mutex), drag-reorder effort tags, click to set default, verify save guard
- [x] `GET /v1/models` against a live upstream — confirm `chat` populates per the per-provider table above