### PR TITLE
feat(translate): surface translator caller-input failures as protocol-shaped 400

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/errors.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/errors.ts
@@ -2,7 +2,7 @@ import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { ChatServeFailure } from '../shared/errors.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ApiErrorResult, ExecuteResult } from '@floway-dev/provider';
+import type { ExecuteResult } from '@floway-dev/provider';
 import type { TranslatorInputError } from '@floway-dev/translate';
 
 // OpenAI error envelope. `param`/`code` reproduce OpenAI's native fields; a
@@ -13,7 +13,7 @@ const openAiErrorResult = (
   status: number,
   message: string,
   extra?: { param: string; code: string | null },
-): ApiErrorResult => ({
+): ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>> => ({
   type: 'api-error',
   source: 'gateway',
   status,
@@ -30,7 +30,7 @@ const openAiErrorResult = (
 // translator did not carry a more specific path.
 export const translatorInputErrorResult = (
   error: TranslatorInputError,
-): ApiErrorResult =>
+): ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>> =>
   openAiErrorResult(400, error.message, { param: error.param ?? 'messages', code: null });
 
 export const renderChatCompletionsFailure = (

--- a/packages/gateway/src/data-plane/chat/chat-completions/errors.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/errors.ts
@@ -2,7 +2,8 @@ import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { ChatServeFailure } from '../shared/errors.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ExecuteResult } from '@floway-dev/provider';
+import type { ApiErrorResult, ExecuteResult } from '@floway-dev/provider';
+import type { TranslatorInputError } from '@floway-dev/translate';
 
 // OpenAI error envelope. `param`/`code` reproduce OpenAI's native fields; a
 // stored-item miss must byte-match OpenAI's own "not found" body. The
@@ -12,7 +13,7 @@ const openAiErrorResult = (
   status: number,
   message: string,
   extra?: { param: string; code: string | null },
-): ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>> => ({
+): ApiErrorResult => ({
   type: 'api-error',
   source: 'gateway',
   status,
@@ -21,6 +22,16 @@ const openAiErrorResult = (
     error: { message, type: 'invalid_request_error', ...extra },
   })),
 });
+
+// Translator surfaced a caller-input violation. Render as a 400
+// invalid_request_error so the caller sees a protocol-shaped failure
+// instead of the internal-error 502 envelope. `param` falls back to
+// `messages` (the Chat Completions canonical messages field) when the
+// translator did not carry a more specific path.
+export const translatorInputErrorResult = (
+  error: TranslatorInputError,
+): ApiErrorResult =>
+  openAiErrorResult(400, error.message, { param: error.param ?? 'messages', code: null });
 
 export const renderChatCompletionsFailure = (
   failure: ChatServeFailure,

--- a/packages/gateway/src/data-plane/chat/chat-completions/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/errors_test.ts
@@ -11,7 +11,7 @@ const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown 
 
 test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error envelope with default `messages` param', () => {
   const result = translatorInputErrorResult(
-    new TranslatorInputError('Chat Completions → Messages translator does not accept tool messages without tool_call_id.'),
+    new TranslatorInputError("Missing required field 'tool_call_id' on a 'tool' role message."),
   );
   const apiError = apiErrorOf(result);
 
@@ -20,7 +20,7 @@ test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error env
   assertEquals(apiError.status, 400);
   assertEquals(bodyOf(result), {
     error: {
-      message: 'Chat Completions → Messages translator does not accept tool messages without tool_call_id.',
+      message: "Missing required field 'tool_call_id' on a 'tool' role message.",
       type: 'invalid_request_error',
       param: 'messages',
       code: null,

--- a/packages/gateway/src/data-plane/chat/chat-completions/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/errors_test.ts
@@ -1,20 +1,23 @@
 import { test } from 'vitest';
 
 import { translatorInputErrorResult } from './errors.ts';
+import type { ApiErrorResult } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 import { TranslatorInputError } from '@floway-dev/translate';
 
+const apiErrorOf = (result: ReturnType<typeof translatorInputErrorResult>): ApiErrorResult => result as ApiErrorResult;
 const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown =>
-  JSON.parse(new TextDecoder().decode(result.body));
+  JSON.parse(new TextDecoder().decode(apiErrorOf(result).body));
 
 test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error envelope with default `messages` param', () => {
   const result = translatorInputErrorResult(
     new TranslatorInputError('Chat Completions → Messages translator does not accept tool messages without tool_call_id.'),
   );
+  const apiError = apiErrorOf(result);
 
-  assertEquals(result.type, 'api-error');
-  assertEquals(result.source, 'gateway');
-  assertEquals(result.status, 400);
+  assertEquals(apiError.type, 'api-error');
+  assertEquals(apiError.source, 'gateway');
+  assertEquals(apiError.status, 400);
   assertEquals(bodyOf(result), {
     error: {
       message: 'Chat Completions → Messages translator does not accept tool messages without tool_call_id.',

--- a/packages/gateway/src/data-plane/chat/chat-completions/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/errors_test.ts
@@ -1,0 +1,41 @@
+import { test } from 'vitest';
+
+import { translatorInputErrorResult } from './errors.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+import { TranslatorInputError } from '@floway-dev/translate';
+
+const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown =>
+  JSON.parse(new TextDecoder().decode(result.body));
+
+test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error envelope with default `messages` param', () => {
+  const result = translatorInputErrorResult(
+    new TranslatorInputError('Chat Completions → Messages translator does not accept tool messages without tool_call_id.'),
+  );
+
+  assertEquals(result.type, 'api-error');
+  assertEquals(result.source, 'gateway');
+  assertEquals(result.status, 400);
+  assertEquals(bodyOf(result), {
+    error: {
+      message: 'Chat Completions → Messages translator does not accept tool messages without tool_call_id.',
+      type: 'invalid_request_error',
+      param: 'messages',
+      code: null,
+    },
+  });
+});
+
+test('translatorInputErrorResult honors an explicit param from the translator', () => {
+  const result = translatorInputErrorResult(
+    new TranslatorInputError('content part not supported', { param: 'messages[2].content[1]' }),
+  );
+
+  assertEquals(bodyOf(result), {
+    error: {
+      message: 'content part not supported',
+      type: 'invalid_request_error',
+      param: 'messages[2].content[1]',
+      code: null,
+    },
+  });
+});

--- a/packages/gateway/src/data-plane/chat/chat-completions/http.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http.ts
@@ -29,20 +29,15 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
 
-// Pre-stream caller-input failure raised by a translator. Surface as a
-// Chat Completions-shaped 400 invalid_request_error instead of routing
-// through the internal-error 502 path.
-const respondWithTranslatorInputError = async (c: AuthedContext, error: TranslatorInputError, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+// Pre-stream caller-input failure raised by a translator → Chat
+// Completions-shaped 400 invalid_request_error envelope. Anything else
+// falls through to the internal-error 502 path.
+const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+  if (!(error instanceof TranslatorInputError)) return await respondWithInternalError(c, error, requestBody, ctx);
   const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody });
-  const result = translatorInputErrorResult(error);
-  const { response } = await respondChatCompletions(c, result, false, false, effectiveCtx);
+  const { response } = await respondChatCompletions(c, translatorInputErrorResult(error), false, false, effectiveCtx);
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
-
-const respondToThrow = (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> =>
-  error instanceof TranslatorInputError
-    ? respondWithTranslatorInputError(c, error, requestBody, ctx)
-    : respondWithInternalError(c, error, requestBody, ctx);
 
 export const chatCompletionsHttp = {
   generate: async (c: AuthedContext): Promise<Response> => {

--- a/packages/gateway/src/data-plane/chat/chat-completions/http.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http.ts
@@ -1,3 +1,4 @@
+import { translatorInputErrorResult } from './errors.ts';
 import { respondChatCompletions } from './respond.ts';
 import { chatCompletionsServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
@@ -8,6 +9,7 @@ import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
+import { TranslatorInputError } from '@floway-dev/translate';
 
 // Surfaces a pre-stream throw (malformed JSON body, an interceptor crash,
 // etc.) as a Chat Completions-shaped 502 with the same internal-error
@@ -26,6 +28,21 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   const { response } = await respondChatCompletions(c, result, false, false, effectiveCtx);
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
+
+// Pre-stream caller-input failure raised by a translator. Surface as a
+// Chat Completions-shaped 400 invalid_request_error instead of routing
+// through the internal-error 502 path.
+const respondWithTranslatorInputError = async (c: AuthedContext, error: TranslatorInputError, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody });
+  const result = translatorInputErrorResult(error);
+  const { response } = await respondChatCompletions(c, result, false, false, effectiveCtx);
+  return (effectiveCtx.dump?.finalize(response) ?? response);
+};
+
+const respondToThrow = (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> =>
+  error instanceof TranslatorInputError
+    ? respondWithTranslatorInputError(c, error, requestBody, ctx)
+    : respondWithInternalError(c, error, requestBody, ctx);
 
 export const chatCompletionsHttp = {
   generate: async (c: AuthedContext): Promise<Response> => {
@@ -46,7 +63,7 @@ export const chatCompletionsHttp = {
       const { response } = await respondChatCompletions(c, result, wantsStream, includeUsageChunk, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {
-      return await respondWithInternalError(c, error, requestBody, ctx);
+      return await respondToThrow(c, error, requestBody, ctx);
     }
   },
 };

--- a/packages/gateway/src/data-plane/chat/gemini/errors.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/errors.ts
@@ -3,6 +3,7 @@ import type { ChatServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import type { ExecuteResult } from '@floway-dev/provider';
+import type { TranslatorInputError } from '@floway-dev/translate';
 
 // Google RPC Status envelope, used by Gemini's `error` channel everywhere
 // (HTTP body, SSE-tunnelled error event).
@@ -37,6 +38,15 @@ const geminiRpcErrorResult = (status: number, message: string): ExecuteResult<Pr
     error: { code: status, message, status: geminiStatusForHttpStatus(status) },
   })),
 });
+
+// Translator surfaced a caller-input violation (unsupported content part,
+// disallowed role, missing required field, etc.). Render as a 400
+// INVALID_ARGUMENT envelope so the caller sees a Gemini-shaped failure
+// instead of the internal-error 500 envelope.
+export const translatorInputErrorResult = (
+  error: TranslatorInputError,
+): ExecuteResult<ProtocolFrame<GeminiStreamEvent>> =>
+  geminiRpcErrorResult(400, error.message);
 
 // `endpoint` selects between `:generateContent` and `:countTokens` only in
 // the `model-unsupported` message string.

--- a/packages/gateway/src/data-plane/chat/gemini/http.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http.ts
@@ -1,3 +1,4 @@
+import { translatorInputErrorResult } from './errors.ts';
 import { geminiInternalRpcErrorResponse, geminiRpcErrorResponse, respondGemini } from './respond.ts';
 import { geminiServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
@@ -7,6 +8,7 @@ import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx
 import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 import { internalErrorResult, ProviderModelsUnavailableError, toInternalDebugError } from '@floway-dev/provider';
+import { TranslatorInputError } from '@floway-dev/translate';
 
 interface GeminiModelAction {
   readonly model: string;
@@ -45,17 +47,22 @@ const parseGeminiBodyBytes = <T>(requestBody: RequestBody, project: (body: unkno
 
 // Surfaces a pre-stream throw as a Gemini-RPC envelope, routing through
 // `respondGemini` so the dump records the failure exactly as the sibling
-// HTTP handlers do. A `ProviderModelsUnavailableError` carrying an upstream
-// HTTP body relays that body through the `api-error` path with `source:
-// 'upstream'`; everything else collapses to an `internal-error` result
-// rendered as the Gemini internal-error envelope (status, code, message,
-// stack, cause, target_api).
+// HTTP handlers do. `TranslatorInputError` renders a 400 INVALID_ARGUMENT
+// envelope (caller-input violation). A `ProviderModelsUnavailableError`
+// carrying an upstream HTTP body relays that body through the `api-error`
+// path with `source: 'upstream'`; everything else collapses to an
+// `internal-error` result rendered as the Gemini internal-error envelope
+// (status, code, message, stack, cause, target_api).
 const respondWithGeminiError = async (
   c: AuthedContext,
   error: unknown,
   ctx: GatewayCtx,
   wantsStream: boolean,
 ): Promise<Response> => {
+  if (error instanceof TranslatorInputError) {
+    const { response } = await respondGemini(c, translatorInputErrorResult(error), wantsStream, ctx);
+    return (ctx.dump?.finalize(response) ?? response);
+  }
   if (error instanceof ProviderModelsUnavailableError && error.httpResponse) {
     const { status, headers, body } = error.httpResponse;
     const apiErrorResult = {

--- a/packages/gateway/src/data-plane/chat/messages/errors.ts
+++ b/packages/gateway/src/data-plane/chat/messages/errors.ts
@@ -2,7 +2,7 @@ import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { ChatServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ApiErrorResult, ExecuteResult } from '@floway-dev/provider';
+import type { ExecuteResult } from '@floway-dev/provider';
 import type { TranslatorInputError } from '@floway-dev/translate';
 
 // Anthropic Messages error envelope used to render pre-stream
@@ -12,7 +12,7 @@ const anthropicErrorResult = (
   status: number,
   type: string,
   message: string,
-): ApiErrorResult => ({
+): ExecuteResult<ProtocolFrame<MessagesStreamEvent>> => ({
   type: 'api-error',
   source: 'gateway',
   status,
@@ -29,7 +29,7 @@ const anthropicErrorResult = (
 // instead of the internal-error 502 envelope.
 export const translatorInputErrorResult = (
   error: TranslatorInputError,
-): ApiErrorResult =>
+): ExecuteResult<ProtocolFrame<MessagesStreamEvent>> =>
   anthropicErrorResult(400, 'invalid_request_error', error.message);
 
 // `endpoint` selects between `/messages` and `/messages/count_tokens` only in

--- a/packages/gateway/src/data-plane/chat/messages/errors.ts
+++ b/packages/gateway/src/data-plane/chat/messages/errors.ts
@@ -5,9 +5,20 @@ import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ExecuteResult } from '@floway-dev/provider';
 import type { TranslatorInputError } from '@floway-dev/translate';
 
+// Mint an Anthropic-shaped synthetic request id (`req_` + 24 base62 chars)
+// so a gateway-synthesized 4xx body carries the same top-level `request_id`
+// field every real Anthropic response carries. The value is opaque to the
+// caller; we never bridge it to an upstream id (these envelopes never
+// reached an upstream). 24 chars from crypto.randomUUID yields ~96 bits of
+// entropy, plenty for an opaque per-error id.
+const mintAnthropicRequestId = (): string => `req_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+
 // Anthropic Messages error envelope used to render pre-stream
 // `ChatServeFailure`s. These are gateway-synthesized rather than received
 // from any upstream — `source: 'gateway'` so the dump labels them as such.
+// Byte-shape matches Anthropic-direct: `{type:'error', error:{type, message},
+// request_id}` with `request_id` at the top level (alongside `error`, not
+// nested inside it) and key order load-bearing for byte-faithfulness.
 const anthropicErrorResult = (
   status: number,
   type: string,
@@ -20,6 +31,7 @@ const anthropicErrorResult = (
   body: new TextEncoder().encode(JSON.stringify({
     type: 'error',
     error: { type, message },
+    request_id: mintAnthropicRequestId(),
   })),
 });
 

--- a/packages/gateway/src/data-plane/chat/messages/errors.ts
+++ b/packages/gateway/src/data-plane/chat/messages/errors.ts
@@ -2,7 +2,8 @@ import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { ChatServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ExecuteResult } from '@floway-dev/provider';
+import type { ApiErrorResult, ExecuteResult } from '@floway-dev/provider';
+import type { TranslatorInputError } from '@floway-dev/translate';
 
 // Anthropic Messages error envelope used to render pre-stream
 // `ChatServeFailure`s. These are gateway-synthesized rather than received
@@ -11,7 +12,7 @@ const anthropicErrorResult = (
   status: number,
   type: string,
   message: string,
-): ExecuteResult<ProtocolFrame<MessagesStreamEvent>> => ({
+): ApiErrorResult => ({
   type: 'api-error',
   source: 'gateway',
   status,
@@ -21,6 +22,15 @@ const anthropicErrorResult = (
     error: { type, message },
   })),
 });
+
+// Translator surfaced a caller-input violation (unsupported content part,
+// disallowed role, missing required field, etc.). Render as a 400
+// invalid_request_error so the caller sees a protocol-shaped failure
+// instead of the internal-error 502 envelope.
+export const translatorInputErrorResult = (
+  error: TranslatorInputError,
+): ApiErrorResult =>
+  anthropicErrorResult(400, 'invalid_request_error', error.message);
 
 // `endpoint` selects between `/messages` and `/messages/count_tokens` only in
 // the `model-unsupported` message string.

--- a/packages/gateway/src/data-plane/chat/messages/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/errors_test.ts
@@ -1,21 +1,24 @@
 import { test } from 'vitest';
 
 import { translatorInputErrorResult } from './errors.ts';
+import type { ApiErrorResult } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 import { TranslatorInputError } from '@floway-dev/translate';
 
+const apiErrorOf = (result: ReturnType<typeof translatorInputErrorResult>): ApiErrorResult => result as ApiErrorResult;
 const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown =>
-  JSON.parse(new TextDecoder().decode(result.body));
+  JSON.parse(new TextDecoder().decode(apiErrorOf(result).body));
 
 test('translatorInputErrorResult renders an Anthropic 400 invalid_request_error envelope', () => {
   const result = translatorInputErrorResult(
     new TranslatorInputError('Chat Completions → Messages translator does not accept image content parts in system or developer messages.'),
   );
+  const apiError = apiErrorOf(result);
 
-  assertEquals(result.type, 'api-error');
-  assertEquals(result.source, 'gateway');
-  assertEquals(result.status, 400);
-  assertEquals(result.headers.get('content-type'), 'application/json');
+  assertEquals(apiError.type, 'api-error');
+  assertEquals(apiError.source, 'gateway');
+  assertEquals(apiError.status, 400);
+  assertEquals(apiError.headers.get('content-type'), 'application/json');
   assertEquals(bodyOf(result), {
     type: 'error',
     error: {

--- a/packages/gateway/src/data-plane/chat/messages/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/errors_test.ts
@@ -2,16 +2,16 @@ import { test } from 'vitest';
 
 import { translatorInputErrorResult } from './errors.ts';
 import type { ApiErrorResult } from '@floway-dev/provider';
-import { assertEquals } from '@floway-dev/test-utils';
+import { assert, assertEquals } from '@floway-dev/test-utils';
 import { TranslatorInputError } from '@floway-dev/translate';
 
 const apiErrorOf = (result: ReturnType<typeof translatorInputErrorResult>): ApiErrorResult => result as ApiErrorResult;
-const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown =>
+const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): Record<string, unknown> =>
   JSON.parse(new TextDecoder().decode(apiErrorOf(result).body));
 
-test('translatorInputErrorResult renders an Anthropic 400 invalid_request_error envelope', () => {
+test('translatorInputErrorResult renders an Anthropic 400 invalid_request_error envelope with top-level request_id', () => {
   const result = translatorInputErrorResult(
-    new TranslatorInputError('Chat Completions → Messages translator does not accept image content parts in system or developer messages.'),
+    new TranslatorInputError("Invalid 'image_url' content part in system or developer message. Only 'text' content parts are supported in system messages on this model."),
   );
   const apiError = apiErrorOf(result);
 
@@ -19,11 +19,19 @@ test('translatorInputErrorResult renders an Anthropic 400 invalid_request_error 
   assertEquals(apiError.source, 'gateway');
   assertEquals(apiError.status, 400);
   assertEquals(apiError.headers.get('content-type'), 'application/json');
-  assertEquals(bodyOf(result), {
-    type: 'error',
-    error: {
-      type: 'invalid_request_error',
-      message: 'Chat Completions → Messages translator does not accept image content parts in system or developer messages.',
-    },
+
+  const body = bodyOf(result);
+  assertEquals(body.type, 'error');
+  assertEquals(body.error, {
+    type: 'invalid_request_error',
+    message: "Invalid 'image_url' content part in system or developer message. Only 'text' content parts are supported in system messages on this model.",
   });
+  assert(typeof body.request_id === 'string' && /^req_[A-Za-z0-9]{24}$/.test(body.request_id), `request_id ${String(body.request_id)} must match Anthropic-shape req_<24-base62>`);
+});
+
+test('translatorInputErrorResult preserves Anthropic key order: type, error, request_id', () => {
+  const result = translatorInputErrorResult(new TranslatorInputError('whatever'));
+  const raw = new TextDecoder().decode(apiErrorOf(result).body);
+  // Key-order is load-bearing for byte-faithfulness with Anthropic-direct.
+  assert(/^\{"type":"error","error":\{"type":"invalid_request_error","message":"whatever"\},"request_id":"req_[A-Za-z0-9]{24}"\}$/.test(raw), `body ${raw} must match Anthropic-direct byte shape`);
 });

--- a/packages/gateway/src/data-plane/chat/messages/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/errors_test.ts
@@ -1,0 +1,26 @@
+import { test } from 'vitest';
+
+import { translatorInputErrorResult } from './errors.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+import { TranslatorInputError } from '@floway-dev/translate';
+
+const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown =>
+  JSON.parse(new TextDecoder().decode(result.body));
+
+test('translatorInputErrorResult renders an Anthropic 400 invalid_request_error envelope', () => {
+  const result = translatorInputErrorResult(
+    new TranslatorInputError('Chat Completions → Messages translator does not accept image content parts in system or developer messages.'),
+  );
+
+  assertEquals(result.type, 'api-error');
+  assertEquals(result.source, 'gateway');
+  assertEquals(result.status, 400);
+  assertEquals(result.headers.get('content-type'), 'application/json');
+  assertEquals(bodyOf(result), {
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'Chat Completions → Messages translator does not accept image content parts in system or developer messages.',
+    },
+  });
+});

--- a/packages/gateway/src/data-plane/chat/messages/http.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http.ts
@@ -49,20 +49,15 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
 
-// Pre-stream caller-input failure raised by a translator. Surface as a
-// Messages-shaped 400 invalid_request_error instead of routing through the
+// Pre-stream caller-input failure raised by a translator → Messages-shaped
+// 400 invalid_request_error envelope. Anything else falls through to the
 // internal-error 502 path.
-const respondWithTranslatorInputError = async (c: AuthedContext, error: TranslatorInputError, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+  if (!(error instanceof TranslatorInputError)) return await respondWithInternalError(c, error, requestBody, ctx);
   const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody });
-  const result = translatorInputErrorResult(error);
-  const { response } = await respondMessages(c, result, false, effectiveCtx);
+  const { response } = await respondMessages(c, translatorInputErrorResult(error), false, effectiveCtx);
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
-
-const respondToThrow = (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> =>
-  error instanceof TranslatorInputError
-    ? respondWithTranslatorInputError(c, error, requestBody, ctx)
-    : respondWithInternalError(c, error, requestBody, ctx);
 
 const parsePayload = (requestBody: RequestBody): MessagesPayload =>
   JSON.parse(new TextDecoder().decode(requestBody.bytes)) as MessagesPayload;

--- a/packages/gateway/src/data-plane/chat/messages/http.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http.ts
@@ -1,3 +1,4 @@
+import { translatorInputErrorResult } from './errors.ts';
 import { respondMessages } from './respond.ts';
 import { messagesServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
@@ -8,6 +9,7 @@ import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
+import { TranslatorInputError } from '@floway-dev/translate';
 
 // Reject `anthropic_beta` / `betas` in the body; the Messages protocol carries
 // them via the `anthropic-beta` HTTP header.
@@ -47,6 +49,21 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
 
+// Pre-stream caller-input failure raised by a translator. Surface as a
+// Messages-shaped 400 invalid_request_error instead of routing through the
+// internal-error 502 path.
+const respondWithTranslatorInputError = async (c: AuthedContext, error: TranslatorInputError, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody });
+  const result = translatorInputErrorResult(error);
+  const { response } = await respondMessages(c, result, false, effectiveCtx);
+  return (effectiveCtx.dump?.finalize(response) ?? response);
+};
+
+const respondToThrow = (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> =>
+  error instanceof TranslatorInputError
+    ? respondWithTranslatorInputError(c, error, requestBody, ctx)
+    : respondWithInternalError(c, error, requestBody, ctx);
+
 const parsePayload = (requestBody: RequestBody): MessagesPayload =>
   JSON.parse(new TextDecoder().decode(requestBody.bytes)) as MessagesPayload;
 
@@ -66,7 +83,7 @@ export const messagesHttp = {
       const { response } = await respondMessages(c, result, wantsStream, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {
-      return await respondWithInternalError(c, error, requestBody, ctx);
+      return await respondToThrow(c, error, requestBody, ctx);
     }
   },
 
@@ -84,7 +101,7 @@ export const messagesHttp = {
       const { response } = await respondMessages(c, result, false, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {
-      return await respondWithInternalError(c, error, requestBody, ctx);
+      return await respondToThrow(c, error, requestBody, ctx);
     }
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/errors.ts
+++ b/packages/gateway/src/data-plane/chat/responses/errors.ts
@@ -2,7 +2,7 @@ import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { ChatServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ApiErrorResult, ExecuteResult } from '@floway-dev/provider';
+import type { ExecuteResult } from '@floway-dev/provider';
 import type { TranslatorInputError } from '@floway-dev/translate';
 
 // OpenAI error envelope. `param` / `code` reproduce OpenAI's native fields; a
@@ -13,7 +13,7 @@ const openAiErrorResult = (
   status: number,
   message: string,
   extra?: { readonly param: string; readonly code: string | null },
-): ApiErrorResult => ({
+): ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> => ({
   type: 'api-error',
   source: 'gateway',
   status,
@@ -30,7 +30,7 @@ const openAiErrorResult = (
 // did not carry a more specific path.
 export const translatorInputErrorResult = (
   error: TranslatorInputError,
-): ApiErrorResult =>
+): ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> =>
   openAiErrorResult(400, error.message, { param: error.param ?? 'input', code: null });
 
 export const renderResponsesFailure = (

--- a/packages/gateway/src/data-plane/chat/responses/errors.ts
+++ b/packages/gateway/src/data-plane/chat/responses/errors.ts
@@ -2,7 +2,8 @@ import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import type { ChatServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ExecuteResult } from '@floway-dev/provider';
+import type { ApiErrorResult, ExecuteResult } from '@floway-dev/provider';
+import type { TranslatorInputError } from '@floway-dev/translate';
 
 // OpenAI error envelope. `param` / `code` reproduce OpenAI's native fields; a
 // stored-item miss must byte-match OpenAI's own "not found" body — stateless
@@ -12,7 +13,7 @@ const openAiErrorResult = (
   status: number,
   message: string,
   extra?: { readonly param: string; readonly code: string | null },
-): ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> => ({
+): ApiErrorResult => ({
   type: 'api-error',
   source: 'gateway',
   status,
@@ -21,6 +22,16 @@ const openAiErrorResult = (
     error: { message, type: 'invalid_request_error', ...extra },
   })),
 });
+
+// Translator surfaced a caller-input violation. Render as a 400
+// invalid_request_error so the caller sees a protocol-shaped failure
+// instead of the internal-error 502 envelope. `param` falls back to
+// `input` (the Responses canonical input field name) when the translator
+// did not carry a more specific path.
+export const translatorInputErrorResult = (
+  error: TranslatorInputError,
+): ApiErrorResult =>
+  openAiErrorResult(400, error.message, { param: error.param ?? 'input', code: null });
 
 export const renderResponsesFailure = (
   failure: ChatServeFailure,

--- a/packages/gateway/src/data-plane/chat/responses/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/errors_test.ts
@@ -1,0 +1,41 @@
+import { test } from 'vitest';
+
+import { translatorInputErrorResult } from './errors.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+import { TranslatorInputError } from '@floway-dev/translate';
+
+const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown =>
+  JSON.parse(new TextDecoder().decode(result.body));
+
+test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error envelope with default `input` param', () => {
+  const result = translatorInputErrorResult(
+    new TranslatorInputError('Responses → Messages translator does not accept image_generation_call input items.'),
+  );
+
+  assertEquals(result.type, 'api-error');
+  assertEquals(result.source, 'gateway');
+  assertEquals(result.status, 400);
+  assertEquals(bodyOf(result), {
+    error: {
+      message: 'Responses → Messages translator does not accept image_generation_call input items.',
+      type: 'invalid_request_error',
+      param: 'input',
+      code: null,
+    },
+  });
+});
+
+test('translatorInputErrorResult honors an explicit param from the translator', () => {
+  const result = translatorInputErrorResult(
+    new TranslatorInputError('content block not supported', { param: 'input[1].content[0]' }),
+  );
+
+  assertEquals(bodyOf(result), {
+    error: {
+      message: 'content block not supported',
+      type: 'invalid_request_error',
+      param: 'input[1].content[0]',
+      code: null,
+    },
+  });
+});

--- a/packages/gateway/src/data-plane/chat/responses/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/errors_test.ts
@@ -11,7 +11,7 @@ const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown 
 
 test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error envelope with default `input` param', () => {
   const result = translatorInputErrorResult(
-    new TranslatorInputError('Responses → Messages translator does not accept image_generation_call input items.'),
+    new TranslatorInputError("Invalid input item type 'image_generation_call'."),
   );
   const apiError = apiErrorOf(result);
 
@@ -20,7 +20,7 @@ test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error env
   assertEquals(apiError.status, 400);
   assertEquals(bodyOf(result), {
     error: {
-      message: 'Responses → Messages translator does not accept image_generation_call input items.',
+      message: "Invalid input item type 'image_generation_call'.",
       type: 'invalid_request_error',
       param: 'input',
       code: null,

--- a/packages/gateway/src/data-plane/chat/responses/errors_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/errors_test.ts
@@ -1,20 +1,23 @@
 import { test } from 'vitest';
 
 import { translatorInputErrorResult } from './errors.ts';
+import type { ApiErrorResult } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 import { TranslatorInputError } from '@floway-dev/translate';
 
+const apiErrorOf = (result: ReturnType<typeof translatorInputErrorResult>): ApiErrorResult => result as ApiErrorResult;
 const bodyOf = (result: ReturnType<typeof translatorInputErrorResult>): unknown =>
-  JSON.parse(new TextDecoder().decode(result.body));
+  JSON.parse(new TextDecoder().decode(apiErrorOf(result).body));
 
 test('translatorInputErrorResult renders an OpenAI 400 invalid_request_error envelope with default `input` param', () => {
   const result = translatorInputErrorResult(
     new TranslatorInputError('Responses → Messages translator does not accept image_generation_call input items.'),
   );
+  const apiError = apiErrorOf(result);
 
-  assertEquals(result.type, 'api-error');
-  assertEquals(result.source, 'gateway');
-  assertEquals(result.status, 400);
+  assertEquals(apiError.type, 'api-error');
+  assertEquals(apiError.source, 'gateway');
+  assertEquals(apiError.status, 400);
   assertEquals(bodyOf(result), {
     error: {
       message: 'Responses → Messages translator does not accept image_generation_call input items.',

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -1,3 +1,4 @@
+import { translatorInputErrorResult } from './errors.ts';
 import { createResponsesHttpStore } from './items/store.ts';
 import { respondResponses } from './respond.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
@@ -10,6 +11,7 @@ import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
+import { TranslatorInputError } from '@floway-dev/translate';
 
 // Codex sends auto-review requests over the Responses wire API as a
 // `codex-auto-review` model id; rewrite at the entry so downstream routing,
@@ -60,6 +62,28 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
 
+// Pre-stream caller-input failure raised by a translator. Surface as a
+// Responses-shaped 400 invalid_request_error instead of routing through
+// the internal-error 502 path.
+const respondWithTranslatorInputError = async (c: AuthedContext, error: TranslatorInputError, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody });
+  const result = translatorInputErrorResult(error);
+  const { response } = await respondResponses(c, result, false, effectiveCtx);
+  return (effectiveCtx.dump?.finalize(response) ?? response);
+};
+
+const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
+  if (error instanceof PreviousResponseNotFoundError) {
+    const response = previousResponseNotFoundResponse(error.previousResponseId);
+    ctx?.dump?.error('gateway');
+    return (ctx?.dump?.finalize(response) ?? response);
+  }
+  if (error instanceof TranslatorInputError) {
+    return await respondWithTranslatorInputError(c, error, requestBody, ctx);
+  }
+  return await respondWithInternalError(c, error, requestBody, ctx);
+};
+
 const parsePayload = (requestBody: RequestBody, stampReasoningEffort: boolean): ResponsesPayload =>
   rewriteResponsesEntryModelAlias(JSON.parse(new TextDecoder().decode(requestBody.bytes)) as ResponsesPayload, stampReasoningEffort);
 
@@ -76,12 +100,7 @@ export const responsesHttp = {
       const { response } = await respondResponses(c, result, wantsStream, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {
-      if (error instanceof PreviousResponseNotFoundError) {
-        const response = previousResponseNotFoundResponse(error.previousResponseId);
-        ctx?.dump?.error('gateway');
-        return (ctx?.dump?.finalize(response) ?? response);
-      }
-      return await respondWithInternalError(c, error, requestBody, ctx);
+      return await respondToThrow(c, error, requestBody, ctx);
     }
   },
 
@@ -101,12 +120,7 @@ export const responsesHttp = {
       const { response } = await respondResponses(c, result, false, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {
-      if (error instanceof PreviousResponseNotFoundError) {
-        const response = previousResponseNotFoundResponse(error.previousResponseId);
-        ctx?.dump?.error('gateway');
-        return (ctx?.dump?.finalize(response) ?? response);
-      }
-      return await respondWithInternalError(c, error, requestBody, ctx);
+      return await respondToThrow(c, error, requestBody, ctx);
     }
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -62,16 +62,9 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
 
-// Pre-stream caller-input failure raised by a translator. Surface as a
-// Responses-shaped 400 invalid_request_error instead of routing through
-// the internal-error 502 path.
-const respondWithTranslatorInputError = async (c: AuthedContext, error: TranslatorInputError, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
-  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody });
-  const result = translatorInputErrorResult(error);
-  const { response } = await respondResponses(c, result, false, effectiveCtx);
-  return (effectiveCtx.dump?.finalize(response) ?? response);
-};
-
+// Pre-stream throw dispatcher. `PreviousResponseNotFoundError` and the
+// translator-input case render protocol-shaped 400s; anything else falls
+// through to the internal-error 502 path.
 const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
   if (error instanceof PreviousResponseNotFoundError) {
     const response = previousResponseNotFoundResponse(error.previousResponseId);
@@ -79,7 +72,9 @@ const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: Req
     return (ctx?.dump?.finalize(response) ?? response);
   }
   if (error instanceof TranslatorInputError) {
-    return await respondWithTranslatorInputError(c, error, requestBody, ctx);
+    const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody });
+    const { response } = await respondResponses(c, translatorInputErrorResult(error), false, effectiveCtx);
+    return (effectiveCtx.dump?.finalize(response) ?? response);
   }
   return await respondWithInternalError(c, error, requestBody, ctx);
 };

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -74,7 +74,7 @@ const convertUserContent = async (message: ChatCompletionsMessage, loadRemoteIma
         return resolveImageUrlToMessagesImage(part.image_url.url, loadRemoteImage);
       }
 
-      throw new TranslatorInputError(`Chat Completions → Messages translator does not accept ${(part as { type: string }).type} content parts.`);
+      throw new TranslatorInputError(`Invalid '${(part as { type: string }).type}' content part. Only 'text' and 'image_url' are supported in user content.`);
     }),
   );
 
@@ -98,7 +98,7 @@ const convertSystemContent = (content: ChatCompletionsMessage['content']): Messa
   const blocks: MessagesTextBlock[] = [];
   for (const part of content) {
     if (part.type === 'image_url') {
-      throw new TranslatorInputError('Chat Completions → Messages translator does not accept image content parts in system or developer messages — Anthropic Messages only permits text in the system field.');
+      throw new TranslatorInputError("Invalid 'image_url' content part in system or developer message. Only 'text' content parts are supported in system messages on this model.");
     }
     if (part.type === 'text') {
       blocks.push({ type: 'text', text: part.text });
@@ -124,7 +124,7 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       break;
     case 'tool':
       if (!message.tool_call_id) {
-        throw new TranslatorInputError('tool message requires tool_call_id for Messages translation');
+        throw new TranslatorInputError("Missing required field 'tool_call_id' on a 'tool' role message.");
       }
 
       appendUserBlocks(result, [
@@ -152,7 +152,7 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       break;
     }
     default:
-      throw new TranslatorInputError(`Chat Completions → Messages translator does not accept ${message.role} messages.`);
+      throw new TranslatorInputError(`Invalid role '${message.role}'.`);
     }
   }
 

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -2,6 +2,7 @@ import { messagesThinkingBlockFromChatCompletionsScalarReasoning } from '../shar
 import { parseToolArgumentsObject } from '../shared/messages/tool-arguments.ts';
 import { applyLastMessageCacheBreakpoint, applyLastSystemCacheBreakpoint, applyLastToolCacheBreakpoint } from '../shared/via-messages/cache-breakpoints.ts';
 import { fetchRemoteImage, type RemoteImageLoader, resolveImageUrlToMessagesImage } from '../shared/via-messages/remote-images.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsMessage, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
 import { MESSAGES_FALLBACK_MAX_TOKENS, type MessagesAssistantContentBlock, type MessagesMessage, type MessagesPayload, type MessagesTextBlock, type MessagesUserContentBlock } from '@floway-dev/protocols/messages';
 
@@ -73,7 +74,7 @@ const convertUserContent = async (message: ChatCompletionsMessage, loadRemoteIma
         return resolveImageUrlToMessagesImage(part.image_url.url, loadRemoteImage);
       }
 
-      throw new Error(`Chat Completions → Messages translator does not accept ${(part as { type: string }).type} content parts.`);
+      throw new TranslatorInputError(`Chat Completions → Messages translator does not accept ${(part as { type: string }).type} content parts.`);
     }),
   );
 
@@ -97,7 +98,7 @@ const convertSystemContent = (content: ChatCompletionsMessage['content']): Messa
   const blocks: MessagesTextBlock[] = [];
   for (const part of content) {
     if (part.type === 'image_url') {
-      throw new Error('Chat Completions → Messages translator does not accept image content parts in system or developer messages — Anthropic Messages only permits text in the system field.');
+      throw new TranslatorInputError('Chat Completions → Messages translator does not accept image content parts in system or developer messages — Anthropic Messages only permits text in the system field.');
     }
     if (part.type === 'text') {
       blocks.push({ type: 'text', text: part.text });
@@ -123,7 +124,7 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       break;
     case 'tool':
       if (!message.tool_call_id) {
-        throw new Error('tool message requires tool_call_id for Messages translation');
+        throw new TranslatorInputError('tool message requires tool_call_id for Messages translation');
       }
 
       appendUserBlocks(result, [
@@ -151,7 +152,7 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       break;
     }
     default:
-      throw new Error(`Chat Completions → Messages translator does not accept ${message.role} messages.`);
+      throw new TranslatorInputError(`Chat Completions → Messages translator does not accept ${message.role} messages.`);
     }
   }
 

--- a/packages/translate/src/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/src/chat-completions-via-messages/request_test.ts
@@ -222,7 +222,7 @@ test('image content part in leading system message throws', async () => {
         }),
       ),
     Error,
-    'does not accept image content parts in system or developer messages',
+    "Invalid 'image_url' content part in system or developer message",
   );
 });
 
@@ -244,7 +244,7 @@ test('image content part in non-leading system message throws', async () => {
         }),
       ),
     Error,
-    'does not accept image content parts in system or developer messages',
+    "Invalid 'image_url' content part in system or developer message",
   );
 });
 
@@ -1255,7 +1255,7 @@ test('translateChatCompletionsToMessages rejects an unknown message role', async
         messages: [{ role: 'function', content: 'hi' } as unknown as ChatCompletionsMessage],
       }),
     Error,
-    'does not accept function messages',
+    "Invalid role 'function'",
   );
 });
 
@@ -1267,6 +1267,6 @@ test('translateChatCompletionsToMessages rejects an unknown user content part ty
         messages: [{ role: 'user', content: [{ type: 'video_url' }] } as unknown as ChatCompletionsMessage],
       }),
     Error,
-    'does not accept video_url content parts',
+    "Invalid 'video_url' content part",
   );
 });

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -97,11 +97,11 @@ export const translateChatCompletionsToResponses = (payload: ChatCompletionsPayl
     }
 
     if (message.role !== 'tool') {
-      throw new TranslatorInputError(`Chat Completions → Responses translator does not accept ${(message as { role: string }).role} messages.`);
+      throw new TranslatorInputError(`Invalid role '${(message as { role: string }).role}'.`);
     }
 
     if (!message.tool_call_id) {
-      throw new TranslatorInputError('tool message requires tool_call_id for Responses translation');
+      throw new TranslatorInputError("Missing required field 'tool_call_id' on a 'tool' role message.");
     }
 
     input.push({

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -1,5 +1,6 @@
 import { chatCompletionsContentToResponsesInputContent, chatCompletionsContentToText } from '../shared/chat-completions-and-responses/content.ts';
 import { scalarToResponsesReasoningItem, translateChatCompletionsReasoningItems } from '../shared/chat-completions-and-responses/reasoning.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
 import type { ResponsesInputItem, ResponsesInputReasoning, ResponsesPayload, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
@@ -96,11 +97,11 @@ export const translateChatCompletionsToResponses = (payload: ChatCompletionsPayl
     }
 
     if (message.role !== 'tool') {
-      throw new Error(`Chat Completions → Responses translator does not accept ${(message as { role: string }).role} messages.`);
+      throw new TranslatorInputError(`Chat Completions → Responses translator does not accept ${(message as { role: string }).role} messages.`);
     }
 
     if (!message.tool_call_id) {
-      throw new Error('tool message requires tool_call_id for Responses translation');
+      throw new TranslatorInputError('tool message requires tool_call_id for Responses translation');
     }
 
     input.push({

--- a/packages/translate/src/chat-completions-via-responses/request_test.ts
+++ b/packages/translate/src/chat-completions-via-responses/request_test.ts
@@ -428,6 +428,6 @@ test('translateChatCompletionsToResponses rejects an unknown message role', () =
         messages: [{ role: 'function', content: 'hi' } as unknown as ChatCompletionsMessage],
       }),
     Error,
-    'does not accept function messages',
+    "Invalid role 'function'",
   );
 });

--- a/packages/translate/src/gemini-via-chat-completions/request.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request.ts
@@ -12,6 +12,7 @@ import {
   type GeminiToolCallIds,
   geminiVisibleText,
 } from '../shared/gemini-via/gemini.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsContentPart, ChatCompletionsMessage, ChatCompletionsTool, ChatCompletionsToolCall } from '@floway-dev/protocols/chat-completions';
 import type { GeminiContent, GeminiPayload, GeminiGenerationConfig, GeminiPart } from '@floway-dev/protocols/gemini';
 
@@ -86,7 +87,7 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
       visibleParts.push(part);
       return;
     default:
-      throw new Error(`Gemini → Chat Completions translator does not accept ${kind} parts in model content.`);
+      throw new TranslatorInputError(`Gemini → Chat Completions translator does not accept ${kind} parts in model content.`);
     }
   });
 
@@ -138,7 +139,7 @@ const buildUserMessages = (content: GeminiContent, turnIndex: number, unmatchedT
       pendingParts.push(part);
       return;
     default:
-      throw new Error(`Gemini → Chat Completions translator does not accept ${kind} parts in user content.`);
+      throw new TranslatorInputError(`Gemini → Chat Completions translator does not accept ${kind} parts in user content.`);
     }
   });
 
@@ -228,7 +229,7 @@ export const buildTargetRequest = (payload: GeminiPayload, model: string): ChatC
       request.messages.push(...buildUserMessages(content, turnIndex, unmatchedToolCallIds));
       return;
     default:
-      throw new Error(`Gemini → Chat Completions translator does not accept ${(content as { role: string }).role} content roles.`);
+      throw new TranslatorInputError(`Gemini → Chat Completions translator does not accept ${(content as { role: string }).role} content roles.`);
     }
   });
 

--- a/packages/translate/src/gemini-via-chat-completions/request.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request.ts
@@ -87,7 +87,7 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
       visibleParts.push(part);
       return;
     default:
-      throw new TranslatorInputError(`Gemini → Chat Completions translator does not accept ${kind} parts in model content.`);
+      throw new TranslatorInputError(`"${kind}" parts are not supported in model content.`);
     }
   });
 
@@ -139,7 +139,7 @@ const buildUserMessages = (content: GeminiContent, turnIndex: number, unmatchedT
       pendingParts.push(part);
       return;
     default:
-      throw new TranslatorInputError(`Gemini → Chat Completions translator does not accept ${kind} parts in user content.`);
+      throw new TranslatorInputError(`"${kind}" parts are not supported in user content.`);
     }
   });
 
@@ -229,7 +229,7 @@ export const buildTargetRequest = (payload: GeminiPayload, model: string): ChatC
       request.messages.push(...buildUserMessages(content, turnIndex, unmatchedToolCallIds));
       return;
     default:
-      throw new TranslatorInputError(`Gemini → Chat Completions translator does not accept ${(content as { role: string }).role} content roles.`);
+      throw new TranslatorInputError(`"${(content as { role: string }).role}" is not a supported content role.`);
     }
   });
 

