### PR TITLE
refactor(chat): move the stateful-responses store into ChatGatewayCtx

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -6,7 +6,7 @@ import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewr
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../shared/attempt-helpers.ts';
 import { tryCatchChatServeFailure } from '../shared/errors.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
 import { createUpstreamLatencyRecorder } from '../shared/upstream-telemetry.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
@@ -22,17 +22,16 @@ export const chatCompletionsTarget = chatTargetPicker(['chat-completions', 'mess
 
 export interface ChatCompletionsAttemptArgs {
   readonly payload: ChatCompletionsPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly candidate: ProviderCandidate;
   readonly headers: Headers;
 }
 
 export const chatCompletionsAttempt = {
   generate: async (args: ChatCompletionsAttemptArgs): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
-    const { payload, ctx, store, candidate, headers } = args;
+    const { payload, ctx, candidate, headers } = args;
     const targetApi = chatCompletionsTarget.pick(candidate.model.endpoints);
-    const rewritten = await rewriteOrRenderChatCompletionsFailure(payload, store, candidate);
+    const rewritten = await rewriteOrRenderChatCompletionsFailure(payload, ctx.store, candidate);
     if (rewritten.failure) return rewritten.failure;
     const invocation: ChatCompletionsInvocation = {
       payload: rewritten.payload,
@@ -52,7 +51,7 @@ export const chatCompletionsAttempt = {
             fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,
           }),
           translated => messagesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }
@@ -61,7 +60,7 @@ export const chatCompletionsAttempt = {
           invocation.payload,
           p => translateChatCompletionsViaResponses(p, { model: candidate.model.id }),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }
@@ -106,7 +105,7 @@ const rewriteOrRenderChatCompletionsFailure = async (
 
 const callChatCompletionsAsExecuteResult = async (
   payload: ChatCompletionsPayload,
-  ctx: GatewayCtx,
+  ctx: ChatGatewayCtx,
   candidate: ProviderCandidate,
   headers: Headers,
 ): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
@@ -4,7 +4,7 @@ import { chatCompletionsAttempt } from './attempt.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -14,7 +14,7 @@ import { assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-
 
 const API_KEY_ID = 'key_chat_completions_attempt_test';
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -23,6 +23,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
 const makePayload = (overrides: Partial<ChatCompletionsPayload> = {}): ChatCompletionsPayload => ({
@@ -112,7 +113,6 @@ test('generate native chat-completions target calls provider.callChatCompletions
   const result = await chatCompletionsAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callChatCompletions }),
     headers: new Headers(),
   });
@@ -131,7 +131,6 @@ test('generate translates through the Messages target when only that endpoint is
   const result = await chatCompletionsAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessages, endpoints: { messages: {} } }),
     headers: new Headers(),
   });
@@ -161,7 +160,6 @@ test('generate translates through the Responses target when only that endpoint i
   const result = await chatCompletionsAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callResponses, endpoints: { responses: {} } }),
     headers: new Headers(),
   });
@@ -184,7 +182,6 @@ test('generate propagates upstream response headers onto the EventResult so resp
   const result = await chatCompletionsAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callChatCompletions }),
     headers: new Headers(),
   });

