### PR TITLE
fix(compact-shim): register synthesized cmp_* id as synthetic to prevent routing lock

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -118,7 +118,7 @@ const extractTextFromResult = (result: ResponsesResult): string => {
   return parts.join('');
 };
 
-const buildCompactionEnvelope = (summaryText: string, upstream: ResponsesResult): ResponsesResult => {
+const buildCompactionEnvelope = (cmpId: string, summaryText: string, upstream: ResponsesResult): ResponsesResult => {
   const summaryItem: ResponsesInputItem = {
     type: 'message',
     role: 'user',
@@ -146,7 +146,7 @@ const buildCompactionEnvelope = (summaryText: string, upstream: ResponsesResult)
     output: [
       {
         type: 'compaction',
-        id: `cmp_${crypto.randomUUID()}`,
+        id: cmpId,
         encrypted_content: encryptedContent,
       },
     ] as unknown as ResponsesResult['output'],
@@ -216,7 +216,16 @@ const simulateCompaction = async (ctx: ResponsesInvocation, run: ChainRun): Prom
 
   const collected = await collectResponsesProtocolEventsToResult(upstreamResult.events);
   const summaryText = extractTextFromResult(collected);
-  const synthesized = buildCompactionEnvelope(summaryText, collected);
+  // The minted compaction id is gateway-internal — the upstream never issued
+  // it. Register it as synthetic so `wrapResponsesOutputForStorage` stores
+  // the row with `upstreamId: null`, which keeps `classifyStoredResponsesAffinity`
+  // from treating a future echo of this compaction as a forcing reference that
+  // pins routing to whichever upstream happened to run the summarization turn.
+  // (For non-responses targets the targetApi check already suppresses
+  // ownership; this also covers the responses-target + flag-on engagement.)
+  const cmpId = `cmp_${crypto.randomUUID()}`;
+  ctx.store.addSyntheticItem(cmpId);
+  const synthesized = buildCompactionEnvelope(cmpId, summaryText, collected);
 
   return {
     ...upstreamResult,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -187,6 +187,25 @@ test('compact + flag on: synthesized encrypted_content decodes to a user message
   assertEquals(decoded[0].content[0].text, 'THE SUMMARY');
 });
 
+test('compact + flag on: synthesized compaction id is registered as synthetic so storage drops upstream affinity', async () => {
+  // The minted `cmp_<uuid>` is gateway-internal — no upstream issued it.
+  // wrapResponsesOutputForStorage keys upstreamOwned on
+  // `targetApi === 'responses' && !store.isSyntheticItem(upstreamId)`; without
+  // the synthetic registration, a flag-on engagement against a responses
+  // target would store the row with the originating upstreamId set, and
+  // classifyStoredResponsesAffinity would lock routing to that upstream
+  // on any later turn that echoes the compaction.
+  const inv = makeInvocation(
+    { input: [{ type: 'message', role: 'user', content: 'history' }] },
+    { action: 'compact' },
+  );
+  const result = await withResponsesCompactShim(inv, stubCtx, fakeUpstreamRun('summary'));
+  if (result.type !== 'events') throw new Error('expected events branch');
+  const collected = await collectResponsesProtocolEventsToResult(result.events);
+  const compactionItem = collected.output[0] as { type: string; id: string };
+  assertEquals(inv.store.isSyntheticItem(compactionItem.id), true);
+});
+
 test('compact + flag on: upstream `output_text` SDK alias is dropped from the synthesized envelope', async () => {
   const inv = makeInvocation(
     { input: [{ type: 'message', role: 'user', content: 'history' }] },


### PR DESCRIPTION
## Summary

`responses-compact-shim`'s synthesized `cmp_*` ids were getting stored with an upstream identity, which makes `classifyStoredResponsesAffinity` treat the row as `'forcing'` on any later turn that echoes the compaction. Routing then locks to whichever upstream happened to run the summarization turn — even though the shim can decode the `encrypted_content` (gateway-internal base64url-JSON) and expand it inline against any upstream the data plane could route to.

Register the minted `cmp_<uuid>` via `store.addSyntheticItem(cmpId)` before the synthesized envelope reaches `wrapResponsesOutputForStorage`. The wrap layer keys `upstreamOwned` on `targetApi === 'responses' && !store.isSyntheticItem(upstreamId)`; the synthetic flag flips that to `false`, the row stores with `upstreamId: null`, and the affinity classifier resolves it as `'non_affinity'` — no false lock, no spurious "Stored Responses items in this request require upstream X" failures across upstream pool changes.

## Engagement coverage

The shim engages on the OR of (per-upstream `responses-compact-shim` flag is on) and (`candidate.targetApi !== 'responses'`).

- **Non-responses target** (the structurally-required engagement on `claude-code`/`ollama`): wrap's `targetApi === 'responses'` precondition already suppressed upstream ownership, so this path was incidentally correct. The synthetic registration is a harmless second layer.
- **Responses target + flag on** (operator manually enables the shim for `azure`/`copilot`/`custom`/`codex`): wrap fell straight through to upstream-owned storage, and a future echo would pin routing. This path is what the fix actually rescues.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm vitest run packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim` — 19/19 pass, including a new test that asserts `store.isSyntheticItem(<minted cmp id>)` is true after the shim engages
- [x] `pnpm run lint`
- [x] `pnpm run test` — full suite clean (3551 tests)
