### PR TITLE
refactor(chat): require failedUpstreams on ChatServeFailure model-* variants

### DIFF
--- a/packages/gateway/src/data-plane/chat/shared/errors.ts
+++ b/packages/gateway/src/data-plane/chat/shared/errors.ts
@@ -3,8 +3,8 @@
 // carries the upstream names whose catalog fetch threw during this
 // resolution — surfaced parenthetically so the caller can tell a genuine
 // "no upstream has this model" miss from a transient outage where the
-// upstream that owns the model is currently unreachable. Empty means
-// every consulted upstream returned a catalog.
+// upstream that owns the model is currently unreachable. An empty array
+// means every consulted upstream returned a catalog.
 export type ChatServeFailure =
   | { readonly kind: 'model-missing'; readonly model: string; readonly failedUpstreams: readonly string[] }
   | { readonly kind: 'model-unsupported'; readonly model: string; readonly failedUpstreams: readonly string[] }


### PR DESCRIPTION
\`ChatServeFailure\` carries a \`failedUpstreams\` field on the \`model-missing\` / \`model-unsupported\` variants — the upstream names whose catalog fetch threw during this resolution. Promote it from optional to required so the renderer always has the list and the per-protocol failure copy can surface it consistently. Callers that have no failed upstreams pass an empty array; the construction sites that used to omit the field now construct it with \`failedUpstreams: []\` explicitly.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\`