--- a/packages/gateway/src/data-plane/chat/chat-completions/http.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http.ts
@@ -4,7 +4,7 @@ import { chatCompletionsServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createChatGatewayCtxFromHono, createGatewayCtxFromHono, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
@@ -42,7 +42,7 @@ const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: Req
 export const chatCompletionsHttp = {
   generate: async (c: AuthedContext): Promise<Response> => {
     const requestBody = await readRequestBody(c);
-    let ctx: GatewayCtx | undefined;
+    let ctx: ChatGatewayCtx | undefined;
     try {
       const payload = JSON.parse(new TextDecoder().decode(requestBody.bytes)) as ChatCompletionsPayload;
       const wantsStream = payload.stream === true;
@@ -52,9 +52,8 @@ export const chatCompletionsHttp = {
       // slots — the value lives in this http-entry closure for the duration of
       // the request.
       const includeUsageChunk = payload.stream_options?.include_usage === true;
-      ctx = createGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model });
-      const store = createNonResponsesSourceStore(ctx.apiKeyId);
-      const result = await chatCompletionsServe.generate({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model }, createNonResponsesSourceStore);
+      const result = await chatCompletionsServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondChatCompletions(c, result, wantsStream, includeUsageChunk, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
@@ -2,12 +2,13 @@ import { test } from 'vitest';
 
 import { withDemoteDeveloperToSystem } from './demote-developer-to-system.ts';
 import type { ChatCompletionsInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ChatCompletionsInvocation => ({

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
@@ -2,12 +2,13 @@ import { test } from 'vitest';
 
 import { withInterleavedSystemDemotedToUser } from './demote-interleaved-system-to-user.ts';
 import type { ChatCompletionsInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () => Promise.resolve(eventResult((async function* () {})(), testTelemetryModelIdentity));

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -2,12 +2,13 @@ import { test } from 'vitest';
 
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
 import type { ChatCompletionsInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () => Promise.resolve(eventResult((async function* () {})(), testTelemetryModelIdentity));

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/include-usage-stream-options_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/include-usage-stream-options_test.ts
@@ -2,12 +2,13 @@ import { test } from 'vitest';
 
 import { withUsageStreamOptionsIncluded } from './include-usage-stream-options.ts';
 import type { ChatCompletionsInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () => Promise.resolve(eventResult((async function* () {})(), testTelemetryModelIdentity));

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/normalize-usage_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/normalize-usage_test.ts
@@ -2,13 +2,14 @@ import { test } from 'vitest';
 
 import { withUsageNormalized } from './normalize-usage.ts';
 import type { ChatCompletionsInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -17,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const invocation = (payload: ChatCompletionsPayload = { model: 'test-model', messages: [] }): ChatCompletionsInvocation => ({

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
@@ -2,7 +2,8 @@ import { test } from 'vitest';
 
 import type { ChatCompletionsInvocation } from './types.ts';
 import { withVendorDeepseekChatCompletionsNormalize } from './vendor-deepseek-normalize.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
@@ -12,7 +13,7 @@ type DeepseekReasoningDelta = ChatCompletionsStreamEvent['choices'][number]['del
   reasoning_content?: string;
 };
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -21,6 +22,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ChatCompletionsInvocation => ({

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
@@ -2,13 +2,14 @@ import { test } from 'vitest';
 
 import type { ChatCompletionsInvocation } from './types.ts';
 import { withVendorKimiChatCompletionsNormalize } from './vendor-kimi-normalize.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -17,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-kimi'])): ChatCompletionsInvocation => ({

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
@@ -2,12 +2,13 @@ import { test } from 'vitest';
 
 import type { ChatCompletionsInvocation } from './types.ts';
 import { withVendorQwenChatCompletionsNormalize } from './vendor-qwen-normalize.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ChatCompletionsInvocation => ({

--- a/packages/gateway/src/data-plane/chat/chat-completions/routing.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/routing.ts
@@ -1,5 +1,5 @@
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProviderCandidate } from '@floway-dev/provider';
@@ -8,11 +8,11 @@ import { chatCompletionsViaResponsesItemsView } from '@floway-dev/translate/via-
 export const planChatCompletionsRouting = async (input: {
   readonly payload: ChatCompletionsPayload;
   readonly candidates: readonly ProviderCandidate[];
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
 }): Promise<RoutingDecision> =>
   await classifyResponsesItemAffinity({
     sourceItems: input.payload.messages,
     view: chatCompletionsViaResponsesItemsView,
-    store: input.store,
+    store: input.ctx.store,
     candidates: input.candidates,
   });

--- a/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
@@ -5,12 +5,25 @@ import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createStoredResponsesItemId } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { ProviderCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_chat_completions_routing_test';
+
+const makeCtx = (): ChatGatewayCtx => ({
+  apiKeyId: API_KEY_ID,
+  upstreamIds: null,
+  wantsStream: false,
+  runtimeLocation: 'TEST',
+  currentColo: 'TEST',
+  dump: null,
+  backgroundScheduler: () => {},
+  requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
+});
 
 const candidateFor = (upstream: string): ProviderCandidate => {
   const upstreamModel = stubUpstreamModel();
@@ -45,7 +58,7 @@ test('chat-completions payload with no reasoning carriers passes candidates thro
   const decision = await planChatCompletionsRouting({
     payload: payload([{ role: 'user', content: 'hello' }]),
     candidates,
-    store: createNonResponsesSourceStore(API_KEY_ID),
+    ctx: makeCtx(),
   });
 
   assertEquals(decision.kind, 'success');
@@ -68,7 +81,7 @@ test('an assistant reasoning_items carrier naming an unknown stored id fails rou
       },
     ]),
     candidates: [candidateFor('up_a')],
-    store: createNonResponsesSourceStore(API_KEY_ID),
+    ctx: makeCtx(),
   });
 
   assertEquals(decision.kind, 'failure');

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -2,23 +2,21 @@ import { chatCompletionsAttempt, chatCompletionsTarget } from './attempt.ts';
 import { renderChatCompletionsFailure } from './errors.ts';
 import { planChatCompletionsRouting } from './routing.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ExecuteResult } from '@floway-dev/provider';
 
 export interface ChatCompletionsServeGenerateArgs {
   readonly payload: ChatCompletionsPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly headers: Headers;
 }
 
 export const chatCompletionsServe = {
   generate: async (args: ChatCompletionsServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
-    const { payload, ctx, store, headers } = args;
+    const { payload, ctx, headers } = args;
     const { candidates: enumerated, sawModel, failedUpstreams } = await enumerateModelCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
@@ -27,7 +25,7 @@ export const chatCompletionsServe = {
       currentColo: ctx.currentColo,
     });
     const viable = enumerated.filter(c => chatCompletionsTarget.canServe(c.model.endpoints));
-    const decision = await planChatCompletionsRouting({ payload, candidates: viable, store });
+    const decision = await planChatCompletionsRouting({ payload, candidates: viable, ctx });
     if (decision.kind === 'failure') return renderChatCompletionsFailure(decision.failure);
 
     // Any non-throwing attempt result — events, api-error, or
@@ -36,6 +34,6 @@ export const chatCompletionsServe = {
     // upstream.
     const [candidate] = decision.candidates;
     if (candidate === undefined) return renderChatCompletionsFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams));
-    return await chatCompletionsAttempt.generate({ payload, ctx, store, candidate, headers });
+    return await chatCompletionsAttempt.generate({ payload, ctx, candidate, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -3,7 +3,7 @@ import { afterEach, test, vi } from 'vitest';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ProviderCandidate, directFetcher, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
@@ -40,7 +40,7 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -49,6 +49,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
 const makePayload = (overrides: Partial<ChatCompletionsPayload> = {}): ChatCompletionsPayload => ({
@@ -114,7 +115,6 @@ test('generate routes a native Chat Completions candidate end to end', async () 
   const result = await chatCompletionsServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -136,7 +136,6 @@ test('generate filters out candidates that do not expose any chat-completions-ta
   const result = await chatCompletionsServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -170,7 +169,6 @@ test('generate stops at the first candidate even when it yields an upstream erro
   const result = await chatCompletionsServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -197,7 +195,6 @@ test('generate is a routing no-op when the payload carries no reasoning carriers
     // refs → both candidates surface in the original order.
     payload: makePayload({ messages: [{ role: 'user', content: 'hi' }] }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -214,7 +211,6 @@ test('generate renders model-missing when no candidates are available', async ()
   const result = await chatCompletionsServe.generate({
     payload: makePayload({ model: 'unknown-model' }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -5,9 +5,8 @@ import { stripUnsupportedToolsFromPayload } from './interceptors/strip-unsupport
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { chatTargetPicker } from '../shared/attempt-helpers.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
@@ -23,23 +22,21 @@ export const geminiCountTokensTarget = chatTargetPicker(['messages']);
 
 export interface GeminiAttemptGenerateArgs {
   readonly payload: GeminiPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly candidate: ProviderCandidate;
   readonly headers: Headers;
 }
 
 export interface GeminiAttemptCountTokensArgs {
   readonly payload: GeminiPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly candidate: ProviderCandidate;
   readonly headers: Headers;
 }
 
 export const geminiAttempt = {
   generate: async (args: GeminiAttemptGenerateArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> => {
-    const { payload, ctx, store, candidate, headers } = args;
+    const { payload, ctx, candidate, headers } = args;
     const targetApi = geminiGenerateTarget.pick(candidate.model.endpoints);
     const invocation: GeminiInvocation = { payload, candidate, targetApi, headers };
     return await runInterceptors(invocation, ctx, geminiInterceptors, async () => {
@@ -56,7 +53,7 @@ export const geminiAttempt = {
           invocation.payload,
           p => translateGeminiViaMessages(p, transCtx),
           translated => messagesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }
@@ -65,7 +62,7 @@ export const geminiAttempt = {
           invocation.payload,
           p => translateGeminiViaResponses(p, transCtx),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }
@@ -74,7 +71,7 @@ export const geminiAttempt = {
           invocation.payload,
           p => translateGeminiViaChatCompletions(p, transCtx),
           translated => chatCompletionsAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }
@@ -83,7 +80,7 @@ export const geminiAttempt = {
   },
 
   countTokens: async (args: GeminiAttemptCountTokensArgs): Promise<PlainResult> => {
-    const { payload, ctx, store, candidate, headers } = args;
+    const { payload, ctx, candidate, headers } = args;
     const targetApi = geminiCountTokensTarget.pick(candidate.model.endpoints);
     const invocation: GeminiInvocation = { payload, candidate, targetApi, headers };
     return await runInterceptors(invocation, ctx, geminiCountTokensInterceptors, async () => {
@@ -106,7 +103,7 @@ export const geminiAttempt = {
       const trip = await translateGeminiViaMessages(cleaned, transCtx);
       const { stream: _stream, ...target } = trip.target;
       const messagesResult = await messagesAttempt.countTokens({
-        payload: target, ctx, store, candidate, headers: invocation.headers,
+        payload: target, ctx, candidate, headers: invocation.headers,
       });
       return reshapeMessagesCountAsGemini(messagesResult);
     });

--- a/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
@@ -4,7 +4,7 @@ import { geminiAttempt } from './attempt.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
@@ -15,7 +15,7 @@ import { assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-
 
 const API_KEY_ID = 'key_gemini_attempt_test';
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -24,6 +24,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
 const makePayload = (overrides: Partial<GeminiPayload> = {}): GeminiPayload => ({
@@ -122,7 +123,6 @@ test('generate translates through Chat Completions when targetApi is chat-comple
   const result = await geminiAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callChatCompletions }),
     headers: new Headers(),
   });
@@ -141,7 +141,6 @@ test('generate translates through Messages when targetApi is messages', async ()
   const result = await geminiAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessages, endpoints: { messages: {} } }),
     headers: new Headers(),
   });
@@ -160,7 +159,6 @@ test('generate translates through Responses when targetApi is responses', async 
   const result = await geminiAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callResponses, endpoints: { responses: {} } }),
     headers: new Headers(),
   });
@@ -187,7 +185,6 @@ test('countTokens translates Gemini to Messages count_tokens and reshapes to tot
   const result = await geminiAttempt.countTokens({
     payload: makePayload({ systemInstruction: { parts: [{ text: 'system' }] } }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessagesCountTokens }),
     headers: new Headers(),
   });
@@ -209,7 +206,6 @@ test('countTokens accepts the upstream total_tokens dialect and refuses unknown 
   const totalTokensResp = await geminiAttempt.countTokens({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({
       callMessagesCountTokens: async () => ({
         response: new Response(JSON.stringify({ total_tokens: 19 }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) }),
@@ -225,7 +221,6 @@ test('countTokens accepts the upstream total_tokens dialect and refuses unknown 
   const unexpectedResp = await geminiAttempt.countTokens({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({
       callMessagesCountTokens: async () => ({
         response: new Response(JSON.stringify({ unexpected: true }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) }),
@@ -249,7 +244,6 @@ test('countTokens refuses a non-messages candidate', async () => {
     await geminiAttempt.countTokens({
       payload: makePayload(),
       ctx: makeGatewayCtx(),
-      store: createNonResponsesSourceStore(API_KEY_ID),
       candidate: makeCandidate({ endpoints: { responses: {} } }),
       headers: new Headers(),
     });
@@ -272,7 +266,6 @@ test('generate propagates upstream response headers through the chat-completions
   const result = await geminiAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callChatCompletions }),
     headers: new Headers(),
   });

--- a/packages/gateway/src/data-plane/chat/gemini/http.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http.ts
@@ -4,7 +4,7 @@ import { geminiServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createChatGatewayCtxFromHono, type ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 import { internalErrorResult, ProviderModelsUnavailableError, toInternalDebugError } from '@floway-dev/provider';
@@ -56,7 +56,7 @@ const parseGeminiBodyBytes = <T>(requestBody: RequestBody, project: (body: unkno
 const respondWithGeminiError = async (
   c: AuthedContext,
   error: unknown,
-  ctx: GatewayCtx,
+  ctx: ChatGatewayCtx,
   wantsStream: boolean,
 ): Promise<Response> => {
   if (error instanceof TranslatorInputError) {
@@ -99,10 +99,9 @@ const runGeminiGenerate = async (c: AuthedContext, model: string, wantsStream: b
   const payload = parseGeminiBodyBytes(requestBody, body => body as GeminiPayload);
   if (payload instanceof Response) return payload;
 
-  const ctx = createGatewayCtxFromHono(c, { wantsStream, requestBody, model });
-  const store = createNonResponsesSourceStore(ctx.apiKeyId);
+  const ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model }, createNonResponsesSourceStore);
   try {
-    const result = await geminiServe.generate({ payload, ctx, store, model, headers: inboundHeadersForUpstream(c) });
+    const result = await geminiServe.generate({ payload, ctx, model, headers: inboundHeadersForUpstream(c) });
     const { response } = await respondGemini(c, result, wantsStream, ctx);
     return (ctx.dump?.finalize(response) ?? response);
   } catch (error) {
@@ -115,10 +114,9 @@ const runGeminiCountTokens = async (c: AuthedContext, model: string): Promise<Re
   const payload = parseGeminiBodyBytes(requestBody, parseGeminiCountTokensPayload);
   if (payload instanceof Response) return payload;
 
-  const ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody, model });
-  const store = createNonResponsesSourceStore(ctx.apiKeyId);
+  const ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody, model }, createNonResponsesSourceStore);
   try {
-    const result = await geminiServe.countTokens({ payload, ctx, store, model, headers: inboundHeadersForUpstream(c) });
+    const result = await geminiServe.countTokens({ payload, ctx, model, headers: inboundHeadersForUpstream(c) });
     const { response } = await respondGemini(c, result, false, ctx);
     return (ctx.dump?.finalize(response) ?? response);
   } catch (error) {

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-safety-settings_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-safety-settings_test.ts
@@ -1,13 +1,14 @@
 import { test } from 'vitest';
 
 import { stripSafetySettings } from './strip-safety-settings.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-part-fields_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-part-fields_test.ts
@@ -1,13 +1,14 @@
 import { test } from 'vitest';
 
 import { stripUnsupportedPartFields } from './strip-unsupported-part-fields.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-tools_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-tools_test.ts
@@ -1,13 +1,14 @@
 import { test } from 'vitest';
 
 import { stripUnsupportedTools } from './strip-unsupported-tools.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/suppress-thought-parts_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/suppress-thought-parts_test.ts
@@ -1,13 +1,14 @@
 import { test } from 'vitest';
 
 import { suppressThoughtParts } from './suppress-thought-parts.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -16,6 +17,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({

--- a/packages/gateway/src/data-plane/chat/gemini/respond_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/respond_test.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono';
 import { test } from 'vitest';
 
 import { respondGemini } from './respond.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { GeminiErrorResponse } from '@floway-dev/protocols/gemini';
@@ -18,7 +19,7 @@ const testTelemetryModelIdentity = {
   cost: null,
 };
 
-const ctx = (): GatewayCtx => ({
+const ctx = (): ChatGatewayCtx => ({
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -27,6 +28,7 @@ const ctx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 });
 
 const requestGeminiResponse = async (result: ExecuteResult<ProtocolFrame<GeminiErrorResponse>>): Promise<Response> => {

--- a/packages/gateway/src/data-plane/chat/gemini/routing.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/routing.ts
@@ -1,5 +1,5 @@
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 import type { ProviderCandidate } from '@floway-dev/provider';
@@ -10,11 +10,11 @@ export type GeminiRoutingDecision = RoutingDecision;
 export const planGeminiRouting = async (input: {
   readonly payload: GeminiPayload;
   readonly candidates: readonly ProviderCandidate[];
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
 }): Promise<GeminiRoutingDecision> =>
   await classifyResponsesItemAffinity({
     sourceItems: input.payload.contents ?? [],
     view: geminiViaResponsesItemsView,
-    store: input.store,
+    store: input.ctx.store,
     candidates: input.candidates,
   });

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -2,17 +2,15 @@ import { geminiAttempt, geminiCountTokensTarget, geminiGenerateTarget } from './
 import { renderGeminiFailure } from './errors.ts';
 import { planGeminiRouting } from './routing.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
 
 export interface GeminiServeGenerateArgs {
   readonly payload: GeminiPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   // Per-request model id (Gemini carries it in the URL path, not the body),
   // resolved by the HTTP entry and threaded through here so candidate
   // enumeration and failure rendering all see the same value.
@@ -22,15 +20,14 @@ export interface GeminiServeGenerateArgs {
 
 export interface GeminiServeCountTokensArgs {
   readonly payload: GeminiPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly model: string;
   readonly headers: Headers;
 }
 
 export const geminiServe = {
   generate: async (args: GeminiServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> => {
-    const { payload, ctx, store, model, headers } = args;
+    const { payload, ctx, model, headers } = args;
     const { candidates: enumerated, sawModel, failedUpstreams } = await enumerateModelCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
@@ -39,7 +36,7 @@ export const geminiServe = {
       currentColo: ctx.currentColo,
     });
     const viable = enumerated.filter(c => geminiGenerateTarget.canServe(c.model.endpoints));
-    const decision = await planGeminiRouting({ payload, candidates: viable, store });
+    const decision = await planGeminiRouting({ payload, candidates: viable, ctx });
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'generate');
 
     // Any non-throwing attempt result — events, api-error, or
@@ -48,11 +45,11 @@ export const geminiServe = {
     // upstream.
     const [candidate] = decision.candidates;
     if (candidate === undefined) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'generate');
-    return await geminiAttempt.generate({ payload, ctx, store, candidate, headers });
+    return await geminiAttempt.generate({ payload, ctx, candidate, headers });
   },
 
   countTokens: async (args: GeminiServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | PlainResult> => {
-    const { payload, ctx, store, model, headers } = args;
+    const { payload, ctx, model, headers } = args;
     const { candidates: enumerated, sawModel, failedUpstreams } = await enumerateModelCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
@@ -61,7 +58,7 @@ export const geminiServe = {
       currentColo: ctx.currentColo,
     });
     const viable = enumerated.filter(c => geminiCountTokensTarget.canServe(c.model.endpoints));
-    const decision = await planGeminiRouting({ payload, candidates: viable, store });
+    const decision = await planGeminiRouting({ payload, candidates: viable, ctx });
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'countTokens');
 
     // PlainResult always represents a final response — both 2xx and upstream
@@ -69,6 +66,6 @@ export const geminiServe = {
     // is the answer. Provider-level transport errors throw and propagate.
     const [candidate] = decision.candidates;
     if (candidate === undefined) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'countTokens');
-    return await geminiAttempt.countTokens({ payload, ctx, store, candidate, headers });
+    return await geminiAttempt.countTokens({ payload, ctx, candidate, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -3,7 +3,7 @@ import { afterEach, test, vi } from 'vitest';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
@@ -41,7 +41,7 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -50,6 +50,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
 const makePayload = (overrides: Partial<GeminiPayload> = {}): GeminiPayload => ({
@@ -162,7 +163,6 @@ test('generate translates through native Chat Completions target end to end', as
   const result = await geminiServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'test-model',
     headers: new Headers(),
   });
@@ -182,7 +182,6 @@ test('generate translates through Messages when only that endpoint is exposed', 
   const result = await geminiServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'test-model',
     headers: new Headers(),
   });
@@ -202,7 +201,6 @@ test('generate translates through Responses when only that endpoint is exposed',
   const result = await geminiServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'test-model',
     headers: new Headers(),
   });
@@ -231,7 +229,6 @@ test('generate stops at the first candidate even when it yields an upstream erro
   const result = await geminiServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'test-model',
     headers: new Headers(),
   });
@@ -257,7 +254,6 @@ test('generate is a routing no-op for a bare user-text request (degenerate path)
   const result = await geminiServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'test-model',
     headers: new Headers(),
   });
@@ -274,7 +270,6 @@ test('generate renders model-missing as a Google RPC 404 when no candidates are 
   const result = await geminiServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'unknown-model',
     headers: new Headers(),
   });
@@ -297,7 +292,6 @@ test('generate filters out candidates whose endpoints do not satisfy the gemini-
   const result = await geminiServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'wrong-endpoint-model',
     headers: new Headers(),
   });
@@ -328,7 +322,6 @@ test('countTokens translates Gemini to Messages count_tokens and returns the Gem
   const result = await geminiServe.countTokens({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'test-model',
     headers: new Headers(),
   });
@@ -347,7 +340,6 @@ test('countTokens renders a Google RPC NOT_FOUND when no Messages-capable candid
   const result = await geminiServe.countTokens({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'no-messages-model',
     headers: new Headers(),
   });
@@ -370,7 +362,6 @@ test('countTokens filters out candidates whose endpoints do not satisfy the gemi
   const result = await geminiServe.countTokens({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     model: 'wrong-endpoint-model',
     headers: new Headers(),
   });

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -7,7 +7,7 @@ import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewr
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../shared/attempt-helpers.ts';
 import { tryCatchChatServeFailure } from '../shared/errors.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { plainResultFromResponse } from '../shared/respond.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
 import { createUpstreamLatencyRecorder } from '../shared/upstream-telemetry.ts';
@@ -28,23 +28,22 @@ export const messagesCountTokensTarget = chatTargetPicker(['messages']);
 
 export interface MessagesAttemptGenerateArgs {
   readonly payload: MessagesPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly candidate: ProviderCandidate;
   readonly headers: Headers;
 }
 
 export interface MessagesAttemptCountTokensArgs {
   readonly payload: MessagesPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly candidate: ProviderCandidate;
   readonly headers: Headers;
 }
 
 export const messagesAttempt = {
   generate: async (args: MessagesAttemptGenerateArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => {
-    const { payload, ctx, store, candidate, headers } = args;
+    const { payload, ctx, candidate, headers } = args;
+    const { store } = ctx;
     const targetApi = messagesGenerateTarget.pick(candidate.model.endpoints);
     const rewritten = await rewriteOrRenderMessagesFailure(payload, store, candidate);
     if (rewritten.failure) return rewritten.failure;
@@ -71,7 +70,7 @@ export const messagesAttempt = {
           invocation.payload,
           p => translateMessagesViaResponses(p, { model: candidate.model.id }),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }
@@ -80,7 +79,7 @@ export const messagesAttempt = {
           invocation.payload,
           p => translateMessagesViaChatCompletions(p, { model: candidate.model.id }),
           translated => chatCompletionsAttempt.generate({
-            payload: translated, ctx, store, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }
@@ -89,7 +88,8 @@ export const messagesAttempt = {
   },
 
   countTokens: async (args: MessagesAttemptCountTokensArgs): Promise<PlainResult> => {
-    const { payload, ctx, store, candidate, headers } = args;
+    const { payload, ctx, candidate, headers } = args;
+    const { store } = ctx;
     // `pick` here is contractually total — serve filtered with
     // `messagesCountTokensTarget.canServe`, so a non-messages candidate is
     // a contract breach.

--- a/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
@@ -4,7 +4,7 @@ import { messagesAttempt } from './attempt.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -14,7 +14,7 @@ import { assertEquals, assertExists, stubProvider, stubUpstreamModel } from '@fl
 
 const API_KEY_ID = 'key_messages_attempt_test';
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -23,6 +23,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
 const makePayload = (overrides: Partial<MessagesPayload> = {}): MessagesPayload => ({
@@ -105,7 +106,6 @@ test('generate native messages target calls provider.callMessages with no rewrit
   const result = await messagesAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessages }),
     headers: new Headers(),
   });
@@ -135,7 +135,6 @@ test('generate translate-to-responses branch routes through responsesAttempt', a
   const result = await messagesAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callResponses, endpoints: { responses: {} } }),
     headers: new Headers(),
   });
@@ -156,7 +155,6 @@ test('countTokens proxies the upstream response as a plain result', async () => 
   const result = await messagesAttempt.countTokens({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessagesCountTokens }),
     headers: new Headers(),
   });
@@ -176,7 +174,6 @@ test('countTokens refuses a non-messages candidate', async () => {
     await messagesAttempt.countTokens({
       payload: makePayload(),
       ctx: makeGatewayCtx(),
-      store: createNonResponsesSourceStore(API_KEY_ID),
       candidate: makeCandidate({ endpoints: { responses: {} } }),
       headers: new Headers(),
     });
@@ -190,10 +187,10 @@ test('countTokens refuses a non-messages candidate', async () => {
 test('generate attaches the performance context and records upstream_success', async () => {
   const repo = installRepo();
   const background: Promise<unknown>[] = [];
-  const ctx: GatewayCtx = {
+  const ctx: ChatGatewayCtx = {
     ...makeGatewayCtx(),
     runtimeLocation: 'SJC',
-    backgroundScheduler: promise => { background.push(promise); },
+    backgroundScheduler: (promise: Promise<unknown>) => { background.push(promise); },
   };
   const callMessages = vi.fn(async (): Promise<ProviderStreamResult<MessagesStreamEvent>> => ({
     ok: true, events: makeProtocolFrames(makeMessagesEvents()), modelKey: 'gpt-test', headers: new Headers(),
@@ -202,7 +199,6 @@ test('generate attaches the performance context and records upstream_success', a
   const result = await messagesAttempt.generate({
     payload: makePayload(),
     ctx,
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ upstream: 'up_perf', callMessages }),
     headers: new Headers(),
   });
@@ -239,7 +235,6 @@ test('generate propagates upstream response headers onto the EventResult so resp
   const result = await messagesAttempt.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     candidate: makeCandidate({ callMessages }),
     headers: new Headers(),
   });

--- a/packages/gateway/src/data-plane/chat/messages/http.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http.ts
@@ -4,7 +4,7 @@ import { messagesServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createChatGatewayCtxFromHono, createGatewayCtxFromHono, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
@@ -65,16 +65,15 @@ const parsePayload = (requestBody: RequestBody): MessagesPayload =>
 export const messagesHttp = {
   generate: async (c: AuthedContext): Promise<Response> => {
     const requestBody = await readRequestBody(c);
-    let ctx: GatewayCtx | undefined;
+    let ctx: ChatGatewayCtx | undefined;
     try {
       const payload = parsePayload(requestBody);
       const rejected = rejectBodyBetaResponse(payload);
       if (rejected) return rejected;
 
       const wantsStream = payload.stream === true;
-      ctx = createGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model });
-      const store = createNonResponsesSourceStore(ctx.apiKeyId);
-      const result = await messagesServe.generate({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model }, createNonResponsesSourceStore);
+      const result = await messagesServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondMessages(c, result, wantsStream, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {
@@ -84,15 +83,14 @@ export const messagesHttp = {
 
   countTokens: async (c: AuthedContext): Promise<Response> => {
     const requestBody = await readRequestBody(c);
-    let ctx: GatewayCtx | undefined;
+    let ctx: ChatGatewayCtx | undefined;
     try {
       const payload = parsePayload(requestBody);
       const rejected = rejectBodyBetaResponse(payload);
       if (rejected) return rejected;
 
-      ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody, model: payload.model });
-      const store = createNonResponsesSourceStore(ctx.apiKeyId);
-      const result = await messagesServe.countTokens({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody, model: payload.model }, createNonResponsesSourceStore);
+      const result = await messagesServe.countTokens({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondMessages(c, result, false, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user_test.ts
@@ -2,13 +2,14 @@ import { test } from 'vitest';
 
 import { demoteInterleavedSystemToUser } from './demote-interleaved-system-to-user.ts';
 import type { MessagesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -17,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -2,13 +2,14 @@ import { test } from 'vitest';
 
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
 import type { MessagesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { stubProviderCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -17,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution_test.ts
@@ -2,13 +2,14 @@ import { test } from 'vitest';
 
 import { stripBillingAttribution } from './strip-billing-attribution.ts';
 import type { MessagesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -17,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> =>

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
@@ -15,7 +15,8 @@ import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import { DEFAULT_SEARCH_CONFIG } from '../../../tools/web-search/search-config.ts';
 import type { WebSearchProvider, WebSearchProviderResult } from '../../../tools/web-search/types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { type ProtocolFrame, eventFrame } from '@floway-dev/protocols/common';
 import { messagesProtocolFrameToSSEFrame } from '@floway-dev/protocols/messages';
 import type {
@@ -50,7 +51,7 @@ const invocation = (payload: MessagesPayload): MessagesInvocation => ({
   headers: new Headers(),
 });
 
-const gatewayCtx = (apiKeyId: string = 'test-key'): GatewayCtx => ({
+const gatewayCtx = (apiKeyId: string = 'test-key'): ChatGatewayCtx => ({
   apiKeyId,
   upstreamIds: null,
   wantsStream: false,
@@ -59,6 +60,7 @@ const gatewayCtx = (apiKeyId: string = 'test-key'): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(apiKeyId),
 });
 
 const encodeUnsignedPayload = (payload: unknown): string => btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');

--- a/packages/gateway/src/data-plane/chat/messages/respond_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/respond_test.ts
@@ -4,7 +4,8 @@ import { test } from 'vitest';
 import { createMessagesStreamUsageState, respondMessages, tokenUsageFromMessagesFrame } from './respond.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { eventResult, type ExecuteResult } from '@floway-dev/provider';
@@ -528,7 +529,7 @@ const forwardedHeadersFixture = (): Headers => new Headers({
   'set-cookie': 'session=secret',
 });
 
-const makeRespondCtx = (): GatewayCtx => ({
+const makeRespondCtx = (): ChatGatewayCtx => ({
   apiKeyId: 'key_respond_test',
   upstreamIds: null,
   wantsStream: false,
@@ -537,6 +538,7 @@ const makeRespondCtx = (): GatewayCtx => ({
   requestStartedAt: 0,
   currentColo: 'TEST',
   dump: null,
+  store: createNonResponsesSourceStore('key_respond_test'),
 });
 
 const messagesEventsForRespond = (): readonly MessagesStreamEvent[] => [
@@ -668,7 +670,7 @@ test('respondMessages records the last observed message_delta usage when the cli
       { headers: new Headers({ 'content-type': 'text/event-stream' }) },
     );
     const downstreamAbortController = new AbortController();
-    const ctx: GatewayCtx = { ...makeRespondCtx(), wantsStream: true, downstreamAbortController };
+    const ctx: ChatGatewayCtx = { ...makeRespondCtx(), wantsStream: true, downstreamAbortController };
     return respondMessages(c, result, true, ctx).then(({ response }) => response);
   });
   const response = await app.request('/');

--- a/packages/gateway/src/data-plane/chat/messages/routing.ts
+++ b/packages/gateway/src/data-plane/chat/messages/routing.ts
@@ -1,5 +1,5 @@
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import type { ProviderCandidate } from '@floway-dev/provider';
@@ -10,11 +10,11 @@ export type MessagesRoutingDecision = RoutingDecision;
 export const planMessagesRouting = async (input: {
   readonly payload: MessagesPayload;
   readonly candidates: readonly ProviderCandidate[];
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
 }): Promise<MessagesRoutingDecision> =>
   await classifyResponsesItemAffinity({
     sourceItems: input.payload.messages,
     view: messagesViaResponsesItemsView,
-    store: input.store,
+    store: input.ctx.store,
     candidates: input.candidates,
   });

--- a/packages/gateway/src/data-plane/chat/messages/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/routing_test.ts
@@ -5,12 +5,25 @@ import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createStoredResponsesItemId } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import type { ProviderCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_messages_routing_test';
+
+const makeCtx = (): ChatGatewayCtx => ({
+  apiKeyId: API_KEY_ID,
+  upstreamIds: null,
+  wantsStream: false,
+  runtimeLocation: 'TEST',
+  currentColo: 'TEST',
+  dump: null,
+  backgroundScheduler: () => {},
+  requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
+});
 
 const candidateFor = (upstream: string): ProviderCandidate => {
   const upstreamModel = stubUpstreamModel();
@@ -46,7 +59,7 @@ test('messages payload with no reasoning carriers passes candidates through unch
   const decision = await planMessagesRouting({
     payload: payload([{ role: 'user', content: 'hello' }]),
     candidates,
-    store: createNonResponsesSourceStore(API_KEY_ID),
+    ctx: makeCtx(),
   });
 
   assertEquals(decision.kind, 'success');
@@ -73,7 +86,7 @@ test('a reasoning signature naming an unknown stored id fails routing as item-no
       },
     ]),
     candidates: [candidateFor('up_a')],
-    store: createNonResponsesSourceStore(API_KEY_ID),
+    ctx: makeCtx(),
   });
 
   assertEquals(decision.kind, 'failure');

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -2,30 +2,27 @@ import { messagesAttempt, messagesGenerateTarget, messagesCountTokensTarget } fr
 import { renderMessagesFailure } from './errors.ts';
 import { planMessagesRouting } from './routing.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
-import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
 
 export interface MessagesServeGenerateArgs {
   readonly payload: MessagesPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly headers: Headers;
 }
 
 export interface MessagesServeCountTokensArgs {
   readonly payload: MessagesPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly headers: Headers;
 }
 
 export const messagesServe = {
   generate: async (args: MessagesServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => {
-    const { payload, ctx, store, headers } = args;
+    const { payload, ctx, headers } = args;
     const { candidates: enumerated, sawModel, failedUpstreams } = await enumerateModelCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
@@ -34,7 +31,7 @@ export const messagesServe = {
       currentColo: ctx.currentColo,
     });
     const viable = enumerated.filter(c => messagesGenerateTarget.canServe(c.model.endpoints));
-    const decision = await planMessagesRouting({ payload, candidates: viable, store });
+    const decision = await planMessagesRouting({ payload, candidates: viable, ctx });
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'generate');
 
     // Any non-throwing attempt result — events, api-error, or
@@ -43,11 +40,11 @@ export const messagesServe = {
     // upstream.
     const [candidate] = decision.candidates;
     if (candidate === undefined) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'generate');
-    return await messagesAttempt.generate({ payload, ctx, store, candidate, headers });
+    return await messagesAttempt.generate({ payload, ctx, candidate, headers });
   },
 
   countTokens: async (args: MessagesServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | PlainResult> => {
-    const { payload, ctx, store, headers } = args;
+    const { payload, ctx, headers } = args;
     const { candidates: enumerated, sawModel, failedUpstreams } = await enumerateModelCandidates({
       upstreamIds: ctx.upstreamIds,
       model: payload.model,
@@ -56,7 +53,7 @@ export const messagesServe = {
       currentColo: ctx.currentColo,
     });
     const viable = enumerated.filter(c => messagesCountTokensTarget.canServe(c.model.endpoints));
-    const decision = await planMessagesRouting({ payload, candidates: viable, store });
+    const decision = await planMessagesRouting({ payload, candidates: viable, ctx });
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'countTokens');
 
     // PlainResult always represents a final response — both 2xx and upstream
@@ -64,6 +61,6 @@ export const messagesServe = {
     // is the answer. Provider-level transport errors throw and propagate.
     const [candidate] = decision.candidates;
     if (candidate === undefined) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'countTokens');
-    return await messagesAttempt.countTokens({ payload, ctx, store, candidate, headers });
+    return await messagesAttempt.countTokens({ payload, ctx, candidate, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -3,7 +3,7 @@ import { afterEach, test, vi } from 'vitest';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -39,7 +39,7 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -48,6 +48,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
 const makePayload = (overrides: Partial<MessagesPayload> = {}): MessagesPayload => ({
@@ -181,7 +182,6 @@ test('generate routes a native Messages candidate end to end', async () => {
   const result = await messagesServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -203,7 +203,6 @@ test('generate translates through the Responses target when only that endpoint i
   const result = await messagesServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -230,7 +229,6 @@ test('generate stops at the first candidate even when it yields an upstream erro
   const result = await messagesServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -258,7 +256,6 @@ test('generate stops at the first candidate when the payload has no reasoning ca
   const result = await messagesServe.generate({
     payload: makePayload({ messages: [{ role: 'user', content: 'hi' }] }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -273,7 +270,6 @@ test('generate renders model-missing when no candidates are available', async ()
   const result = await messagesServe.generate({
     payload: makePayload({ model: 'unknown-model' }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -294,7 +290,6 @@ test('generate filters out candidates whose endpoints do not satisfy the message
   const result = await messagesServe.generate({
     payload: makePayload({ model: 'wrong-endpoint-model' }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -320,7 +315,6 @@ test('countTokens proxies the upstream measurement response as a plain result', 
   const result = await messagesServe.countTokens({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -338,7 +332,6 @@ test('countTokens renders model-missing as a 404 when no candidates are availabl
   const result = await messagesServe.countTokens({
     payload: makePayload({ model: 'unknown-model' }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -359,7 +352,6 @@ test('countTokens filters out candidates whose endpoints do not satisfy the mess
   const result = await messagesServe.countTokens({
     payload: makePayload({ model: 'wrong-endpoint-model' }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -416,7 +408,6 @@ test('claude-code candidate preserves x-anthropic-billing-header system block th
       ],
     }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 
@@ -472,7 +463,6 @@ test('copilot candidate strips x-anthropic-billing-header system block via the d
       ],
     }),
     ctx: makeGatewayCtx(),
-    store: createNonResponsesSourceStore(API_KEY_ID),
     headers: new Headers(),
   });
 

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -1,5 +1,5 @@
 import { responsesInterceptors } from './interceptors/index.ts';
-import type { ResponsesAttemptResult, ResponsesInvocation } from './interceptors/types.ts';
+import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { createStoredResponseId } from './items/format.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
 import { drainAsync, syntheticEventsFromResult, wrapResponsesOutputForStorage } from './items/output.ts';
@@ -18,7 +18,7 @@ import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
 import { type ResponsesPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction } from '@floway-dev/provider';
+import { type ProviderCandidate, eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction, type ResponsesInvocation } from '@floway-dev/provider';
 import { translateResponsesViaChatCompletions, translateResponsesViaMessages } from '@floway-dev/translate';
 
 // `/v1/responses` generate prefers the native Responses target, then the

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -11,7 +11,7 @@ import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, telemetryModelIdentity, chatTargetPicker } from '../shared/attempt-helpers.ts';
 import { tryCatchChatServeFailure } from '../shared/errors.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
 import { createUpstreamLatencyRecorder, recordUpstreamHttpFailure, upstreamPerformanceContext } from '../shared/upstream-telemetry.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
@@ -31,8 +31,7 @@ export const responsesTarget = chatTargetPicker(['responses', 'messages', 'chat-
 export interface ResponsesAttemptInvokeArgs {
   readonly payload: ResponsesPayload;
   readonly action: ResponsesAction;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly candidate: ProviderCandidate;
   readonly headers: Headers;
 }
@@ -76,7 +75,8 @@ export interface ResponsesAttemptInvokeArgs {
 // no-op at the store-write layer.
 export const responsesAttempt = {
   invoke: async (args: ResponsesAttemptInvokeArgs): Promise<ResponsesAttemptResult> => {
-    const { payload, action, ctx, store, candidate, headers } = args;
+    const { payload, action, ctx, candidate, headers } = args;
+    const { store } = ctx;
     const targetApi = responsesTarget.pick(candidate.model.endpoints);
     // Rewrite + privatePayload seed + assistant-content normalization all run
     // BEFORE the interceptor chain so source interceptors — most importantly
@@ -102,7 +102,6 @@ export const responsesAttempt = {
       action,
       candidate,
       targetApi,
-      store,
       headers,
     };
     const chainResult = await runInterceptors(invocation, ctx, responsesInterceptors, async () =>
@@ -216,9 +215,9 @@ const rewriteOrRenderFailure = async (
 
 const dispatchResponses = async (
   invocation: ResponsesInvocation,
-  ctx: GatewayCtx,
+  ctx: ChatGatewayCtx,
 ): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
-  const { candidate, targetApi, store } = invocation;
+  const { candidate, targetApi } = invocation;
   switch (targetApi) {
   case 'responses': {
     const recorder = createUpstreamLatencyRecorder();
@@ -266,7 +265,7 @@ const dispatchResponses = async (
         fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,
       }),
       translated => messagesAttempt.generate({
-        payload: translated, ctx, store, candidate, headers: invocation.headers,
+        payload: translated, ctx, candidate, headers: invocation.headers,
       }),
     );
   case 'chat-completions':
@@ -277,7 +276,7 @@ const dispatchResponses = async (
       invocation.payload,
       p => translateResponsesViaChatCompletions(p, { model: candidate.model.id }),
       translated => chatCompletionsAttempt.generate({
-        payload: translated, ctx, store, candidate, headers: invocation.headers,
+        payload: translated, ctx, candidate, headers: invocation.headers,
       }),
     );
   default: {
@@ -296,7 +295,7 @@ const providerResponsesResultToExecuteResult = async (
   providerResult: ProviderResponsesResult,
   candidate: ProviderCandidate,
   targetApi: ChatTargetApi,
-  ctx: GatewayCtx,
+  ctx: ChatGatewayCtx,
   recorder: ReturnType<typeof createUpstreamLatencyRecorder>,
 ): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
   if (providerResult.action === 'generate') {

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -3,11 +3,11 @@ import { test, vi } from 'vitest';
 import { responsesAttempt } from './attempt.ts';
 import { createStoredResponsesItemId, isStoredResponseId } from './items/format.ts';
 import * as outputModule from './items/output.ts';
-import { createResponsesHttpStore } from './items/store.ts';
+import { createResponsesHttpStore, createNonResponsesSourceStore } from './items/store.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../repo/types.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -16,7 +16,7 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 
 const API_KEY_ID = 'key_attempt_test';
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (store?: ChatGatewayCtx['store']): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -25,6 +25,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: store ?? createNonResponsesSourceStore(API_KEY_ID),
 });
 
 const makePayload = (overrides: Partial<ResponsesPayload> = {}): ResponsesPayload => ({
@@ -120,14 +121,13 @@ test('generate native success wraps the upstream event stream once', async () =>
   }));
 
   const candidate = makeCandidate(callResponses);
-  const ctx = makeGatewayCtx();
   const store = createResponsesHttpStore(API_KEY_ID, true);
+  const ctx = makeGatewayCtx(store);
   const commitSpy = vi.spyOn(store, 'commitSnapshot').mockResolvedValue();
 
   const result = await responsesAttempt.generate({
     payload: makePayload(),
     ctx,
-    store,
     candidate,
     headers: new Headers(),
   });
@@ -192,8 +192,7 @@ test('generate derives snapshotMode=replace when the upstream emits a compaction
         { type: 'message', role: 'user', content: 'kept message' },
       ],
     }),
-    ctx: makeGatewayCtx(),
-    store,
+    ctx: makeGatewayCtx(store),
     candidate,
     headers: new Headers(),
   });
@@ -240,8 +239,7 @@ test('generate returns failure when rewrite throws item-not-found', async () => 
 
   const result = await responsesAttempt.generate({
     payload: makePayload({ input: [{ type: 'item_reference', id: missingId }] }),
-    ctx: makeGatewayCtx(),
-    store,
+    ctx: makeGatewayCtx(store),
     candidate,
     headers: new Headers(),
   });
@@ -269,8 +267,7 @@ test('generate passes non-events provider result through unchanged', async () =>
   const candidate = makeCandidate(callResponses);
   const result = await responsesAttempt.generate({
     payload: makePayload(),
-    ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
+    ctx: makeGatewayCtx(createResponsesHttpStore(API_KEY_ID, true)),
     candidate,
     headers: new Headers(),
   });
@@ -321,8 +318,7 @@ test('compact reshapes the trigger turn into a result and derives snapshotMode=r
       ],
     }),
     action: 'compact',
-    ctx: makeGatewayCtx(),
-    store,
+    ctx: makeGatewayCtx(store),
     candidate,
     headers: new Headers(),
   });
@@ -386,8 +382,7 @@ test('generate inherits invocation headers across translation to Messages', asyn
 
   const result = await responsesAttempt.generate({
     payload: makePayload(),
-    ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
+    ctx: makeGatewayCtx(createResponsesHttpStore(API_KEY_ID, true)),
     candidate,
     headers: new Headers({ 'x-test': 'abc' }),
   });
@@ -495,8 +490,7 @@ test('generate seeds privatePayload before interceptors so the web-search shim r
       ],
       tools: [{ type: 'web_search' }],
     }),
-    ctx: makeGatewayCtx(),
-    store,
+    ctx: makeGatewayCtx(store),
     candidate,
     headers: new Headers(),
   });
@@ -543,8 +537,7 @@ test('generate propagates upstream response headers onto the EventResult so resp
   const store = createResponsesHttpStore(API_KEY_ID, true);
   const result = await responsesAttempt.generate({
     payload: makePayload(),
-    ctx: makeGatewayCtx(),
-    store,
+    ctx: makeGatewayCtx(store),
     candidate,
     headers: new Headers(),
   });

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -6,7 +6,7 @@ import { responsesServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
 import { CODEX_AUTO_REVIEW_ALIAS, CODEX_AUTO_REVIEW_TARGET } from '../../codex/auto-review-alias.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
-import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createChatGatewayCtxFromHono, createGatewayCtxFromHono, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
@@ -85,13 +85,12 @@ const parsePayload = (requestBody: RequestBody, stampReasoningEffort: boolean): 
 export const responsesHttp = {
   generate: async (c: AuthedContext): Promise<Response> => {
     const requestBody = await readRequestBody(c);
-    let ctx: GatewayCtx | undefined;
+    let ctx: ChatGatewayCtx | undefined;
     try {
       const payload = parsePayload(requestBody, true);
       const wantsStream = payload.stream === true;
-      ctx = createGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model });
-      const store = createResponsesHttpStore(ctx.apiKeyId, payload.store ?? undefined);
-      const result = await responsesServe.generate({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model }, apiKeyId => createResponsesHttpStore(apiKeyId, payload.store ?? undefined));
+      const result = await responsesServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondResponses(c, result, wantsStream, ctx);
       return (ctx.dump?.finalize(response) ?? response);
     } catch (error) {
@@ -101,12 +100,11 @@ export const responsesHttp = {
 
   compact: async (c: AuthedContext): Promise<Response> => {
     const requestBody = await readRequestBody(c);
-    let ctx: GatewayCtx | undefined;
+    let ctx: ChatGatewayCtx | undefined;
     try {
       const payload = parsePayload(requestBody, false);
-      ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody, model: payload.model });
-      const store = createResponsesHttpStore(ctx.apiKeyId, payload.store ?? undefined);
-      const result = await responsesServe.compact({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody, model: payload.model }, apiKeyId => createResponsesHttpStore(apiKeyId, payload.store ?? undefined));
+      const result = await responsesServe.compact({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       if (result.type === 'result') {
         ctx.dump?.success(result.modelIdentity, result.usage);
         const compactResponse = Response.json(result.result);

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
@@ -2,14 +2,14 @@ import { test } from 'vitest';
 
 import { withResponsesOutputItemsCanonicalized } from './canonicalize-output-items.ts';
 import type { ResponsesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { stubProviderCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -18,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const invocation = (): ResponsesInvocation => ({
@@ -25,13 +26,6 @@ const invocation = (): ResponsesInvocation => ({
   action: 'generate',
   candidate: stubProviderCandidate(),
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
 });
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
@@ -1,12 +1,11 @@
 import { test } from 'vitest';
 
 import { withResponsesOutputItemsCanonicalized } from './canonicalize-output-items.ts';
-import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ExecuteResult, eventResult } from '@floway-dev/provider';
+import { type ExecuteResult, eventResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { stubProviderCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -45,14 +45,14 @@
 // untouched, so the operator can selectively turn the flag off for codex /
 // copilot / azure / custom upstreams that natively support compaction.
 
-import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
+import type { ResponsesInterceptor } from './types.ts';
 import { decodeBase64UrlJson, encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import { isJsonObject } from '../../../../shared/json-helpers.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { syntheticEventsFromResult } from '../items/output.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ExecuteResult } from '@floway-dev/provider';
+import type { ExecuteResult, ResponsesInvocation } from '@floway-dev/provider';
 
 // Vendored from openai/codex (Apache-2.0):
 // https://github.com/openai/codex/blob/ba2b67f9cda954bcdda43c2a65ac58e807b996bd/codex-rs/prompts/templates/compact/prompt.md

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -48,6 +48,7 @@
 import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
 import { decodeBase64UrlJson, encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import { isJsonObject } from '../../../../shared/json-helpers.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { syntheticEventsFromResult } from '../items/output.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -153,7 +154,7 @@ const buildCompactionEnvelope = (cmpId: string, summaryText: string, upstream: R
   };
 };
 
-const simulateCompaction = async (ctx: ResponsesInvocation, run: ChainRun): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
+const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGatewayCtx, run: ChainRun): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
   const originalPayload = ctx.payload;
 
   // Materialize the user-supplied input (string or array) into Responses items,
@@ -224,7 +225,7 @@ const simulateCompaction = async (ctx: ResponsesInvocation, run: ChainRun): Prom
   // (For non-responses targets the targetApi check already suppresses
   // ownership; this also covers the responses-target + flag-on engagement.)
   const cmpId = `cmp_${crypto.randomUUID()}`;
-  ctx.store.addSyntheticItem(cmpId);
+  gatewayCtx.store.addSyntheticItem(cmpId);
   const synthesized = buildCompactionEnvelope(cmpId, summaryText, collected);
 
   return {
@@ -240,7 +241,7 @@ const simulateCompaction = async (ctx: ResponsesInvocation, run: ChainRun): Prom
 export const containsCompactionTrigger = (input: ResponsesPayload['input']): boolean =>
   typeof input !== 'string' && input.some(item => item.type === 'compaction_trigger');
 
-export const withResponsesCompactShim: ResponsesInterceptor = async (ctx, _gatewayCtx, run) => {
+export const withResponsesCompactShim: ResponsesInterceptor = async (ctx, gatewayCtx, run) => {
   // The shim is engaged when the operator turned it on for this upstream,
   // OR when the upstream's targetApi is not Responses (Messages /
   // Chat Completions have no compaction wire and would crash on the
@@ -258,5 +259,5 @@ export const withResponsesCompactShim: ResponsesInterceptor = async (ctx, _gatew
   const isCompactShaped = ctx.action === 'compact' || containsCompactionTrigger(ctx.payload.input);
   if (!isCompactShaped) return await run();
 
-  return await simulateCompaction(ctx, run);
+  return await simulateCompaction(ctx, gatewayCtx, run);
 };

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -1,13 +1,12 @@
 import { test } from 'vitest';
 
 import { expandShimCompactionItems, withResponsesCompactShim } from './compact-shim.ts';
-import type { ResponsesInvocation } from './types.ts';
 import { encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { eventResult, type ExecuteResult } from '@floway-dev/provider';
+import { eventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -3,14 +3,14 @@ import { test } from 'vitest';
 import { expandShimCompactionItems, withResponsesCompactShim } from './compact-shim.ts';
 import type { ResponsesInvocation } from './types.ts';
 import { encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { LayeredStatefulResponsesStore, MemoryStatefulResponsesBacking } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -19,6 +19,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const makeInvocation = (
@@ -31,13 +32,6 @@ const makeInvocation = (
     model: { enabledFlags: new Set(options.flagOn === false ? [] : ['responses-compact-shim']) },
   }),
   targetApi: options.targetApi ?? 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
 });
 
@@ -203,7 +197,7 @@ test('compact + flag on: synthesized compaction id is registered as synthetic so
   if (result.type !== 'events') throw new Error('expected events branch');
   const collected = await collectResponsesProtocolEventsToResult(result.events);
   const compactionItem = collected.output[0] as { type: string; id: string };
-  assertEquals(inv.store.isSyntheticItem(compactionItem.id), true);
+  assertEquals(stubCtx.store.isSyntheticItem(compactionItem.id), true);
 });
 
 test('compact + flag on: upstream `output_text` SDK alias is dropped from the synthesized envelope', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -1,12 +1,11 @@
 import { test } from 'vitest';
 
 import { withDemoteDeveloperToSystem } from './demote-developer-to-system.ts';
-import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -2,14 +2,14 @@ import { test } from 'vitest';
 
 import { withDemoteDeveloperToSystem } from './demote-developer-to-system.ts';
 import type { ResponsesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -18,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () =>
@@ -34,13 +35,6 @@ const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string>
   payload,
   candidate: stubProviderCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
   action: 'generate',
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -1,12 +1,11 @@
 import { test } from 'vitest';
 
 import { withInterleavedSystemDemotedToUser } from './demote-interleaved-system-to-user.ts';
-import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -2,14 +2,14 @@ import { test } from 'vitest';
 
 import { withInterleavedSystemDemotedToUser } from './demote-interleaved-system-to-user.ts';
 import type { ResponsesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -18,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () =>
@@ -37,13 +38,6 @@ const invocation = (
   payload,
   candidate: stubProviderCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
   action: 'generate',
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -2,14 +2,14 @@ import { test } from 'vitest';
 
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
 import type { ResponsesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -18,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () =>
@@ -37,13 +38,6 @@ const invocation = (
   payload,
   candidate: stubProviderCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
   action: 'generate',
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -1,12 +1,11 @@
 import { test } from 'vitest';
 
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
-import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -2,8 +2,8 @@ import { test } from 'vitest';
 
 import { withCyberPolicyRetried } from './retry-cyber-policy.ts';
 import type { ResponsesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult } from '@floway-dev/provider';
@@ -28,18 +28,11 @@ const makeInvocation = (payload: ResponsesPayload): ResponsesInvocation => ({
   payload,
   candidate: stubProviderCandidate({ model: { enabledFlags: new Set(['retry-cyber-policy']) } }),
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
   action: 'generate',
 });
 
-const stubCtx = (overrides: { abortSignal?: AbortSignal } = {}): GatewayCtx => ({
+const stubCtx = (overrides: { abortSignal?: AbortSignal } = {}): ChatGatewayCtx => ({
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: true,
@@ -48,6 +41,7 @@ const stubCtx = (overrides: { abortSignal?: AbortSignal } = {}): GatewayCtx => (
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
   ...overrides,
 });
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -1,12 +1,11 @@
 import { test } from 'vitest';
 
 import { withCyberPolicyRetried } from './retry-cyber-policy.ts';
-import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { eventResult, type ExecuteResult } from '@floway-dev/provider';
+import { eventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const makePayload = (): ResponsesPayload => ({

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -1,7 +1,7 @@
 import { jsonrepair } from 'jsonrepair';
 
 import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { truncatePreservingCodePoints } from '../../shared/text.ts';
 import type { StatefulResponsesStore } from '../items/store.ts';
 import type { InterceptorRun } from '@floway-dev/interceptor';
@@ -131,7 +131,7 @@ export type ServerToolPrepareResult =
     hosted?: ServerToolHostedDispatch;
   };
 
-export type ServerToolRegistration = (invocation: ResponsesInvocation, gatewayCtx: GatewayCtx) => ServerToolPrepareResult | Promise<ServerToolPrepareResult>;
+export type ServerToolRegistration = (invocation: ResponsesInvocation, gatewayCtx: ChatGatewayCtx) => ServerToolPrepareResult | Promise<ServerToolPrepareResult>;
 
 type ActiveServerTool = Extract<ServerToolPrepareResult, { type: 'active' }> & {
   toolName: string;
@@ -1034,7 +1034,7 @@ export const withResponsesServerToolShim = (
       demoteForcedServerToolChoiceAfterFirstTurn,
       turn1Iter,
       dispatchers,
-      statefulResponsesStore: ctx.store,
+      statefulResponsesStore: gatewayCtx.store,
       canonicalInput,
       active,
       metadata,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -1,6 +1,6 @@
 import { jsonrepair } from 'jsonrepair';
 
-import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
+import type { ResponsesInterceptor } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { truncatePreservingCodePoints } from '../../shared/text.ts';
 import type { StatefulResponsesStore } from '../items/store.ts';
@@ -16,7 +16,7 @@ import type {
   ResponsesTool,
   ResponsesToolChoice,
 } from '@floway-dev/protocols/responses';
-import type { EventResultMetadata, ExecuteResult } from '@floway-dev/provider';
+import type { EventResultMetadata, ExecuteResult, ResponsesInvocation } from '@floway-dev/provider';
 
 export interface MergeUsage {
   input_tokens?: number;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -13,7 +13,7 @@ import {
   type UpstreamTerminal,
 } from './server-tool-shim.ts';
 import { SHIM_TOOL_NAME, webSearchServerTool } from './server-tools/web-search.ts';
-import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
+import type { ResponsesInterceptor } from './types.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import { resolveConfiguredWebSearchProvider } from '../../../tools/web-search/provider.ts';
@@ -42,7 +42,7 @@ import type {
   ResponsesToolChoice,
   ResponsesWebSearchAction,
 } from '@floway-dev/protocols/responses';
-import { directFetcher, type EventResult, type ExecuteResult } from '@floway-dev/provider';
+import { directFetcher, type EventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse } from '@floway-dev/test-utils';
 
 const withResponsesWebSearchShim = withResponsesServerToolShim([webSearchServerTool]);

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -26,9 +26,8 @@ import type {
   WebSearchProviderRequest,
   WebSearchProviderResult,
 } from '../../../tools/web-search/types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
-import type { StatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
@@ -307,15 +306,6 @@ interface InvocationOverrides {
   payload?: Partial<ResponsesPayload>;
 }
 
-const makeStore = (apiKeyId: string | null = 'k1'): StatefulResponsesStore =>
-  new LayeredStatefulResponsesStore({
-    apiKeyId,
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  });
-
 const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocation => ({
   candidate: {
     provider: {
@@ -337,7 +327,6 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
   // function_call_output path. Tests that care about a specific target
   // set targetApi explicitly.
   targetApi: overrides.targetApi ?? 'chat-completions',
-  store: makeStore(),
   payload: {
     model: 'claude-x',
     input: [{ type: 'message', role: 'user', content: 'hi' }],
@@ -352,7 +341,7 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
   action: 'generate',
 });
 
-const makeGatewayCtx = (apiKeyId: string = 'k1'): GatewayCtx => ({
+const makeGatewayCtx = (apiKeyId: string = 'k1'): ChatGatewayCtx => ({
   apiKeyId,
   upstreamIds: null,
   wantsStream: true,
@@ -361,6 +350,7 @@ const makeGatewayCtx = (apiKeyId: string = 'k1'): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore(apiKeyId),
 });
 
 const collectFrames = async <T>(iter: AsyncIterable<T>): Promise<T[]> => {
@@ -375,7 +365,7 @@ const collectFrames = async <T>(iter: AsyncIterable<T>): Promise<T[]> => {
 const runShimAndDrain = async (
   shim: ResponsesInterceptor,
   inv: ResponsesInvocation,
-  gatewayCtx: GatewayCtx,
+  gatewayCtx: ChatGatewayCtx,
   run: () => Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>>,
 ): Promise<{
   result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>;
@@ -664,19 +654,20 @@ test('synthesized web_search_call ids are registered as gateway-synthetic on the
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation();
+  const ctx = makeGatewayCtx();
   const script = scriptedRun([
     searchCallTurn(0, 'call_1', 'q1'),
     messageTurn('summary', 0),
   ]);
 
-  const { frames } = await runShimAndDrain(shim, inv, makeGatewayCtx(), script.run);
+  const { frames } = await runShimAndDrain(shim, inv, ctx, script.run);
 
   // Every web_search_call the shim synthesizes carries a gateway-minted id no
   // upstream issued; persistence relies on these being registered so it stores
   // them with no upstream identity (non_affinity).
   const doneEvents = outputItemDoneEvents(frames);
   const wsCallDoneIds = doneEvents.filter(e => e.item.type === 'web_search_call').map(e => e.item.id!);
-  const store = inv.store;
+  const store = ctx.store;
   assert(wsCallDoneIds.length > 0, 'expected a synthesized web_search_call');
   for (const id of wsCallDoneIds) {
     assert(id.startsWith('ws_gw_'));
@@ -4500,7 +4491,7 @@ test('downstream AbortSignal threads through to provider search / fetchPage and 
   });
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation();
-  const gatewayCtx: GatewayCtx = {
+  const gatewayCtx: ChatGatewayCtx = {
     apiKeyId: 'k1',
     upstreamIds: null,
     wantsStream: true,
@@ -4509,6 +4500,7 @@ test('downstream AbortSignal threads through to provider search / fetchPage and 
     dump: null,
     backgroundScheduler: () => {},
     requestStartedAt: 0,
+    store: createNonResponsesSourceStore('k1'),
     abortSignal: controller.signal,
   };
   const script = scriptedRun([

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -4,11 +4,10 @@ import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
 import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../../items/store.ts';
-import type { ResponsesInvocation } from '../types.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { directFetcher, type EventResult, type ExecuteResult } from '@floway-dev/provider';
+import { directFetcher, type EventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assert, assertEquals } from '@floway-dev/test-utils';
 
 // Dirty integration harness: mock the model registry so the image backend is a

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -2,8 +2,8 @@ import { beforeEach, test, vi } from 'vitest';
 
 import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
-import type { GatewayCtx } from '../../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../../items/store.ts';
+import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../items/store.ts';
 import type { ResponsesInvocation } from '../types.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
@@ -146,18 +146,11 @@ const makeCtx = (input: unknown[], action: 'generate' | 'edit' | 'auto' = 'auto'
     fetcher: directFetcher,
   },
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   payload: { model: 'orchestrator', input, tools: [{ type: 'image_generation', action, ...extraTool }] } as never,
   headers: new Headers(),
   action: 'generate',
 });
-const gatewayCtx = (): GatewayCtx => ({
+const gatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: true,
@@ -166,6 +159,7 @@ const gatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 });
 
 const drain = async (result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesStreamEvent[]> => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -3,7 +3,7 @@ import { enumerateModelCandidates } from '../../../../providers/registry.ts';
 import { appendFailedUpstreams } from '../../../../shared/failed-upstreams.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, requireRecordedDurationMs } from '../../../../shared/telemetry/performance.ts';
 import { recordTokenUsage, tokenUsageFromImagesBody } from '../../../../shared/telemetry/usage.ts';
-import type { GatewayCtx } from '../../../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
 import type { ServerToolLifecycleEvent, ServerToolOutputItem, ServerToolRegistration, ServerToolTerminal } from '../server-tool-shim.ts';
 import { parseSSEStream } from '@floway-dev/protocols/common';
 import type {
@@ -453,7 +453,7 @@ interface ShimState {
   config: ImageGenerationConfig;
   apiKeyId: string;
   upstreamIds: readonly string[] | null;
-  backgroundScheduler: GatewayCtx['backgroundScheduler'];
+  backgroundScheduler: ChatGatewayCtx['backgroundScheduler'];
   runtimeLocation: string;
   currentColo: string;
   downstreamAbortSignal: AbortSignal | undefined;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -3,8 +3,8 @@ import { enumerateModelCandidates } from '../../../../providers/registry.ts';
 import { appendFailedUpstreams } from '../../../../shared/failed-upstreams.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, requireRecordedDurationMs } from '../../../../shared/telemetry/performance.ts';
 import { recordTokenUsage, tokenUsageFromImagesBody } from '../../../../shared/telemetry/usage.ts';
-import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
 import type { ServerToolLifecycleEvent, ServerToolOutputItem, ServerToolRegistration, ServerToolTerminal } from '../server-tool-shim.ts';
+import type { BackgroundScheduler } from '@floway-dev/platform';
 import { parseSSEStream } from '@floway-dev/protocols/common';
 import type {
   ResponsesFunctionCallOutputItem,
@@ -453,7 +453,7 @@ interface ShimState {
   config: ImageGenerationConfig;
   apiKeyId: string;
   upstreamIds: readonly string[] | null;
-  backgroundScheduler: ChatGatewayCtx['backgroundScheduler'];
+  backgroundScheduler: BackgroundScheduler;
   runtimeLocation: string;
   currentColo: string;
   downstreamAbortSignal: AbortSignal | undefined;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -21,9 +21,8 @@ import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
 import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../../items/store.ts';
-import type { ResponsesInvocation } from '../types.ts';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
-import { directFetcher } from '@floway-dev/provider';
+import { directFetcher, type ResponsesInvocation } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse, assertStringIncludes } from '@floway-dev/test-utils';
 
 const PNG_B64 = 'aGVsbG8='; // "hello" — any decodable base64 works for source tests.

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -19,8 +19,8 @@ import {
 } from './image-generation.ts';
 import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
-import type { GatewayCtx } from '../../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../../items/store.ts';
+import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../../items/store.ts';
 import type { ResponsesInvocation } from '../types.ts';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
 import { directFetcher } from '@floway-dev/provider';
@@ -44,18 +44,11 @@ const makeCtx = (payload: Partial<ResponsesPayload>): ResponsesInvocation => ({
     fetcher: directFetcher,
   },
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   payload: { model: 'm', input: [], ...payload } as ResponsesPayload,
   headers: new Headers(),
   action: 'generate',
 });
-const gatewayCtx = (): GatewayCtx => ({
+const gatewayCtx = (): ChatGatewayCtx => ({
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: true,
@@ -64,6 +57,7 @@ const gatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 });
 
 beforeEach(() => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -1343,7 +1343,7 @@ export const webSearchServerTool: ServerToolRegistration = (invocation, gatewayC
   return {
     type: 'active',
     baseToolName: SHIM_TOOL_NAME,
-    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName, id => invocation.store.getPrivatePayload(id)),
+    transformItems: (items, toolName) => transformInputItemsForWebSearch(items, toolName, id => gatewayCtx.store.getPrivatePayload(id)),
     ...(hasHostedWebSearch
       ? {
           hosted: {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
@@ -5,8 +5,6 @@ import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult, ResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
 
-export type { ResponsesInvocation };
-
 // The chain runner produces an event stream for both actions — the attempt
 // post-processes it into a single `response.compaction` envelope when the
 // caller's intent action was 'compact'. `modelIdentity` and `usage` carry

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
@@ -1,22 +1,11 @@
 import type { TokenUsage } from '../../../../repo/types.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import type { StatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { Interceptor } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ExecuteResult, ResponsesInvocation as ProviderResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
+import type { ExecuteResult, ResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
 
-// App-side ResponsesInvocation extends the provider-package slim shape with
-// the per-request stateful store. Provider interceptors only see the slim
-// fields (parameter contravariance lets app-side richer instances flow in),
-// while api-internal interceptors that need stored-item lookups read `store`.
-// The `action` field on the provider shape is mutable through the chain;
-// mutations are one-way per the project's interceptor convention (no
-// interceptor restores fields it wrote). Whatever consumes the chain's
-// outputs post-run keeps its own captured copy of the caller's intent.
-export interface ResponsesInvocation extends ProviderResponsesInvocation {
-  readonly store: StatefulResponsesStore;
-}
+export type { ResponsesInvocation };
 
 // The chain runner produces an event stream for both actions — the attempt
 // post-processes it into a single `response.compaction` envelope when the
@@ -34,6 +23,6 @@ export type ResponsesAttemptResult =
 
 export type ResponsesInterceptor = Interceptor<
   ResponsesInvocation,
-  GatewayCtx,
+  ChatGatewayCtx,
   ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>
 >;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -1,12 +1,11 @@
 import { test } from 'vitest';
 
-import type { ResponsesInvocation } from './types.ts';
 import { withVendorDeepseekResponsesNormalize } from './vendor-deepseek-normalize.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -2,14 +2,14 @@ import { test } from 'vitest';
 
 import type { ResponsesInvocation } from './types.ts';
 import { withVendorDeepseekResponsesNormalize } from './vendor-deepseek-normalize.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -18,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () =>
@@ -34,13 +35,6 @@ const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string>
   payload,
   candidate: stubProviderCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
   action: 'generate',
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -1,12 +1,11 @@
 import { test } from 'vitest';
 
-import type { ResponsesInvocation } from './types.ts';
 import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -2,14 +2,14 @@ import { test } from 'vitest';
 
 import type { ResponsesInvocation } from './types.ts';
 import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
-import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import { MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from '../items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const stubCtx: GatewayCtx = {
+const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
   upstreamIds: null,
   wantsStream: false,
@@ -18,6 +18,7 @@ const stubCtx: GatewayCtx = {
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
 };
 
 const okEvents = () =>
@@ -34,13 +35,6 @@ const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string>
   payload,
   candidate: stubProviderCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
-  store: new LayeredStatefulResponsesStore({
-    apiKeyId: 'test-key',
-    reads: [new MemoryStatefulResponsesBacking()],
-    itemWrites: [],
-    snapshotWrites: [],
-    stageInputs: false,
-  }),
   headers: new Headers(),
   action: 'generate',
 });

--- a/packages/gateway/src/data-plane/chat/responses/routing.ts
+++ b/packages/gateway/src/data-plane/chat/responses/routing.ts
@@ -1,6 +1,6 @@
 import { classifyResponsesItemAffinity } from './items/affinity.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
-import type { StatefulResponsesStore } from './items/store.ts';
 import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
 import type { ProviderCandidate } from '@floway-dev/provider';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
@@ -8,7 +8,7 @@ import { responsesItemsView } from '@floway-dev/translate/via-responses/response
 export const planResponsesRouting = async (input: {
   readonly payload: ResponsesPayload;
   readonly candidates: readonly ProviderCandidate[];
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
 }): Promise<RoutingDecision> => {
   // A bare-string input is wrapped into a synthetic user message for staging;
   // the affinity walk receives an empty item array since strings carry no
@@ -22,7 +22,7 @@ export const planResponsesRouting = async (input: {
   return await classifyResponsesItemAffinity({
     sourceItems,
     view: responsesItemsView,
-    store: input.store,
+    store: input.ctx.store,
     candidates: input.candidates,
     inputItemsToStage,
   });

--- a/packages/gateway/src/data-plane/chat/responses/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/routing_test.ts
@@ -6,12 +6,25 @@ import { planResponsesRouting } from './routing.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../repo/types.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import type { ProviderCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_routing_test';
+
+const makeCtx = (): ChatGatewayCtx => ({
+  apiKeyId: API_KEY_ID,
+  upstreamIds: null,
+  wantsStream: false,
+  runtimeLocation: 'TEST',
+  currentColo: 'TEST',
+  dump: null,
+  backgroundScheduler: () => {},
+  requestStartedAt: 0,
+  store: createNonResponsesSourceStore(API_KEY_ID),
+});
 
 const candidateFor = (upstream: string): ProviderCandidate => {
   const modelProvider = stubProvider({
@@ -66,7 +79,7 @@ test('payload with no stored references passes candidates through unchanged', as
   const decision = await planResponsesRouting({
     payload: payload([{ type: 'message', role: 'user', content: 'hello' }]),
     candidates,
-    store: createNonResponsesSourceStore(API_KEY_ID),
+    ctx: makeCtx(),
   });
 
   assertEquals(decision.kind, 'success');
@@ -85,7 +98,7 @@ test('item_reference forcing an upstream absent from candidates fails routing', 
   const decision = await planResponsesRouting({
     payload: payload([{ type: 'item_reference', id }]),
     candidates: [candidateFor('up_b')],
-    store: createNonResponsesSourceStore(API_KEY_ID),
+    ctx: makeCtx(),
   });
 
   assertEquals(decision.kind, 'failure');

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -4,7 +4,7 @@ import type { StatefulResponsesStore } from './items/store.ts';
 import { planResponsesRouting } from './routing.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ProviderCandidate, ExecuteResult } from '@floway-dev/provider';
@@ -84,10 +84,10 @@ export type ResponsesServePlan =
 // directly without re-deriving the model-error branch.
 export const prepareResponsesServePlan = async (args: {
   readonly payload: ResponsesPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
 }): Promise<ResponsesServePlan> => {
-  const { payload, ctx, store } = args;
+  const { payload, ctx } = args;
+  const { store } = ctx;
   const prepared = await expandPreviousResponseId(payload, store);
   const { candidates: enumerated, sawModel, failedUpstreams } = await enumerateModelCandidates({
     upstreamIds: ctx.upstreamIds,
@@ -97,7 +97,7 @@ export const prepareResponsesServePlan = async (args: {
     currentColo: ctx.currentColo,
   });
   const viable = enumerated.filter(c => responsesTarget.canServe(c.model.endpoints));
-  const decision = await planResponsesRouting({ payload: prepared, candidates: viable, store });
+  const decision = await planResponsesRouting({ payload: prepared, candidates: viable, ctx });
   if (decision.kind === 'failure') return { kind: 'failure', result: renderResponsesFailure(decision.failure) };
   // Stage the user-supplied input from the original payload — not the
   // expansion's `item_reference` prefix — so the next-turn snapshot picks

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,36 +1,33 @@
 import { responsesAttempt } from './attempt.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
-import type { StatefulResponsesStore } from './items/store.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 
 export interface ResponsesServeGenerateArgs {
   readonly payload: ResponsesPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly headers: Headers;
 }
 
 export interface ResponsesServeCompactArgs {
   readonly payload: ResponsesPayload;
-  readonly ctx: GatewayCtx;
-  readonly store: StatefulResponsesStore;
+  readonly ctx: ChatGatewayCtx;
   readonly headers: Headers;
 }
 
 export const responsesServe = {
   generate: async (args: ResponsesServeGenerateArgs): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
-    const { payload, ctx, store, headers } = args;
-    const plan = await prepareResponsesServePlan({ payload, ctx, store });
+    const { payload, ctx, headers } = args;
+    const plan = await prepareResponsesServePlan({ payload, ctx });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.generate({ payload: plan.prepared, ctx, store, candidate: plan.candidate, headers });
+    return await responsesAttempt.generate({ payload: plan.prepared, ctx, candidate: plan.candidate, headers });
   },
 
   compact: async (args: ResponsesServeCompactArgs): Promise<ResponsesAttemptResult> => {
-    const { payload, ctx, store, headers } = args;
+    const { payload, ctx, headers } = args;
     // Compact accepts `previous_response_id` (the official endpoint documents
     // it). When present serve-prep expands it the same way generate does so
     // the upstream sees the same item_reference + current input shape.
@@ -39,8 +36,8 @@ export const responsesServe = {
     // request inside the interceptor chain, flips action='compact' to
     // 'generate', runs a SUMMARIZATION_PROMPT turn through translation, and
     // re-tags the result as compact on the way out.
-    const plan = await prepareResponsesServePlan({ payload, ctx, store });
+    const plan = await prepareResponsesServePlan({ payload, ctx });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, store, candidate: plan.candidate, headers });
+    return await responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate: plan.candidate, headers });
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -5,7 +5,7 @@ import { createResponsesHttpStore, MemoryStatefulResponsesBacking, LayeredStatef
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { StoredResponsesItem, StoredResponsesSnapshot } from '../../../repo/types.ts';
-import type { GatewayCtx } from '../shared/gateway-ctx.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -50,7 +50,7 @@ const installRepo = (): InMemoryRepo => {
   return repo;
 };
 
-const makeGatewayCtx = (): GatewayCtx => ({
+const makeGatewayCtx = (store?: ChatGatewayCtx['store']): ChatGatewayCtx => ({
   apiKeyId: API_KEY_ID,
   upstreamIds: null,
   wantsStream: true,
@@ -59,6 +59,7 @@ const makeGatewayCtx = (): GatewayCtx => ({
   dump: null,
   backgroundScheduler: () => {},
   requestStartedAt: 0,
+  store: store ?? createResponsesHttpStore(API_KEY_ID, true),
 });
 
 const makePayload = (overrides: Partial<ResponsesPayload> = {}): ResponsesPayload => ({
@@ -153,7 +154,6 @@ test('generate routes a native Responses candidate end to end', async () => {
   const result = await responsesServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -182,7 +182,6 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
   const result = await responsesServe.compact({
     payload: compactPayload(),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -216,7 +215,6 @@ test('generate stops at the first candidate even when it yields an upstream erro
   const result = await responsesServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -235,7 +233,6 @@ test('generate renders model-missing when no candidates are available', async ()
   const result = await responsesServe.generate({
     payload: makePayload({ model: 'unknown-model' }),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -257,7 +254,6 @@ test('generate filters out candidates whose endpoints do not satisfy the respons
   const result = await responsesServe.generate({
     payload: makePayload({ model: 'wrong-endpoint-model' }),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -293,7 +289,6 @@ test('generate renders routing-unavailable as a 400 when a forcing item names an
   const result = await responsesServe.generate({
     payload: makePayload({ input: [{ type: 'item_reference', id }] }),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -326,7 +321,6 @@ test('compact renders routing-unavailable when no candidate exposes the response
   const result = await responsesServe.compact({
     payload: makePayload({ input: [{ type: 'item_reference', id }] }),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -344,7 +338,6 @@ test('compact renders model-missing as a 404 when no candidates are available', 
   const result = await responsesServe.compact({
     payload: compactPayload({ model: 'unknown-model' }),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -366,7 +359,6 @@ test('compact renders model-unsupported as a 400 when the only candidate\'s endp
   const result = await responsesServe.compact({
     payload: compactPayload({ model: 'wrong-endpoint-model' }),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -505,7 +497,6 @@ test('generate falls through translate-out to messages target', async () => {
   const result = await responsesServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -546,7 +537,6 @@ test('generate falls through translate-out to chat-completions target', async ()
   const result = await responsesServe.generate({
     payload: makePayload(),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 
@@ -576,12 +566,12 @@ test('generate reuses an existing input row when a later turn echoes the same us
   const payload = makePayload({ input: [{ type: 'message', role: 'user', content: 'hello' }] });
 
   queueCandidates([makeCandidate({ callResponses })]);
-  const turn1 = await responsesServe.generate({ payload, ctx: makeGatewayCtx(), store, headers: new Headers() });
+  const turn1 = await responsesServe.generate({ payload, ctx: makeGatewayCtx(store), headers: new Headers() });
   if (turn1.type !== 'events') throw new Error('turn 1: expected events');
   const turn1Events = await collectEvents(turn1.events);
 
   queueCandidates([makeCandidate({ callResponses })]);
-  const turn2 = await responsesServe.generate({ payload, ctx: makeGatewayCtx(), store, headers: new Headers() });
+  const turn2 = await responsesServe.generate({ payload, ctx: makeGatewayCtx(store), headers: new Headers() });
   if (turn2.type !== 'events') throw new Error('turn 2: expected events');
   const turn2Events = await collectEvents(turn2.events);
 
@@ -656,7 +646,6 @@ test('generate treats compaction_trigger-bearing input as compaction: snapshot r
       input: [{ type: 'compaction_trigger' }],
     }),
     ctx: makeGatewayCtx(),
-    store: createResponsesHttpStore(API_KEY_ID, true),
     headers: new Headers(),
   });
 

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -6,7 +6,7 @@ import { responsesServe } from './serve.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
 import { apiKeyFromContext, type AuthedContext } from '../../../middleware/auth.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
-import { createGatewayCtxFromHono, type GatewayCtx } from '../shared/gateway-ctx.ts';
+import { createChatGatewayCtxFromHono, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { SourceStreamState, eventResultMetadata, recordPerformance, recordUsage } from '../shared/respond.ts';
 import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS, type StreamCompletion } from '../shared/stream/sse.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
@@ -132,7 +132,7 @@ const handleClientMessage = async (
 ): Promise<void> => {
   const signal = downstreamAbortController.signal;
   let eventId: string | undefined;
-  let ctx: GatewayCtx | undefined;
+  let ctx: ChatGatewayCtx | undefined;
   try {
     // Capture raw frame bytes up front so they're available as the dump's
     // request body when `ctx` is constructed below. Payloads that fail to
@@ -162,7 +162,7 @@ const handleClientMessage = async (
       ? message.response
       : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
     const payload = responsesPayloadFromClientSource(source);
-    ctx = createGatewayCtxFromHono(c, {
+    ctx = createChatGatewayCtxFromHono(c, {
       wantsStream: true,
       downstreamAbortController,
       // The WS upgrade has no HTTP body; the dump's request body is the
@@ -171,12 +171,11 @@ const handleClientMessage = async (
       requestBody: { bytes: requestBytes, streamError: null },
       method: 'WS',
       model: payload.model,
-    });
-    const store = session.createStore(payload.store ?? undefined);
+    }, () => session.createStore(payload.store ?? undefined));
 
     let result;
     try {
-      result = await responsesServe.generate({ payload, ctx, store, headers: inboundHeadersForUpstream(c) });
+      result = await responsesServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
     } catch (error) {
       if (signal.aborted || isClosed()) return;
       // The HTTP entry renders this verbatim envelope as a 400; WS surfaces the

--- a/packages/gateway/src/data-plane/chat/shared/gateway-ctx.ts
+++ b/packages/gateway/src/data-plane/chat/shared/gateway-ctx.ts
@@ -3,6 +3,7 @@ import { type DumpAccumulator, openDumpAccumulator } from '../../../dump/accumul
 import { apiKeyFromContext, type AuthedContext, effectiveUpstreamIdsFromContext } from '../../../middleware/auth.ts';
 import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { getCurrentColo } from '../../../runtime/runtime-info.ts';
+import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 
 export interface GatewayCtx {
@@ -25,6 +26,15 @@ export interface GatewayCtx {
   // respond layer's `ctx.dump?.X(...)` calls collapse to no-ops and
   // `ctx.dump?.finalize(response) ?? response` returns the response unchanged.
   readonly dump: DumpAccumulator | null;
+}
+
+// Chat-protocol ctx — `GatewayCtx` plus the request-scoped stored-items
+// store. Every chat HTTP/WS entry constructs this via
+// `createChatGatewayCtxFromHono` and threads it through serve → narrow →
+// attempt. Passthrough endpoints (embeddings / images / completions) have
+// no stored-items concept and stay on plain `GatewayCtx`.
+export interface ChatGatewayCtx extends GatewayCtx {
+  readonly store: StatefulResponsesStore;
 }
 
 export interface CreateGatewayCtxOptions {
@@ -71,4 +81,18 @@ export const createGatewayCtxFromHono = (c: AuthedContext, opts: CreateGatewayCt
     currentColo: colo,
     dump,
   };
+};
+
+// Chat-protocol counterpart of `createGatewayCtxFromHono`. Calls the base
+// factory, then attaches the stored-items store the caller chose for this
+// protocol (messages / gemini / chat-completions use
+// `createNonResponsesSourceStore`; responses HTTP/WS use
+// `createResponsesHttpStore(_, payload.store)`).
+export const createChatGatewayCtxFromHono = (
+  c: AuthedContext,
+  opts: CreateGatewayCtxOptions,
+  storeFactory: (apiKeyId: string) => StatefulResponsesStore,
+): ChatGatewayCtx => {
+  const base = createGatewayCtxFromHono(c, opts);
+  return { ...base, store: storeFactory(base.apiKeyId) };
 };

--- a/packages/gateway/src/data-plane/chat/shared/respond_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/respond_test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, test } from 'vitest';
 
-import type { ChatGatewayCtx } from './gateway-ctx.ts';
+import type { GatewayCtx } from './gateway-ctx.ts';
 import { SourceStreamState, recordPerformance, recordUsage } from './respond.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
-import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { PerformanceTelemetryContext, TelemetryModelIdentity } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 
@@ -27,7 +26,7 @@ const testPerformanceContext: PerformanceTelemetryContext = {
 interface Harness {
   repo: InMemoryRepo;
   background: Promise<unknown>[];
-  ctx: (overrides?: { apiKeyId?: string; requestStartedAt?: number }) => ChatGatewayCtx;
+  ctx: (overrides?: { apiKeyId?: string; requestStartedAt?: number }) => GatewayCtx;
 }
 
 const setup = (): Harness => {
@@ -44,9 +43,8 @@ const setup = (): Harness => {
       runtimeLocation: 'TEST',
       currentColo: 'TEST',
       dump: null,
-      backgroundScheduler: (promise: Promise<unknown>) => { background.push(promise); },
+      backgroundScheduler: promise => { background.push(promise); },
       requestStartedAt,
-      store: createNonResponsesSourceStore(apiKeyId),
     }),
   };
 };

--- a/packages/gateway/src/data-plane/chat/shared/respond_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/respond_test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, test } from 'vitest';
 
-import type { GatewayCtx } from './gateway-ctx.ts';
+import type { ChatGatewayCtx } from './gateway-ctx.ts';
 import { SourceStreamState, recordPerformance, recordUsage } from './respond.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { PerformanceTelemetryContext, TelemetryModelIdentity } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 
@@ -26,7 +27,7 @@ const testPerformanceContext: PerformanceTelemetryContext = {
 interface Harness {
   repo: InMemoryRepo;
   background: Promise<unknown>[];
-  ctx: (overrides?: { apiKeyId?: string; requestStartedAt?: number }) => GatewayCtx;
+  ctx: (overrides?: { apiKeyId?: string; requestStartedAt?: number }) => ChatGatewayCtx;
 }
 
 const setup = (): Harness => {
@@ -43,8 +44,9 @@ const setup = (): Harness => {
       runtimeLocation: 'TEST',
       currentColo: 'TEST',
       dump: null,
-      backgroundScheduler: promise => { background.push(promise); },
+      backgroundScheduler: (promise: Promise<unknown>) => { background.push(promise); },
       requestStartedAt,
+      store: createNonResponsesSourceStore(apiKeyId),
     }),
   };
 };

--- a/packages/gateway/src/data-plane/chat/shared/upstream-telemetry_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/upstream-telemetry_test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, test } from 'vitest';
 
-import type { ChatGatewayCtx } from './gateway-ctx.ts';
+import type { GatewayCtx } from './gateway-ctx.ts';
 import { withUpstreamTelemetry } from './upstream-telemetry.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
-import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { PerformanceTelemetryContext } from '@floway-dev/provider';
@@ -19,7 +18,7 @@ const CONTEXT: PerformanceTelemetryContext = {
   runtimeLocation: 'TEST',
 };
 
-const baseCtx = (overrides: Partial<ChatGatewayCtx> = {}): ChatGatewayCtx => {
+const baseCtx = (overrides: Partial<GatewayCtx> = {}): GatewayCtx => {
   const downstream = new AbortController();
   return {
     apiKeyId: 'key_1',
@@ -31,8 +30,7 @@ const baseCtx = (overrides: Partial<ChatGatewayCtx> = {}): ChatGatewayCtx => {
     dump: null,
     abortSignal: downstream.signal,
     downstreamAbortController: downstream,
-    backgroundScheduler: (promise: Promise<unknown>) => { void promise; },
-    store: createNonResponsesSourceStore('key_1'),
+    backgroundScheduler: promise => { void promise; },
     ...overrides,
   };
 };

--- a/packages/gateway/src/data-plane/chat/shared/upstream-telemetry_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/upstream-telemetry_test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, test } from 'vitest';
 
-import type { GatewayCtx } from './gateway-ctx.ts';
+import type { ChatGatewayCtx } from './gateway-ctx.ts';
 import { withUpstreamTelemetry } from './upstream-telemetry.ts';
 import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
+import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { PerformanceTelemetryContext } from '@floway-dev/provider';
@@ -18,7 +19,7 @@ const CONTEXT: PerformanceTelemetryContext = {
   runtimeLocation: 'TEST',
 };
 
-const baseCtx = (overrides: Partial<GatewayCtx> = {}): GatewayCtx => {
+const baseCtx = (overrides: Partial<ChatGatewayCtx> = {}): ChatGatewayCtx => {
   const downstream = new AbortController();
   return {
     apiKeyId: 'key_1',
@@ -30,7 +31,8 @@ const baseCtx = (overrides: Partial<GatewayCtx> = {}): GatewayCtx => {
     dump: null,
     abortSignal: downstream.signal,
     downstreamAbortController: downstream,
-    backgroundScheduler: promise => { void promise; },
+    backgroundScheduler: (promise: Promise<unknown>) => { void promise; },
+    store: createNonResponsesSourceStore('key_1'),
     ...overrides,
   };
 };


### PR DESCRIPTION
Introduce `ChatGatewayCtx extends GatewayCtx { store: StatefulResponsesStore }` — a chat-flavored ctx variant that carries the per-request stateful-responses store as a first-class field. Every chat HTTP/WS entry constructs it via `createChatGatewayCtxFromHono(c, opts, storeFactory)`, where the factory is the entry's protocol-specific store choice:

- messages / gemini / chat-completions: `createNonResponsesSourceStore`
- responses HTTP: `createResponsesHttpStore(_, payload.store ?? undefined)`
- responses WebSocket session: `session.createStore(payload.store ?? undefined)`

The per-request `store` parameter drops from every chat `serve` / `attempt` args object, and the `ResponsesInterceptor` Ctx parameter widens to `ChatGatewayCtx`. Interceptors and dispatch that previously read a plumbed-through `store` now read `gatewayCtx.store` — covering the compact-shim, the server-tool-shim, and the web-search server tool's `getPrivatePayload` closure. `ServerToolRegistration` receives `(invocation, gatewayCtx: ChatGatewayCtx)` so registrations reach the store through ctx.

`ResponsesInvocation` stays the provider-package slim shape. `interceptors/types.ts` no longer wraps or re-exports it; callers import it directly from `@floway-dev/provider`. The local `./types.ts` continues to own the app-side `ResponsesInterceptor` and `ResponsesAttemptResult` types.

Passthrough endpoints (embeddings / images / completions) stay on plain `GatewayCtx` — they have no stored-items concept. The shared-scoped chat helpers (`recordUsage`, `recordPerformance`, `withUpstreamTelemetry`) likewise keep `GatewayCtx` since they never touch `store`.

`image-generation.ts` references `BackgroundScheduler` from `@floway-dev/platform` directly for its shim state's scheduler field rather than narrowing via a ctx-indexed type — the scheduler is a runtime primitive, not a ctx-shape concern.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`