### PR TITLE
cleanup(resolve): retire stale 'binding' narration and other resolver-layer docs polish

### DIFF
--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -120,19 +120,24 @@ Steps:
    normalization hook above the catalog; an upstream that wants the
    gateway to accept a non-listed alternate id must list it in its
    catalog.
-4. **Kind-filter** the resolved set: keep only entries whose
+4. If the resolved set is empty **and** the inbound id matches
+   `-\d{8}$`, strip the eight-digit dated suffix and rerun steps 2–3
+   once against the stripped id. The retry is bounded to one iteration;
+   a second dated suffix on the stripped id is not stripped again. The
+   gate runs on the pre-kind-filter raw resolution: if any upstream's
+   catalog already lists the dated id verbatim (at any kind), the
+   strip-and-retry never fires.
+5. **Kind-filter** the surviving resolved set: keep only entries whose
    `model.kind === inboundKind`. No endpoint-level capability check
    happens here.
-5. If the resolved set is non-empty, return the candidates plus
-   `sawModel: true` and `failedUpstreams`.
-6. If the resolved set is empty **and** the inbound id matches `-\d{8}$`,
-   strip the eight-digit dated suffix and rerun steps 2–5 once against
-   the stripped id. The retry is bounded to one iteration; a second
-   dated suffix on the stripped id is not stripped again.
-7. If both attempts produce zero candidates, return `sawModel:
-   false` with the union of `failedUpstreams` seen across the
-   attempts. The caller renders a 404 / 400 with the standard wording
-   plus the failed-upstreams parenthetical.
+6. Return the kind-filtered candidates plus `sawModel` (true iff the
+   raw resolution from steps 2–4 produced at least one match, of any
+   kind) and `failedUpstreams` (deduped union across both attempts when
+   the retry fired). When both attempts produce zero raw resolutions
+   the caller renders a 404 with the standard wording; when raw
+   resolutions exist but kind-filter rejects them all the caller
+   renders a 400 "model does not support this endpoint" with the same
+   failed-upstreams parenthetical.
 
 The dated-suffix fallback exists for clients that pin to a vendor's dated
 release id (typical for Anthropic-style `claude-sonnet-4-5-20250929`)

--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -1,0 +1,252 @@
+# Model Resolution
+
+This document describes how the gateway turns an inbound `model` string into a
+provider candidate the dispatch layer can call. Three concerns are kept apart:
+
+- **Catalog assembly** — every enabled upstream's catalog is collapsed into
+  one gateway-wide list of public model ids keyed by public id, with a
+  reverse index of which upstream instances expose each id.
+- **Resolution** — an inbound `model` string is matched against the catalog
+  to produce a flat list of `(provider, model)` candidates, kind-filtered
+  against the inbound endpoint kind. This step never inspects per-endpoint
+  capabilities.
+- **Endpoint selection** — when a candidate is actually dispatched, the
+  attempt layer reads `model.endpoints` and picks a target protocol from
+  its inbound-protocol preference table. A candidate that cannot serve the
+  current operation falls over to the next candidate.
+
+## Catalog Assembly
+
+Inputs: the operator's enabled upstreams (filtered to the caller's effective
+scope when one is set), each upstream's SWR-cached `getProvidedModels`
+output, and each upstream's `modelPrefix` policy.
+
+For every upstream model entry, one or more catalog entries are emitted:
+
+- If the upstream has no `modelPrefix`, one entry is emitted at the model's
+  bare id.
+- If the upstream has a `modelPrefix` with `listed` surfaces, one entry is
+  emitted per surface (`unprefixed`, `prefixed`, or both). The prefixed
+  surface clones the upstream model with the rewritten id and synthesizes
+  `display_name: "<upstreamName>: <originalName>"` so the dashboard tells
+  the operator which upstream a prefixed id came from. `providerData` is
+  preserved by the clone — the per-provider wire-call still reads the
+  real upstream model id from there.
+
+Operator-disabled public ids vanish for that upstream before the entries
+are emitted, so a disabled `gpt-4o` hides both `gpt-4o` and
+`<prefix>gpt-4o` from the upstream's contribution. The disable does not
+cascade to other upstreams.
+
+When two upstreams emit an entry under the same public id, the first wins
+for metadata and the later one **endpoint-unions** into it. The merged
+`endpoints` is the OR of the participants' endpoint capability flags, and
+`kind` is recomputed from the union. Runtime dispatch still uses each
+upstream's own `UpstreamModel`, so capability-sensitive calls do not
+depend on the merged view.
+
+Catalog assembly returns two artefacts together:
+
+- `models: CatalogModel[]` — public-id-keyed metadata (`InternalModel`
+  fields plus the merged `endpoints`). `toPublicModel` projects each row
+  onto the wire DTO at `/v1/models` and `/models`.
+- `upstreamsByPublicId: Map<string, ModelProviderInstance[]>` — every
+  upstream instance that emitted an entry under the given public id, in
+  enumeration order. Resolution reads this to know which upstreams can
+  serve a given inbound id without re-walking the catalog.
+
+Output ordering: the public-facing list is sorted by `compareModelIds`
+before it crosses any gateway boundary — `/v1/models`, `/models`,
+`/v1beta/models`, and the control-plane catalog endpoint.
+
+Failed-upstream surfacing: a catalog fetch that rejects with `AbortError`
+propagates so the per-request abort signal cannot be masked by a slow
+upstream. Any other rejection is captured into the assembly's
+`failedUpstreams: string[]`, which the per-request resolver later inlines
+into 404 / 400 wording so the client sees parenthetical names of the
+upstreams whose catalog was unreachable this round.
+
+## Addressable Surfaces
+
+`modelPrefix.addressable` controls which inbound id forms an upstream
+**accepts** at resolution time, independent of which forms it `listed` at
+catalog assembly time:
+
+- `[unprefixed]` — the inbound id is looked up verbatim against the
+  upstream's catalog.
+- `[prefixed]` — the inbound id is accepted only if it starts with the
+  configured prefix, and the lookup uses `inbound.slice(prefix.length)`.
+- `[unprefixed, prefixed]` — both interpretations are tried; the
+  unprefixed interpretation is enumerated first, so when both succeed the
+  bare lookup wins ordering ties.
+
+A single inbound id can therefore produce **two interpretations against
+the same upstream** when both surfaces are addressable and the inbound id
+literally starts with the configured prefix. Each interpretation is its
+own catalog lookup and yields its own candidate; no deduplication is
+performed.
+
+An upstream with no `modelPrefix` is implicitly fully unprefixed.
+
+## Resolution
+
+The per-request resolver runs once at the data-plane entry point and
+produces the candidate list every dispatch layer reads.
+
+Inputs:
+
+- `model` — the inbound id verbatim as the client sent it.
+- `upstreamIds` — the caller's effective upstream cap (`null` =
+  unrestricted; empty list = no providers visible). The cap is the
+  intersection of per-user and per-api-key allow-lists; unknown ids raise
+  a configuration error rather than silently narrowing.
+- `inboundKind` — `chat` / `embedding` / `image` / `completion`,
+  determined by the inbound endpoint, not by the inbound payload.
+
+Steps:
+
+1. **List the visible providers** through `listModelProviders(upstreamIds)`
+   in configured `sort_order`. Empty list → throw a
+   "no upstream provider configured" error before any lookup.
+2. **Enumerate interpretations** for the inbound id across the visible
+   providers (Addressable Surfaces above). One inbound id expands into
+   zero, one, or two interpretations per provider.
+3. **Resolve each interpretation** against the upstream's SWR-cached
+   catalog. Resolution is a single exact match — `find(model.id ===
+   lookupId && !disabled.has(model.id))`. Providers contribute no
+   normalization hook above the catalog; an upstream that wants the
+   gateway to accept a non-listed alternate id must list it in its
+   catalog.
+4. **Kind-filter** the resolved set: keep only entries whose
+   `model.kind === inboundKind`. No endpoint-level capability check
+   happens here.
+5. If the resolved set is non-empty, return the candidates plus
+   `sawModel: true` and `failedUpstreams`.
+6. If the resolved set is empty **and** the inbound id matches `-\d{8}$`,
+   strip the eight-digit dated suffix and rerun steps 2–5 once against
+   the stripped id. The retry is bounded to one iteration; a second
+   dated suffix on the stripped id is not stripped again.
+7. If both attempts produce zero candidates, return `sawModel:
+   false` with the union of `failedUpstreams` seen across the
+   attempts. The caller renders a 404 / 400 with the standard wording
+   plus the failed-upstreams parenthetical.
+
+The dated-suffix fallback exists for clients that pin to a vendor's dated
+release id (typical for Anthropic-style `claude-sonnet-4-5-20250929`)
+against a catalog that only lists the base id. It deliberately operates
+on the **full resolution flow**, not on a single upstream's catalog, so
+the stripped id is tried against every visible upstream in its own
+enumeration order.
+
+The resolver never mutates the inbound id on the request body. The
+returned candidates carry the actual `UpstreamModel` (with its own `id`
+and `providerData`), and the dispatch layer reads from there.
+
+## Candidate Shape
+
+```ts
+interface ProviderCandidate {
+  readonly provider: ModelProviderInstance;
+  readonly model: UpstreamModel;
+  readonly fetcher: Fetcher;
+}
+```
+
+- `provider` is the resolved upstream provider instance — every wire call,
+  capability flag, and pricing lookup reads off it directly. Fields the
+  candidate used to copy (upstream id, upstream name, provider kind,
+  `supportsResponsesItemReference`) are read from `provider.*`.
+- `model` is the specific `UpstreamModel` entry that the catalog match
+  produced for this upstream. Its `id` is the upstream's catalog id;
+  `providerData` carries the per-provider wire id; `enabledFlags` carries
+  the operator's per-binding flag set. Same fields the candidate used to
+  copy off `binding.enabledFlags` / `binding.upstreamModel` are read from
+  `model.*`.
+- `fetcher` is the per-request proxy-chain-bound `Fetcher` for the
+  candidate's upstream, minted once at resolution time and shared by every
+  attempt that dispatches against this candidate.
+
+A target protocol (e.g. `messages` / `responses` / `chat-completions`) is
+deliberately **not** part of the candidate — see Endpoint Selection.
+
+## Endpoint Selection
+
+Resolution returns kind-matched candidates without consulting
+`model.endpoints`. The actual target endpoint is chosen at attempt
+dispatch, by a per-inbound-operation preference table that lives next to
+the attempt code:
+
+- `/v1/messages` generate: `messages` > `responses` > `chat-completions`.
+- `/v1/messages` countTokens: `messages` only.
+- `/v1/responses` generate: `responses` > `messages` > `chat-completions`.
+- `/v1/responses/compact`: `responses` only.
+- `/v1/chat/completions`: `chat-completions` > `messages` > `responses`.
+- `/v1beta/models/{m}:generateContent` and `:streamGenerateContent`:
+  `chat-completions` > `messages` > `responses` (Gemini is always served
+  via translation).
+- `/v1beta/models/{m}:countTokens`: `messages` only.
+
+Each table picks the first entry whose flag is set on
+`candidate.model.endpoints`. The result is the target protocol the attempt
+dispatches on for that candidate (native call or translation, as the
+TRANSLATION document specifies).
+
+A picker returning `null` means the candidate cannot serve the current
+operation. Attempt treats this exactly like an attempt-level failure —
+control falls to the next candidate in the planner's ordering. The same
+failover path handles upstream-side rejection of a candidate that the
+picker accepted; the only difference is that null-pick failover happens
+before any wire call.
+
+Passthrough endpoints (`/v1/embeddings`, `/v1/images/*`, `/v1/completions`)
+follow the same rule with a single-key predicate
+(`endpoints[endpointKey] !== undefined`) instead of a multi-target
+preference list. The kind-filter at resolution time guarantees a
+chat-kind candidate is never offered to a passthrough endpoint and vice
+versa; the endpoint-key check at attempt time then narrows within the
+kind.
+
+## Failover Ordering
+
+Candidates are ordered before they reach the attempt loop:
+
+- Across upstreams, by configured `sort_order` (lower first). An upstream
+  with an explicit `sort_order` ahead of another upstream's gets first
+  shot at the inbound id.
+- Within a single upstream, the unprefixed interpretation precedes the
+  prefixed one when both apply.
+
+For Responses-shape inbound, a planner pass adjusts the ordering by
+stored-item affinity before the attempt loop sees it (see the Responses
+items affinity module). The planner reads
+`provider.supportsResponsesItemReference` to decide whether a candidate
+can absorb an unexpanded `item_reference` carrier and rejects a request
+that names a forcing upstream the candidate list does not include. The
+planner never invents new candidates; it only narrows or re-orders the
+list the resolver produced.
+
+The attempt loop walks the ordered list and stops at the first attempt
+that returns a terminal answer — events, an upstream-shaped API error,
+or an internal-debug failure are all terminal. Only the null-endpoint-
+pick case and the planner-rejected-but-not-forced cases fall through to
+the next candidate.
+
+## Known Edges
+
+- A catalog that disabled the inbound id under one upstream still serves
+  it from another that allows it; the operator's per-upstream disable
+  list is intentionally not cross-cutting.
+- A `-\d{8}$` strip is the only inbound-id normalization the gateway
+  applies. Vendor variant suffixes (effort tiers, context-window
+  variants, fast-mode) are routed by request-body fields against a
+  catalog that lists only the base id; clients that send raw variant ids
+  receive a model-missing 404 unless their inbound id happens to match
+  another upstream's catalog entry verbatim.
+- The catalog is SWR-cached per upstream. A model the operator just
+  enabled is visible to resolution as soon as the next cached refresh
+  lands; SWR-soft hits do not block the request.
+- Dual-addressable surfaces (`[unprefixed, prefixed]`) intentionally
+  retain both candidate paths instead of deduping. A request that
+  resolves through both surfaces of the same upstream will attempt the
+  bare lookup first, then the prefix-stripped lookup if the first
+  attempt fell over.

