### PR TITLE
fix(responses): cross-protocol callers use a no-op inner store

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -3,7 +3,7 @@ import type { ChatCompletionsInvocation } from './interceptors/types.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
 import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
+import { createNoOpResponsesStore, type StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions } from '../shared/attempt-helpers.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import { tryCatchChatServeFailure } from '../shared/errors.ts';
@@ -53,7 +53,7 @@ export const chatCompletionsAttempt = {
         return await traverseTranslation(
           invocation.payload,
           p => translateChatCompletionsViaResponses(p, { model: candidate.binding.upstreamModel.id }),
-          translated => responsesAttempt.generate({ payload: translated, ctx, store, candidate, snapshotMode: 'none', headers: invocation.headers }),
+          translated => responsesAttempt.generate({ payload: translated, ctx, store: createNoOpResponsesStore(store.apiKeyId), candidate, snapshotMode: 'none', headers: invocation.headers }),
         );
       }
       throw new Error(`chatCompletionsAttempt.generate: unexpected targetApi '${(candidate as { targetApi: string }).targetApi}'`);

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
@@ -3,6 +3,7 @@ import { test, vi } from 'vitest';
 import { chatCompletionsAttempt } from './attempt.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import { hashResponsesItemContent } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
@@ -150,15 +151,15 @@ test('generate translate-to-messages branch routes through messagesAttempt', asy
   assertEquals(callMessages.mock.calls.length, 1);
 });
 
