### PR TITLE
fix(translate): hoist leading system prefix to top-level, keep non-leading inline

### DIFF
--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -178,9 +178,7 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
   // MessagesPayload.system, preserving each ContentPart text as its own
   // MessagesTextBlock so part boundaries survive the hoist. Non-leading
   // system/developer messages stay inline as MessagesSystemMessage at their
-  // chronological position; the gateway's
-  // `demote-interleaved-system-to-user` interceptor flag handles upstreams
-  // that reject inline system.
+  // chronological position.
   const systemBlocks: MessagesTextBlock[] = [];
   let prefixEnd = 0;
   for (const message of payload.messages) {

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -186,10 +186,8 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
   // system/developer messages stay inline as MessagesSystemMessage at their
   // chronological position; the gateway's
   // `demote-interleaved-system-to-user` interceptor flag handles upstreams
-  // that reject inline system. Empty system content contributes zero
-  // blocks — its prefix slot is consumed (so a subsequent non-empty leading
-  // system still counts as part of the same prefix) but it does not produce
-  // an empty top-level system entry.
+  // that reject inline system. An empty-content leading message still
+  // extends the contiguous prefix even though it contributes no block.
   const systemBlocks: MessagesTextBlock[] = [];
   let prefixEnd = 0;
   for (const message of payload.messages) {

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -1,6 +1,6 @@
 import { messagesThinkingBlockFromChatCompletionsScalarReasoning } from '../shared/chat-completions-and-messages/reasoning.ts';
 import { parseToolArgumentsObject } from '../shared/messages/tool-arguments.ts';
-import { applyLastMessageCacheBreakpoint, applyLastToolCacheBreakpoint } from '../shared/via-messages/cache-breakpoints.ts';
+import { applyLastMessageCacheBreakpoint, applyLastToolCacheBreakpoint, EPHEMERAL_CACHE_CONTROL } from '../shared/via-messages/cache-breakpoints.ts';
 import { fetchRemoteImage, type RemoteImageLoader, resolveImageUrlToMessagesImage } from '../shared/via-messages/remote-images.ts';
 import type { ChatCompletionsPayload, ChatCompletionsContentPart, ChatCompletionsMessage, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
 import { MESSAGES_FALLBACK_MAX_TOKENS, type MessagesAssistantContentBlock, type MessagesMessage, type MessagesPayload, type MessagesTextBlock, type MessagesUserContentBlock } from '@floway-dev/protocols/messages';
@@ -122,11 +122,6 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       break;
     case 'system':
     case 'developer':
-      // Both Chat Completions system and developer messages map to Messages
-      // role: 'system' inline. The Messages role enum admits 'system'
-      // (https://platform.claude.com/docs/en/api/messages); developer content
-      // is the same intent layer and normalizes to system on the Messages
-      // wire.
       result.push({
         role: 'system',
         content: convertSystemContent(message.content),
@@ -161,12 +156,34 @@ const CHAT_TOOL_CHOICES = {
 } satisfies Record<Extract<ChatCompletionsPayload['tool_choice'], string>, MessagesPayload['tool_choice']>;
 
 export const translateChatCompletionsToMessages = async (payload: ChatCompletionsPayload, options: TranslateChatCompletionsToMessagesOptions = {}): Promise<MessagesPayload> => {
-  // System / developer messages pass through inline as Messages role: 'system'
-  // items (the Messages role enum supports it). Chat Completions has no
-  // canonical top-level system field, so nothing is hoisted to MessagesPayload.system.
-  const messages = await buildMessagesInput(payload.messages, options.loadRemoteImage ?? fetchRemoteImage);
+  // Hoist the leading contiguous run of system/developer messages to
+  // MessagesPayload.system. Non-leading system/developer messages stay inline
+  // as MessagesSystemMessage; upstreams that reject them can be handled by the
+  // `demote-interleaved-system-to-user` interceptor.
+  const systemParts: string[] = [];
+  let prefixEnd = 0;
+  for (const message of payload.messages) {
+    if (message.role !== 'system' && message.role !== 'developer') break;
+    const text =
+      typeof message.content === 'string'
+        ? message.content
+        : Array.isArray(message.content)
+          ? message.content
+              .filter((part): part is Extract<ChatCompletionsContentPart, { type: 'text' }> => part.type === 'text')
+              .map(part => part.text)
+              .join('')
+          : '';
+    if (text) systemParts.push(text);
+    prefixEnd++;
+  }
+
+  const messages = await buildMessagesInput(payload.messages.slice(prefixEnd), options.loadRemoteImage ?? fetchRemoteImage);
 
   const maxTokens = payload.max_tokens ?? options.fallbackMaxOutputTokens ?? MESSAGES_FALLBACK_MAX_TOKENS;
+  const systemText = systemParts.length > 0 ? systemParts.join('\n\n') : '';
+  const systemBlocks: MessagesTextBlock[] | undefined = systemText
+    ? [{ type: 'text', text: systemText, cache_control: EPHEMERAL_CACHE_CONTROL }]
+    : undefined;
   const tools = payload.tools?.length ? translateChatCompletionsTools(payload.tools) : undefined;
   applyLastToolCacheBreakpoint(tools);
   applyLastMessageCacheBreakpoint(messages);
@@ -204,6 +221,7 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
     model: payload.model,
     messages,
     max_tokens: maxTokens,
+    ...(systemBlocks ? { system: systemBlocks } : {}),
     ...(payload.temperature != null ? { temperature: payload.temperature } : {}),
     ...(payload.top_p != null ? { top_p: payload.top_p } : {}),
     ...(payload.stop != null

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -133,14 +133,10 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       break;
     case 'system':
     case 'developer':
-      // Non-leading system / developer messages stay inline as
-      // MessagesSystemMessage: their leading contiguous prefix has already
-      // been hoisted to MessagesPayload.system by
-      // translateChatCompletionsToMessages before buildMessagesInput runs,
-      // so anything reaching this branch was deliberately placed mid-history
-      // by the caller and we preserve that chronological position. Anthropic
-      // upstreams diverge on inline role:'system' (Bedrock accepts it under
-      // placement rules; Vertex rejects it outright), so the gateway's
+      // Inline path for non-leading system / developer (the leading prefix
+      // was hoisted earlier). Anthropic upstreams diverge on inline
+      // role:'system' here (Bedrock accepts it under placement rules;
+      // Vertex rejects it outright), so the gateway's
       // `demote-interleaved-system-to-user` interceptor flag is the safety
       // net for any inline system that would otherwise reach an upstream
       // that does not accept it.
@@ -184,8 +180,7 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
   // system/developer messages stay inline as MessagesSystemMessage at their
   // chronological position; the gateway's
   // `demote-interleaved-system-to-user` interceptor flag handles upstreams
-  // that reject inline system. An empty-content leading message still
-  // extends the contiguous prefix even though it contributes no block.
+  // that reject inline system.
   const systemBlocks: MessagesTextBlock[] = [];
   let prefixEnd = 0;
   for (const message of payload.messages) {

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -86,10 +86,13 @@ const convertUserContent = async (message: ChatCompletionsMessage, loadRemoteIma
 // inline `MessagesSystemMessage.content`) accepts only text. Image parts in
 // system / developer messages are rejected here at the translator boundary so
 // the caller hits an explicit failure instead of having the image silently
-// dropped on the wire.
-const convertSystemContent = (content: ChatCompletionsMessage['content']): string | MessagesTextBlock[] => {
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return '';
+// dropped on the wire. Returns blocks (possibly empty) so the hoist and
+// inline call sites share one shape.
+const convertSystemContent = (content: ChatCompletionsMessage['content']): MessagesTextBlock[] => {
+  if (typeof content === 'string') {
+    return content ? [{ type: 'text', text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
 
   const blocks: MessagesTextBlock[] = [];
   for (const part of content) {
@@ -101,7 +104,7 @@ const convertSystemContent = (content: ChatCompletionsMessage['content']): strin
     }
   }
 
-  return blocks.length > 0 ? blocks : '';
+  return blocks;
 };
 
 const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemoteImage: RemoteImageLoader): Promise<MessagesMessage[]> => {
@@ -132,7 +135,7 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       ]);
       break;
     case 'system':
-    case 'developer':
+    case 'developer': {
       // Inline path for non-leading system / developer (the leading prefix
       // was hoisted earlier). Anthropic upstreams diverge on inline
       // role:'system' here (Bedrock accepts it under placement rules;
@@ -140,11 +143,13 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       // `demote-interleaved-system-to-user` interceptor flag is the safety
       // net for any inline system that would otherwise reach an upstream
       // that does not accept it.
+      const blocks = convertSystemContent(message.content);
       result.push({
         role: 'system',
-        content: convertSystemContent(message.content),
+        content: blocks.length > 0 ? blocks : '',
       });
       break;
+    }
     default:
       throw new Error(`Chat Completions → Messages translator does not accept ${message.role} messages.`);
     }
@@ -183,12 +188,7 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
   let prefixEnd = 0;
   for (const message of payload.messages) {
     if (message.role !== 'system' && message.role !== 'developer') break;
-    const converted = convertSystemContent(message.content);
-    if (typeof converted === 'string') {
-      if (converted) systemBlocks.push({ type: 'text', text: converted });
-    } else {
-      systemBlocks.push(...converted);
-    }
+    systemBlocks.push(...convertSystemContent(message.content));
     prefixEnd++;
   }
 

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -138,11 +138,9 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       // been hoisted to MessagesPayload.system by
       // translateChatCompletionsToMessages before buildMessagesInput runs,
       // so anything reaching this branch was deliberately placed mid-history
-      // by the caller and we preserve that chronological position. Developer
-      // is the same intent layer as system on the Chat Completions wire and
-      // normalizes to role:'system' here. Anthropic upstreams diverge on
-      // inline role:'system' (Bedrock accepts it under placement rules;
-      // Vertex rejects it outright), so the gateway's
+      // by the caller and we preserve that chronological position. Anthropic
+      // upstreams diverge on inline role:'system' (Bedrock accepts it under
+      // placement rules; Vertex rejects it outright), so the gateway's
       // `demote-interleaved-system-to-user` interceptor flag is the safety
       // net for any inline system that would otherwise reach an upstream
       // that does not accept it.

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -1,8 +1,8 @@
 import { messagesThinkingBlockFromChatCompletionsScalarReasoning } from '../shared/chat-completions-and-messages/reasoning.ts';
 import { parseToolArgumentsObject } from '../shared/messages/tool-arguments.ts';
-import { applyLastMessageCacheBreakpoint, applyLastToolCacheBreakpoint, EPHEMERAL_CACHE_CONTROL } from '../shared/via-messages/cache-breakpoints.ts';
+import { applyLastMessageCacheBreakpoint, applyLastSystemCacheBreakpoint, applyLastToolCacheBreakpoint } from '../shared/via-messages/cache-breakpoints.ts';
 import { fetchRemoteImage, type RemoteImageLoader, resolveImageUrlToMessagesImage } from '../shared/via-messages/remote-images.ts';
-import type { ChatCompletionsPayload, ChatCompletionsContentPart, ChatCompletionsMessage, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
+import type { ChatCompletionsPayload, ChatCompletionsMessage, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
 import { MESSAGES_FALLBACK_MAX_TOKENS, type MessagesAssistantContentBlock, type MessagesMessage, type MessagesPayload, type MessagesTextBlock, type MessagesUserContentBlock } from '@floway-dev/protocols/messages';
 
 interface TranslateChatCompletionsToMessagesOptions {
@@ -82,13 +82,24 @@ const convertUserContent = async (message: ChatCompletionsMessage, loadRemoteIma
   return blocks.length > 0 ? blocks : [{ type: 'text', text: '' }];
 };
 
+// Anthropic's Messages system field (top-level `MessagesPayload.system` and
+// inline `MessagesSystemMessage.content`) accepts only text. Image parts in
+// system / developer messages are rejected here at the translator boundary so
+// the caller hits an explicit failure instead of having the image silently
+// dropped on the wire.
 const convertSystemContent = (content: ChatCompletionsMessage['content']): string | MessagesTextBlock[] => {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return '';
 
-  const blocks: MessagesTextBlock[] = content
-    .filter((part): part is Extract<ChatCompletionsContentPart, { type: 'text' }> => part.type === 'text')
-    .map(part => ({ type: 'text', text: part.text }));
+  const blocks: MessagesTextBlock[] = [];
+  for (const part of content) {
+    if (part.type === 'image_url') {
+      throw new Error('Chat Completions → Messages translator does not accept image content parts in system or developer messages — Anthropic Messages only permits text in the system field.');
+    }
+    if (part.type === 'text') {
+      blocks.push({ type: 'text', text: part.text });
+    }
+  }
 
   return blocks.length > 0 ? blocks : '';
 };
@@ -122,6 +133,19 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       break;
     case 'system':
     case 'developer':
+      // Non-leading system / developer messages stay inline as
+      // MessagesSystemMessage: their leading contiguous prefix has already
+      // been hoisted to MessagesPayload.system by
+      // translateChatCompletionsToMessages before buildMessagesInput runs,
+      // so anything reaching this branch was deliberately placed mid-history
+      // by the caller and we preserve that chronological position. Developer
+      // is the same intent layer as system on the Chat Completions wire and
+      // normalizes to role:'system' here. Anthropic upstreams diverge on
+      // inline role:'system' (Bedrock accepts it under placement rules;
+      // Vertex rejects it outright), so the gateway's
+      // `demote-interleaved-system-to-user` interceptor flag is the safety
+      // net for any inline system that would otherwise reach an upstream
+      // that does not accept it.
       result.push({
         role: 'system',
         content: convertSystemContent(message.content),
@@ -157,34 +181,33 @@ const CHAT_TOOL_CHOICES = {
 
 export const translateChatCompletionsToMessages = async (payload: ChatCompletionsPayload, options: TranslateChatCompletionsToMessagesOptions = {}): Promise<MessagesPayload> => {
   // Hoist the leading contiguous run of system/developer messages to
-  // MessagesPayload.system. Non-leading system/developer messages stay inline
-  // as MessagesSystemMessage; upstreams that reject them can be handled by the
-  // `demote-interleaved-system-to-user` interceptor.
-  const systemParts: string[] = [];
+  // MessagesPayload.system, preserving each ContentPart text as its own
+  // MessagesTextBlock so part boundaries survive the hoist. Non-leading
+  // system/developer messages stay inline as MessagesSystemMessage at their
+  // chronological position; the gateway's
+  // `demote-interleaved-system-to-user` interceptor flag handles upstreams
+  // that reject inline system. Empty system content contributes zero
+  // blocks — its prefix slot is consumed (so a subsequent non-empty leading
+  // system still counts as part of the same prefix) but it does not produce
+  // an empty top-level system entry.
+  const systemBlocks: MessagesTextBlock[] = [];
   let prefixEnd = 0;
   for (const message of payload.messages) {
     if (message.role !== 'system' && message.role !== 'developer') break;
-    const text =
-      typeof message.content === 'string'
-        ? message.content
-        : Array.isArray(message.content)
-          ? message.content
-              .filter((part): part is Extract<ChatCompletionsContentPart, { type: 'text' }> => part.type === 'text')
-              .map(part => part.text)
-              .join('')
-          : '';
-    if (text) systemParts.push(text);
+    const converted = convertSystemContent(message.content);
+    if (typeof converted === 'string') {
+      if (converted) systemBlocks.push({ type: 'text', text: converted });
+    } else {
+      systemBlocks.push(...converted);
+    }
     prefixEnd++;
   }
 
   const messages = await buildMessagesInput(payload.messages.slice(prefixEnd), options.loadRemoteImage ?? fetchRemoteImage);
 
   const maxTokens = payload.max_tokens ?? options.fallbackMaxOutputTokens ?? MESSAGES_FALLBACK_MAX_TOKENS;
-  const systemText = systemParts.length > 0 ? systemParts.join('\n\n') : '';
-  const systemBlocks: MessagesTextBlock[] | undefined = systemText
-    ? [{ type: 'text', text: systemText, cache_control: EPHEMERAL_CACHE_CONTROL }]
-    : undefined;
   const tools = payload.tools?.length ? translateChatCompletionsTools(payload.tools) : undefined;
+  applyLastSystemCacheBreakpoint(systemBlocks);
   applyLastToolCacheBreakpoint(tools);
   applyLastMessageCacheBreakpoint(messages);
 
@@ -221,7 +244,7 @@ export const translateChatCompletionsToMessages = async (payload: ChatCompletion
     model: payload.model,
     messages,
     max_tokens: maxTokens,
-    ...(systemBlocks ? { system: systemBlocks } : {}),
+    ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
     ...(payload.temperature != null ? { temperature: payload.temperature } : {}),
     ...(payload.top_p != null ? { top_p: payload.top_p } : {}),
     ...(payload.stop != null

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -133,7 +133,7 @@ test('non-leading system stays inline, leading is hoisted', async () => {
   assertEquals(result.system, [{ type: 'text', text: 'First', cache_control: { type: 'ephemeral' } }]);
   assertEquals(result.messages.length, 3);
   assertEquals(result.messages[0].role, 'user');
-  assertEquals(result.messages[1], { role: 'system', content: 'Second' });
+  assertEquals(result.messages[1], { role: 'system', content: [{ type: 'text', text: 'Second' }] });
   assertEquals(result.messages[2].role, 'user');
 });
 

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -150,7 +150,7 @@ test('empty leading system content is not hoisted', async () => {
   assertEquals(result.messages.length, 1);
 });
 
-test('leading system with ContentPart array text parts joined and hoisted', async () => {
+test('leading system with ContentPart array preserves text parts as separate blocks', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({
       messages: [
@@ -165,8 +165,72 @@ test('leading system with ContentPart array text parts joined and hoisted', asyn
       ],
     }),
   );
-  assertEquals(result.system, [{ type: 'text', text: 'AB', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.system, [
+    { type: 'text', text: 'A' },
+    { type: 'text', text: 'B', cache_control: { type: 'ephemeral' } },
+  ]);
   assertEquals(result.messages.length, 1);
+});
+
+test('multiple consecutive leading system messages accumulate as separate blocks', async () => {
+  const result = await translateChatCompletionsToMessages(
+    mkPayload({
+      messages: [
+        { role: 'system', content: 'First' },
+        { role: 'developer', content: 'Second' },
+        { role: 'user', content: 'Hi' },
+      ],
+    }),
+  );
+  assertEquals(result.system, [
+    { type: 'text', text: 'First' },
+    { type: 'text', text: 'Second', cache_control: { type: 'ephemeral' } },
+  ]);
+  assertEquals(result.messages.length, 1);
+});
+
+test('image content part in leading system message throws', async () => {
+  await assertRejects(
+    () =>
+      translateChatCompletionsToMessages(
+        mkPayload({
+          messages: [
+            {
+              role: 'system',
+              content: [
+                { type: 'text', text: 'You are helpful.' },
+                { type: 'image_url', image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' } },
+              ],
+            },
+            { role: 'user', content: 'Hi' },
+          ],
+        }),
+      ),
+    Error,
+    'does not accept image content parts in system or developer messages',
+  );
+});
+
+test('image content part in non-leading system message throws', async () => {
+  await assertRejects(
+    () =>
+      translateChatCompletionsToMessages(
+        mkPayload({
+          messages: [
+            { role: 'user', content: 'Hi' },
+            {
+              role: 'system',
+              content: [
+                { type: 'image_url', image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' } },
+              ],
+            },
+            { role: 'user', content: 'Bye' },
+          ],
+        }),
+      ),
+    Error,
+    'does not accept image content parts in system or developer messages',
+  );
 });
 
 // ── Basic message mapping ──

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -92,15 +92,7 @@ test('translateChatCompletionsToMessages omits both speed and service_tier when 
   assertFalse('service_tier' in result);
 });
 
-//
-// Chat Completions system/developer messages translate INLINE as Messages
-// role: 'system' items, preserving chronology. The Messages role enum admits
-// 'system' (https://platform.claude.com/docs/en/api/messages); empirical
-// testing confirms native Messages upstreams accept mid-array system. The
-// Messages top-level `system` field is left untouched — Chat Completions has
-// no canonical top-level system slot to hoist into.
-
-test('system message emitted inline as role: system', async () => {
+test('leading system message hoisted to top-level system field', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({
       messages: [
@@ -109,13 +101,12 @@ test('system message emitted inline as role: system', async () => {
       ],
     }),
   );
-  assertEquals(result.system, undefined);
-  assertEquals(result.messages.length, 2);
-  assertEquals(result.messages[0], { role: 'system', content: 'You are helpful.' });
-  assertEquals(result.messages[1].role, 'user');
+  assertEquals(result.system, [{ type: 'text', text: 'You are helpful.', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.messages.length, 1);
+  assertEquals(result.messages[0].role, 'user');
 });
 
-test('developer message normalized to role: system inline', async () => {
+test('leading developer message hoisted as system', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({
       messages: [
@@ -124,11 +115,11 @@ test('developer message normalized to role: system inline', async () => {
       ],
     }),
   );
-  assertEquals(result.system, undefined);
-  assertEquals(result.messages[0], { role: 'system', content: 'Dev instructions' });
+  assertEquals(result.system, [{ type: 'text', text: 'Dev instructions', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.messages.length, 1);
 });
 
-test('multiple system messages preserve chronology inline', async () => {
+test('non-leading system stays inline, leading is hoisted', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({
       messages: [
@@ -139,15 +130,14 @@ test('multiple system messages preserve chronology inline', async () => {
       ],
     }),
   );
-  assertEquals(result.system, undefined);
-  assertEquals(result.messages.length, 4);
-  assertEquals(result.messages[0], { role: 'system', content: 'First' });
-  assertEquals(result.messages[1].role, 'user');
-  assertEquals(result.messages[2], { role: 'system', content: 'Second' });
-  assertEquals(result.messages[3].role, 'user');
+  assertEquals(result.system, [{ type: 'text', text: 'First', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.messages.length, 3);
+  assertEquals(result.messages[0].role, 'user');
+  assertEquals(result.messages[1], { role: 'system', content: 'Second' });
+  assertEquals(result.messages[2].role, 'user');
 });
 
-test('empty system content emits empty inline system', async () => {
+test('empty leading system content is not hoisted', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({
       messages: [
@@ -157,10 +147,10 @@ test('empty system content emits empty inline system', async () => {
     }),
   );
   assertEquals(result.system, undefined);
-  assertEquals(result.messages[0], { role: 'system', content: '' });
+  assertEquals(result.messages.length, 1);
 });
 
-test('system with ContentPart array maps each text part to a MessagesTextBlock', async () => {
+test('leading system with ContentPart array text parts joined and hoisted', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({
       messages: [
@@ -175,14 +165,8 @@ test('system with ContentPart array maps each text part to a MessagesTextBlock',
       ],
     }),
   );
-  assertEquals(result.system, undefined);
-  assertEquals(result.messages[0], {
-    role: 'system',
-    content: [
-      { type: 'text', text: 'A' },
-      { type: 'text', text: 'B' },
-    ],
-  });
+  assertEquals(result.system, [{ type: 'text', text: 'AB', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.messages.length, 1);
 });
 
 // ── Basic message mapping ──
@@ -1047,14 +1031,13 @@ test('full tool use round-trip conversation', async () => {
       ],
     }),
   );
-  assertEquals(result.system, undefined);
-  assertEquals(result.messages.length, 5);
-  assertEquals(result.messages[0], { role: 'system', content: 'You are helpful.' });
-  assertEquals(result.messages[1].role, 'user');
-  assertEquals(result.messages[2].role, 'assistant');
-  assertEquals(result.messages[3].role, 'user');
-  assertEquals(result.messages[4].role, 'assistant');
-  const trBlocks = result.messages[3].content as MessagesUserContentBlock[];
+  assertEquals(result.system, [{ type: 'text', text: 'You are helpful.', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.messages.length, 4);
+  assertEquals(result.messages[0].role, 'user');
+  assertEquals(result.messages[1].role, 'assistant');
+  assertEquals(result.messages[2].role, 'user');
+  assertEquals(result.messages[3].role, 'assistant');
+  const trBlocks = result.messages[2].content as MessagesUserContentBlock[];
   assertEquals(trBlocks[0].type, 'tool_result');
 });
 
@@ -1080,8 +1063,7 @@ test('attaches ephemeral cache breakpoints to last function tool and last messag
     }),
   );
 
-  // System messages flow through inline; no top-level system field is set.
-  assertEquals(result.system, undefined);
+  assertEquals(result.system, [{ type: 'text', text: 'You are helpful.', cache_control: { type: 'ephemeral' } }]);
 
   const tools = result.tools as MessagesClientTool[];
   assertEquals(tools[0].cache_control, undefined);

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -150,7 +150,7 @@ test('empty leading system content is not hoisted', async () => {
   assertEquals(result.messages.length, 1);
 });
 
-test('leading empty + non-empty system: empty consumes its prefix slot, non-empty contributes its block', async () => {
+test('leading empty system is skipped, leading non-empty is still hoisted', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({
       messages: [

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -150,6 +150,21 @@ test('empty leading system content is not hoisted', async () => {
   assertEquals(result.messages.length, 1);
 });
 
+test('leading empty + non-empty system: empty consumes its prefix slot, non-empty contributes its block', async () => {
+  const result = await translateChatCompletionsToMessages(
+    mkPayload({
+      messages: [
+        { role: 'system', content: '' },
+        { role: 'developer', content: 'Be terse.' },
+        { role: 'user', content: 'Hi' },
+      ],
+    }),
+  );
+  assertEquals(result.system, [{ type: 'text', text: 'Be terse.', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.messages.length, 1);
+  assertEquals(result.messages[0].role, 'user');
+});
+
 test('leading system with ContentPart array preserves text parts as separate blocks', async () => {
   const result = await translateChatCompletionsToMessages(
     mkPayload({

--- a/packages/translate/src/messages-via-chat-completions/request.ts
+++ b/packages/translate/src/messages-via-chat-completions/request.ts
@@ -210,24 +210,32 @@ const translateMessagesAssistant = (message: MessagesAssistantMessage): ChatComp
   return messages;
 };
 
+// Anthropic Messages system blocks are prompt boundaries; preserve each one
+// as a separate Chat Completions text part so a CC→Messages→CC round trip
+// does not silently merge them. Falls back to the simple string form when
+// the source is already a single-string field.
+const systemContentFromBlocks = (system: string | MessagesTextBlock[]): string | ChatCompletionsContentPart[] =>
+  typeof system === 'string'
+    ? system
+    : system.map(block => ({ type: 'text', text: block.text }));
+
 const translateMessagesSystem = (message: MessagesSystemMessage): ChatCompletionsMessage[] => [
   {
     role: 'system',
-    content: typeof message.content === 'string' ? message.content : message.content.map(block => block.text).join('\n\n'),
+    content: systemContentFromBlocks(message.content),
   },
 ];
 
 const translateMessagesInput = (messages: MessagesMessage[], system: string | MessagesTextBlock[] | undefined): ChatCompletionsMessage[] => {
-  // Messages system blocks are prompt boundaries; keep them as separated
-  // paragraphs when falling back to Chat Completions.
-  const systemMessages: ChatCompletionsMessage[] = system
-    ? [
+  const isEmptySystem = system == null || (typeof system === 'string' ? system === '' : system.length === 0);
+  const systemMessages: ChatCompletionsMessage[] = isEmptySystem
+    ? []
+    : [
         {
           role: 'system',
-          content: typeof system === 'string' ? system : system.map(block => block.text).join('\n\n'),
+          content: systemContentFromBlocks(system),
         },
-      ]
-    : [];
+      ];
 
   return [
     ...systemMessages,

--- a/packages/translate/src/messages-via-chat-completions/request_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/request_test.ts
@@ -425,7 +425,7 @@ test('translateMessagesToChatCompletions emits in-array role:"system" inline as 
   assertEquals(result.messages[2].role, 'user');
 });
 
-test('translateMessagesToChatCompletions joins in-array system text blocks with double newline', () => {
+test('translateMessagesToChatCompletions preserves in-array system text blocks as separate content parts', () => {
   const result = translateMessagesToChatCompletions({
     model: 'gpt-test',
     max_tokens: 256,
@@ -441,7 +441,35 @@ test('translateMessagesToChatCompletions joins in-array system text blocks with 
     ],
   });
 
-  assertEquals(result.messages[0], { role: 'system', content: 'Para A\n\nPara B' });
+  assertEquals(result.messages[0], {
+    role: 'system',
+    content: [
+      { type: 'text', text: 'Para A' },
+      { type: 'text', text: 'Para B' },
+    ],
+  });
+});
+
+test('translateMessagesToChatCompletions preserves top-level system text blocks as separate content parts', () => {
+  const result = translateMessagesToChatCompletions({
+    model: 'gpt-test',
+    max_tokens: 256,
+    system: [
+      { type: 'text', text: 'instructions' },
+      { type: 'text', text: 'extra context' },
+    ],
+    messages: [
+      { role: 'user', content: 'hi' },
+    ],
+  });
+
+  assertEquals(result.messages[0], {
+    role: 'system',
+    content: [
+      { type: 'text', text: 'instructions' },
+      { type: 'text', text: 'extra context' },
+    ],
+  });
 });
 
 test('translateMessagesToChatCompletions preserves chronology of multiple in-array system messages', () => {

--- a/packages/translate/src/messages-via-chat-completions/request_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/request_test.ts
@@ -472,6 +472,18 @@ test('translateMessagesToChatCompletions preserves top-level system text blocks 
   });
 });
 
+test('translateMessagesToChatCompletions skips system message when top-level system is empty array', () => {
+  const result = translateMessagesToChatCompletions({
+    model: 'gpt-test',
+    max_tokens: 256,
+    system: [],
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertEquals(result.messages.length, 1);
+  assertEquals(result.messages[0].role, 'user');
+});
+
 test('translateMessagesToChatCompletions preserves chronology of multiple in-array system messages', () => {
   const result = translateMessagesToChatCompletions({
     model: 'gpt-test',

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -133,13 +133,11 @@ const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBloc
 // MessagesSystemMessage at their chronological position. The leading
 // contiguous prefix has already been hoisted to MessagesPayload.system by
 // translateResponsesToMessages before translateResponsesInput's per-item
-// loop hits this branch. Developer is the same intent layer as system on
-// the Responses wire and normalizes to role:'system' here. Anthropic
-// upstreams diverge on inline role:'system' (Bedrock accepts it under
-// placement rules; Vertex rejects it outright), so the gateway's
-// `demote-interleaved-system-to-user` interceptor flag is the safety net
-// for any inline system that would otherwise reach an upstream that does
-// not accept it.
+// loop hits this branch. Anthropic upstreams diverge on inline
+// role:'system' (Bedrock accepts it under placement rules; Vertex rejects
+// it outright), so the gateway's `demote-interleaved-system-to-user`
+// interceptor flag is the safety net for any inline system that would
+// otherwise reach an upstream that does not accept it.
 const translateSystemMessage = (message: ResponsesInputMessage): MessagesSystemMessage => {
   if (typeof message.content === 'string') {
     return { role: 'system', content: message.content };

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -186,9 +186,8 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
   // systemBlocks (→ top-level Messages.system), preserving each input_text
   // part as its own MessagesTextBlock so part boundaries survive the hoist.
   // Non-leading system/developer messages stay inline as MessagesSystemMessage.
-  // Empty system content contributes zero blocks — its prefix slot is still
-  // consumed so a subsequent non-empty leading system stays part of the same
-  // prefix.
+  // An empty-content leading message still extends the contiguous prefix
+  // even though it contributes no block.
   const systemBlocks: MessagesTextBlock[] = [];
   let prefixEnd = 0;
   for (const item of input) {

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -122,9 +122,14 @@ const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBloc
     if (block.type === 'input_image') {
       throw new Error(`Responses → Messages translator does not accept image content parts in ${message.role} messages — Anthropic Messages only permits text in the system field.`);
     }
-    if (block.type === 'input_text' || block.type === 'output_text') {
-      blocks.push({ type: 'text', text: (block as ResponsesInputText).text });
+    if (block.type !== 'input_text' && block.type !== 'output_text') {
+      // Exhaustiveness guard: today ResponsesInputContent is
+      // input_text|input_image|output_text; a future variant must opt into
+      // translator behavior rather than be silently dropped from system
+      // content.
+      throw new Error(`Responses → Messages translator: unexpected content block variant ${(block as { type: string }).type} in ${message.role} message.`);
     }
+    blocks.push({ type: 'text', text: (block as ResponsesInputText).text });
   }
   return blocks;
 };

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -137,9 +137,6 @@ const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBloc
 // for any inline system that would otherwise reach an upstream that does
 // not accept it.
 const translateSystemMessage = (message: ResponsesInputMessage): MessagesSystemMessage => {
-  if (typeof message.content === 'string') {
-    return { role: 'system', content: message.content };
-  }
   const blocks = responsesSystemBlocks(message);
   return { role: 'system', content: blocks.length > 0 ? blocks : '' };
 };

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -1,7 +1,7 @@
 import { parseToolArgumentsObject } from '../shared/messages/tool-arguments.ts';
 import { responsesReasoningToMessagesUpstreamBlock } from '../shared/messages-and-responses/reasoning.ts';
 import { buildCustomToolInputSchema } from '../shared/responses-via/custom-tool-wrap.ts';
-import { applyLastMessageCacheBreakpoint, applyLastToolCacheBreakpoint, EPHEMERAL_CACHE_CONTROL } from '../shared/via-messages/cache-breakpoints.ts';
+import { applyLastMessageCacheBreakpoint, applyLastSystemCacheBreakpoint, applyLastToolCacheBreakpoint } from '../shared/via-messages/cache-breakpoints.ts';
 import { fetchRemoteImage, type RemoteImageLoader, resolveImageUrlToMessagesImage } from '../shared/via-messages/remote-images.ts';
 import {
   MESSAGES_FALLBACK_MAX_TOKENS,
@@ -107,26 +107,45 @@ const translateAssistantMessage = (message: ResponsesInputMessage): MessagesAssi
   return { role: 'assistant', content: content.length > 0 ? content : '' };
 };
 
-const extractSystemText = (message: ResponsesInputMessage): string => {
-  if (typeof message.content === 'string') return message.content;
-  if (!Array.isArray(message.content)) return '';
+// Anthropic's Messages system field (top-level `MessagesPayload.system` and
+// inline `MessagesSystemMessage.content`) accepts only text. Image parts in
+// system / developer Responses input messages are rejected here at the
+// translator boundary so the caller hits an explicit failure instead of
+// having the image silently dropped on the wire.
+const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBlock[] => {
+  if (typeof message.content === 'string') {
+    return message.content ? [{ type: 'text', text: message.content }] : [];
+  }
 
-  return message.content.map(block => ('text' in block ? block.text : '')).join('');
+  const blocks: MessagesTextBlock[] = [];
+  for (const block of message.content) {
+    if (block.type === 'input_image') {
+      throw new Error(`Responses → Messages translator does not accept image content parts in ${message.role} messages — Anthropic Messages only permits text in the system field.`);
+    }
+    if (block.type === 'input_text' || block.type === 'output_text') {
+      blocks.push({ type: 'text', text: (block as ResponsesInputText).text });
+    }
+  }
+  return blocks;
 };
 
+// Non-leading system / developer Responses input messages stay inline as
+// MessagesSystemMessage at their chronological position. The leading
+// contiguous prefix has already been hoisted to MessagesPayload.system by
+// translateResponsesToMessages before translateResponsesInput's per-item
+// loop hits this branch. Developer is the same intent layer as system on
+// the Responses wire and normalizes to role:'system' here. Anthropic
+// upstreams diverge on inline role:'system' (Bedrock accepts it under
+// placement rules; Vertex rejects it outright), so the gateway's
+// `demote-interleaved-system-to-user` interceptor flag is the safety net
+// for any inline system that would otherwise reach an upstream that does
+// not accept it.
 const translateSystemMessage = (message: ResponsesInputMessage): MessagesSystemMessage => {
   if (typeof message.content === 'string') {
     return { role: 'system', content: message.content };
   }
-
-  const content: MessagesTextBlock[] = [];
-  for (const block of message.content) {
-    if (block.type === 'input_text' || block.type === 'output_text') {
-      content.push({ type: 'text', text: (block as ResponsesInputText).text });
-    }
-  }
-
-  return { role: 'system', content: content.length > 0 ? content : '' };
+  const blocks = responsesSystemBlocks(message);
+  return { role: 'system', content: blocks.length > 0 ? blocks : '' };
 };
 
 const appendAssistantBlock = (messages: MessagesMessage[], block: MessagesAssistantContentBlock): void => {
@@ -155,23 +174,26 @@ const unexpectedResponsesInputItem = (value: ResponsesInputItem): never => {
   throw new Error(`Unexpected Responses input item variant: ${JSON.stringify(value)}`);
 };
 
-const translateResponsesInput = async (input: string | ResponsesInputItem[], loadRemoteImage: RemoteImageLoader): Promise<{ messages: MessagesMessage[]; systemParts: string[] }> => {
+const translateResponsesInput = async (input: string | ResponsesInputItem[], loadRemoteImage: RemoteImageLoader): Promise<{ messages: MessagesMessage[]; systemBlocks: MessagesTextBlock[] }> => {
   if (typeof input === 'string') {
     return {
       messages: [{ role: 'user', content: input }],
-      systemParts: [],
+      systemBlocks: [],
     };
   }
 
-  // Hoist the leading contiguous run of system/developer input messages to
-  // systemParts (→ top-level Messages.system). Non-leading system/developer
-  // messages stay inline as MessagesSystemMessage.
-  const systemParts: string[] = [];
+  // Hoist the leading contiguous run of system/developer input messages into
+  // systemBlocks (→ top-level Messages.system), preserving each input_text
+  // part as its own MessagesTextBlock so part boundaries survive the hoist.
+  // Non-leading system/developer messages stay inline as MessagesSystemMessage.
+  // Empty system content contributes zero blocks — its prefix slot is still
+  // consumed so a subsequent non-empty leading system stays part of the same
+  // prefix.
+  const systemBlocks: MessagesTextBlock[] = [];
   let prefixEnd = 0;
   for (const item of input) {
     if (item.type !== 'message' || (item.role !== 'system' && item.role !== 'developer')) break;
-    const text = extractSystemText(item);
-    if (text) systemParts.push(text);
+    systemBlocks.push(...responsesSystemBlocks(item));
     prefixEnd++;
   }
 
@@ -252,7 +274,7 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
     }
   }
 
-  return { messages, systemParts };
+  return { messages, systemBlocks };
 };
 
 const translateTools = (tools: ResponsesTool[] | null | undefined, customToolNames: Set<string>): MessagesTool[] | undefined => {
@@ -316,18 +338,22 @@ const translateToolChoice = (toolChoice: ResponsesToolChoice | undefined): Messa
 
 export const translateResponsesToMessages = async (payload: ResponsesPayload, options: TranslateResponsesToMessagesOptions = {}): Promise<ResponsesToMessagesResult> => {
   const customToolNames = new Set<string>();
-  const { messages, systemParts } = await translateResponsesInput(payload.input, options.loadRemoteImage ?? fetchRemoteImage);
+  const { messages, systemBlocks: hoistedSystemBlocks } = await translateResponsesInput(payload.input, options.loadRemoteImage ?? fetchRemoteImage);
   const tools = translateTools(payload.tools, customToolNames);
   // `payload.instructions` is the Responses canonical system field; leading
-  // system/developer input items are hoisted into `systemParts`. Combine
-  // both into the Messages top-level `system`. Non-leading system items stay
-  // inline as MessagesSystemMessage.
-  const system = [payload.instructions, ...systemParts].filter((part): part is string => Boolean(part)).join('\n\n');
+  // system/developer input items contribute additional blocks immediately
+  // after it. Each source — the instructions field and each leading input
+  // message — is preserved as its own MessagesTextBlock so the boundary
+  // between "canonical instructions" and "leading input system" survives
+  // and the downstream prompt cache sees stable per-source segments. The
+  // cache breakpoint lands on the last block via applyLastSystemCacheBreakpoint.
+  const systemBlocks: MessagesTextBlock[] = [
+    ...(payload.instructions ? [{ type: 'text' as const, text: payload.instructions }] : []),
+    ...hoistedSystemBlocks,
+  ];
   const effort = payload.reasoning?.effort;
   const maxTokens = payload.max_output_tokens ?? options.fallbackMaxOutputTokens ?? MESSAGES_FALLBACK_MAX_TOKENS;
-  const systemBlocks: MessagesTextBlock[] | undefined = system
-    ? [{ type: 'text', text: system, cache_control: EPHEMERAL_CACHE_CONTROL }]
-    : undefined;
+  applyLastSystemCacheBreakpoint(systemBlocks);
   applyLastToolCacheBreakpoint(tools);
   applyLastMessageCacheBreakpoint(messages);
 
@@ -366,7 +392,7 @@ export const translateResponsesToMessages = async (payload: ResponsesPayload, op
     model: payload.model,
     messages,
     max_tokens: maxTokens,
-    ...(systemBlocks ? { system: systemBlocks } : {}),
+    ...(systemBlocks.length > 0 ? { system: systemBlocks } : {}),
     ...(payload.temperature != null ? { temperature: payload.temperature } : {}),
     ...(payload.top_p != null ? { top_p: payload.top_p } : {}),
     stream: true,

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -129,15 +129,13 @@ const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBloc
   return blocks;
 };
 
-// Non-leading system / developer Responses input messages stay inline as
-// MessagesSystemMessage at their chronological position. The leading
-// contiguous prefix has already been hoisted to MessagesPayload.system by
-// translateResponsesToMessages before translateResponsesInput's per-item
-// loop hits this branch. Anthropic upstreams diverge on inline
-// role:'system' (Bedrock accepts it under placement rules; Vertex rejects
-// it outright), so the gateway's `demote-interleaved-system-to-user`
-// interceptor flag is the safety net for any inline system that would
-// otherwise reach an upstream that does not accept it.
+// Inline path for non-leading system / developer Responses input messages
+// (the leading prefix was hoisted earlier). Anthropic upstreams diverge on
+// inline role:'system' here (Bedrock accepts it under placement rules;
+// Vertex rejects it outright), so the gateway's
+// `demote-interleaved-system-to-user` interceptor flag is the safety net
+// for any inline system that would otherwise reach an upstream that does
+// not accept it.
 const translateSystemMessage = (message: ResponsesInputMessage): MessagesSystemMessage => {
   if (typeof message.content === 'string') {
     return { role: 'system', content: message.content };
@@ -184,8 +182,6 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
   // systemBlocks (→ top-level Messages.system), preserving each input_text
   // part as its own MessagesTextBlock so part boundaries survive the hoist.
   // Non-leading system/developer messages stay inline as MessagesSystemMessage.
-  // An empty-content leading message still extends the contiguous prefix
-  // even though it contributes no block.
   const systemBlocks: MessagesTextBlock[] = [];
   let prefixEnd = 0;
   for (const item of input) {
@@ -342,8 +338,7 @@ export const translateResponsesToMessages = async (payload: ResponsesPayload, op
   // after it. Each source — the instructions field and each leading input
   // message — is preserved as its own MessagesTextBlock so the boundary
   // between "canonical instructions" and "leading input system" survives
-  // and the downstream prompt cache sees stable per-source segments. The
-  // cache breakpoint lands on the last block via applyLastSystemCacheBreakpoint.
+  // and the downstream prompt cache sees stable per-source segments.
   const systemBlocks: MessagesTextBlock[] = [
     ...(payload.instructions ? [{ type: 'text' as const, text: payload.instructions }] : []),
     ...hoistedSystemBlocks,

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -107,11 +107,13 @@ const translateAssistantMessage = (message: ResponsesInputMessage): MessagesAssi
   return { role: 'assistant', content: content.length > 0 ? content : '' };
 };
 
-// Both `role: 'system'` and `role: 'developer'` Responses input messages flow
-// through as Messages system items. The Messages role enum admits 'system'
-// directly (https://platform.claude.com/docs/en/api/messages); developer
-// content is the same intent layer and normalizes to 'system' on the
-// Messages wire.
+const extractSystemText = (message: ResponsesInputMessage): string => {
+  if (typeof message.content === 'string') return message.content;
+  if (!Array.isArray(message.content)) return '';
+
+  return message.content.map(block => ('text' in block ? block.text : '')).join('');
+};
+
 const translateSystemMessage = (message: ResponsesInputMessage): MessagesSystemMessage => {
   if (typeof message.content === 'string') {
     return { role: 'system', content: message.content };
@@ -153,14 +155,29 @@ const unexpectedResponsesInputItem = (value: ResponsesInputItem): never => {
   throw new Error(`Unexpected Responses input item variant: ${JSON.stringify(value)}`);
 };
 
-const translateResponsesInput = async (input: string | ResponsesInputItem[], loadRemoteImage: RemoteImageLoader): Promise<MessagesMessage[]> => {
+const translateResponsesInput = async (input: string | ResponsesInputItem[], loadRemoteImage: RemoteImageLoader): Promise<{ messages: MessagesMessage[]; systemParts: string[] }> => {
   if (typeof input === 'string') {
-    return [{ role: 'user', content: input }];
+    return {
+      messages: [{ role: 'user', content: input }],
+      systemParts: [],
+    };
+  }
+
+  // Hoist the leading contiguous run of system/developer input messages to
+  // systemParts (→ top-level Messages.system). Non-leading system/developer
+  // messages stay inline as MessagesSystemMessage.
+  const systemParts: string[] = [];
+  let prefixEnd = 0;
+  for (const item of input) {
+    if (item.type !== 'message' || (item.role !== 'system' && item.role !== 'developer')) break;
+    const text = extractSystemText(item);
+    if (text) systemParts.push(text);
+    prefixEnd++;
   }
 
   const messages: MessagesMessage[] = [];
 
-  for (const item of input) {
+  for (const item of input.slice(prefixEnd)) {
     switch (item.type) {
     case 'message':
       switch (item.role) {
@@ -235,7 +252,7 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
     }
   }
 
-  return messages;
+  return { messages, systemParts };
 };
 
 const translateTools = (tools: ResponsesTool[] | null | undefined, customToolNames: Set<string>): MessagesTool[] | undefined => {
@@ -299,13 +316,13 @@ const translateToolChoice = (toolChoice: ResponsesToolChoice | undefined): Messa
 
 export const translateResponsesToMessages = async (payload: ResponsesPayload, options: TranslateResponsesToMessagesOptions = {}): Promise<ResponsesToMessagesResult> => {
   const customToolNames = new Set<string>();
-  const messages = await translateResponsesInput(payload.input, options.loadRemoteImage ?? fetchRemoteImage);
+  const { messages, systemParts } = await translateResponsesInput(payload.input, options.loadRemoteImage ?? fetchRemoteImage);
   const tools = translateTools(payload.tools, customToolNames);
-  // `payload.instructions` is the Responses canonical system field; it maps
-  // to the Messages top-level `system`. Any `role: 'system'`/`'developer'`
-  // input items are emitted inline as MessagesSystemMessage by the input
-  // translator, preserving chronology.
-  const system = payload.instructions ?? '';
+  // `payload.instructions` is the Responses canonical system field; leading
+  // system/developer input items are hoisted into `systemParts`. Combine
+  // both into the Messages top-level `system`. Non-leading system items stay
+  // inline as MessagesSystemMessage.
+  const system = [payload.instructions, ...systemParts].filter((part): part is string => Boolean(part)).join('\n\n');
   const effort = payload.reasoning?.effort;
   const maxTokens = payload.max_output_tokens ?? options.fallbackMaxOutputTokens ?? MESSAGES_FALLBACK_MAX_TOKENS;
   const systemBlocks: MessagesTextBlock[] | undefined = system

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -129,7 +129,7 @@ const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBloc
       // content.
       throw new Error(`Responses → Messages translator: unexpected content block variant ${(block as { type: string }).type} in ${message.role} message.`);
     }
-    blocks.push({ type: 'text', text: (block as ResponsesInputText).text });
+    blocks.push({ type: 'text', text: block.text });
   }
   return blocks;
 };

--- a/packages/translate/src/responses-via-messages/request_test.ts
+++ b/packages/translate/src/responses-via-messages/request_test.ts
@@ -687,7 +687,7 @@ test('translateResponsesToMessages hoists leading role:"developer" to top-level 
   assertEquals(result.target.system, [{ type: 'text', text: 'dev rule', cache_control: { type: 'ephemeral' } }]);
 });
 
-test('translateResponsesToMessages merges payload.instructions with leading system into top-level, non-leading stays inline', async () => {
+test('translateResponsesToMessages preserves payload.instructions and leading system as separate blocks; non-leading stays inline', async () => {
   const result = await translateResponsesToMessages(
     {
       model: 'claude-test',
@@ -712,10 +712,81 @@ test('translateResponsesToMessages merges payload.instructions with leading syst
   );
 
   assertEquals(result.target.system, [
-    { type: 'text', text: 'canonical top-level instructions\n\nleading note', cache_control: { type: 'ephemeral' } },
+    { type: 'text', text: 'canonical top-level instructions' },
+    { type: 'text', text: 'leading note', cache_control: { type: 'ephemeral' } },
   ]);
   assertEquals(result.target.messages.length, 3);
   assertEquals(result.target.messages[0].role, 'user');
   assertEquals(result.target.messages[1], { role: 'system', content: 'mid-array note' });
   assertEquals(result.target.messages[2].role, 'user');
+});
+
+test('translateResponsesToMessages throws when a system input message contains an image part', async () => {
+  await assertRejects(
+    () =>
+      translateResponsesToMessages(
+        {
+          model: 'claude-test',
+          input: [
+            {
+              type: 'message',
+              role: 'system',
+              content: [
+                { type: 'input_text', text: 'You are helpful.' },
+                { type: 'input_image', image_url: 'data:image/png;base64,iVBORw0KGgo=', detail: 'auto' },
+              ],
+            },
+            { type: 'message', role: 'user', content: 'hi' },
+          ],
+          instructions: null,
+          temperature: null,
+          top_p: null,
+          max_output_tokens: 256,
+          tools: null,
+          tool_choice: 'auto',
+          metadata: null,
+          stream: null,
+          store: false,
+          parallel_tool_calls: true,
+        },
+        { loadRemoteImage: stubRemoteImageLoader(null) },
+      ),
+    Error,
+    'does not accept image content parts in system messages',
+  );
+});
+
+test('translateResponsesToMessages throws when a non-leading developer input message contains an image part', async () => {
+  await assertRejects(
+    () =>
+      translateResponsesToMessages(
+        {
+          model: 'claude-test',
+          input: [
+            { type: 'message', role: 'user', content: 'hi' },
+            {
+              type: 'message',
+              role: 'developer',
+              content: [
+                { type: 'input_image', image_url: 'data:image/png;base64,iVBORw0KGgo=', detail: 'auto' },
+              ],
+            },
+            { type: 'message', role: 'user', content: 'bye' },
+          ],
+          instructions: null,
+          temperature: null,
+          top_p: null,
+          max_output_tokens: 256,
+          tools: null,
+          tool_choice: 'auto',
+          metadata: null,
+          stream: null,
+          store: false,
+          parallel_tool_calls: true,
+        },
+        { loadRemoteImage: stubRemoteImageLoader(null) },
+      ),
+    Error,
+    'does not accept image content parts in developer messages',
+  );
 });

--- a/packages/translate/src/responses-via-messages/request_test.ts
+++ b/packages/translate/src/responses-via-messages/request_test.ts
@@ -603,7 +603,34 @@ test('translateResponsesToMessages drops text.format json_object (no Anthropic e
   assertFalse('output_config' in result.target);
 });
 
-test('translateResponsesToMessages emits in-array role:"system" inline as MessagesSystemMessage', async () => {
+test('translateResponsesToMessages hoists leading role:"system" to top-level system field', async () => {
+  const result = await translateResponsesToMessages(
+    {
+      model: 'claude-test',
+      input: [
+        { type: 'message', role: 'system', content: 'be terse' },
+        { type: 'message', role: 'user', content: 'q1' },
+      ],
+      instructions: null,
+      temperature: null,
+      top_p: null,
+      max_output_tokens: 256,
+      tools: null,
+      tool_choice: 'auto',
+      metadata: null,
+      stream: null,
+      store: false,
+      parallel_tool_calls: true,
+    },
+    { loadRemoteImage: stubRemoteImageLoader(null) },
+  );
+
+  assertEquals(result.target.system, [{ type: 'text', text: 'be terse', cache_control: { type: 'ephemeral' } }]);
+  assertEquals(result.target.messages.length, 1);
+  assertEquals(result.target.messages[0].role, 'user');
+});
+
+test('translateResponsesToMessages keeps non-leading role:"system" inline', async () => {
   const result = await translateResponsesToMessages(
     {
       model: 'claude-test',
@@ -626,16 +653,14 @@ test('translateResponsesToMessages emits in-array role:"system" inline as Messag
     { loadRemoteImage: stubRemoteImageLoader(null) },
   );
 
-  const messages = result.target.messages;
-  assertEquals(messages.length, 3);
-  assertEquals(messages[0].role, 'user');
-  assertEquals(messages[1], { role: 'system', content: 'be terse' });
-  assertEquals(messages[2].role, 'user');
-  // No top-level instructions → no top-level Messages system field
+  assertEquals(result.target.messages.length, 3);
+  assertEquals(result.target.messages[0].role, 'user');
+  assertEquals(result.target.messages[1], { role: 'system', content: 'be terse' });
+  assertEquals(result.target.messages[2].role, 'user');
   assertFalse('system' in result.target);
 });
 
-test('translateResponsesToMessages normalizes role:"developer" to inline role:"system"', async () => {
+test('translateResponsesToMessages hoists leading role:"developer" to top-level system field', async () => {
   const result = await translateResponsesToMessages(
     {
       model: 'claude-test',
@@ -657,16 +682,20 @@ test('translateResponsesToMessages normalizes role:"developer" to inline role:"s
     { loadRemoteImage: stubRemoteImageLoader(null) },
   );
 
-  assertEquals(result.target.messages[0], { role: 'system', content: 'dev rule' });
+  assertEquals(result.target.messages.length, 1);
+  assertEquals(result.target.messages[0].role, 'user');
+  assertEquals(result.target.system, [{ type: 'text', text: 'dev rule', cache_control: { type: 'ephemeral' } }]);
 });
 
-test('translateResponsesToMessages keeps payload.instructions as the Messages top-level system field', async () => {
+test('translateResponsesToMessages merges payload.instructions with leading system into top-level, non-leading stays inline', async () => {
   const result = await translateResponsesToMessages(
     {
       model: 'claude-test',
       input: [
-        { type: 'message', role: 'system', content: 'mid-array note' },
+        { type: 'message', role: 'system', content: 'leading note' },
         { type: 'message', role: 'user', content: 'hi' },
+        { type: 'message', role: 'system', content: 'mid-array note' },
+        { type: 'message', role: 'user', content: 'bye' },
       ],
       instructions: 'canonical top-level instructions',
       temperature: null,
@@ -682,11 +711,11 @@ test('translateResponsesToMessages keeps payload.instructions as the Messages to
     { loadRemoteImage: stubRemoteImageLoader(null) },
   );
 
-  // payload.instructions → top-level Messages.system; in-array system stays inline.
-  // The two layers do not get merged anymore.
   assertEquals(result.target.system, [
-    { type: 'text', text: 'canonical top-level instructions', cache_control: { type: 'ephemeral' } },
+    { type: 'text', text: 'canonical top-level instructions\n\nleading note', cache_control: { type: 'ephemeral' } },
   ]);
-  assertEquals(result.target.messages[0], { role: 'system', content: 'mid-array note' });
-  assertEquals(result.target.messages[1].role, 'user');
+  assertEquals(result.target.messages.length, 3);
+  assertEquals(result.target.messages[0].role, 'user');
+  assertEquals(result.target.messages[1], { role: 'system', content: 'mid-array note' });
+  assertEquals(result.target.messages[2].role, 'user');
 });

--- a/packages/translate/src/responses-via-messages/request_test.ts
+++ b/packages/translate/src/responses-via-messages/request_test.ts
@@ -655,7 +655,7 @@ test('translateResponsesToMessages keeps non-leading role:"system" inline', asyn
 
   assertEquals(result.target.messages.length, 3);
   assertEquals(result.target.messages[0].role, 'user');
-  assertEquals(result.target.messages[1], { role: 'system', content: 'be terse' });
+  assertEquals(result.target.messages[1], { role: 'system', content: [{ type: 'text', text: 'be terse' }] });
   assertEquals(result.target.messages[2].role, 'user');
   assertFalse('system' in result.target);
 });
@@ -717,7 +717,7 @@ test('translateResponsesToMessages preserves payload.instructions and leading sy
   ]);
   assertEquals(result.target.messages.length, 3);
   assertEquals(result.target.messages[0].role, 'user');
-  assertEquals(result.target.messages[1], { role: 'system', content: 'mid-array note' });
+  assertEquals(result.target.messages[1], { role: 'system', content: [{ type: 'text', text: 'mid-array note' }] });
   assertEquals(result.target.messages[2].role, 'user');
 });
 

--- a/packages/translate/src/shared/via-messages/cache-breakpoints.ts
+++ b/packages/translate/src/shared/via-messages/cache-breakpoints.ts
@@ -52,10 +52,6 @@ type CacheableContentBlock = MessagesTextBlock | MessagesImageBlock | MessagesTo
 const isCacheableBlock = (block: MessagesUserContentBlock | MessagesAssistantContentBlock): block is CacheableContentBlock =>
   block.type === 'text' || block.type === 'image' || block.type === 'tool_use' || block.type === 'tool_result';
 
-// Apply ephemeral cache breakpoint to the last text block of the top-level
-// system field. The system field is part of the stable per-request prefix,
-// so the cache breakpoint anchors at its tail to maximise reuse across
-// subsequent turns that build on the same system + tools + history chain.
 export const applyLastSystemCacheBreakpoint = (system: MessagesTextBlock[] | undefined): void => {
   if (!system || system.length === 0) return;
   system[system.length - 1].cache_control = EPHEMERAL_CACHE_CONTROL;

--- a/packages/translate/src/shared/via-messages/cache-breakpoints.ts
+++ b/packages/translate/src/shared/via-messages/cache-breakpoints.ts
@@ -52,6 +52,15 @@ type CacheableContentBlock = MessagesTextBlock | MessagesImageBlock | MessagesTo
 const isCacheableBlock = (block: MessagesUserContentBlock | MessagesAssistantContentBlock): block is CacheableContentBlock =>
   block.type === 'text' || block.type === 'image' || block.type === 'tool_use' || block.type === 'tool_result';
 
+// Apply ephemeral cache breakpoint to the last text block of the top-level
+// system field. The system field is part of the stable per-request prefix,
+// so the cache breakpoint anchors at its tail to maximise reuse across
+// subsequent turns that build on the same system + tools + history chain.
+export const applyLastSystemCacheBreakpoint = (system: MessagesTextBlock[] | undefined): void => {
+  if (!system || system.length === 0) return;
+  system[system.length - 1].cache_control = EPHEMERAL_CACHE_CONTROL;
+};
+
 export const applyLastMessageCacheBreakpoint = (messages: MessagesMessage[]): void => {
   for (let m = messages.length - 1; m >= 0; m--) {
     const message = messages[m];

--- a/packages/translate/src/shared/via-messages/cache-breakpoints_test.ts
+++ b/packages/translate/src/shared/via-messages/cache-breakpoints_test.ts
@@ -1,8 +1,8 @@
 import { test } from 'vitest';
 
-import { applyLastMessageCacheBreakpoint, applyLastToolCacheBreakpoint } from './cache-breakpoints.ts';
+import { applyLastMessageCacheBreakpoint, applyLastSystemCacheBreakpoint, applyLastToolCacheBreakpoint } from './cache-breakpoints.ts';
 import { assert, assertEquals } from '../../test-assert.ts';
-import type { MessagesAssistantMessage, MessagesMessage, MessagesTool, MessagesUserMessage } from '@floway-dev/protocols/messages';
+import type { MessagesAssistantMessage, MessagesMessage, MessagesTextBlock, MessagesTool, MessagesUserMessage } from '@floway-dev/protocols/messages';
 
 const cacheControlOf = (value: unknown): unknown => (value as { cache_control?: unknown }).cache_control;
 
@@ -59,4 +59,23 @@ test('applyLastMessageCacheBreakpoint falls back to an earlier message when the 
   assert(Array.isArray(userContent) && Array.isArray(assistantContent));
   assertEquals(cacheControlOf(userContent[0]), { type: 'ephemeral' });
   assertEquals(cacheControlOf(assistantContent[0]), undefined);
+});
+
+test('applyLastSystemCacheBreakpoint is a no-op on undefined or empty input', () => {
+  applyLastSystemCacheBreakpoint(undefined);
+  const empty: MessagesTextBlock[] = [];
+  applyLastSystemCacheBreakpoint(empty);
+  assertEquals(empty, []);
+});
+
+test('applyLastSystemCacheBreakpoint marks only the last block when multiple are present', () => {
+  const system: MessagesTextBlock[] = [
+    { type: 'text', text: 'instructions' },
+    { type: 'text', text: 'leading note' },
+    { type: 'text', text: 'final block' },
+  ];
+  applyLastSystemCacheBreakpoint(system);
+  assertEquals(cacheControlOf(system[0]), undefined);
+  assertEquals(cacheControlOf(system[1]), undefined);
+  assertEquals(cacheControlOf(system[2]), { type: 'ephemeral' });
 });


### PR DESCRIPTION
## Summary

- 169e592b changed the Chat Completions→Messages and Responses→Messages translators to emit all system/developer messages inline as `role: "system"`. Upstream Anthropic endpoints reject position-0 inline system — the most common Chat Completions pattern (`[{role:"system",...}, {role:"user",...}]`) — causing 400 errors.
- Tested against `claude-opus-4-8`, `claude-opus-4-7`, and `claude-opus-4-6` via GitHub Copilot upstream: all three reject position-0 inline system. `claude-opus-4-8` conditionally accepts non-leading inline system (after a user message), while `claude-opus-4-7` and `claude-opus-4-6` reject it in all positions.
- Hoist the leading contiguous run of system/developer messages to `MessagesPayload.system`. Non-leading system/developer messages stay inline as `MessagesSystemMessage`, preserving chronological position. Upstreams that reject non-leading inline system can enable the existing `demote-interleaved-system-to-user` interceptor.

## Test plan

- [x] `pnpm --filter @floway-dev/translate run test` — 410 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 3493 tests pass, zero regressions
- [x] Manual: verified via local Floway dev server that position-0 system messages reach upstream in the top-level `system` field and return successfully