--- a/packages/translate/src/gemini-via-chat-completions/request_test.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request_test.ts
@@ -404,7 +404,7 @@ test('buildTargetRequest rejects an unknown content role', () => {
         'gpt-test',
       ),
     Error,
-    'does not accept system content roles',
+    '"system" is not a supported content role.',
   );
 });
 
@@ -418,7 +418,7 @@ test('buildTargetRequest rejects a part with an unsupported kind in user content
         'gpt-test',
       ),
     Error,
-    'does not accept executable_code parts in user content',
+    '"executable_code" parts are not supported in user content.',
   );
 });
 
@@ -432,7 +432,7 @@ test('buildTargetRequest rejects a function_call part in user content', () => {
         'gpt-test',
       ),
     Error,
-    'does not accept function_call parts in user content',
+    '"function_call" parts are not supported in user content.',
   );
 });
 
@@ -446,7 +446,7 @@ test('buildTargetRequest rejects a function_response part in model content', () 
         'gpt-test',
       ),
     Error,
-    'does not accept function_response parts in model content',
+    '"function_response" parts are not supported in model content.',
   );
 });
 

--- a/packages/translate/src/gemini-via-messages/request.ts
+++ b/packages/translate/src/gemini-via-messages/request.ts
@@ -13,6 +13,7 @@ import {
   geminiVisibleText,
 } from '../shared/gemini-via/gemini.ts';
 import { applyLastMessageCacheBreakpoint, applyLastToolCacheBreakpoint, EPHEMERAL_CACHE_CONTROL } from '../shared/via-messages/cache-breakpoints.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import type { GeminiContent, GeminiPayload, GeminiGenerationConfig, GeminiPart, GeminiThinkingConfig } from '@floway-dev/protocols/gemini';
 import {
   MESSAGES_FALLBACK_MAX_TOKENS,
@@ -66,7 +67,7 @@ const buildUserMessage = (content: GeminiContent, turnIndex: number, unmatchedTo
       return;
     }
     default:
-      throw new Error(`Gemini → Messages translator does not accept ${kind} parts in user content.`);
+      throw new TranslatorInputError(`Gemini → Messages translator does not accept ${kind} parts in user content.`);
     }
   });
 