-test('generate translate-to-responses branch routes through responsesAttempt', async () => {
-  installRepo();
+test('generate translate-to-responses branch routes through responsesAttempt against a no-op inner store (no Responses-shape orphans in the ChatCompletions-side store)', async () => {
+  const repo = installRepo();
   const respResp: ResponsesResult = {
     id: 'resp_x', object: 'response', model: 'test-model', status: 'completed',
     output: [{
-      type: 'message', id: 'msg_resp', role: 'assistant', status: 'completed',
-      content: [{ type: 'output_text', text: 'hi' }],
+      type: 'message', id: 'msg_resp_orphan_probe', role: 'assistant', status: 'completed',
+      content: [{ type: 'output_text', text: 'unique-orphan-probe-text-cc' }],
     }],
-    output_text: 'hi', error: null, incomplete_details: null,
+    output_text: 'unique-orphan-probe-text-cc', error: null, incomplete_details: null,
   };
   const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
     action: 'generate', ok: true,
@@ -178,6 +179,17 @@ test('generate translate-to-responses branch routes through responsesAttempt', a
   if (result.type !== 'events') throw new Error('unreachable');
   await collectEvents(result.events);
   assertEquals(callResponses.mock.calls.length, 1);
+
+  // The inner Responses call runs against createNoOpResponsesStore, so the
+  // upstream's assistant message does NOT land in the ChatCompletions-side
+  // repo as a Responses-shape orphan row. Probe by content hash.
+  const contentHash = await hashResponsesItemContent({
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'unique-orphan-probe-text-cc' }],
+  } as unknown as Parameters<typeof hashResponsesItemContent>[0]);
+  const rows = await repo.responsesItems.lookupManyByContentHash(API_KEY_ID, [contentHash]);
+  assertEquals(rows.length, 0);
 });
 
 test('generate inherits invocation headers across translation to Messages', async () => {

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -5,7 +5,7 @@ import { stripUnsupportedToolsFromPayload } from './interceptors/strip-unsupport
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
+import { createNoOpResponsesStore, type StatefulResponsesStore } from '../responses/items/store.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
@@ -58,7 +58,7 @@ export const geminiAttempt = {
           invocation.payload,
           p => translateGeminiViaResponses(p, transCtx),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, snapshotMode: 'none', headers: invocation.headers,
+            payload: translated, ctx, store: createNoOpResponsesStore(store.apiKeyId), candidate, snapshotMode: 'none', headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
@@ -3,6 +3,7 @@ import { test, vi } from 'vitest';
 import { geminiAttempt } from './attempt.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import { hashResponsesItemContent } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
@@ -159,8 +160,8 @@ test('generate translates through Messages when targetApi is messages', async ()
   assertEquals(callMessages.mock.calls.length, 1);
 });
 
-test('generate translates through Responses when targetApi is responses', async () => {
-  installRepo();
+test('generate translates through Responses when targetApi is responses against a no-op inner store (no Responses-shape orphans in the Gemini-side store)', async () => {
+  const repo = installRepo();
   const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
     action: 'generate', ok: true, events: makeProtocolFrames([makeResponsesResultEvent()]), modelKey: 'k', headers: new Headers(),
   }));
@@ -176,6 +177,17 @@ test('generate translates through Responses when targetApi is responses', async 
   if (result.type !== 'events') throw new Error('unreachable');
   await collectEvents(result.events);
   assertEquals(callResponses.mock.calls.length, 1);
+
+  // The inner Responses call runs against createNoOpResponsesStore, so the
+  // upstream's assistant message does NOT land in the Gemini-side repo as
+  // a Responses-shape orphan row. Probe by content hash.
+  const contentHash = await hashResponsesItemContent({
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'hi from responses' }],
+  } as unknown as Parameters<typeof hashResponsesItemContent>[0]);
+  const rows = await repo.responsesItems.lookupManyByContentHash(API_KEY_ID, [contentHash]);
+  assertEquals(rows.length, 0);
 });
 
 test('countTokens translates Gemini to Messages count_tokens and reshapes to totalTokens envelope', async () => {

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -4,7 +4,7 @@ import { requireRecordedDurationMs } from '../../shared/telemetry/performance.ts
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
 import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
+import { createNoOpResponsesStore, type StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions } from '../shared/attempt-helpers.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import { tryCatchChatServeFailure } from '../shared/errors.ts';
@@ -62,7 +62,7 @@ export const messagesAttempt = {
           invocation.payload,
           p => translateMessagesViaResponses(p, { model: candidate.binding.upstreamModel.id }),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, snapshotMode: 'none', headers: invocation.headers,
+            payload: translated, ctx, store: createNoOpResponsesStore(store.apiKeyId), candidate, snapshotMode: 'none', headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
@@ -3,6 +3,7 @@ import { test, vi } from 'vitest';
 import { messagesAttempt } from './attempt.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import { hashResponsesItemContent } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
@@ -133,15 +134,15 @@ test('generate native messages target calls provider.callMessages with no rewrit
   assertEquals(callMessages.mock.calls.length, 1);
 });
 
-test('generate translate-to-responses branch routes through responsesAttempt', async () => {
-  installRepo();
+test('generate translate-to-responses branch routes through responsesAttempt against a no-op inner store (no Responses-shape orphans in the Messages-side store)', async () => {
+  const repo = installRepo();
   const respResp: ResponsesResult = {
     id: 'resp_x', object: 'response', model: 'test-model', status: 'completed',
     output: [{
-      type: 'message', id: 'msg_resp', role: 'assistant', status: 'completed',
-      content: [{ type: 'output_text', text: 'hi' }],
+      type: 'message', id: 'msg_resp_orphan_probe', role: 'assistant', status: 'completed',
+      content: [{ type: 'output_text', text: 'unique-orphan-probe-text' }],
     }],
-    output_text: 'hi', error: null, incomplete_details: null,
+    output_text: 'unique-orphan-probe-text', error: null, incomplete_details: null,
   };
   const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
     action: 'generate', ok: true,
@@ -161,6 +162,21 @@ test('generate translate-to-responses branch routes through responsesAttempt', a
   if (result.type !== 'events') throw new Error('unreachable');
   await collectEvents(result.events);
   assertEquals(callResponses.mock.calls.length, 1);
+
+  // The inner Responses call runs against createNoOpResponsesStore, whose
+  // empty itemWrites/snapshotWrites make the wrap-output-storage commits
+  // into no-ops. The upstream's assistant message therefore does NOT land
+  // in the Messages-side repo as a Responses-shape row that nothing reads
+  // (orphan). Probing the underlying repo by encrypted/content hash is the
+  // cleanest way to assert "no Responses-shape row at all" without knowing
+  // the gateway-minted id wrap-output-storage would have picked.
+  const contentHash = await hashResponsesItemContent({
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'unique-orphan-probe-text' }],
+  } as unknown as Parameters<typeof hashResponsesItemContent>[0]);
+  const rows = await repo.responsesItems.lookupManyByContentHash(API_KEY_ID, [contentHash]);
+  assertEquals(rows.length, 0);
 });
 
 test('countTokens proxies the upstream response as a plain result', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -624,6 +624,23 @@ export const createResponsesWsSession = (apiKeyId: string | null): {
   };
 };
 
+// For cross-protocol callers (Messages/Gemini/ChatCompletions translating
+// into Responses): the outer protocol's attempt has already resolved any
+// store-backed item references against its own store and inlined them into
+// the translated payload, so the inner Responses call needs neither reads
+// nor writes. Forwarding the outer store instead would persist
+// Responses-shape rows and snapshots into the outer protocol's store —
+// orphan rows the outer protocol's reader has no path to consume.
+export const createNoOpResponsesStore = (apiKeyId: string | null): StatefulResponsesStore =>
+  new LayeredStatefulResponsesStore({
+    apiKeyId,
+    reads: [],
+    itemWrites: [],
+    snapshotWrites: [],
+    stageInputs: false,
+    shouldStorePayload: false,
+  });
+
 const pushByHash = (target: Map<string, StoredResponsesItem[]>, hash: string, row: StoredResponsesItem): void => {
   const rows = target.get(hash) ?? [];
   if (!rows.some(existing => existing.id === row.id && existing.apiKeyId === row.apiKeyId)) {


### PR DESCRIPTION
## Summary

Cross-protocol Messages / Gemini / Chat-Completions callers route through `responsesAttempt.generate` for the inner Responses dispatch after translating the request shape. They previously forwarded their outer protocol's `StatefulResponsesStore` into that inner call, so the inner Responses path's item writes and snapshot commits landed under rows the outer protocol never reads back. The result was orphan rows accumulating per cross-protocol turn — invisible at runtime but a long-term storage cost the outer protocol doesn't own.

Add a `createNoOpResponsesStore(apiKeyId)` factory whose `reads` / `itemWrites` / `snapshotWrites` are empty so every backing-write iteration is a no-op. Pass it to the inner Responses call in place of the forwarded outer store. The three cross-protocol attempt files (`messages/attempt.ts`, `gemini/attempt.ts`, `chat-completions/attempt.ts`) each pick it up at exactly one site.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`
- [x] Tests assert each cross-protocol attempt path's inner Responses call receives a no-op store (no items / snapshots committed under the outer protocol's apiKeyId)