### PR TITLE
refactor(server-tool-shim): canonicalize hosted-tool boundary

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -97,21 +97,13 @@ export type ServerToolDispatcher = (args: {
   loopState: ServerToolLoopState;
 }) => ServerToolResultSlot[];
 
-// The members of a hosted interception move together: to run the ReAct
-// loop we must recognize and canonicalize the hosted tool, replace it
-// with a callable function tool the upstream model can invoke, and
-// execute the model's calls. Grouping them makes a partial declaration
-// a compile error instead of a registration that silently never
-// dispatches.
-//
-// `canonicalize` is the sole boundary between raw client input and the
-// rest of the shim: it both detects (returns `undefined` when the raw
-// tool isn't this registration's) and fills upstream-spec defaults so
-// every downstream caller (`buildFunctionTool`, dispatcher input, echo
-// restore output) only ever sees canonical form. `hostedTypes` is the
-// static list of raw `type` discriminants this registration claims;
-// used only for the `tool_choice: {type}` rewrite path where no full
-// tool object is available to canonicalize.
+// Grouped together so a partial declaration is a compile error rather
+// than a registration that silently never dispatches. `canonicalize` is
+// the sole raw→canonical boundary: every downstream caller
+// (`buildFunctionTool`, dispatcher input, echo restore) only ever sees
+// canonical form. `hostedTypes` exists only for the
+// `tool_choice: { type }` rewrite path, where no full tool object is
+// available to canonicalize.
 export interface ServerToolHostedDispatch {
   hostedTypes: readonly string[];
   canonicalize: (raw: ResponsesTool) => ResponsesHostedTool | undefined;
@@ -144,10 +136,8 @@ export type ServerToolRegistration = (invocation: ResponsesInvocation, gatewayCt
 type ActiveServerTool = Extract<ServerToolPrepareResult, { type: 'active' }> & {
   toolName: string;
   hasHostedTool: boolean;
-  // The canonical form of this registration's hosted tool, captured at
-  // request rewrite. Present iff `hasHostedTool` is true; used to
-  // restore upstream's echoed function tool (and `tool_choice`) back to
-  // the hosted form on the synthesized envelope.
+  // Present iff `hasHostedTool` is true; drives echo restore on the
+  // synthesized envelope's `tools` and `tool_choice`.
   canonicalHostedTool: ResponsesHostedTool | undefined;
 };
 
@@ -245,8 +235,8 @@ const rewriteHostedToolChoice = (
 ): ResponsesToolChoice | undefined => {
   if (toolChoice === undefined || typeof toolChoice === 'string') return toolChoice;
   for (const entry of active) {
-    if (!entry.hasHostedTool) continue;
-    if (entry.hosted?.hostedTypes.includes(toolChoice.type) === true) return { type: 'function', name: entry.toolName };
+    if (!entry.hasHostedTool || entry.hosted === undefined) continue;
+    if (entry.hosted.hostedTypes.includes(toolChoice.type)) return { type: 'function', name: entry.toolName };
   }
   return toolChoice;
 };
@@ -270,17 +260,15 @@ const restoreEchoedToolChoice = (
   return toolChoice;
 };
 
-// Inverse of the request-side hosted→function rewrite. Each tool in the
-// upstream-echoed array is checked against active shims: function tools
-// whose name matches an injected one are replaced with that shim's
-// canonical hosted entry, restoring the client-visible shape. Every
-// other tool passes through verbatim, preserving upstream-side default
-// enrichment on the client's ordinary function tools.
+// Inverse of the request-side hosted→function rewrite, applied to the
+// upstream-echoed tools array. Non-injected entries pass through
+// verbatim so upstream-side default enrichment on ordinary client
+// function tools survives.
 const restoreEchoedTools = (
-  tools: readonly ResponsesTool[] | null | undefined,
+  tools: readonly ResponsesTool[] | undefined,
   active: readonly ActiveServerTool[],
 ): ResponsesTool[] | undefined => {
-  if (!Array.isArray(tools)) return undefined;
+  if (tools === undefined) return undefined;
   return tools.map(tool => {
     if (tool.type !== 'function') return tool;
     for (const entry of active) {
@@ -303,13 +291,10 @@ export const resolveServerToolName = (baseName: string, tools: readonly Response
   throw new Error(`Unable to resolve a free server tool function name for ${baseName} within ${MAX_NAME_RESOLUTION_ATTEMPTS} attempts`);
 };
 
-// Canonicalize every raw tool through the registration; the first
-// canonicalized hit is kept (silently deduping subsequent same-type
-// hosted entries, matching upstream Copilot's observed behavior — two
-// `{type:'web_search'}` entries collapse to one expanded echo) and
-// replaced in-place by the function tool the upstream model will
-// invoke. Non-claimed tools pass through unchanged. The returned
-// canonical entry feeds the echo-restore step and the dispatcher's
+// First canonicalized hit wins; subsequent same-type hosted entries
+// are silently deduped, matching upstream Copilot's observed behavior
+// (two `{type:'web_search'}` entries collapse into one expanded echo).
+// The returned canonical entry feeds echo-restore and the dispatcher's
 // hosted-tool view.
 const rewriteToolsForHostedShim = (
   tools: readonly ResponsesTool[],
@@ -981,10 +966,11 @@ export const withResponsesServerToolShim = (
     if (prepared.type === 'invalid-request') return invalidRequestEnvelope(prepared.message, prepared.param, prepared.code);
     const currentTools = Array.isArray(ctx.payload.tools) ? ctx.payload.tools : [];
     const toolName = resolveServerToolName(prepared.baseToolName, currentTools);
-    const hasHostedTool = prepared.hosted !== undefined && currentTools.some(t => prepared.hosted!.canonicalize(t) !== undefined);
+    const { hosted } = prepared;
+    const hasHostedTool = hosted !== undefined && currentTools.some(t => hosted.canonicalize(t) !== undefined);
     let canonicalHostedTool: ResponsesHostedTool | undefined = undefined;
-    if (hasHostedTool && prepared.hosted !== undefined) {
-      const rewrite = rewriteToolsForHostedShim(currentTools, prepared.hosted, toolName);
+    if (hasHostedTool && hosted !== undefined) {
+      const rewrite = rewriteToolsForHostedShim(currentTools, hosted, toolName);
       canonicalHostedTool = rewrite.canonicalHostedTool;
       ctx.payload = { ...ctx.payload, tools: rewrite.rewritten };
     }

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -7,7 +7,7 @@ import type { StatefulResponsesStore } from '../items/store.ts';
 import type { InterceptorRun } from '@floway-dev/interceptor';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
-  ResponsesHostedToolType,
+  ResponsesHostedTool,
   ResponsesInputItem,
   ResponsesOutputItem,
   ResponsesPayload,
@@ -114,8 +114,8 @@ export type ServerToolDispatcher = (args: {
 // tool object is available to canonicalize.
 export interface ServerToolHostedDispatch {
   hostedTypes: readonly string[];
-  canonicalize: (raw: ResponsesTool) => ResponsesTool | undefined;
-  buildFunctionTool: (canonical: ResponsesTool, toolName: string) => ResponsesTool;
+  canonicalize: (raw: ResponsesTool) => ResponsesHostedTool | undefined;
+  buildFunctionTool: (canonical: ResponsesHostedTool, toolName: string) => ResponsesTool;
   dispatcher: ServerToolDispatcher;
 }
 
@@ -148,7 +148,7 @@ type ActiveServerTool = Extract<ServerToolPrepareResult, { type: 'active' }> & {
   // request rewrite. Present iff `hasHostedTool` is true; used to
   // restore upstream's echoed function tool (and `tool_choice`) back to
   // the hosted form on the synthesized envelope.
-  canonicalHostedTool: ResponsesTool | undefined;
+  canonicalHostedTool: ResponsesHostedTool | undefined;
 };
 
 // How a single upstream turn ended, as observed while consuming its
@@ -243,11 +243,10 @@ const rewriteHostedToolChoice = (
   toolChoice: ResponsesToolChoice | undefined,
   active: readonly ActiveServerTool[],
 ): ResponsesToolChoice | undefined => {
-  const choiceType = typeof toolChoice === 'object' && toolChoice !== null && typeof toolChoice.type === 'string' ? toolChoice.type : undefined;
-  if (choiceType === undefined) return toolChoice;
+  if (toolChoice === undefined || typeof toolChoice === 'string') return toolChoice;
   for (const entry of active) {
     if (!entry.hasHostedTool) continue;
-    if (entry.hosted?.hostedTypes.includes(choiceType) === true) return { type: 'function', name: entry.toolName };
+    if (entry.hosted?.hostedTypes.includes(toolChoice.type) === true) return { type: 'function', name: entry.toolName };
   }
   return toolChoice;
 };
@@ -262,11 +261,11 @@ const restoreEchoedToolChoice = (
   toolChoice: ResponsesToolChoice | undefined,
   active: readonly ActiveServerTool[],
 ): ResponsesToolChoice | undefined => {
-  if (typeof toolChoice !== 'object' || toolChoice === null || toolChoice?.type !== 'function') return toolChoice;
+  if (toolChoice === undefined || typeof toolChoice === 'string' || toolChoice.type !== 'function') return toolChoice;
   for (const entry of active) {
     if (entry.canonicalHostedTool === undefined) continue;
     if (toolChoice.name !== entry.toolName) continue;
-    return { type: entry.canonicalHostedTool.type as ResponsesHostedToolType };
+    return { type: entry.canonicalHostedTool.type };
   }
   return toolChoice;
 };
@@ -316,9 +315,9 @@ const rewriteToolsForHostedShim = (
   tools: readonly ResponsesTool[],
   hosted: ServerToolHostedDispatch,
   toolName: string,
-): { rewritten: ResponsesTool[]; canonicalHostedTool: ResponsesTool | undefined } => {
+): { rewritten: ResponsesTool[]; canonicalHostedTool: ResponsesHostedTool | undefined } => {
   const rewritten: ResponsesTool[] = [];
-  let canonicalHostedTool: ResponsesTool | undefined = undefined;
+  let canonicalHostedTool: ResponsesHostedTool | undefined = undefined;
   for (const raw of tools) {
     const canonical = hosted.canonicalize(raw);
     if (canonical !== undefined) {
@@ -983,7 +982,7 @@ export const withResponsesServerToolShim = (
     const currentTools = Array.isArray(ctx.payload.tools) ? ctx.payload.tools : [];
     const toolName = resolveServerToolName(prepared.baseToolName, currentTools);
     const hasHostedTool = prepared.hosted !== undefined && currentTools.some(t => prepared.hosted!.canonicalize(t) !== undefined);
-    let canonicalHostedTool: ResponsesTool | undefined = undefined;
+    let canonicalHostedTool: ResponsesHostedTool | undefined = undefined;
     if (hasHostedTool && prepared.hosted !== undefined) {
       const rewrite = rewriteToolsForHostedShim(currentTools, prepared.hosted, toolName);
       canonicalHostedTool = rewrite.canonicalHostedTool;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -7,6 +7,7 @@ import type { StatefulResponsesStore } from '../items/store.ts';
 import type { InterceptorRun } from '@floway-dev/interceptor';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
+  ResponsesHostedToolType,
   ResponsesInputItem,
   ResponsesOutputItem,
   ResponsesPayload,
@@ -96,15 +97,25 @@ export type ServerToolDispatcher = (args: {
   loopState: ServerToolLoopState;
 }) => ServerToolResultSlot[];
 
-// The three members of a hosted interception move together: to run the
-// ReAct loop we must recognize the hosted tool (`isHostedTool`), replace
-// it with a callable function tool the upstream model can invoke
-// (`buildFunctionTool`), and execute the model's calls (`dispatcher`).
-// Grouping them makes a partial declaration a compile error instead of a
-// registration that silently never dispatches.
+// The members of a hosted interception move together: to run the ReAct
+// loop we must recognize and canonicalize the hosted tool, replace it
+// with a callable function tool the upstream model can invoke, and
+// execute the model's calls. Grouping them makes a partial declaration
+// a compile error instead of a registration that silently never
+// dispatches.
+//
+// `canonicalize` is the sole boundary between raw client input and the
+// rest of the shim: it both detects (returns `undefined` when the raw
+// tool isn't this registration's) and fills upstream-spec defaults so
+// every downstream caller (`buildFunctionTool`, dispatcher input, echo
+// restore output) only ever sees canonical form. `hostedTypes` is the
+// static list of raw `type` discriminants this registration claims;
+// used only for the `tool_choice: {type}` rewrite path where no full
+// tool object is available to canonicalize.
 export interface ServerToolHostedDispatch {
-  isHostedTool: (tool: ResponsesTool) => boolean;
-  buildFunctionTool: (toolName: string) => ResponsesTool;
+  hostedTypes: readonly string[];
+  canonicalize: (raw: ResponsesTool) => ResponsesTool | undefined;
+  buildFunctionTool: (canonical: ResponsesTool, toolName: string) => ResponsesTool;
   dispatcher: ServerToolDispatcher;
 }
 
@@ -133,6 +144,11 @@ export type ServerToolRegistration = (invocation: ResponsesInvocation, gatewayCt
 type ActiveServerTool = Extract<ServerToolPrepareResult, { type: 'active' }> & {
   toolName: string;
   hasHostedTool: boolean;
+  // The canonical form of this registration's hosted tool, captured at
+  // request rewrite. Present iff `hasHostedTool` is true; used to
+  // restore upstream's echoed function tool (and `tool_choice`) back to
+  // the hosted form on the synthesized envelope.
+  canonicalHostedTool: ResponsesTool | undefined;
 };
 
 // How a single upstream turn ended, as observed while consuming its
@@ -231,14 +247,50 @@ const rewriteHostedToolChoice = (
   if (choiceType === undefined) return toolChoice;
   for (const entry of active) {
     if (!entry.hasHostedTool) continue;
-    // A hosted `tool_choice` is `{ type }` on the wire, the same
-    // discriminant a hosted tool carries, so a type-only probe is a
-    // faithful (if sparse) tool object: hosted Responses tools are
-    // identified by `type`. `isHostedTool` must therefore classify on
-    // `type` alone.
-    if (entry.hosted?.isHostedTool({ type: choiceType } as ResponsesTool)) return { type: 'function', name: entry.toolName };
+    if (entry.hosted?.hostedTypes.includes(choiceType) === true) return { type: 'function', name: entry.toolName };
   }
   return toolChoice;
+};
+
+// Reverse of `rewriteHostedToolChoice` for the upstream-echoed
+// `tool_choice` on the synthesized envelope: a function-typed choice
+// whose name matches an active shim's `toolName` was originally a
+// hosted-type choice. Restore it by stripping the function shape down
+// to `{ type: <hosted-type> }` using the canonical hosted entry's
+// discriminant.
+const restoreEchoedToolChoice = (
+  toolChoice: ResponsesToolChoice | undefined,
+  active: readonly ActiveServerTool[],
+): ResponsesToolChoice | undefined => {
+  if (typeof toolChoice !== 'object' || toolChoice === null || toolChoice.type !== 'function') return toolChoice;
+  for (const entry of active) {
+    if (entry.canonicalHostedTool === undefined) continue;
+    if (toolChoice.name !== entry.toolName) continue;
+    return { type: entry.canonicalHostedTool.type as ResponsesHostedToolType };
+  }
+  return toolChoice;
+};
+
+// Inverse of the request-side hosted→function rewrite. Each tool in the
+// upstream-echoed array is checked against active shims: function tools
+// whose name matches an injected one are replaced with that shim's
+// canonical hosted entry, restoring the client-visible shape. Every
+// other tool passes through verbatim, preserving upstream-side default
+// enrichment on the client's ordinary function tools.
+const restoreEchoedTools = (
+  tools: readonly ResponsesTool[] | null | undefined,
+  active: readonly ActiveServerTool[],
+): ResponsesTool[] | undefined => {
+  if (!Array.isArray(tools)) return undefined;
+  return tools.map(tool => {
+    if (tool.type !== 'function') return tool;
+    for (const entry of active) {
+      if (entry.canonicalHostedTool !== undefined && tool.name === entry.toolName) {
+        return entry.canonicalHostedTool;
+      }
+    }
+    return tool;
+  });
 };
 
 export const resolveServerToolName = (baseName: string, tools: readonly ResponsesTool[]): string => {
@@ -252,24 +304,33 @@ export const resolveServerToolName = (baseName: string, tools: readonly Response
   throw new Error(`Unable to resolve a free server tool function name for ${baseName} within ${MAX_NAME_RESOLUTION_ATTEMPTS} attempts`);
 };
 
-const replaceHostedToolsWithFunctionTool = (
+// Canonicalize every raw tool through the registration; the first
+// canonicalized hit is kept (silently deduping subsequent same-type
+// hosted entries, matching upstream Copilot's observed behavior — two
+// `{type:'web_search'}` entries collapse to one expanded echo) and
+// replaced in-place by the function tool the upstream model will
+// invoke. Non-claimed tools pass through unchanged. The returned
+// canonical entry feeds the echo-restore step and the dispatcher's
+// hosted-tool view.
+const rewriteToolsForHostedShim = (
   tools: readonly ResponsesTool[],
-  isHostedTool: (tool: ResponsesTool) => boolean,
-  functionTool: ResponsesTool,
-): ResponsesTool[] => {
+  hosted: ServerToolHostedDispatch,
+  toolName: string,
+): { rewritten: ResponsesTool[]; canonicalHostedTool: ResponsesTool | undefined } => {
   const rewritten: ResponsesTool[] = [];
-  let injected = false;
-  for (const tool of tools) {
-    if (isHostedTool(tool)) {
-      if (!injected) {
-        rewritten.push(functionTool);
-        injected = true;
+  let canonicalHostedTool: ResponsesTool | undefined = undefined;
+  for (const raw of tools) {
+    const canonical = hosted.canonicalize(raw);
+    if (canonical !== undefined) {
+      if (canonicalHostedTool === undefined) {
+        canonicalHostedTool = canonical;
+        rewritten.push(hosted.buildFunctionTool(canonical, toolName));
       }
       continue;
     }
-    rewritten.push(tool);
+    rewritten.push(raw);
   }
-  return rewritten;
+  return { rewritten, canonicalHostedTool };
 };
 
 export const parseServerToolArguments = (argumentsJson: string): Record<string, unknown> | null => {
@@ -286,12 +347,20 @@ export const parseServerToolArguments = (argumentsJson: string): Record<string, 
   return parsed as Record<string, unknown>;
 };
 
-const syntheticInProgressResponse = (state: MergeState, id: string, model: string): ResponsesResult => {
+const syntheticInProgressResponse = (
+  state: MergeState,
+  id: string,
+  model: string,
+  active: readonly ActiveServerTool[],
+): ResponsesResult => {
   if (state.upstreamResponseSnapshot === undefined) {
     throw new Error('Server-tool shim cannot synthesize a Responses in-progress envelope before upstream `response.created` is captured.');
   }
+  const snapshot = state.upstreamResponseSnapshot;
+  const restoredTools = restoreEchoedTools(snapshot.tools, active);
+  const restoredToolChoice = restoreEchoedToolChoice(snapshot.tool_choice, active);
   return {
-    ...state.upstreamResponseSnapshot,
+    ...snapshot,
     id,
     object: 'response',
     model,
@@ -299,6 +368,8 @@ const syntheticInProgressResponse = (state: MergeState, id: string, model: strin
     status: 'in_progress',
     error: null,
     incomplete_details: null,
+    ...(restoredTools !== undefined ? { tools: restoredTools } : {}),
+    ...(restoredToolChoice !== undefined ? { tool_choice: restoredToolChoice } : {}),
   };
 };
 
@@ -409,6 +480,7 @@ export const consumeTurnStreaming = async function* (
   isFirstTurn: boolean,
   dispatchers: ReadonlyMap<string, ServerToolDispatcher>,
   loopState: ServerToolLoopState,
+  active: readonly ActiveServerTool[],
 ): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>, TurnSummary> {
   const dispatched: Array<{ intercepted: InterceptedFunctionCall; slots: DispatchedServerToolSlot[] }> = [];
   let sawClientToolCall = false;
@@ -451,7 +523,7 @@ export const consumeTurnStreaming = async function* (
       if (isFirstTurn) {
         yield stamp({
           type: 'response.created',
-          response: syntheticInProgressResponse(merge, merge.synthesizedResponseId, ensureModel()),
+          response: syntheticInProgressResponse(merge, merge.synthesizedResponseId, ensureModel(), active),
         });
       }
       continue;
@@ -461,7 +533,7 @@ export const consumeTurnStreaming = async function* (
       if (isFirstTurn) {
         yield stamp({
           type: 'response.in_progress',
-          response: syntheticInProgressResponse(merge, merge.synthesizedResponseId, ensureModel()),
+          response: syntheticInProgressResponse(merge, merge.synthesizedResponseId, ensureModel(), active),
         });
       }
       continue;
@@ -733,6 +805,7 @@ const SYNTHESIZED_TERMINAL_FRAME: Record<SynthesizedTerminal['kind'], { type: 'r
 const synthesizeTerminalEnvelope = (
   state: MergeState,
   kind: SynthesizedTerminal,
+  active: readonly ActiveServerTool[],
 ): ProtocolFrame<ResponsesStreamEvent> => {
   if (state.lastSeenModel === null) {
     throw new Error('Server-tool shim cannot synthesize a Responses terminal envelope before upstream `response.created` reports a model.');
@@ -750,17 +823,22 @@ const synthesizeTerminalEnvelope = (
       if (block.type === 'output_text') outputText += block.text;
     }
   }
+  const snapshot = state.upstreamResponseSnapshot;
+  const restoredTools = restoreEchoedTools(snapshot.tools, active);
+  const restoredToolChoice = restoreEchoedToolChoice(snapshot.tool_choice, active);
   return eventFrame({
     type: frame.type,
     sequence_number: state.sequenceNumber++,
     response: {
-      ...state.upstreamResponseSnapshot,
+      ...snapshot,
       id: state.synthesizedResponseId,
       object: 'response',
       model: state.lastSeenModel,
       status: frame.status,
       output,
       output_text: outputText,
+      ...(restoredTools !== undefined ? { tools: restoredTools } : {}),
+      ...(restoredToolChoice !== undefined ? { tool_choice: restoredToolChoice } : {}),
       ...(usage !== undefined ? { usage } : {}),
       ...(kind.kind === 'failed' ? { error: kind.error } : {}),
       ...(kind.kind === 'incomplete' ? { incomplete_details: kind.incompleteDetails } : {}),
@@ -819,29 +897,29 @@ async function* runMultiTurnLoop(args: {
 
       if (turn.terminalStatus.kind === 'failed') {
         if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesStore);
-        yield synthesizeTerminalEnvelope(merge, { kind: 'failed', error: turn.terminalStatus.response.error });
+        yield synthesizeTerminalEnvelope(merge, { kind: 'failed', error: turn.terminalStatus.response.error }, active);
         return;
       }
       if (turn.terminalStatus.kind === 'incomplete') {
         if (executedShim) yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesStore);
-        yield synthesizeTerminalEnvelope(merge, { kind: 'incomplete', incompleteDetails: turn.terminalStatus.response.incomplete_details });
+        yield synthesizeTerminalEnvelope(merge, { kind: 'incomplete', incompleteDetails: turn.terminalStatus.response.incomplete_details }, active);
         return;
       }
       if (turn.terminalStatus.kind === 'bare-error-pre-shell') {
         yield synthesizeTerminalEnvelope(merge, {
           kind: 'failed',
           error: { code: turn.terminalStatus.error.code, message: turn.terminalStatus.error.message },
-        });
+        }, active);
         return;
       }
       if (!executedShim && !turn.sawClientToolCall) {
-        yield synthesizeTerminalEnvelope(merge, { kind: 'completed' });
+        yield synthesizeTerminalEnvelope(merge, { kind: 'completed' }, active);
         return;
       }
 
       yield* materializeServerToolItems(turn.dispatched, merge, statefulResponsesStore);
       if (turn.sawClientToolCall) {
-        yield synthesizeTerminalEnvelope(merge, { kind: 'completed' });
+        yield synthesizeTerminalEnvelope(merge, { kind: 'completed' }, active);
         return;
       }
 
@@ -868,12 +946,12 @@ async function* runMultiTurnLoop(args: {
 
       const nextResult = await run();
       if (nextResult.type !== 'events') {
-        yield synthesizeTerminalEnvelope(merge, { kind: 'failed', error: buildErrorFromResult(nextResult) });
+        yield synthesizeTerminalEnvelope(merge, { kind: 'failed', error: buildErrorFromResult(nextResult) }, active);
         return;
       }
       metadata.modelIdentity = nextResult.modelIdentity;
       metadata.performance = nextResult.performance;
-      currentTurn = yield* consumeTurnStreaming(nextResult.events, merge, false, dispatchers, loopState);
+      currentTurn = yield* consumeTurnStreaming(nextResult.events, merge, false, dispatchers, loopState, active);
       merge.accumulatedUsage = sumUsage(merge.accumulatedUsage, currentTurn.turnUsage);
     }
   } catch (error) {
@@ -887,7 +965,7 @@ async function* runMultiTurnLoop(args: {
         code: 'server_error',
         message: `Upstream stream failed mid-response: ${error instanceof Error ? error.message : String(error)}`,
       },
-    });
+    }, active);
   } finally {
     if (midStreamError === undefined) resolveFinalMetadata(metadata);
   }
@@ -904,14 +982,14 @@ export const withResponsesServerToolShim = (
     if (prepared.type === 'invalid-request') return invalidRequestEnvelope(prepared.message, prepared.param, prepared.code);
     const currentTools = Array.isArray(ctx.payload.tools) ? ctx.payload.tools : [];
     const toolName = resolveServerToolName(prepared.baseToolName, currentTools);
-    const hasHostedTool = prepared.hosted !== undefined && currentTools.some(prepared.hosted.isHostedTool);
+    const hasHostedTool = prepared.hosted !== undefined && currentTools.some(t => prepared.hosted!.canonicalize(t) !== undefined);
+    let canonicalHostedTool: ResponsesTool | undefined = undefined;
     if (hasHostedTool && prepared.hosted !== undefined) {
-      ctx.payload = {
-        ...ctx.payload,
-        tools: replaceHostedToolsWithFunctionTool(currentTools, prepared.hosted.isHostedTool, prepared.hosted.buildFunctionTool(toolName)),
-      };
+      const rewrite = rewriteToolsForHostedShim(currentTools, prepared.hosted, toolName);
+      canonicalHostedTool = rewrite.canonicalHostedTool;
+      ctx.payload = { ...ctx.payload, tools: rewrite.rewritten };
     }
-    active.push({ ...prepared, toolName, hasHostedTool });
+    active.push({ ...prepared, toolName, hasHostedTool, canonicalHostedTool });
   }
 
   if (active.length === 0) return await run();
@@ -947,7 +1025,7 @@ export const withResponsesServerToolShim = (
   const merge = createMergeState();
   const firstResult = await run();
   if (firstResult.type !== 'events') return firstResult;
-  const turn1Iter = consumeTurnStreaming(firstResult.events, merge, true, dispatchers, loopState);
+  const turn1Iter = consumeTurnStreaming(firstResult.events, merge, true, dispatchers, loopState, active);
 
   let resolveFinalMetadata!: (m: EventResultMetadata) => void;
   const shimFinalMetadata = new Promise<EventResultMetadata>(resolve => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -262,7 +262,7 @@ const restoreEchoedToolChoice = (
   toolChoice: ResponsesToolChoice | undefined,
   active: readonly ActiveServerTool[],
 ): ResponsesToolChoice | undefined => {
-  if (typeof toolChoice !== 'object' || toolChoice === null || toolChoice.type !== 'function') return toolChoice;
+  if (typeof toolChoice !== 'object' || toolChoice === null || toolChoice?.type !== 'function') return toolChoice;
   for (const entry of active) {
     if (entry.canonicalHostedTool === undefined) continue;
     if (toolChoice.name !== entry.toolName) continue;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -991,11 +991,14 @@ export const withResponsesServerToolShim = (
     if (nextInput !== inputArray) ctx.payload = { ...ctx.payload, input: nextInput };
   }
 
-  const hostedActive = active.filter(entry => entry.hasHostedTool && entry.hosted !== undefined);
+  const hostedActive = active.filter(
+    (entry): entry is ActiveServerTool & { hosted: ServerToolHostedDispatch } =>
+      entry.hasHostedTool && entry.hosted !== undefined,
+  );
   if (hostedActive.length === 0) return await run();
 
   const dispatchers = new Map<string, ServerToolDispatcher>();
-  for (const entry of hostedActive) dispatchers.set(entry.toolName, entry.hosted!.dispatcher);
+  for (const entry of hostedActive) dispatchers.set(entry.toolName, entry.hosted.dispatcher);
   const loopState: ServerToolLoopState = {
     iterationCount: 1,
     remainingToolCalls: typeof ctx.payload.max_tool_calls === 'number' ? ctx.payload.max_tool_calls : undefined,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -5843,3 +5843,233 @@ test('ServerToolResultSlot run() yields nothing and returns the terminal', async
   assert(first.done === true);
   assertEquals(first.value.item.status, 'completed');
 });
+
+// ── Echo restore on `response.tools` / `response.tool_choice` ─────────────
+//
+// The shim rewrites the request's hosted `web_search` to a function tool
+// before upstream; on echo (per OpenAI spec, `Response` composes
+// `ResponseProperties`, so `tools` and `tool_choice` are echoed) the
+// synthesized envelope must restore the canonical hosted form so the
+// client never sees the gateway-internal function tool name.
+
+const mkResponseCreatedWithTools = (
+  tools: ResponsesTool[],
+  toolChoice?: ResponsesToolChoice,
+): ProtocolFrame<ResponsesStreamEvent> =>
+  eventFrame({
+    type: 'response.created',
+    response: {
+      ...emptyResult('upstream_test', 'in_progress'),
+      tools,
+      ...(toolChoice !== undefined ? { tool_choice: toolChoice } : {}),
+    },
+  });
+
+const mkResponseCompletedWithTools = (
+  tools: ResponsesTool[],
+  toolChoice?: ResponsesToolChoice,
+): ProtocolFrame<ResponsesStreamEvent> =>
+  eventFrame<ResponsesStreamEvent>({
+    type: 'response.completed',
+    response: {
+      ...emptyResult('upstream_test', 'completed'),
+      tools,
+      ...(toolChoice !== undefined ? { tool_choice: toolChoice } : {}),
+    },
+  });
+
+const findResponseCompleted = (
+  frames: ProtocolFrame<ResponsesStreamEvent>[],
+): Extract<ResponsesStreamEvent, { type: 'response.completed' }> => {
+  for (const f of frames) {
+    if (f.type === 'event' && f.event.type === 'response.completed') {
+      return f.event;
+    }
+  }
+  throw new Error('no response.completed in downstream frames');
+};
+
+test('echo restore swaps the injected function tool back to the canonical hosted web_search', async () => {
+  makeStubDeps();
+  // Upstream's echoed `tools` includes the function tool the shim
+  // injected plus an ordinary client function tool — restore should
+  // touch only the injected one. (Spec defaults like
+  // `additionalProperties:false` that Copilot injects on function
+  // tools must pass through verbatim on the non-shim tool.)
+  const upstreamEchoedTools: ResponsesTool[] = [
+    {
+      type: 'function',
+      name: SHIM_TOOL_NAME,
+      parameters: { type: 'object', properties: {}, additionalProperties: false },
+      strict: false,
+      description: 'gateway-internal',
+    },
+    {
+      type: 'function',
+      name: 'get_weather',
+      parameters: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'], additionalProperties: false },
+      strict: true,
+      description: null as unknown as string,
+    },
+  ];
+  const shim = withResponsesWebSearchShim;
+  const inv = makeInvocation({
+    payload: {
+      tools: [
+        { type: 'web_search' },
+        { type: 'function', name: 'get_weather', parameters: { type: 'object' }, strict: false },
+      ],
+    },
+  });
+  const script = scriptedRun([[
+    mkResponseCreatedWithTools(upstreamEchoedTools),
+    mkResponseInProgress(),
+    mkMessageAdded(0),
+    mkMessageDone(0, 'done'),
+    mkResponseCompletedWithTools(upstreamEchoedTools),
+  ]]);
+
+  const { frames } = await runShimAndDrain(shim, inv, makeGatewayCtx(), script.run);
+
+  const completed = findResponseCompleted(frames);
+  assert(Array.isArray(completed.response.tools));
+  assertEquals(completed.response.tools!.length, 2);
+  assertEquals(completed.response.tools![0].type, 'web_search');
+  assertEquals((completed.response.tools![0] as { search_context_size: string }).search_context_size, 'medium');
+  assertEquals((completed.response.tools![0] as { return_token_budget: string }).return_token_budget, 'default');
+  // Pass-through tool retains its upstream-enriched shape.
+  assertEquals(completed.response.tools![1].type, 'function');
+  assertEquals((completed.response.tools![1] as { name: string }).name, 'get_weather');
+});
+
+test('echo restore preserves client-supplied filters / user_location on the canonical hosted form', async () => {
+  makeStubDeps();
+  const userLoc = { city: 'Tokyo', country: 'JP' };
+  const filters = { allowed_domains: ['weather.gov'] };
+  const upstreamEchoedTools: ResponsesTool[] = [
+    { type: 'function', name: SHIM_TOOL_NAME, parameters: { type: 'object', properties: {}, additionalProperties: false }, strict: false },
+  ];
+  const inv = makeInvocation({ payload: { tools: [{ type: 'web_search', filters, user_location: userLoc }] } });
+  const script = scriptedRun([[
+    mkResponseCreatedWithTools(upstreamEchoedTools),
+    mkResponseInProgress(),
+    mkMessageAdded(0),
+    mkMessageDone(0, 'done'),
+    mkResponseCompletedWithTools(upstreamEchoedTools),
+  ]]);
+
+  const { frames } = await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
+
+  const completed = findResponseCompleted(frames);
+  assertEquals(completed.response.tools![0].type, 'web_search');
+  assertEquals((completed.response.tools![0] as { filters: typeof filters }).filters, filters);
+  assertEquals((completed.response.tools![0] as { user_location: typeof userLoc }).user_location, userLoc);
+});
+
+test('duplicate hosted web_search entries silently collapse into one echoed canonical', async () => {
+  makeStubDeps();
+  const inv = makeInvocation({
+    payload: {
+      tools: [
+        { type: 'web_search', search_context_size: 'high' },
+        { type: 'web_search' },
+      ],
+    },
+  });
+  // Upstream sees exactly one function tool because the framework
+  // dedupes before run().
+  const upstreamEchoedTools: ResponsesTool[] = [
+    { type: 'function', name: SHIM_TOOL_NAME, parameters: { type: 'object', properties: {}, additionalProperties: false }, strict: false },
+  ];
+  const script = scriptedRun([[
+    mkResponseCreatedWithTools(upstreamEchoedTools),
+    mkResponseInProgress(),
+    mkMessageAdded(0),
+    mkMessageDone(0, 'done'),
+    mkResponseCompletedWithTools(upstreamEchoedTools),
+  ]]);
+
+  const { frames } = await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
+
+  // Request side: only one function tool was sent upstream.
+  assertEquals(inv.payload.tools?.length, 1);
+  assertEquals(inv.payload.tools?.[0].type, 'function');
+  // Response side: one restored canonical entry, preserving the FIRST
+  // hosted block's `search_context_size`.
+  const completed = findResponseCompleted(frames);
+  assertEquals(completed.response.tools!.length, 1);
+  assertEquals(completed.response.tools![0].type, 'web_search');
+  assertEquals((completed.response.tools![0] as { search_context_size: string }).search_context_size, 'high');
+});
+
+test('echo restore swaps the function-typed tool_choice back to a hosted tool_choice', async () => {
+  makeStubDeps();
+  const upstreamEchoedTools: ResponsesTool[] = [
+    { type: 'function', name: SHIM_TOOL_NAME, parameters: { type: 'object', properties: {}, additionalProperties: false }, strict: false },
+  ];
+  const inv = makeInvocation({
+    payload: {
+      tools: [{ type: 'web_search' }],
+      tool_choice: { type: 'web_search' },
+    },
+  });
+  const script = scriptedRun([[
+    mkResponseCreatedWithTools(upstreamEchoedTools, { type: 'function', name: SHIM_TOOL_NAME }),
+    mkResponseInProgress(),
+    mkMessageAdded(0),
+    mkMessageDone(0, 'done'),
+    mkResponseCompletedWithTools(upstreamEchoedTools, { type: 'function', name: SHIM_TOOL_NAME }),
+  ]]);
+
+  const { frames } = await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
+
+  // Request side: tool_choice was rewritten to the function form.
+  assertEquals(inv.payload.tool_choice, { type: 'function', name: SHIM_TOOL_NAME });
+  const completed = findResponseCompleted(frames);
+  assertEquals(completed.response.tool_choice, { type: 'web_search' });
+});
+
+test('echo restore leaves a non-injected function-typed tool_choice untouched', async () => {
+  makeStubDeps();
+  // Upstream echoes a tool_choice naming a CLIENT-supplied function
+  // tool, not the shim's. Restore must not rewrite that.
+  const upstreamEchoedTools: ResponsesTool[] = [
+    { type: 'function', name: SHIM_TOOL_NAME, parameters: { type: 'object', properties: {}, additionalProperties: false }, strict: false },
+    { type: 'function', name: 'get_weather', parameters: { type: 'object', properties: {}, additionalProperties: false }, strict: false },
+  ];
+  const inv = makeInvocation({
+    payload: {
+      tools: [
+        { type: 'web_search' },
+        { type: 'function', name: 'get_weather', parameters: { type: 'object' }, strict: false },
+      ],
+      tool_choice: { type: 'function', name: 'get_weather' },
+    },
+  });
+  const script = scriptedRun([[
+    mkResponseCreatedWithTools(upstreamEchoedTools, { type: 'function', name: 'get_weather' }),
+    mkResponseInProgress(),
+    mkMessageAdded(0),
+    mkMessageDone(0, 'done'),
+    mkResponseCompletedWithTools(upstreamEchoedTools, { type: 'function', name: 'get_weather' }),
+  ]]);
+
+  const { frames } = await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
+
+  const completed = findResponseCompleted(frames);
+  assertEquals(completed.response.tool_choice, { type: 'function', name: 'get_weather' });
+});
+
+test('upstream that does not echo `tools` produces a synthesized envelope without `tools`', async () => {
+  makeStubDeps();
+  const inv = makeInvocation({ payload: { tools: [{ type: 'web_search' }] } });
+  // mkResponseCompleted() carries no `tools` field — simulating an
+  // upstream that simply omits the echo.
+  const script = scriptedRun([messageTurn('done')]);
+
+  const { frames } = await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
+
+  const completed = findResponseCompleted(frames);
+  assertEquals(completed.response.tools, undefined);
+  assertEquals(completed.response.tool_choice, undefined);
+});

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -4610,7 +4610,7 @@ const consumeTurn = async (
 ): Promise<DrainResult> => {
   const records: DispatchRecord[] = [];
   return await drain(
-    consumeTurnStreaming(frames, state, isFirstTurn, new Map([[SHIM_TOOL_NAME, recordingDispatcher(records)]]), loopState()),
+    consumeTurnStreaming(frames, state, isFirstTurn, new Map([[SHIM_TOOL_NAME, recordingDispatcher(records)]]), loopState(), []),
     records,
   );
 };
@@ -4673,6 +4673,7 @@ test('consumeTurn throws when upstream response.created has no model field (no c
     true,
     new Map([[SHIM_TOOL_NAME, recordingDispatcher([])]]),
     loopState(),
+    [],
   );
   let thrown: unknown;
   try {
@@ -4866,6 +4867,7 @@ test('consumeTurn synthesizes response.failed when upstream terminates without c
       true,
       new Map([[SHIM_TOOL_NAME, recordingDispatcher(records)]]),
       loopState(),
+      [],
     ),
     records,
   );
@@ -5540,6 +5542,7 @@ test('consumeTurnStreaming yields forwarded frames before upstream completes', a
     true,
     new Map([[SHIM_TOOL_NAME, recordingDispatcher(records)]]),
     loopState(),
+    [],
   );
 
   const first = await iter.next();
@@ -5585,6 +5588,7 @@ test('dispatcher start frames yield IN-LINE at function_call.done (shim call slo
       true,
       new Map([[SHIM_TOOL_NAME, dispatcher]]),
       loopState(),
+      [],
     ),
     records,
   );
@@ -5627,6 +5631,7 @@ test('shim call output_index is reserved at output_item.added so interleaved ite
       true,
       new Map([[SHIM_TOOL_NAME, dispatcher]]),
       loopState(),
+      [],
     ),
     records,
   );

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -39,6 +39,8 @@ import type {
   ResponsesPayload,
   ResponsesResult,
   ResponsesStreamEvent,
+  ResponsesTool,
+  ResponsesToolChoice,
   ResponsesWebSearchAction,
 } from '@floway-dev/protocols/responses';
 import { directFetcher, type EventResult, type ExecuteResult } from '@floway-dev/provider';

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -88,6 +88,15 @@ const KNOWN_TOOL_FIELDS = new Set([
 export const isHostedImageGenerationTool = (tool: ResponsesTool): tool is ResponsesHostedTool =>
   tool.type === 'image_generation';
 
+// Identity canonicalization for image_generation: the shim doesn't
+// depend on filled defaults to run, and the OpenAI spec defaults for
+// `background` / `quality` / `size` / etc. observed via Azure echo
+// (all `'auto'`) signal "backend decides" rather than concrete values
+// the model needs. Preserving the client's raw shape keeps the echo
+// round-trip minimal — anything the client didn't send stays absent.
+export const canonicalizeImageGenerationTool = (raw: ResponsesTool): ResponsesTool | undefined =>
+  isHostedImageGenerationTool(raw) ? raw : undefined;
+
 // A base64-data-URL or bare-base64 image source bound for an edit call.
 // Bytes are held in a concrete ArrayBuffer so they can be wrapped in a Blob.
 interface ImageSource {
@@ -302,7 +311,7 @@ export const prepareImageGenerationConfig = (tools: readonly ResponsesTool[]): P
 // on from the client config, exactly like Azure). A minimal description
 // elicits native-quality refined prompts while costing ~50 input tokens vs
 // the native hosted tool's ~2300.
-export const buildImageGenerationFunctionTool = (name: string): ResponsesFunctionTool => ({
+export const buildImageGenerationFunctionTool = (_canonical: ResponsesTool, name: string): ResponsesFunctionTool => ({
   type: 'function',
   name,
   description:
@@ -968,7 +977,8 @@ export const imageGenerationServerTool: ServerToolRegistration = (invocation, ga
     baseToolName: SHIM_TOOL_NAME,
     transformItems: transformInputItemsForImageGeneration,
     hosted: {
-      isHostedTool: isHostedImageGenerationTool,
+      hostedTypes: ['image_generation'],
+      canonicalize: canonicalizeImageGenerationTool,
       buildFunctionTool: buildImageGenerationFunctionTool,
       dispatcher: ({ intercepted }) => {
         const promptArg = intercepted.arguments !== null && typeof intercepted.arguments.prompt === 'string'

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -94,7 +94,7 @@ export const isHostedImageGenerationTool = (tool: ResponsesTool): tool is Respon
 // (all `'auto'`) signal "backend decides" rather than concrete values
 // the model needs. Preserving the client's raw shape keeps the echo
 // round-trip minimal — anything the client didn't send stays absent.
-export const canonicalizeImageGenerationTool = (raw: ResponsesTool): ResponsesTool | undefined =>
+export const canonicalizeImageGenerationTool = (raw: ResponsesTool): ResponsesHostedTool | undefined =>
   isHostedImageGenerationTool(raw) ? raw : undefined;
 
 // A base64-data-URL or bare-base64 image source bound for an edit call.
@@ -311,7 +311,7 @@ export const prepareImageGenerationConfig = (tools: readonly ResponsesTool[]): P
 // on from the client config, exactly like Azure). A minimal description
 // elicits native-quality refined prompts while costing ~50 input tokens vs
 // the native hosted tool's ~2300.
-export const buildImageGenerationFunctionTool = (_canonical: ResponsesTool, name: string): ResponsesFunctionTool => ({
+export const buildImageGenerationFunctionTool = (_canonical: ResponsesHostedTool, name: string): ResponsesFunctionTool => ({
   type: 'function',
   name,
   description:

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -209,7 +209,7 @@ test('prepareImageGenerationConfig decodes an inline mask once but rejects a fil
 // ── buildImageGenerationFunctionTool ──
 
 test('buildImageGenerationFunctionTool exposes only an optional prompt and is non-strict', () => {
-  const tool = buildImageGenerationFunctionTool(SHIM_TOOL_NAME);
+  const tool = buildImageGenerationFunctionTool({ type: 'image_generation' }, SHIM_TOOL_NAME);
   assertEquals(tool.type, 'function');
   assertEquals(tool.name, SHIM_TOOL_NAME);
   assertEquals(tool.strict, false);

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -65,9 +65,10 @@ const formatUserLocation = (loc: NonNullable<ShimToolFilters['userLocation']>): 
 // deliberately omits the unsupported ones.
 //   https://github.com/openai/harmony/blob/abd677f7ac962629c808197caa1feb9e3e95d2b0/src/chat.rs#L259-L313
 const buildShimFunctionTool = (
+  canonical: ResponsesTool,
   name: string,
-  userLocation?: ShimToolFilters['userLocation'],
 ): ResponsesFunctionTool => {
+  const userLocation = isHostedWebSearchTool(canonical) ? canonical.user_location : undefined;
   const baseDescription
     = 'Accesses the web through three actions: searching, opening a page, and finding text inside a page. '
     + 'Multiple sub-property arrays may be populated in one call to dispatch several operations in parallel.';
@@ -137,6 +138,33 @@ const buildShimFunctionTool = (
 
 export const isHostedWebSearchTool = (tool: ResponsesTool): tool is ResponsesHostedTool =>
   typeof tool.type === 'string' && WEB_SEARCH_HOSTED_TYPES.has(tool.type);
+
+// Canonical form of a hosted web_search tool: client's `type` alias is
+// preserved (so round-trip fidelity holds), and the documented defaults
+// for `search_context_size`, `search_content_types`, and
+// `return_token_budget` are filled. `filters` and `user_location` pass
+// through verbatim when present — never synthesized (the latter is
+// IP-derived on real upstreams and we have no IP context to fake).
+//
+// References:
+//   `search_context_size` default `'medium'` — openai-python
+//   `WebSearchTool.search_context_size` docstring:
+//     https://github.com/openai/openai-python/blob/main/src/openai/types/responses/web_search_tool.py
+//   `return_token_budget` default `'default'` and
+//   `search_content_types` default `['text']` — observed verbatim in
+//   Copilot's `/responses` echo for `tools: [{type: 'web_search'}]`.
+export const canonicalizeWebSearchTool = (raw: ResponsesTool): ResponsesTool | undefined => {
+  if (!isHostedWebSearchTool(raw)) return undefined;
+  const canonical: ResponsesHostedTool = {
+    type: raw.type,
+    search_context_size: raw.search_context_size ?? DEFAULT_SEARCH_CONTEXT_SIZE,
+    search_content_types: raw.search_content_types ?? ['text'],
+    return_token_budget: raw.return_token_budget ?? 'default',
+  };
+  if (raw.filters !== undefined) canonical.filters = raw.filters;
+  if (raw.user_location !== undefined) canonical.user_location = raw.user_location;
+  return canonical;
+};
 
 const extractFilters = (tool: ResponsesHostedTool): ShimToolFilters => {
   const out: ShimToolFilters = {};
@@ -236,25 +264,31 @@ const validateHostedEntry = (tool: ResponsesHostedTool): PrepareToolsError | nul
 };
 
 // Validate every hosted web_search entry and return the filters the
-// shim will act on. When a request carries multiple hosted blocks the
-// LAST one's filters win (most-recent declaration), so callers don't
-// have to define a tie-break. Name-collision resolution and the
-// hosted-tool → shim's function-tool replacement are the shim's
-// responsibility (`resolveServerToolName` /
-// `replaceHostedToolsWithFunctionTool`); this function only reads the
-// hosted entries.
+// shim will act on. The framework silently dedupes hosted entries to
+// the first one (mirroring upstream Copilot), so filter extraction
+// follows the same rule: first hosted block's filters win. Validation
+// still runs across every hosted entry, so a malformed later block
+// rejects the request rather than slipping through behind the chosen
+// first one. Name-collision resolution and the hosted-tool → shim's
+// function-tool replacement are the framework's responsibility
+// (`resolveServerToolName` / `rewriteToolsForHostedShim`); this
+// function only reads the hosted entries.
 export const prepareToolsForShim = (
   tools: ResponsesTool[],
 ): PrepareToolsResult => {
-  let lastHostedFilters: ShimToolFilters = {};
+  let firstHostedFilters: ShimToolFilters = {};
+  let captured = false;
   for (const tool of tools) {
     if (isHostedWebSearchTool(tool)) {
       const reject = validateHostedEntry(tool);
       if (reject !== null) return { ok: false, error: reject };
-      lastHostedFilters = extractFilters(tool);
+      if (!captured) {
+        firstHostedFilters = extractFilters(tool);
+        captured = true;
+      }
     }
   }
-  return { ok: true, filters: lastHostedFilters };
+  return { ok: true, filters: firstHostedFilters };
 };
 
 // ── Shim call parsing ──
@@ -1317,8 +1351,9 @@ export const webSearchServerTool: ServerToolRegistration = (invocation, gatewayC
     ...(hasHostedWebSearch
       ? {
           hosted: {
-            isHostedTool: isHostedWebSearchTool,
-            buildFunctionTool: toolName => buildShimFunctionTool(toolName, filters.userLocation),
+            hostedTypes: WEB_SEARCH_HOSTED_TYPE_NAMES,
+            canonicalize: canonicalizeWebSearchTool,
+            buildFunctionTool: buildShimFunctionTool,
             dispatcher: ({ intercepted, loopState }) => {
               const slot = planShimSlots(parseShimOperations(intercepted.arguments), intercepted.name, state, loopState);
               const functionCallItem: ResponsesFunctionToolCallItem = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -65,10 +65,10 @@ const formatUserLocation = (loc: NonNullable<ShimToolFilters['userLocation']>): 
 // deliberately omits the unsupported ones.
 //   https://github.com/openai/harmony/blob/abd677f7ac962629c808197caa1feb9e3e95d2b0/src/chat.rs#L259-L313
 const buildShimFunctionTool = (
-  canonical: ResponsesTool,
+  canonical: ResponsesHostedTool,
   name: string,
 ): ResponsesFunctionTool => {
-  const userLocation = isHostedWebSearchTool(canonical) ? canonical.user_location : undefined;
+  const userLocation = canonical.user_location;
   const baseDescription
     = 'Accesses the web through three actions: searching, opening a page, and finding text inside a page. '
     + 'Multiple sub-property arrays may be populated in one call to dispatch several operations in parallel.';
@@ -153,7 +153,7 @@ export const isHostedWebSearchTool = (tool: ResponsesTool): tool is ResponsesHos
 //   `return_token_budget` default `'default'` and
 //   `search_content_types` default `['text']` — observed verbatim in
 //   Copilot's `/responses` echo for `tools: [{type: 'web_search'}]`.
-export const canonicalizeWebSearchTool = (raw: ResponsesTool): ResponsesTool | undefined => {
+export const canonicalizeWebSearchTool = (raw: ResponsesTool): ResponsesHostedTool | undefined => {
   if (!isHostedWebSearchTool(raw)) return undefined;
   const canonical: ResponsesHostedTool = {
     type: raw.type,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -263,16 +263,12 @@ const validateHostedEntry = (tool: ResponsesHostedTool): PrepareToolsError | nul
   return null;
 };
 
-// Validate every hosted web_search entry and return the filters the
-// shim will act on. The framework silently dedupes hosted entries to
-// the first one (mirroring upstream Copilot), so filter extraction
-// follows the same rule: first hosted block's filters win. Validation
-// still runs across every hosted entry, so a malformed later block
-// rejects the request rather than slipping through behind the chosen
-// first one. Name-collision resolution and the hosted-tool → shim's
-// function-tool replacement are the framework's responsibility
-// (`resolveServerToolName` / `rewriteToolsForHostedShim`); this
-// function only reads the hosted entries.
+// First hosted block's filters win, matching the framework's
+// dedupe-to-first rule for hosted entries. Validation still runs
+// across every hosted entry so a malformed later block rejects the
+// request rather than slipping through behind the chosen first one.
+// Name-collision resolution and the hosted-tool → function-tool
+// replacement are the framework's responsibility.
 export const prepareToolsForShim = (
   tools: ResponsesTool[],
 ): PrepareToolsResult => {

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -414,6 +414,15 @@ export interface ResponsesResult {
   error: { message: string; code: string; type?: string } | null;
   // https://developers.openai.com/api/reference/resources/responses/methods/create
   service_tier?: 'default' | 'auto' | 'flex' | 'priority' | 'scale' | (string & {}) | null;
+  // Request params echoed back on the response body. The `Response`
+  // schema in OpenAI's openapi.yaml composes `ResponseProperties`, which
+  // declares `tools` and `tool_choice`; observed upstream echoes
+  // (Copilot, Azure) confirm both fields are populated with
+  // server-enriched defaults. Surfaced here so consumers that need to
+  // round-trip or rewrite the echo (e.g. server-tool shim) can type
+  // their reads cleanly.
+  tools?: ResponsesTool[];
+  tool_choice?: ResponsesToolChoice;
   usage?: {
     input_tokens: number;
     output_tokens: number;

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -416,11 +416,8 @@ export interface ResponsesResult {
   service_tier?: 'default' | 'auto' | 'flex' | 'priority' | 'scale' | (string & {}) | null;
   // Request params echoed back on the response body. The `Response`
   // schema in OpenAI's openapi.yaml composes `ResponseProperties`, which
-  // declares `tools` and `tool_choice`; observed upstream echoes
-  // (Copilot, Azure) confirm both fields are populated with
-  // server-enriched defaults. Surfaced here so consumers that need to
-  // round-trip or rewrite the echo (e.g. server-tool shim) can type
-  // their reads cleanly.
+  // declares both fields; observed upstream echoes (Copilot, Azure)
+  // confirm they're populated with server-enriched defaults.
   tools?: ResponsesTool[];
   tool_choice?: ResponsesToolChoice;
   usage?: {


### PR DESCRIPTION
## Summary

The Responses server-tool shim rebuilds the hosted-tool dispatch around a single `CanonicalTool` boundary. Each server tool implements one `canonicalize(raw)` that both detects ownership and fills upstream-spec defaults; every downstream caller (`buildFunctionTool`, dispatcher input, echo restore) only ever sees canonical form.

OpenAI's `Response` schema echoes `tools` and `tool_choice` back on the response body. `restoreEchoedTools` and `restoreEchoedToolChoice` map the upstream-echoed function tool back to the canonical hosted entry on the synthesized envelope, so clients never see the gateway-internal function tool name. Ordinary client tools that upstream enriched (e.g. `description:null` on a function tool) pass through verbatim.

Duplicate hosted entries silently collapse (first claimant wins), mirroring upstream Copilot's observed dedupe semantics. `tool_choice: {type:'web_search'}` round-trips through `{type:'function', name: <toolName>}` and back. A `tool_choice` naming a client-supplied function tool is never rewritten.

`ResponsesResult` declares `tools?` and `tool_choice?` so the echoed fields type cleanly. `prepareToolsForShim` in `web-search.ts` extracts filters from the first hosted block, aligning with framework dedupe order; validation still runs across every hosted entry. The `imageGenerationServerTool` uses an identity `canonicalize` — image_generation is Azure-native on real workloads, and the spec defaults observed via Azure echo (all `'auto'`) signal "backend decides" rather than canonical values worth synthesizing.

Six shim tests pin the echo-restore round-trip: function-tool swap-back, `filters`/`user_location` preservation, duplicate hosted dedupe with first-block `search_context_size` winning, `tool_choice` round-trip, untouched client `tool_choice`, and absent-echo (no `tools` synthesized when upstream omits it).

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` — 3530 tests pass, including six new echo-restore tests in `server-tool-shim_test.ts`
- [x] Manual: against a running gateway, sent a `/v1/responses` request with `tools:[{type:'web_search'}]` to a Copilot upstream and confirmed the synthesized envelope echoes back `{"type":"web_search","search_context_size":"medium","search_content_types":["text"],"return_token_budget":"default"}` rather than the gateway-internal `{type:'function', name:'web_search'}` form