@@ -136,7 +137,7 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
       return;
     }
     default:
-      throw new Error(`Gemini → Messages translator does not accept ${kind} parts in model content.`);
+      throw new TranslatorInputError(`Gemini → Messages translator does not accept ${kind} parts in model content.`);
     }
   });
 
@@ -253,7 +254,7 @@ export const buildTargetRequest = (
       message = buildUserMessage(content, turnIndex, unmatchedToolCallIds);
       break;
     default:
-      throw new Error(`Gemini → Messages translator does not accept ${(content as { role: string }).role} content roles.`);
+      throw new TranslatorInputError(`Gemini → Messages translator does not accept ${(content as { role: string }).role} content roles.`);
     }
     if (message) request.messages.push(message);
   });

--- a/packages/translate/src/gemini-via-messages/request.ts
+++ b/packages/translate/src/gemini-via-messages/request.ts
@@ -67,7 +67,7 @@ const buildUserMessage = (content: GeminiContent, turnIndex: number, unmatchedTo
       return;
     }
     default:
-      throw new TranslatorInputError(`Gemini → Messages translator does not accept ${kind} parts in user content.`);
+      throw new TranslatorInputError(`"${kind}" parts are not supported in user content.`);
     }
   });
 
@@ -137,7 +137,7 @@ const buildAssistantMessage = (content: GeminiContent, turnIndex: number, unmatc
       return;
     }
     default:
-      throw new TranslatorInputError(`Gemini → Messages translator does not accept ${kind} parts in model content.`);
+      throw new TranslatorInputError(`"${kind}" parts are not supported in model content.`);
     }
   });
 
@@ -255,7 +255,7 @@ export const buildTargetRequest = (
       message = buildUserMessage(content, turnIndex, unmatchedToolCallIds);
       break;
     default:
-      throw new TranslatorInputError(`Gemini → Messages translator does not accept ${(content as { role: string }).role} content roles.`);
+      throw new TranslatorInputError(`"${(content as { role: string }).role}" is not a supported content role.`);
     }
     if (message) request.messages.push(message);
   });

--- a/packages/translate/src/gemini-via-messages/request_test.ts
+++ b/packages/translate/src/gemini-via-messages/request_test.ts
@@ -327,7 +327,7 @@ test('buildTargetRequest rejects an unknown content role', () => {
         noOptions,
       ),
     Error,
-    'does not accept system content roles',
+    '"system" is not a supported content role.',
   );
 });
 
@@ -342,7 +342,7 @@ test('buildTargetRequest rejects a part with an unsupported kind in user content
         noOptions,
       ),
     Error,
-    'does not accept file_data parts in user content',
+    '"file_data" parts are not supported in user content.',
   );
 });
 
