### PR TITLE
refactor(responses): derive snapshot mode from output compaction items

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -53,7 +53,7 @@ export const chatCompletionsAttempt = {
         return await traverseTranslation(
           invocation.payload,
           p => translateChatCompletionsViaResponses(p, { model: candidate.binding.upstreamModel.id }),
-          translated => responsesAttempt.generate({ payload: translated, ctx, store, candidate, snapshotMode: 'none', headers: invocation.headers }),
+          translated => responsesAttempt.generate({ payload: translated, ctx, store, candidate, headers: invocation.headers }),
         );
       }
       throw new Error(`chatCompletionsAttempt.generate: unexpected targetApi '${(candidate as { targetApi: string }).targetApi}'`);

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -58,7 +58,7 @@ export const geminiAttempt = {
           invocation.payload,
           p => translateGeminiViaResponses(p, transCtx),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, snapshotMode: 'none', headers: invocation.headers,
+            payload: translated, ctx, store, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -62,7 +62,7 @@ export const messagesAttempt = {
           invocation.payload,
           p => translateMessagesViaResponses(p, { model: candidate.binding.upstreamModel.id }),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, snapshotMode: 'none', headers: invocation.headers,
+            payload: translated, ctx, store, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -4,7 +4,7 @@ import { createStoredResponseId } from './items/format.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
 import { drainAsync, syntheticEventsFromResult, wrapResponsesOutputForStorage } from './items/output.ts';
 import { rewriteResponsesItemsForCandidate, type RewrittenResponsesPayload } from './items/rewrite.ts';
-import type { ResponsesSnapshotMode, StatefulResponsesStore } from './items/store.ts';
+import type { StatefulResponsesStore } from './items/store.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
 import { recordPerformanceLatency, requireRecordedDurationMs } from '../../shared/telemetry/performance.ts';
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
@@ -29,37 +29,31 @@ export interface ResponsesAttemptInvokeArgs {
   readonly store: StatefulResponsesStore;
   readonly candidate: ProviderCandidate;
   readonly headers: Headers;
-  // Cross-protocol translation paths (Messages/Gemini/ChatCompletions
-  // translating into Responses) own snapshot persistence at the outer
-  // protocol's attempt and pass `'none'` so the inner Responses call does
-  // not double-write. Native Responses HTTP leaves this absent so the
-  // attempt derives snapshot mode from the post-chain action +
-  // `payload.store` (compact → 'replace'; generate with store=false →
-  // 'none'; generate otherwise → 'append'). WS passes 'append' explicitly
-  // so in-session snapshots survive even when the caller opted out of
-  // durable storage.
-  readonly snapshotMode?: ResponsesSnapshotMode;
 }
 
 // Single entry point for both `action: 'generate'` and `action: 'compact'`.
 // The interceptor chain owns the action through `invocation.action` and may
-// flip it; post-chain we read `invocation.action` to pick snapshot mode
-// ('replace' for compact, 'append'/'none' for generate) and decide whether
-// to drain the event stream into a single compaction envelope.
+// flip it; post-chain we read `invocation.action` to decide whether to drain
+// the event stream into a single compaction envelope (compact branch) or to
+// hand it back as a streaming `ExecuteResult` (generate branch).
+//
+// Snapshot persistence is owned end-to-end by `wrapResponsesOutputForStorage`,
+// which derives the snapshot mode by observing the output stream — `'replace'`
+// when any output item is a compaction (the three convergence cases:
+// native `/v1/responses/compact`, a `compaction_trigger` input on
+// `/v1/responses` reshaped by the upstream, and the server-side
+// `context_management` `compact_threshold` mode), `'append'` otherwise.
+// "Don't write" is expressed by the store itself: cross-protocol translation
+// stores (`createNonResponsesSourceStore`) and `store=false` HTTP turns ship
+// with an empty `snapshotWrites` configuration, so `commitSnapshot` is a
+// no-op at the store-write layer.
 export const responsesAttempt = {
   invoke: async (args: ResponsesAttemptInvokeArgs): Promise<ResponsesAttemptResult> => {
-    const { payload, action, ctx, store, candidate, headers, snapshotMode: snapshotModeOverride } = args;
+    const { payload, action, ctx, store, candidate, headers } = args;
     // Read the caller's intent `action` (NOT `invocation.action`) — the guard
     // runs pre-chain, before any interceptor can flip the value.
     if (action === 'compact' && candidate.targetApi !== 'responses') {
       throw new Error(`responsesAttempt.invoke(action='compact') requires targetApi='responses', got '${candidate.targetApi}'`);
-    }
-    // Compact always replaces history wholesale; an override would be a
-    // contract violation. Only `serve.compact` reaches this branch today
-    // and it never passes one, but pin the invariant so a future caller
-    // that does pass one fails loudly instead of silently overwriting.
-    if (action === 'compact' && snapshotModeOverride !== undefined) {
-      throw new Error('responsesAttempt.invoke: snapshotMode override is not supported in the compact branch — compact always replaces');
     }
     // Rewrite + privatePayload seed + assistant-content normalization all run
     // BEFORE the interceptor chain so source interceptors — most importantly
@@ -92,22 +86,17 @@ export const responsesAttempt = {
 
     if (chainResult.type !== 'events') return chainResult;
 
-    // Snapshot mode reads the post-chain action on the invocation: an
-    // interceptor that pivots 'compact'→'generate' (or vice versa) steers
-    // storage end-to-end. A generate request carrying a `compaction_trigger`
-    // input item produces a compaction-shape envelope at the upstream and
-    // must also snapshot=replace.
     const responseId = createStoredResponseId();
     if (invocation.action === 'compact') {
       // Drain the events into a single envelope and return the value branch
       // so the http compact endpoint can JSON-encode it directly. Storage
       // still runs over the synthesized event stream so the snapshot is
-      // committed under the same id the client will see.
+      // committed under the same id the client will see — wrap detects the
+      // `compaction` output item and writes a `'replace'` snapshot.
       const upstreamCompacted = await collectResponsesProtocolEventsToResult(chainResult.events);
       await drainAsync(wrapResponsesOutputForStorage(syntheticEventsFromResult(upstreamCompacted), {
         store,
         upstream: candidate.binding.upstream,
-        snapshotMode: 'replace',
         targetApi: 'responses',
         responseId,
       }));
@@ -119,16 +108,6 @@ export const responsesAttempt = {
       };
     }
 
-    // The base mode comes from the caller's override (WS pins 'append',
-    // cross-protocol translation pins 'none') or, when absent (native HTTP),
-    // is derived from `payload.store`. A `compaction_trigger` in the input
-    // then upgrades the base to 'replace' — except when the base is 'none',
-    // which the translation-in path uses to opt out of inner persistence.
-    const baseSnapshotMode: ResponsesSnapshotMode = snapshotModeOverride
-      ?? (normalized.store === false ? 'none' : 'append');
-    const snapshotMode: ResponsesSnapshotMode = baseSnapshotMode !== 'none' && containsCompactionTrigger(normalized.input)
-      ? 'replace'
-      : baseSnapshotMode;
     // Persistence and id rewriting wrap the *outermost* stream — after every
     // interceptor (including the server-tool shim) has emitted its final
     // events. This is the only seam at which the gateway-owned response id
@@ -141,7 +120,6 @@ export const responsesAttempt = {
       wrapResponsesOutputForStorage(chainResult.events, {
         store,
         upstream: candidate.binding.upstream,
-        snapshotMode,
         targetApi: candidate.targetApi,
         responseId,
       }),
@@ -168,18 +146,6 @@ export const responsesAttempt = {
     return result;
   },
 };
-
-// Codex's RemoteCompactionV2 performs compaction through the generate path
-// by appending a `compaction_trigger` control item to the input. Semantically
-// this is the same operation as `/responses/compact`: the upstream replaces
-// the prior history with a single `compaction` output, and any later
-// `previous_response_id` should resolve to that blob alone — not the dropped
-// history. Treat such a request like compact at the snapshot seam even when
-// the action stays 'generate' (the codex provider's compact branch goes
-// through action='compact', but a direct generate carrying the trigger
-// reaches the same upstream behavior).
-const containsCompactionTrigger = (input: ResponsesPayload['input']): boolean =>
-  typeof input !== 'string' && input.some(item => item.type === 'compaction_trigger');
 
 type RewriteOutcome =
   | RewrittenResponsesPayload

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -134,13 +134,13 @@ test('generate native success wraps the upstream event stream once', async () =>
   const candidate = makeCandidate(callResponses);
   const ctx = makeGatewayCtx();
   const store = createResponsesHttpStore(API_KEY_ID, true);
+  const commitSpy = vi.spyOn(store, 'commitSnapshot').mockResolvedValue();
 
   const result = await responsesAttempt.generate({
     payload: makePayload(),
     ctx,
     store,
     candidate,
-    snapshotMode: 'append',
     headers: new Headers(),
   });
 
@@ -154,29 +154,38 @@ test('generate native success wraps the upstream event stream once', async () =>
   assertEquals(callResponses.mock.calls.length, 1);
   assertEquals(wrapSpy.mock.calls.length, 1);
   const wrapArgs = wrapSpy.mock.calls[0][1];
-  assertEquals(wrapArgs.snapshotMode, 'append');
   assertEquals(wrapArgs.upstream, 'up_test');
   assertEquals(wrapArgs.targetApi, 'responses');
+  // The upstream emitted no compaction-shape item, so wrap derived 'append'.
+  assertEquals(commitSpy.mock.calls.length, 1);
+  assertEquals(commitSpy.mock.calls[0][1], 'append');
 
   wrapSpy.mockRestore();
 });
 
-test('generate upgrades snapshotMode to replace when input carries compaction_trigger, even under a WS-pinned append override', async () => {
-  // WS pins `snapshotMode: 'append'` so in-session snapshots survive when
-  // the caller opted out of durable storage. A turn whose input carries a
-  // `compaction_trigger` item is semantically a compaction — the upstream
-  // replaces history with a single summary — and the snapshot must follow
-  // suit. The pre-fix derivation used `override ?? trigger ? 'replace' :
-  // ...`, so the WS override short-circuited and the trigger-upgrade
-  // never ran; this test pins the post-fix behavior where the upgrade
-  // wins on shape grounds whenever the base mode is not 'none'.
+test('generate derives snapshotMode=replace when the upstream emits a compaction output item', async () => {
+  // A direct `/v1/responses` generate carrying a `compaction_trigger` input
+  // (Codex's RemoteCompactionV2) — or a `context_management` `compact_threshold`
+  // turn that triggers server-side compaction — yields a compaction-shape
+  // output envelope on the wire. Wrap observes that output and derives a
+  // 'replace' snapshot regardless of how the request was framed.
   installRepo();
   const wrapSpy = vi.spyOn(outputModule, 'wrapResponsesOutputForStorage');
 
+  const compactionItem = {
+    type: 'compaction',
+    id: 'cmp_trigger',
+    encrypted_content: 'ENC',
+  };
+  const compactionResponse: ResponsesResult = {
+    ...makeResponsesResult(),
+    object: 'response.compaction',
+    output: [compactionItem] as unknown as ResponsesResult['output'],
+  };
   const completedEvent: ResponsesStreamEvent = {
     type: 'response.completed',
     sequence_number: 0,
-    response: makeResponsesResult(),
+    response: compactionResponse,
   };
   const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
     action: 'generate', ok: true,
@@ -187,6 +196,7 @@ test('generate upgrades snapshotMode to replace when input carries compaction_tr
 
   const candidate = makeCandidate(callResponses);
   const store = createResponsesHttpStore(API_KEY_ID, true);
+  const commitSpy = vi.spyOn(store, 'commitSnapshot').mockResolvedValue();
 
   const result = await responsesAttempt.generate({
     payload: makePayload({
@@ -198,7 +208,6 @@ test('generate upgrades snapshotMode to replace when input carries compaction_tr
     ctx: makeGatewayCtx(),
     store,
     candidate,
-    snapshotMode: 'append',
     headers: new Headers(),
   });
 
@@ -207,7 +216,8 @@ test('generate upgrades snapshotMode to replace when input carries compaction_tr
   await collectEvents(result.events);
 
   assertEquals(wrapSpy.mock.calls.length, 1);
-  assertEquals(wrapSpy.mock.calls[0][1].snapshotMode, 'replace');
+  assertEquals(commitSpy.mock.calls.length, 1);
+  assertEquals(commitSpy.mock.calls[0][1], 'replace');
 
   wrapSpy.mockRestore();
 });
@@ -246,7 +256,6 @@ test('generate returns failure when rewrite throws item-not-found', async () => 
     ctx: makeGatewayCtx(),
     store,
     candidate,
-    snapshotMode: 'append',
     headers: new Headers(),
   });
 
@@ -276,7 +285,6 @@ test('generate passes non-events provider result through unchanged', async () =>
     ctx: makeGatewayCtx(),
     store: createResponsesHttpStore(API_KEY_ID, true),
     candidate,
-    snapshotMode: 'append',
     headers: new Headers(),
   });
 
@@ -288,7 +296,7 @@ test('generate passes non-events provider result through unchanged', async () =>
   wrapSpy.mockRestore();
 });
 
-test('compact reshapes the trigger turn into a result and forwards snapshotMode=replace', async () => {
+test('compact reshapes the trigger turn into a result and derives snapshotMode=replace from the synthesized envelope', async () => {
   installRepo();
   const wrapSpy = vi.spyOn(outputModule, 'wrapResponsesOutputForStorage');
 
@@ -296,7 +304,8 @@ test('compact reshapes the trigger turn into a result and forwards snapshotMode=
   // the `action: 'compact'` branch of `provider.callResponses` does the
   // Copilot compaction_trigger reshape internally — so the attempt receives
   // a ResponsesResult, expands it into synthetic frames, and wraps the
-  // output for storage.
+  // output for storage. The synthesized envelope carries a `compaction`
+  // output item; wrap observes it and derives the 'replace' snapshot.
   const compactionItem = {
     type: 'compaction' as const,
     id: 'cmp_1',
@@ -316,6 +325,8 @@ test('compact reshapes the trigger turn into a result and forwards snapshotMode=
   });
 
   const candidate = makeCandidate(callResponses);
+  const store = createResponsesHttpStore(API_KEY_ID, true);
+  const commitSpy = vi.spyOn(store, 'commitSnapshot').mockResolvedValue();
   const result = await responsesAttempt.invoke({
     payload: makePayload({
       input: [
@@ -324,7 +335,7 @@ test('compact reshapes the trigger turn into a result and forwards snapshotMode=
     }),
     action: 'compact',
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
+    store,
     candidate,
     headers: new Headers(),
   });
@@ -339,10 +350,11 @@ test('compact reshapes the trigger turn into a result and forwards snapshotMode=
   assert(isStoredResponseId(result.result.id));
 
   // wrap-output-storage runs exactly once on the synthesized compaction
-  // events, with snapshotMode='replace'.
+  // events; the compaction item in the output drives commitSnapshot('replace').
   assertEquals(wrapSpy.mock.calls.length, 1);
-  assertEquals(wrapSpy.mock.calls[0][1].snapshotMode, 'replace');
   assertEquals(wrapSpy.mock.calls[0][1].targetApi, 'responses');
+  assertEquals(commitSpy.mock.calls.length, 1);
+  assertEquals(commitSpy.mock.calls[0][1], 'replace');
 
   wrapSpy.mockRestore();
 });
@@ -396,7 +408,6 @@ test('generate inherits invocation headers across translation to Messages', asyn
     ctx: makeGatewayCtx(),
     store: createResponsesHttpStore(API_KEY_ID, true),
     candidate,
-    snapshotMode: 'append',
     headers: new Headers({ 'x-test': 'abc' }),
   });
   assertEquals(result.type, 'events');
@@ -507,7 +518,6 @@ test('generate seeds privatePayload before interceptors so the web-search shim r
     ctx: makeGatewayCtx(),
     store,
     candidate,
-    snapshotMode: 'append',
     headers: new Headers(),
   });
   assertEquals(result.type, 'events');
@@ -556,7 +566,6 @@ test('generate propagates upstream response headers onto the EventResult so resp
     ctx: makeGatewayCtx(),
     store,
     candidate,
-    snapshotMode: 'append',
     headers: new Headers(),
   });
 

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -202,7 +202,6 @@ test('generate derives snapshotMode=replace when the upstream emits a compaction
     payload: makePayload({
       input: [
         { type: 'message', role: 'user', content: 'kept message' },
-        { type: 'compaction_trigger' },
       ],
     }),
     ctx: makeGatewayCtx(),

--- a/packages/gateway/src/data-plane/chat/responses/items/format.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/format.ts
@@ -22,6 +22,11 @@ const itemTypePrefixes = {
   tool_search_call: 'ts',
   tool_search_output: 'tso',
   compaction: 'cmp',
+  // `compaction_summary` is the Codex-side wire alias for `compaction` (the
+  // protocol declares them as one variant via `#[serde(alias = ...)]`); both
+  // mint the same `cmp_` prefix so a row written under either spelling
+  // round-trips through `isStoredResponsesItemId`.
+  compaction_summary: 'cmp',
   image_generation_call: 'ig',
   code_interpreter_call: 'ci',
   local_shell_call: 'lsh',

--- a/packages/gateway/src/data-plane/chat/responses/items/format_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/format_test.ts
@@ -22,6 +22,7 @@ const explicitPrefixes = [
   ['tool_search_call', 'ts'],
   ['tool_search_output', 'tso'],
   ['compaction', 'cmp'],
+  ['compaction_summary', 'cmp'],
   ['image_generation_call', 'ig'],
   ['code_interpreter_call', 'ci'],
   ['local_shell_call', 'lsh'],

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -1,5 +1,5 @@
 import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
-import type { StatefulResponsesStore, ResponsesSnapshotMode } from './store.ts';
+import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { responsesResultToEvents, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -24,17 +24,27 @@ import type { ChatTargetApi } from '@floway-dev/provider';
 // (Copilot's encrypted blob, OpenAI's `resp_*`, the server-tool runtime's
 // internal `resp_shim_*` placeholder) is discarded at this seam — we never
 // persist or surface an upstream-owned response id.
+//
+// Snapshot mode is decided by observing the output stream: when any output
+// item carries `type === 'compaction'` (or its wire alias
+// `compaction_summary` — Codex's protocol pins them as the same variant via
+// `#[serde(alias = "compaction_summary")]`), the turn's output is a
+// self-contained compaction envelope and the snapshot mode is `'replace'`;
+// otherwise `'append'`. This captures every shape that produces a
+// compaction-shape envelope — the native `/v1/responses/compact` endpoint,
+// a `compaction_trigger` input on `/v1/responses` (Codex's RemoteCompactionV2),
+// and the server-side `context_management` `compact_threshold` mode — without
+// each path needing its own gateway-side detector.
 export const wrapResponsesOutputForStorage = async function* (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   args: {
     readonly store: StatefulResponsesStore;
     readonly upstream: string;
-    readonly snapshotMode: ResponsesSnapshotMode;
     readonly targetApi: ChatTargetApi;
     readonly responseId: string;
   },
 ): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
-  const { store, upstream, snapshotMode, targetApi, responseId } = args;
+  const { store, upstream, targetApi, responseId } = args;
   const upstreamToStored = new Map<string, string>();
 
   const idMapper = (upstreamId: string, itemType: string): string => {
@@ -89,6 +99,7 @@ export const wrapResponsesOutputForStorage = async function* (
   // type, so we look the type up before re-invoking idMapper.
   const seenItemTypes = new Map<string, string>();
   const finalized = new Set<string>();
+  let sawCompactionItem = false;
 
   for await (const frame of frames) {
     if (frame.type !== 'event') {
@@ -121,6 +132,7 @@ export const wrapResponsesOutputForStorage = async function* (
       if (upstreamId === null) { yield frame; continue; }
       seenItemTypes.set(upstreamId, event.item.type);
       const newId = idMapper(upstreamId, event.item.type);
+      if (isCompactionItemType(event.item.type)) sawCompactionItem = true;
       if (!finalized.has(upstreamId)) {
         finalized.add(upstreamId);
         await onItemFinalized(event.item as unknown as ResponsesInputItem, newId);
@@ -132,6 +144,7 @@ export const wrapResponsesOutputForStorage = async function* (
     if (event.type === 'response.completed' || event.type === 'response.incomplete') {
       const output: ResponsesInputItem[] = [];
       for (const item of event.response.output) {
+        if (isCompactionItemType(item.type)) sawCompactionItem = true;
         const upstreamId = itemId(item);
         if (upstreamId === null) { output.push(item as unknown as ResponsesInputItem); continue; }
         seenItemTypes.set(upstreamId, item.type);
@@ -151,12 +164,10 @@ export const wrapResponsesOutputForStorage = async function* (
       // generator another tick, so any post-yield work would be lost.
       // The downstream HTTP entry has nothing to observe pre-snapshot —
       // ordering matches a synchronous emit.
-      if (snapshotMode !== 'none') {
-        try {
-          await store.commitSnapshot(responseId, snapshotMode);
-        } catch (error) {
-          console.error('Failed to persist stored Responses snapshot:', error);
-        }
+      try {
+        await store.commitSnapshot(responseId, sawCompactionItem ? 'replace' : 'append');
+      } catch (error) {
+        console.error('Failed to persist stored Responses snapshot:', error);
       }
       yield rewritten;
       return;
@@ -187,6 +198,14 @@ const itemId = (item: { id?: unknown }): string | null => {
   const id = item.id;
   return typeof id === 'string' && id.length > 0 ? id : null;
 };
+
+// `compaction` and `compaction_summary` are the same wire variant — Codex's
+// protocol declares the latter as a serde alias for the former (see
+// https://github.com/openai/codex/blob/main/codex-rs/protocol/src/models.rs).
+// An output stream carrying either is a self-contained compaction envelope
+// and replaces the conversation history.
+const isCompactionItemType = (type: string): boolean =>
+  type === 'compaction' || type === 'compaction_summary';
 
 // Expands a non-streaming compact result into the same frame sequence a live
 // upstream would emit: every output item as bare added/done pairs (no inner

--- a/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
@@ -455,9 +455,10 @@ test('derives snapshotMode=replace from a streamed compaction_summary alias item
 test('derives snapshotMode=replace when the compaction item only appears in the terminal envelope', async () => {
   // The non-streaming compact path runs through `syntheticEventsFromResult`,
   // which emits the compaction item via generic `output_item.added`/`done`
-  // pairs — but the upstream-rejecting compact branch and any future shape
-  // that surfaces the item only in `response.completed.output[]` must still
-  // trigger `'replace'`. This covers the terminal-envelope-only case.
+  // pairs. A fully non-streaming upstream that surfaces the item only in
+  // `response.completed.output[]` — without any preceding `output_item.done`
+  // — must still trigger `'replace'`. This covers that terminal-envelope-only
+  // case.
   const repo = new InMemoryRepo();
   initRepo(repo);
   const compactionItem = {

--- a/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
@@ -2,7 +2,7 @@ import { test, vi } from 'vitest';
 
 import { isStoredResponsesItemId } from './format.ts';
 import { drainAsync, syntheticEventsFromResult, wrapResponsesOutputForStorage } from './output.ts';
-import { createResponsesHttpStore, LayeredStatefulResponsesStore, RepoStatefulResponsesBacking, type StatefulResponsesBacking } from './store.ts';
+import { createResponsesHttpStore, LayeredStatefulResponsesStore, RepoStatefulResponsesBacking, type StatefulResponsesBacking, type StatefulResponsesStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { ResponsesItemsRepo, StoredResponsesItem } from '../../../../repo/types.ts';
@@ -53,14 +53,13 @@ const TEST_RESPONSE_ID = 'resp_test123';
 const wrap = (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   overrides: Parameters<typeof makeStore>[0] = {},
-  extra: { snapshotMode?: 'none' | 'append' | 'replace'; targetApi?: 'responses' | 'messages' | 'chat-completions'; responseId?: string } = {},
+  extra: { targetApi?: 'responses' | 'messages' | 'chat-completions'; responseId?: string } = {},
 ) => {
   const store = makeStore(overrides);
   return {
     events: wrapResponsesOutputForStorage(frames, {
       store,
       upstream: 'up_native',
-      snapshotMode: extra.snapshotMode ?? 'none',
       targetApi: extra.targetApi ?? 'responses',
       responseId: extra.responseId ?? TEST_RESPONSE_ID,
     }),
@@ -70,12 +69,11 @@ const wrap = (
 
 const wrapWithStore = (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
-  store: ReturnType<typeof createResponsesHttpStore>,
-  extra: { snapshotMode?: 'none' | 'append' | 'replace'; targetApi?: 'responses' | 'messages' | 'chat-completions'; upstream?: string; responseId?: string } = {},
+  store: StatefulResponsesStore,
+  extra: { targetApi?: 'responses' | 'messages' | 'chat-completions'; upstream?: string; responseId?: string } = {},
 ) => wrapResponsesOutputForStorage(frames, {
   store,
   upstream: extra.upstream ?? 'up_native',
-  snapshotMode: extra.snapshotMode ?? 'none',
   targetApi: extra.targetApi ?? 'responses',
   responseId: extra.responseId ?? TEST_RESPONSE_ID,
 });
@@ -205,7 +203,18 @@ test('insert failure does not sink the stream', async () => {
   const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   try {
     const original = messageItem('raw_msg_native', 'hello');
-    const store = createResponsesHttpStore(apiKeyId, undefined);
+    // The controlled repo holds insertMany pending until told to resolve.
+    // To keep this test focused on item-insert failure handling, configure
+    // the store without snapshotWrites so the terminal frame does not
+    // re-trigger the controlled insertMany via the snapshot commit path.
+    const repoBacking = new RepoStatefulResponsesBacking(() => repo);
+    const store = new LayeredStatefulResponsesStore({
+      apiKeyId,
+      reads: [repoBacking],
+      itemWrites: [{ backing: repoBacking, durable: true }],
+      snapshotWrites: [],
+      stageInputs: false,
+    });
     const iterator = wrapWithStore(framesFrom([
       { type: 'response.output_item.added', output_index: 0, item: { ...original, content: [] } },
       { type: 'response.output_item.done', output_index: 0, item: original },
@@ -365,56 +374,151 @@ test('private payload registered on the request is attached to the persisted row
   assertEquals(row.payload?.private, privateBlob);
 });
 
-// --- snapshotMode tests ---
+// --- snapshot-mode derivation tests ---
+//
+// Wrap derives the snapshot mode by observing the output stream: a
+// `compaction` or its `compaction_summary` wire alias surfaces `'replace'`,
+// any other shape surfaces `'append'`. The mode is asserted directly on
+// `store.commitSnapshot` rather than via repo state because the store
+// configuration ('append' vs 'replace') flows into the snapshot's itemIds
+// shape — itemIds is a downstream consequence we don't need to re-test here.
 
-test('snapshotMode=none: no snapshot written after terminal event', async () => {
+const spyCommitSnapshot = (store: ReturnType<typeof createResponsesHttpStore>) =>
+  vi.spyOn(store, 'commitSnapshot').mockResolvedValue();
+
+test('derives snapshotMode=append when no compaction item appears in output', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);
-  const original = messageItem('raw_msg_snap_none', 'hi');
+  const original = messageItem('raw_msg_append', 'hi');
+  const store = createResponsesHttpStore(apiKeyId, undefined);
+  const commitSpy = spyCommitSnapshot(store);
+
+  const events = wrapWithStore(framesFrom([
+    { type: 'response.output_item.done', output_index: 0, item: original },
+    { type: 'response.completed', response: { ...response([original]), id: 'resp_upstream_ignored' } },
+  ]), store, { responseId: 'resp_append' });
+
+  await collectEvents(events);
+  assertEquals(commitSpy.mock.calls.length, 1);
+  assertEquals(commitSpy.mock.calls[0][0], 'resp_append');
+  assertEquals(commitSpy.mock.calls[0][1], 'append');
+});
+
+test('derives snapshotMode=replace from a streamed compaction output item', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  // `compaction` is an input-shaped item type the protocol's `ResponsesOutputItem`
+  // union does not declare; cast through the assertion so the event payload
+  // mirrors what a real upstream emits on the wire.
+  const compactionItem = {
+    type: 'compaction',
+    id: 'cmp_streamed',
+    encrypted_content: 'ENC',
+  } as unknown as ResponsesOutputItem;
+  const store = createResponsesHttpStore(apiKeyId, undefined);
+  const commitSpy = spyCommitSnapshot(store);
+
+  const events = wrapWithStore(framesFrom([
+    { type: 'response.output_item.done', output_index: 0, item: compactionItem },
+    { type: 'response.completed', response: { ...response([compactionItem]), object: 'response.compaction' } },
+  ]), store, { responseId: 'resp_replace_streamed' });
+
+  await collectEvents(events);
+  assertEquals(commitSpy.mock.calls.length, 1);
+  assertEquals(commitSpy.mock.calls[0][1], 'replace');
+});
+
+test('derives snapshotMode=replace from a streamed compaction_summary alias item', async () => {
+  // Codex's protocol pins `compaction_summary` as a serde alias for
+  // `compaction` (https://github.com/openai/codex/blob/main/codex-rs/protocol/src/models.rs);
+  // wrap treats either literal as a compaction-shape envelope.
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const summaryItem = {
+    type: 'compaction_summary',
+    id: 'cmp_summary',
+    encrypted_content: 'ENC',
+  } as unknown as ResponsesOutputItem;
+  const store = createResponsesHttpStore(apiKeyId, undefined);
+  const commitSpy = spyCommitSnapshot(store);
+
+  const events = wrapWithStore(framesFrom([
+    { type: 'response.output_item.done', output_index: 0, item: summaryItem },
+    { type: 'response.completed', response: { ...response([summaryItem]), object: 'response.compaction' } },
+  ]), store, { responseId: 'resp_replace_summary' });
+
+  await collectEvents(events);
+  assertEquals(commitSpy.mock.calls.length, 1);
+  assertEquals(commitSpy.mock.calls[0][1], 'replace');
+});
+
+test('derives snapshotMode=replace when the compaction item only appears in the terminal envelope', async () => {
+  // The non-streaming compact path runs through `syntheticEventsFromResult`,
+  // which emits the compaction item via generic `output_item.added`/`done`
+  // pairs — but the upstream-rejecting compact branch and any future shape
+  // that surfaces the item only in `response.completed.output[]` must still
+  // trigger `'replace'`. This covers the terminal-envelope-only case.
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const compactionItem = {
+    type: 'compaction',
+    id: 'cmp_terminal_only',
+    encrypted_content: 'ENC',
+  } as unknown as ResponsesOutputItem;
+  const store = createResponsesHttpStore(apiKeyId, undefined);
+  const commitSpy = spyCommitSnapshot(store);
+
+  const events = wrapWithStore(framesFrom([
+    { type: 'response.completed', response: { ...response([compactionItem]), object: 'response.compaction' } },
+  ]), store, { responseId: 'resp_replace_terminal' });
+
+  await collectEvents(events);
+  assertEquals(commitSpy.mock.calls.length, 1);
+  assertEquals(commitSpy.mock.calls[0][1], 'replace');
+});
+
+test('snapshot is committed under the gateway-minted id', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const original = messageItem('raw_msg_snap', 'hi');
   const store = createResponsesHttpStore(apiKeyId, undefined);
 
   const events = wrapWithStore(framesFrom([
     { type: 'response.output_item.done', output_index: 0, item: original },
-    { type: 'response.completed', response: { ...response([original]), id: 'resp_snap_none' } },
-  ]), store, { snapshotMode: 'none' });
+    { type: 'response.completed', response: { ...response([original]), id: 'resp_upstream_ignored' } },
+  ]), store, { responseId: 'resp_snap_id' });
 
   await collectEvents(events);
-  const snapshot = await repo.responsesSnapshots.lookup(apiKeyId, 'resp_snap_none');
+  const snapshot = await repo.responsesSnapshots.lookup(apiKeyId, 'resp_snap_id');
+  assert(snapshot !== null, 'expected snapshot to be written under Floway-minted id');
+  assertEquals(snapshot.id, 'resp_snap_id');
+});
+
+test('no snapshot is written when the store has no snapshotWrites configured', async () => {
+  // Cross-protocol stores (`createNonResponsesSourceStore`) ship with an
+  // empty `snapshotWrites` configuration; commitSnapshot is then a no-op
+  // at the store-write layer, so the wrap layer's unconditional call has
+  // no externally observable effect.
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const repoBacking = new RepoStatefulResponsesBacking(() => repo);
+  const noSnapshotStore = new LayeredStatefulResponsesStore({
+    apiKeyId,
+    reads: [repoBacking],
+    itemWrites: [{ backing: repoBacking, durable: true }],
+    snapshotWrites: [],
+    stageInputs: false,
+  });
+  const original = messageItem('raw_msg_no_snap', 'hi');
+
+  const events = wrapWithStore(framesFrom([
+    { type: 'response.output_item.done', output_index: 0, item: original },
+    { type: 'response.completed', response: { ...response([original]), id: 'resp_upstream_ignored' } },
+  ]), noSnapshotStore, { responseId: 'resp_no_snap' });
+
+  await collectEvents(events);
+  const snapshot = await repo.responsesSnapshots.lookup(apiKeyId, 'resp_no_snap');
   assertEquals(snapshot, null);
-});
-
-test('snapshotMode=append: snapshot written after terminal event', async () => {
-  const repo = new InMemoryRepo();
-  initRepo(repo);
-  const original = messageItem('raw_msg_snap_append', 'hi');
-  const store = createResponsesHttpStore(apiKeyId, undefined);
-
-  const events = wrapWithStore(framesFrom([
-    { type: 'response.output_item.done', output_index: 0, item: original },
-    { type: 'response.completed', response: { ...response([original]), id: 'resp_upstream_ignored' } },
-  ]), store, { snapshotMode: 'append', responseId: 'resp_snap_append' });
-
-  await collectEvents(events);
-  const snapshot = await repo.responsesSnapshots.lookup(apiKeyId, 'resp_snap_append');
-  assert(snapshot !== null, 'expected snapshot to be written under Floway-minted id');
-  assertEquals(snapshot.id, 'resp_snap_append');
-});
-
-test('snapshotMode=replace: snapshot written after terminal event', async () => {
-  const repo = new InMemoryRepo();
-  initRepo(repo);
-  const original = messageItem('raw_msg_snap_replace', 'hi');
-  const store = createResponsesHttpStore(apiKeyId, undefined);
-
-  const events = wrapWithStore(framesFrom([
-    { type: 'response.output_item.done', output_index: 0, item: original },
-    { type: 'response.completed', response: { ...response([original]), id: 'resp_upstream_ignored' } },
-  ]), store, { snapshotMode: 'replace', responseId: 'resp_snap_replace' });
-
-  await collectEvents(events);
-  const snapshot = await repo.responsesSnapshots.lookup(apiKeyId, 'resp_snap_replace');
-  assert(snapshot !== null, 'expected snapshot to be written under Floway-minted id');
-  assertEquals(snapshot.id, 'resp_snap_replace');
 });
 
 test('snapshot commit error does not sink the stream', async () => {
@@ -445,7 +549,7 @@ test('snapshot commit error does not sink the stream', async () => {
     const events = wrapWithStore(framesFrom([
       { type: 'response.output_item.done', output_index: 0, item: original },
       { type: 'response.completed', response: { ...response([original]), id: 'resp_snap_fail' } },
-    ]), faultyStore, { snapshotMode: 'append' });
+    ]), faultyStore);
 
     const collected = await collectEvents(events);
     // Stream should complete despite snapshot failure

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -51,15 +51,21 @@ export interface LayeredStatefulResponsesStoreOptions {
 }
 
 // How a Responses turn should commit its snapshot:
-//   - 'none'    : do not write a snapshot at all
 //   - 'append'  : conversation continuation — previous snapshot + this turn's
-//                 input + this turn's output. Default for /responses generate.
+//                 input + this turn's output. Default for a normal generate.
 //   - 'replace' : the turn's output IS the new conversation — drop prior
-//                 history and the stitched-in input. Used by /responses/compact
-//                 so that referencing the compact response via
-//                 previous_response_id replays only the retained messages +
-//                 the encrypted compaction blob, not the original full history.
-export type ResponsesSnapshotMode = 'none' | 'append' | 'replace';
+//                 history and the stitched-in input. Used when the output is
+//                 a self-contained compaction envelope so referencing this
+//                 response via `previous_response_id` replays only the
+//                 retained messages + the encrypted compaction blob, not the
+//                 original full history.
+//
+// The mode is derived inside `wrapResponsesOutputForStorage` by observing the
+// output stream; callers no longer pass it. Skipping the snapshot entirely is
+// expressed at the store layer via an empty `snapshotWrites` configuration
+// (see `createNonResponsesSourceStore` and the `store=false` branch of
+// `createResponsesHttpStore`).
+export type ResponsesSnapshotMode = 'append' | 'replace';
 
 export interface StatefulResponsesStore {
   readonly apiKeyId: string | null;
@@ -85,7 +91,7 @@ export interface StatefulResponsesStore {
   getPrivatePayload(id: string): unknown;
   stageOutputItem(row: StoredResponsesItem): void;
   commitOutputItems(): Promise<void>;
-  commitSnapshot(responseId: string, mode: 'append' | 'replace'): Promise<void>;
+  commitSnapshot(responseId: string, mode: ResponsesSnapshotMode): Promise<void>;
   refreshTouchedItems(): Promise<void>;
 }
 
@@ -224,7 +230,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     await this.commitItems([...this.stagedOutputItems.values()]);
   }
 
-  async commitSnapshot(responseId: string, mode: 'append' | 'replace'): Promise<void> {
+  async commitSnapshot(responseId: string, mode: ResponsesSnapshotMode): Promise<void> {
     if (this.options.snapshotWrites.length === 0 || this.committedSnapshotIds.has(responseId)) return;
     await this.commitItems([...this.stagedInputItems.values(), ...this.stagedOutputItems.values()]);
     const itemIds = mode === 'replace'
@@ -270,11 +276,11 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
   private async stageInputItem(item: ResponsesInputItem): Promise<void> {
     // `compaction_trigger` is a per-request control signal, not content:
     // payload-free, idless, never persisted in codex's own rollout/history,
-    // and never re-sent on subsequent turns. A trigger-bearing generate is
-    // treated as a compaction (serve forces snapshotMode='replace') so the
-    // next snapshot is the resulting `compaction` blob alone; this row
-    // would have no reader. Skipping it also keeps `createStoredResponsesItemId`
-    // from minting a prefix for a type that never needs one.
+    // and never re-sent on subsequent turns. The output of such a turn is a
+    // self-contained `compaction` envelope which wrap detects and commits as
+    // snapshot mode 'replace', so this row would have no reader. Skipping it
+    // also keeps `createStoredResponsesItemId` from minting a prefix for a
+    // type that never needs one.
     if (item.type === 'compaction_trigger') return;
 
     if (item.type === 'item_reference') {

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -61,7 +61,7 @@ export interface LayeredStatefulResponsesStoreOptions {
 //                 original full history.
 //
 // The mode is derived inside `wrapResponsesOutputForStorage` by observing the
-// output stream; callers no longer pass it. Skipping the snapshot entirely is
+// output stream, so callers do not pass it. Skipping the snapshot entirely is
 // expressed at the store layer via an empty `snapshotWrites` configuration
 // (see `createNonResponsesSourceStore` and the `store=false` branch of
 // `createResponsesHttpStore`).

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,6 +1,6 @@
 import { responsesAttempt } from './attempt.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
-import type { ResponsesSnapshotMode, StatefulResponsesStore } from './items/store.ts';
+import type { StatefulResponsesStore } from './items/store.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
@@ -12,12 +12,6 @@ export interface ResponsesServeGenerateArgs {
   readonly ctx: GatewayCtx;
   readonly store: StatefulResponsesStore;
   readonly headers: Headers;
-  // WS overrides this to 'append' regardless of payload.store; the
-  // session-cache layer (StatefulResponsesStore) already filters durable
-  // writes — the WS path wants in-session snapshots even when the caller
-  // opted out of durable storage. HTTP omits the override so the attempt's
-  // post-chain derivation runs.
-  readonly snapshotMode?: ResponsesSnapshotMode;
 }
 
 export interface ResponsesServeCompactArgs {
@@ -29,7 +23,7 @@ export interface ResponsesServeCompactArgs {
 
 export const responsesServe = {
   generate: async (args: ResponsesServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
-    const { payload, ctx, store, headers, snapshotMode } = args;
+    const { payload, ctx, store, headers } = args;
     const plan = await prepareResponsesServePlan({
       payload, ctx, store,
       pickTarget: endpoints =>
@@ -39,7 +33,7 @@ export const responsesServe = {
               : null,
     });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.generate({ payload: plan.prepared, ctx, store, candidate: plan.candidate, headers, ...(snapshotMode !== undefined ? { snapshotMode } : {}) });
+    return await responsesAttempt.generate({ payload: plan.prepared, ctx, store, candidate: plan.candidate, headers });
   },
 
   compact: async (args: ResponsesServeCompactArgs): Promise<ResponsesAttemptResult> => {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -176,7 +176,7 @@ const handleClientMessage = async (
 
     let result;
     try {
-      result = await responsesServe.generate({ payload, ctx, store, snapshotMode: 'append', headers: inboundHeadersForUpstream(c) });
+      result = await responsesServe.generate({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
     } catch (error) {
       if (signal.aborted || isClosed()) return;
       // The HTTP entry renders this verbatim envelope as a 400; WS surfaces the


### PR DESCRIPTION
## Summary

`wrapResponsesOutputForStorage` derives the snapshot mode by observing the output stream — `'replace'` when any output item carries `type === 'compaction'` (or the `compaction_summary` wire alias the Codex protocol exposes via `#[serde(alias = "compaction_summary")]`), `'append'` otherwise. The mode is no longer carried as an argument from any caller; the override field on `ResponsesAttemptInvokeArgs` and `ResponsesServeGenerateArgs` is dropped, and `'none'` is removed from the `ResponsesSnapshotMode` union.

## Why output-side detection

Three independent code paths converge on a compaction-shape envelope on the wire:

- the native `/v1/responses/compact` endpoint,
- a `compaction_trigger` input on `/v1/responses` (Codex CLI's RemoteCompactionV2 pattern),
- the server-side `context_management.compact_threshold` mode on `/v1/responses` ([compaction guide](https://developers.openai.com/api/docs/guides/compaction)).

Each previously needed its own gateway-side detector at a different seam: the compact branch of `responsesAttempt` pinned `'replace'` explicitly, generate scanned input for `compaction_trigger`, and the third path (server-side compaction with no trigger in input) was simply unhandled. Detecting at the output seam captures all three uniformly and pre-emptively covers any future shape that surfaces a compaction item without a request-side marker.

## "Don't write a snapshot" moves to the store

The intent that callers used to express via `snapshotMode: 'none'` (cross-protocol translation inner Responses calls, HTTP `store=false`) is now expressed at the store layer: the store object ships with an empty `snapshotWrites` configuration so `commitSnapshot` is a no-op at the write layer. `createNonResponsesSourceStore` and the `store=false` branch of `createResponsesHttpStore` both already do this, so no plumbing changes are needed beyond removing the argument.

## Call-site cleanup

The WebSocket entry, the three cross-protocol attempt files (messages / gemini / chat-completions), the serve layer, and the test stubs each lose one argument. The WS path's in-session continuity is preserved by `createResponsesWsSession.createStore`, which wires `localWrite` into `snapshotWrites` unconditionally.

`format.ts` gains `compaction_summary: 'cmp'` alongside `compaction: 'cmp'` so a row written under either spelling round-trips through `isStoredResponsesItemId` — same wire variant, same id prefix.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` — 3502 tests pass
- [x] `output_test.ts` covers each of the three compaction-shaped output paths (streamed `compaction`, streamed `compaction_summary` alias, terminal-envelope-only compaction) plus the no-compaction `'append'` baseline; `attempt_test.ts` pins the output-driven derivation by dropping a stray input-side `compaction_trigger` from the fixture