--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -161,15 +161,13 @@ interface ProviderCandidate {
 ```
 
 - `provider` is the resolved upstream provider instance — every wire call,
-  capability flag, and pricing lookup reads off it directly. Fields the
-  candidate used to copy (upstream id, upstream name, provider kind,
-  `supportsResponsesItemReference`) are read from `provider.*`.
+  capability flag, and pricing lookup reads off it directly. It carries
+  the upstream id, upstream name, provider kind, and
+  `supportsResponsesItemReference`.
 - `model` is the specific `UpstreamModel` entry that the catalog match
   produced for this upstream. Its `id` is the upstream's catalog id;
   `providerData` carries the per-provider wire id; `enabledFlags` carries
-  the operator's per-binding flag set. Same fields the candidate used to
-  copy off `binding.enabledFlags` / `binding.upstreamModel` are read from
-  `model.*`.
+  the operator's per-model flag set.
 - `fetcher` is the per-request proxy-chain-bound `Fetcher` for the
   candidate's upstream, minted once at resolution time and shared by every
   attempt that dispatches against this candidate.

--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -100,14 +100,17 @@ Inputs:
   unrestricted; empty list = no providers visible). The cap is the
   intersection of per-user and per-api-key allow-lists; unknown ids raise
   a configuration error rather than silently narrowing.
-- `inboundKind` — `chat` / `embedding` / `image` / `completion`,
-  determined by the inbound endpoint, not by the inbound payload.
+- `inboundKind` — `chat` / `embedding` / `image`, determined by the
+  inbound endpoint, not by the inbound payload. `/v1/completions` reuses
+  the `chat` kind and narrows further via its endpoint-key predicate
+  (`endpoints.completions !== undefined`).
 
 Steps:
 
 1. **List the visible providers** through `listModelProviders(upstreamIds)`
-   in configured `sort_order`. Empty list → throw a
-   "no upstream provider configured" error before any lookup.
+   in configured `sort_order`. An empty list yields zero candidates with
+   `sawModel: false`; the caller's failure renderer surfaces the resulting
+   `model-missing` 404 without a separate throw at this layer.
 2. **Enumerate interpretations** for the inbound id across the visible
    providers (Addressable Surfaces above). One inbound id expands into
    zero, one, or two interpretations per provider.
@@ -179,7 +182,10 @@ the attempt code:
 - `/v1/messages` generate: `messages` > `responses` > `chat-completions`.
 - `/v1/messages` countTokens: `messages` only.
 - `/v1/responses` generate: `responses` > `messages` > `chat-completions`.
-- `/v1/responses/compact`: `responses` only.
+- `/v1/responses/compact`: `responses` > `messages` > `chat-completions`.
+  Non-responses targets are reached through the responses-compact-shim
+  interceptor, which pivots the action and synthesizes the compact
+  envelope from a generate-shaped turn.
 - `/v1/chat/completions`: `chat-completions` > `messages` > `responses`.
 - `/v1beta/models/{m}:generateContent` and `:streamGenerateContent`:
   `chat-completions` > `messages` > `responses` (Gemini is always served
@@ -192,11 +198,11 @@ dispatches on for that candidate (native call or translation, as the
 TRANSLATION document specifies).
 
 A picker returning `null` means the candidate cannot serve the current
-operation. Attempt treats this exactly like an attempt-level failure —
-control falls to the next candidate in the planner's ordering. The same
-failover path handles upstream-side rejection of a candidate that the
-picker accepted; the only difference is that null-pick failover happens
-before any wire call.
+operation. `planChatCandidates` drops these candidates before they reach
+the planner, so the attempt loop sees only viable items. The same
+ordered list is what the planner reorders by routing affinity; per-
+attempt failover (upstream-side rejection of a candidate the picker
+accepted) reuses that same ordered list one step further down.
 
 Passthrough endpoints (`/v1/embeddings`, `/v1/images/*`, `/v1/completions`)
 follow the same rule with a single-key predicate

--- a/packages/gateway/src/control-plane/models/routes.ts
+++ b/packages/gateway/src/control-plane/models/routes.ts
@@ -9,7 +9,7 @@ import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getCurrentColo } from '../../runtime/runtime-info.ts';
 import type { PublicModel, PublicModelsResponse } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
-import type { ResolvedModel, UpstreamProviderKind } from '@floway-dev/provider';
+import type { CatalogModel, ModelProviderInstance, UpstreamProviderKind } from '@floway-dev/provider';
 
 // Same DTO as the public /models endpoint, plus one dashboard-only field:
 // `upstreams` lists every provider binding for this model as { kind, id, name }
@@ -24,9 +24,9 @@ interface ControlPlaneModelsResponse extends Omit<PublicModelsResponse, 'data'> 
   data: ControlPlaneModel[];
 }
 
-const toControlPlaneModel = (model: ResolvedModel): ControlPlaneModel => ({
+const toControlPlaneModel = (model: CatalogModel, instances: readonly ModelProviderInstance[]): ControlPlaneModel => ({
   ...toPublicModel(model),
-  upstreams: model.providers.map(binding => ({ kind: binding.providerKind, id: binding.upstream, name: binding.upstreamName })),
+  upstreams: instances.map(instance => ({ kind: instance.providerKind, id: instance.upstream, name: instance.name })),
 });
 
 export const controlPlaneModels = async (c: Context) => {
@@ -36,8 +36,8 @@ export const controlPlaneModels = async (c: Context) => {
     // API key, so this resolves to the user's per-user upstream cap: a user who
     // has had an upstream removed must not see its models in the Models tab.
     const fetcherForUpstream = await createPerRequestFetcher(getCurrentColo(c.req.raw));
-    const models = await getModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c));
-    const data = models.map(toControlPlaneModel);
+    const { models, upstreamsByPublicId } = await getModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c));
+    const data = models.map(model => toControlPlaneModel(model, upstreamsByPublicId.get(model.id) ?? []));
     const response: ControlPlaneModelsResponse = {
       object: 'list',
       has_more: false,

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -13,7 +13,7 @@ import { createUpstreamLatencyRecorder } from '../shared/upstream-telemetry.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ChatCompletionsMessage, ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { type ExecuteResult } from '@floway-dev/provider';
+import { type ChatTargetApi, type ExecuteResult } from '@floway-dev/provider';
 import { translateChatCompletionsViaMessages, translateChatCompletionsViaResponses } from '@floway-dev/translate';
 import { chatCompletionsViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -22,41 +22,43 @@ export interface ChatCompletionsAttemptArgs {
   readonly ctx: GatewayCtx;
   readonly store: StatefulResponsesStore;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
 export const chatCompletionsAttempt = {
   generate: async (args: ChatCompletionsAttemptArgs): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
-    const { payload, ctx, store, candidate, headers } = args;
+    const { payload, ctx, store, candidate, targetApi, headers } = args;
     const rewritten = await rewriteOrRenderChatCompletionsFailure(payload, store, candidate);
     if (rewritten.failure) return rewritten.failure;
     const invocation: ChatCompletionsInvocation = {
       payload: rewritten.payload,
       candidate,
+      targetApi,
       headers,
     };
     return await runInterceptors(invocation, ctx, chatCompletionsInterceptors, async () => {
-      if (candidate.targetApi === 'chat-completions') {
+      if (targetApi === 'chat-completions') {
         return await callChatCompletionsAsExecuteResult(invocation.payload, ctx, candidate, invocation.headers);
       }
-      if (candidate.targetApi === 'messages') {
+      if (targetApi === 'messages') {
         return await traverseTranslation(
           invocation.payload,
           p => translateChatCompletionsViaMessages(p, {
-            model: candidate.binding.upstreamModel.id,
-            fallbackMaxOutputTokens: candidate.binding.upstreamModel.limits.max_output_tokens,
+            model: candidate.model.id,
+            fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,
           }),
-          translated => messagesAttempt.generate({ payload: translated, ctx, store, candidate, headers: invocation.headers }),
+          translated => messagesAttempt.generate({ payload: translated, ctx, store, candidate, targetApi: 'messages', headers: invocation.headers }),
         );
       }
-      if (candidate.targetApi === 'responses') {
+      if (targetApi === 'responses') {
         return await traverseTranslation(
           invocation.payload,
-          p => translateChatCompletionsViaResponses(p, { model: candidate.binding.upstreamModel.id }),
-          translated => responsesAttempt.generate({ payload: translated, ctx, store, candidate, headers: invocation.headers }),
+          p => translateChatCompletionsViaResponses(p, { model: candidate.model.id }),
+          translated => responsesAttempt.generate({ payload: translated, ctx, store, candidate, targetApi: 'responses', headers: invocation.headers }),
         );
       }
-      throw new Error(`chatCompletionsAttempt.generate: unexpected targetApi '${(candidate as { targetApi: string }).targetApi}'`);
+      throw new Error(`chatCompletionsAttempt.generate: unexpected targetApi '${targetApi as string}'`);
     });
   },
 };
@@ -103,11 +105,11 @@ const callChatCompletionsAsExecuteResult = async (
 ): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
   const { model: _model, ...body } = payload;
   const recorder = createUpstreamLatencyRecorder();
-  const providerResult = await candidate.binding.provider.callChatCompletions(
-    candidate.binding.upstreamModel,
+  const providerResult = await candidate.provider.provider.callChatCompletions(
+    candidate.model,
     body,
     ctx.abortSignal,
     buildUpstreamCallOptions(candidate, ctx, recorder.record, headers),
   );
-  return await providerStreamResultToExecuteResult(providerResult, candidate, ctx, recorder);
+  return await providerStreamResultToExecuteResult(providerResult, candidate, 'chat-completions', ctx, recorder);
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
@@ -70,14 +70,11 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const targetApi = overrides.targetApi ?? 'chat-completions';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callChatCompletions: overrides.callChatCompletions,
     callMessages: overrides.callMessages,
@@ -88,12 +85,7 @@ const makeCandidate = (overrides: {
       upstream, providerKind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream, upstreamName: upstream, providerKind: 'custom',
-      provider, upstreamModel, enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };
@@ -122,6 +114,7 @@ test('generate native chat-completions target calls provider.callChatCompletions
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callChatCompletions }),
+    targetApi: 'chat-completions',
     headers: new Headers(),
   });
 
@@ -140,7 +133,8 @@ test('generate translate-to-messages branch routes through messagesAttempt', asy
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'messages', callMessages }),
+    candidate: makeCandidate({ callMessages }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
 
@@ -170,7 +164,8 @@ test('generate translate-to-responses branch routes through responsesAttempt', a
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'responses', callResponses }),
+    candidate: makeCandidate({ callResponses }),
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -191,7 +186,8 @@ test('generate inherits invocation headers across translation to Messages', asyn
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'messages', callMessages }),
+    candidate: makeCandidate({ callMessages }),
+    targetApi: 'messages',
     headers: new Headers({ 'x-test': 'abc' }),
   });
   assertEquals(result.type, 'events');
@@ -224,7 +220,8 @@ test('generate inherits invocation headers across translation to Responses', asy
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'responses', callResponses }),
+    candidate: makeCandidate({ callResponses }),
+    targetApi: 'responses',
     headers: new Headers({ 'x-test': 'abc' }),
   });
   assertEquals(result.type, 'events');
@@ -247,6 +244,7 @@ test('generate propagates upstream response headers onto the EventResult so resp
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callChatCompletions }),
+    targetApi: 'chat-completions',
     headers: new Headers(),
   });
   assertEquals(result.type, 'events');

--- a/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
@@ -11,7 +11,7 @@ import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols
 import { directFetcher, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../shared/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../shared/candidates.ts')>();
   return {
@@ -29,7 +29,7 @@ const { chatCompletionsHttp } = await import('./http.ts');
 const API_KEY_ID = 'key_chat_completions_http_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {
@@ -104,20 +104,13 @@ const makeCandidate = (overrides: {
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({ callChatCompletions: overrides.callChatCompletions });
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream, upstreamName: upstream, providerKind: 'custom',
-      provider, upstreamModel, enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi: 'chat-completions',
-
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
@@ -12,8 +12,8 @@ import { directFetcher, type ProviderStreamResult, type UpstreamCallOptions } fr
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async () => {

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system.ts
@@ -18,7 +18,7 @@ const downgradeRole = (message: ChatCompletionsMessage): ChatCompletionsMessage 
 };
 
 export const withDemoteDeveloperToSystem: ChatCompletionsInterceptor = async (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('demote-developer-to-system')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('demote-developer-to-system')) return await run();
 
   ctx.payload = {
     ...ctx.payload,

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
@@ -20,7 +20,8 @@ const stubCtx: GatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user.ts
@@ -6,7 +6,7 @@ import type { ChatCompletionsInterceptor } from './types.ts';
 // any non-system role, every later `role: 'system'` is rewritten to
 // `role: 'user'` with content preserved.
 export const withInterleavedSystemDemotedToUser: ChatCompletionsInterceptor = (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('demote-interleaved-system-to-user')) return run();
+  if (!ctx.candidate.model.enabledFlags.has('demote-interleaved-system-to-user')) return run();
 
   const { messages } = ctx.payload;
   let crossedLeadingRun = false;

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
@@ -25,7 +25,8 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['demote-interleaved-system-to-user']),
 ): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice.ts
@@ -15,7 +15,7 @@ const hasForcedToolChoice = (payload: ChatCompletionsPayload): boolean => {
 };
 
 export const withReasoningDisabledOnForcedToolChoice: ChatCompletionsInterceptor = async (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('disable-reasoning-on-forced-tool-choice')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('disable-reasoning-on-forced-tool-choice')) return await run();
   if (!hasForcedToolChoice(ctx.payload)) return await run();
   ctx.payload = { ...ctx.payload, reasoning_effort: 'none' };
   return await run();

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -25,7 +25,8 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/include-usage-stream-options_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/include-usage-stream-options_test.ts
@@ -22,7 +22,8 @@ const okEvents = () => Promise.resolve(eventResult((async function* () {})(), te
 
 const invocation = (payload: ChatCompletionsPayload): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions' }),
+  candidate: stubProviderCandidate(),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
@@ -10,7 +10,7 @@ import { withVendorQwenChatCompletionsNormalize } from './vendor-qwen-normalize.
 
 // Unified Chat Completions interceptor list. All entries are attached to
 // every binding; each interceptor's body decides whether to act (flag-gated
-// entries early-return on `ctx.candidate.binding.enabledFlags.has(flagId)`).
+// entries early-return on `ctx.candidate.model.enabledFlags.has(flagId)`).
 //
 // Order follows source-then-target semantics collapsed into a single chain.
 //

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/normalize-usage_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/normalize-usage_test.ts
@@ -21,7 +21,8 @@ const stubCtx: GatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload = { model: 'test-model', messages: [] }): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions' }),
+  candidate: stubProviderCandidate(),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize.ts
@@ -119,7 +119,7 @@ const rewriteInboundUsage = (chunk: ChatCompletionsStreamEvent): ChatCompletions
 };
 
 export const withVendorDeepseekChatCompletionsNormalize: ChatCompletionsInterceptor = async (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('vendor-deepseek')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('vendor-deepseek')) return await run();
 
   ctx.payload = rewriteOutboundPayload(ctx.payload);
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
@@ -25,7 +25,8 @@ const stubCtx: GatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize.ts
@@ -37,7 +37,7 @@ const rewriteInboundUsage = (chunk: ChatCompletionsStreamEvent): ChatCompletions
 };
 
 export const withVendorKimiChatCompletionsNormalize: ChatCompletionsInterceptor = async (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('vendor-kimi')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('vendor-kimi')) return await run();
 
   const result = await run();
   if (result.type !== 'events') return result;

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
@@ -21,7 +21,8 @@ const stubCtx: GatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-kimi'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize.ts
@@ -18,7 +18,7 @@ import type { ChatCompletionsInterceptor } from './types.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 
 export const withVendorQwenChatCompletionsNormalize: ChatCompletionsInterceptor = async (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('vendor-qwen')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('vendor-qwen')) return await run();
 
   if (ctx.payload.reasoning_effort === 'none') {
     const { reasoning_effort: _stripped, ...rest } = ctx.payload;

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
@@ -20,7 +20,8 @@ const stubCtx: GatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'chat-completions', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'chat-completions',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/routing.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/routing.ts
@@ -1,13 +1,13 @@
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import type { ProviderCandidate } from '../shared/candidates.ts';
+import type { ChatPlanItem } from '../shared/candidates.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { chatCompletionsViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 export const planChatCompletionsRouting = async (input: {
   readonly payload: ChatCompletionsPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ChatPlanItem[];
   readonly store: StatefulResponsesStore;
 }): Promise<RoutingDecision> =>
   await classifyResponsesItemAffinity({

--- a/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
@@ -5,33 +5,29 @@ import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createStoredResponsesItemId } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { ProviderCandidate } from '../shared/candidates.ts';
+import type { ChatPlanItem } from '../shared/candidates.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_chat_completions_routing_test';
 
-const candidate = (upstream: string): ProviderCandidate => {
+const planItem = (upstream: string): ChatPlanItem => {
   const upstreamModel = stubUpstreamModel();
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([upstreamModel]),
   });
   return {
-    provider: {
-      upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider: modelProvider,
-      supportsResponsesItemReference: true,
-    },
-    binding: {
-      upstream, upstreamName: upstream, providerKind: 'custom',
-      provider: modelProvider, upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
+    candidate: {
+      provider: {
+        upstream, providerKind: 'custom', name: upstream,
+        disabledPublicModelIds: [], modelPrefix: null, provider: modelProvider,
+        supportsResponsesItemReference: true,
+      },
+      model: upstreamModel,
+      fetcher: directFetcher,
     },
     targetApi: 'chat-completions',
-
-    fetcher: directFetcher,
   };
 };
 
@@ -47,7 +43,7 @@ const payload = (messages: ChatCompletionsPayload['messages']): ChatCompletionsP
 
 test('chat-completions payload with no reasoning carriers passes candidates through unchanged', async () => {
   installRepo();
-  const candidates = [candidate('up_a'), candidate('up_b')];
+  const candidates = [planItem('up_a'), planItem('up_b')];
 
   const decision = await planChatCompletionsRouting({
     payload: payload([{ role: 'user', content: 'hello' }]),
@@ -58,7 +54,7 @@ test('chat-completions payload with no reasoning carriers passes candidates thro
   assertEquals(decision.kind, 'success');
   if (decision.kind === 'success') {
     assertEquals(decision.candidates.length, candidates.length);
-    assertEquals(decision.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+    assertEquals(decision.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
   }
 });
 
@@ -74,7 +70,7 @@ test('an assistant reasoning_items carrier naming an unknown stored id fails rou
         reasoning_items: [{ type: 'reasoning', id: reasoningId, summary: [{ type: 'summary_text', text: 't' }] }],
       },
     ]),
-    candidates: [candidate('up_a')],
+    candidates: [planItem('up_a')],
     store: createNonResponsesSourceStore(API_KEY_ID),
   });
 

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -1,8 +1,9 @@
 import { chatCompletionsAttempt } from './attempt.ts';
 import { renderChatCompletionsFailure } from './errors.ts';
 import { planChatCompletionsRouting } from './routing.ts';
+import { enumerateProviderCandidates } from '../../providers/candidates.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import { enumerateProviderCandidates, planChatCandidates } from '../shared/candidates.ts';
+import { planChatCandidates } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
@@ -27,6 +28,7 @@ export const chatCompletionsServe = {
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
+      kind: 'chat',
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -2,11 +2,11 @@ import { chatCompletionsAttempt } from './attempt.ts';
 import { renderChatCompletionsFailure } from './errors.ts';
 import { planChatCompletionsRouting } from './routing.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import { enumerateProviderCandidates } from '../shared/candidates.ts';
+import { enumerateProviderCandidates, planChatCandidates } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
-import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ExecuteResult } from '@floway-dev/provider';
+import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
+import type { ChatTargetApi, ExecuteResult } from '@floway-dev/provider';
 
 export interface ChatCompletionsServeGenerateArgs {
   readonly payload: ChatCompletionsPayload;
@@ -15,35 +15,37 @@ export interface ChatCompletionsServeGenerateArgs {
   readonly headers: Headers;
 }
 
+const pickChatCompletionsTarget = (endpoints: ModelEndpoints): ChatTargetApi | null =>
+  endpoints.chatCompletions ? 'chat-completions'
+    : endpoints.messages ? 'messages'
+      : endpoints.responses ? 'responses'
+        : null;
+
 export const chatCompletionsServe = {
   generate: async (args: ChatCompletionsServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
     const { payload, ctx, store, headers } = args;
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
-      pickTarget: endpoints =>
-        endpoints.chatCompletions ? 'chat-completions'
-          : endpoints.messages ? 'messages'
-            : endpoints.responses ? 'responses'
-              : null,
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });
-    const decision = await planChatCompletionsRouting({ payload, candidates, store });
+    const planItems = planChatCandidates(candidates, pickChatCompletionsTarget);
+    const decision = await planChatCompletionsRouting({ payload, candidates: planItems, store });
     if (decision.kind === 'failure') return renderChatCompletionsFailure(decision.failure);
 
     // Any non-throwing attempt result — events, api-error, or
     // internal-error — IS the answer for this request: an upstream 4xx/5xx
     // from the first viable candidate is final, not a hint to try another
     // upstream.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) {
+    const [item] = decision.candidates;
+    if (item === undefined) {
       return renderChatCompletionsFailure(
         sawModel
           ? { kind: 'model-unsupported', model: payload.model, failedUpstreams }
           : { kind: 'model-missing', model: payload.model, failedUpstreams },
       );
     }
-    return await chatCompletionsAttempt.generate({ payload, ctx, store, candidate, headers });
+    return await chatCompletionsAttempt.generate({ payload, ctx, store, candidate: item.candidate, targetApi: item.targetApi, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -15,8 +15,8 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 // Mock the candidates seam so each test hands the serve exactly the
 // provider candidates it wants.
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async () => {

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
-import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
@@ -14,7 +14,7 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 
 // Mock the candidates seam so each test hands the serve exactly the
 // provider candidates it wants.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../shared/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../shared/candidates.ts')>();
   return {
@@ -32,7 +32,7 @@ const { chatCompletionsServe } = await import('./serve.ts');
 const API_KEY_ID = 'key_chat_completions_serve_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {
@@ -108,14 +108,12 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
+  endpoints?: ModelEndpoints;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const targetApi = overrides.targetApi ?? 'chat-completions';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callChatCompletions: overrides.callChatCompletions,
     callMessages: overrides.callMessages,
@@ -126,12 +124,7 @@ const makeCandidate = (overrides: {
       upstream, providerKind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream, upstreamName: upstream, providerKind: 'custom',
-      provider, upstreamModel, enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
     fetcher: directFetcher,
   };
 };
@@ -170,7 +163,7 @@ test('generate translates through the Messages target when only that endpoint is
   const callMessages = vi.fn(async (): Promise<ProviderStreamResult<MessagesStreamEvent>> => ({
     ok: true, events: makeProtocolFrames(makeMessagesResultEvents()), modelKey: 'messages-model-key', headers: new Headers(),
   }));
-  queueCandidates([makeCandidate({ upstream: 'up_m', targetApi: 'messages', callMessages })]);
+  queueCandidates([makeCandidate({ upstream: 'up_m', endpoints: { messages: {} }, callMessages })]);
 
   const result = await chatCompletionsServe.generate({
     payload: makePayload(),
@@ -190,7 +183,7 @@ test('generate translates through the Responses target when only that endpoint i
   const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
     action: 'generate', ok: true, events: makeProtocolFrames([makeResponsesResultEvent()]), modelKey: 'responses-model-key', headers: new Headers(),
   }));
-  queueCandidates([makeCandidate({ upstream: 'up_r', targetApi: 'responses', callResponses })]);
+  queueCandidates([makeCandidate({ upstream: 'up_r', endpoints: { responses: {} }, callResponses })]);
 
   const result = await chatCompletionsServe.generate({
     payload: makePayload(),

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -12,7 +12,7 @@ import { traverseTranslation } from '../shared/translate-traverse.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
-import { plainResult, type ExecuteResult, type GeminiInvocation, type PlainResult } from '@floway-dev/provider';
+import { plainResult, type ChatTargetApi, type ExecuteResult, type GeminiInvocation, type PlainResult } from '@floway-dev/provider';
 import { translateGeminiViaChatCompletions, translateGeminiViaMessages, translateGeminiViaResponses } from '@floway-dev/translate';
 
 export interface GeminiAttemptGenerateArgs {
@@ -20,6 +20,7 @@ export interface GeminiAttemptGenerateArgs {
   readonly ctx: GatewayCtx;
   readonly store: StatefulResponsesStore;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
@@ -28,59 +29,60 @@ export interface GeminiAttemptCountTokensArgs {
   readonly ctx: GatewayCtx;
   readonly store: StatefulResponsesStore;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
 export const geminiAttempt = {
   generate: async (args: GeminiAttemptGenerateArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> => {
-    const { payload, ctx, store, candidate, headers } = args;
-    const invocation: GeminiInvocation = { payload, candidate, headers };
+    const { payload, ctx, store, candidate, targetApi, headers } = args;
+    const invocation: GeminiInvocation = { payload, candidate, targetApi, headers };
     return await runInterceptors(invocation, ctx, geminiInterceptors, async () => {
       // Gemini has no native upstream target today — every targetApi we
-      // pickTarget for is reached via translation. The dispatch threads each
-      // branch through `traverseTranslation` so each inner attempt owns its
-      // own interceptor chain and rewrite.
+      // pick is reached via translation. The dispatch threads each branch
+      // through `traverseTranslation` so each inner attempt owns its own
+      // interceptor chain and rewrite.
       const transCtx = {
-        model: candidate.binding.upstreamModel.id,
-        fallbackMaxOutputTokens: candidate.binding.upstreamModel.limits.max_output_tokens,
+        model: candidate.model.id,
+        fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,
       };
-      if (candidate.targetApi === 'messages') {
+      if (targetApi === 'messages') {
         return await traverseTranslation(
           invocation.payload,
           p => translateGeminiViaMessages(p, transCtx),
           translated => messagesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, store, candidate, targetApi: 'messages', headers: invocation.headers,
           }),
         );
       }
-      if (candidate.targetApi === 'responses') {
+      if (targetApi === 'responses') {
         return await traverseTranslation(
           invocation.payload,
           p => translateGeminiViaResponses(p, transCtx),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, store, candidate, targetApi: 'responses', headers: invocation.headers,
           }),
         );
       }
-      if (candidate.targetApi === 'chat-completions') {
+      if (targetApi === 'chat-completions') {
         return await traverseTranslation(
           invocation.payload,
           p => translateGeminiViaChatCompletions(p, transCtx),
           translated => chatCompletionsAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, store, candidate, targetApi: 'chat-completions', headers: invocation.headers,
           }),
         );
       }
-      throw new Error(`geminiAttempt.generate: unexpected targetApi '${(candidate as { targetApi: string }).targetApi}'`);
+      throw new Error(`geminiAttempt.generate: unexpected targetApi '${targetApi as string}'`);
     });
   },
 
   countTokens: async (args: GeminiAttemptCountTokensArgs): Promise<PlainResult> => {
-    const { payload, ctx, store, candidate, headers } = args;
-    if (candidate.targetApi !== 'messages') {
-      throw new Error(`geminiAttempt.countTokens requires targetApi='messages', got '${candidate.targetApi}'`);
+    const { payload, ctx, store, candidate, targetApi, headers } = args;
+    if (targetApi !== 'messages') {
+      throw new Error(`geminiAttempt.countTokens requires targetApi='messages', got '${targetApi}'`);
     }
-    const invocation: GeminiInvocation = { payload, candidate, headers };
+    const invocation: GeminiInvocation = { payload, candidate, targetApi, headers };
     return await runInterceptors(invocation, ctx, geminiCountTokensInterceptors, async () => {
       // Gemini countTokens has no native upstream; translate to Messages and
       // delegate to `messagesAttempt.countTokens`, then reshape the Messages
@@ -91,8 +93,8 @@ export const geminiAttempt = {
       // payload-mutators are applied inline here on a structuredClone of
       // the source so the caller's payload stays intact.
       const transCtx = {
-        model: candidate.binding.upstreamModel.id,
-        fallbackMaxOutputTokens: candidate.binding.upstreamModel.limits.max_output_tokens,
+        model: candidate.model.id,
+        fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,
       };
       const cleaned = structuredClone(invocation.payload);
       stripUnsupportedPartFieldsFromPayload(cleaned);
@@ -101,7 +103,7 @@ export const geminiAttempt = {
       const trip = await translateGeminiViaMessages(cleaned, transCtx);
       const { stream: _stream, ...target } = trip.target;
       const messagesResult = await messagesAttempt.countTokens({
-        payload: target, ctx, store, candidate, headers: invocation.headers,
+        payload: target, ctx, store, candidate, targetApi: 'messages', headers: invocation.headers,
       });
       return reshapeMessagesCountAsGemini(messagesResult);
     });

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -38,10 +38,10 @@ export const geminiAttempt = {
     const { payload, ctx, store, candidate, targetApi, headers } = args;
     const invocation: GeminiInvocation = { payload, candidate, targetApi, headers };
     return await runInterceptors(invocation, ctx, geminiInterceptors, async () => {
-      // Gemini has no native upstream target today — every targetApi we
-      // pick is reached via translation. The dispatch threads each branch
-      // through `traverseTranslation` so each inner attempt owns its own
-      // interceptor chain and rewrite.
+      // Gemini has no native upstream target today — every target we
+      // pick is reached via translation. The dispatch threads each
+      // branch through `traverseTranslation` so each inner attempt owns
+      // its own interceptor chain and rewrite.
       const transCtx = {
         model: candidate.model.id,
         fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,

--- a/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
@@ -84,15 +84,12 @@ const makeChatCompletionsEvents = (): readonly ChatCompletionsStreamEvent[] => [
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const targetApi = overrides.targetApi ?? 'chat-completions';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callMessages: overrides.callMessages,
     callResponses: overrides.callResponses,
@@ -104,11 +101,7 @@ const makeCandidate = (overrides: {
       upstream, providerKind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream, upstreamName: upstream, providerKind: 'custom', provider, upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags, supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };
@@ -130,7 +123,8 @@ test('generate translates through Chat Completions when targetApi is chat-comple
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'chat-completions', callChatCompletions }),
+    candidate: makeCandidate({ callChatCompletions }),
+    targetApi: 'chat-completions',
     headers: new Headers(),
   });
 
@@ -149,7 +143,8 @@ test('generate translates through Messages when targetApi is messages', async ()
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'messages', callMessages }),
+    candidate: makeCandidate({ callMessages }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
 
@@ -168,7 +163,8 @@ test('generate translates through Responses when targetApi is responses', async 
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'responses', callResponses }),
+    candidate: makeCandidate({ callResponses }),
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -195,7 +191,8 @@ test('countTokens translates Gemini to Messages count_tokens and reshapes to tot
     payload: makePayload({ systemInstruction: { parts: [{ text: 'system' }] } }),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'messages', callMessagesCountTokens }),
+    candidate: makeCandidate({ callMessagesCountTokens }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
 
@@ -218,12 +215,12 @@ test('countTokens accepts the upstream total_tokens dialect and refuses unknown 
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({
-      targetApi: 'messages',
       callMessagesCountTokens: async () => ({
         response: new Response(JSON.stringify({ total_tokens: 19 }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) }),
         modelKey: 'k',
       }),
     }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
   assertEquals(totalTokensResp.type, 'plain');
@@ -235,12 +232,12 @@ test('countTokens accepts the upstream total_tokens dialect and refuses unknown 
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({
-      targetApi: 'messages',
       callMessagesCountTokens: async () => ({
         response: new Response(JSON.stringify({ unexpected: true }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) }),
         modelKey: 'k',
       }),
     }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
   assertEquals(unexpectedResp.type, 'plain');
@@ -259,7 +256,8 @@ test('countTokens refuses a non-messages candidate', async () => {
       payload: makePayload(),
       ctx: makeGatewayCtx(),
       store: createNonResponsesSourceStore(API_KEY_ID),
-      candidate: makeCandidate({ targetApi: 'responses' }),
+      candidate: makeCandidate(),
+      targetApi: 'responses',
       headers: new Headers(),
     });
   } catch (error) {
@@ -282,7 +280,8 @@ test('generate propagates upstream response headers through the chat-completions
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'chat-completions', callChatCompletions }),
+    candidate: makeCandidate({ callChatCompletions }),
+    targetApi: 'chat-completions',
     headers: new Headers(),
   });
   assertEquals(result.type, 'events');

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -12,7 +12,7 @@ import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -30,7 +30,7 @@ const { geminiHttp } = await import('./http.ts');
 const API_KEY_ID = 'key_gemini_http_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -92,14 +92,21 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
+  targetApi?: 'chat-completions' | 'messages' | 'responses';
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const targetApi = overrides.targetApi ?? 'chat-completions';
-  const upstreamModel = stubUpstreamModel();
+  // The gemini serve layer picks the target from model.endpoints (chat-completions
+  // first, then messages, then responses). Narrow endpoints to the target this
+  // test wants so planChatCandidates resolves the expected branch.
+  const endpoints = targetApi === 'chat-completions'
+    ? { chatCompletions: {} }
+    : targetApi === 'messages'
+      ? { messages: {} }
+      : { responses: {} };
   const provider = stubProvider({
     callChatCompletions: overrides.callChatCompletions,
     callMessages: overrides.callMessages,
@@ -110,11 +117,7 @@ const makeCandidate = (overrides: {
       upstream, providerKind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream, upstreamName: upstream, providerKind: 'custom', provider, upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags, supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel({ endpoints }),
     fetcher: directFetcher,
   };
 };

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -12,7 +12,7 @@ import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -30,7 +30,7 @@ const { geminiHttp } = await import('./http.ts');
 const API_KEY_ID = 'key_gemini_http_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -13,8 +13,8 @@ import { directFetcher, type ProviderCallResult, type ProviderStreamResult, type
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async () => {

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-safety-settings_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-safety-settings_test.ts
@@ -23,7 +23,8 @@ const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'messages' }),
+  candidate: stubProviderCandidate(),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-part-fields_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-part-fields_test.ts
@@ -23,7 +23,8 @@ const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'messages' }),
+  candidate: stubProviderCandidate(),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-tools_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-tools_test.ts
@@ -23,7 +23,8 @@ const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'messages' }),
+  candidate: stubProviderCandidate(),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/suppress-thought-parts_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/suppress-thought-parts_test.ts
@@ -20,7 +20,8 @@ const stubCtx: GatewayCtx = {
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'messages' }),
+  candidate: stubProviderCandidate(),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/gemini/routing.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/routing.ts
@@ -1,6 +1,6 @@
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import type { ProviderCandidate } from '../shared/candidates.ts';
+import type { ChatPlanItem } from '../shared/candidates.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 import { geminiViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
@@ -9,7 +9,7 @@ export type GeminiRoutingDecision = RoutingDecision;
 
 export const planGeminiRouting = async (input: {
   readonly payload: GeminiPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ChatPlanItem[];
   readonly store: StatefulResponsesStore;
 }): Promise<GeminiRoutingDecision> =>
   await classifyResponsesItemAffinity({

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -31,7 +31,7 @@ export interface GeminiServeCountTokensArgs {
 // Gemini has no native upstream target in the provider API; prefer Chat
 // Completions, then Messages, then Responses for generate. countTokens has
 // no translation path beyond native Messages count_tokens, so only
-// Messages-endpoint bindings qualify there.
+// Messages-endpoint candidates qualify there.
 const pickGeminiGenerateTarget = (endpoints: ModelEndpoints): ChatTargetApi | null =>
   endpoints.chatCompletions ? 'chat-completions'
     : endpoints.messages ? 'messages'

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -1,8 +1,9 @@
 import { geminiAttempt } from './attempt.ts';
 import { renderGeminiFailure } from './errors.ts';
 import { planGeminiRouting } from './routing.ts';
+import { enumerateProviderCandidates } from '../../providers/candidates.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import { enumerateProviderCandidates, planChatCandidates } from '../shared/candidates.ts';
+import { planChatCandidates } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
@@ -46,6 +47,7 @@ export const geminiServe = {
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
+      kind: 'chat',
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });
@@ -74,6 +76,7 @@ export const geminiServe = {
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
+      kind: 'chat',
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -2,11 +2,11 @@ import { geminiAttempt } from './attempt.ts';
 import { renderGeminiFailure } from './errors.ts';
 import { planGeminiRouting } from './routing.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import { enumerateProviderCandidates } from '../shared/candidates.ts';
+import { enumerateProviderCandidates, planChatCandidates } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
-import type { ProtocolFrame } from '@floway-dev/protocols/common';
+import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
-import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
+import type { ChatTargetApi, ExecuteResult, PlainResult } from '@floway-dev/provider';
 
 export interface GeminiServeGenerateArgs {
   readonly payload: GeminiPayload;
@@ -27,27 +27,38 @@ export interface GeminiServeCountTokensArgs {
   readonly headers: Headers;
 }
 
+// Gemini has no native upstream target in the provider API; prefer Chat
+// Completions, then Messages, then Responses for generate. countTokens has
+// no translation path beyond native Messages count_tokens, so only
+// Messages-endpoint bindings qualify there.
+const pickGeminiGenerateTarget = (endpoints: ModelEndpoints): ChatTargetApi | null =>
+  endpoints.chatCompletions ? 'chat-completions'
+    : endpoints.messages ? 'messages'
+      : endpoints.responses ? 'responses'
+        : null;
+
+const pickGeminiCountTokensTarget = (endpoints: ModelEndpoints): ChatTargetApi | null =>
+  endpoints.messages ? 'messages' : null;
+
 export const geminiServe = {
   generate: async (args: GeminiServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> => {
     const { payload, ctx, store, model, headers } = args;
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
-      // Gemini has no native upstream target in the provider API; prefer
-      // Chat Completions, then Messages, then Responses.
-      pickTarget: endpoints => endpoints.chatCompletions ? 'chat-completions' : endpoints.messages ? 'messages' : endpoints.responses ? 'responses' : null,
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });
-    const decision = await planGeminiRouting({ payload, candidates, store });
+    const planItems = planChatCandidates(candidates, pickGeminiGenerateTarget);
+    const decision = await planGeminiRouting({ payload, candidates: planItems, store });
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'generate');
 
     // Any non-throwing attempt result — events, api-error, or
     // internal-error — IS the answer for this request: an upstream 4xx/5xx
     // from the first viable candidate is final, not a hint to try another
     // upstream.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) {
+    const [item] = decision.candidates;
+    if (item === undefined) {
       return renderGeminiFailure(
         sawModel
           ? { kind: 'model-unsupported', model, failedUpstreams }
@@ -55,7 +66,7 @@ export const geminiServe = {
         'generate',
       );
     }
-    return await geminiAttempt.generate({ payload, ctx, store, candidate, headers });
+    return await geminiAttempt.generate({ payload, ctx, store, candidate: item.candidate, targetApi: item.targetApi, headers });
   },
 
   countTokens: async (args: GeminiServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | PlainResult> => {
@@ -63,21 +74,18 @@ export const geminiServe = {
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
-      // Gemini countTokens has no native upstream support; only providers
-      // exposing the Messages endpoint qualify because we translate Gemini
-      // → Messages and call Messages count_tokens upstream.
-      pickTarget: endpoints => endpoints.messages ? 'messages' : null,
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });
-    const decision = await planGeminiRouting({ payload, candidates, store });
+    const planItems = planChatCandidates(candidates, pickGeminiCountTokensTarget);
+    const decision = await planGeminiRouting({ payload, candidates: planItems, store });
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'countTokens');
 
     // PlainResult always represents a final response — both 2xx and upstream
     // errors come back as a `plain` envelope, so the first candidate's result
     // is the answer. Provider-level transport errors throw and propagate.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) {
+    const [item] = decision.candidates;
+    if (item === undefined) {
       return renderGeminiFailure(
         sawModel
           ? { kind: 'model-unsupported', model, failedUpstreams }
@@ -85,6 +93,6 @@ export const geminiServe = {
         'countTokens',
       );
     }
-    return await geminiAttempt.countTokens({ payload, ctx, store, candidate, headers });
+    return await geminiAttempt.countTokens({ payload, ctx, store, candidate: item.candidate, targetApi: item.targetApi, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -14,8 +14,8 @@ import { directFetcher, type ProviderCallResult, type ProviderResponsesResult, t
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async () => {

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -102,7 +102,7 @@ const makeResponsesResultEvent = (id = 'resp_test'): ResponsesStreamEvent => {
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
+  targetApi?: 'chat-completions' | 'messages' | 'responses';
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
@@ -110,7 +110,14 @@ const makeCandidate = (overrides: {
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const targetApi = overrides.targetApi ?? 'chat-completions';
-  const upstreamModel = stubUpstreamModel();
+  // The gemini serve layer picks the target from model.endpoints (chat-completions
+  // first, then messages, then responses). Narrow endpoints to the target this
+  // test wants so planChatCandidates resolves the expected branch.
+  const endpoints = targetApi === 'chat-completions'
+    ? { chatCompletions: {} }
+    : targetApi === 'messages'
+      ? { messages: {} }
+      : { responses: {} };
   const provider = stubProvider({
     callChatCompletions: overrides.callChatCompletions,
     callMessages: overrides.callMessages,
@@ -122,11 +129,7 @@ const makeCandidate = (overrides: {
       upstream, providerKind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream, upstreamName: upstream, providerKind: 'custom', provider, upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags, supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel({ endpoints }),
     fetcher: directFetcher,
   };
 };

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -13,7 +13,7 @@ import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocol
 import { directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -31,7 +31,7 @@ const { geminiServe } = await import('./serve.ts');
 const API_KEY_ID = 'key_gemini_serve_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -13,7 +13,7 @@ import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocol
 import { directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -31,7 +31,7 @@ const { geminiServe } = await import('./serve.ts');
 const API_KEY_ID = 'key_gemini_serve_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -15,7 +15,7 @@ import { createUpstreamLatencyRecorder } from '../shared/upstream-telemetry.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesMessage, MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import { type ExecuteResult, type PlainResult } from '@floway-dev/provider';
+import { type ChatTargetApi, type ExecuteResult, type PlainResult } from '@floway-dev/provider';
 import { translateMessagesViaChatCompletions, translateMessagesViaResponses } from '@floway-dev/translate';
 import { messagesViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -24,6 +24,7 @@ export interface MessagesAttemptGenerateArgs {
   readonly ctx: GatewayCtx;
   readonly store: StatefulResponsesStore;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
@@ -32,57 +33,59 @@ export interface MessagesAttemptCountTokensArgs {
   readonly ctx: GatewayCtx;
   readonly store: StatefulResponsesStore;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
 export const messagesAttempt = {
   generate: async (args: MessagesAttemptGenerateArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => {
-    const { payload, ctx, store, candidate, headers } = args;
+    const { payload, ctx, store, candidate, targetApi, headers } = args;
     const rewritten = await rewriteOrRenderMessagesFailure(payload, store, candidate);
     if (rewritten.failure) return rewritten.failure;
     const invocation: MessagesInvocation = {
       payload: rewritten.payload,
       candidate,
+      targetApi,
       headers,
     };
     return await runInterceptors(invocation, ctx, messagesInterceptors, async () => {
-      if (candidate.targetApi === 'messages') {
+      if (targetApi === 'messages') {
         const { model: _model, ...body } = invocation.payload;
         const recorder = createUpstreamLatencyRecorder();
-        const providerResult = await candidate.binding.provider.callMessages(
-          candidate.binding.upstreamModel,
+        const providerResult = await candidate.provider.provider.callMessages(
+          candidate.model,
           body,
           ctx.abortSignal,
           buildUpstreamCallOptions(candidate, ctx, recorder.record, invocation.headers),
         );
-        return await providerStreamResultToExecuteResult(providerResult, candidate, ctx, recorder);
+        return await providerStreamResultToExecuteResult(providerResult, candidate, targetApi, ctx, recorder);
       }
-      if (candidate.targetApi === 'responses') {
+      if (targetApi === 'responses') {
         return await traverseTranslation(
           invocation.payload,
-          p => translateMessagesViaResponses(p, { model: candidate.binding.upstreamModel.id }),
+          p => translateMessagesViaResponses(p, { model: candidate.model.id }),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, store, candidate, targetApi, headers: invocation.headers,
           }),
         );
       }
-      if (candidate.targetApi === 'chat-completions') {
+      if (targetApi === 'chat-completions') {
         return await traverseTranslation(
           invocation.payload,
-          p => translateMessagesViaChatCompletions(p, { model: candidate.binding.upstreamModel.id }),
+          p => translateMessagesViaChatCompletions(p, { model: candidate.model.id }),
           translated => chatCompletionsAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, store, candidate, targetApi, headers: invocation.headers,
           }),
         );
       }
-      throw new Error(`messagesAttempt.generate: unexpected targetApi '${(candidate as { targetApi: string }).targetApi}'`);
+      throw new Error(`messagesAttempt.generate: unexpected targetApi '${targetApi as string}'`);
     });
   },
 
   countTokens: async (args: MessagesAttemptCountTokensArgs): Promise<PlainResult> => {
-    const { payload, ctx, store, candidate, headers } = args;
-    if (candidate.targetApi !== 'messages') {
-      throw new Error(`messagesAttempt.countTokens requires targetApi='messages', got '${candidate.targetApi}'`);
+    const { payload, ctx, store, candidate, targetApi, headers } = args;
+    if (targetApi !== 'messages') {
+      throw new Error(`messagesAttempt.countTokens requires targetApi='messages', got '${targetApi}'`);
     }
     const rewritten = await rewriteOrRenderMessagesFailure(payload, store, candidate);
     if (rewritten.failure) {
@@ -93,13 +96,14 @@ export const messagesAttempt = {
     const invocation: MessagesInvocation = {
       payload: rewritten.payload,
       candidate,
+      targetApi,
       headers,
     };
     const recorder = createUpstreamLatencyRecorder();
     const response = await runInterceptors(invocation, ctx, messagesCountTokensInterceptors, async () => {
       const { model: _model, ...body } = invocation.payload;
-      const { response } = await candidate.binding.provider.callMessagesCountTokens(
-        candidate.binding.upstreamModel,
+      const { response } = await candidate.provider.provider.callMessagesCountTokens(
+        candidate.model,
         body,
         ctx.abortSignal,
         buildUpstreamCallOptions(candidate, ctx, recorder.record, invocation.headers),
@@ -111,7 +115,7 @@ export const messagesAttempt = {
     // contract still has to fire so a provider that forgets to wrap fails
     // loud on the happy path.
     requireRecordedDurationMs(recorder, 'callMessagesCountTokens');
-    return await plainResultFromResponse(response, candidate.binding.upstream);
+    return await plainResultFromResponse(response, candidate.provider.upstream);
   },
 };
 

--- a/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
@@ -61,15 +61,12 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const targetApi = overrides.targetApi ?? 'messages';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callMessages: overrides.callMessages,
     callResponses: overrides.callResponses,
@@ -78,24 +75,10 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream,
-      providerKind: 'custom',
-      name: upstream,
-      disabledPublicModelIds: [],
-      modelPrefix: null,
-      provider,
-      supportsResponsesItemReference: true,
+      upstream, providerKind: 'custom', name: upstream,
+      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };
@@ -124,6 +107,7 @@ test('generate native messages target calls provider.callMessages with no rewrit
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessages }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
 
@@ -153,7 +137,8 @@ test('generate translate-to-responses branch routes through responsesAttempt', a
     payload: makePayload(),
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
-    candidate: makeCandidate({ targetApi: 'responses', callResponses }),
+    candidate: makeCandidate({ callResponses }),
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -175,6 +160,7 @@ test('countTokens proxies the upstream response as a plain result', async () => 
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessagesCountTokens }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
 
@@ -194,7 +180,8 @@ test('countTokens refuses a non-messages candidate', async () => {
       payload: makePayload(),
       ctx: makeGatewayCtx(),
       store: createNonResponsesSourceStore(API_KEY_ID),
-      candidate: makeCandidate({ targetApi: 'responses' }),
+      candidate: makeCandidate(),
+      targetApi: 'responses',
       headers: new Headers(),
     });
   } catch (error) {
@@ -221,6 +208,7 @@ test('generate attaches the performance context and records upstream_success', a
     ctx,
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ upstream: 'up_perf', callMessages }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
 
@@ -258,6 +246,7 @@ test('generate propagates upstream response headers onto the EventResult so resp
     ctx: makeGatewayCtx(),
     store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessages }),
+    targetApi: 'messages',
     headers: new Headers(),
   });
 

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -12,8 +12,8 @@ import { directFetcher, type ProviderCallResult, type ProviderStreamResult, type
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async () => {

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -11,7 +11,7 @@ import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -29,7 +29,7 @@ const { messagesHttp } = await import('./http.ts');
 const API_KEY_ID = 'key_messages_http_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -11,7 +11,7 @@ import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -29,7 +29,7 @@ const { messagesHttp } = await import('./http.ts');
 const API_KEY_ID = 'key_messages_http_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -106,32 +106,16 @@ const makeCandidate = (overrides: {
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callMessages: overrides.callMessages,
     callMessagesCountTokens: overrides.callMessagesCountTokens,
   });
   return {
     provider: {
-      upstream,
-      providerKind: 'custom',
-      name: upstream,
-      disabledPublicModelIds: [],
-      modelPrefix: null,
-      provider,
-      supportsResponsesItemReference: true,
+      upstream, providerKind: 'custom', name: upstream,
+      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi: 'messages',
-
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user.ts
@@ -6,7 +6,7 @@ import type { MessagesInterceptor } from './types.ts';
 // any inline message with `role: 'system'` is therefore by definition
 // interleaved, and gets demoted to `role: 'user'` with content preserved.
 export const demoteInterleavedSystemToUser: MessagesInterceptor = (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('demote-interleaved-system-to-user')) return run();
+  if (!ctx.candidate.model.enabledFlags.has('demote-interleaved-system-to-user')) return run();
 
   const { messages } = ctx.payload;
   for (let i = 0; i < messages.length; i++) {

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user_test.ts
@@ -6,7 +6,7 @@ import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, stubUpstreamModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: GatewayCtx = {
   apiKeyId: 'test-key',
@@ -29,12 +29,12 @@ interface InvocationOptions {
 const invocation = (payload: MessagesPayload, { flagOn = true }: InvocationOptions = {}): MessagesInvocation => ({
   payload,
   candidate: stubProviderCandidate({
-    targetApi: 'messages',
-    binding: {
-      upstreamModel: stubUpstreamModel({ endpoints: { messages: {} } }),
+    model: {
+      endpoints: { messages: {} },
       enabledFlags: flagOn ? new Set(['demote-interleaved-system-to-user']) : new Set(),
     },
   }),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice.ts
@@ -23,7 +23,7 @@ const disableMessagesReasoning = (payload: MessagesPayload): MessagesPayload => 
 };
 
 export const withReasoningDisabledOnForcedToolChoice: MessagesInterceptor = async (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('disable-reasoning-on-forced-tool-choice')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('disable-reasoning-on-forced-tool-choice')) return await run();
   if (!hasForcedToolChoice(ctx.payload)) return await run();
   ctx.payload = disableMessagesReasoning(ctx.payload);
   return await run();

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -6,7 +6,7 @@ import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { stubProviderCandidate, stubUpstreamModel, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
+import { stubProviderCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
 const stubCtx: GatewayCtx = {
   apiKeyId: 'test-key',
@@ -28,9 +28,9 @@ const invocation = (
 ): MessagesInvocation => ({
   payload,
   candidate: stubProviderCandidate({
-    targetApi: 'messages',
-    binding: { upstreamModel: stubUpstreamModel({ endpoints: { messages: {} } }), enabledFlags },
+    model: { endpoints: { messages: {} }, enabledFlags },
   }),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
@@ -6,7 +6,7 @@ import { withMessagesWebSearchShim } from './web-search-shim.ts';
 
 // Unified Messages interceptor list. All entries are attached to every
 // binding; each interceptor's body decides whether to act (flag-gated entries
-// early-return on `ctx.candidate.binding.enabledFlags.has(flagId)`).
+// early-return on `ctx.candidate.model.enabledFlags.has(flagId)`).
 //
 // Order follows source-then-target semantics collapsed into a single chain:
 //   - withMessagesWebSearchShim: registered first so its replay rewrite and

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution.ts
@@ -21,7 +21,7 @@ const CCH_HASH_RE = /cch=[0-9a-f]{5,};?/gi;
 const stripText = (text: string): string => text.replace(BILLING_HEADER_LINE_RE, '').replace(CCH_HASH_RE, '').trim();
 
 export const stripBillingAttribution: MessagesInterceptor = (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('strip-billing-attribution')) return run();
+  if (!ctx.candidate.model.enabledFlags.has('strip-billing-attribution')) return run();
 
   const { payload } = ctx;
 

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution_test.ts
@@ -6,7 +6,7 @@ import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, stubUpstreamModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: GatewayCtx = {
   apiKeyId: 'test-key',
@@ -29,12 +29,12 @@ interface InvocationOptions {
 const invocation = (payload: MessagesPayload, { flagOn = true }: InvocationOptions = {}): MessagesInvocation => ({
   payload,
   candidate: stubProviderCandidate({
-    targetApi: 'messages',
-    binding: {
-      upstreamModel: stubUpstreamModel({ endpoints: { messages: {} } }),
+    model: {
+      endpoints: { messages: {} },
       enabledFlags: flagOn ? new Set(['strip-billing-attribution']) : new Set(),
     },
   }),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
@@ -894,7 +894,7 @@ const resolveActiveMessagesWebSearchProvider = async (apiKeyId: string): Promise
  * may or may not be able to serve web_search natively).
  */
 export const withMessagesWebSearchShim: MessagesInterceptor = async (ctx, gatewayCtx, run) => {
-  if (ctx.candidate.targetApi === 'messages' && !ctx.candidate.binding.enabledFlags.has('messages-web-search-shim')) return await run();
+  if (ctx.targetApi === 'messages' && !ctx.candidate.model.enabledFlags.has('messages-web-search-shim')) return await run();
 
   const prepared = prepareMessagesWebSearchShimRequest(ctx.payload);
 

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
@@ -29,7 +29,7 @@ import type {
   MessagesToolResultContentBlock,
   MessagesUserContentBlock,
 } from '@floway-dev/protocols/messages';
-import { assertEquals, assertExists, assertRejects, stubProviderCandidate, stubUpstreamModel } from '@floway-dev/test-utils';
+import { assertEquals, assertExists, assertRejects, stubProviderCandidate } from '@floway-dev/test-utils';
 
 const testTelemetryModelIdentity = {
   model: 'test-model',
@@ -41,12 +41,12 @@ const testTelemetryModelIdentity = {
 const invocation = (payload: MessagesPayload): MessagesInvocation => ({
   payload,
   candidate: stubProviderCandidate({
-    targetApi: 'messages',
-    binding: {
-      upstreamModel: stubUpstreamModel({ endpoints: { messages: {} } }),
+    model: {
+      endpoints: { messages: {} },
       enabledFlags: new Set(['messages-web-search-shim']),
     },
   }),
+  targetApi: 'messages',
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/messages/routing.ts
+++ b/packages/gateway/src/data-plane/chat/messages/routing.ts
@@ -1,6 +1,6 @@
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import type { ProviderCandidate } from '../shared/candidates.ts';
+import type { ChatPlanItem } from '../shared/candidates.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import { messagesViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
@@ -9,7 +9,7 @@ export type MessagesRoutingDecision = RoutingDecision;
 
 export const planMessagesRouting = async (input: {
   readonly payload: MessagesPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ChatPlanItem[];
   readonly store: StatefulResponsesStore;
 }): Promise<MessagesRoutingDecision> =>
   await classifyResponsesItemAffinity({

--- a/packages/gateway/src/data-plane/chat/messages/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/routing_test.ts
@@ -5,40 +5,29 @@ import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createStoredResponsesItemId } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { ProviderCandidate } from '../shared/candidates.ts';
+import type { ChatPlanItem } from '../shared/candidates.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_messages_routing_test';
 
-const candidate = (upstream: string): ProviderCandidate => {
+const planItem = (upstream: string): ChatPlanItem => {
   const upstreamModel = stubUpstreamModel();
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([upstreamModel]),
   });
   return {
-    provider: {
-      upstream,
-      providerKind: 'custom',
-      name: upstream,
-      disabledPublicModelIds: [],
-      modelPrefix: null,
-      provider: modelProvider,
-      supportsResponsesItemReference: true,
-    },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider: modelProvider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
+    candidate: {
+      provider: {
+        upstream, providerKind: 'custom', name: upstream,
+        disabledPublicModelIds: [], modelPrefix: null, provider: modelProvider,
+        supportsResponsesItemReference: true,
+      },
+      model: upstreamModel,
+      fetcher: directFetcher,
     },
     targetApi: 'messages',
-
-    fetcher: directFetcher,
   };
 };
 
@@ -55,7 +44,7 @@ const payload = (messages: MessagesPayload['messages']): MessagesPayload => ({
 
 test('messages payload with no reasoning carriers passes candidates through unchanged', async () => {
   installRepo();
-  const candidates = [candidate('up_a'), candidate('up_b')];
+  const candidates = [planItem('up_a'), planItem('up_b')];
 
   const decision = await planMessagesRouting({
     payload: payload([{ role: 'user', content: 'hello' }]),
@@ -66,7 +55,7 @@ test('messages payload with no reasoning carriers passes candidates through unch
   assertEquals(decision.kind, 'success');
   if (decision.kind === 'success') {
     assertEquals(decision.candidates.length, candidates.length);
-    assertEquals(decision.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+    assertEquals(decision.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
   }
 });
 
@@ -86,7 +75,7 @@ test('a reasoning signature naming an unknown stored id fails routing as item-no
         ],
       },
     ]),
-    candidates: [candidate('up_a')],
+    candidates: [planItem('up_a')],
     store: createNonResponsesSourceStore(API_KEY_ID),
   });
 

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -2,11 +2,11 @@ import { messagesAttempt } from './attempt.ts';
 import { renderMessagesFailure } from './errors.ts';
 import { planMessagesRouting } from './routing.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import { enumerateProviderCandidates } from '../shared/candidates.ts';
+import { enumerateProviderCandidates, planChatCandidates } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
-import type { ProtocolFrame } from '@floway-dev/protocols/common';
+import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
+import type { ChatTargetApi, ExecuteResult, PlainResult } from '@floway-dev/provider';
 
 export interface MessagesServeGenerateArgs {
   readonly payload: MessagesPayload;
@@ -22,29 +22,38 @@ export interface MessagesServeCountTokensArgs {
   readonly headers: Headers;
 }
 
+// `/v1/messages` generate prefers a native Messages target, then the
+// translated Responses path, then the translated Chat Completions path.
+const pickMessagesGenerateTarget = (endpoints: ModelEndpoints): ChatTargetApi | null =>
+  endpoints.messages ? 'messages'
+    : endpoints.responses ? 'responses'
+      : endpoints.chatCompletions ? 'chat-completions'
+        : null;
+
+// `count_tokens` has no translation path — only a native Messages target
+// satisfies the operation.
+const pickMessagesCountTokensTarget = (endpoints: ModelEndpoints): ChatTargetApi | null =>
+  endpoints.messages ? 'messages' : null;
+
 export const messagesServe = {
   generate: async (args: MessagesServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => {
     const { payload, ctx, store, headers } = args;
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
-      pickTarget: endpoints =>
-        endpoints.messages ? 'messages'
-          : endpoints.responses ? 'responses'
-            : endpoints.chatCompletions ? 'chat-completions'
-              : null,
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });
-    const decision = await planMessagesRouting({ payload, candidates, store });
+    const planItems = planChatCandidates(candidates, pickMessagesGenerateTarget);
+    const decision = await planMessagesRouting({ payload, candidates: planItems, store });
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'generate');
 
     // Any non-throwing attempt result — events, api-error, or
     // internal-error — IS the answer for this request: an upstream 4xx/5xx
     // from the first viable candidate is final, not a hint to try another
     // upstream.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) {
+    const [item] = decision.candidates;
+    if (item === undefined) {
       return renderMessagesFailure(
         sawModel
           ? { kind: 'model-unsupported', model: payload.model, failedUpstreams }
@@ -52,7 +61,7 @@ export const messagesServe = {
         'generate',
       );
     }
-    return await messagesAttempt.generate({ payload, ctx, store, candidate, headers });
+    return await messagesAttempt.generate({ payload, ctx, store, candidate: item.candidate, targetApi: item.targetApi, headers });
   },
 
   countTokens: async (args: MessagesServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | PlainResult> => {
@@ -60,18 +69,18 @@ export const messagesServe = {
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
-      pickTarget: endpoints => endpoints.messages ? 'messages' : null,
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });
-    const decision = await planMessagesRouting({ payload, candidates, store });
+    const planItems = planChatCandidates(candidates, pickMessagesCountTokensTarget);
+    const decision = await planMessagesRouting({ payload, candidates: planItems, store });
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'countTokens');
 
     // PlainResult always represents a final response — both 2xx and upstream
     // errors come back as a `plain` envelope, so the first candidate's result
     // is the answer. Provider-level transport errors throw and propagate.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) {
+    const [item] = decision.candidates;
+    if (item === undefined) {
       return renderMessagesFailure(
         sawModel
           ? { kind: 'model-unsupported', model: payload.model, failedUpstreams }
@@ -79,6 +88,6 @@ export const messagesServe = {
         'countTokens',
       );
     }
-    return await messagesAttempt.countTokens({ payload, ctx, store, candidate, headers });
+    return await messagesAttempt.countTokens({ payload, ctx, store, candidate: item.candidate, targetApi: item.targetApi, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -1,8 +1,9 @@
 import { messagesAttempt } from './attempt.ts';
 import { renderMessagesFailure } from './errors.ts';
 import { planMessagesRouting } from './routing.ts';
+import { enumerateProviderCandidates } from '../../providers/candidates.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
-import { enumerateProviderCandidates, planChatCandidates } from '../shared/candidates.ts';
+import { planChatCandidates } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -41,6 +42,7 @@ export const messagesServe = {
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
+      kind: 'chat',
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });
@@ -69,6 +71,7 @@ export const messagesServe = {
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
+      kind: 'chat',
       scheduler: ctx.backgroundScheduler,
       currentColo: ctx.currentColo,
     });

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocol
 import { defaultsForProvider, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -29,7 +29,7 @@ const { messagesServe } = await import('./serve.ts');
 const API_KEY_ID = 'key_messages_serve_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -11,7 +11,7 @@ import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocol
 import { defaultsForProvider, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -29,7 +29,7 @@ const { messagesServe } = await import('./serve.ts');
 const API_KEY_ID = 'key_messages_serve_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -5,7 +5,7 @@ import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
-import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { defaultsForProvider, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
@@ -116,7 +116,7 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
+  endpoints?: ModelEndpoints;
   providerKind?: ProviderCandidate['provider']['providerKind'];
   enabledFlags?: ReadonlySet<string>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
@@ -124,9 +124,7 @@ const makeCandidate = (overrides: {
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const targetApi = overrides.targetApi ?? 'messages';
   const providerKind = overrides.providerKind ?? 'custom';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callMessages: overrides.callMessages,
     callResponses: overrides.callResponses,
@@ -134,24 +132,13 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream,
-      providerKind,
-      name: upstream,
-      disabledPublicModelIds: [],
-      modelPrefix: null,
-      provider,
-      supportsResponsesItemReference: true,
+      upstream, providerKind, name: upstream,
+      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind,
-      provider,
-      upstreamModel,
-      enabledFlags: overrides.enabledFlags ?? upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel({
+      ...(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
+      ...(overrides.enabledFlags ? { enabledFlags: overrides.enabledFlags } : {}),
+    }),
     fetcher: directFetcher,
   };
 };
@@ -210,7 +197,7 @@ test('generate translates through the Responses target when only that endpoint i
     modelKey: 'responses-model-key',
     headers: new Headers(),
   }));
-  queueCandidates([makeCandidate({ upstream: 'up_r', targetApi: 'responses', callResponses })]);
+  queueCandidates([makeCandidate({ upstream: 'up_r', endpoints: { responses: {} }, callResponses })]);
 
   const result = await messagesServe.generate({
     payload: makePayload(),

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -12,8 +12,8 @@ import { defaultsForProvider, directFetcher, type ProviderCallResult, type Provi
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async () => {

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -19,7 +19,7 @@ import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
 import { type ResponsesPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { eventResult, readUpstreamApiError, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction } from '@floway-dev/provider';
+import { eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction } from '@floway-dev/provider';
 import { translateResponsesViaChatCompletions, translateResponsesViaMessages } from '@floway-dev/translate';
 
 export interface ResponsesAttemptInvokeArgs {
@@ -28,6 +28,7 @@ export interface ResponsesAttemptInvokeArgs {
   readonly ctx: GatewayCtx;
   readonly store: StatefulResponsesStore;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
@@ -70,7 +71,7 @@ export interface ResponsesAttemptInvokeArgs {
 // no-op at the store-write layer.
 export const responsesAttempt = {
   invoke: async (args: ResponsesAttemptInvokeArgs): Promise<ResponsesAttemptResult> => {
-    const { payload, action, ctx, store, candidate, headers } = args;
+    const { payload, action, ctx, store, candidate, targetApi, headers } = args;
     // Rewrite + privatePayload seed + assistant-content normalization all run
     // BEFORE the interceptor chain so source interceptors — most importantly
     // the web-search server-tool shim — see fully inline-expanded input items
@@ -94,6 +95,7 @@ export const responsesAttempt = {
       payload: normalized,
       action,
       candidate,
+      targetApi,
       store,
       headers,
     };
@@ -115,7 +117,7 @@ export const responsesAttempt = {
       const upstreamCompacted = await collectResponsesProtocolEventsToResult(chainResult.events);
       await drainAsync(wrapResponsesOutputForStorage(syntheticEventsFromResult(upstreamCompacted), {
         store,
-        upstream: candidate.binding.upstream,
+        upstream: candidate.provider.upstream,
         targetApi: 'responses',
         responseId,
       }));
@@ -138,8 +140,8 @@ export const responsesAttempt = {
     return eventResult(
       wrapResponsesOutputForStorage(chainResult.events, {
         store,
-        upstream: candidate.binding.upstream,
-        targetApi: candidate.targetApi,
+        upstream: candidate.provider.upstream,
+        targetApi,
         responseId,
       }),
       chainResult.modelIdentity,
@@ -210,8 +212,8 @@ const dispatchResponses = async (
   invocation: ResponsesInvocation,
   ctx: GatewayCtx,
 ): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
-  const { candidate, store } = invocation;
-  switch (candidate.targetApi) {
+  const { candidate, targetApi, store } = invocation;
+  switch (targetApi) {
   case 'responses': {
     const recorder = createUpstreamLatencyRecorder();
     if (invocation.action === 'compact') {
@@ -222,24 +224,24 @@ const dispatchResponses = async (
       // provider can decide for itself (every provider's streaming call
       // forces stream=true anyway).
       const { model: _model, stream: _stream, store: _store, ...body } = invocation.payload;
-      const providerResult = await candidate.binding.provider.callResponses(
-        candidate.binding.upstreamModel,
+      const providerResult = await candidate.provider.provider.callResponses(
+        candidate.model,
         body,
         invocation.action,
         ctx.abortSignal,
         buildUpstreamCallOptions(candidate, ctx, recorder.record, invocation.headers),
       );
-      return await providerResponsesResultToExecuteResult(providerResult, candidate, ctx, recorder);
+      return await providerResponsesResultToExecuteResult(providerResult, candidate, targetApi, ctx, recorder);
     }
     const { model: _model, ...body } = invocation.payload;
-    const providerResult = await candidate.binding.provider.callResponses(
-      candidate.binding.upstreamModel,
+    const providerResult = await candidate.provider.provider.callResponses(
+      candidate.model,
       body,
       invocation.action,
       ctx.abortSignal,
       buildUpstreamCallOptions(candidate, ctx, recorder.record, invocation.headers),
     );
-    return await providerResponsesResultToExecuteResult(providerResult, candidate, ctx, recorder);
+    return await providerResponsesResultToExecuteResult(providerResult, candidate, targetApi, ctx, recorder);
   }
   case 'messages':
     if (invocation.action === 'compact') {
@@ -254,11 +256,11 @@ const dispatchResponses = async (
     return await traverseTranslation(
       invocation.payload,
       p => translateResponsesViaMessages(p, {
-        model: candidate.binding.upstreamModel.id,
-        fallbackMaxOutputTokens: candidate.binding.upstreamModel.limits.max_output_tokens,
+        model: candidate.model.id,
+        fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,
       }),
       translated => messagesAttempt.generate({
-        payload: translated, ctx, store, candidate, headers: invocation.headers,
+        payload: translated, ctx, store, candidate, targetApi: 'messages', headers: invocation.headers,
       }),
     );
   case 'chat-completions':
@@ -267,13 +269,13 @@ const dispatchResponses = async (
     }
     return await traverseTranslation(
       invocation.payload,
-      p => translateResponsesViaChatCompletions(p, { model: candidate.binding.upstreamModel.id }),
+      p => translateResponsesViaChatCompletions(p, { model: candidate.model.id }),
       translated => chatCompletionsAttempt.generate({
-        payload: translated, ctx, store, candidate, headers: invocation.headers,
+        payload: translated, ctx, store, candidate, targetApi: 'chat-completions', headers: invocation.headers,
       }),
     );
   default: {
-    const exhaustive: never = candidate.targetApi;
+    const exhaustive: never = targetApi;
     throw new Error(`unexpected targetApi '${exhaustive as string}'`);
   }
   }
@@ -287,6 +289,7 @@ const dispatchResponses = async (
 const providerResponsesResultToExecuteResult = async (
   providerResult: ProviderResponsesResult,
   candidate: ProviderCandidate,
+  targetApi: ChatTargetApi,
   ctx: GatewayCtx,
   recorder: ReturnType<typeof createUpstreamLatencyRecorder>,
 ): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
@@ -296,6 +299,7 @@ const providerResponsesResultToExecuteResult = async (
         ? { ok: true, events: providerResult.events, modelKey: providerResult.modelKey, ...(providerResult.headers ? { headers: providerResult.headers } : {}) }
         : { ok: false, response: providerResult.response, modelKey: providerResult.modelKey },
       candidate,
+      targetApi,
       ctx,
       recorder,
     );
@@ -305,7 +309,7 @@ const providerResponsesResultToExecuteResult = async (
   const context = upstreamPerformanceContext(ctx, candidate, providerResult.modelKey);
   if (!providerResult.ok) {
     recordUpstreamHttpFailure(ctx, context);
-    return { ...(await readUpstreamApiError(providerResult.response, candidate.binding.upstream)), performance: context };
+    return { ...(await readUpstreamApiError(providerResult.response, candidate.provider.upstream)), performance: context };
   }
   ctx.backgroundScheduler(recordPerformanceLatency(context, 'upstream_success', requireRecordedDurationMs(recorder, 'callResponses(action=compact)')));
   return eventResult(

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -57,7 +57,6 @@ const makeProviderEvents = async function* (events: readonly ResponsesStreamEven
 };
 
 const makeCandidate = (callResponses: (model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions) => Promise<ProviderResponsesResult>): ProviderCandidate => {
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({ callResponses });
   return {
     provider: {
@@ -69,17 +68,7 @@ const makeCandidate = (callResponses: (model: UpstreamModel, body: Omit<Response
       provider,
       supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream: 'up_test',
-      upstreamName: 'up_test',
-      providerKind: 'custom',
-      provider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi: 'responses',
-
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };
@@ -141,6 +130,7 @@ test('generate native success wraps the upstream event stream once', async () =>
     ctx,
     store,
     candidate,
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -207,6 +197,7 @@ test('generate derives snapshotMode=replace when the upstream emits a compaction
     ctx: makeGatewayCtx(),
     store,
     candidate,
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -229,7 +220,7 @@ test('generate returns failure when rewrite throws item-not-found', async () => 
   const candidate = makeCandidate(callResponses);
   // Force `supportsResponsesItemReference: false` so a stored row with no
   // inline payload triggers the rewrite-side throw.
-  candidate.binding.supportsResponsesItemReference = false;
+  candidate.provider.supportsResponsesItemReference = false;
 
   const missingId = createStoredResponsesItemId('message');
   // Pre-seed the store cache: a row with no inline payload, referenced as
@@ -255,6 +246,7 @@ test('generate returns failure when rewrite throws item-not-found', async () => 
     ctx: makeGatewayCtx(),
     store,
     candidate,
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -284,6 +276,7 @@ test('generate passes non-events provider result through unchanged', async () =>
     ctx: makeGatewayCtx(),
     store: createResponsesHttpStore(API_KEY_ID, true),
     candidate,
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -336,6 +329,7 @@ test('compact reshapes the trigger turn into a result and derives snapshotMode=r
     ctx: makeGatewayCtx(),
     store,
     candidate,
+    targetApi: 'responses',
     headers: new Headers(),
   });
 
@@ -392,13 +386,7 @@ test('generate inherits invocation headers across translation to Messages', asyn
       upstream: 'up_test', providerKind: 'custom', name: 'up_test',
       disabledPublicModelIds: [], modelPrefix: null, provider: messagesProvider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream: 'up_test', upstreamName: 'up_test', providerKind: 'custom',
-      provider: messagesProvider, upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags, supportsResponsesItemReference: true,
-    },
-    targetApi: 'messages',
-
+    model: upstreamModel,
     fetcher: directFetcher,
   };
 
@@ -407,6 +395,7 @@ test('generate inherits invocation headers across translation to Messages', asyn
     ctx: makeGatewayCtx(),
     store: createResponsesHttpStore(API_KEY_ID, true),
     candidate,
+    targetApi: 'messages',
     headers: new Headers({ 'x-test': 'abc' }),
   });
   assertEquals(result.type, 'events');
@@ -482,12 +471,11 @@ test('generate seeds privatePayload before interceptors so the web-search shim r
     return { action: 'generate', ok: true, events: makeProviderEvents(upstreamEvents), modelKey: 'test-model-key', headers: new Headers() };
   });
   const candidate = makeCandidate(callResponses);
-  // The shim early-returns inactive unless the binding has the flag. The
-  // candidate shape is `readonly`, so swap the enabledFlags via Object.assign
-  // on both the binding and its upstreamModel (which the binding aliases).
+  // The shim early-returns inactive unless the model has the flag. The
+  // candidate shape is `readonly`, so swap the enabledFlags on the model via
+  // Object.assign.
   const enabledFlags = new Set(['responses-web-search-shim']);
-  Object.assign(candidate.binding.upstreamModel, { enabledFlags });
-  Object.assign(candidate.binding, { enabledFlags });
+  Object.assign(candidate.model, { enabledFlags });
 
   const store = createResponsesHttpStore(API_KEY_ID, true);
   await store.loadInputItems({
@@ -517,6 +505,7 @@ test('generate seeds privatePayload before interceptors so the web-search shim r
     ctx: makeGatewayCtx(),
     store,
     candidate,
+    targetApi: 'responses',
     headers: new Headers(),
   });
   assertEquals(result.type, 'events');
@@ -565,6 +554,7 @@ test('generate propagates upstream response headers onto the EventResult so resp
     ctx: makeGatewayCtx(),
     store,
     candidate,
+    targetApi: 'responses',
     headers: new Headers(),
   });
 

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -14,7 +14,7 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 
 // Mock the candidates seam so each test hands the http entry exactly the
 // provider candidates it wants. Mirrors the pattern from serve_test.ts.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
 const seenModels: string[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
@@ -34,7 +34,7 @@ const { responsesHttp } = await import('./http.ts');
 const API_KEY_ID = 'key_http_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -14,7 +14,7 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 
 // Mock the candidates seam so each test hands the http entry exactly the
 // provider candidates it wants. Mirrors the pattern from serve_test.ts.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 const seenModels: string[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
@@ -34,7 +34,7 @@ const { responsesHttp } = await import('./http.ts');
 const API_KEY_ID = 'key_http_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -105,12 +105,9 @@ const makeProviderEvents = async function* (events: readonly ResponsesStreamEven
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const targetApi = overrides.targetApi ?? 'responses';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callResponses: overrides.callResponses,
   });
@@ -124,16 +121,7 @@ const makeCandidate = (overrides: {
       provider,
       supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -16,8 +16,8 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 // provider candidates it wants. Mirrors the pattern from serve_test.ts.
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
 const seenModels: string[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async (args: { model: string }) => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
@@ -23,7 +23,8 @@ const stubCtx: GatewayCtx = {
 const invocation = (): ResponsesInvocation => ({
   payload: { model: 'gpt-test', input: 'hi' } as ResponsesPayload,
   action: 'generate',
-  candidate: stubProviderCandidate({ targetApi: 'responses' }),
+  candidate: stubProviderCandidate(),
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -245,8 +245,8 @@ export const withResponsesCompactShim: ResponsesInterceptor = async (ctx, _gatew
   // OR when the upstream's targetApi is not Responses (Messages /
   // Chat Completions have no compaction wire and would crash on the
   // unknown `compaction_trigger` input variant).
-  const flagOn = ctx.candidate.binding.enabledFlags.has('responses-compact-shim');
-  const structurallyRequired = ctx.candidate.targetApi !== 'responses';
+  const flagOn = ctx.candidate.model.enabledFlags.has('responses-compact-shim');
+  const structurallyRequired = ctx.targetApi !== 'responses';
   if (!flagOn && !structurallyRequired) return await run();
 
   // Inbound: expand any prior shim-encoded compactions back into their

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -28,9 +28,9 @@ const makeInvocation = (
   payload: { model: 'test-model', input: [], ...payload } as ResponsesPayload,
   action: options.action ?? 'generate',
   candidate: stubProviderCandidate({
-    targetApi: options.targetApi ?? 'responses',
-    binding: { enabledFlags: new Set(options.flagOn === false ? [] : ['responses-compact-shim']) },
+    model: { enabledFlags: new Set(options.flagOn === false ? [] : ['responses-compact-shim']) },
   }),
+  targetApi: options.targetApi ?? 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system.ts
@@ -24,7 +24,7 @@ const downgradeRole = (item: ResponsesInputItem): ResponsesInputItem => {
 };
 
 export const withDemoteDeveloperToSystem: ResponsesInterceptor = async (ctx, _request, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('demote-developer-to-system')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('demote-developer-to-system')) return await run();
 
   if (Array.isArray(ctx.payload.input)) {
     ctx.payload = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -32,7 +32,8 @@ const okEvents = () =>
 
 const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'responses', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user.ts
@@ -10,7 +10,7 @@ import type { ResponsesInterceptor } from './types.ts';
 // `role: 'system'` message item is rewritten to `role: 'user'` with its
 // content kept verbatim.
 export const withInterleavedSystemDemotedToUser: ResponsesInterceptor = (ctx, _gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('demote-interleaved-system-to-user')) return run();
+  if (!ctx.candidate.model.enabledFlags.has('demote-interleaved-system-to-user')) return run();
 
   const { input } = ctx.payload;
   if (typeof input === 'string') return run();

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -35,7 +35,8 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['demote-interleaved-system-to-user']),
 ): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'responses', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice.ts
@@ -16,7 +16,7 @@ const hasForcedToolChoice = (payload: ResponsesPayload): boolean => {
 };
 
 export const withReasoningDisabledOnForcedToolChoice: ResponsesInterceptor = async (ctx, _request, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('disable-reasoning-on-forced-tool-choice')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('disable-reasoning-on-forced-tool-choice')) return await run();
   if (!hasForcedToolChoice(ctx.payload)) return await run();
   ctx.payload = { ...ctx.payload, reasoning: { effort: 'none' } };
   return await run();

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -35,7 +35,8 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'responses', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
@@ -13,7 +13,7 @@ import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 
 // Unified Responses interceptor list. All entries are attached to every
 // binding; each interceptor's body decides whether to act (flag-gated entries
-// early-return on `ctx.candidate.binding.enabledFlags.has(flagId)`).
+// early-return on `ctx.candidate.model.enabledFlags.has(flagId)`).
 //
 // Order matters: earlier entries wrap later ones.
 //   - withResponsesCompactShim: runs outermost so the action pivot

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy.ts
@@ -173,7 +173,7 @@ const retryCyberPolicyEvents = async function* (
  * operators can inspect detailed upstream failures.
  */
 export const withCyberPolicyRetried: ResponsesInterceptor = async (ctx, gatewayCtx, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('retry-cyber-policy')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('retry-cyber-policy')) return await run();
 
   let finalResult: ResponsesResultFrames | undefined;
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -26,7 +26,8 @@ const makePayload = (): ResponsesPayload => ({
 
 const makeInvocation = (payload: ResponsesPayload): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'responses', binding: { enabledFlags: new Set(['retry-cyber-policy']) } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags: new Set(['retry-cyber-policy']) } }),
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -318,16 +318,25 @@ const makeStore = (apiKeyId: string | null = 'k1'): StatefulResponsesStore =>
 
 const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocation => ({
   candidate: {
-    // Default chat-completions so existing tests exercise the
-    // function_call_output path. Tests that care about a specific target
-    // set targetApi explicitly.
-    targetApi: overrides.targetApi ?? 'chat-completions',
-    provider: {} as never,
-    binding: {
+    provider: {
+      // Tests don't care about provider identity here; the shim reads
+      // targetApi off the invocation and enabledFlags off the candidate's
+      // model. Use `never` to skip the full ModelProviderInstance literal.
+      upstream: 'test-upstream', providerKind: 'custom', name: 'test',
+      disabledPublicModelIds: [], modelPrefix: null,
+      provider: {} as never, supportsResponsesItemReference: false,
+    },
+    model: {
+      id: 'claude-x', limits: {}, kind: 'chat',
+      endpoints: { chatCompletions: {}, responses: {}, messages: {} },
       enabledFlags: overrides.enabledFlags ?? new Set<string>(),
-    } as never,
+    },
     fetcher: directFetcher,
   },
+  // Default chat-completions so existing tests exercise the
+  // function_call_output path. Tests that care about a specific target
+  // set targetApi explicitly.
+  targetApi: overrides.targetApi ?? 'chat-completions',
   store: makeStore(),
   payload: {
     model: 'claude-x',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -37,9 +37,13 @@ vi.mock('../../../../providers/registry.ts', () => ({
         id: 'gpt-image-2',
         endpoints: { imagesGenerations: {}, imagesEdits: {} },
       },
-      binding: {
+      provider: {
         upstream: 'u',
-        upstreamModel: { id: 'gpt-image-2', endpoints: { imagesGenerations: {}, imagesEdits: {} } },
+        providerKind: 'custom',
+        name: 'mock-image',
+        disabledPublicModelIds: [],
+        modelPrefix: null,
+        supportsResponsesItemReference: false,
         provider: {
           getPricingForModelKey: () => null,
           callImagesGenerations: async (_model: unknown, body: Record<string, unknown>, _signal: unknown, opts: { recordUpstreamLatency: <T>(p: Promise<T>) => Promise<T> }) => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -29,14 +29,9 @@ interface BackendStub {
 // `next*` queues and read back the recorded calls.
 const stub = vi.hoisted((): BackendStub => ({ generationsCalls: [], editsForms: [], nextGenerations: [], nextEdits: [] }));
 
-vi.mock('../../../../providers/registry.ts', () => ({
-  resolveModelForRequest: vi.fn(async () => ({
-    matches: [{
-      id: 'gpt-image-2',
-      model: {
-        id: 'gpt-image-2',
-        endpoints: { imagesGenerations: {}, imagesEdits: {} },
-      },
+vi.mock('../../../../providers/candidates.ts', () => ({
+  enumerateProviderCandidates: vi.fn(async () => ({
+    candidates: [{
       provider: {
         upstream: 'u',
         providerKind: 'custom',
@@ -60,6 +55,11 @@ vi.mock('../../../../providers/registry.ts', () => ({
           },
         },
       },
+      model: {
+        id: 'gpt-image-2',
+        endpoints: { imagesGenerations: {}, imagesEdits: {} },
+      },
+      fetcher: (request: Request) => fetch(request),
     }],
     failedUpstreams: [],
   })),

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -119,13 +119,19 @@ const scriptedRun = (turns: ProtocolFrame<ResponsesStreamEvent>[][]) => {
 
 const makeCtx = (input: unknown[], action: 'generate' | 'edit' | 'auto' = 'auto', extraTool: Record<string, unknown> = {}): ResponsesInvocation => ({
   candidate: {
-    targetApi: 'responses',
-    provider: {} as never,
-    binding: {
+    provider: {
+      upstream: 'test-upstream', providerKind: 'custom', name: 'test',
+      disabledPublicModelIds: [], modelPrefix: null,
+      provider: {} as never, supportsResponsesItemReference: false,
+    },
+    model: {
+      id: 'm', limits: {}, kind: 'chat',
+      endpoints: { responses: {} },
       enabledFlags: new Set<string>(['responses-image-generation-shim']),
-    } as never,
+    },
     fetcher: directFetcher,
   },
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -548,7 +548,7 @@ const resolveImageBinding = async (
   } catch (e) {
     return { ok: false, error: serverError(e) };
   }
-  const match = resolution.matches.find(m => m.binding.upstreamModel.endpoints[endpointKey] !== undefined);
+  const match = resolution.matches.find(m => m.model.endpoints[endpointKey] !== undefined);
   if (match === undefined) {
     return {
       ok: false,
@@ -892,7 +892,7 @@ export const transformInputItemsForImageGeneration = (
 };
 
 export const imageGenerationServerTool: ServerToolRegistration = (invocation, gatewayCtx) => {
-  if (invocation.candidate.targetApi === 'responses' && !invocation.candidate.binding.enabledFlags.has('responses-image-generation-shim')) {
+  if (invocation.targetApi === 'responses' && !invocation.candidate.model.enabledFlags.has('responses-image-generation-shim')) {
     return { type: 'inactive' };
   }
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -535,7 +535,7 @@ const serverError = (e: unknown): ImageError => ({
 // model for the target endpoint. A resolution/availability failure is
 // normalized into an `ImageError` so the caller always produces a
 // terminal image item.
-const resolveImageBinding = async (
+const resolveImageCandidate = async (
   isEdit: boolean,
   state: ShimState,
 ): Promise<{ ok: true; provider: ModelProviderInstance; model: UpstreamModel; fetcher: Fetcher } | { ok: false; error: ImageError }> => {
@@ -773,7 +773,7 @@ const streamImageGeneration = (
   sources: readonly ImageSource[],
   state: ShimState,
 ) => async function* (): AsyncGenerator<ServerToolLifecycleEvent, ServerToolTerminal> {
-  const resolved = await resolveImageBinding(isEdit, state);
+  const resolved = await resolveImageCandidate(isEdit, state);
   if (!resolved.ok) return imageTerminal(prompt, action, { ok: false, error: resolved.error });
   const { provider, model, fetcher } = resolved;
   const wantsPartials = (state.config.partial_images ?? 0) > 0;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -1,6 +1,5 @@
-import { createPerRequestFetcher } from '../../../../../dial/per-request.ts';
 import { sleep } from '../../../../../shared/sleep.ts';
-import { resolveModelForRequest } from '../../../../providers/registry.ts';
+import { enumerateProviderCandidates } from '../../../../providers/candidates.ts';
 import { appendFailedUpstreams } from '../../../../shared/failed-upstreams.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, requireRecordedDurationMs } from '../../../../shared/telemetry/performance.ts';
 import { recordTokenUsage, tokenUsageFromImagesBody } from '../../../../shared/telemetry/usage.ts';
@@ -539,17 +538,22 @@ const serverError = (e: unknown): ImageError => ({
 const resolveImageBinding = async (
   isEdit: boolean,
   state: ShimState,
-  fetcherForUpstream: (upstreamId: string) => Fetcher,
-): Promise<{ ok: true; provider: ModelProviderInstance; model: UpstreamModel } | { ok: false; error: ImageError }> => {
+): Promise<{ ok: true; provider: ModelProviderInstance; model: UpstreamModel; fetcher: Fetcher } | { ok: false; error: ImageError }> => {
   const endpointKey = isEdit ? 'imagesEdits' : 'imagesGenerations';
   const endpointPath = isEdit ? '/images/edits' : '/images/generations';
   let resolution;
   try {
-    resolution = await resolveModelForRequest(state.config.model, state.upstreamIds, fetcherForUpstream, state.backgroundScheduler);
+    resolution = await enumerateProviderCandidates({
+      upstreamIds: state.upstreamIds,
+      model: state.config.model,
+      kind: 'image',
+      scheduler: state.backgroundScheduler,
+      currentColo: state.currentColo,
+    });
   } catch (e) {
     return { ok: false, error: serverError(e) };
   }
-  const match = resolution.matches.find(m => m.model.endpoints[endpointKey] !== undefined);
+  const match = resolution.candidates.find(c => c.model.endpoints[endpointKey] !== undefined);
   if (match === undefined) {
     return {
       ok: false,
@@ -561,7 +565,7 @@ const resolveImageBinding = async (
       },
     };
   }
-  return { ok: true, provider: match.provider, model: match.model };
+  return { ok: true, provider: match.provider, model: match.model, fetcher: match.fetcher };
 };
 
 // 60s cap matches the per-minute refill window of Azure TPM/RPM and
@@ -769,11 +773,9 @@ const streamImageGeneration = (
   sources: readonly ImageSource[],
   state: ShimState,
 ) => async function* (): AsyncGenerator<ServerToolLifecycleEvent, ServerToolTerminal> {
-  const fetcherForUpstream = await createPerRequestFetcher(state.currentColo);
-  const resolved = await resolveImageBinding(isEdit, state, fetcherForUpstream);
+  const resolved = await resolveImageBinding(isEdit, state);
   if (!resolved.ok) return imageTerminal(prompt, action, { ok: false, error: resolved.error });
-  const { provider, model } = resolved;
-  const fetcher = fetcherForUpstream(provider.upstream);
+  const { provider, model, fetcher } = resolved;
   const wantsPartials = (state.config.partial_images ?? 0) > 0;
 
   let response: Response;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -19,7 +19,7 @@ import type {
   ResponsesPayload,
   ResponsesTool,
 } from '@floway-dev/protocols/responses';
-import type { Fetcher, PerformanceTelemetryContext, ProviderModelRecord } from '@floway-dev/provider';
+import type { Fetcher, ModelProviderInstance, PerformanceTelemetryContext, UpstreamModel } from '@floway-dev/provider';
 
 export const SHIM_TOOL_NAME = 'image_generation';
 
@@ -461,14 +461,14 @@ interface ShimState {
   imageDispatchCount: number;
 }
 
-const recordImageUsage = (state: ShimState, binding: ProviderModelRecord, modelKey: string, responseBody: unknown): void => {
+const recordImageUsage = (state: ShimState, provider: ModelProviderInstance, model: UpstreamModel, modelKey: string, responseBody: unknown): void => {
   const usage = tokenUsageFromImagesBody(responseBody);
   if (usage === null) return;
   const promise = recordTokenUsage(state.apiKeyId, {
-    model: binding.upstreamModel.id,
-    upstream: binding.upstream,
+    model: model.id,
+    upstream: provider.upstream,
     modelKey,
-    cost: binding.provider.getPricingForModelKey(modelKey) ?? null,
+    cost: provider.provider.getPricingForModelKey(modelKey) ?? null,
   }, usage).catch((error: unknown) => {
     console.error('Failed to record image generation usage:', error);
   });
@@ -532,14 +532,15 @@ const serverError = (e: unknown): ImageError => ({
   retryable: true,
 });
 
-// Resolve the binding that serves the configured image model for the target
-// endpoint. A resolution/availability failure is normalized into an
-// `ImageError` so the caller always produces a terminal image item.
+// Resolve the (provider, model) pair that serves the configured image
+// model for the target endpoint. A resolution/availability failure is
+// normalized into an `ImageError` so the caller always produces a
+// terminal image item.
 const resolveImageBinding = async (
   isEdit: boolean,
   state: ShimState,
   fetcherForUpstream: (upstreamId: string) => Fetcher,
-): Promise<{ ok: true; binding: ProviderModelRecord } | { ok: false; error: ImageError }> => {
+): Promise<{ ok: true; provider: ModelProviderInstance; model: UpstreamModel } | { ok: false; error: ImageError }> => {
   const endpointKey = isEdit ? 'imagesEdits' : 'imagesGenerations';
   const endpointPath = isEdit ? '/images/edits' : '/images/generations';
   let resolution;
@@ -560,7 +561,7 @@ const resolveImageBinding = async (
       },
     };
   }
-  return { ok: true, binding: match.binding };
+  return { ok: true, provider: match.provider, model: match.model };
 };
 
 // 60s cap matches the per-minute refill window of Azure TPM/RPM and
@@ -605,7 +606,8 @@ export const parseRetryAfterMs = (headers: Headers): number | null => {
 // unread body — intermediate failed responses are drained inside the loop so
 // the underlying socket can be reused while we sleep.
 const issueImageCall = async (
-  binding: ProviderModelRecord,
+  provider: ModelProviderInstance,
+  model: UpstreamModel,
   fetcher: Fetcher,
   prompt: string,
   isEdit: boolean,
@@ -616,12 +618,12 @@ const issueImageCall = async (
   for (let attempt = 0; ; attempt++) {
     const recorder = createUpstreamLatencyRecorder();
     const { response, modelKey } = await (isEdit
-      ? binding.provider.callImagesEdits(binding.upstreamModel, buildEditsForm(prompt, state.config, sources, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() })
-      : binding.provider.callImagesGenerations(binding.upstreamModel, buildGenerationsBody(prompt, state.config, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() }));
+      ? provider.provider.callImagesEdits(model, buildEditsForm(prompt, state.config, sources, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() })
+      : provider.provider.callImagesGenerations(model, buildGenerationsBody(prompt, state.config, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() }));
     const context: PerformanceTelemetryContext = {
       keyId: state.apiKeyId,
-      model: binding.upstreamModel.id,
-      upstream: binding.upstream,
+      model: model.id,
+      upstream: provider.upstream,
       modelKey,
       stream: false,
       runtimeLocation: state.runtimeLocation,
@@ -648,7 +650,8 @@ const issueImageCall = async (
 // outcome. Transport/backend failures become `{ok:false}` rather than
 // throwing, so the caller always produces a terminal image item.
 const consumeImageResponse = async (
-  binding: ProviderModelRecord,
+  provider: ModelProviderInstance,
+  model: UpstreamModel,
   modelKey: string,
   response: Response,
   state: ShimState,
@@ -674,7 +677,7 @@ const consumeImageResponse = async (
   if (b64 === null) {
     return { ok: false, error: { type: 'image_generation_error', message: 'Image backend response did not contain image bytes.', code: 'server_error', retryable: true } };
   }
-  recordImageUsage(state, binding, modelKey, parsed);
+  recordImageUsage(state, provider, model, modelKey, parsed);
   return { ok: true, b64, echo: extractEcho(parsed) };
 };
 
@@ -769,20 +772,20 @@ const streamImageGeneration = (
   const fetcherForUpstream = await createPerRequestFetcher(state.currentColo);
   const resolved = await resolveImageBinding(isEdit, state, fetcherForUpstream);
   if (!resolved.ok) return imageTerminal(prompt, action, { ok: false, error: resolved.error });
-  const { binding } = resolved;
-  const fetcher = fetcherForUpstream(binding.upstream);
+  const { provider, model } = resolved;
+  const fetcher = fetcherForUpstream(provider.upstream);
   const wantsPartials = (state.config.partial_images ?? 0) > 0;
 
   let response: Response;
   let modelKey: string;
   try {
-    ({ response, modelKey } = await issueImageCall(binding, fetcher, prompt, isEdit, sources, state, wantsPartials));
+    ({ response, modelKey } = await issueImageCall(provider, model, fetcher, prompt, isEdit, sources, state, wantsPartials));
   } catch (e) {
     return imageTerminal(prompt, action, { ok: false, error: serverError(e) });
   }
 
   if (!wantsPartials) {
-    return imageTerminal(prompt, action, await consumeImageResponse(binding, modelKey, response, state));
+    return imageTerminal(prompt, action, await consumeImageResponse(provider, model, modelKey, response, state));
   }
 
   if (!response.ok) {
@@ -812,7 +815,7 @@ const streamImageGeneration = (
   if (finalB64 === undefined) {
     return imageTerminal(prompt, action, { ok: false, error: { type: 'image_generation_error', message: 'Image backend stream ended without a completed image.', code: 'server_error', retryable: true } });
   }
-  recordImageUsage(state, binding, modelKey, { usage });
+  recordImageUsage(state, provider, model, modelKey, { usage });
   return imageTerminal(prompt, action, { ok: true, b64: finalB64, echo: finalEcho });
 };
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -31,13 +31,19 @@ const PNG_B64 = 'aGVsbG8='; // "hello" — any decodable base64 works for source
 // The registration only reads targetApi / enabledFlags / payload off the invocation.
 const makeCtx = (payload: Partial<ResponsesPayload>): ResponsesInvocation => ({
   candidate: {
-    targetApi: 'responses',
-    provider: {} as never,
-    binding: {
+    provider: {
+      upstream: 'test-upstream', providerKind: 'custom', name: 'test',
+      disabledPublicModelIds: [], modelPrefix: null,
+      provider: {} as never, supportsResponsesItemReference: false,
+    },
+    model: {
+      id: 'm', limits: {}, kind: 'chat',
+      endpoints: { responses: {} },
       enabledFlags: new Set<string>(['responses-image-generation-shim']),
-    } as never,
+    },
     fetcher: directFetcher,
   },
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -1306,7 +1306,7 @@ const planShimSlots = (
 };
 
 export const webSearchServerTool: ServerToolRegistration = (invocation, gatewayCtx) => {
-  if (invocation.candidate.targetApi === 'responses' && !invocation.candidate.binding.enabledFlags.has('responses-web-search-shim')) {
+  if (invocation.targetApi === 'responses' && !invocation.candidate.model.enabledFlags.has('responses-web-search-shim')) {
     return { type: 'inactive' };
   }
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
@@ -35,7 +35,7 @@ const stripCanonicalReasoningSentinel = (payload: ResponsesPayload): ResponsesPa
 };
 
 export const withVendorDeepseekResponsesNormalize: ResponsesInterceptor = async (ctx, _request, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('vendor-deepseek')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('vendor-deepseek')) return await run();
 
   ctx.payload = stripCanonicalReasoningSentinel(ctx.payload);
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -32,7 +32,8 @@ const okEvents = () =>
 
 const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'responses', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
@@ -17,7 +17,7 @@ import type { ResponsesInterceptor } from './types.ts';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 export const withVendorQwenResponsesNormalize: ResponsesInterceptor = async (ctx, _request, run) => {
-  if (!ctx.candidate.binding.enabledFlags.has('vendor-qwen')) return await run();
+  if (!ctx.candidate.model.enabledFlags.has('vendor-qwen')) return await run();
 
   if (ctx.payload.reasoning?.effort === 'none') {
     const { reasoning: _stripped, ...rest } = ctx.payload;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -32,7 +32,8 @@ const okEvents = () =>
 
 const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ targetApi: 'responses', binding: { enabledFlags } }),
+  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  targetApi: 'responses',
   store: new LayeredStatefulResponsesStore({
     apiKeyId: 'test-key',
     reads: [new MemoryStatefulResponsesBacking()],

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
@@ -1,7 +1,7 @@
 import { hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
-import type { ProviderCandidate } from '../../shared/candidates.ts';
+import type { ChatPlanItem } from '../../shared/candidates.ts';
 import type { ChatServeFailure } from '../../shared/errors.ts';
 import type { RoutingDecision } from '../../shared/routing.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
@@ -99,17 +99,17 @@ const collectStoredResponsesItemRefs = async <TSourceItems>(
 };
 
 const orderCandidatesByStoredResponsesAffinity = (
-  candidates: readonly ProviderCandidate[],
+  candidates: readonly ChatPlanItem[],
   preferredUpstreamIds: ReadonlySet<string>,
-): readonly ProviderCandidate[] => {
+): readonly ChatPlanItem[] => {
   const preferred = [...preferredUpstreamIds].reverse();
   if (preferred.length === 0) return candidates;
 
   const order = new Map(preferred.map((upstreamId, index) => [upstreamId, index]));
   const preferredCandidates = candidates
-    .filter(cand => order.has(cand.binding.upstream))
-    .toSorted((a, b) => order.get(a.binding.upstream)! - order.get(b.binding.upstream)!);
-  const remainingCandidates = candidates.filter(cand => !order.has(cand.binding.upstream));
+    .filter(cand => order.has(cand.candidate.provider.upstream))
+    .toSorted((a, b) => order.get(a.candidate.provider.upstream)! - order.get(b.candidate.provider.upstream)!);
+  const remainingCandidates = candidates.filter(cand => !order.has(cand.candidate.provider.upstream));
   return [...preferredCandidates, ...remainingCandidates];
 };
 
@@ -117,7 +117,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems>(input: {
   sourceItems: TSourceItems;
   view: ResponsesItemsView<TSourceItems>;
   store: StatefulResponsesStore;
-  candidates: readonly ProviderCandidate[];
+  candidates: readonly ChatPlanItem[];
   // Items the caller will stage as inputs after the affinity walk; passed
   // here so `loadInputItems` can pre-load any stored row whose content hash
   // matches one of them. Without this, a duplicate user message resent on
@@ -193,7 +193,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems>(input: {
 
   if (forcingUpstreamList.length === 1) {
     const [upstreamId] = forcingUpstreamList;
-    const matching = candidates.filter(cand => cand.binding.upstream === upstreamId);
+    const matching = candidates.filter(cand => cand.candidate.provider.upstream === upstreamId);
     if (matching.length === 0) {
       return {
         kind: 'failure',
@@ -205,7 +205,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems>(input: {
     }
     const unexpandedReferenceId = findUnexpandedItemReferenceForcingId(references, upstreamId);
     if (unexpandedReferenceId !== null) {
-      const itemReferenceCapable = matching.filter(cand => cand.binding.supportsResponsesItemReference);
+      const itemReferenceCapable = matching.filter(cand => cand.candidate.provider.supportsResponsesItemReference);
       if (itemReferenceCapable.length === 0) {
         return { kind: 'failure', failure: { kind: 'item-not-found', itemId: unexpandedReferenceId } };
       }

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
-import type { ProviderCandidate } from '../../shared/candidates.ts';
+import type { ChatPlanItem } from '../../shared/candidates.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
@@ -14,33 +14,25 @@ import { responsesItemsView } from '@floway-dev/translate/via-responses/response
 
 const API_KEY_ID = 'key_affinity_test';
 
-const candidate = (upstream: string, supportsResponsesItemReference = true): ProviderCandidate => {
-  const upstreamModel = stubUpstreamModel();
+const candidate = (upstream: string, supportsResponsesItemReference = true): ChatPlanItem => {
   const modelProvider = stubProvider({
-    getProvidedModels: () => Promise.resolve([upstreamModel]),
+    getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
   });
   return {
-    provider: {
-      upstream,
-      providerKind: 'custom',
-      name: upstream,
-      disabledPublicModelIds: [],
-      modelPrefix: null,
-      provider: modelProvider,
-      supportsResponsesItemReference,
-    },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider: modelProvider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference,
+    candidate: {
+      provider: {
+        upstream,
+        providerKind: 'custom',
+        name: upstream,
+        disabledPublicModelIds: [],
+        modelPrefix: null,
+        provider: modelProvider,
+        supportsResponsesItemReference,
+      },
+      model: stubUpstreamModel(),
+      fetcher: directFetcher,
     },
     targetApi: 'responses',
-
-    fetcher: directFetcher,
   };
 };
 
@@ -75,7 +67,7 @@ const storedRow = (
 
 const classifyItems = async (
   sourceItems: readonly ResponsesInputItem[],
-  candidates: readonly ProviderCandidate[],
+  candidates: readonly ChatPlanItem[],
 ) => {
   const store = createNonResponsesSourceStore(API_KEY_ID);
   return await classifyResponsesItemAffinity({
@@ -145,7 +137,7 @@ test('empty references pass through all candidates unchanged', async () => {
   const result = await classifyItems([], [candidate('up_a'), candidate('up_b')]);
 
   assertEquals(result.kind, 'success');
-  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
 });
 
 test('non-affinity items (no id, no encrypted_content) pass through candidates unchanged', async () => {
@@ -155,7 +147,7 @@ test('non-affinity items (no id, no encrypted_content) pass through candidates u
   const result = await classifyItems(items, [candidate('up_a'), candidate('up_b')]);
 
   assertEquals(result.kind, 'success');
-  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
 });
 
 test('duplicate stored ids dedupe preferred upstreams by last occurrence', async () => {
@@ -174,7 +166,7 @@ test('duplicate stored ids dedupe preferred upstreams by last occurrence', async
 
   // up_a appears last so it should be sorted first; up_b second
   assertEquals(result.kind, 'success');
-  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
 });
 
 test('mixed portable upstreams are ordered by reverse last occurrence before remaining candidates', async () => {
@@ -191,7 +183,7 @@ test('mixed portable upstreams are ordered by reverse last occurrence before rem
   ], [candidate('up_c'), candidate('up_a'), candidate('up_b')]);
 
   assertEquals(result.kind, 'success');
-  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.binding.upstream), ['up_b', 'up_a', 'up_c']);
+  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.candidate.provider.upstream), ['up_b', 'up_a', 'up_c']);
 });
 
 test('conflicting compaction forcing upstreams reject the request', async () => {
@@ -265,7 +257,7 @@ test('id-less reasoning is matched by encrypted_content hash and prefers its own
   const result = await classifyItems(items, [candidate('up_b'), candidate('up_a')]);
 
   assertEquals(result.kind, 'success');
-  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
 });
 
 test('id-less encrypted_content duplicate hash keeps the freshest stored row for affinity', async () => {
@@ -280,7 +272,7 @@ test('id-less encrypted_content duplicate hash keeps the freshest stored row for
   const result = await classifyItems(items, [candidate('up_old'), candidate('up_new')]);
 
   assertEquals(result.kind, 'success');
-  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.binding.upstream), ['up_new', 'up_old']);
+  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.candidate.provider.upstream), ['up_new', 'up_old']);
 });
 
 test('id-less compaction is matched by encrypted_content hash and forces its owning upstream', async () => {
@@ -294,7 +286,7 @@ test('id-less compaction is matched by encrypted_content hash and forces its own
 
   const resultWithOwner = await classifyItems(items, [candidate('up_b'), candidate('up_a')]);
   assertEquals(resultWithOwner.kind, 'success');
-  if (resultWithOwner.kind === 'success') assertEquals(resultWithOwner.candidates.map(c => c.binding.upstream), ['up_a']);
+  if (resultWithOwner.kind === 'success') assertEquals(resultWithOwner.candidates.map(c => c.candidate.provider.upstream), ['up_a']);
 
   const resultWithoutOwner = await classifyItems(items, [candidate('up_b')]);
   assertEquals(resultWithoutOwner.kind, 'failure');
@@ -308,5 +300,5 @@ test('id-less encrypted_content with no stored match is a benign passthrough wit
   const result = await classifyItems(items, [candidate('up_a'), candidate('up_b')]);
 
   assertEquals(result.kind, 'success');
-  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+  if (result.kind === 'success') assertEquals(result.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
 });

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
@@ -15,9 +15,7 @@ import { responsesItemsView } from '@floway-dev/translate/via-responses/response
 const API_KEY_ID = 'key_affinity_test';
 
 const candidate = (upstream: string, supportsResponsesItemReference = true): ChatPlanItem => {
-  const modelProvider = stubProvider({
-    getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
-  });
+  const model = stubUpstreamModel();
   return {
     candidate: {
       provider: {
@@ -26,10 +24,10 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Cha
         name: upstream,
         disabledPublicModelIds: [],
         modelPrefix: null,
-        provider: modelProvider,
+        provider: stubProvider({ getProvidedModels: () => Promise.resolve([model]) }),
         supportsResponsesItemReference,
       },
-      model: stubUpstreamModel(),
+      model,
       fetcher: directFetcher,
     },
     targetApi: 'responses',

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -30,7 +30,7 @@ const rewriteItemForCandidate = (
   // An `item_reference` whose stored row has no inline payload can only
   // travel as a reference on the wire; a provider that doesn't support
   // `item_reference` input has no way to expand it.
-  if (item.type === 'item_reference' && row.payload === null && !candidate.binding.supportsResponsesItemReference) {
+  if (item.type === 'item_reference' && row.payload === null && !candidate.provider.supportsResponsesItemReference) {
     throwChatServeFailure({ kind: 'item-not-found', itemId: row.id });
   }
 
@@ -45,13 +45,13 @@ const rewriteItemForCandidate = (
 
   // Owned reasoning is bound to the upstream that produced it; drop it when
   // routing elsewhere.
-  if (row.itemType === 'reasoning' && row.upstreamId !== candidate.binding.upstream) return null;
+  if (row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return null;
 
-  if (row.upstreamId === candidate.binding.upstream && row.upstreamItemId) {
+  if (row.upstreamId === candidate.provider.upstream && row.upstreamItemId) {
     // Same upstream: substitute the original upstream-issued id. A
     // reference-capable provider keeps the wire item as `item_reference`;
     // others inline-expand against the stored payload.
-    return item.type === 'item_reference' && candidate.binding.supportsResponsesItemReference
+    return item.type === 'item_reference' && candidate.provider.supportsResponsesItemReference
       ? itemWithId(item, row.upstreamItemId)
       : itemWithId(storedItemReplacementBase(item, row), row.upstreamItemId);
   }

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -16,9 +16,7 @@ import { responsesItemsView } from '@floway-dev/translate/via-responses/response
 const API_KEY_ID = 'key_rewrite_test';
 
 const candidate = (upstream: string, supportsResponsesItemReference = true): ProviderCandidate => {
-  const modelProvider = stubProvider({
-    getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
-  });
+  const model = stubUpstreamModel();
   return {
     provider: {
       upstream,
@@ -26,10 +24,10 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Pro
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,
-      provider: modelProvider,
+      provider: stubProvider({ getProvidedModels: () => Promise.resolve([model]) }),
       supportsResponsesItemReference,
     },
-    model: stubUpstreamModel(),
+    model,
     fetcher: directFetcher,
   };
 };

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -16,9 +16,8 @@ import { responsesItemsView } from '@floway-dev/translate/via-responses/response
 const API_KEY_ID = 'key_rewrite_test';
 
 const candidate = (upstream: string, supportsResponsesItemReference = true): ProviderCandidate => {
-  const upstreamModel = stubUpstreamModel();
   const modelProvider = stubProvider({
-    getProvidedModels: () => Promise.resolve([upstreamModel]),
+    getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
   });
   return {
     provider: {
@@ -30,17 +29,7 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Pro
       provider: modelProvider,
       supportsResponsesItemReference,
     },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider: modelProvider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference,
-    },
-    targetApi: 'responses',
-
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };
@@ -90,7 +79,7 @@ const rewrite = async (
   const store = createNonResponsesSourceStore(API_KEY_ID);
   await store.loadInputItems({ sourceItems: input, view: responsesItemsView });
   // Simulate the affinity classification that populates the store cache.
-  await classifyResponsesItemAffinity({ sourceItems: input, view: responsesItemsView, store, candidates: [cand] });
+  await classifyResponsesItemAffinity({ sourceItems: input, view: responsesItemsView, store, candidates: [{ candidate: cand, targetApi: 'responses' }] });
   const result = await rewriteResponsesItemsForCandidate(makePayload(input), store, cand);
   return result.payload.input as ResponsesInputItem[];
 };

--- a/packages/gateway/src/data-plane/chat/responses/routing.ts
+++ b/packages/gateway/src/data-plane/chat/responses/routing.ts
@@ -1,5 +1,5 @@
 import { classifyResponsesItemAffinity } from './items/affinity.ts';
-import type { ProviderCandidate } from '../shared/candidates.ts';
+import type { ChatPlanItem } from '../shared/candidates.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { StatefulResponsesStore } from './items/store.ts';
 import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
@@ -7,7 +7,7 @@ import { responsesItemsView } from '@floway-dev/translate/via-responses/response
 
 export const planResponsesRouting = async (input: {
   readonly payload: ResponsesPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ChatPlanItem[];
   readonly store: StatefulResponsesStore;
 }): Promise<RoutingDecision> => {
   // A bare-string input is wrapped into a synthetic user message for staging;

--- a/packages/gateway/src/data-plane/chat/responses/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/routing_test.ts
@@ -6,40 +6,32 @@ import { planResponsesRouting } from './routing.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../repo/types.ts';
-import type { ProviderCandidate } from '../shared/candidates.ts';
+import type { ChatPlanItem } from '../shared/candidates.ts';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_routing_test';
 
-const candidate = (upstream: string): ProviderCandidate => {
-  const upstreamModel = stubUpstreamModel();
+const candidate = (upstream: string): ChatPlanItem => {
   const modelProvider = stubProvider({
-    getProvidedModels: () => Promise.resolve([upstreamModel]),
+    getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
   });
   return {
-    provider: {
-      upstream,
-      providerKind: 'custom',
-      name: upstream,
-      disabledPublicModelIds: [],
-      modelPrefix: null,
-      provider: modelProvider,
-      supportsResponsesItemReference: true,
-    },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider: modelProvider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
+    candidate: {
+      provider: {
+        upstream,
+        providerKind: 'custom',
+        name: upstream,
+        disabledPublicModelIds: [],
+        modelPrefix: null,
+        provider: modelProvider,
+        supportsResponsesItemReference: true,
+      },
+      model: stubUpstreamModel(),
+      fetcher: directFetcher,
     },
     targetApi: 'responses',
-
-    fetcher: directFetcher,
   };
 };
 
@@ -83,7 +75,7 @@ test('payload with no stored references passes candidates through unchanged', as
   assertEquals(decision.kind, 'success');
   if (decision.kind === 'success') {
     assertEquals(decision.candidates.length, candidates.length);
-    assertEquals(decision.candidates.map(c => c.binding.upstream), ['up_a', 'up_b']);
+    assertEquals(decision.candidates.map(c => c.candidate.provider.upstream), ['up_a', 'up_b']);
   }
 });
 

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -1,7 +1,8 @@
 import { renderResponsesFailure } from './errors.ts';
 import type { StatefulResponsesStore } from './items/store.ts';
 import { planResponsesRouting } from './routing.ts';
-import { enumerateProviderCandidates, planChatCandidates, type ProviderCandidate } from '../shared/candidates.ts';
+import { enumerateProviderCandidates } from '../../providers/candidates.ts';
+import { planChatCandidates, type ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -91,6 +92,7 @@ export const prepareResponsesServePlan = async (args: {
   const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
     upstreamIds: ctx.upstreamIds,
     model: prepared.model,
+    kind: 'chat',
     scheduler: ctx.backgroundScheduler,
     currentColo: ctx.currentColo,
   });

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -1,7 +1,7 @@
 import { renderResponsesFailure } from './errors.ts';
 import type { StatefulResponsesStore } from './items/store.ts';
 import { planResponsesRouting } from './routing.ts';
-import { enumerateProviderCandidates, type ProviderCandidate } from '../shared/candidates.ts';
+import { enumerateProviderCandidates, planChatCandidates, type ProviderCandidate } from '../shared/candidates.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -72,7 +72,7 @@ const stageUserInputItems = async (input: ResponsesPayload['input'], store: Stat
 
 export type ResponsesServePlan =
   | { readonly kind: 'failure'; readonly result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> }
-  | { readonly kind: 'ready'; readonly prepared: ResponsesPayload; readonly candidate: ProviderCandidate };
+  | { readonly kind: 'ready'; readonly prepared: ResponsesPayload; readonly candidate: ProviderCandidate; readonly targetApi: ChatTargetApi };
 
 // Runs the shared serve-side prep both `responsesServe.generate` and
 // `responsesServe.compact` need before dispatching to `responsesAttempt`:
@@ -91,11 +91,11 @@ export const prepareResponsesServePlan = async (args: {
   const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
     upstreamIds: ctx.upstreamIds,
     model: prepared.model,
-    pickTarget,
     scheduler: ctx.backgroundScheduler,
     currentColo: ctx.currentColo,
   });
-  const decision = await planResponsesRouting({ payload: prepared, candidates, store });
+  const planItems = planChatCandidates(candidates, pickTarget);
+  const decision = await planResponsesRouting({ payload: prepared, candidates: planItems, store });
   if (decision.kind === 'failure') return { kind: 'failure', result: renderResponsesFailure(decision.failure) };
   // Stage the user-supplied input from the original payload — not the
   // expansion's `item_reference` prefix — so the next-turn snapshot picks
@@ -108,8 +108,8 @@ export const prepareResponsesServePlan = async (args: {
   // internal-error — IS the answer for this request: an upstream 4xx/5xx
   // from the first viable candidate is final, not a hint to try another
   // upstream.
-  const [candidate] = decision.candidates;
-  if (candidate === undefined) {
+  const [item] = decision.candidates;
+  if (item === undefined) {
     return {
       kind: 'failure',
       result: renderResponsesFailure(
@@ -119,5 +119,5 @@ export const prepareResponsesServePlan = async (args: {
       ),
     };
   }
-  return { kind: 'ready', prepared, candidate };
+  return { kind: 'ready', prepared, candidate: item.candidate, targetApi: item.targetApi };
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -33,7 +33,7 @@ export const responsesServe = {
               : null,
     });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.generate({ payload: plan.prepared, ctx, store, candidate: plan.candidate, headers });
+    return await responsesAttempt.generate({ payload: plan.prepared, ctx, store, candidate: plan.candidate, targetApi: plan.targetApi, headers });
   },
 
   compact: async (args: ResponsesServeCompactArgs): Promise<ResponsesAttemptResult> => {
@@ -56,6 +56,6 @@ export const responsesServe = {
               : null,
     });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, store, candidate: plan.candidate, headers });
+    return await responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, store, candidate: plan.candidate, targetApi: plan.targetApi, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -21,7 +21,7 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 // `sawModel` defaults to true when at least one candidate was queued; the
 // `model-missing` failure tests queue an empty list and expect `sawModel:
 // false` so the serve renders 404 rather than 400.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -40,7 +40,7 @@ const { expandPreviousResponseId } = await import('./serve-prep.ts');
 const API_KEY_ID = 'key_serve_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
+  candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -22,8 +22,8 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 // `model-missing` failure tests queue an empty list and expect `sawModel:
 // false` so the serve renders 404 rather than 400.
 const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
-vi.mock('../shared/candidates.ts', async importOriginal => {
-  const original = await importOriginal<typeof import('../shared/candidates.ts')>();
+vi.mock('../../providers/candidates.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
     ...original,
     enumerateProviderCandidates: vi.fn(async () => {

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -90,12 +90,9 @@ const makeProtocolFrames = async function* <E>(events: readonly E[]): AsyncGener
 
 const makeCandidate = (overrides: {
   upstream?: string;
-  targetApi?: ProviderCandidate['targetApi'];
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
 } = {}): ProviderCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const targetApi = overrides.targetApi ?? 'responses';
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({
     callResponses: overrides.callResponses,
   });
@@ -109,16 +106,7 @@ const makeCandidate = (overrides: {
       provider,
       supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream,
-      upstreamName: upstream,
-      providerKind: 'custom',
-      provider,
-      upstreamModel,
-      enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi,
+    model: stubUpstreamModel(),
     fetcher: directFetcher,
   };
 };
@@ -431,19 +419,13 @@ test('generate falls through translate-out to messages target', async () => {
     modelKey: 'messages-key',
     headers: new Headers(),
   }));
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({ callMessages });
   const candidate: ProviderCandidate = {
     provider: {
       upstream: 'up_m', providerKind: 'custom', name: 'up_m',
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream: 'up_m', upstreamName: 'up_m', providerKind: 'custom',
-      provider, upstreamModel, enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi: 'messages',
+    model: stubUpstreamModel({ endpoints: { messages: {} } }),
     fetcher: directFetcher,
   };
   queueCandidates([candidate]);
@@ -486,19 +468,13 @@ test('generate falls through translate-out to chat-completions target', async ()
     modelKey: 'chat-completions-key',
     headers: new Headers(),
   }));
-  const upstreamModel = stubUpstreamModel();
   const provider = stubProvider({ callChatCompletions });
   const candidate: ProviderCandidate = {
     provider: {
       upstream: 'up_c', providerKind: 'custom', name: 'up_c',
       disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
     },
-    binding: {
-      upstream: 'up_c', upstreamName: 'up_c', providerKind: 'custom',
-      provider, upstreamModel, enabledFlags: upstreamModel.enabledFlags,
-      supportsResponsesItemReference: true,
-    },
-    targetApi: 'chat-completions',
+    model: stubUpstreamModel({ endpoints: { chatCompletions: {} } }),
     fetcher: directFetcher,
   };
   queueCandidates([candidate]);

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -21,7 +21,7 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 // `sawModel` defaults to true when at least one candidate was queued; the
 // `model-missing` failure tests queue an empty list and expect `sawModel:
 // false` so the serve renders 404 rather than 400.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean }[] = [];
+const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean ; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/candidates.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/candidates.ts')>();
   return {
@@ -40,7 +40,7 @@ const { expandPreviousResponseId } = await import('./serve-prep.ts');
 const API_KEY_ID = 'key_serve_test';
 
 const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
-  candidatesQueue.push({ candidates, sawModel });
+  candidatesQueue.push({ candidates, sawModel , failedUpstreams: [] });
 };
 
 const installRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/chat/shared/attempt-helpers.ts
+++ b/packages/gateway/src/data-plane/chat/shared/attempt-helpers.ts
@@ -3,22 +3,22 @@ import type { GatewayCtx } from './gateway-ctx.ts';
 import { recordUpstreamHttpFailure, upstreamPerformanceContext, withUpstreamTelemetry } from './upstream-telemetry.ts';
 import { requireRecordedDurationMs, type UpstreamLatencyRecorder } from '../../shared/telemetry/performance.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { eventResult, readUpstreamApiError, type ExecuteResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
+import { eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
 
 // Telemetry identity for the chosen candidate plus the upstream-reported
 // model key. Pricing reads off the provider so the cost lookup respects any
 // provider-specific override.
 //
-// `model` is the upstream-facing bare id (`candidate.binding.upstreamModel.id`,
+// `model` is the upstream-facing bare id (`candidate.model.id`,
 // e.g. `gpt-4o`) regardless of which surface form the client called
 // (`or/gpt-4o` or `gpt-4o`). Usage and performance aggregates therefore key on
 // the canonical upstream id, and a dashboard slice over `model` rolls up both
 // surfaces of the same upstream model under one row.
 export const telemetryModelIdentity = (candidate: ProviderCandidate, modelKey: string): TelemetryModelIdentity => ({
-  model: candidate.binding.upstreamModel.id,
-  upstream: candidate.binding.upstream,
+  model: candidate.model.id,
+  upstream: candidate.provider.upstream,
   modelKey,
-  cost: candidate.binding.provider.getPricingForModelKey(modelKey),
+  cost: candidate.provider.provider.getPricingForModelKey(modelKey),
 });
 
 // Per-call UpstreamCallOptions for the chosen candidate; see
@@ -50,16 +50,17 @@ export const buildUpstreamCallOptions = (
 export const providerStreamResultToExecuteResult = async <TEvent>(
   providerResult: ProviderStreamResult<TEvent>,
   candidate: ProviderCandidate,
+  targetApi: ChatTargetApi,
   ctx: GatewayCtx,
   recorder: UpstreamLatencyRecorder,
 ): Promise<ExecuteResult<ProtocolFrame<TEvent>>> => {
   const context = upstreamPerformanceContext(ctx, candidate, providerResult.modelKey);
   if (!providerResult.ok) {
     recordUpstreamHttpFailure(ctx, context);
-    return { ...(await readUpstreamApiError(providerResult.response, candidate.binding.upstream)), performance: context };
+    return { ...(await readUpstreamApiError(providerResult.response, candidate.provider.upstream)), performance: context };
   }
   return eventResult(
-    withUpstreamTelemetry(providerResult.events, ctx, context, candidate.targetApi, requireRecordedDurationMs(recorder, 'upstream success')),
+    withUpstreamTelemetry(providerResult.events, ctx, context, targetApi, requireRecordedDurationMs(recorder, 'upstream success')),
     telemetryModelIdentity(candidate, providerResult.modelKey),
     { performance: context, headers: providerResult.headers },
   );

--- a/packages/gateway/src/data-plane/chat/shared/candidates.ts
+++ b/packages/gateway/src/data-plane/chat/shared/candidates.ts
@@ -6,19 +6,30 @@ import type { ChatTargetApi, ProviderCandidate } from '@floway-dev/provider';
 
 export type { ProviderCandidate };
 
-// Returns the candidates that satisfy both the model resolution and the
-// target-endpoint pick, plus a `sawModel` flag that distinguishes the
-// "model is missing entirely" failure from "model exists but does not
-// expose the endpoint this source needs", plus the names of upstreams
-// whose catalog fetch rejected this round so the caller's failure
-// renderer can surface them parenthetically.
+// Pairs a resolved candidate with the chat target protocol the calling
+// serve picked for it. Chat dispatch operates on these pairs end-to-end:
+// the planner reorders them by routing affinity, the attempt layer
+// receives one and switches on `targetApi` to choose between the native
+// wire call and a translation-shim path.
+export interface ChatPlanItem {
+  readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
+}
+
+// Returns every chat-kind candidate the resolver produced for the inbound
+// id, plus a `sawModel` flag that distinguishes the "model is missing
+// entirely" failure from "model exists but is the wrong kind for this
+// source", plus the names of upstreams whose catalog fetch rejected this
+// round so the caller's failure renderer can surface them parenthetically.
+// The picker callback is the calling serve's responsibility; this layer
+// stays kind-aware and endpoint-blind so the same resolution path is
+// reusable across protocols and operations.
 export const enumerateProviderCandidates = async ({
-  upstreamIds, model, pickTarget, scheduler, currentColo,
+  upstreamIds, model, scheduler, currentColo,
 }: {
   // null = unrestricted; empty list = no providers visible.
   upstreamIds: readonly string[] | null;
   model: string;
-  pickTarget: (endpoints: ModelEndpoints) => ChatTargetApi | null;
   // Threaded into `resolveModelForProvider` so the per-upstream catalog
   // lookup hits the SWR-cached `fetchUpstreamModelsCached` instead of
   // round-tripping to the upstream on every chat serve.
@@ -32,11 +43,13 @@ export const enumerateProviderCandidates = async ({
   const providers = await listModelProviders(upstreamIds);
 
   // The shared resolver expands each inbound id into (provider, lookupId)
-  // interpretations against the unprefixed and prefixed addressable
-  // surfaces, runs the SWR-cached per-upstream lookup, and retries once
-  // with the dated suffix stripped if the first pass found nothing. The
-  // chat path then narrows the resulting resolutions to bindings whose
-  // endpoint map satisfies the inbound source's target preference.
+  // interpretations across unprefixed and prefixed addressable surfaces,
+  // runs the SWR-cached per-upstream lookup, and retries once with the
+  // dated suffix stripped if the first pass found nothing. The chat path
+  // then keeps only chat-kind entries; non-chat resolutions are visible
+  // to `sawModel` (so the failure renderer can distinguish "model exists
+  // but wrong kind" from "model missing entirely") but never reach the
+  // candidate list.
   const { resolutions, failedUpstreams } = await resolveInterpretationsAcrossProviders(model, providers, fetcherForUpstream, scheduler);
 
   const candidates: ProviderCandidate[] = [];
@@ -44,10 +57,28 @@ export const enumerateProviderCandidates = async ({
 
   for (const { provider, resolved } of resolutions) {
     sawModel = true;
-    const targetApi = pickTarget(resolved.binding.upstreamModel.endpoints);
-    if (!targetApi) continue;
-    candidates.push({ provider, binding: resolved.binding, targetApi, fetcher: fetcherForUpstream(provider.upstream) });
+    if (resolved.model.kind !== 'chat') continue;
+    candidates.push({ provider, model: resolved.model, fetcher: fetcherForUpstream(provider.upstream) });
   }
 
   return { candidates, sawModel, failedUpstreams };
+};
+
+// Map raw candidates to plan items by running each candidate's
+// `model.endpoints` through the caller's inbound-protocol preference
+// picker. Candidates whose endpoints don't satisfy any preference are
+// dropped — they cannot serve the current operation, so dispatching to
+// them would be a guaranteed failure. The picker's null return is the
+// failover signal; we apply it ahead of the planner so a non-routable
+// candidate never reaches affinity reordering.
+export const planChatCandidates = (
+  candidates: readonly ProviderCandidate[],
+  pickTarget: (endpoints: ModelEndpoints) => ChatTargetApi | null,
+): readonly ChatPlanItem[] => {
+  const items: ChatPlanItem[] = [];
+  for (const candidate of candidates) {
+    const targetApi = pickTarget(candidate.model.endpoints);
+    if (targetApi !== null) items.push({ candidate, targetApi });
+  }
+  return items;
 };

--- a/packages/gateway/src/data-plane/chat/shared/candidates.ts
+++ b/packages/gateway/src/data-plane/chat/shared/candidates.ts
@@ -1,9 +1,11 @@
-import { createPerRequestFetcher } from '../../../dial/per-request.ts';
-import { listModelProviders, resolveInterpretationsAcrossProviders } from '../../providers/registry.ts';
-import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { ModelEndpoints } from '@floway-dev/protocols/common';
 import type { ChatTargetApi, ProviderCandidate } from '@floway-dev/provider';
 
+// Re-export here so chat call sites do not have to know that the
+// underlying type lives in `@floway-dev/provider`. Tests and serves
+// already import `ProviderCandidate` from this module; keeping the alias
+// avoids a sprawling import-rewrite that would obscure the actual
+// candidate-shape change.
 export type { ProviderCandidate };
 
 // Pairs a resolved candidate with the chat target protocol the calling
@@ -16,55 +18,7 @@ export interface ChatPlanItem {
   readonly targetApi: ChatTargetApi;
 }
 
-// Returns every chat-kind candidate the resolver produced for the inbound
-// id, plus a `sawModel` flag that distinguishes the "model is missing
-// entirely" failure from "model exists but is the wrong kind for this
-// source", plus the names of upstreams whose catalog fetch rejected this
-// round so the caller's failure renderer can surface them parenthetically.
-// The picker callback is the calling serve's responsibility; this layer
-// stays kind-aware and endpoint-blind so the same resolution path is
-// reusable across protocols and operations.
-export const enumerateProviderCandidates = async ({
-  upstreamIds, model, scheduler, currentColo,
-}: {
-  // null = unrestricted; empty list = no providers visible.
-  upstreamIds: readonly string[] | null;
-  model: string;
-  // Threaded into `resolveModelForProvider` so the per-upstream catalog
-  // lookup hits the SWR-cached `fetchUpstreamModelsCached` instead of
-  // round-tripping to the upstream on every chat serve.
-  scheduler: BackgroundScheduler;
-  // Current colo for this request — see GatewayCtx.currentColo. Threaded
-  // into the per-request fetcher so colo-scoped fallback entries can be
-  // honoured at dial time.
-  currentColo: string;
-}): Promise<{ readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }> => {
-  const fetcherForUpstream = await createPerRequestFetcher(currentColo);
-  const providers = await listModelProviders(upstreamIds);
-
-  // The shared resolver expands each inbound id into (provider, lookupId)
-  // interpretations across unprefixed and prefixed addressable surfaces,
-  // runs the SWR-cached per-upstream lookup, and retries once with the
-  // dated suffix stripped if the first pass found nothing. The chat path
-  // then keeps only chat-kind entries; non-chat resolutions are visible
-  // to `sawModel` (so the failure renderer can distinguish "model exists
-  // but wrong kind" from "model missing entirely") but never reach the
-  // candidate list.
-  const { resolutions, failedUpstreams } = await resolveInterpretationsAcrossProviders(model, providers, fetcherForUpstream, scheduler);
-
-  const candidates: ProviderCandidate[] = [];
-  let sawModel = false;
-
-  for (const { provider, resolved } of resolutions) {
-    sawModel = true;
-    if (resolved.model.kind !== 'chat') continue;
-    candidates.push({ provider, model: resolved.model, fetcher: fetcherForUpstream(provider.upstream) });
-  }
-
-  return { candidates, sawModel, failedUpstreams };
-};
-
-// Map raw candidates to plan items by running each candidate's
+// Map raw chat-kind candidates to plan items by running each candidate's
 // `model.endpoints` through the caller's inbound-protocol preference
 // picker. Candidates whose endpoints don't satisfy any preference are
 // dropped — they cannot serve the current operation, so dispatching to

--- a/packages/gateway/src/data-plane/chat/shared/candidates.ts
+++ b/packages/gateway/src/data-plane/chat/shared/candidates.ts
@@ -1,11 +1,8 @@
 import type { ModelEndpoints } from '@floway-dev/protocols/common';
 import type { ChatTargetApi, ProviderCandidate } from '@floway-dev/provider';
 
-// Re-export here so chat call sites do not have to know that the
-// underlying type lives in `@floway-dev/provider`. Tests and serves
-// already import `ProviderCandidate` from this module; keeping the alias
-// avoids a sprawling import-rewrite that would obscure the actual
-// candidate-shape change.
+// Re-exported here so chat call sites do not have to know that the
+// underlying type lives in `@floway-dev/provider`.
 export type { ProviderCandidate };
 
 // Pairs a resolved candidate with the chat target protocol the calling

--- a/packages/gateway/src/data-plane/chat/shared/candidates.ts
+++ b/packages/gateway/src/data-plane/chat/shared/candidates.ts
@@ -1,5 +1,5 @@
 import { createPerRequestFetcher } from '../../../dial/per-request.ts';
-import { collectInterpretationOutcomes, enumerateModelInterpretations, listModelProviders } from '../../providers/registry.ts';
+import { listModelProviders, resolveInterpretationsAcrossProviders } from '../../providers/registry.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { ModelEndpoints } from '@floway-dev/protocols/common';
 import type { ChatTargetApi, ProviderCandidate } from '@floway-dev/provider';
@@ -31,16 +31,13 @@ export const enumerateProviderCandidates = async ({
   const fetcherForUpstream = await createPerRequestFetcher(currentColo);
   const providers = await listModelProviders(upstreamIds);
 
-  // Each (provider, lookupId) interpretation describes one way the inbound
-  // id can address an upstream — bare form for `[unprefixed]`-addressable
-  // upstreams, stripped form for `[prefixed]`-addressable upstreams when the
-  // inbound starts with the configured prefix. A dual-addressable upstream
-  // contributes both when applicable. The fan-out is shared with
-  // `resolveModelForRequest`; first-viable-wins ordering follows configured
-  // sort_order across upstreams, with the unprefixed interpretation pushed
-  // before the prefixed one within a single upstream.
-  const interpretations = enumerateModelInterpretations(model, providers);
-  const { resolutions, failedUpstreams } = await collectInterpretationOutcomes(interpretations, fetcherForUpstream, scheduler);
+  // The shared resolver expands each inbound id into (provider, lookupId)
+  // interpretations against the unprefixed and prefixed addressable
+  // surfaces, runs the SWR-cached per-upstream lookup, and retries once
+  // with the dated suffix stripped if the first pass found nothing. The
+  // chat path then narrows the resulting resolutions to bindings whose
+  // endpoint map satisfies the inbound source's target preference.
+  const { resolutions, failedUpstreams } = await resolveInterpretationsAcrossProviders(model, providers, fetcherForUpstream, scheduler);
 
   const candidates: ProviderCandidate[] = [];
   let sawModel = false;

--- a/packages/gateway/src/data-plane/chat/shared/candidates_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/candidates_test.ts
@@ -67,7 +67,7 @@ describe('enumerateProviderCandidates', () => {
     assertEquals(sawModel, true);
   });
 
-  test('provider with binding yields a candidate regardless of endpoint shape', async () => {
+  test('provider yields a candidate regardless of endpoint shape', async () => {
     // Resolution is kind-aware and endpoint-blind: a chat-kind model with
     // only `chatCompletions` set is a candidate at this layer. Whether the
     // serve's preference table accepts it is the planner's job.

--- a/packages/gateway/src/data-plane/chat/shared/candidates_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/candidates_test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'vitest';
 
-import { enumerateProviderCandidates } from './candidates.ts';
+import { enumerateProviderCandidates, planChatCandidates } from './candidates.ts';
 import { buildCustomUpstreamRecord, setupAppTest } from '../../../test-helpers.ts';
 import { clearInFlightForTesting } from '../../providers/models-cache.ts';
 import type { ModelEndpoints } from '@floway-dev/protocols/common';
@@ -55,19 +55,20 @@ describe('enumerateProviderCandidates', () => {
     const { candidates, sawModel } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
-      pickTarget: pickMessages,
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
 
     assertEquals(candidates.length, 1);
     assertEquals(candidates[0].provider.upstream, 'up_a');
-    assertEquals(candidates[0].binding.upstreamModel.id, 'test-model');
-    assertEquals(candidates[0].targetApi, 'messages');
+    assertEquals(candidates[0].model.id, 'test-model');
     assertEquals(sawModel, true);
   });
 
-  test('provider with binding but pickTarget returns null yields no candidate but sets sawModel', async () => {
+  test('provider with binding yields a candidate regardless of endpoint shape', async () => {
+    // Resolution is kind-aware and endpoint-blind: a chat-kind model with
+    // only `chatCompletions` set is a candidate at this layer. Whether the
+    // serve's preference table accepts it is the planner's job.
     const { repo } = await setupAppTest();
     await repo.upstreams.deleteAll();
     await repo.upstreams.save(azureUpstream('up_chat', 10, ['test-model'], { chatCompletions: {} }));
@@ -75,15 +76,12 @@ describe('enumerateProviderCandidates', () => {
     const { candidates, sawModel } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
-      pickTarget: pickMessages,
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
 
-    assertEquals(candidates.length, 0);
-    // The model exists on a provider — sawModel distinguishes this from a
-    // model that no provider knows about, so the serve renders 400
-    // model-unsupported instead of 404 model-missing.
+    assertEquals(candidates.length, 1);
+    assertEquals(candidates[0].provider.upstream, 'up_chat');
     assertEquals(sawModel, true);
   });
 
@@ -95,7 +93,6 @@ describe('enumerateProviderCandidates', () => {
     const { candidates, sawModel } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
-      pickTarget: pickMessages,
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -114,7 +111,6 @@ describe('enumerateProviderCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
-      pickTarget: pickMessages,
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -134,7 +130,6 @@ describe('enumerateProviderCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: ['up_c', 'up_a'],
       model: 'test-model',
-      pickTarget: pickMessages,
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -156,66 +151,12 @@ describe('enumerateProviderCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
-      pickTarget: pickMessages,
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
 
     assertEquals(candidates.length, 1);
     assertEquals(candidates[0].provider.upstream, 'up_enabled');
-  });
-
-  test('pickTarget preference: multi-endpoint binding picks according to pickTarget logic', async () => {
-    const { repo } = await setupAppTest();
-    await repo.upstreams.deleteAll();
-    await repo.upstreams.save(azureUpstream('up_multi', 10, ['test-model'], { messages: {}, responses: {} }));
-
-    const { candidates: msgCandidates } = await enumerateProviderCandidates({
-      upstreamIds: null,
-      model: 'test-model',
-      pickTarget: pickMessagesOrResponses,
-      scheduler: testScheduler,
-      currentColo: 'TEST',
-    });
-    assertEquals(msgCandidates.length, 1);
-    assertEquals(msgCandidates[0].targetApi, 'messages');
-
-    const { candidates: resCandidates } = await enumerateProviderCandidates({
-      upstreamIds: null,
-      model: 'test-model',
-      pickTarget: pickResponses,
-      scheduler: testScheduler,
-      currentColo: 'TEST',
-    });
-    assertEquals(resCandidates.length, 1);
-    assertEquals(resCandidates[0].targetApi, 'responses');
-  });
-
-  test('pickTarget returning null filters out an otherwise-matching provider', async () => {
-    const { repo } = await setupAppTest();
-    await repo.upstreams.deleteAll();
-    await repo.upstreams.save(azureUpstream('up_chat', 10, ['test-model'], { chatCompletions: {} }));
-
-    const { candidates: anyCandidates } = await enumerateProviderCandidates({
-      upstreamIds: null,
-      model: 'test-model',
-      pickTarget: pickAny,
-      scheduler: testScheduler,
-      currentColo: 'TEST',
-    });
-    assertEquals(anyCandidates.length, 1);
-    assertEquals(anyCandidates[0].targetApi, 'chat-completions');
-
-    const { candidates: msgCandidates, sawModel } = await enumerateProviderCandidates({
-      upstreamIds: null,
-      model: 'test-model',
-      pickTarget: pickMessages,
-      scheduler: testScheduler,
-      currentColo: 'TEST',
-    });
-    assertEquals(msgCandidates.length, 0);
-    // pickTarget filtered out, but the model exists — sawModel stays true.
-    assertEquals(sawModel, true);
   });
 
   // Regression: a single upstream whose catalog fetch rejects must not poison
@@ -246,7 +187,6 @@ describe('enumerateProviderCandidates', () => {
         const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
           upstreamIds: null,
           model: 'test-model',
-          pickTarget: pickMessages,
           scheduler: testScheduler,
           currentColo: 'TEST',
         });
@@ -289,7 +229,6 @@ describe('enumerateProviderCandidates', () => {
         const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
           upstreamIds: null,
           model: 'test-model',
-          pickTarget: pickMessages,
           scheduler: testScheduler,
           currentColo: 'TEST',
         });
@@ -299,5 +238,52 @@ describe('enumerateProviderCandidates', () => {
         assertEquals(failedUpstreams, ['A', 'B']);
       },
     );
+  });
+});
+
+describe('planChatCandidates', () => {
+  // The picker callback runs at the serve layer, after resolution: it maps
+  // each candidate's `model.endpoints` to a target protocol via the
+  // inbound-protocol preference table. Candidates whose picker returns null
+  // drop out before the planner sees them.
+  test('multi-endpoint candidate picks the picker-preferred target', async () => {
+    const { repo } = await setupAppTest();
+    await repo.upstreams.deleteAll();
+    await repo.upstreams.save(azureUpstream('up_multi', 10, ['test-model'], { messages: {}, responses: {} }));
+
+    const { candidates } = await enumerateProviderCandidates({
+      upstreamIds: null,
+      model: 'test-model',
+      scheduler: testScheduler,
+      currentColo: 'TEST',
+    });
+
+    const messagesItems = planChatCandidates(candidates, pickMessagesOrResponses);
+    assertEquals(messagesItems.length, 1);
+    assertEquals(messagesItems[0].targetApi, 'messages');
+
+    const responsesItems = planChatCandidates(candidates, pickResponses);
+    assertEquals(responsesItems.length, 1);
+    assertEquals(responsesItems[0].targetApi, 'responses');
+  });
+
+  test('picker returning null drops the candidate', async () => {
+    const { repo } = await setupAppTest();
+    await repo.upstreams.deleteAll();
+    await repo.upstreams.save(azureUpstream('up_chat', 10, ['test-model'], { chatCompletions: {} }));
+
+    const { candidates } = await enumerateProviderCandidates({
+      upstreamIds: null,
+      model: 'test-model',
+      scheduler: testScheduler,
+      currentColo: 'TEST',
+    });
+
+    const anyItems = planChatCandidates(candidates, pickAny);
+    assertEquals(anyItems.length, 1);
+    assertEquals(anyItems[0].targetApi, 'chat-completions');
+
+    const messagesItems = planChatCandidates(candidates, pickMessages);
+    assertEquals(messagesItems.length, 0);
   });
 });

--- a/packages/gateway/src/data-plane/chat/shared/candidates_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/candidates_test.ts
@@ -1,7 +1,8 @@
 import { describe, test } from 'vitest';
 
-import { enumerateProviderCandidates, planChatCandidates } from './candidates.ts';
+import { planChatCandidates } from './candidates.ts';
 import { buildCustomUpstreamRecord, setupAppTest } from '../../../test-helpers.ts';
+import { enumerateProviderCandidates } from '../../providers/candidates.ts';
 import { clearInFlightForTesting } from '../../providers/models-cache.ts';
 import type { ModelEndpoints } from '@floway-dev/protocols/common';
 import type { ChatTargetApi, UpstreamRecord } from '@floway-dev/provider';
@@ -55,6 +56,7 @@ describe('enumerateProviderCandidates', () => {
     const { candidates, sawModel } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -76,6 +78,7 @@ describe('enumerateProviderCandidates', () => {
     const { candidates, sawModel } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -93,6 +96,7 @@ describe('enumerateProviderCandidates', () => {
     const { candidates, sawModel } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -111,6 +115,7 @@ describe('enumerateProviderCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -130,6 +135,7 @@ describe('enumerateProviderCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: ['up_c', 'up_a'],
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -151,6 +157,7 @@ describe('enumerateProviderCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -187,6 +194,7 @@ describe('enumerateProviderCandidates', () => {
         const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
           upstreamIds: null,
           model: 'test-model',
+          kind: 'chat',
           scheduler: testScheduler,
           currentColo: 'TEST',
         });
@@ -229,6 +237,7 @@ describe('enumerateProviderCandidates', () => {
         const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
           upstreamIds: null,
           model: 'test-model',
+          kind: 'chat',
           scheduler: testScheduler,
           currentColo: 'TEST',
         });
@@ -254,6 +263,7 @@ describe('planChatCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });
@@ -275,6 +285,7 @@ describe('planChatCandidates', () => {
     const { candidates } = await enumerateProviderCandidates({
       upstreamIds: null,
       model: 'test-model',
+      kind: 'chat',
       scheduler: testScheduler,
       currentColo: 'TEST',
     });

--- a/packages/gateway/src/data-plane/chat/shared/routing.ts
+++ b/packages/gateway/src/data-plane/chat/shared/routing.ts
@@ -1,6 +1,6 @@
-import type { ProviderCandidate } from './candidates.ts';
+import type { ChatPlanItem } from './candidates.ts';
 import type { ChatServeFailure } from './errors.ts';
 
 export type RoutingDecision =
-  | { readonly kind: 'success'; readonly candidates: readonly ProviderCandidate[] }
+  | { readonly kind: 'success'; readonly candidates: readonly ChatPlanItem[] }
   | { readonly kind: 'failure'; readonly failure: ChatServeFailure };

--- a/packages/gateway/src/data-plane/chat/shared/upstream-telemetry.ts
+++ b/packages/gateway/src/data-plane/chat/shared/upstream-telemetry.ts
@@ -13,8 +13,8 @@ type TerminalKind = 'success' | 'failure';
 // dimensions off the chosen candidate plus the upstream-reported model key.
 export const upstreamPerformanceContext = (ctx: GatewayCtx, candidate: ProviderCandidate, modelKey: string): PerformanceTelemetryContext => ({
   keyId: ctx.apiKeyId,
-  model: candidate.binding.upstreamModel.id,
-  upstream: candidate.binding.upstream,
+  model: candidate.model.id,
+  upstream: candidate.provider.upstream,
   modelKey,
   stream: ctx.wantsStream,
   runtimeLocation: ctx.runtimeLocation,

--- a/packages/gateway/src/data-plane/codex/models.ts
+++ b/packages/gateway/src/data-plane/codex/models.ts
@@ -32,7 +32,7 @@ import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getCurrentColo } from '../../runtime/runtime-info.ts';
-import { getInternalModels } from '../providers/registry.ts';
+import { getModels } from '../providers/registry.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { Fetcher } from '@floway-dev/provider';
 
@@ -56,9 +56,9 @@ const computeCatalog = async (
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<CodexCatalog> => {
-  const [catalog, internalModels] = await Promise.all([
+  const [catalog, { models: internalModels }] = await Promise.all([
     resolveCodexCatalog(userAgent),
-    getInternalModels(upstreamIds, fetcherForUpstream, scheduler),
+    getModels(upstreamIds, fetcherForUpstream, scheduler),
   ]);
   const slugContextWindow = new Map<string, number>();
   for (const m of internalModels) {

--- a/packages/gateway/src/data-plane/completions/serve.ts
+++ b/packages/gateway/src/data-plane/completions/serve.ts
@@ -101,9 +101,9 @@ export const completions = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/completions',
     model: request.model,
-    bindingServesEndpoint: binding => binding.upstreamModel.endpoints.completions !== undefined,
-    call: (binding, opts) =>
-      binding.provider.callCompletions(binding.upstreamModel, upstreamBody, ctx.abortSignal, opts),
+    modelServesEndpoint: model => model.endpoints.completions !== undefined,
+    call: (provider, model, opts) =>
+      provider.provider.callCompletions(model, upstreamBody, ctx.abortSignal, opts),
     response: request.wantsStream
       ? { format: 'sse', transformFrame, settleUsage }
       : {

--- a/packages/gateway/src/data-plane/completions/serve.ts
+++ b/packages/gateway/src/data-plane/completions/serve.ts
@@ -101,6 +101,7 @@ export const completions = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/completions',
     model: request.model,
+    kind: 'chat',
     modelServesEndpoint: model => model.endpoints.completions !== undefined,
     call: (provider, model, opts) =>
       provider.provider.callCompletions(model, upstreamBody, ctx.abortSignal, opts),

--- a/packages/gateway/src/data-plane/embeddings/serve.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve.ts
@@ -59,10 +59,10 @@ export const embeddings = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/embeddings',
     model: request.model,
-    bindingServesEndpoint: binding => binding.upstreamModel.endpoints.embeddings !== undefined,
-    call: async (binding, opts) => {
+    modelServesEndpoint: model => model.endpoints.embeddings !== undefined,
+    call: async (provider, model, opts) => {
       const { model: _model, ...body } = request.body;
-      return await binding.provider.callEmbeddings(binding.upstreamModel, body, undefined, opts);
+      return await provider.provider.callEmbeddings(model, body, undefined, opts);
     },
     response: { format: 'json', extractBilling: tokenUsageFromEmbeddingsBody },
   });

--- a/packages/gateway/src/data-plane/embeddings/serve.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve.ts
@@ -59,6 +59,7 @@ export const embeddings = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/embeddings',
     model: request.model,
+    kind: 'embedding',
     modelServesEndpoint: model => model.endpoints.embeddings !== undefined,
     call: async (provider, model, opts) => {
       const { model: _model, ...body } = request.body;

--- a/packages/gateway/src/data-plane/images/serve.ts
+++ b/packages/gateway/src/data-plane/images/serve.ts
@@ -58,6 +58,7 @@ export const imagesGenerations = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/images/generations',
     model: request.model,
+    kind: 'image',
     modelServesEndpoint: model => model.endpoints.imagesGenerations !== undefined,
     call: (provider, model, opts) => {
       const { model: _model, ...body } = request.body;
@@ -99,6 +100,7 @@ export const imagesEdits = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/images/edits',
     model: modelRaw,
+    kind: 'image',
     modelServesEndpoint: model => model.endpoints.imagesEdits !== undefined,
     call: (provider, model, opts) => {
       // ModelProvider.callImagesEdits takes ownership of the FormData and

--- a/packages/gateway/src/data-plane/images/serve.ts
+++ b/packages/gateway/src/data-plane/images/serve.ts
@@ -58,10 +58,10 @@ export const imagesGenerations = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/images/generations',
     model: request.model,
-    bindingServesEndpoint: binding => binding.upstreamModel.endpoints.imagesGenerations !== undefined,
-    call: (binding, opts) => {
+    modelServesEndpoint: model => model.endpoints.imagesGenerations !== undefined,
+    call: (provider, model, opts) => {
       const { model: _model, ...body } = request.body;
-      return binding.provider.callImagesGenerations(binding.upstreamModel, body, undefined, opts);
+      return provider.provider.callImagesGenerations(model, body, undefined, opts);
     },
     response: { format: 'json', extractBilling: tokenUsageFromImagesBody },
   });
@@ -99,19 +99,19 @@ export const imagesEdits = async (c: Context): Promise<Response> => {
     ctx,
     sourceApi: '/images/edits',
     model: modelRaw,
-    bindingServesEndpoint: binding => binding.upstreamModel.endpoints.imagesEdits !== undefined,
-    call: (binding, opts) => {
+    modelServesEndpoint: model => model.endpoints.imagesEdits !== undefined,
+    call: (provider, model, opts) => {
       // ModelProvider.callImagesEdits takes ownership of the FormData and
       // appends the upstream-specific model/deployment id; allocate a fresh
-      // copy per binding so the contract holds even if cross-binding
-      // fallback is ever extended to try a second binding. File-blob entries
+      // copy per candidate so the contract holds even if cross-candidate
+      // fallback is ever extended to try a second match. File-blob entries
       // are passed by reference so no buffer copy happens.
       const passthrough = new FormData();
       for (const [name, value] of form.entries()) {
         if (name === 'model') continue;
         passthrough.append(name, value);
       }
-      return binding.provider.callImagesEdits(binding.upstreamModel, passthrough, undefined, opts);
+      return provider.provider.callImagesEdits(model, passthrough, undefined, opts);
     },
     response: { format: 'json', extractBilling: tokenUsageFromImagesBody },
   });

--- a/packages/gateway/src/data-plane/images/serve_test.ts
+++ b/packages/gateway/src/data-plane/images/serve_test.ts
@@ -78,8 +78,9 @@ test('/v1/images/generations rejects model on custom upstream without /images/ge
   clearInProcessCopilotTokenCache();
 
   // Chat-only custom upstream. Its /models response advertises gpt-4o
-  // (which the id heuristic leaves as the chat fallback), so the model exists
-  // in the registry but no binding accepts an /images/generations request.
+  // (which the id heuristic leaves as the chat fallback), so the inbound
+  // id resolves but the kind filter rejects every candidate for the
+  // /images/generations endpoint — `sawModel=true` + no candidates → 400.
   await repo.upstreams.save(buildCustomUpstreamRecord({
     id: 'up_chat_only',
     name: 'Chat Only Provider',

--- a/packages/gateway/src/data-plane/models/gemini.ts
+++ b/packages/gateway/src/data-plane/models/gemini.ts
@@ -6,11 +6,11 @@ import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getCurrentColo } from '../../runtime/runtime-info.ts';
 import { geminiStatusForHttpStatus } from '../chat/gemini/errors.ts';
-import { getInternalModels } from '../providers/registry.ts';
+import { getModels } from '../providers/registry.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { ModelPricing } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
-import type { Fetcher, InternalModel } from '@floway-dev/provider';
+import type { CatalogModel, Fetcher } from '@floway-dev/provider';
 
 type GeminiGenerationMethod = 'generateContent' | 'streamGenerateContent' | 'countTokens';
 
@@ -30,7 +30,7 @@ interface GeminiModel {
   cost?: ModelPricing;
 }
 
-const toGeminiModel = (model: InternalModel): GeminiModel => {
+const toGeminiModel = (model: CatalogModel): GeminiModel => {
   const limits = model.limits;
   const inputTokenLimit = limits.max_prompt_tokens ?? limits.max_context_window_tokens;
   const outputTokenLimit = limits.max_output_tokens;
@@ -67,7 +67,7 @@ const loadGeminiModels = async (
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<GeminiModel[]> => {
-  const models = await getInternalModels(upstreamFilter, fetcherForUpstream, scheduler);
+  const { models } = await getModels(upstreamFilter, fetcherForUpstream, scheduler);
   // Only chat models are representable in the Gemini /models shape.
   return models.filter(model => model.kind === 'chat').map(toGeminiModel);
 };

--- a/packages/gateway/src/data-plane/models/load.ts
+++ b/packages/gateway/src/data-plane/models/load.ts
@@ -1,9 +1,12 @@
-import { getInternalModels } from '../providers/registry.ts';
+import { getModels } from '../providers/registry.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { PublicModel, PublicModelsResponse } from '@floway-dev/protocols/common';
-import type { Fetcher, InternalModel } from '@floway-dev/provider';
+import type { CatalogModel, Fetcher } from '@floway-dev/provider';
 
-export const toPublicModel = (model: InternalModel): PublicModel => {
+// Project a CatalogModel onto the public-facing `/v1/models` wire DTO,
+// dropping the merged `endpoints` capability map (an internal artefact
+// of catalog assembly that the public API does not surface).
+export const toPublicModel = (model: CatalogModel): PublicModel => {
   const info: PublicModel = {
     id: model.id,
     object: 'model',
@@ -27,7 +30,8 @@ export const loadModels = async (
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<PublicModelsResponse> => {
-  const data = (await getInternalModels(upstreamFilter, fetcherForUpstream, scheduler)).map(toPublicModel);
+  const { models } = await getModels(upstreamFilter, fetcherForUpstream, scheduler);
+  const data = models.map(toPublicModel);
   return {
     object: 'list',
     has_more: false,

--- a/packages/gateway/src/data-plane/models/load_test.ts
+++ b/packages/gateway/src/data-plane/models/load_test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from 'vitest';
 
 import { toPublicModel } from './load.ts';
-import type { InternalModel } from '@floway-dev/provider';
+import type { CatalogModel } from '@floway-dev/provider';
 
-const base: InternalModel = {
+const base: CatalogModel = {
   id: 'm1',
   kind: 'chat',
   limits: { max_context_window_tokens: 100000 },
+  endpoints: { chatCompletions: {} },
 };
 
 describe('toPublicModel', () => {

--- a/packages/gateway/src/data-plane/providers/candidates.ts
+++ b/packages/gateway/src/data-plane/providers/candidates.ts
@@ -6,23 +6,10 @@ import type { ProviderCandidate } from '@floway-dev/provider';
 
 export type { ProviderCandidate };
 
-// Per-request model resolution: resolve the inbound id against every
-// upstream the caller's scope allows, retry once with an `-YYYYMMDD`
-// suffix stripped, then keep only resolutions whose model.kind matches
-// the inbound endpoint family. Each surviving resolution becomes a
-// `(provider, model, fetcher)` candidate the dispatch layer can call.
-//
-// `sawModel` is true whenever the inbound id resolved against at least
-// one upstream catalog, regardless of kind. Callers use it to
-// distinguish "model id is unknown to every configured upstream"
-// (sawModel=false) from "model exists but is the wrong kind for this
-// endpoint" (sawModel=true, candidates=[]).
-//
-// Endpoint-level narrowing — picking the chat target protocol from
-// `model.endpoints`, or checking the specific `imagesEdits` /
-// `imagesGenerations` / `completions` endpoint key — is the caller's
-// job. This function stays endpoint-blind so the same path serves
-// chat, embeddings, image generation/edits, and legacy completions.
+// Per-request model resolution. See RESOLUTION.md for the pipeline
+// spec; this function is its single entry point for every data-plane
+// endpoint. `sawModel=true` with empty `candidates` distinguishes
+// "right id, wrong kind" (400) from "unknown id" (404, sawModel=false).
 export const enumerateProviderCandidates = async ({
   upstreamIds, model, kind, scheduler, currentColo,
 }: {
@@ -30,13 +17,7 @@ export const enumerateProviderCandidates = async ({
   upstreamIds: readonly string[] | null;
   model: string;
   kind: ModelKind;
-  // Threaded into `resolveModelForProvider` so the per-upstream catalog
-  // lookup hits the SWR-cached `fetchUpstreamModelsCached` instead of
-  // round-tripping to the upstream on every request.
   scheduler: BackgroundScheduler;
-  // Current colo for this request — see GatewayCtx.currentColo. Threaded
-  // into the per-request fetcher so colo-scoped fallback entries can be
-  // honoured at dial time.
   currentColo: string;
 }): Promise<{
   readonly candidates: readonly ProviderCandidate[];

--- a/packages/gateway/src/data-plane/providers/candidates.ts
+++ b/packages/gateway/src/data-plane/providers/candidates.ts
@@ -1,0 +1,58 @@
+import { listModelProviders, resolveInterpretationsAcrossProviders } from './registry.ts';
+import { createPerRequestFetcher } from '../../dial/per-request.ts';
+import type { BackgroundScheduler } from '@floway-dev/platform';
+import type { ModelKind } from '@floway-dev/protocols/common';
+import type { ProviderCandidate } from '@floway-dev/provider';
+
+export type { ProviderCandidate };
+
+// Per-request model resolution: resolve the inbound id against every
+// upstream the caller's scope allows, retry once with an `-YYYYMMDD`
+// suffix stripped, then keep only resolutions whose model.kind matches
+// the inbound endpoint family. Each surviving resolution becomes a
+// `(provider, model, fetcher)` candidate the dispatch layer can call.
+//
+// `sawModel` is true whenever the inbound id resolved against at least
+// one upstream catalog, regardless of kind. Callers use it to
+// distinguish "model id is unknown to every configured upstream"
+// (sawModel=false) from "model exists but is the wrong kind for this
+// endpoint" (sawModel=true, candidates=[]).
+//
+// Endpoint-level narrowing — picking the chat target protocol from
+// `model.endpoints`, or checking the specific `imagesEdits` /
+// `imagesGenerations` / `completions` endpoint key — is the caller's
+// job. This function stays endpoint-blind so the same path serves
+// chat, embeddings, image generation/edits, and legacy completions.
+export const enumerateProviderCandidates = async ({
+  upstreamIds, model, kind, scheduler, currentColo,
+}: {
+  // null = unrestricted; empty list = no providers visible.
+  upstreamIds: readonly string[] | null;
+  model: string;
+  kind: ModelKind;
+  // Threaded into `resolveModelForProvider` so the per-upstream catalog
+  // lookup hits the SWR-cached `fetchUpstreamModelsCached` instead of
+  // round-tripping to the upstream on every request.
+  scheduler: BackgroundScheduler;
+  // Current colo for this request — see GatewayCtx.currentColo. Threaded
+  // into the per-request fetcher so colo-scoped fallback entries can be
+  // honoured at dial time.
+  currentColo: string;
+}): Promise<{
+  readonly candidates: readonly ProviderCandidate[];
+  readonly sawModel: boolean;
+  readonly failedUpstreams: readonly string[];
+}> => {
+  const fetcherForUpstream = await createPerRequestFetcher(currentColo);
+  const providers = await listModelProviders(upstreamIds);
+  const { resolutions, failedUpstreams } = await resolveInterpretationsAcrossProviders(model, providers, fetcherForUpstream, scheduler);
+
+  const candidates: ProviderCandidate[] = [];
+  let sawModel = false;
+  for (const resolved of resolutions) {
+    sawModel = true;
+    if (resolved.model.kind !== kind) continue;
+    candidates.push({ provider: resolved.provider, model: resolved.model, fetcher: fetcherForUpstream(resolved.provider.upstream) });
+  }
+  return { candidates, sawModel, failedUpstreams };
+};

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -358,6 +358,45 @@ export const collectInterpretationOutcomes = async (
   return { resolutions, failedUpstreams };
 };
 
+// Inbound id forms ending in an 8-digit dated suffix (`-YYYYMMDD`) are a
+// compatibility shape: vendor clients sometimes pin to a release date even
+// though the gateway's merged catalog only carries the base id. When the
+// initial resolution finds no match for such an id, the resolver strips
+// the suffix and retries against the full provider list once. The retry
+// runs the same interpretation + outcome fan-out, so the stripped id is
+// exposed to every visible upstream in the same enumeration order as the
+// original attempt. Failed catalog fetches across the two attempts dedupe
+// into a single `failedUpstreams` list for the caller's renderer.
+const DATED_SUFFIX = /-\d{8}$/;
+
+export const resolveInterpretationsAcrossProviders = async (
+  modelId: string,
+  providers: readonly ModelProviderInstance[],
+  fetcherForUpstream: (upstreamId: string) => Fetcher,
+  scheduler: BackgroundScheduler,
+): Promise<{
+  readonly resolutions: ReadonlyArray<{ provider: ModelProviderInstance; resolved: ProviderModelResolution }>;
+  readonly failedUpstreams: readonly string[];
+}> => {
+  const first = await collectInterpretationOutcomes(
+    enumerateModelInterpretations(modelId, providers),
+    fetcherForUpstream,
+    scheduler,
+  );
+  if (first.resolutions.length > 0 || !DATED_SUFFIX.test(modelId)) return first;
+
+  const stripped = modelId.replace(DATED_SUFFIX, '');
+  const second = await collectInterpretationOutcomes(
+    enumerateModelInterpretations(stripped, providers),
+    fetcherForUpstream,
+    scheduler,
+  );
+  return {
+    resolutions: second.resolutions,
+    failedUpstreams: [...new Set([...first.failedUpstreams, ...second.failedUpstreams])],
+  };
+};
+
 export const resolveModelForRequest = async (
   modelId: string,
   upstreamFilter: readonly string[] | null,
@@ -368,9 +407,7 @@ export const resolveModelForRequest = async (
   if (providers.length === 0) {
     throw new Error(NO_UPSTREAM_CONFIGURED_MESSAGE);
   }
-
-  const interpretations = enumerateModelInterpretations(modelId, providers);
-  const { resolutions, failedUpstreams } = await collectInterpretationOutcomes(interpretations, fetcherForUpstream, scheduler);
+  const { resolutions, failedUpstreams } = await resolveInterpretationsAcrossProviders(modelId, providers, fetcherForUpstream, scheduler);
   return { matches: resolutions.map(r => r.resolved), failedUpstreams };
 };
 
@@ -383,11 +420,5 @@ export const resolveModelForProvider = async (
   const providedModels = await fetchUpstreamModelsCached(instance, { scheduler, fetcher });
   const disabled = new Set(instance.disabledPublicModelIds);
   const exact = providedModels.find(model => model.id === modelId && !disabled.has(model.id));
-  if (exact) return { id: exact.id, model: exact, binding: providerModelRecord(instance, exact) };
-
-  const aliasTarget = instance.resolveRequestedModelId?.(modelId);
-  if (!aliasTarget || aliasTarget === modelId) return undefined;
-
-  const alias = providedModels.find(model => model.id === aliasTarget && !disabled.has(model.id));
-  return alias ? { id: alias.id, model: alias, binding: providerModelRecord(instance, alias) } : undefined;
+  return exact ? { id: exact.id, model: exact, binding: providerModelRecord(instance, exact) } : undefined;
 };

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -338,15 +338,9 @@ export const collectInterpretationOutcomes = async (
   return { resolutions, failedUpstreams };
 };
 
-// Inbound id forms ending in an 8-digit dated suffix (`-YYYYMMDD`) are a
-// compatibility shape: vendor clients sometimes pin to a release date even
-// though the gateway's merged catalog only carries the base id. When the
-// initial resolution finds no match for such an id, the resolver strips
-// the suffix and retries against the full provider list once. The retry
-// runs the same interpretation + outcome fan-out, so the stripped id is
-// exposed to every visible upstream in the same enumeration order as the
-// original attempt. Failed catalog fetches across the two attempts dedupe
-// into a single `failedUpstreams` list for the caller's renderer.
+// Eight-digit dated suffix on the inbound id — a vendor-pin shape some
+// clients use. When the first resolution misses, the resolver strips
+// the suffix and retries once. See RESOLUTION.md.
 const DATED_SUFFIX = /-\d{8}$/;
 
 export const resolveInterpretationsAcrossProviders = async (

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -2,7 +2,7 @@ import { fetchUpstreamModelsCached } from './models-cache.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import { type ModelEndpointKey, type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/common';
-import type { InternalModel, ModelProviderInstance, ProviderModelRecord, ResolvedModel, Fetcher, UpstreamModel, UpstreamProviderKind, UpstreamRecord } from '@floway-dev/provider';
+import type { CatalogModel, Fetcher, ModelProviderInstance, UpstreamModel, UpstreamProviderKind, UpstreamRecord } from '@floway-dev/provider';
 import { createAzureProvider } from '@floway-dev/provider-azure';
 import { createClaudeCodeProvider } from '@floway-dev/provider-claude-code';
 import { createCodexProvider } from '@floway-dev/provider-codex';
@@ -11,7 +11,11 @@ import { createCustomProvider } from '@floway-dev/provider-custom';
 import { createOllamaProvider } from '@floway-dev/provider-ollama';
 
 interface ProviderModelsResult {
-  models: ResolvedModel[];
+  models: CatalogModel[];
+  // Reverse index: every upstream instance that emitted an entry under the
+  // given public id, in enumeration order. The control-plane catalog
+  // endpoint reads this to render `upstreams: [{kind, id, name}]` per row.
+  upstreamsByPublicId: Map<string, ModelProviderInstance[]>;
   sawSuccess: boolean;
   lastError: unknown;
   // Upstream names whose catalog fetch rejected this round, in the same
@@ -37,10 +41,9 @@ export const createProviderInstance = (record: UpstreamRecord): ModelProviderIns
   providerFactories[record.provider](record);
 
 // The upstream scope is a required argument across the catalog-assembly chain
-// (this, getModels, getInternalModels) so a caller can never omit it and
-// silently receive the full, unscoped catalog — a missing scope is a compile
-// error, not a runtime leak. Pass `null` to deliberately request every enabled
-// upstream.
+// (this, getModels) so a caller can never omit it and silently receive the
+// full, unscoped catalog — a missing scope is a compile error, not a runtime
+// leak. Pass `null` to deliberately request every enabled upstream.
 export const listModelProviders = async (
   upstreamFilter: readonly string[] | null,
 ): Promise<ModelProviderInstance[]> => {
@@ -91,39 +94,29 @@ const unionEndpoints = (a: ModelEndpoints, b: ModelEndpoints): ModelEndpoints =>
   return result;
 };
 
-const resolvedFromUpstreamModel = (upstreamModel: UpstreamModel, record: ProviderModelRecord): ResolvedModel => {
+const catalogFromUpstreamModel = (upstreamModel: UpstreamModel): CatalogModel => {
   const { providerData: _providerData, endpoints, ...internal } = upstreamModel;
-  return {
-    ...internal,
-    endpoints: { ...endpoints },
-    providers: [record],
-  };
+  return { ...internal, endpoints: { ...endpoints } };
 };
 
-const providerModelRecord = (instance: ModelProviderInstance, upstreamModel: UpstreamModel): ProviderModelRecord => ({
-  upstream: instance.upstream,
-  upstreamName: instance.name,
-  providerKind: instance.providerKind,
-  provider: instance.provider,
-  upstreamModel,
-  enabledFlags: upstreamModel.enabledFlags,
-  supportsResponsesItemReference: instance.supportsResponsesItemReference,
-});
-
 // When multiple upstreams expose the same public model id, the first wins
-// for /models metadata and later ones union-merge their endpoints + provider
-// binding. Runtime execution still uses each provider's own UpstreamModel, so
-// capability-sensitive calls do not depend on this merged view.
+// for /models metadata and later ones union-merge their endpoint capability
+// flags. Runtime execution still uses each provider's own UpstreamModel, so
+// capability-sensitive calls do not depend on this merged view. The reverse
+// index `upstreamsByPublicId` accumulates every upstream that surfaced the
+// id, in enumeration order, so the control plane can render its per-model
+// upstream chips without re-walking the catalog.
 const mergeIntoCatalog = (
-  byId: Map<string, ResolvedModel>,
+  byId: Map<string, CatalogModel>,
+  upstreamsByPublicId: Map<string, ModelProviderInstance[]>,
   instance: ModelProviderInstance,
   surfacedModel: UpstreamModel,
   publicId: string,
 ): void => {
-  const record = providerModelRecord(instance, surfacedModel);
   const existing = byId.get(publicId);
   if (!existing) {
-    byId.set(publicId, resolvedFromUpstreamModel(surfacedModel, record));
+    byId.set(publicId, catalogFromUpstreamModel(surfacedModel));
+    upstreamsByPublicId.set(publicId, [instance]);
     return;
   }
   const endpoints = unionEndpoints(existing.endpoints, surfacedModel.endpoints);
@@ -131,8 +124,8 @@ const mergeIntoCatalog = (
     ...existing,
     endpoints,
     kind: kindForEndpoints(endpoints),
-    providers: [...existing.providers, record],
   });
+  upstreamsByPublicId.get(publicId)?.push(instance);
 };
 
 const collectProviderModels = async (
@@ -140,7 +133,8 @@ const collectProviderModels = async (
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<ProviderModelsResult> => {
-  const byId = new Map<string, ResolvedModel>();
+  const byId = new Map<string, CatalogModel>();
+  const upstreamsByPublicId = new Map<string, ModelProviderInstance[]>();
   let sawSuccess = false;
   let lastError: unknown = null;
   const failedUpstreams: string[] = [];
@@ -198,15 +192,15 @@ const collectProviderModels = async (
           const surfacedModel: UpstreamModel = form === 'prefixed'
             ? { ...upstreamModel, id: publicId, display_name: `${instance.name}: ${upstreamModel.display_name ?? upstreamModel.id}` }
             : upstreamModel;
-          mergeIntoCatalog(byId, instance, surfacedModel, publicId);
+          mergeIntoCatalog(byId, upstreamsByPublicId, instance, surfacedModel, publicId);
         }
       } else {
-        mergeIntoCatalog(byId, instance, upstreamModel, upstreamModel.id);
+        mergeIntoCatalog(byId, upstreamsByPublicId, instance, upstreamModel, upstreamModel.id);
       }
     }
   }
 
-  return { models: [...byId.values()], sawSuccess, lastError, failedUpstreams };
+  return { models: [...byId.values()], upstreamsByPublicId, sawSuccess, lastError, failedUpstreams };
 };
 
 // Public-facing model-id ordering, applied in getModels() to every list that
@@ -244,30 +238,26 @@ export const compareModelIds = (a: string, b: string): number => {
 };
 
 // `fetcherForUpstream` routes each upstream's catalog fetch through its
-// per-upstream proxy chain.
+// per-upstream proxy chain. Returns the merged catalog together with the
+// reverse `upstreamsByPublicId` map; callers that only want the bare
+// metadata projection (`/v1/models`, `/models`, etc.) destructure
+// `models` and ignore the map.
 export const getModels = async (
   upstreamFilter: readonly string[] | null,
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
-): Promise<ResolvedModel[]> => {
+): Promise<{ models: CatalogModel[]; upstreamsByPublicId: Map<string, ModelProviderInstance[]> }> => {
   const providers = await listModelProviders(upstreamFilter);
   if (providers.length === 0) {
     throw new Error(NO_UPSTREAM_CONFIGURED_MESSAGE);
   }
 
-  const { models, sawSuccess, lastError } = await collectProviderModels(providers, fetcherForUpstream, scheduler);
+  const { models, upstreamsByPublicId, sawSuccess, lastError } = await collectProviderModels(providers, fetcherForUpstream, scheduler);
 
-  if (sawSuccess) return models.sort((a, b) => compareModelIds(a.id, b.id));
+  if (sawSuccess) return { models: models.sort((a, b) => compareModelIds(a.id, b.id)), upstreamsByPublicId };
   if (lastError) throw lastError;
-  return [];
+  return { models: [], upstreamsByPublicId };
 };
-
-export const getInternalModels = async (
-  upstreamFilter: readonly string[] | null,
-  fetcherForUpstream: (upstreamId: string) => Fetcher,
-  scheduler: BackgroundScheduler,
-): Promise<InternalModel[]> =>
-  (await getModels(upstreamFilter, fetcherForUpstream, scheduler)).map(({ providers: _providers, endpoints: _endpoints, ...model }) => model);
 
 interface ModelResolution {
   matches: readonly ProviderModelResolution[];
@@ -279,10 +269,15 @@ interface ModelResolution {
   failedUpstreams: readonly string[];
 }
 
+// A single (provider, upstream-catalog model) pair the resolver matched
+// against an inbound id. `id` is the upstream's bare catalog id (which
+// equals `model.id` and differs from the inbound id when the inbound
+// matched the prefixed surface); telemetry and dump records key on that
+// canonical id while error envelopes echo the inbound `model` instead.
 export interface ProviderModelResolution {
   id: string;
   model: UpstreamModel;
-  binding: ProviderModelRecord;
+  provider: ModelProviderInstance;
 }
 
 export interface ModelInterpretation {
@@ -420,5 +415,5 @@ export const resolveModelForProvider = async (
   const providedModels = await fetchUpstreamModelsCached(instance, { scheduler, fetcher });
   const disabled = new Set(instance.disabledPublicModelIds);
   const exact = providedModels.find(model => model.id === modelId && !disabled.has(model.id));
-  return exact ? { id: exact.id, model: exact, binding: providerModelRecord(instance, exact) } : undefined;
+  return exact ? { id: exact.id, model: exact, provider: instance } : undefined;
 };

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -259,16 +259,6 @@ export const getModels = async (
   return { models: [], upstreamsByPublicId };
 };
 
-interface ModelResolution {
-  matches: readonly ProviderModelResolution[];
-  // Upstream names whose catalog fetch rejected during this resolution.
-  // Threaded out so the caller's failure renderer can mention them
-  // parenthetically — same data the dashboard's `modelsCache.lastError`
-  // surfaces, but inlined into the per-request 404/400 so a client sees
-  // why their model might be temporarily missing.
-  failedUpstreams: readonly string[];
-}
-
 // A single (provider, upstream-catalog model) pair the resolver matched
 // against an inbound id. `id` is the upstream's bare catalog id (which
 // equals `model.id` and differs from the inbound id when the inbound
@@ -312,25 +302,22 @@ export const enumerateModelInterpretations = (
 
 // Fan out per-interpretation against the SWR cache and collect the resolved
 // matches plus a deduped list of upstreams whose catalog fetch rejected.
-// Shared by `resolveModelForRequest` and `enumerateProviderCandidates`; the
-// per-caller divergence (passthrough vs LLM-candidate shape) happens after
-// this returns. Cancellation (`AbortError`) propagates so the per-request
-// abort signal cannot be masked by a slow upstream's rejection.
+// Cancellation (`AbortError`) propagates so the per-request abort signal
+// cannot be masked by a slow upstream's rejection.
 export const collectInterpretationOutcomes = async (
   interpretations: readonly ModelInterpretation[],
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<{
-  resolutions: Array<{ provider: ModelProviderInstance; resolved: ProviderModelResolution }>;
+  resolutions: ProviderModelResolution[];
   failedUpstreams: string[];
 }> => {
   const settled = await Promise.allSettled(interpretations.map(({ provider, lookupId }) =>
-    resolveModelForProvider(provider, lookupId, fetcherForUpstream(provider.upstream), scheduler)
-      .then(resolved => ({ provider, resolved }))));
+    resolveModelForProvider(provider, lookupId, fetcherForUpstream(provider.upstream), scheduler)));
 
   const failedUpstreams: string[] = [];
   const failedSeen = new Set<string>();
-  const resolutions: Array<{ provider: ModelProviderInstance; resolved: ProviderModelResolution }> = [];
+  const resolutions: ProviderModelResolution[] = [];
 
   for (const [index, result] of settled.entries()) {
     if (result.status === 'rejected') {
@@ -345,9 +332,7 @@ export const collectInterpretationOutcomes = async (
       }
       continue;
     }
-    const { provider, resolved } = result.value;
-    if (!resolved) continue;
-    resolutions.push({ provider, resolved });
+    if (result.value !== undefined) resolutions.push(result.value);
   }
 
   return { resolutions, failedUpstreams };
@@ -370,7 +355,7 @@ export const resolveInterpretationsAcrossProviders = async (
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<{
-  readonly resolutions: ReadonlyArray<{ provider: ModelProviderInstance; resolved: ProviderModelResolution }>;
+  readonly resolutions: readonly ProviderModelResolution[];
   readonly failedUpstreams: readonly string[];
 }> => {
   const first = await collectInterpretationOutcomes(
@@ -390,20 +375,6 @@ export const resolveInterpretationsAcrossProviders = async (
     resolutions: second.resolutions,
     failedUpstreams: [...new Set([...first.failedUpstreams, ...second.failedUpstreams])],
   };
-};
-
-export const resolveModelForRequest = async (
-  modelId: string,
-  upstreamFilter: readonly string[] | null,
-  fetcherForUpstream: (upstreamId: string) => Fetcher,
-  scheduler: BackgroundScheduler,
-): Promise<ModelResolution> => {
-  const providers = await listModelProviders(upstreamFilter);
-  if (providers.length === 0) {
-    throw new Error(NO_UPSTREAM_CONFIGURED_MESSAGE);
-  }
-  const { resolutions, failedUpstreams } = await resolveInterpretationsAcrossProviders(modelId, providers, fetcherForUpstream, scheduler);
-  return { matches: resolutions.map(r => r.resolved), failedUpstreams };
 };
 
 export const resolveModelForProvider = async (

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest';
 
+import { enumerateProviderCandidates } from './candidates.ts';
 import { clearInFlightForTesting } from './models-cache.ts';
-import { compareModelIds, enumerateModelInterpretations, getModels, listModelProviders, resolveModelForProvider, resolveModelForRequest } from './registry.ts';
+import { compareModelIds, enumerateModelInterpretations, getModels, listModelProviders, resolveModelForProvider } from './registry.ts';
 import { buildCopilotUpstreamRecord, buildCustomUpstreamRecord, copilotModels, setupAppTest } from '../../test-helpers.ts';
 import { directFetcher, type ModelProviderInstance } from '@floway-dev/provider';
 import { assertEquals, jsonResponse, stubProvider, withMockedFetch } from '@floway-dev/test-utils';
@@ -182,16 +183,16 @@ test('getModels returns the merged catalog plus the per-id upstream index', asyn
       // enumeration order — copilot first, then custom.
       assertEquals(upstreamsByPublicId.get('shared-model')?.map(p => p.upstream), ['up_copilot', 'up_custom']);
 
-      const resolved = await resolveModelForRequest('shared-model', null, () => directFetcher, testScheduler);
-      assertEquals(resolved.matches.map(m => m.provider.upstream), ['up_copilot', 'up_custom']);
+      const resolved = await enumerateProviderCandidates({ upstreamIds: null, model: 'shared-model', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+      assertEquals(resolved.candidates.map(m => m.provider.upstream), ['up_copilot', 'up_custom']);
       // Each match carries its own per-provider endpoints — no merge.
-      assertEquals(resolved.matches[0]?.model.endpoints, { messages: {} });
-      assertEquals(resolved.matches[1]?.model.endpoints, { chatCompletions: {} });
+      assertEquals(resolved.candidates[0]?.model.endpoints, { messages: {} });
+      assertEquals(resolved.candidates[1]?.model.endpoints, { chatCompletions: {} });
     },
   );
 });
 
-test('resolveModelForRequest strips an -YYYYMMDD suffix when nothing matched and retries across every visible upstream', async () => {
+test('enumerateProviderCandidates strips an -YYYYMMDD suffix when nothing matched and retries across every visible upstream', async () => {
   const { repo } = await setupAppTest();
 
   await repo.upstreams.save(
@@ -233,19 +234,19 @@ test('resolveModelForRequest strips an -YYYYMMDD suffix when nothing matched and
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const resolved = await resolveModelForRequest('claude-opus-4-7-20300101', null, () => directFetcher, testScheduler);
+      const resolved = await enumerateProviderCandidates({ upstreamIds: null, model: 'claude-opus-4-7-20300101', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
 
       // No upstream's catalog literally lists `claude-opus-4-7-20300101`,
       // so the resolver retries against the stripped `claude-opus-4-7`,
       // which both upstreams expose. Both bindings end up in the match
       // list in configured `sort_order`.
-      assertEquals(resolved.matches.map(m => m.provider.upstream).sort(), ['up_copilot', 'up_custom'].sort());
-      assertEquals(resolved.matches.map(m => m.id), ['claude-opus-4-7', 'claude-opus-4-7']);
+      assertEquals(resolved.candidates.map(m => m.provider.upstream).sort(), ['up_copilot', 'up_custom'].sort());
+      assertEquals(resolved.candidates.map(m => m.model.id), ['claude-opus-4-7', 'claude-opus-4-7']);
     },
   );
 });
 
-test('resolveModelForRequest does not retry when the inbound id has no dated suffix', async () => {
+test('enumerateProviderCandidates does not retry when the inbound id has no dated suffix', async () => {
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
   await repo.upstreams.save(
@@ -269,8 +270,8 @@ test('resolveModelForRequest does not retry when the inbound id has no dated suf
     },
     async () => {
       // Plain typo / unknown id — no dated suffix, no retry.
-      const resolved = await resolveModelForRequest('claude-opus-4-7-unknown', null, () => directFetcher, testScheduler);
-      assertEquals(resolved.matches.length, 0);
+      const resolved = await enumerateProviderCandidates({ upstreamIds: null, model: 'claude-opus-4-7-unknown', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+      assertEquals(resolved.candidates.length, 0);
     },
   );
 });
@@ -387,16 +388,16 @@ test('disabledPublicModelIds hides models from the catalog and routing, per upst
   assertEquals([...catalog.map(m => m.id)].sort(), ['gpt-keep', 'gpt-shared']);
 
   // The solo and override ids resolve to nothing (hidden + unroutable).
-  assertEquals((await resolveModelForRequest('gpt-solo', null, () => directFetcher, testScheduler)).matches.length, 0);
-  assertEquals((await resolveModelForRequest('gpt-override', null, () => directFetcher, testScheduler)).matches.length, 0);
+  assertEquals((await enumerateProviderCandidates({ upstreamIds: null, model: 'gpt-solo', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' })).candidates.length, 0);
+  assertEquals((await enumerateProviderCandidates({ upstreamIds: null, model: 'gpt-override', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' })).candidates.length, 0);
 
   // The shared id survives because up_b allows it; only up_b binds it.
-  const shared = await resolveModelForRequest('gpt-shared', null, () => directFetcher, testScheduler);
-  assertEquals(shared.matches.map(m => m.provider.upstream), ['up_b']);
+  const shared = await enumerateProviderCandidates({ upstreamIds: null, model: 'gpt-shared', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+  assertEquals(shared.candidates.map(m => m.provider.upstream), ['up_b']);
 
   // The untouched model still routes from up_a.
-  const keep = await resolveModelForRequest('gpt-keep', null, () => directFetcher, testScheduler);
-  assertEquals(keep.matches.map(m => m.provider.upstream), ['up_a']);
+  const keep = await enumerateProviderCandidates({ upstreamIds: null, model: 'gpt-keep', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+  assertEquals(keep.candidates.map(m => m.provider.upstream), ['up_a']);
 });
 
 test('resolveModelForProvider rejects a model id disabled on that upstream (filter parity with the catalog)', async () => {
@@ -555,7 +556,7 @@ test('getModels: a rejected provider does not block other providers', async () =
 // site asking for a model belonging to one of the *healthy* upstreams must
 // still resolve. The broken upstream's display name flows back via
 // `failedUpstreams` so the eventual error renderer can mention it.
-test('resolveModelForRequest: healthy upstream still resolves alongside a rejecting one, with failedUpstreams reported', async () => {
+test('enumerateProviderCandidates: healthy upstream still resolves alongside a rejecting one, with failedUpstreams reported', async () => {
   clearInFlightForTesting();
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
@@ -585,17 +586,17 @@ test('resolveModelForRequest: healthy upstream still resolves alongside a reject
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const resolvedExisting = await resolveModelForRequest('ok-model', null, () => directFetcher, testScheduler);
-      assertEquals(resolvedExisting.matches.map(m => m.provider.upstream), ['up_ok']);
-      assertEquals(resolvedExisting.matches[0]?.id, 'ok-model');
+      const resolvedExisting = await enumerateProviderCandidates({ upstreamIds: null, model: 'ok-model', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+      assertEquals(resolvedExisting.candidates.map(m => m.provider.upstream), ['up_ok']);
+      assertEquals(resolvedExisting.candidates[0]?.model.id, 'ok-model');
       assertEquals(resolvedExisting.failedUpstreams, ['Broken upstream']);
 
       // A model nobody currently knows about must NOT rethrow the broken
       // upstream's catalog error — the caller's failure renderer is the right
       // place to surface that, parenthetically, alongside the model-missing
       // body.
-      const resolvedMissing = await resolveModelForRequest('unknown-model', null, () => directFetcher, testScheduler);
-      assertEquals(resolvedMissing.matches.length, 0);
+      const resolvedMissing = await enumerateProviderCandidates({ upstreamIds: null, model: 'unknown-model', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+      assertEquals(resolvedMissing.candidates.length, 0);
       assertEquals(resolvedMissing.failedUpstreams, ['Broken upstream']);
     },
   );
@@ -742,14 +743,14 @@ describe('catalog listing under modelPrefix', () => {
         // the prefixed surface, so a byId-based routing lookup against the
         // stripped bare id would miss. Routing must instead consult each
         // scoped upstream's own catalog, where the bare id is always present.
-        const resolved = await resolveModelForRequest('or/gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(resolved.matches.map(m => m.provider.upstream), ['up_prefixed']);
-        assertEquals(resolved.matches[0]?.id, 'gpt-4o');
+        const resolved = await enumerateProviderCandidates({ upstreamIds: null, model: 'or/gpt-4o', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+        assertEquals(resolved.candidates.map(m => m.provider.upstream), ['up_prefixed']);
+        assertEquals(resolved.candidates[0]?.model.id, 'gpt-4o');
 
         // The bare-id request must NOT route to a prefix-only-addressable
         // upstream, regardless of routing path.
-        const bare = await resolveModelForRequest('gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(bare.matches.length, 0);
+        const bare = await enumerateProviderCandidates({ upstreamIds: null, model: 'gpt-4o', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+        assertEquals(bare.candidates.length, 0);
       },
     );
   });
@@ -781,16 +782,16 @@ describe('catalog listing under modelPrefix', () => {
         const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
         assertEquals(catalog.map(m => m.id), ['or/gpt-4o']);
 
-        const bare = await resolveModelForRequest('gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(bare.matches.map(m => m.provider.upstream), ['up_dual_addressable']);
-        assertEquals(bare.matches[0]?.id, 'gpt-4o');
+        const bare = await enumerateProviderCandidates({ upstreamIds: null, model: 'gpt-4o', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+        assertEquals(bare.candidates.map(m => m.provider.upstream), ['up_dual_addressable']);
+        assertEquals(bare.candidates[0]?.model.id, 'gpt-4o');
 
         // The prefixed request enumerates both forms against `up_dual_addressable`:
         // the unprefixed lookup (`or/gpt-4o`) misses the upstream catalog, and
         // the prefix-stripped lookup (`gpt-4o`) hits — yielding a single match.
-        const prefixed = await resolveModelForRequest('or/gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(prefixed.matches.map(m => m.provider.upstream), ['up_dual_addressable']);
-        assertEquals(prefixed.matches[0]?.id, 'gpt-4o');
+        const prefixed = await enumerateProviderCandidates({ upstreamIds: null, model: 'or/gpt-4o', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+        assertEquals(prefixed.candidates.map(m => m.provider.upstream), ['up_dual_addressable']);
+        assertEquals(prefixed.candidates[0]?.model.id, 'gpt-4o');
       },
     );
   });
@@ -832,14 +833,14 @@ describe('catalog listing under modelPrefix', () => {
         // Both upstreams enumerate against the bare id: up_plain via its only
         // form, up_dual via the unprefixed interpretation. Order follows the
         // configured sort_order across providers, then FORM_ORDER within one.
-        const bare = await resolveModelForRequest('gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(bare.matches.map(m => m.provider.upstream), ['up_plain', 'up_dual']);
+        const bare = await enumerateProviderCandidates({ upstreamIds: null, model: 'gpt-4o', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+        assertEquals(bare.candidates.map(m => m.provider.upstream), ['up_plain', 'up_dual']);
 
         // The prefixed id resolves only against up_dual: up_plain's catalog
         // does not contain `or/gpt-4o`, and up_dual's prefix-stripped lookup
         // hits its catalog's bare `gpt-4o`.
-        const prefixed = await resolveModelForRequest('or/gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(prefixed.matches.map(m => m.provider.upstream), ['up_dual']);
+        const prefixed = await enumerateProviderCandidates({ upstreamIds: null, model: 'or/gpt-4o', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+        assertEquals(prefixed.candidates.map(m => m.provider.upstream), ['up_dual']);
       },
     );
   });
@@ -922,9 +923,9 @@ describe('catalog listing under modelPrefix', () => {
         throw new Error(`Unhandled fetch ${request.url}`);
       },
       async () => {
-        const resolved = await resolveModelForRequest('aa/bb/gpt-5', null, () => directFetcher, testScheduler);
-        assertEquals(resolved.matches.map(m => m.provider.upstream), ['up_short_prefix', 'up_long_prefix', 'up_bare']);
-        assertEquals(resolved.matches.map(m => m.id), ['bb/gpt-5', 'gpt-5', 'aa/bb/gpt-5']);
+        const resolved = await enumerateProviderCandidates({ upstreamIds: null, model: 'aa/bb/gpt-5', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+        assertEquals(resolved.candidates.map(m => m.provider.upstream), ['up_short_prefix', 'up_long_prefix', 'up_bare']);
+        assertEquals(resolved.candidates.map(m => m.model.id), ['bb/gpt-5', 'gpt-5', 'aa/bb/gpt-5']);
       },
     );
   });

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { clearInFlightForTesting } from './models-cache.ts';
-import { compareModelIds, enumerateModelInterpretations, getInternalModels, listModelProviders, resolveModelForProvider, resolveModelForRequest } from './registry.ts';
+import { compareModelIds, enumerateModelInterpretations, getModels, listModelProviders, resolveModelForProvider, resolveModelForRequest } from './registry.ts';
 import { buildCopilotUpstreamRecord, buildCustomUpstreamRecord, copilotModels, setupAppTest } from '../../test-helpers.ts';
 import { directFetcher, type ModelProviderInstance } from '@floway-dev/provider';
 import { assertEquals, jsonResponse, stubProvider, withMockedFetch } from '@floway-dev/test-utils';
@@ -121,7 +121,7 @@ test('listModelProviders creates enabled provider instances with upstream row id
   assertEquals(providers.map(provider => provider.upstream), ['up_custom', 'up_azure', 'up_copilot']);
 });
 
-test('getInternalModels returns the catalog projection without execution bindings', async () => {
+test('getModels returns the merged catalog plus the per-id upstream index', async () => {
   const { repo } = await setupAppTest();
 
   await repo.upstreams.save(buildCustomUpstreamRecord());
@@ -168,17 +168,22 @@ test('getInternalModels returns the catalog projection without execution binding
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
-      const model = catalog.find(candidate => candidate.id === 'shared-model');
+      const { models, upstreamsByPublicId } = await getModels(null, () => directFetcher, testScheduler);
+      const model = models.find(candidate => candidate.id === 'shared-model');
 
       assertEquals(model?.display_name, 'Shared Model');
-      assertEquals(Object.hasOwn(model!, 'endpoints'), false);
+      // The merged endpoint surface is the OR of both upstreams' bindings.
+      assertEquals(model?.endpoints, { messages: {}, chatCompletions: {} });
       assertEquals(model?.kind, 'chat');
-      assertEquals(Object.hasOwn(model!, 'providers'), false);
+      // `providerData` (the per-provider wire id carrier) belongs to the
+      // upstream-facing UpstreamModel, not the gateway-merged catalog row.
       assertEquals(Object.hasOwn(model!, 'providerData'), false);
+      // The reverse index lists every upstream that surfaced this id, in
+      // enumeration order — copilot first, then custom.
+      assertEquals(upstreamsByPublicId.get('shared-model')?.map(p => p.upstream), ['up_copilot', 'up_custom']);
 
       const resolved = await resolveModelForRequest('shared-model', null, () => directFetcher, testScheduler);
-      assertEquals(resolved.matches.map(m => m.binding.upstream), ['up_copilot', 'up_custom']);
+      assertEquals(resolved.matches.map(m => m.provider.upstream), ['up_copilot', 'up_custom']);
       // Each match carries its own per-provider endpoints — no merge.
       assertEquals(resolved.matches[0]?.model.endpoints, { messages: {} });
       assertEquals(resolved.matches[1]?.model.endpoints, { chatCompletions: {} });
@@ -234,7 +239,7 @@ test('resolveModelForRequest strips an -YYYYMMDD suffix when nothing matched and
       // so the resolver retries against the stripped `claude-opus-4-7`,
       // which both upstreams expose. Both bindings end up in the match
       // list in configured `sort_order`.
-      assertEquals(resolved.matches.map(m => m.binding.upstream).sort(), ['up_copilot', 'up_custom'].sort());
+      assertEquals(resolved.matches.map(m => m.provider.upstream).sort(), ['up_copilot', 'up_custom'].sort());
       assertEquals(resolved.matches.map(m => m.id), ['claude-opus-4-7', 'claude-opus-4-7']);
     },
   );
@@ -305,7 +310,7 @@ test('resolveModelForProvider only loads the selected provider catalog', async (
       const resolved = await resolveModelForProvider(providers[0], 'target-model', directFetcher, testScheduler);
 
       assertEquals(resolved?.model.id, 'target-model');
-      assertEquals(resolved?.binding.upstream, 'up_first');
+      assertEquals(resolved?.provider.upstream, 'up_first');
     },
   );
 
@@ -378,7 +383,7 @@ test('disabledPublicModelIds hides models from the catalog and routing, per upst
     disabledPublicModelIds: [],
   }));
 
-  const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+  const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
   assertEquals([...catalog.map(m => m.id)].sort(), ['gpt-keep', 'gpt-shared']);
 
   // The solo and override ids resolve to nothing (hidden + unroutable).
@@ -387,11 +392,11 @@ test('disabledPublicModelIds hides models from the catalog and routing, per upst
 
   // The shared id survives because up_b allows it; only up_b binds it.
   const shared = await resolveModelForRequest('gpt-shared', null, () => directFetcher, testScheduler);
-  assertEquals(shared.matches.map(m => m.binding.upstream), ['up_b']);
+  assertEquals(shared.matches.map(m => m.provider.upstream), ['up_b']);
 
   // The untouched model still routes from up_a.
   const keep = await resolveModelForRequest('gpt-keep', null, () => directFetcher, testScheduler);
-  assertEquals(keep.matches.map(m => m.binding.upstream), ['up_a']);
+  assertEquals(keep.matches.map(m => m.provider.upstream), ['up_a']);
 });
 
 test('resolveModelForProvider rejects a model id disabled on that upstream (filter parity with the catalog)', async () => {
@@ -451,7 +456,7 @@ test('listModelProviders throws on unknown upstream ids in the whitelist', async
 // tracks the slowest upstream, not the sum. The bound is loose because CI
 // timer noise eats into a tight `< sum` comparison; what matters is the
 // ratio.
-test('getInternalModels fans out per-upstream catalog fetches in parallel', async () => {
+test('getModels fans out per-upstream catalog fetches in parallel', async () => {
   clearInFlightForTesting();
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
@@ -483,7 +488,7 @@ test('getInternalModels fans out per-upstream catalog fetches in parallel', asyn
     },
     async () => {
       const start = Date.now();
-      const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+      const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
       const elapsed = Date.now() - start;
 
       assertEquals([...catalog.map(m => m.id)].sort(), ['p1-model', 'p2-model', 'p3-model']);
@@ -501,7 +506,7 @@ test('getInternalModels fans out per-upstream catalog fetches in parallel', asyn
 // A single upstream's catalog fetch failure is surfaced as `lastError` and
 // recorded against `sawSuccess === true`; the public catalog still includes
 // every successful upstream's models.
-test('getInternalModels: a rejected provider does not block other providers', async () => {
+test('getModels: a rejected provider does not block other providers', async () => {
   clearInFlightForTesting();
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
@@ -540,7 +545,7 @@ test('getInternalModels: a rejected provider does not block other providers', as
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+      const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
       assertEquals([...catalog.map(m => m.id)].sort(), ['ok-1-model', 'ok-2-model']);
     },
   );
@@ -581,7 +586,7 @@ test('resolveModelForRequest: healthy upstream still resolves alongside a reject
     },
     async () => {
       const resolvedExisting = await resolveModelForRequest('ok-model', null, () => directFetcher, testScheduler);
-      assertEquals(resolvedExisting.matches.map(m => m.binding.upstream), ['up_ok']);
+      assertEquals(resolvedExisting.matches.map(m => m.provider.upstream), ['up_ok']);
       assertEquals(resolvedExisting.matches[0]?.id, 'ok-model');
       assertEquals(resolvedExisting.failedUpstreams, ['Broken upstream']);
 
@@ -680,7 +685,7 @@ describe('enumerateModelInterpretations', () => {
 });
 
 // End-to-end listing checks for the prefix policy. The catalog walk goes
-// through getInternalModels, which threads custom upstreams' /v1/models
+// through getModels, which threads custom upstreams' /v1/models
 // responses through fetchUpstreamModelsCached just like production does.
 describe('catalog listing under modelPrefix', () => {
   test('null prefix lists bare ids only (today\'s behavior)', async () => {
@@ -701,7 +706,7 @@ describe('catalog listing under modelPrefix', () => {
         throw new Error(`Unhandled fetch ${request.url}`);
       },
       async () => {
-        const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+        const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
         assertEquals(catalog.map(m => m.id), ['gpt-4o']);
       },
     );
@@ -726,7 +731,7 @@ describe('catalog listing under modelPrefix', () => {
         throw new Error(`Unhandled fetch ${request.url}`);
       },
       async () => {
-        const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+        const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
         assertEquals(catalog.map(m => m.id), ['or/gpt-4o']);
         // Prefixed surface gets a synthesized display_name prepending the
         // upstream's display name so the dashboard tells the operator at a
@@ -738,7 +743,7 @@ describe('catalog listing under modelPrefix', () => {
         // stripped bare id would miss. Routing must instead consult each
         // scoped upstream's own catalog, where the bare id is always present.
         const resolved = await resolveModelForRequest('or/gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(resolved.matches.map(m => m.binding.upstream), ['up_prefixed']);
+        assertEquals(resolved.matches.map(m => m.provider.upstream), ['up_prefixed']);
         assertEquals(resolved.matches[0]?.id, 'gpt-4o');
 
         // The bare-id request must NOT route to a prefix-only-addressable
@@ -773,18 +778,18 @@ describe('catalog listing under modelPrefix', () => {
         throw new Error(`Unhandled fetch ${request.url}`);
       },
       async () => {
-        const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+        const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
         assertEquals(catalog.map(m => m.id), ['or/gpt-4o']);
 
         const bare = await resolveModelForRequest('gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(bare.matches.map(m => m.binding.upstream), ['up_dual_addressable']);
+        assertEquals(bare.matches.map(m => m.provider.upstream), ['up_dual_addressable']);
         assertEquals(bare.matches[0]?.id, 'gpt-4o');
 
         // The prefixed request enumerates both forms against `up_dual_addressable`:
         // the unprefixed lookup (`or/gpt-4o`) misses the upstream catalog, and
         // the prefix-stripped lookup (`gpt-4o`) hits — yielding a single match.
         const prefixed = await resolveModelForRequest('or/gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(prefixed.matches.map(m => m.binding.upstream), ['up_dual_addressable']);
+        assertEquals(prefixed.matches.map(m => m.provider.upstream), ['up_dual_addressable']);
         assertEquals(prefixed.matches[0]?.id, 'gpt-4o');
       },
     );
@@ -821,20 +826,20 @@ describe('catalog listing under modelPrefix', () => {
         throw new Error(`Unhandled fetch ${request.url}`);
       },
       async () => {
-        const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+        const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
         assertEquals([...catalog.map(m => m.id)].sort(), ['gpt-4o', 'or/gpt-4o']);
 
         // Both upstreams enumerate against the bare id: up_plain via its only
         // form, up_dual via the unprefixed interpretation. Order follows the
         // configured sort_order across providers, then FORM_ORDER within one.
         const bare = await resolveModelForRequest('gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(bare.matches.map(m => m.binding.upstream), ['up_plain', 'up_dual']);
+        assertEquals(bare.matches.map(m => m.provider.upstream), ['up_plain', 'up_dual']);
 
         // The prefixed id resolves only against up_dual: up_plain's catalog
         // does not contain `or/gpt-4o`, and up_dual's prefix-stripped lookup
         // hits its catalog's bare `gpt-4o`.
         const prefixed = await resolveModelForRequest('or/gpt-4o', null, () => directFetcher, testScheduler);
-        assertEquals(prefixed.matches.map(m => m.binding.upstream), ['up_dual']);
+        assertEquals(prefixed.matches.map(m => m.provider.upstream), ['up_dual']);
       },
     );
   });
@@ -868,7 +873,7 @@ describe('catalog listing under modelPrefix', () => {
         throw new Error(`Unhandled fetch ${request.url}`);
       },
       async () => {
-        const catalog = await getInternalModels(null, () => directFetcher, testScheduler);
+        const catalog = (await getModels(null, () => directFetcher, testScheduler)).models;
         assertEquals([...catalog.map(m => m.id)].sort(), ['gpt-mini', 'or/gpt-mini']);
       },
     );
@@ -918,7 +923,7 @@ describe('catalog listing under modelPrefix', () => {
       },
       async () => {
         const resolved = await resolveModelForRequest('aa/bb/gpt-5', null, () => directFetcher, testScheduler);
-        assertEquals(resolved.matches.map(m => m.binding.upstream), ['up_short_prefix', 'up_long_prefix', 'up_bare']);
+        assertEquals(resolved.matches.map(m => m.provider.upstream), ['up_short_prefix', 'up_long_prefix', 'up_bare']);
         assertEquals(resolved.matches.map(m => m.id), ['bb/gpt-5', 'gpt-5', 'aa/bb/gpt-5']);
       },
     );

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -4,7 +4,6 @@ import { clearInFlightForTesting } from './models-cache.ts';
 import { compareModelIds, enumerateModelInterpretations, getInternalModels, listModelProviders, resolveModelForProvider, resolveModelForRequest } from './registry.ts';
 import { buildCopilotUpstreamRecord, buildCustomUpstreamRecord, copilotModels, setupAppTest } from '../../test-helpers.ts';
 import { directFetcher, type ModelProviderInstance } from '@floway-dev/provider';
-import { createCopilotProvider } from '@floway-dev/provider-copilot';
 import { assertEquals, jsonResponse, stubProvider, withMockedFetch } from '@floway-dev/test-utils';
 
 const sortedIds = (ids: readonly string[]): string[] => [...ids].sort(compareModelIds);
@@ -85,17 +84,6 @@ test('compareModelIds keeps case-only differences adjacent via lowercase tie-bre
     'gpt-4O',
     'GPT-4o',
   ]);
-});
-
-test('createCopilotProvider exposes provider-owned requested model aliases', async () => {
-  const { copilotUpstream } = await setupAppTest();
-  const instance = await createCopilotProvider(copilotUpstream);
-  const resolveAlias = instance.resolveRequestedModelId;
-
-  assertEquals(resolveAlias?.('claude-opus-4-7-20300101'), 'claude-opus-4-7');
-  assertEquals(resolveAlias?.('claude-opus-4-7-xhigh-20300101'), 'claude-opus-4-7');
-  assertEquals(resolveAlias?.('claude-opus-4.7'), 'claude-opus-4-7');
-  assertEquals(resolveAlias?.('codex-auto-review'), undefined);
 });
 
 test('listModelProviders creates enabled provider instances with upstream row ids', async () => {
@@ -198,7 +186,7 @@ test('getInternalModels returns the catalog projection without execution binding
   );
 });
 
-test('resolveModelForRequest applies provider-owned aliases only to that provider', async () => {
+test('resolveModelForRequest strips an -YYYYMMDD suffix when nothing matched and retries across every visible upstream', async () => {
   const { repo } = await setupAppTest();
 
   await repo.upstreams.save(
@@ -242,12 +230,42 @@ test('resolveModelForRequest applies provider-owned aliases only to that provide
     async () => {
       const resolved = await resolveModelForRequest('claude-opus-4-7-20300101', null, () => directFetcher, testScheduler);
 
-      // Only the Copilot upstream's `resolveRequestedModelId` aliases the
-      // dated id back to `claude-opus-4-7`; the custom upstream resolves
-      // nothing for the dated id, so only one match emerges.
-      assertEquals(resolved.matches.map(m => m.binding.upstream), ['up_copilot']);
-      assertEquals(resolved.matches[0]?.id, 'claude-opus-4-7');
-      assertEquals(resolved.matches[0]?.model.endpoints, { messages: {} });
+      // No upstream's catalog literally lists `claude-opus-4-7-20300101`,
+      // so the resolver retries against the stripped `claude-opus-4-7`,
+      // which both upstreams expose. Both bindings end up in the match
+      // list in configured `sort_order`.
+      assertEquals(resolved.matches.map(m => m.binding.upstream).sort(), ['up_copilot', 'up_custom'].sort());
+      assertEquals(resolved.matches.map(m => m.id), ['claude-opus-4-7', 'claude-opus-4-7']);
+    },
+  );
+});
+
+test('resolveModelForRequest does not retry when the inbound id has no dated suffix', async () => {
+  const { repo } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+  await repo.upstreams.save(
+    buildCustomUpstreamRecord({
+      config: {
+        baseUrl: 'https://custom.example.com',
+        authStyle: 'bearer',
+        apiKey: 'sk-custom',
+        endpoints: { messages: {} },
+      },
+    }),
+  );
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'custom.example.com' && url.pathname === '/v1/models') {
+        return jsonResponse({ object: 'list', data: [{ id: 'claude-opus-4-7' }] });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      // Plain typo / unknown id — no dated suffix, no retry.
+      const resolved = await resolveModelForRequest('claude-opus-4-7-unknown', null, () => directFetcher, testScheduler);
+      assertEquals(resolved.matches.length, 0);
     },
   );
 });

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -276,6 +276,46 @@ test('enumerateProviderCandidates does not retry when the inbound id has no date
   );
 });
 
+test('enumerateProviderCandidates prefers the literal dated id over the stripped base when the catalog lists both', async () => {
+  // The dated suffix fallback is a SECOND attempt, gated on the first
+  // attempt finding nothing. When the upstream catalog already lists the
+  // dated id verbatim, the first attempt wins and the stripped form
+  // never enters the candidate list.
+  const { repo } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+  await repo.upstreams.save(
+    buildCustomUpstreamRecord({
+      config: {
+        baseUrl: 'https://custom.example.com',
+        authStyle: 'bearer',
+        apiKey: 'sk-custom',
+        endpoints: { messages: {} },
+      },
+    }),
+  );
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'custom.example.com' && url.pathname === '/v1/models') {
+        return jsonResponse({
+          object: 'list',
+          data: [
+            { id: 'claude-sonnet-4-5' },
+            { id: 'claude-sonnet-4-5-20251101' },
+          ],
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const resolved = await enumerateProviderCandidates({ upstreamIds: null, model: 'claude-sonnet-4-5-20251101', kind: 'chat', scheduler: testScheduler, currentColo: 'TEST' });
+      assertEquals(resolved.candidates.length, 1);
+      assertEquals(resolved.candidates[0]?.model.id, 'claude-sonnet-4-5-20251101');
+    },
+  );
+});
+
 test('resolveModelForProvider only loads the selected provider catalog', async () => {
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -173,7 +173,7 @@ test('getModels returns the merged catalog plus the per-id upstream index', asyn
       const model = models.find(candidate => candidate.id === 'shared-model');
 
       assertEquals(model?.display_name, 'Shared Model');
-      // The merged endpoint surface is the OR of both upstreams' bindings.
+      // The merged endpoint surface is the OR of both upstreams' endpoint maps.
       assertEquals(model?.endpoints, { messages: {}, chatCompletions: {} });
       assertEquals(model?.kind, 'chat');
       // `providerData` (the per-provider wire id carrier) belongs to the
@@ -238,8 +238,8 @@ test('enumerateProviderCandidates strips an -YYYYMMDD suffix when nothing matche
 
       // No upstream's catalog literally lists `claude-opus-4-7-20300101`,
       // so the resolver retries against the stripped `claude-opus-4-7`,
-      // which both upstreams expose. Both bindings end up in the match
-      // list in configured `sort_order`.
+      // which both upstreams expose. Both candidates end up in the
+      // result list in configured `sort_order`.
       assertEquals(resolved.candidates.map(m => m.provider.upstream).sort(), ['up_copilot', 'up_custom'].sort());
       assertEquals(resolved.candidates.map(m => m.model.id), ['claude-opus-4-7', 'claude-opus-4-7']);
     },

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -19,14 +19,13 @@ import { inboundHeadersForUpstream } from './inbound-headers.ts';
 import type { PerformanceTelemetryContext } from './telemetry/performance.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, recordRequestPerformance, requireRecordedDurationMs } from './telemetry/performance.ts';
 import { recordTokenUsage } from './telemetry/usage.ts';
-import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import type { AuthedContext } from '../../middleware/auth.ts';
 import type { TokenUsage } from '../../repo/types.ts';
 import type { GatewayCtx } from '../chat/shared/gateway-ctx.ts';
 import { type StreamCompletion, writeSSEFrames } from '../chat/shared/stream/sse.ts';
-import { resolveModelForRequest } from '../providers/registry.ts';
+import { enumerateProviderCandidates } from '../providers/candidates.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
-import { doneFrame, eventFrame, parseSSEStream, parseTargetStreamFrames, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
+import { doneFrame, eventFrame, type ModelKind, parseSSEStream, parseTargetStreamFrames, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { httpResponseToResponse, ProviderModelsUnavailableError, toInternalDebugError } from '@floway-dev/provider';
 import type { ModelProviderInstance, ProviderCallResult, UpstreamCallOptions, UpstreamModel } from '@floway-dev/provider';
 
@@ -100,8 +99,13 @@ interface PassthroughServeContext {
   readonly sourceApi: PassthroughServeApiName;
   // Already-validated public model id the client requested. The helper
   // resolves it against the provider registry; if no upstream serves the
-  // id, the client sees a 404 with the standard wording.
+  // id with the requested kind, the client sees a 404 with the standard
+  // wording.
   readonly model: string;
+  // The model kind this endpoint serves. The resolver filters candidates
+  // to `model.kind === kind`; `sawModel=true && candidates=[]` becomes
+  // the "model exists but doesn't support this endpoint" 400.
+  readonly kind: ModelKind;
   readonly modelServesEndpoint: (model: UpstreamModel) => boolean;
   // Performs the upstream HTTP call for the chosen (provider, model) pair.
   // Any throw here is preserved and becomes a 502 with the internal-debug
@@ -118,41 +122,56 @@ export const passthroughApiError = (c: Context, message: string, status: Content
   c.json({ error: { message, type: 'api_error' } }, status);
 
 export const passthroughServe = async (input: PassthroughServeContext): Promise<Response> => {
-  const { c, ctx, sourceApi, model, modelServesEndpoint, call, response: responseHandling } = input;
+  const { c, ctx, sourceApi, model, kind, modelServesEndpoint, call, response: responseHandling } = input;
   const requestStartedAt = performance.now();
   let lastPerformance: PerformanceTelemetryContext | undefined;
 
   try {
-    const fetcherForUpstream = await createPerRequestFetcher(ctx.currentColo);
-    // Each match is one (upstream, upstream-catalog id) pair that interprets
-    // the inbound public id. Iteration order follows configured sort_order
-    // across upstreams, with the unprefixed interpretation pushed before the
-    // prefixed one within a single upstream. The first match whose upstream
-    // model satisfies the endpoint capability wins.
-    const { matches, failedUpstreams } = await resolveModelForRequest(model, ctx.upstreamIds, fetcherForUpstream, ctx.backgroundScheduler);
-    if (matches.length === 0) {
+    // The shared resolver returns every candidate of the requested kind:
+    // unprefixed + prefixed addressable surfaces fan out across upstreams,
+    // a dated-suffix retry catches `-YYYYMMDD` ids the catalog only lists
+    // in base form, and the kind filter rejects models of the wrong
+    // family before they reach `modelServesEndpoint`. Iteration order
+    // follows configured sort_order across upstreams, with the unprefixed
+    // interpretation pushed before the prefixed one within a single
+    // upstream. The first candidate whose `modelServesEndpoint` is true
+    // wins.
+    const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
+      upstreamIds: ctx.upstreamIds,
+      model,
+      kind,
+      scheduler: ctx.backgroundScheduler,
+      currentColo: ctx.currentColo,
+    });
+    if (candidates.length === 0) {
       ctx.dump?.error('gateway');
-      return passthroughApiError(c, appendFailedUpstreams(`Model ${model} is not available on any configured upstream.`, failedUpstreams), 404);
+      // `sawModel === false` means no upstream catalog knew the inbound id
+      // at all (404); `sawModel === true` with zero candidates means the
+      // id is known but every match was the wrong kind for this endpoint
+      // (400), which mirrors the per-candidate-endpoint-miss case below.
+      return sawModel
+        ? passthroughApiError(c, appendFailedUpstreams(`Model ${model} does not support the ${sourceApi} endpoint.`, failedUpstreams), 400)
+        : passthroughApiError(c, appendFailedUpstreams(`Model ${model} is not available on any configured upstream.`, failedUpstreams), 404);
     }
 
-    for (const match of matches) {
-      if (!modelServesEndpoint(match.model)) continue;
+    for (const candidate of candidates) {
+      if (!modelServesEndpoint(candidate.model)) continue;
 
       const recorder = createUpstreamLatencyRecorder();
-      const { response, modelKey } = await call(match.provider, match.model, {
-        fetcher: fetcherForUpstream(match.provider.upstream),
+      const { response, modelKey } = await call(candidate.provider, candidate.model, {
+        fetcher: candidate.fetcher,
         recordUpstreamLatency: recorder.record,
         waitUntil: ctx.backgroundScheduler,
         headers: inboundHeadersForUpstream(c),
       });
       const upstreamDurationMs = requireRecordedDurationMs(recorder, 'passthrough upstream call');
-      // Telemetry keys on `match.id` (the upstream's bare catalog id);
+      // Telemetry keys on the upstream's bare catalog id (`model.id`);
       // user-facing error bodies echo the inbound `model`.
       const identity = {
-        model: match.id,
-        upstream: match.provider.upstream,
+        model: candidate.model.id,
+        upstream: candidate.provider.upstream,
         modelKey,
-        cost: match.provider.provider.getPricingForModelKey(modelKey),
+        cost: candidate.provider.provider.getPricingForModelKey(modelKey),
       };
       const performanceContext: PerformanceTelemetryContext = {
         keyId: ctx.apiKeyId,
@@ -165,7 +184,7 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
       if (!response.ok) {
         recordUpstreamPerformance(ctx.backgroundScheduler, performanceContext, true, upstreamDurationMs);
         recordRequestPerformance(ctx.backgroundScheduler, performanceContext, true, performance.now() - requestStartedAt);
-        ctx.dump?.error('upstream', match.provider.upstream);
+        ctx.dump?.error('upstream', candidate.provider.upstream);
         return forwardUpstreamResponse(response);
       }
 

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -28,7 +28,7 @@ import { resolveModelForRequest } from '../providers/registry.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import { doneFrame, eventFrame, parseSSEStream, parseTargetStreamFrames, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { httpResponseToResponse, ProviderModelsUnavailableError, toInternalDebugError } from '@floway-dev/provider';
-import type { ProviderCallResult, ProviderModelRecord, UpstreamCallOptions } from '@floway-dev/provider';
+import type { ModelProviderInstance, ProviderCallResult, UpstreamCallOptions, UpstreamModel } from '@floway-dev/provider';
 
 // Headers we forward verbatim from a successful upstream response, plus
 // content-type with an application/json fallback when the upstream omitted
@@ -102,14 +102,14 @@ interface PassthroughServeContext {
   // resolves it against the provider registry; if no upstream serves the
   // id, the client sees a 404 with the standard wording.
   readonly model: string;
-  readonly bindingServesEndpoint: (binding: ProviderModelRecord) => boolean;
-  // Performs the upstream HTTP call for the chosen binding. Any throw here
-  // is preserved and becomes a 502 with the internal-debug envelope —
-  // exceptions thrown from the actual fetch must not be silently swallowed.
-  // `opts` carries the per-call hooks the gateway threads in (the
-  // recordUpstreamLatency wrapper for the upstream_success metric); the
-  // callback forwards it verbatim to the chosen provider call method.
-  readonly call: (binding: ProviderModelRecord, opts: UpstreamCallOptions) => Promise<ProviderCallResult>;
+  readonly modelServesEndpoint: (model: UpstreamModel) => boolean;
+  // Performs the upstream HTTP call for the chosen (provider, model) pair.
+  // Any throw here is preserved and becomes a 502 with the internal-debug
+  // envelope — exceptions thrown from the actual fetch must not be silently
+  // swallowed. `opts` carries the per-call hooks the gateway threads in
+  // (the recordUpstreamLatency wrapper for the upstream_success metric);
+  // the callback forwards it verbatim to the chosen provider call method.
+  readonly call: (provider: ModelProviderInstance, model: UpstreamModel, opts: UpstreamCallOptions) => Promise<ProviderCallResult>;
   readonly response: PassthroughResponseHandling;
 }
 
@@ -118,7 +118,7 @@ export const passthroughApiError = (c: Context, message: string, status: Content
   c.json({ error: { message, type: 'api_error' } }, status);
 
 export const passthroughServe = async (input: PassthroughServeContext): Promise<Response> => {
-  const { c, ctx, sourceApi, model, bindingServesEndpoint, call, response: responseHandling } = input;
+  const { c, ctx, sourceApi, model, modelServesEndpoint, call, response: responseHandling } = input;
   const requestStartedAt = performance.now();
   let lastPerformance: PerformanceTelemetryContext | undefined;
 
@@ -127,8 +127,8 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
     // Each match is one (upstream, upstream-catalog id) pair that interprets
     // the inbound public id. Iteration order follows configured sort_order
     // across upstreams, with the unprefixed interpretation pushed before the
-    // prefixed one within a single upstream. The first match whose binding
-    // satisfies the endpoint capability wins.
+    // prefixed one within a single upstream. The first match whose upstream
+    // model satisfies the endpoint capability wins.
     const { matches, failedUpstreams } = await resolveModelForRequest(model, ctx.upstreamIds, fetcherForUpstream, ctx.backgroundScheduler);
     if (matches.length === 0) {
       ctx.dump?.error('gateway');
@@ -136,11 +136,11 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
     }
 
     for (const match of matches) {
-      if (!bindingServesEndpoint(match.binding)) continue;
+      if (!modelServesEndpoint(match.model)) continue;
 
       const recorder = createUpstreamLatencyRecorder();
-      const { response, modelKey } = await call(match.binding, {
-        fetcher: fetcherForUpstream(match.binding.upstream),
+      const { response, modelKey } = await call(match.provider, match.model, {
+        fetcher: fetcherForUpstream(match.provider.upstream),
         recordUpstreamLatency: recorder.record,
         waitUntil: ctx.backgroundScheduler,
         headers: inboundHeadersForUpstream(c),
@@ -150,9 +150,9 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
       // user-facing error bodies echo the inbound `model`.
       const identity = {
         model: match.id,
-        upstream: match.binding.upstream,
+        upstream: match.provider.upstream,
         modelKey,
-        cost: match.binding.provider.getPricingForModelKey(modelKey),
+        cost: match.provider.provider.getPricingForModelKey(modelKey),
       };
       const performanceContext: PerformanceTelemetryContext = {
         keyId: ctx.apiKeyId,
@@ -165,7 +165,7 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
       if (!response.ok) {
         recordUpstreamPerformance(ctx.backgroundScheduler, performanceContext, true, upstreamDurationMs);
         recordRequestPerformance(ctx.backgroundScheduler, performanceContext, true, performance.now() - requestStartedAt);
-        ctx.dump?.error('upstream', match.binding.upstream);
+        ctx.dump?.error('upstream', match.provider.upstream);
         return forwardUpstreamResponse(response);
       }
 

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -97,22 +97,15 @@ interface PassthroughServeContext {
   readonly c: AuthedContext;
   readonly ctx: GatewayCtx;
   readonly sourceApi: PassthroughServeApiName;
-  // Already-validated public model id the client requested. The helper
-  // resolves it against the provider registry; if no upstream serves the
-  // id with the requested kind, the client sees a 404 with the standard
-  // wording.
+  // Already-validated public model id from the request body.
   readonly model: string;
-  // The model kind this endpoint serves. The resolver filters candidates
-  // to `model.kind === kind`; `sawModel=true && candidates=[]` becomes
-  // the "model exists but doesn't support this endpoint" 400.
+  // Model kind this endpoint serves; the resolver kind-filters before
+  // the per-binding endpoint check.
   readonly kind: ModelKind;
   readonly modelServesEndpoint: (model: UpstreamModel) => boolean;
-  // Performs the upstream HTTP call for the chosen (provider, model) pair.
-  // Any throw here is preserved and becomes a 502 with the internal-debug
-  // envelope — exceptions thrown from the actual fetch must not be silently
-  // swallowed. `opts` carries the per-call hooks the gateway threads in
-  // (the recordUpstreamLatency wrapper for the upstream_success metric);
-  // the callback forwards it verbatim to the chosen provider call method.
+  // Performs the upstream HTTP call. A throw becomes a 502 with the
+  // internal-debug envelope; `opts` carries the per-call hooks
+  // (recordUpstreamLatency, fetcher, waitUntil, headers).
   readonly call: (provider: ModelProviderInstance, model: UpstreamModel, opts: UpstreamCallOptions) => Promise<ProviderCallResult>;
   readonly response: PassthroughResponseHandling;
 }
@@ -127,15 +120,6 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
   let lastPerformance: PerformanceTelemetryContext | undefined;
 
   try {
-    // The shared resolver returns every candidate of the requested kind:
-    // unprefixed + prefixed addressable surfaces fan out across upstreams,
-    // a dated-suffix retry catches `-YYYYMMDD` ids the catalog only lists
-    // in base form, and the kind filter rejects models of the wrong
-    // family before they reach `modelServesEndpoint`. Iteration order
-    // follows configured sort_order across upstreams, with the unprefixed
-    // interpretation pushed before the prefixed one within a single
-    // upstream. The first candidate whose `modelServesEndpoint` is true
-    // wins.
     const { candidates, sawModel, failedUpstreams } = await enumerateProviderCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
@@ -145,10 +129,7 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
     });
     if (candidates.length === 0) {
       ctx.dump?.error('gateway');
-      // `sawModel === false` means no upstream catalog knew the inbound id
-      // at all (404); `sawModel === true` with zero candidates means the
-      // id is known but every match was the wrong kind for this endpoint
-      // (400), which mirrors the per-candidate-endpoint-miss case below.
+      // sawModel=false: unknown id (404). sawModel=true: wrong kind (400).
       return sawModel
         ? passthroughApiError(c, appendFailedUpstreams(`Model ${model} does not support the ${sourceApi} endpoint.`, failedUpstreams), 400)
         : passthroughApiError(c, appendFailedUpstreams(`Model ${model} is not available on any configured upstream.`, failedUpstreams), 404);

--- a/packages/provider-claude-code/src/models.ts
+++ b/packages/provider-claude-code/src/models.ts
@@ -200,14 +200,3 @@ export const buildClaudeCodeCatalog = (
     ...(chat ? { chat } : {}),
   };
 });
-
-// Hook for `ModelProviderInstance.resolveRequestedModelId`: a client that
-// addresses a model by its dated upstream id resolves to the catalog alias
-// the dispatcher actually carries. The catalog publishes only aliases, so
-// any id that already lacks a date suffix needs no remap. We don't validate
-// against the live catalog here — the dispatcher's own model-id lookup is
-// what fails a request that names a model the upstream doesn't expose.
-export const claudeCodeResolveRequestedModelId = (modelId: string): string | undefined => {
-  const alias = aliasFromApiId(modelId);
-  return alias === modelId ? undefined : alias;
-};

--- a/packages/provider-claude-code/src/models_test.ts
+++ b/packages/provider-claude-code/src/models_test.ts
@@ -4,7 +4,6 @@ import {
   aliasFromApiId,
   buildClaudeCodeCatalog,
   chatFromCapabilities,
-  claudeCodeResolveRequestedModelId,
   type ClaudeCodeApiModel,
 } from './models.ts';
 import { pricingForClaudeCodeModelKey } from './pricing.ts';
@@ -244,31 +243,5 @@ describe('buildClaudeCodeCatalog', () => {
     for (const m of built) {
       expect(m.chat).toBeUndefined();
     }
-  });
-});
-
-describe('claudeCodeResolveRequestedModelId', () => {
-  test('resolves a dated id to its public alias', () => {
-    expect(claudeCodeResolveRequestedModelId('claude-sonnet-4-5-20250929')).toBe('claude-sonnet-4-5');
-    expect(claudeCodeResolveRequestedModelId('claude-opus-4-5-20251101')).toBe('claude-opus-4-5');
-    expect(claudeCodeResolveRequestedModelId('claude-haiku-4-5-20251001')).toBe('claude-haiku-4-5');
-    expect(claudeCodeResolveRequestedModelId('claude-opus-4-1-20250805')).toBe('claude-opus-4-1');
-  });
-
-  test('returns undefined when the id is already in alias shape', () => {
-    expect(claudeCodeResolveRequestedModelId('claude-sonnet-4-5')).toBeUndefined();
-    expect(claudeCodeResolveRequestedModelId('claude-opus-4-5')).toBeUndefined();
-    expect(claudeCodeResolveRequestedModelId('claude-opus-4-7')).toBeUndefined();
-    expect(claudeCodeResolveRequestedModelId('claude-fable-5')).toBeUndefined();
-  });
-
-  test('returns undefined for ids outside the claude- namespace', () => {
-    expect(claudeCodeResolveRequestedModelId('gpt-4')).toBeUndefined();
-    expect(claudeCodeResolveRequestedModelId('gemini-2.5-pro')).toBeUndefined();
-  });
-
-  test('returns undefined for malformed dated ids (not exactly 8 digits)', () => {
-    expect(claudeCodeResolveRequestedModelId('claude-sonnet-4-5-foo')).toBeUndefined();
-    expect(claudeCodeResolveRequestedModelId('claude-sonnet-4-5-2025')).toBeUndefined();
   });
 });

--- a/packages/provider-claude-code/src/provider.ts
+++ b/packages/provider-claude-code/src/provider.ts
@@ -3,7 +3,7 @@ import { assertClaudeCodeUpstreamRecord } from './config.ts';
 import { isClaudeCodeShapedRequest } from './detection.ts';
 import { detectHaikuProbe, callClaudeCodeMessages } from './fetch.ts';
 import { claudeCodeMessagesChain, type ClaudeCodeMessagesBoundaryCtx } from './interceptors/messages/index.ts';
-import { buildClaudeCodeCatalog, claudeCodeResolveRequestedModelId, fetchClaudeCodeModelsList } from './models.ts';
+import { buildClaudeCodeCatalog, fetchClaudeCodeModelsList } from './models.ts';
 import { pricingForClaudeCodeModelKey } from './pricing.ts';
 import { assertClaudeCodeUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
@@ -106,7 +106,6 @@ export const createClaudeCodeProvider = async (record: UpstreamRecord): Promise<
     modelPrefix: record.modelPrefix,
     provider,
     supportsResponsesItemReference: false,
-    resolveRequestedModelId: claudeCodeResolveRequestedModelId,
   };
 };
 

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -144,12 +144,6 @@ describe('createClaudeCodeProvider — factory surface', () => {
     expect(instance.supportsResponsesItemReference).toBe(false);
     expect(instance.upstream).toBe(upstreamId);
   });
-
-  test('resolveRequestedModelId maps a dated id to its alias', async () => {
-    const instance = await createClaudeCodeProvider(currentRecord);
-    expect(instance.resolveRequestedModelId?.('claude-sonnet-4-5-20250929')).toBe('claude-sonnet-4-5');
-    expect(instance.resolveRequestedModelId?.('claude-sonnet-4-5')).toBeUndefined();
-  });
 });
 
 describe('createClaudeCodeProvider — callMessages routes through chain', () => {

--- a/packages/provider-copilot/src/model-name.ts
+++ b/packages/provider-copilot/src/model-name.ts
@@ -13,11 +13,3 @@ export const copilotPublicModelId = (id: string): string => {
     .replace(CLAUDE_VARIANT_SUFFIX, '')
     .replace(/(\d)\.(\d)/g, '$1-$2');
 };
-
-export const copilotRequestedModelAliasTarget = (id: string): string | undefined => {
-  if (!id.startsWith('claude-')) return undefined;
-  const withoutDate = id.replace(CLAUDE_DATE_SUFFIX, '');
-  const publicId = copilotPublicModelId(id);
-  if (withoutDate !== id) return copilotPublicModelId(withoutDate);
-  return publicId !== id ? publicId : undefined;
-};

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -10,7 +10,7 @@ import { COPILOT_RESPONSES_BOUNDARY } from './interceptors/responses/index.ts';
 import type { ResponsesBoundaryCtx } from './interceptors/responses/types.ts';
 import { emptyKnownModels, mergeKnownModels, projectKnownModels } from './known-models.ts';
 import { mergeClaudeVariants } from './merge-claude-variants.ts';
-import { copilotPublicModelId, copilotRequestedModelAliasTarget } from './model-name.ts';
+import { copilotPublicModelId } from './model-name.ts';
 import { CONTEXT_1M_BETA, copilotModelSupportsFastMode, type ModelSelectionHints, resolveCopilotRawModel } from './model-selection.ts';
 import { pricingForCopilotModelKey, pricingForCopilotPublicModelId } from './pricing.ts';
 import { readCopilotUpstreamState, type CopilotUpstreamState } from './state.ts';
@@ -456,6 +456,5 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
     modelPrefix: copilot.modelPrefix,
     provider,
     supportsResponsesItemReference: false,
-    resolveRequestedModelId: copilotRequestedModelAliasTarget,
   };
 };

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -42,13 +42,12 @@ export type { AddressableForm, ModelPrefixConfig } from './model-prefix.ts';
 export { MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX, normalizeModelPrefix } from './model-prefix.ts';
 
 export type {
+  CatalogModel,
   ModelProvider,
   ModelProviderInstance,
   ProviderCallResult,
-  ProviderModelRecord,
   ProviderResponsesResult,
   ProviderStreamResult,
-  ResolvedModel,
   ResponsesAction,
   UpstreamCallOptions,
 } from './provider.ts';

--- a/packages/provider/src/invocation.ts
+++ b/packages/provider/src/invocation.ts
@@ -8,17 +8,9 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 export type ChatTargetApi = 'messages' | 'responses' | 'chat-completions';
 
-// One (provider, model) pair the resolver matched against an inbound id,
-// plus the per-request `Fetcher` minted for the provider's upstream. The
-// pair is the smallest unit the dispatch layer needs to make a wire call:
-// `provider.provider.callXxx(model, body, ...)`. Every field the dispatch
-// layer needs (upstream id, upstream name, provider kind, capability
-// flags, model id, providerData, endpoints) is read directly off
-// `provider.*` and `model.*`.
-//
-// Resolution narrows by `model.kind` only — choosing the inbound target
-// protocol from `model.endpoints` is the attempt layer's job, not part of
-// the candidate.
+// One (provider, model) pair the resolver matched, plus the per-request
+// `Fetcher` for the provider's upstream. The smallest unit dispatch
+// needs to make a wire call.
 export interface ProviderCandidate {
   readonly provider: ModelProviderInstance;
   readonly model: UpstreamModel;
@@ -27,11 +19,9 @@ export interface ProviderCandidate {
 
 // Per-protocol invocation shape passed to interceptors. Carries the
 // source-shape request body (mutable, so the body can be cleaned), the
-// candidate the attempt is dispatching against, the chat target protocol
-// the attempt picked for this candidate, and a mutable `Headers` instance
-// carried into the boundary chain — so workarounds that only need to set
-// or drop a header stay at the owning interceptor boundary instead of
-// widening the provider call signature.
+// candidate the attempt is dispatching against, the chat target
+// protocol the attempt picked, and a mutable `Headers` bag interceptors
+// use to set or drop wire headers.
 export interface MessagesInvocation {
   payload: MessagesPayload;
   readonly candidate: ProviderCandidate;

--- a/packages/provider/src/invocation.ts
+++ b/packages/provider/src/invocation.ts
@@ -1,5 +1,6 @@
+import type { UpstreamModel } from './model.ts';
 import type { Fetcher } from './options.ts';
-import type { ModelProviderInstance, ProviderModelRecord, ResponsesAction } from './provider.ts';
+import type { ModelProviderInstance, ResponsesAction } from './provider.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
@@ -7,27 +8,34 @@ import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 
 export type ChatTargetApi = 'messages' | 'responses' | 'chat-completions';
 
-// The provider-binding decision for this attempt: which upstream's binding
-// to call and which target protocol to invoke on it. `provider` is the
-// resolved upstream provider instance the binding came from, retained
-// alongside `binding` so dispatch can run without re-resolving the registry.
-// `fetcher` is the per-upstream Fetcher minted at request time.
+// One (provider, model) pair the resolver matched against an inbound id,
+// plus the per-request `Fetcher` minted for the provider's upstream. The
+// pair is the smallest unit the dispatch layer needs to make a wire call:
+// `provider.provider.callXxx(model, body, ...)`. Every field the dispatch
+// layer used to read off a wrapping `binding` (upstream id, upstream name,
+// provider kind, capability flags, model id, providerData, endpoints) is
+// now read directly off `provider.*` and `model.*`.
+//
+// Resolution narrows by `model.kind` only — choosing the inbound target
+// protocol from `model.endpoints` is the attempt layer's job, not part of
+// the candidate.
 export interface ProviderCandidate {
   readonly provider: ModelProviderInstance;
-  readonly binding: ProviderModelRecord;
-  readonly targetApi: ChatTargetApi;
+  readonly model: UpstreamModel;
   readonly fetcher: Fetcher;
 }
 
 // Per-protocol invocation shape passed to interceptors. Carries the
 // source-shape request body (mutable, so the body can be cleaned), the
-// planner's binding decision, and a mutable `Headers` instance carried into
-// the boundary chain — so workarounds that only need to set or drop a
-// header stay at the owning interceptor boundary instead of widening the
-// provider call signature.
+// candidate the attempt is dispatching against, the chat target protocol
+// the attempt picked for this candidate, and a mutable `Headers` instance
+// carried into the boundary chain — so workarounds that only need to set
+// or drop a header stay at the owning interceptor boundary instead of
+// widening the provider call signature.
 export interface MessagesInvocation {
   payload: MessagesPayload;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
@@ -39,17 +47,20 @@ export interface ResponsesInvocation {
   // post-chain action carried on the provider's tagged result.
   action: ResponsesAction;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
 export interface ChatCompletionsInvocation {
   payload: ChatCompletionsPayload;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
 export interface GeminiInvocation {
   payload: GeminiPayload;
   readonly candidate: ProviderCandidate;
+  readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }

--- a/packages/provider/src/invocation.ts
+++ b/packages/provider/src/invocation.ts
@@ -12,9 +12,9 @@ export type ChatTargetApi = 'messages' | 'responses' | 'chat-completions';
 // plus the per-request `Fetcher` minted for the provider's upstream. The
 // pair is the smallest unit the dispatch layer needs to make a wire call:
 // `provider.provider.callXxx(model, body, ...)`. Every field the dispatch
-// layer used to read off a wrapping `binding` (upstream id, upstream name,
-// provider kind, capability flags, model id, providerData, endpoints) is
-// now read directly off `provider.*` and `model.*`.
+// layer needs (upstream id, upstream name, provider kind, capability
+// flags, model id, providerData, endpoints) is read directly off
+// `provider.*` and `model.*`.
 //
 // Resolution narrows by `model.kind` only — choosing the inbound target
 // protocol from `model.endpoints` is the attempt layer's job, not part of

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -19,19 +19,14 @@ import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@f
 // turn against the SUMMARIZATION_PROMPT).
 export type ResponsesAction = 'generate' | 'compact';
 
-export interface ProviderModelRecord {
-  upstream: string;
-  upstreamName: string;
-  providerKind: UpstreamProviderKind;
-  provider: ModelProvider;
-  upstreamModel: UpstreamModel;
-  enabledFlags: ReadonlySet<string>;
-  supportsResponsesItemReference: boolean;
-}
-
-export interface ResolvedModel extends InternalModel {
+// A gateway-wide catalog row: InternalModel metadata plus the merged
+// endpoint capability map. `/v1/models`, `/models`, `/v1beta/models`, and
+// the control-plane catalog endpoint all project this onto their wire DTOs.
+// The `endpoints` field is the OR-union across every upstream that emitted
+// an entry under the same public id; per-request dispatch still reads each
+// upstream's own `UpstreamModel.endpoints` instead of this merged view.
+export interface CatalogModel extends InternalModel {
   endpoints: ModelEndpoints;
-  providers: readonly ProviderModelRecord[];
 }
 
 export interface ModelProviderInstance {

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -46,7 +46,6 @@ export interface ModelProviderInstance {
   modelPrefix: ModelPrefixConfig | null;
   provider: ModelProvider;
   supportsResponsesItemReference: boolean;
-  resolveRequestedModelId?(modelId: string): string | undefined;
 }
 
 export interface ProviderCallResult {

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -1,4 +1,4 @@
-import { directFetcher, type ChatTargetApi, type ModelProvider, type ModelProviderInstance, type ProviderCandidate, type ProviderModelRecord, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamModel } from '@floway-dev/provider';
+import { directFetcher, type ModelProvider, type ModelProviderInstance, type ProviderCandidate, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamModel } from '@floway-dev/provider';
 
 // No-op UpstreamCallOptions factory for tests calling provider methods
 // directly: identity recordUpstreamLatency satisfies the contract without
@@ -57,7 +57,7 @@ export const stubProvider = (overrides: Partial<ModelProvider> = {}): ModelProvi
   callImagesEdits: autoWrap(overrides.callImagesEdits) ?? (() => Promise.reject(new Error('stubProvider.callImagesEdits was called'))),
 });
 
-export const stubProviderCandidate = (overrides: { targetApi?: ChatTargetApi; binding?: Partial<ProviderModelRecord>; provider?: ModelProviderInstance } = {}): ProviderCandidate => {
+export const stubProviderCandidate = (overrides: { model?: Partial<UpstreamModel>; provider?: ModelProviderInstance } = {}): ProviderCandidate => {
   const provider = overrides.provider ?? {
     upstream: 'test-upstream',
     providerKind: 'custom',
@@ -67,20 +67,9 @@ export const stubProviderCandidate = (overrides: { targetApi?: ChatTargetApi; bi
     provider: stubProvider(),
     supportsResponsesItemReference: false,
   };
-  const bindingOverrides = overrides.binding ?? {};
   return {
     provider,
-    binding: {
-      upstream: 'test-upstream',
-      upstreamName: 'Test Upstream',
-      providerKind: 'custom',
-      provider: provider.provider,
-      upstreamModel: stubUpstreamModel(),
-      enabledFlags: new Set<string>(),
-      supportsResponsesItemReference: false,
-      ...bindingOverrides,
-    },
-    targetApi: overrides.targetApi ?? 'messages',
+    model: stubUpstreamModel(overrides.model ?? {}),
     fetcher: directFetcher,
   };
 };


### PR DESCRIPTION
Follow-up cleanups against the resolver layer's prose and tests.

- Drop migration-only prose ('used to be X, now Y') from `RESOLUTION.md` Candidate Shape and inline comments.
- Retire the lingering 'binding' vocabulary in narration and one candidate-test name — the shape is `ModelCandidate { provider, model, fetcher }`, not a binding.
- Clarify retry-vs-kind-filter ordering in two comments.
- Trim restating prose from four resolver-layer files.
- Fix trailing-whitespace patching traces left in six test mocks.
- Dedupe a duplicate `stubUpstreamModel` and finish a half-rewritten comment.
- Refresh one comment that still narrated the pre-kind-filter flow.

No code behavior changes — only comments, names, and test scaffolding.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`