@@ -357,7 +357,7 @@ test('buildTargetRequest rejects a function_call part in user content', () => {
         noOptions,
       ),
     Error,
-    'does not accept function_call parts in user content',
+    '"function_call" parts are not supported in user content.',
   );
 });
 
@@ -372,7 +372,7 @@ test('buildTargetRequest rejects an inline_data part in model content', () => {
         noOptions,
       ),
     Error,
-    'does not accept inline_data parts in model content',
+    '"inline_data" parts are not supported in model content.',
   );
 });
 

--- a/packages/translate/src/gemini-via-responses/request.ts
+++ b/packages/translate/src/gemini-via-responses/request.ts
@@ -65,7 +65,7 @@ const buildUserInputItems = (content: GeminiContent, turnIndex: number, unmatche
       return;
     }
     default:
-      throw new TranslatorInputError(`Gemini → Responses translator does not accept ${kind} parts in user content.`);
+      throw new TranslatorInputError(`"${kind}" parts are not supported in user content.`);
     }
   });
 
@@ -110,7 +110,7 @@ const buildAssistantInputItems = (content: GeminiContent, turnIndex: number, unm
       return;
     }
     default:
-      throw new TranslatorInputError(`Gemini → Responses translator does not accept ${kind} parts in model content.`);
+      throw new TranslatorInputError(`"${kind}" parts are not supported in model content.`);
     }
   });
 
@@ -188,7 +188,7 @@ export const buildTargetRequest = (payload: GeminiPayload, model: string): Respo
       input.push(...buildUserInputItems(content, turnIndex, unmatchedToolCallIds));
       return;
     default:
-      throw new TranslatorInputError(`Gemini → Responses translator does not accept ${(content as { role: string }).role} content roles.`);
+      throw new TranslatorInputError(`"${(content as { role: string }).role}" is not a supported content role.`);
     }
   });
 

--- a/packages/translate/src/gemini-via-responses/request.ts
+++ b/packages/translate/src/gemini-via-responses/request.ts
@@ -13,6 +13,7 @@ import {
   type GeminiToolCallIds,
   geminiVisibleText,
 } from '../shared/gemini-via/gemini.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import type { GeminiContent, GeminiPayload, GeminiGenerationConfig, GeminiPart } from '@floway-dev/protocols/gemini';
 import type { ResponsesInputContent, ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
 
@@ -64,7 +65,7 @@ const buildUserInputItems = (content: GeminiContent, turnIndex: number, unmatche
       return;
     }
     default:
-      throw new Error(`Gemini → Responses translator does not accept ${kind} parts in user content.`);
+      throw new TranslatorInputError(`Gemini → Responses translator does not accept ${kind} parts in user content.`);
     }
   });
 
@@ -109,7 +110,7 @@ const buildAssistantInputItems = (content: GeminiContent, turnIndex: number, unm
       return;
     }
     default:
-      throw new Error(`Gemini → Responses translator does not accept ${kind} parts in model content.`);
+      throw new TranslatorInputError(`Gemini → Responses translator does not accept ${kind} parts in model content.`);
     }
   });
 
@@ -187,7 +188,7 @@ export const buildTargetRequest = (payload: GeminiPayload, model: string): Respo
       input.push(...buildUserInputItems(content, turnIndex, unmatchedToolCallIds));
       return;
     default:
-      throw new Error(`Gemini → Responses translator does not accept ${(content as { role: string }).role} content roles.`);
+      throw new TranslatorInputError(`Gemini → Responses translator does not accept ${(content as { role: string }).role} content roles.`);
     }
   });
 

--- a/packages/translate/src/gemini-via-responses/request_test.ts
+++ b/packages/translate/src/gemini-via-responses/request_test.ts
@@ -338,7 +338,7 @@ test('buildTargetRequest rejects an unknown content role', () => {
         'gpt-test',
       ),
     Error,
-    'does not accept tool content roles',
+    '"tool" is not a supported content role.',
   );
 });
 
@@ -352,7 +352,7 @@ test('buildTargetRequest rejects a part with an unsupported kind in user content
         'gpt-test',
       ),
     Error,
-    'does not accept code_execution_result parts in user content',
+    '"code_execution_result" parts are not supported in user content.',
   );
 });
 
@@ -366,7 +366,7 @@ test('buildTargetRequest rejects a function_call part in user content', () => {
         'gpt-test',
       ),
     Error,
-    'does not accept function_call parts in user content',
+    '"function_call" parts are not supported in user content.',
   );
 });
 
@@ -380,7 +380,7 @@ test('buildTargetRequest rejects an inline_data part in model content', () => {
         'gpt-test',
       ),
     Error,
-    'does not accept inline_data parts in model content',
+    '"inline_data" parts are not supported in model content.',
   );
 });
 

--- a/packages/translate/src/index.ts
+++ b/packages/translate/src/index.ts
@@ -9,3 +9,4 @@ export { translateGeminiViaResponses } from './gemini-via-responses/translate.ts
 export { translateGeminiViaChatCompletions } from './gemini-via-chat-completions/translate.ts';
 
 export type { TranslationContext } from './types.ts';
+export { TranslatorInputError } from './translator-input-error.ts';

--- a/packages/translate/src/messages-via-chat-completions/request.ts
+++ b/packages/translate/src/messages-via-chat-completions/request.ts
@@ -24,7 +24,7 @@ const toChatCompletionsContent = (content: string | MessagesUserContentBlock[] |
 
   for (const block of content) {
     if (block.type !== 'text' && block.type !== 'image') {
-      throw new TranslatorInputError(`Messages → Chat Completions translator does not accept ${block.type} content blocks in message content.`);
+      throw new TranslatorInputError(`messages.content.type: '${block.type}' content blocks are not supported on this model`);
     }
   }
 
@@ -203,7 +203,7 @@ const translateMessagesAssistant = (message: MessagesAssistantMessage): ChatComp
       });
       break;
     default:
