### PR TITLE
refactor(translate): preserve system block boundaries on Messages → Responses round trip

### DIFF
--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -141,11 +141,15 @@ const translateAssistantMessage = (message: MessagesAssistantMessage): Responses
   return input;
 };
 
+// Preserve per-block boundaries when the source carries a
+// MessagesTextBlock[]; single-string source stays as string content.
 const translateMessagesSystem = (message: MessagesSystemMessage): ResponsesInputItem[] => [
   {
     type: 'message',
     role: 'system',
-    content: typeof message.content === 'string' ? message.content : message.content.map(block => block.text).join('\n\n'),
+    content: typeof message.content === 'string'
+      ? message.content
+      : message.content.map(block => ({ type: 'input_text', text: block.text })),
   },
 ];
 
@@ -159,14 +163,32 @@ const translateMessagesInput = (messages: MessagesMessage[]): ResponsesInputItem
     }
   });
 
-const translateSystemPrompt = (system: string | MessagesTextBlock[] | undefined): string | null => {
-  if (typeof system === 'string') return system;
-  if (!system) return null;
+// Responses' `instructions` field is `string | null` — it cannot carry
+// multiple text blocks faithfully. When the source `MessagesPayload.system`
+// is a single string or a single block, the canonical `instructions` slot
+// is the right home. When the source is a multi-block array, the canonical
+// slot would silently merge the boundaries, so emit a leading input
+// system message with multi-part `input_text` content instead and leave
+// `instructions` null; both placements act as a system prompt prefix at
+// the upstream and the multi-part form preserves the caller-visible block
+// structure.
+interface SystemPlacement {
+  readonly instructions: string | null;
+  readonly prependItems: readonly ResponsesInputItem[];
+}
 
-  // Messages system blocks are prompt boundaries. Keep paragraph separation on
-  // OpenAI fallbacks instead of collapsing headings or lists with spaces.
-  const text = system.map(block => block.text).join('\n\n');
-  return text.length > 0 ? text : null;
+const placeMessagesSystem = (system: string | MessagesTextBlock[] | undefined): SystemPlacement => {
+  if (typeof system === 'string') return { instructions: system, prependItems: [] };
+  if (!system || system.length === 0) return { instructions: null, prependItems: [] };
+  if (system.length === 1) return { instructions: system[0].text, prependItems: [] };
+  return {
+    instructions: null,
+    prependItems: [{
+      type: 'message',
+      role: 'system',
+      content: system.map(block => ({ type: 'input_text', text: block.text })),
+    }],
+  };
 };
 
 const translateTools = (tools: MessagesClientTool[] | undefined): ResponsesTool[] | null => {
@@ -209,7 +231,7 @@ export const translateMessagesToResponses = (payload: MessagesPayload): Response
   const effort = resolveMessagesReasoningEffort(payload);
   const reasoning = effort ? { effort } : undefined;
   const clientTools = getClientTools(payload.tools);
-  const instructions = translateSystemPrompt(payload.system);
+  const { instructions, prependItems } = placeMessagesSystem(payload.system);
   const jsonSchema = openAiJsonSchemaCoreFromMessagesFormat(payload.output_config?.format);
   const text = jsonSchema ? { format: { type: 'json_schema' as const, ...jsonSchema } } : undefined;
 
@@ -224,7 +246,7 @@ export const translateMessagesToResponses = (payload: MessagesPayload): Response
   // Messages source did not express those knobs.
   return {
     model: payload.model,
-    input: translateMessagesInput(payload.messages),
+    input: [...prependItems, ...translateMessagesInput(payload.messages)],
     ...(instructions !== null ? { instructions } : {}),
     ...(payload.temperature !== undefined ? { temperature: payload.temperature } : {}),
     ...(payload.top_p !== undefined ? { top_p: payload.top_p } : {}),

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -234,7 +234,7 @@ test('translateMessagesToResponses omits temperature when the source omitted it'
   assertFalse('temperature' in result);
 });
 
-test('translateMessagesToResponses joins multi-block system text with double newlines', () => {
+test('translateMessagesToResponses prepends multi-block top-level system as a leading input system message preserving block boundaries', () => {
   const result = translateMessagesToResponses({
     model: 'gpt-test',
     max_tokens: 256,
@@ -245,7 +245,29 @@ test('translateMessagesToResponses joins multi-block system text with double new
     messages: [{ role: 'user', content: 'hi' }],
   });
 
-  assertEquals(result.instructions, 'Alpha\n\nBeta');
+  assertFalse('instructions' in result);
+  const input = result.input as Array<{ type: string; role?: string; content?: unknown }>;
+  assertEquals(input[0], {
+    type: 'message',
+    role: 'system',
+    content: [
+      { type: 'input_text', text: 'Alpha' },
+      { type: 'input_text', text: 'Beta' },
+    ],
+  });
+});
+
+test('translateMessagesToResponses keeps a single-block top-level system in canonical `instructions` slot', () => {
+  const result = translateMessagesToResponses({
+    model: 'gpt-test',
+    max_tokens: 256,
+    system: [{ type: 'text', text: 'You are helpful.' }],
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertEquals(result.instructions, 'You are helpful.');
+  const input = result.input as Array<{ type: string; role?: string }>;
+  assertEquals(input[0].role, 'user');
 });
 
 test('translateMessagesToResponses preserves redacted_thinking as a native-signature reasoning item', () => {
@@ -448,7 +470,7 @@ test('translateMessagesToResponses emits in-array role:"system" inline as a Resp
   assertEquals(input[2].role, 'user');
 });
 
-test('translateMessagesToResponses joins in-array system text blocks with double newline', () => {
+test('translateMessagesToResponses preserves in-array system text blocks as separate input_text parts', () => {
   const result = translateMessagesToResponses({
     model: 'gpt-test',
     max_tokens: 256,
@@ -465,7 +487,14 @@ test('translateMessagesToResponses joins in-array system text blocks with double
   });
 
   const input = result.input as Array<{ type: string; role?: string; content?: unknown }>;
-  assertEquals(input[0], { type: 'message', role: 'system', content: 'Para A\n\nPara B' });
+  assertEquals(input[0], {
+    type: 'message',
+    role: 'system',
+    content: [
+      { type: 'input_text', text: 'Para A' },
+      { type: 'input_text', text: 'Para B' },
+    ],
+  });
 });
 
 test('translateMessagesToResponses preserves chronology of multiple in-array system messages', () => {


### PR DESCRIPTION
## Summary

The Messages → Responses translator collapsed multi-block `MessagesPayload.system` and inline `MessagesSystemMessage` content with a `\n\n` join, dropping the per-block boundaries the caller carries on the wire. The forward direction (`responses-via-messages`) already preserves these boundaries by emitting separate `MessagesTextBlock` entries; the reverse direction is now symmetric.

Inline `MessagesSystemMessage` (non-leading `role:'system'` carried through the messages array) with multi-block content now becomes a Responses input system message whose `content` is a `ResponsesInputContent[]` of `input_text` parts — one part per source block — rather than a single `\n\n`-joined string. Single-string source content unchanged.

Top-level `MessagesPayload.system` is trickier because Responses' canonical `instructions` slot is `string | null`. Single-string and single-block sources stay in `instructions` (canonical placement, no boundaries to preserve). Multi-block sources move to a leading input system message prepended to `input` with multi-part `input_text` content, with `instructions` left null; both placements act as a system prompt prefix at the upstream and the multi-part form preserves the caller-visible block structure that `instructions` cannot represent.

The two existing tests that asserted the `\n\n`-join behavior on the inline and top-level paths are replaced by tests asserting per-part preservation; a new test covers the single-block top-level path remaining in `instructions`.

## Test plan

- [x] `pnpm --filter @floway-dev/translate run test` — 425 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 3543 tests pass, zero regressions
- [x] `pnpm run lint` — clean