### PR TITLE
chore(translate): route gemini-via-messages system through applyLastSystemCacheBreakpoint

### DIFF
--- a/packages/translate/src/gemini-via-messages/request.ts
+++ b/packages/translate/src/gemini-via-messages/request.ts
@@ -12,7 +12,7 @@ import {
   type GeminiToolCallIds,
   geminiVisibleText,
 } from '../shared/gemini-via/gemini.ts';
-import { applyLastMessageCacheBreakpoint, applyLastToolCacheBreakpoint, EPHEMERAL_CACHE_CONTROL } from '../shared/via-messages/cache-breakpoints.ts';
+import { applyLastMessageCacheBreakpoint, applyLastSystemCacheBreakpoint, applyLastToolCacheBreakpoint } from '../shared/via-messages/cache-breakpoints.ts';
 import type { GeminiContent, GeminiPayload, GeminiGenerationConfig, GeminiPart, GeminiThinkingConfig } from '@floway-dev/protocols/gemini';
 import {
   MESSAGES_FALLBACK_MAX_TOKENS,
@@ -238,8 +238,9 @@ export const buildTargetRequest = (
 
   const system = geminiText(payload.systemInstruction);
   if (system !== null) {
-    const systemBlock: MessagesTextBlock = { type: 'text', text: system, cache_control: EPHEMERAL_CACHE_CONTROL };
-    request.system = [systemBlock];
+    const systemBlocks: MessagesTextBlock[] = [{ type: 'text', text: system }];
+    applyLastSystemCacheBreakpoint(systemBlocks);
+    request.system = systemBlocks;
   }
 
   payload.contents?.forEach((content, turnIndex) => {


### PR DESCRIPTION
## Summary

The other two `*-via-messages` translators (chat-completions and responses) go through the shared `applyLastSystemCacheBreakpoint` helper for the ephemeral cache breakpoint placement on `MessagesPayload.system`; only `gemini-via-messages` still hand-rolled its own `cache_control: EPHEMERAL_CACHE_CONTROL` on the constructed text block. Switch it to the helper so all three forward translators share one breakpoint policy, and drop the now-unused `EPHEMERAL_CACHE_CONTROL` direct import.

No behavior change — the helper sets the same ephemeral breakpoint on the same block, just through the shared file-private constant.

## Test plan

- [x] `pnpm --filter @floway-dev/translate run test` — 422 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 3542 tests pass, zero regressions
- [x] `pnpm run lint` — clean