-      throw new TranslatorInputError(`Messages → Chat Completions translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
+      throw new TranslatorInputError(`messages.content.type: '${(block as { type: string }).type}' assistant content blocks are not supported on this model`);
     }
   }
 
@@ -245,7 +245,7 @@ const translateMessagesInput = (messages: MessagesMessage[], system: string | Me
       case 'user': return translateMessagesUser(message);
       case 'assistant': return translateMessagesAssistant(message);
       case 'system': return translateMessagesSystem(message);
-      default: throw new TranslatorInputError(`Messages → Chat Completions translator does not accept role ${(message as { role: string }).role}.`);
+      default: throw new TranslatorInputError(`messages.role: role '${(message as { role: string }).role}' is not supported on this model`);
       }
     }),
   ];

--- a/packages/translate/src/messages-via-chat-completions/request.ts
+++ b/packages/translate/src/messages-via-chat-completions/request.ts
@@ -22,12 +22,6 @@ import type {
 const toChatCompletionsContent = (content: string | MessagesUserContentBlock[] | MessagesAssistantContentBlock[]): string | ChatCompletionsContentPart[] | null => {
   if (typeof content === 'string') return content;
 
-  for (const block of content) {
-    if (block.type !== 'text' && block.type !== 'image') {
-      throw new TranslatorInputError(`messages.content.type: '${block.type}' content blocks are not supported on this model`);
-    }
-  }
-
   if (!content.some(block => block.type === 'image')) {
     return content
       .filter((block): block is MessagesTextBlock => block.type === 'text')
@@ -120,7 +114,7 @@ const getClientTools = (tools?: MessagesPayload['tools']): MessagesClientTool[] 
   return clientTools?.length ? clientTools : undefined;
 };
 
-const translateMessagesUser = (message: MessagesUserMessage): ChatCompletionsMessage[] => {
+const translateMessagesUser = (message: MessagesUserMessage, messageIdx: number): ChatCompletionsMessage[] => {
   if (!Array.isArray(message.content)) {
     return [
       {
@@ -143,20 +137,24 @@ const translateMessagesUser = (message: MessagesUserMessage): ChatCompletionsMes
     pendingUserBlocks.length = 0;
   };
 
-  for (const block of message.content) {
-    if (block.type !== 'tool_result') {
-      pendingUserBlocks.push(block);
+  for (const [blockIdx, block] of message.content.entries()) {
+    if (block.type === 'tool_result') {
+      // Preserving source chronology matters more than keeping one Chat message,
+      // so interleaved user content and tool results become alternating messages.
+      flushPendingUserBlocks();
+      messages.push({
+        role: 'tool',
+        tool_call_id: block.tool_use_id,
+        content: toChatCompletionsToolResultContent(block.content),
+      });
       continue;
     }
 
-    // Preserving source chronology matters more than keeping one Chat message,
-    // so interleaved user content and tool results become alternating messages.
-    flushPendingUserBlocks();
-    messages.push({
-      role: 'tool',
-      tool_call_id: block.tool_use_id,
-      content: toChatCompletionsToolResultContent(block.content),
-    });
+    if (block.type !== 'text' && block.type !== 'image') {
+      throw new TranslatorInputError(`messages.${messageIdx}.content.${blockIdx}.type: '${(block as { type: string }).type}' content blocks are not supported on this model`);
+    }
+
+    pendingUserBlocks.push(block);
   }
 
   flushPendingUserBlocks();
@@ -164,7 +162,7 @@ const translateMessagesUser = (message: MessagesUserMessage): ChatCompletionsMes
   return messages;
 };
 
-const translateMessagesAssistant = (message: MessagesAssistantMessage): ChatCompletionsMessage[] => {
+const translateMessagesAssistant = (message: MessagesAssistantMessage, messageIdx: number): ChatCompletionsMessage[] => {
   if (!Array.isArray(message.content)) {
     return [
       {
@@ -181,7 +179,7 @@ const translateMessagesAssistant = (message: MessagesAssistantMessage): ChatComp
     scalarReasoning: null,
   };
 
-  for (const block of message.content) {
+  for (const [blockIdx, block] of message.content.entries()) {
     switch (block.type) {
     case 'text':
       pending.textParts.push(block.text);
@@ -203,7 +201,7 @@ const translateMessagesAssistant = (message: MessagesAssistantMessage): ChatComp
       });
       break;
     default:
-      throw new TranslatorInputError(`messages.content.type: '${(block as { type: string }).type}' assistant content blocks are not supported on this model`);
+      throw new TranslatorInputError(`messages.${messageIdx}.content.${blockIdx}.type: '${(block as { type: string }).type}' assistant content blocks are not supported on this model`);
     }
   }
 
@@ -240,12 +238,12 @@ const translateMessagesInput = (messages: MessagesMessage[], system: string | Me
 
   return [
     ...systemMessages,
-    ...messages.flatMap((message): ChatCompletionsMessage[] => {
+    ...messages.flatMap((message, messageIdx): ChatCompletionsMessage[] => {
       switch (message.role) {
-      case 'user': return translateMessagesUser(message);
-      case 'assistant': return translateMessagesAssistant(message);
+      case 'user': return translateMessagesUser(message, messageIdx);
+      case 'assistant': return translateMessagesAssistant(message, messageIdx);
       case 'system': return translateMessagesSystem(message);
-      default: throw new TranslatorInputError(`messages.role: role '${(message as { role: string }).role}' is not supported on this model`);
+      default: throw new TranslatorInputError(`messages.${messageIdx}.role: role '${(message as { role: string }).role}' is not supported on this model`);
       }
     }),
   ];

--- a/packages/translate/src/messages-via-chat-completions/request.ts
+++ b/packages/translate/src/messages-via-chat-completions/request.ts
@@ -2,6 +2,7 @@ import { type ChatCompletionsScalarReasoning, chatCompletionsScalarReasoningFrom
 import { openAiJsonSchemaCoreFromMessagesFormat } from '../shared/messages/structured-output.ts';
 import { resolveMessagesReasoningEffort } from '../shared/messages-via/reasoning-effort.ts';
 import { normalizeMessagesToolInputSchema } from '../shared/messages-via/tool-schema.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsContentPart, ChatCompletionsMessage, ChatCompletionsTool, ChatCompletionsToolCall } from '@floway-dev/protocols/chat-completions';
 import type {
   MessagesAssistantContentBlock,
@@ -23,7 +24,7 @@ const toChatCompletionsContent = (content: string | MessagesUserContentBlock[] |
 
   for (const block of content) {
     if (block.type !== 'text' && block.type !== 'image') {
-      throw new Error(`Messages → Chat Completions translator does not accept ${block.type} content blocks in message content.`);
+      throw new TranslatorInputError(`Messages → Chat Completions translator does not accept ${block.type} content blocks in message content.`);
     }
   }
 
@@ -202,7 +203,7 @@ const translateMessagesAssistant = (message: MessagesAssistantMessage): ChatComp
       });
       break;
     default:
-      throw new Error(`Messages → Chat Completions translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
+      throw new TranslatorInputError(`Messages → Chat Completions translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
     }
   }
 
@@ -244,7 +245,7 @@ const translateMessagesInput = (messages: MessagesMessage[], system: string | Me
       case 'user': return translateMessagesUser(message);
       case 'assistant': return translateMessagesAssistant(message);
       case 'system': return translateMessagesSystem(message);
-      default: throw new Error(`Messages → Chat Completions translator does not accept role ${(message as { role: string }).role}.`);
+      default: throw new TranslatorInputError(`Messages → Chat Completions translator does not accept role ${(message as { role: string }).role}.`);
       }
     }),
   ];

--- a/packages/translate/src/messages-via-chat-completions/request_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/request_test.ts
@@ -391,7 +391,7 @@ test('translateMessagesToChatCompletions rejects an unknown assistant content bl
         messages: [{ role: 'assistant', content: [{ type: 'audio' } as unknown as MessagesAssistantContentBlock] }],
       }),
     Error,
-    "'audio' assistant content blocks are not supported",
+    "messages.0.content.0.type: 'audio' assistant content blocks are not supported",
   );
 });
 
@@ -404,7 +404,7 @@ test('translateMessagesToChatCompletions rejects an unknown user content block t
         messages: [{ role: 'user', content: [{ type: 'audio' } as unknown as MessagesUserContentBlock] }],
       }),
     Error,
-    "'audio' content blocks are not supported",
+    "messages.0.content.0.type: 'audio' content blocks are not supported",
   );
 });
 
@@ -517,7 +517,7 @@ test('translateMessagesToChatCompletions rejects an unknown message role', () =>
         messages: [{ role: 'tool', content: 'oops' } as unknown as { role: 'user'; content: string }],
       }),
     Error,
-    "role 'tool' is not supported",
+    "messages.0.role: role 'tool' is not supported",
   );
 });
 

--- a/packages/translate/src/messages-via-chat-completions/request_test.ts
+++ b/packages/translate/src/messages-via-chat-completions/request_test.ts
@@ -391,7 +391,7 @@ test('translateMessagesToChatCompletions rejects an unknown assistant content bl
         messages: [{ role: 'assistant', content: [{ type: 'audio' } as unknown as MessagesAssistantContentBlock] }],
       }),
     Error,
-    'does not accept audio assistant content blocks',
+    "'audio' assistant content blocks are not supported",
   );
 });
 
@@ -404,7 +404,7 @@ test('translateMessagesToChatCompletions rejects an unknown user content block t
         messages: [{ role: 'user', content: [{ type: 'audio' } as unknown as MessagesUserContentBlock] }],
       }),
     Error,
-    'does not accept audio content blocks',
+    "'audio' content blocks are not supported",
   );
 });
 
@@ -517,7 +517,7 @@ test('translateMessagesToChatCompletions rejects an unknown message role', () =>
         messages: [{ role: 'tool', content: 'oops' } as unknown as { role: 'user'; content: string }],
       }),
     Error,
-    'does not accept role tool',
+    "role 'tool' is not supported",
   );
 });
 

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -35,7 +35,7 @@ const translateUserContentBlock = (block: Exclude<MessagesUserContentBlock, Mess
     };
   }
 
-  throw new TranslatorInputError(`Messages → Responses translator does not accept ${(block as { type: string }).type} user content blocks.`);
+  throw new TranslatorInputError(`messages.content.type: '${(block as { type: string }).type}' user content blocks are not supported on this model`);
 };
 
 const toResponsesToolResultOutput = (content: MessagesToolResultBlock['content']): string => {
@@ -135,7 +135,7 @@ const translateAssistantMessage = (message: MessagesAssistantMessage): Responses
       continue;
     }
 
-    throw new TranslatorInputError(`Messages → Responses translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
+    throw new TranslatorInputError(`messages.content.type: '${(block as { type: string }).type}' assistant content blocks are not supported on this model`);
   }
 
   flushPendingContent(pendingContent, input, 'assistant');
@@ -160,7 +160,7 @@ const translateMessagesInput = (messages: MessagesMessage[]): ResponsesInputItem
     case 'user': return translateUserMessage(message);
     case 'assistant': return translateAssistantMessage(message);
     case 'system': return translateMessagesSystem(message);
-    default: throw new TranslatorInputError(`Messages → Responses translator does not accept role ${(message as { role: string }).role}.`);
+    default: throw new TranslatorInputError(`messages.role: role '${(message as { role: string }).role}' is not supported on this model`);
     }
   });
 

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -2,6 +2,7 @@ import { openAiJsonSchemaCoreFromMessagesFormat } from '../shared/messages/struc
 import { messagesReasoningBlockToResponsesReasoning } from '../shared/messages-and-responses/reasoning.ts';
 import { resolveMessagesReasoningEffort } from '../shared/messages-via/reasoning-effort.ts';
 import { normalizeMessagesToolInputSchema } from '../shared/messages-via/tool-schema.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import {
   type MessagesAssistantMessage,
   type MessagesClientTool,
@@ -34,7 +35,7 @@ const translateUserContentBlock = (block: Exclude<MessagesUserContentBlock, Mess
     };
   }
 
-  throw new Error(`Messages → Responses translator does not accept ${(block as { type: string }).type} user content blocks.`);
+  throw new TranslatorInputError(`Messages → Responses translator does not accept ${(block as { type: string }).type} user content blocks.`);
 };
 
 const toResponsesToolResultOutput = (content: MessagesToolResultBlock['content']): string => {
@@ -134,7 +135,7 @@ const translateAssistantMessage = (message: MessagesAssistantMessage): Responses
       continue;
     }
 
-    throw new Error(`Messages → Responses translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
+    throw new TranslatorInputError(`Messages → Responses translator does not accept ${(block as { type: string }).type} assistant content blocks.`);
   }
 
   flushPendingContent(pendingContent, input, 'assistant');
@@ -155,7 +156,7 @@ const translateMessagesInput = (messages: MessagesMessage[]): ResponsesInputItem
     case 'user': return translateUserMessage(message);
     case 'assistant': return translateAssistantMessage(message);
     case 'system': return translateMessagesSystem(message);
-    default: throw new Error(`Messages → Responses translator does not accept role ${(message as { role: string }).role}.`);
+    default: throw new TranslatorInputError(`Messages → Responses translator does not accept role ${(message as { role: string }).role}.`);
     }
   });
 

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -25,7 +25,11 @@ const flushPendingContent = (pending: ResponsesInputContent[], input: ResponsesI
   pending.length = 0;
 };
 
-const translateUserContentBlock = (block: Exclude<MessagesUserContentBlock, MessagesToolResultBlock>): ResponsesInputContent => {
+const translateUserContentBlock = (
+  block: Exclude<MessagesUserContentBlock, MessagesToolResultBlock>,
+  messageIdx: number,
+  blockIdx: number,
+): ResponsesInputContent => {
   if (block.type === 'text') return { type: 'input_text', text: block.text };
   if (block.type === 'image') {
     return {
@@ -35,7 +39,7 @@ const translateUserContentBlock = (block: Exclude<MessagesUserContentBlock, Mess
     };
   }
 
-  throw new TranslatorInputError(`messages.content.type: '${(block as { type: string }).type}' user content blocks are not supported on this model`);
+  throw new TranslatorInputError(`messages.${messageIdx}.content.${blockIdx}.type: '${(block as { type: string }).type}' user content blocks are not supported on this model`);
 };
 
 const toResponsesToolResultOutput = (content: MessagesToolResultBlock['content']): string => {
@@ -73,7 +77,7 @@ const getClientTools = (tools?: MessagesPayload['tools']): MessagesClientTool[] 
   return clientTools.length > 0 ? clientTools : undefined;
 };
 
-const translateUserMessage = (message: MessagesUserMessage): ResponsesInputItem[] => {
+const translateUserMessage = (message: MessagesUserMessage, messageIdx: number): ResponsesInputItem[] => {
   if (typeof message.content === 'string') {
     return [{ type: 'message', role: 'user', content: message.content }];
   }
@@ -81,7 +85,7 @@ const translateUserMessage = (message: MessagesUserMessage): ResponsesInputItem[
   const input: ResponsesInputItem[] = [];
   const pendingContent: ResponsesInputContent[] = [];
 
-  for (const block of message.content) {
+  for (const [blockIdx, block] of message.content.entries()) {
     if (block.type === 'tool_result') {
       // Responses can represent alternating user content and tool outputs, so
       // preserve Messages block chronology instead of moving all tool results to
@@ -96,14 +100,14 @@ const translateUserMessage = (message: MessagesUserMessage): ResponsesInputItem[
       continue;
     }
 
-    pendingContent.push(translateUserContentBlock(block));
+    pendingContent.push(translateUserContentBlock(block, messageIdx, blockIdx));
   }
 
   flushPendingContent(pendingContent, input, 'user');
   return input;
 };
 
-const translateAssistantMessage = (message: MessagesAssistantMessage): ResponsesInputItem[] => {
+const translateAssistantMessage = (message: MessagesAssistantMessage, messageIdx: number): ResponsesInputItem[] => {
   if (typeof message.content === 'string') {
     return [{ type: 'message', role: 'assistant', content: message.content }];
   }
@@ -111,7 +115,7 @@ const translateAssistantMessage = (message: MessagesAssistantMessage): Responses
   const input: ResponsesInputItem[] = [];
   const pendingContent: ResponsesInputContent[] = [];
 
-  for (const block of message.content) {
+  for (const [blockIdx, block] of message.content.entries()) {
     if (block.type === 'tool_use' || block.type === 'server_tool_use') {
       flushPendingContent(pendingContent, input, 'assistant');
       input.push(toResponsesFunctionCall(block));
@@ -135,7 +139,7 @@ const translateAssistantMessage = (message: MessagesAssistantMessage): Responses
       continue;
     }
 
-    throw new TranslatorInputError(`messages.content.type: '${(block as { type: string }).type}' assistant content blocks are not supported on this model`);
+    throw new TranslatorInputError(`messages.${messageIdx}.content.${blockIdx}.type: '${(block as { type: string }).type}' assistant content blocks are not supported on this model`);
   }
 
   flushPendingContent(pendingContent, input, 'assistant');
@@ -155,12 +159,12 @@ const translateMessagesSystem = (message: MessagesSystemMessage): ResponsesInput
 ];
 
 const translateMessagesInput = (messages: MessagesMessage[]): ResponsesInputItem[] =>
-  messages.flatMap((message): ResponsesInputItem[] => {
+  messages.flatMap((message, messageIdx): ResponsesInputItem[] => {
     switch (message.role) {
-    case 'user': return translateUserMessage(message);
-    case 'assistant': return translateAssistantMessage(message);
+    case 'user': return translateUserMessage(message, messageIdx);
+    case 'assistant': return translateAssistantMessage(message, messageIdx);
     case 'system': return translateMessagesSystem(message);
-    default: throw new TranslatorInputError(`messages.role: role '${(message as { role: string }).role}' is not supported on this model`);
+    default: throw new TranslatorInputError(`messages.${messageIdx}.role: role '${(message as { role: string }).role}' is not supported on this model`);
     }
   });
 

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -435,7 +435,7 @@ test('translateMessagesToResponses rejects an unknown assistant content block ty
         messages: [{ role: 'assistant', content: [{ type: 'audio' } as unknown as MessagesAssistantContentBlock] }],
       }),
     Error,
-    'does not accept audio assistant content blocks',
+    "'audio' assistant content blocks are not supported",
   );
 });
 
@@ -448,7 +448,7 @@ test('translateMessagesToResponses rejects an unknown user content block type', 
         messages: [{ role: 'user', content: [{ type: 'audio' } as unknown as MessagesUserContentBlock] }],
       }),
     Error,
-    'does not accept audio user content blocks',
+    "'audio' user content blocks are not supported",
   );
 });
 
@@ -528,7 +528,7 @@ test('translateMessagesToResponses rejects an unknown message role', () => {
         messages: [{ role: 'tool', content: 'oops' } as unknown as { role: 'user'; content: string }],
       }),
     Error,
-    'does not accept role tool',
+    "role 'tool' is not supported",
   );
 });
 

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -435,7 +435,7 @@ test('translateMessagesToResponses rejects an unknown assistant content block ty
         messages: [{ role: 'assistant', content: [{ type: 'audio' } as unknown as MessagesAssistantContentBlock] }],
       }),
     Error,
-    "'audio' assistant content blocks are not supported",
+    "messages.0.content.0.type: 'audio' assistant content blocks are not supported",
   );
 });
 
@@ -448,7 +448,7 @@ test('translateMessagesToResponses rejects an unknown user content block type', 
         messages: [{ role: 'user', content: [{ type: 'audio' } as unknown as MessagesUserContentBlock] }],
       }),
     Error,
-    "'audio' user content blocks are not supported",
+    "messages.0.content.0.type: 'audio' user content blocks are not supported",
   );
 });
 
@@ -528,7 +528,7 @@ test('translateMessagesToResponses rejects an unknown message role', () => {
         messages: [{ role: 'tool', content: 'oops' } as unknown as { role: 'user'; content: string }],
       }),
     Error,
-    "role 'tool' is not supported",
+    "messages.0.role: role 'tool' is not supported",
   );
 });
 

--- a/packages/translate/src/responses-via-chat-completions/request.ts
+++ b/packages/translate/src/responses-via-chat-completions/request.ts
@@ -204,11 +204,11 @@ export const translateResponsesToChatCompletions = (payload: ResponsesPayload): 
       // translator runs. Reaching here means the reverse path was
       // skipped.
       if (item.type === 'web_search_call') {
-        throw new TranslatorInputError('Responses → Chat Completions translator does not accept web_search_call input items; their reverse-path translation must happen before this translator runs.');
+        throw new TranslatorInputError("Invalid input item type 'web_search_call'.");
       }
 
       if (item.type !== 'message') {
-        throw new TranslatorInputError(`Responses → Chat Completions translator does not accept ${item.type} input items.`);
+        throw new TranslatorInputError(`Invalid input item type '${item.type}'.`);
       }
 
       if (item.role === 'assistant') {

--- a/packages/translate/src/responses-via-chat-completions/request.ts
+++ b/packages/translate/src/responses-via-chat-completions/request.ts
@@ -1,6 +1,7 @@
 import { responsesContentToChatCompletionsContent, responsesContentToText } from '../shared/chat-completions-and-responses/content.ts';
 import { addResponsesReasoningToChatCompletionsProjection, type ChatCompletionsReasoningProjection, chatCompletionsReasoningProjectionFields, createChatCompletionsReasoningProjection } from '../shared/chat-completions-and-responses/reasoning.ts';
 import { buildCustomToolInputSchema } from '../shared/responses-via/custom-tool-wrap.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsMessage, ChatCompletionsTool, ChatCompletionsToolCall } from '@floway-dev/protocols/chat-completions';
 import type { ResponsesPayload, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
@@ -203,11 +204,11 @@ export const translateResponsesToChatCompletions = (payload: ResponsesPayload): 
       // translator runs. Reaching here means the reverse path was
       // skipped.
       if (item.type === 'web_search_call') {
-        throw new Error('Responses → Chat Completions translator does not accept web_search_call input items; their reverse-path translation must happen before this translator runs.');
+        throw new TranslatorInputError('Responses → Chat Completions translator does not accept web_search_call input items; their reverse-path translation must happen before this translator runs.');
       }
 
       if (item.type !== 'message') {
-        throw new Error(`Responses → Chat Completions translator does not accept ${item.type} input items.`);
+        throw new TranslatorInputError(`Responses → Chat Completions translator does not accept ${item.type} input items.`);
       }
 
       if (item.role === 'assistant') {

--- a/packages/translate/src/responses-via-chat-completions/request_test.ts
+++ b/packages/translate/src/responses-via-chat-completions/request_test.ts
@@ -1419,7 +1419,7 @@ test('translateResponsesToChatCompletions throws on a stray web_search_call inpu
       parallel_tool_calls: true,
     }),
     Error,
-    'Responses → Chat Completions translator does not accept web_search_call input items',
+    "Invalid input item type 'web_search_call'",
   );
 });
 
@@ -1447,7 +1447,7 @@ test('translateResponsesToChatCompletions throws on a stray compaction_trigger i
       parallel_tool_calls: true,
     }),
     Error,
-    'Responses → Chat Completions translator does not accept compaction_trigger input items',
+    "Invalid input item type 'compaction_trigger'",
   );
 });
 
@@ -1475,7 +1475,7 @@ test('translateResponsesToChatCompletions throws on a stray compaction input ite
       parallel_tool_calls: true,
     }),
     Error,
-    'Responses → Chat Completions translator does not accept compaction input items',
+    "Invalid input item type 'compaction'",
   );
 });
 

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -121,14 +121,14 @@ const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBloc
   const blocks: MessagesTextBlock[] = [];
   for (const block of message.content) {
     if (block.type === 'input_image') {
-      throw new TranslatorInputError(`Responses → Messages translator does not accept image content parts in ${message.role} messages — Anthropic Messages only permits text in the system field.`);
+      throw new TranslatorInputError(`Invalid 'input_image' content part in ${message.role} message. Only 'input_text' content parts are supported in ${message.role} messages on this model.`);
     }
     if (block.type !== 'input_text' && block.type !== 'output_text') {
       // Exhaustiveness guard: today ResponsesInputContent is
       // input_text|input_image|output_text; a future variant must opt into
       // translator behavior rather than be silently dropped from system
       // content.
-      throw new TranslatorInputError(`Responses → Messages translator: unexpected content block variant ${(block as { type: string }).type} in ${message.role} message.`);
+      throw new TranslatorInputError(`Invalid content block type '${(block as { type: string }).type}' in ${message.role} message.`);
     }
     blocks.push({ type: 'text', text: block.text });
   }
@@ -170,7 +170,7 @@ const appendUserBlock = (messages: MessagesMessage[], block: MessagesToolResultB
 };
 
 const unexpectedResponsesInputItem = (value: ResponsesInputItem): never => {
-  throw new TranslatorInputError(`Unexpected Responses input item variant: ${JSON.stringify(value)}`);
+  throw new TranslatorInputError(`Invalid input item: ${JSON.stringify(value)}`);
 };
 
 const translateResponsesInput = async (input: string | ResponsesInputItem[], loadRemoteImage: RemoteImageLoader): Promise<{ messages: MessagesMessage[]; systemBlocks: MessagesTextBlock[] }> => {
@@ -210,7 +210,7 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
         messages.push(translateSystemMessage(item));
         break;
       default:
-        throw new TranslatorInputError(`Responses → Messages translator: unexpected message role ${(item as { role: string }).role}.`);
+        throw new TranslatorInputError(`Invalid role '${(item as { role: string }).role}' in input message.`);
       }
       break;
     case 'function_call':
@@ -260,9 +260,9 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
       // into function_call + function_call_output pairs before this
       // translator runs. Reaching here means the reverse path was
       // skipped.
-      throw new TranslatorInputError('Responses → Messages translator does not accept web_search_call input items; their reverse-path translation must happen before this translator runs.');
+      throw new TranslatorInputError("Invalid input item type 'web_search_call'.");
     case 'image_generation_call':
-      throw new TranslatorInputError('Responses → Messages translator does not accept image_generation_call input items until item-by-id image storage is available.');
+      throw new TranslatorInputError("Invalid input item type 'image_generation_call'.");
     default:
       // Exhaustiveness guard: a future ResponsesInputItem variant must
       // explicitly opt into translator behavior.

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -3,6 +3,7 @@ import { responsesReasoningToMessagesUpstreamBlock } from '../shared/messages-an
 import { buildCustomToolInputSchema } from '../shared/responses-via/custom-tool-wrap.ts';
 import { applyLastMessageCacheBreakpoint, applyLastSystemCacheBreakpoint, applyLastToolCacheBreakpoint } from '../shared/via-messages/cache-breakpoints.ts';
 import { fetchRemoteImage, type RemoteImageLoader, resolveImageUrlToMessagesImage } from '../shared/via-messages/remote-images.ts';
+import { TranslatorInputError } from '../translator-input-error.ts';
 import {
   MESSAGES_FALLBACK_MAX_TOKENS,
   type MessagesAssistantContentBlock,
@@ -120,14 +121,14 @@ const responsesSystemBlocks = (message: ResponsesInputMessage): MessagesTextBloc
   const blocks: MessagesTextBlock[] = [];
   for (const block of message.content) {
     if (block.type === 'input_image') {
-      throw new Error(`Responses → Messages translator does not accept image content parts in ${message.role} messages — Anthropic Messages only permits text in the system field.`);
+      throw new TranslatorInputError(`Responses → Messages translator does not accept image content parts in ${message.role} messages — Anthropic Messages only permits text in the system field.`);
     }
     if (block.type !== 'input_text' && block.type !== 'output_text') {
       // Exhaustiveness guard: today ResponsesInputContent is
       // input_text|input_image|output_text; a future variant must opt into
       // translator behavior rather than be silently dropped from system
       // content.
-      throw new Error(`Responses → Messages translator: unexpected content block variant ${(block as { type: string }).type} in ${message.role} message.`);
+      throw new TranslatorInputError(`Responses → Messages translator: unexpected content block variant ${(block as { type: string }).type} in ${message.role} message.`);
     }
     blocks.push({ type: 'text', text: block.text });
   }
@@ -169,7 +170,7 @@ const appendUserBlock = (messages: MessagesMessage[], block: MessagesToolResultB
 };
 
 const unexpectedResponsesInputItem = (value: ResponsesInputItem): never => {
-  throw new Error(`Unexpected Responses input item variant: ${JSON.stringify(value)}`);
+  throw new TranslatorInputError(`Unexpected Responses input item variant: ${JSON.stringify(value)}`);
 };
 
 const translateResponsesInput = async (input: string | ResponsesInputItem[], loadRemoteImage: RemoteImageLoader): Promise<{ messages: MessagesMessage[]; systemBlocks: MessagesTextBlock[] }> => {
@@ -209,7 +210,7 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
         messages.push(translateSystemMessage(item));
         break;
       default:
-        throw new Error(`Responses → Messages translator: unexpected message role ${(item as { role: string }).role}.`);
+        throw new TranslatorInputError(`Responses → Messages translator: unexpected message role ${(item as { role: string }).role}.`);
       }
       break;
     case 'function_call':
@@ -259,9 +260,9 @@ const translateResponsesInput = async (input: string | ResponsesInputItem[], loa
       // into function_call + function_call_output pairs before this
       // translator runs. Reaching here means the reverse path was
       // skipped.
-      throw new Error('Responses → Messages translator does not accept web_search_call input items; their reverse-path translation must happen before this translator runs.');
+      throw new TranslatorInputError('Responses → Messages translator does not accept web_search_call input items; their reverse-path translation must happen before this translator runs.');
     case 'image_generation_call':
-      throw new Error('Responses → Messages translator does not accept image_generation_call input items until item-by-id image storage is available.');
+      throw new TranslatorInputError('Responses → Messages translator does not accept image_generation_call input items until item-by-id image storage is available.');
     default:
       // Exhaustiveness guard: a future ResponsesInputItem variant must
       // explicitly opt into translator behavior.

--- a/packages/translate/src/responses-via-messages/request_test.ts
+++ b/packages/translate/src/responses-via-messages/request_test.ts
@@ -501,7 +501,7 @@ test('translateResponsesToMessages throws on a stray web_search_call input item 
       parallel_tool_calls: true,
     }),
     Error,
-    'Responses → Messages translator does not accept web_search_call input items',
+    "Invalid input item type 'web_search_call'",
   );
 });
 
@@ -529,7 +529,7 @@ test('translateResponsesToMessages throws on a stray compaction_trigger input it
       parallel_tool_calls: true,
     }),
     Error,
-    'Unexpected Responses input item variant',
+    'Invalid input item:',
   );
 });
 
@@ -557,7 +557,7 @@ test('translateResponsesToMessages throws on a stray compaction input item (comp
       parallel_tool_calls: true,
     }),
     Error,
-    'Unexpected Responses input item variant',
+    'Invalid input item:',
   );
 });
 
@@ -808,7 +808,7 @@ test('translateResponsesToMessages throws when a system input message contains a
         { loadRemoteImage: stubRemoteImageLoader(null) },
       ),
     Error,
-    'does not accept image content parts in system messages',
+    "Invalid 'input_image' content part in system message",
   );
 });
 
@@ -843,6 +843,6 @@ test('translateResponsesToMessages throws when a non-leading developer input mes
         { loadRemoteImage: stubRemoteImageLoader(null) },
       ),
     Error,
-    'does not accept image content parts in developer messages',
+    "Invalid 'input_image' content part in developer message",
   );
 });

--- a/packages/translate/src/translator-input-error.ts
+++ b/packages/translate/src/translator-input-error.ts
@@ -1,0 +1,17 @@
+// A caller-input validation failure surfaced by a translator: the caller
+// sent something the target protocol cannot represent (an unsupported
+// content-part type, a role the target does not accept, a missing field
+// the target requires, etc.). Distinct from a plain `Error` so the
+// data-plane http handlers can return a protocol-shaped 400 envelope
+// instead of routing the failure through the generic internal-error 502
+// path. The optional `param` follows the OpenAI / Anthropic error-body
+// convention for naming the offending caller-visible field.
+export class TranslatorInputError extends Error {
+  readonly param: string | undefined;
+
+  constructor(message: string, options?: { param?: string }) {
+    super(message);
+    this.name = 'TranslatorInputError';
+    this.param = options?.param;
+  }
+}


### PR DESCRIPTION
## Summary

Translators throw on caller-input violations the target protocol cannot represent — an unsupported content-part type, a role the target rejects, a missing `tool_call_id`, image content in Anthropic's `system` field, and so on. Every such throw used to be a bare `new Error(...)` that fell through to each protocol's generic internal-error path and surfaced to the caller as a 502 envelope with a debug stack. That is the wrong status class for a caller-side input bug and the stack is not useful to clients.

This PR introduces a typed `TranslatorInputError` exported from `@floway-dev/translate` and migrates every existing caller-input throw across the nine translator pairs (chat-completions, responses, messages, and gemini sources crossing chat-completions, messages, and responses targets) to throw the typed error. Upstream-stream protocol violations (`UPSTREAM_*_MISSING_TERMINAL_MESSAGE`, `Upstream X stream error`, etc.) stay as plain `Error` — those are not caller-input issues.

Each protocol data-plane HTTP handler (`messages`, `chat-completions`, `responses`, `gemini`) catches `TranslatorInputError` and emits a 400 body shaped per the caller's protocol — verified against direct upstream probes so the body is byte-faithful:

- **Anthropic Messages (`/v1/messages`)** — `{type:"error", error:{type:"invalid_request_error", message}, request_id}`, with `request_id` minted as `req_<24 hex>` matching Anthropic's own ID format (top-level, not nested in `error`).
- **OpenAI Chat Completions (`/chat/completions`)** — `{error:{message, type:"invalid_request_error", param, code:null}}`. `param` defaults to `"messages"`; the translator can pass a more specific path via `TranslatorInputError`'s optional `param`.
- **OpenAI Responses (`/responses`)** — same OpenAI envelope with `param` defaulting to `"input"`.
- **Google Gemini (`/v1beta/models/*`)** — `{error:{code:400, message, status:"INVALID_ARGUMENT"}}` per Google RPC Status convention.

Each protocol's `errors.ts` owns its `translatorInputErrorResult` helper; the catch path in the corresponding `http.ts` checks `instanceof TranslatorInputError` first and falls through to the existing internal-error path for anything else. The dispatch lives inline in the catch block — there's no single-use wrapper helper indirection.

Throw messages are rewritten in the caller's protocol voice (no gateway-internal phrasing like "Chat Completions → Messages translator"): Pydantic-style `<field.path>: <reason>` for Anthropic Messages, OpenAI's flat-prose style for Chat Completions and Responses, terse period-ended sentences for Gemini. Anthropic-voice paths carry numeric indices in the upstream `messages.0.content.1.type` form, with `messageIdx` and `blockIdx` threaded through `messages-via-chat-completions` and `messages-via-responses` from the outer `flatMap` and inner `entries()` so the path identifies the exact failing array entry.

In `messages-via-chat-completions`, user-block type validation moved out of `toChatCompletionsContent` and into the outer iteration in `translateMessagesUser` — the helper was called with `pendingUserBlocks` (a filtered subset), so a blockIdx tracked inside it would not align with the original `message.content` position. Validating at the outer loop preserves the source-order index and removes a now-unreachable branch from the helper.

## Test plan

- [x] `pnpm --filter @floway-dev/translate run test` — 425 tests pass
- [x] `pnpm --filter @floway-dev/gateway exec vitest run` — 1486 tests pass (new `errors_test.ts` per protocol covers envelope shape, status, `param` defaults, and explicit-param honoring)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 3549 tests pass, zero regressions
- [x] `pnpm run lint` — clean