### PR TITLE
refactor(provider): rename provider-domain concepts to clarify the (Provider, ModelCandidate) shape

### DIFF
--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -55,7 +55,7 @@ Catalog assembly returns two artefacts together:
 - `models: InternalModel[]` — public-id-keyed metadata (id, kind, limits,
   cost, plus the merged `endpoints`). `toPublicModel` projects each row
   onto the wire DTO at `/v1/models` and `/models`.
-- `upstreamsByPublicId: Map<string, ModelProviderInstance[]>` — every
+- `upstreamsByPublicId: Map<string, Provider[]>` — every
   upstream instance that emitted an entry under the given public id, in
   enumeration order. The control-plane catalog endpoint reads this to
   render per-model upstream chips without re-walking the catalog.
@@ -157,7 +157,7 @@ lookups against the same SWR-cached catalog fetch:
 For each branch that found a match:
 
 - If the catalog match's `kind === inboundKind`, push a
-  `ProviderCandidate { provider, model, fetcher }` into the result.
+  `ModelCandidate { provider, model, fetcher }` into the result.
 - If the match exists but `kind !== inboundKind`, set `sawAnyId = true`
   but do not push.
 
@@ -199,8 +199,8 @@ and `providerData`), and the dispatch layer reads from there.
 ## Candidate Shape
 
 ```ts
-interface ProviderCandidate {
-  readonly provider: ModelProviderInstance;
+interface ModelCandidate {
+  readonly provider: Provider;
   readonly model: UpstreamModel;
   readonly fetcher: Fetcher;
 }

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -281,17 +281,17 @@ interface UpstreamRecordBase {
   };
 }
 
-// Provider-keyed discriminated union: each variant pins `provider` and the
-// matching `config` / `state` shape, so `switch (record.provider)` narrows
+// Kind-keyed discriminated union: each variant pins `kind` and the
+// matching `config` / `state` shape, so `switch (record.kind)` narrows
 // both fields without an `as` cast. Codex's `codex_quota` field rides on the
 // codex variant only.
 export type UpstreamRecord =
-  | (UpstreamRecordBase & { provider: 'custom'; config: CustomUpstreamConfig; state: null })
-  | (UpstreamRecordBase & { provider: 'azure'; config: AzureUpstreamConfig; state: null })
-  | (UpstreamRecordBase & { provider: 'copilot'; config: CopilotUpstreamConfig; state: CopilotUpstreamState | null })
-  | (UpstreamRecordBase & { provider: 'codex'; config: CodexUpstreamConfig; state: CodexUpstreamState | null; codex_quota?: CodexQuotaSnapshot | null })
-  | (UpstreamRecordBase & { provider: 'claude-code'; config: ClaudeCodeUpstreamConfig; state: ClaudeCodeUpstreamState | null })
-  | (UpstreamRecordBase & { provider: 'ollama'; config: OllamaUpstreamConfig; state: null });
+  | (UpstreamRecordBase & { kind: 'custom'; config: CustomUpstreamConfig; state: null })
+  | (UpstreamRecordBase & { kind: 'azure'; config: AzureUpstreamConfig; state: null })
+  | (UpstreamRecordBase & { kind: 'copilot'; config: CopilotUpstreamConfig; state: CopilotUpstreamState | null })
+  | (UpstreamRecordBase & { kind: 'codex'; config: CodexUpstreamConfig; state: CodexUpstreamState | null; codex_quota?: CodexQuotaSnapshot | null })
+  | (UpstreamRecordBase & { kind: 'claude-code'; config: ClaudeCodeUpstreamConfig; state: ClaudeCodeUpstreamState | null })
+  | (UpstreamRecordBase & { kind: 'ollama'; config: OllamaUpstreamConfig; state: null });
 
 export interface FlagDef {
   id: string;

--- a/apps/web/src/components/settings/UpstreamRow.vue
+++ b/apps/web/src/components/settings/UpstreamRow.vue
@@ -26,7 +26,7 @@ const modelSummary = computed(() => `${props.modelCount} model${props.modelCount
 
 const subtitle = computed(() => {
   const u = props.upstream;
-  switch (u.provider) {
+  switch (u.kind) {
   case 'azure': return u.config.endpoint;
   case 'custom': return u.config.baseUrl;
   case 'copilot': {
@@ -60,8 +60,8 @@ const subtitle = computed(() => {
         <div class="mb-1.5 flex min-w-0 flex-wrap items-center gap-2">
           <span
             class="rounded border px-2 py-0.5 text-xs font-semibold uppercase tracking-wide"
-            :class="providerBadgeClass(upstream.provider)"
-          >{{ providerMeta(upstream.provider).label }}</span>
+            :class="providerBadgeClass(upstream.kind)"
+          >{{ providerMeta(upstream.kind).label }}</span>
           <span class="rounded bg-surface-900/70 px-2 py-0.5 text-[11px] font-medium text-gray-400">{{ modelSummary }}</span>
         </div>
         <p class="truncate text-sm font-semibold text-white">{{ upstream.name }}</p>

--- a/apps/web/src/components/settings/UpstreamsSettingsCard.vue
+++ b/apps/web/src/components/settings/UpstreamsSettingsCard.vue
@@ -29,7 +29,7 @@ const api = useApi();
 // the other providers count public models that are served by this upstream
 // row.
 const modelCountFor = (record: UpstreamRecord): number => {
-  if (record.provider === 'azure') return record.config.models.length;
+  if (record.kind === 'azure') return record.config.models.length;
   const list = props.models ?? [];
   return list.filter(m => m.upstreams.some(b => b.id === record.id)).length;
 };

--- a/apps/web/src/components/upstream-edit/ClaudeCodeAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/ClaudeCodeAccountCard.vue
@@ -20,7 +20,7 @@ import { formatClaudeCodeSubscriptionType } from '../../lib/claude-code-format.t
 import { providerSwatchClass } from '../upstreams/provider-meta.ts';
 import { Badge, Button, Spinner } from '@floway-dev/ui';
 
-type ClaudeCodeUpstreamRecord = Extract<UpstreamRecord, { provider: 'claude-code' }>;
+type ClaudeCodeUpstreamRecord = Extract<UpstreamRecord, { kind: 'claude-code' }>;
 
 const props = defineProps<{
   record: ClaudeCodeUpstreamRecord;

--- a/apps/web/src/components/upstream-edit/ClaudeCodeConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/ClaudeCodeConfigPanel.vue
@@ -9,7 +9,7 @@ import type { ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 import { clearPkce, deriveChallenge, generatePkce, parseCallbackPaste, peekStashedPkce, pkceStorageKey, recallPkce, stashPkce } from '../../lib/pkce.ts';
 import { Button, Spinner } from '@floway-dev/ui';
 
-type ClaudeCodeUpstreamRecord = Extract<UpstreamRecord, { provider: 'claude-code' }>;
+type ClaudeCodeUpstreamRecord = Extract<UpstreamRecord, { kind: 'claude-code' }>;
 
 const props = defineProps<
   | {

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -16,8 +16,8 @@ const props = defineProps<{
 // Pinning the narrow at the script-setup boundary lets every computed below
 // reach `config` / `state` / `codex_quota` without `as` casts.
 const codexRecord = computed(() => {
-  if (props.record.provider !== 'codex') {
-    throw new Error(`CodexAccountCard requires a codex upstream, got ${props.record.provider}`);
+  if (props.record.kind !== 'codex') {
+    throw new Error(`CodexAccountCard requires a codex upstream, got ${props.record.kind}`);
   }
   return props.record;
 });

--- a/apps/web/src/components/upstream-edit/CodexConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CodexConfigPanel.vue
@@ -9,7 +9,7 @@ import type { ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 import { clearPkce, deriveChallenge, generatePkce, parseCallbackPaste, peekStashedPkce, pkceStorageKey, recallPkce, stashPkce } from '../../lib/pkce.ts';
 import { Button, Spinner } from '@floway-dev/ui';
 
-type CodexUpstreamRecord = Extract<UpstreamRecord, { provider: 'codex' }>;
+type CodexUpstreamRecord = Extract<UpstreamRecord, { kind: 'codex' }>;
 
 const props = defineProps<
   | {

--- a/apps/web/src/components/upstream-edit/CopilotConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CopilotConfigPanel.vue
@@ -4,7 +4,7 @@ import CopilotDeviceFlow from './CopilotDeviceFlow.vue';
 import CopilotInfo from './CopilotInfo.vue';
 import type { CopilotQuotaSnapshot, ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 
-type CopilotUpstreamRecord = Extract<UpstreamRecord, { provider: 'copilot' }>;
+type CopilotUpstreamRecord = Extract<UpstreamRecord, { kind: 'copilot' }>;
 
 defineProps<
   | {

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -14,7 +14,7 @@ const overrides = defineModel<Record<string, boolean>>({ required: true });
 
 const props = withDefaults(defineProps<{
   flags: FlagDef[];
-  providerKind: UpstreamProviderKind;
+  kind: UpstreamProviderKind;
   inheritedOverrides?: Record<string, boolean>;
   namePrefix?: string;
   class?: HTMLAttributes['class'];
@@ -40,7 +40,7 @@ const setState = (flagId: string, next: TriState) => {
 const inheritedLabel = (flag: FlagDef): 'on' | 'off' => {
   const inherited = props.inheritedOverrides[flag.id];
   if (typeof inherited === 'boolean') return inherited ? 'on' : 'off';
-  return flag.defaultFor.includes(props.providerKind) ? 'on' : 'off';
+  return flag.defaultFor.includes(props.kind) ? 'on' : 'off';
 };
 
 const stateLabel = (state: TriState, flag: FlagDef) => {

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -943,7 +943,7 @@ const toggleMandatory = (on: boolean) => {
             v-if="editable && config.flagOverrides?.enabled"
             :model-value="config.flagOverrides?.values ?? {}"
             :flags="flags"
-            :provider-kind="flagProviderKind"
+            :kind="flagProviderKind"
             :inherited-overrides="upstreamFlagOverrides"
             :name-prefix="`${row.uiId}-flag`"
             class="max-h-72"

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -27,7 +27,7 @@ const proxyFallbackList = defineModel<ProxyFallbackEntry[]>('proxyFallbackList',
 const modelPrefix = defineModel<ModelPrefixConfig | null>('modelPrefix', { required: true });
 
 type CommonConfigPanelProps = {
-  provider: UpstreamProviderKind;
+  kind: UpstreamProviderKind;
   flags: FlagDef[];
   customApiKeySet: boolean;
   azureApiKeySet: boolean;
@@ -113,7 +113,7 @@ const measureFloor = () => {
   if (header) h += header.getBoundingClientRect().height;
   intrinsicFloorPx.value = h;
 };
-watch([contentRef, flagSectionRef, headerRef, () => props.provider], () => {
+watch([contentRef, flagSectionRef, headerRef, () => props.kind], () => {
   floorObserver?.disconnect();
   const content = contentRef.value;
   if (!content) return;
@@ -135,8 +135,8 @@ onBeforeUnmount(() => floorObserver?.disconnect());
     <header ref="headerRef" class="flex shrink-0 items-center gap-3 border-b border-white/[0.06] px-5 py-4">
       <span
         class="rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider"
-        :class="providerBadgeClass(provider)"
-      >{{ providerMeta(provider).label }}</span>
+        :class="providerBadgeClass(kind)"
+      >{{ providerMeta(kind).label }}</span>
       <h2 class="min-w-0 truncate text-sm font-semibold text-white">
         {{ name || (mode === 'create' ? 'New upstream' : 'Upstream') }}
       </h2>
@@ -145,7 +145,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
 
     <div ref="contentRef" class="flex min-h-0 flex-1 flex-col gap-6 px-5 py-5">
 
-      <section v-if="!(mode === 'create' && (provider === 'copilot' || provider === 'codex' || provider === 'claude-code'))" class="shrink-0">
+      <section v-if="!(mode === 'create' && (kind === 'copilot' || kind === 'codex' || kind === 'claude-code'))" class="shrink-0">
         <label class="mb-1.5 block text-xs font-medium text-gray-500">Name</label>
         <Input v-model="name" placeholder="e.g. OpenAI Production" />
       </section>
@@ -164,7 +164,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         class="shrink-0"
       />
 
-      <section v-if="provider === 'custom'" class="shrink-0">
+      <section v-if="kind === 'custom'" class="shrink-0">
         <CustomConfigPanel
           v-model="customDraft"
           :api-key-set="customApiKeySet"
@@ -176,7 +176,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         />
       </section>
 
-      <section v-else-if="provider === 'azure'" class="shrink-0">
+      <section v-else-if="kind === 'azure'" class="shrink-0">
         <AzureConfigPanel
           v-model="azureDraft"
           :api-key-set="azureApiKeySet"
@@ -184,7 +184,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         />
       </section>
 
-      <section v-else-if="provider === 'ollama'" class="shrink-0">
+      <section v-else-if="kind === 'ollama'" class="shrink-0">
         <OllamaConfigPanel
           v-model="ollamaDraft"
           :api-key-set="ollamaApiKeySet"
@@ -196,7 +196,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         />
       </section>
 
-      <section v-else-if="provider === 'copilot' && copilotPanel" class="shrink-0">
+      <section v-else-if="kind === 'copilot' && copilotPanel" class="shrink-0">
         <CopilotConfigPanel
           v-bind="copilotPanel"
           :initial-quota="initialCopilotQuota"
@@ -206,7 +206,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         />
       </section>
 
-      <section v-else-if="provider === 'codex' && codexPanel" class="shrink-0">
+      <section v-else-if="kind === 'codex' && codexPanel" class="shrink-0">
         <CodexConfigPanel
           v-bind="codexPanel"
           :proxy-fallback-list="proxyFallbackList"
@@ -215,7 +215,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         />
       </section>
 
-      <section v-else-if="provider === 'claude-code' && claudeCodePanel" class="shrink-0">
+      <section v-else-if="kind === 'claude-code' && claudeCodePanel" class="shrink-0">
         <ClaudeCodeConfigPanel
           v-bind="claudeCodePanel"
           :proxy-fallback-list="proxyFallbackList"
@@ -264,7 +264,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         <FlagOverridesEditor
           v-model="flagOverrides"
           :flags="flags"
-          :provider-kind="provider"
+          :kind="kind"
           name-prefix="upstream-flag"
           class="min-h-0 flex-1"
         />

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -63,25 +63,25 @@ defineEmits<{
 
 // Per-provider narrowed views of (mode, record) so each child panel receives
 // the matching discriminated variant without inline casts. Edit mode and a
-// record-of-the-wrong-provider both yield null — the per-provider section is
-// already gated on `provider === '<kind>'` in the template, so this only
+// record-of-the-wrong-kind both yield null — the per-provider section is
+// already gated on `kind === '<kind>'` in the template, so this only
 // happens during the brief window when a sibling section is mounting.
-type CodexRecord = Extract<UpstreamRecord, { provider: 'codex' }>;
-type ClaudeCodeRecord = Extract<UpstreamRecord, { provider: 'claude-code' }>;
-type CopilotRecord = Extract<UpstreamRecord, { provider: 'copilot' }>;
+type CodexRecord = Extract<UpstreamRecord, { kind: 'codex' }>;
+type ClaudeCodeRecord = Extract<UpstreamRecord, { kind: 'claude-code' }>;
+type CopilotRecord = Extract<UpstreamRecord, { kind: 'copilot' }>;
 type PanelMode<R> = { mode: 'create'; record: null } | { mode: 'edit'; record: R };
 
 const codexPanel = computed<PanelMode<CodexRecord> | null>(() => {
   if (props.mode === 'create') return { mode: 'create', record: null };
-  return props.record.provider === 'codex' ? { mode: 'edit', record: props.record } : null;
+  return props.record.kind === 'codex' ? { mode: 'edit', record: props.record } : null;
 });
 const claudeCodePanel = computed<PanelMode<ClaudeCodeRecord> | null>(() => {
   if (props.mode === 'create') return { mode: 'create', record: null };
-  return props.record.provider === 'claude-code' ? { mode: 'edit', record: props.record } : null;
+  return props.record.kind === 'claude-code' ? { mode: 'edit', record: props.record } : null;
 });
 const copilotPanel = computed<PanelMode<CopilotRecord> | null>(() => {
   if (props.mode === 'create') return { mode: 'create', record: null };
-  return props.record.provider === 'copilot' ? { mode: 'edit', record: props.record } : null;
+  return props.record.kind === 'copilot' ? { mode: 'edit', record: props.record } : null;
 });
 
 // Intrinsic floor for the aside: smallest height at which every

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -69,7 +69,7 @@ type PatchBody = InferRequestType<(typeof api.api.upstreams)[':id']['$patch']>['
 
 // Edit mode: provider follows the record. Create mode: locked in by the
 // route param at mount time.
-const activeProvider = computed<UpstreamProviderKind>(() => props.mode === 'edit' ? props.record.provider : props.initialProvider);
+const activeProvider = computed<UpstreamProviderKind>(() => props.mode === 'edit' ? props.record.kind : props.initialProvider);
 
 // Discriminated (mode, record) pair forwarded to UpstreamConfigPanel. The
 // page's own union already guarantees this shape; the explicit pairing
@@ -120,7 +120,7 @@ const seedFromRecord = (r: UpstreamRecord) => {
         listed: [...r.model_prefix.listed],
       };
 
-  if (r.provider === 'custom') {
+  if (r.kind === 'custom') {
     const cfg = r.config;
     customDraft.value = {
       baseUrl: cfg.baseUrl,
@@ -137,14 +137,14 @@ const seedFromRecord = (r: UpstreamRecord) => {
       // deep, proxy-free copy that the field can mutate freely.
       models: cfg.models ? (JSON.parse(JSON.stringify(cfg.models)) as UpstreamModelConfig[]) : [],
     };
-  } else if (r.provider === 'azure') {
+  } else if (r.kind === 'azure') {
     const cfg = r.config;
     azureDraft.value = {
       endpoint: cfg.endpoint,
       apiKey: '',
       models: cfg.models ? (JSON.parse(JSON.stringify(cfg.models)) as UpstreamModelConfig[]) : [],
     };
-  } else if (r.provider === 'ollama') {
+  } else if (r.kind === 'ollama') {
     const cfg = r.config;
     ollamaDraft.value = {
       baseUrl: cfg.baseUrl,
@@ -171,11 +171,11 @@ if (props.mode === 'edit') seedFromRecord(props.record);
 else seedFresh();
 
 const customApiKeySet = computed(() => {
-  if (props.record?.provider !== 'custom') return false;
+  if (props.record?.kind !== 'custom') return false;
   return props.record.config.apiKeySet === true;
 });
 const azureApiKeySet = computed(() => {
-  if (props.record?.provider !== 'azure') return false;
+  if (props.record?.kind !== 'azure') return false;
   return props.record.config.apiKeySet === true;
 });
 const ollamaApiKeySet = computed(() => {
@@ -231,7 +231,7 @@ const fetchDraftModels = async () => {
     if (activeProvider.value === 'custom') {
       const { data, error } = await callApi<{ data: CustomRawModel[] }>(
         () => api.api.upstreams['fetch-models'].$post({
-          json: { provider: 'custom', config: { ...buildCustomConfigCore(customDraft.value), models: customDraft.value.models } },
+          json: { kind: 'custom', config: { ...buildCustomConfigCore(customDraft.value), models: customDraft.value.models } },
         }),
       );
       // The toggle may have been turned off while this request was in flight;
@@ -244,14 +244,14 @@ const fetchDraftModels = async () => {
       fetchedAtMs.value = Date.now();
     } else if (activeProvider.value === 'ollama') {
       type FetchModelsBody = InferRequestType<typeof api.api.upstreams['fetch-models']['$post']>['json'];
-      type OllamaFetchConfig = Extract<FetchModelsBody, { provider: 'ollama' }>['config'];
+      type OllamaFetchConfig = Extract<FetchModelsBody, { kind: 'ollama' }>['config'];
       const config: OllamaFetchConfig = {
         baseUrl: ollamaDraft.value.baseUrl.trim(),
         models: ollamaDraft.value.models,
       };
       if (ollamaDraft.value.apiKey.trim()) config.apiKey = ollamaDraft.value.apiKey.trim();
       const { data, error } = await callApi<{ data: UpstreamModelConfig[] }>(
-        () => api.api.upstreams['fetch-models'].$post({ json: { provider: 'ollama', config } }),
+        () => api.api.upstreams['fetch-models'].$post({ json: { kind: 'ollama', config } }),
       );
       if (error) { fetchError.value = error.message; return; }
       fetchedOllamaModels.value = data.data;
@@ -283,7 +283,7 @@ const fetchStatus = computed<string | null>(() => {
 
 const refreshing = ref(false);
 const refreshCachedModels = async () => {
-  if (!props.record || props.record.provider === 'azure') return;
+  if (!props.record || props.record.kind === 'azure') return;
   refreshing.value = true;
   upstreamModelsError.value = null;
   try {
@@ -315,8 +315,8 @@ const saving = ref(false);
 const saveError = ref<string | null>(null);
 const modelsPanelInvalid = ref(false);
 
-const buildCustomConfig = (): Extract<CreateBody, { provider: 'custom' }>['config'] => {
-  const config: Extract<CreateBody, { provider: 'custom' }>['config'] = {
+const buildCustomConfig = (): Extract<CreateBody, { kind: 'custom' }>['config'] => {
+  const config: Extract<CreateBody, { kind: 'custom' }>['config'] = {
     ...buildCustomConfigCore(customDraft.value),
     models: customDraft.value.models,
   };
@@ -330,8 +330,8 @@ const buildCustomConfig = (): Extract<CreateBody, { provider: 'custom' }>['confi
   return config;
 };
 
-const buildAzureConfig = (): Extract<CreateBody, { provider: 'azure' }>['config'] => {
-  const config: Extract<CreateBody, { provider: 'azure' }>['config'] = {
+const buildAzureConfig = (): Extract<CreateBody, { kind: 'azure' }>['config'] => {
+  const config: Extract<CreateBody, { kind: 'azure' }>['config'] = {
     endpoint: azureDraft.value.endpoint.trim(),
     models: azureDraft.value.models,
   };
@@ -339,8 +339,8 @@ const buildAzureConfig = (): Extract<CreateBody, { provider: 'azure' }>['config'
   return config;
 };
 
-const buildOllamaConfig = (): Extract<CreateBody, { provider: 'ollama' }>['config'] => {
-  const config: Extract<CreateBody, { provider: 'ollama' }>['config'] = {
+const buildOllamaConfig = (): Extract<CreateBody, { kind: 'ollama' }>['config'] => {
+  const config: Extract<CreateBody, { kind: 'ollama' }>['config'] = {
     baseUrl: ollamaDraft.value.baseUrl.trim(),
     models: ollamaDraft.value.models,
   };
@@ -370,11 +370,11 @@ const save = async () => {
     if (props.mode === 'create') {
       let body: CreateBody;
       if (activeProvider.value === 'custom') {
-        body = { provider: 'custom', ...baseFields(), config: buildCustomConfig() };
+        body = { kind: 'custom', ...baseFields(), config: buildCustomConfig() };
       } else if (activeProvider.value === 'azure') {
-        body = { provider: 'azure', ...baseFields(), config: buildAzureConfig() };
+        body = { kind: 'azure', ...baseFields(), config: buildAzureConfig() };
       } else if (activeProvider.value === 'ollama') {
-        body = { provider: 'ollama', ...baseFields(), config: buildOllamaConfig() };
+        body = { kind: 'ollama', ...baseFields(), config: buildOllamaConfig() };
       } else {
         // Unreachable: see showSaveButton.
         saveError.value = `${activeProvider.value} upstreams are created through their dedicated panel.`;
@@ -464,7 +464,7 @@ const showSaveButton = computed(() => props.mode === 'edit' || (activeProvider.v
 // force-refresh shortcut. Azure is the one provider whose catalog is pure
 // form data — there is nothing the gateway can fetch — so the panel is
 // suppressed for it.
-const showCacheStatus = computed(() => props.mode === 'edit' && props.record !== null && props.record.provider !== 'azure');
+const showCacheStatus = computed(() => props.mode === 'edit' && props.record !== null && props.record.kind !== 'azure');
 
 // Public-id catalogue feeding the disabled-models combobox: every model
 // currently surfaced for this provider, deduped by public id. A model's

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -44,12 +44,12 @@ const props = defineProps<
     mode: 'create';
     record: null;
     // Default provider for create mode; ignored in edit mode (taken from record).
-    initialProvider: UpstreamProviderKind;
+    initialKind: UpstreamProviderKind;
   })
   | (CommonPageProps & {
     mode: 'edit';
     record: UpstreamRecord;
-    initialProvider?: undefined;
+    initialKind?: undefined;
   })
 >();
 
@@ -69,7 +69,7 @@ type PatchBody = InferRequestType<(typeof api.api.upstreams)[':id']['$patch']>['
 
 // Edit mode: provider follows the record. Create mode: locked in by the
 // route param at mount time.
-const activeProvider = computed<UpstreamProviderKind>(() => props.mode === 'edit' ? props.record.kind : props.initialProvider);
+const activeKind = computed<UpstreamProviderKind>(() => props.mode === 'edit' ? props.record.kind : props.initialKind);
 
 // Discriminated (mode, record) pair forwarded to UpstreamConfigPanel. The
 // page's own union already guarantees this shape; the explicit pairing
@@ -155,7 +155,7 @@ const seedFromRecord = (r: UpstreamRecord) => {
 };
 
 const seedFresh = () => {
-  name.value = providerMeta(activeProvider.value).defaultName;
+  name.value = providerMeta(activeKind.value).defaultName;
   enabled.value = true;
   sortOrder.value = props.nextSortOrder;
   flagOverrides.value = {};
@@ -228,7 +228,7 @@ const fetchDraftModels = async () => {
   fetchLoading.value = true;
   fetchError.value = null;
   try {
-    if (activeProvider.value === 'custom') {
+    if (activeKind.value === 'custom') {
       const { data, error } = await callApi<{ data: CustomRawModel[] }>(
         () => api.api.upstreams['fetch-models'].$post({
           json: { kind: 'custom', config: { ...buildCustomConfigCore(customDraft.value), models: customDraft.value.models } },
@@ -242,7 +242,7 @@ const fetchDraftModels = async () => {
       fetchedRaw.value = data.data;
       fetchedCount.value = data.data.length;
       fetchedAtMs.value = Date.now();
-    } else if (activeProvider.value === 'ollama') {
+    } else if (activeKind.value === 'ollama') {
       type FetchModelsBody = InferRequestType<typeof api.api.upstreams['fetch-models']['$post']>['json'];
       type OllamaFetchConfig = Extract<FetchModelsBody, { kind: 'ollama' }>['config'];
       const config: OllamaFetchConfig = {
@@ -369,15 +369,15 @@ const save = async () => {
   try {
     if (props.mode === 'create') {
       let body: CreateBody;
-      if (activeProvider.value === 'custom') {
+      if (activeKind.value === 'custom') {
         body = { kind: 'custom', ...baseFields(), config: buildCustomConfig() };
-      } else if (activeProvider.value === 'azure') {
+      } else if (activeKind.value === 'azure') {
         body = { kind: 'azure', ...baseFields(), config: buildAzureConfig() };
-      } else if (activeProvider.value === 'ollama') {
+      } else if (activeKind.value === 'ollama') {
         body = { kind: 'ollama', ...baseFields(), config: buildOllamaConfig() };
       } else {
         // Unreachable: see showSaveButton.
-        saveError.value = `${activeProvider.value} upstreams are created through their dedicated panel.`;
+        saveError.value = `${activeKind.value} upstreams are created through their dedicated panel.`;
         return;
       }
       const { data, error } = await callApi<UpstreamRecord>(() => api.api.upstreams.$post({ json: body }));
@@ -385,9 +385,9 @@ const save = async () => {
       emit('saved', data);
     } else {
       const patch: PatchBody = baseFields();
-      if (activeProvider.value === 'custom') patch.config = buildCustomConfig();
-      else if (activeProvider.value === 'azure') patch.config = buildAzureConfig();
-      else if (activeProvider.value === 'ollama') patch.config = buildOllamaConfig();
+      if (activeKind.value === 'custom') patch.config = buildCustomConfig();
+      else if (activeKind.value === 'azure') patch.config = buildAzureConfig();
+      else if (activeKind.value === 'ollama') patch.config = buildOllamaConfig();
       const { error } = await callApi(
         () => api.api.upstreams[':id'].$patch({ param: { id: props.record.id }, json: patch }),
       );
@@ -424,15 +424,15 @@ const onImportError = (message: string) => {
 // Read-only providers never invoke the v-model setter; the getter returns [] to satisfy the type contract.
 const modelsManualForActive = computed<UpstreamModelConfig[]>({
   get: () => {
-    if (activeProvider.value === 'custom') return customDraft.value.models;
-    if (activeProvider.value === 'azure') return azureDraft.value.models;
-    if (activeProvider.value === 'ollama') return ollamaDraft.value.models;
+    if (activeKind.value === 'custom') return customDraft.value.models;
+    if (activeKind.value === 'azure') return azureDraft.value.models;
+    if (activeKind.value === 'ollama') return ollamaDraft.value.models;
     return [];
   },
   set: next => {
-    if (activeProvider.value === 'custom') customDraft.value = { ...customDraft.value, models: next };
-    else if (activeProvider.value === 'azure') azureDraft.value = { ...azureDraft.value, models: next };
-    else if (activeProvider.value === 'ollama') ollamaDraft.value = { ...ollamaDraft.value, models: next };
+    if (activeKind.value === 'custom') customDraft.value = { ...customDraft.value, models: next };
+    else if (activeKind.value === 'azure') azureDraft.value = { ...azureDraft.value, models: next };
+    else if (activeKind.value === 'ollama') ollamaDraft.value = { ...ollamaDraft.value, models: next };
   },
 });
 
@@ -444,21 +444,21 @@ const modelsManualForActive = computed<UpstreamModelConfig[]>({
 // has no auto rows (the loader does not fetch for it), so `upstreamModels`
 // is empty and the same fall-through is correct.
 const autoForActive = computed<UpstreamModelConfig[]>(() => {
-  if (activeProvider.value === 'custom') {
+  if (activeKind.value === 'custom') {
     if (!customDraft.value.modelsFetch.enabled) return [];
     if (props.mode === 'edit') return upstreamModels.value;
     return customAutoModelsFromDraft.value;
   }
-  if (activeProvider.value === 'ollama') {
+  if (activeKind.value === 'ollama') {
     if (props.mode === 'edit') return upstreamModels.value;
     return fetchedOllamaModels.value;
   }
   return upstreamModels.value;
 });
 
-const upstreamIdLabelForActive = computed(() => activeProvider.value === 'azure' ? 'Deployment' : 'Upstream Model ID');
+const upstreamIdLabelForActive = computed(() => activeKind.value === 'azure' ? 'Deployment' : 'Upstream Model ID');
 // Provider import panels (copilot/codex/claude-code) land the row themselves on create, so the page-level Save button stays hidden until they emit.
-const showSaveButton = computed(() => props.mode === 'edit' || (activeProvider.value !== 'copilot' && activeProvider.value !== 'codex' && activeProvider.value !== 'claude-code'));
+const showSaveButton = computed(() => props.mode === 'edit' || (activeKind.value !== 'copilot' && activeKind.value !== 'codex' && activeKind.value !== 'claude-code'));
 
 // The cache-status panel reads the row's `modelsCache` summary and offers a
 // force-refresh shortcut. Azure is the one provider whose catalog is pure
@@ -550,7 +550,7 @@ const workbenchStyle = computed(() => ({ '--right-pane-h': `${Math.ceil(rightCon
     <div :style="workbenchStyle" class="grid grid-cols-1 gap-5 lg:grid-cols-[400px_minmax(0,1fr)]">
       <UpstreamConfigPanel
         v-bind="modeRecord"
-        :provider="activeProvider"
+        :kind="activeKind"
         v-model:name="name"
         v-model:enabled="enabled"
         v-model:flag-overrides="flagOverrides"
@@ -588,10 +588,10 @@ const workbenchStyle = computed(() => ({ '--right-pane-h': `${Math.ceil(rightCon
         :auto-models="autoForActive"
         :flags="flags"
         :upstream-flag-overrides="flagOverrides"
-        :flag-provider-kind="activeProvider"
+        :flag-provider-kind="activeKind"
         :upstream-id-label="upstreamIdLabelForActive"
-        :read-only="activeProvider === 'copilot' || activeProvider === 'codex' || activeProvider === 'claude-code'"
-        :all-manual="activeProvider === 'azure'"
+        :read-only="activeKind === 'copilot' || activeKind === 'codex' || activeKind === 'claude-code'"
+        :all-manual="activeKind === 'azure'"
         @update:invalid="v => modelsPanelInvalid = v"
       />
     </div>

--- a/apps/web/src/components/upstreams/UpstreamPicker.vue
+++ b/apps/web/src/components/upstreams/UpstreamPicker.vue
@@ -14,7 +14,7 @@ export interface UpstreamPickerValue {
 interface RowState {
   id: string;
   name: string;
-  provider: UpstreamProviderKind | null;
+  kind: UpstreamProviderKind | null;
   enabled: boolean;
 }
 
@@ -35,9 +35,9 @@ const reset = () => {
   rows.value = [
     ...orderedIds.map(id => {
       const u = props.available.find(x => x.id === id);
-      return { id, name: u?.name ?? `Unknown (${id})`, provider: u?.provider ?? null, enabled: true };
+      return { id, name: u?.name ?? `Unknown (${id})`, kind: u?.kind ?? null, enabled: true };
     }),
-    ...rest.map(u => ({ id: u.id, name: u.name, provider: u.provider, enabled: false })),
+    ...rest.map(u => ({ id: u.id, name: u.name, kind: u.kind, enabled: false })),
   ];
 };
 
@@ -59,11 +59,11 @@ const toggleRow = (id: string, enabled: boolean) => {
 const badgeCount = computed(() => value.value.override ? rows.value.filter(r => r.enabled).length : props.available.length);
 
 interface ProviderMeta { tone: 'amber' | 'emerald' | 'cyan' | 'rose' | 'zinc'; label: string }
-const providerMeta = (provider: UpstreamProviderKind | null): ProviderMeta => {
-  // The row's provider goes null when an upstream id in the saved value list
+const providerMeta = (kind: UpstreamProviderKind | null): ProviderMeta => {
+  // The row's kind goes null when an upstream id in the saved value list
   // no longer matches anything in `available` (e.g. a deleted upstream).
-  if (provider === null) return { tone: 'zinc', label: 'Unknown' };
-  switch (provider) {
+  if (kind === null) return { tone: 'zinc', label: 'Unknown' };
+  switch (kind) {
   case 'custom': return { tone: 'amber', label: 'Custom' };
   case 'azure': return { tone: 'emerald', label: 'Azure' };
   case 'copilot': return { tone: 'cyan', label: 'Copilot' };
@@ -71,7 +71,7 @@ const providerMeta = (provider: UpstreamProviderKind | null): ProviderMeta => {
   case 'claude-code': return { tone: 'rose', label: 'Claude Code' };
   case 'ollama': return { tone: 'rose', label: 'Ollama' };
   }
-  return assertNever(provider);
+  return assertNever(kind);
 };
 </script>
 
@@ -107,7 +107,7 @@ const providerMeta = (provider: UpstreamProviderKind | null): ProviderMeta => {
             <i class="i-lucide-grip-vertical size-4" />
           </button>
           <Switch :model-value="row.enabled" @update:model-value="v => toggleRow(row.id, !!v)" />
-          <Badge :tone="providerMeta(row.provider).tone" size="sm" class="shrink-0 !rounded !uppercase tracking-wide">{{ providerMeta(row.provider).label }}</Badge>
+          <Badge :tone="providerMeta(row.kind).tone" size="sm" class="shrink-0 !rounded !uppercase tracking-wide">{{ providerMeta(row.kind).label }}</Badge>
           <span class="min-w-0 flex-1 truncate text-sm text-white">{{ row.name }}</span>
           <code class="text-xs text-gray-500">{{ row.id }}</code>
         </li>

--- a/apps/web/src/composables/useUpstreamOptions.ts
+++ b/apps/web/src/composables/useUpstreamOptions.ts
@@ -10,7 +10,7 @@ import type { UpstreamProviderKind } from '../api/types.ts';
 export interface UpstreamOption {
   id: string;
   name: string;
-  provider: UpstreamProviderKind;
+  kind: UpstreamProviderKind;
   enabled: boolean;
 }
 

--- a/apps/web/src/pages/dashboard/upstreams/[id].vue
+++ b/apps/web/src/pages/dashboard/upstreams/[id].vue
@@ -29,11 +29,11 @@ export const useEditUpstreamData = defineBasicLoader('/dashboard/upstreams/[id]'
   // Every provider except Azure resolves its catalog through the SWR cache
   // backing GET /upstreams/:id/models. Azure's catalog is operator-edited
   // form data — there is nothing to fetch — so it is skipped here.
-  if (record && record.provider !== 'azure') {
+  if (record && record.kind !== 'azure') {
     const modelsPromise = callApi<{ data: UpstreamModelConfig[] }>(
       () => api.api.upstreams[':id'].models.$get({ param: { id: record.id } }),
     );
-    const quotaPromise = record.provider === 'copilot'
+    const quotaPromise = record.kind === 'copilot'
       ? callApi<CopilotQuotaSnapshot>(() => api.api.upstreams[':id'].copilot.quota.$get({ param: { id: record.id } }))
       : null;
     const [modelsRes, quotaRes] = await Promise.all([modelsPromise, quotaPromise ?? Promise.resolve(null)]);

--- a/apps/web/src/pages/dashboard/upstreams/new/[provider].vue
+++ b/apps/web/src/pages/dashboard/upstreams/new/[provider].vue
@@ -51,7 +51,7 @@ const onSaved = async () => {
     v-if="provider"
     mode="create"
     :record="null"
-    :initial-provider="provider"
+    :initial-kind="provider"
     :next-sort-order="data.data.value.nextSortOrder"
     :flags="data.data.value.flags"
     @saved="onSaved"

--- a/packages/gateway/src/control-plane/auth/routes_test.ts
+++ b/packages/gateway/src/control-plane/auth/routes_test.ts
@@ -255,7 +255,7 @@ test('/api/upstreams/copilot/auth/poll creates a Copilot upstream row and seeds 
       assertEquals(body.status, 'complete');
       assertEquals(/^up_[0-9a-f]{24}$/.test(body.upstream.id), true);
       assertEquals(body.upstream.id.includes('copilot'), false);
-      assertEquals(body.upstream.provider, 'copilot');
+      assertEquals(body.upstream.kind, 'copilot');
       assertEquals(body.upstream.config.githubToken, undefined);
       assertEquals(body.upstream.config.githubTokenSet, true);
       // The serialized state exposes only the per-tier baseUrl; the bearer
@@ -266,7 +266,7 @@ test('/api/upstreams/copilot/auth/poll creates a Copilot upstream row and seeds 
 
   const rows = await repo.upstreams.list();
   assertEquals(rows.length, 1);
-  assertEquals(rows[0].provider, 'copilot');
+  assertEquals(rows[0].kind, 'copilot');
   assertEquals((rows[0].config as Record<string, any>).githubToken, 'ghu_new');
   assertEquals((rows[0].config as Record<string, any>).accountType, undefined);
   assertEquals((rows[0].config as Record<string, any>).user.id, 777);

--- a/packages/gateway/src/control-plane/copilot-quota/routes.ts
+++ b/packages/gateway/src/control-plane/copilot-quota/routes.ts
@@ -38,7 +38,7 @@ export const copilotQuota = async (c: Context) => {
     const id = c.req.param('id')!;
     const upstream = await getRepo().upstreams.getById(id);
     if (!upstream) return c.json({ error: 'Upstream not found' }, 404);
-    if (upstream.provider !== 'copilot') return c.json({ error: 'Upstream is not a Copilot upstream' }, 400);
+    if (upstream.kind !== 'copilot') return c.json({ error: 'Upstream is not a Copilot upstream' }, 400);
 
     const { config } = assertCopilotUpstreamRecord(upstream);
 

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -150,7 +150,7 @@ const parseUpstreamRecords = (value: unknown): { type: 'ok'; records: UpstreamRe
         throw new Error("legacy 'enabled_fixes' field is no longer supported; re-export with current code");
       }
       if (typeof item.kind !== 'string' || !UPSTREAM_PROVIDERS.has(item.kind as UpstreamProviderKind)) {
-        throw new Error('kind must be one of custom, azure, copilot, codex, claude-code');
+        throw new Error(`kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}`);
       }
       if (typeof item.enabled !== 'boolean') throw new Error('enabled must be a boolean');
       if (typeof item.sort_order !== 'number' || !Number.isFinite(item.sort_order)) throw new Error('sort_order must be a finite number');

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -83,13 +83,13 @@ const importErrorBuilder = (field: string, expected: string) => new Error(`${fie
 const nonEmptyString = (value: unknown, field: string): string => nonEmptyStringField(value, field, importErrorBuilder);
 
 const normalizeUpstreamConfig = (record: UpstreamRecord): unknown => {
-  if (record.provider === 'custom') return assertCustomUpstreamRecord(record).config;
-  if (record.provider === 'azure') return assertAzureUpstreamRecord(record).config;
-  if (record.provider === 'codex') {
+  if (record.kind === 'custom') return assertCustomUpstreamRecord(record).config;
+  if (record.kind === 'azure') return assertAzureUpstreamRecord(record).config;
+  if (record.kind === 'codex') {
     assertCodexUpstreamRecord(record);
     return record.config;
   }
-  if (record.provider === 'claude-code') {
+  if (record.kind === 'claude-code') {
     assertClaudeCodeUpstreamRecord(record);
     return record.config;
   }
@@ -149,8 +149,8 @@ const parseUpstreamRecords = (value: unknown): { type: 'ok'; records: UpstreamRe
       if (hasOwn(item, 'enabled_fixes')) {
         throw new Error("legacy 'enabled_fixes' field is no longer supported; re-export with current code");
       }
-      if (typeof item.provider !== 'string' || !UPSTREAM_PROVIDERS.has(item.provider as UpstreamProviderKind)) {
-        throw new Error('provider must be one of custom, azure, copilot, codex, claude-code');
+      if (typeof item.kind !== 'string' || !UPSTREAM_PROVIDERS.has(item.kind as UpstreamProviderKind)) {
+        throw new Error('kind must be one of custom, azure, copilot, codex, claude-code');
       }
       if (typeof item.enabled !== 'boolean') throw new Error('enabled must be a boolean');
       if (typeof item.sort_order !== 'number' || !Number.isFinite(item.sort_order)) throw new Error('sort_order must be a finite number');
@@ -158,10 +158,10 @@ const parseUpstreamRecords = (value: unknown): { type: 'ok'; records: UpstreamRe
       const id = nonEmptyString(item.id, 'id');
       if (isLegacyUpstreamIdentity(id)) throw new Error('id must use a raw upstream id, not a legacy provider-prefixed identity');
 
-      const provider = item.provider as UpstreamProviderKind;
+      const kind = item.kind as UpstreamProviderKind;
       const record: UpstreamRecord = {
         id,
-        provider,
+        kind,
         name: nonEmptyString(item.name, 'name'),
         enabled: item.enabled,
         sortOrder: Math.floor(item.sort_order),
@@ -172,7 +172,7 @@ const parseUpstreamRecords = (value: unknown): { type: 'ok'; records: UpstreamRe
         proxyFallbackList: parseProxyFallbackListField(item.proxy_fallback_list),
         modelPrefix: normalizeModelPrefix(item.model_prefix),
         config: item.config,
-        state: normalizeUpstreamState(provider, item.state),
+        state: normalizeUpstreamState(kind, item.state),
       };
       records.push({ ...record, config: normalizeUpstreamConfig(record) });
     } catch (error) {

--- a/packages/gateway/src/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes_test.ts
@@ -73,7 +73,7 @@ const USER_BOB: User = {
 
 const CUSTOM_UPSTREAM: UpstreamRecord = {
   id: 'up_custom_a',
-  provider: 'custom',
+  kind: 'custom',
   name: 'Custom A',
   enabled: true,
   sortOrder: 10,
@@ -95,7 +95,7 @@ const CUSTOM_UPSTREAM: UpstreamRecord = {
 
 const COPILOT_UPSTREAM: UpstreamRecord = {
   id: 'up_copilot_a',
-  provider: 'copilot',
+  kind: 'copilot',
   name: 'GitHub Copilot (alice)',
   enabled: true,
   sortOrder: 0,
@@ -119,7 +119,7 @@ const COPILOT_UPSTREAM: UpstreamRecord = {
 
 const AZURE_UPSTREAM: UpstreamRecord = {
   id: 'up_azure_a',
-  provider: 'azure',
+  kind: 'azure',
   name: 'Azure A',
   enabled: true,
   sortOrder: 20,
@@ -151,7 +151,7 @@ const AZURE_UPSTREAM: UpstreamRecord = {
 
 const CODEX_UPSTREAM: UpstreamRecord = {
   id: 'up_codex_a',
-  provider: 'codex',
+  kind: 'codex',
   name: 'ChatGPT Codex (alice)',
   enabled: true,
   sortOrder: 30,

--- a/packages/gateway/src/control-plane/models/routes.ts
+++ b/packages/gateway/src/control-plane/models/routes.ts
@@ -9,7 +9,7 @@ import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getCurrentColo } from '../../runtime/runtime-info.ts';
 import type { PublicModel, PublicModelsResponse } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
-import type { InternalModel, ModelProviderInstance, UpstreamProviderKind } from '@floway-dev/provider';
+import type { InternalModel, Provider, UpstreamProviderKind } from '@floway-dev/provider';
 
 // Same DTO as the public /models endpoint, plus one dashboard-only field:
 // `upstreams` lists every upstream that surfaces this model as { kind, id, name }
@@ -24,7 +24,7 @@ interface ControlPlaneModelsResponse extends Omit<PublicModelsResponse, 'data'> 
   data: ControlPlaneModel[];
 }
 
-const toControlPlaneModel = (model: InternalModel, instances: readonly ModelProviderInstance[]): ControlPlaneModel => ({
+const toControlPlaneModel = (model: InternalModel, instances: readonly Provider[]): ControlPlaneModel => ({
   ...toPublicModel(model),
   upstreams: instances.map(instance => ({ kind: instance.providerKind, id: instance.upstream, name: instance.name })),
 });

--- a/packages/gateway/src/control-plane/models/routes.ts
+++ b/packages/gateway/src/control-plane/models/routes.ts
@@ -26,7 +26,7 @@ interface ControlPlaneModelsResponse extends Omit<PublicModelsResponse, 'data'> 
 
 const toControlPlaneModel = (model: InternalModel, instances: readonly Provider[]): ControlPlaneModel => ({
   ...toPublicModel(model),
-  upstreams: instances.map(instance => ({ kind: instance.providerKind, id: instance.upstream, name: instance.name })),
+  upstreams: instances.map(instance => ({ kind: instance.kind, id: instance.upstream, name: instance.name })),
 });
 
 export const controlPlaneModels = async (c: Context) => {

--- a/packages/gateway/src/control-plane/models/routes_test.ts
+++ b/packages/gateway/src/control-plane/models/routes_test.ts
@@ -6,7 +6,7 @@ import { assertEquals, jsonResponse, withMockedFetch } from '@floway-dev/test-ut
 
 const azureUpstream = (): UpstreamRecord => ({
   id: 'up_azure_models',
-  provider: 'azure',
+  kind: 'azure',
   name: 'Azure Models',
   enabled: true,
   sortOrder: 200,

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -307,37 +307,37 @@ const upstreamBaseFields = {
   model_prefix: modelPrefixSchema.optional(),
 };
 
-// Create accepts a discriminated union on `provider` for per-provider config
+// Create accepts a discriminated union on `kind` for per-provider config
 // validation. Copilot upstreams normally originate from the device-flow poll
 // endpoint, but POST also accepts them for the import flow. `enabled` and
 // `sort_order` are optional — the handler defaults them to `true` and
 // `nextSortOrder()` respectively when omitted.
 //
 // `codex` and `claude-code` are listed here so the handler can return the
-// canonical "use POST /api/upstreams/<provider>-import" 400 instead of the
+// canonical "use POST /api/upstreams/<kind>-import" 400 instead of the
 // cryptic zod "invalid discriminator value" message. The `config` slot is
 // `unknown()` because the real config is derived from the OAuth flow, not
 // from anything posted against this endpoint.
-export const createUpstreamBody = z.discriminatedUnion('provider', [
-  z.object({ provider: z.literal('custom'), ...upstreamBaseFields, config: customConfigSchema }),
-  z.object({ provider: z.literal('azure'), ...upstreamBaseFields, config: azureConfigSchema }),
-  z.object({ provider: z.literal('copilot'), ...upstreamBaseFields, config: copilotConfigSchema }),
-  z.object({ provider: z.literal('codex'), ...upstreamBaseFields, config: z.unknown() }),
-  z.object({ provider: z.literal('claude-code'), ...upstreamBaseFields, config: z.unknown() }),
-  z.object({ provider: z.literal('ollama'), ...upstreamBaseFields, config: ollamaConfigSchema }),
+export const createUpstreamBody = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('custom'), ...upstreamBaseFields, config: customConfigSchema }),
+  z.object({ kind: z.literal('azure'), ...upstreamBaseFields, config: azureConfigSchema }),
+  z.object({ kind: z.literal('copilot'), ...upstreamBaseFields, config: copilotConfigSchema }),
+  z.object({ kind: z.literal('codex'), ...upstreamBaseFields, config: z.unknown() }),
+  z.object({ kind: z.literal('claude-code'), ...upstreamBaseFields, config: z.unknown() }),
+  z.object({ kind: z.literal('ollama'), ...upstreamBaseFields, config: ollamaConfigSchema }),
 ]);
 
-// Update is provider-agnostic: provider is read from the existing record, and
-// the config shape is validated by the handler against that record's provider.
+// Update is kind-agnostic: kind is read from the existing record, and
+// the config shape is validated by the handler against that record's kind.
 // Patches omit fields they don't change; `config` may be a partial patch object
 // that the handler shallow-merges with the existing config.
 //
-// `provider` may appear in the body so the handler can return the canonical
-// "provider cannot be changed" 400 when a caller tries to switch providers;
+// `kind` may appear in the body so the handler can return the canonical
+// "kind cannot be changed" 400 when a caller tries to switch kinds;
 // without this field the schema would silently strip it and the API would
 // look like it had accepted the change.
 export const updateUpstreamBody = z.object({
-  provider: z.enum(['custom', 'azure', 'copilot', 'codex', 'claude-code', 'ollama']).optional(),
+  kind: z.enum(['custom', 'azure', 'copilot', 'codex', 'claude-code', 'ollama']).optional(),
   name: z.string().min(1).optional(),
   enabled: z.boolean().optional(),
   sort_order: z.number().int().optional(),
@@ -351,11 +351,11 @@ export const updateUpstreamBody = z.object({
 // Draft /models browse: accepts an in-progress upstream config so callers can
 // fetch the upstream's live model list before saving. `id` is present in
 // edit mode so the handler can substitute the stored secret when the secret
-// is left blank ("keep the stored secret"). Discriminated by `provider` so
+// is left blank ("keep the stored secret"). Discriminated by `kind` so
 // each provider's draft preview surfaces a typed catalog.
-export const fetchModelsBody = z.discriminatedUnion('provider', [
-  z.object({ provider: z.literal('custom'), id: z.string().optional(), config: customConfigSchema }),
-  z.object({ provider: z.literal('ollama'), id: z.string().optional(), config: ollamaConfigSchema }),
+export const fetchModelsBody = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('custom'), id: z.string().optional(), config: customConfigSchema }),
+  z.object({ kind: z.literal('ollama'), id: z.string().optional(), config: ollamaConfigSchema }),
 ]);
 
 // --- copilot device flow ---
@@ -369,7 +369,7 @@ export const copilotAuthPollBody = z.object({
 
 // --- codex import / authorize-url / refresh ---
 //
-// The control plane refuses `provider: 'codex'` on the generic create / update
+// The control plane refuses `kind: 'codex'` on the generic create / update
 // upstream endpoints; Codex credentials enter only through these dedicated
 // routes so the id_token parsing lives in one place.
 //
@@ -456,7 +456,7 @@ export const codexRefreshNowBody = z.object({
 // --- claude-code import / authorize-url / refresh ---
 //
 // Same shape rationale as the codex routes above: the generic create / update
-// upstream endpoints reject `provider: 'claude-code'` and dedicated
+// upstream endpoints reject `kind: 'claude-code'` and dedicated
 // authorize-url + import + re-import endpoints own the OAuth handoff so
 // credential parsing lives in one place. PKCE state is SPA-held (see codex
 // section above for the architecture). The single authorize-url endpoint

--- a/packages/gateway/src/control-plane/schemas_test.ts
+++ b/packages/gateway/src/control-plane/schemas_test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { createUpstreamBody } from './schemas.ts';
 
 const baseAzure = {
-  provider: 'azure' as const,
+  kind: 'azure' as const,
   name: 'azure',
   config: {
     endpoint: 'https://a.example.com',

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -72,7 +72,7 @@ import { assertOllamaUpstreamRecord, createOllamaProvider } from '@floway-dev/pr
 // expects.
 const serializeForResponse = async (record: UpstreamRecord): Promise<SerializedUpstreamRecord> => {
   let codexQuotaPromise: Promise<CodexQuotaSnapshot | null> | null = null;
-  if (record.provider === 'codex') {
+  if (record.kind === 'codex') {
     assertCodexUpstreamRecord(record);
     codexQuotaPromise = getCodexQuota(record.id, record.config.accounts[0].chatgptAccountId);
   }
@@ -117,14 +117,14 @@ const providerDataUpstreamModelId = (data: unknown): string | undefined => {
 // that the provider packages own.
 const normalizeConfig = (record: UpstreamRecord): ValidationResult<unknown> => {
   try {
-    if (record.provider === 'custom') return { ok: true, value: assertCustomUpstreamRecord(record).config };
-    if (record.provider === 'azure') return { ok: true, value: assertAzureUpstreamRecord(record).config };
-    if (record.provider === 'ollama') return { ok: true, value: assertOllamaUpstreamRecord(record).config };
-    if (record.provider === 'codex') {
+    if (record.kind === 'custom') return { ok: true, value: assertCustomUpstreamRecord(record).config };
+    if (record.kind === 'azure') return { ok: true, value: assertAzureUpstreamRecord(record).config };
+    if (record.kind === 'ollama') return { ok: true, value: assertOllamaUpstreamRecord(record).config };
+    if (record.kind === 'codex') {
       assertCodexUpstreamRecord(record);
       return { ok: true, value: record.config };
     }
-    if (record.provider === 'claude-code') {
+    if (record.kind === 'claude-code') {
       assertClaudeCodeUpstreamRecord(record);
       return { ok: true, value: record.config };
     }
@@ -224,7 +224,7 @@ export const listUpstreamOptions = async (c: Context) => {
     .map(upstream => ({
       id: upstream.id,
       name: upstream.name,
-      provider: upstream.provider,
+      kind: upstream.kind,
       enabled: upstream.enabled,
     })));
 };
@@ -236,15 +236,15 @@ export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) 
 
   // Codex credentials carry an OAuth refresh_token + id_token-derived identity
   // that this endpoint cannot synthesize. Route the operator to the dedicated
-  // PKCE / import flow instead of letting a `provider: 'codex'` body through
+  // PKCE / import flow instead of letting a `kind: 'codex'` body through
   // with no credential material.
-  if (body.provider === 'codex') {
+  if (body.kind === 'codex') {
     return c.json({ error: 'Use POST /api/upstreams/codex-import for codex provider' }, 400);
   }
   // Same rationale for claude-code: the row carries an OAuth refresh token and
   // an identity derived from /api/oauth/profile, neither of which is
   // synthesizable from a plain POST.
-  if (body.provider === 'claude-code') {
+  if (body.kind === 'claude-code') {
     return c.json({ error: 'Use POST /api/upstreams/claude-code-import for claude-code provider' }, 400);
   }
 
@@ -260,7 +260,7 @@ export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) 
   const now = new Date().toISOString();
   const upstream: UpstreamRecord = {
     id: newId(),
-    provider: body.provider,
+    kind: body.kind,
     name: body.name,
     enabled: body.enabled ?? true,
     sortOrder: body.sort_order ?? nextSortOrder(existing),
@@ -289,21 +289,21 @@ export const updateUpstream = async (c: CtxWithJson<typeof updateUpstreamBody, '
   if (!existing) return c.json({ error: 'Upstream not found' }, 404);
 
   const body = c.req.valid('json');
-  if (body.provider !== undefined && body.provider !== existing.provider) {
-    return c.json({ error: 'provider cannot be changed' }, 400);
+  if (body.kind !== undefined && body.kind !== existing.kind) {
+    return c.json({ error: 'kind cannot be changed' }, 400);
   }
 
   // Codex `config` (id_token-derived identity) and credential state are
   // owned by the dedicated re-import / refresh endpoints. Generic PATCH still
   // adjusts the surrounding row metadata (name, enabled, sort_order, flag
   // overrides, disabled model ids) but never the credential payload.
-  if (existing.provider === 'codex' && body.config !== undefined) {
+  if (existing.kind === 'codex' && body.config !== undefined) {
     return c.json({ error: 'Use POST /api/upstreams/:id/codex-reimport to update codex credentials' }, 400);
   }
   // Same gate for claude-code: identity comes from /api/oauth/profile at
   // import time and the credential state belongs to refresh-now / re-import,
   // not a generic field patch.
-  if (existing.provider === 'claude-code' && body.config !== undefined) {
+  if (existing.kind === 'claude-code' && body.config !== undefined) {
     return c.json({ error: 'Use POST /api/upstreams/:id/claude-code-reimport to update claude-code credentials' }, 400);
   }
 
@@ -325,7 +325,7 @@ export const updateUpstream = async (c: CtxWithJson<typeof updateUpstreamBody, '
     next = { ...next, modelPrefix: result.value };
   }
   if (body.config !== undefined) {
-    const config = mergeConfigPatch(existing.provider, existing.config, body.config);
+    const config = mergeConfigPatch(existing.kind, existing.config, body.config);
     if (!config.ok) return c.json({ error: config.error }, 400);
     next = { ...next, config: config.value };
   }
@@ -370,8 +370,8 @@ export const fetchModels = async (c: CtxWithJson<typeof fetchModelsBody>) => {
   const now = new Date().toISOString();
   const record: UpstreamRecord = {
     id: newId(),
-    provider: body.provider,
-    name: `Draft ${body.provider} upstream`,
+    kind: body.kind,
+    name: `Draft ${body.kind} upstream`,
     enabled: true,
     sortOrder: 0,
     createdAt: now,
@@ -385,18 +385,18 @@ export const fetchModels = async (c: CtxWithJson<typeof fetchModelsBody>) => {
   };
 
   try {
-    if (body.provider === 'custom') {
+    if (body.kind === 'custom') {
       const assertedConfig = assertCustomUpstreamRecord(record).config;
       const result = await fetchCustomModels(assertedConfig, directFetcher);
       return c.json(result);
     }
-    // body.provider === 'ollama' — the provider's own getProvidedModels
+    // body.kind === 'ollama' — the provider's own getProvidedModels
     // already projects /api/tags + /api/show into UpstreamModel; reshape each
     // into UpstreamModelConfig so the dashboard can drop them straight into
     // the auto rows without re-deriving endpoints from capabilities.
     assertOllamaUpstreamRecord(record);
     const instance = createOllamaProvider(record);
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     const data = models.map(model => {
       const upstreamModelId = model.providerData as string;
       const config: Record<string, unknown> = {
@@ -497,7 +497,7 @@ export const copilotAuthPoll = async (c: CtxWithJson<typeof copilotAuthPollBody>
 
     const repo = getRepo().upstreams;
     const upstreams = await repo.list();
-    const existing = upstreams.find(upstream => upstream.provider === 'copilot' && copilotConfigUserId(upstream.config) === user.id);
+    const existing = upstreams.find(upstream => upstream.kind === 'copilot' && copilotConfigUserId(upstream.config) === user.id);
     const now = new Date().toISOString();
     const config: CopilotUpstreamConfig = {
       githubToken: data.access_token,
@@ -518,7 +518,7 @@ export const copilotAuthPoll = async (c: CtxWithJson<typeof copilotAuthPollBody>
         }
       : {
           id: newId(),
-          provider: 'copilot',
+          kind: 'copilot',
           name: user.login ? `GitHub Copilot (${user.login})` : 'GitHub Copilot',
           enabled: true,
           sortOrder: nextSortOrder(upstreams),
@@ -621,7 +621,7 @@ export const codexImport = async (c: CtxWithJson<typeof codexImportBody>) => {
   const defaultName = `ChatGPT Codex (${ingestion.config.accounts[0].email})`;
   const upstream: UpstreamRecord = {
     id: newId(),
-    provider: 'codex',
+    kind: 'codex',
     name: body.name ?? defaultName,
     enabled: true,
     sortOrder: body.sort_order ?? nextSortOrder(existing),
@@ -644,7 +644,7 @@ export const codexImport = async (c: CtxWithJson<typeof codexImportBody>) => {
 export const codexReimport = async (c: CtxWithJson<typeof codexReimportBody, '/:id'>) => {
   const id = c.req.param('id');
   const existing = await getRepo().upstreams.getById(id);
-  if (existing?.provider !== 'codex') {
+  if (existing?.kind !== 'codex') {
     return c.json({ error: 'Codex upstream not found' }, 404);
   }
 
@@ -685,7 +685,7 @@ export const codexReimport = async (c: CtxWithJson<typeof codexReimportBody, '/:
 export const codexRefreshNow = async (c: CtxWithJson<typeof codexRefreshNowBody, '/:id'>) => {
   const id = c.req.param('id');
   const existing = await getRepo().upstreams.getById(id);
-  if (existing?.provider !== 'codex') {
+  if (existing?.kind !== 'codex') {
     return c.json({ error: 'Codex upstream not found' }, 404);
   }
   // A throw from assertCodexUpstreamState means the row's state column was
@@ -837,7 +837,7 @@ export const claudeCodeImport = async (c: CtxWithJson<typeof claudeCodeImportBod
   const defaultName = `Claude Code (${ingestion.config.accounts[0].email})`;
   const upstream: UpstreamRecord = {
     id: newId(),
-    provider: 'claude-code',
+    kind: 'claude-code',
     name: body.name ?? defaultName,
     enabled: true,
     sortOrder: body.sort_order ?? nextSortOrder(existing),
@@ -860,7 +860,7 @@ export const claudeCodeImport = async (c: CtxWithJson<typeof claudeCodeImportBod
 export const claudeCodeReimport = async (c: CtxWithJson<typeof claudeCodeReimportBody, '/:id'>) => {
   const id = c.req.param('id');
   const existing = await getRepo().upstreams.getById(id);
-  if (existing?.provider !== 'claude-code') {
+  if (existing?.kind !== 'claude-code') {
     return c.json({ error: 'Claude Code upstream not found' }, 404);
   }
   // Cross-kind re-import would silently replace a setup-token credential
@@ -922,7 +922,7 @@ export const claudeCodeSetupTokenImport = async (c: CtxWithJson<typeof claudeCod
   const defaultName = `Claude Code Setup Token (${account.email ?? account.accountUuid.slice(0, 8)})`;
   const upstream: UpstreamRecord = {
     id: newId(),
-    provider: 'claude-code',
+    kind: 'claude-code',
     name: body.name ?? defaultName,
     enabled: true,
     sortOrder: body.sort_order ?? nextSortOrder(existing),
@@ -943,7 +943,7 @@ export const claudeCodeSetupTokenImport = async (c: CtxWithJson<typeof claudeCod
 export const claudeCodeSetupTokenReimport = async (c: CtxWithJson<typeof claudeCodeSetupTokenReimportBody, '/:id'>) => {
   const id = c.req.param('id');
   const existing = await getRepo().upstreams.getById(id);
-  if (existing?.provider !== 'claude-code') {
+  if (existing?.kind !== 'claude-code') {
     return c.json({ error: 'Claude Code upstream not found' }, 404);
   }
   // Symmetric guard to claudeCodeReimport: an OAuth row must not be replaced
@@ -1092,7 +1092,7 @@ const attemptClaudeCodeRefresh = async (id: string, fetcher: Fetcher): Promise<R
 export const claudeCodeRefreshNow = async (c: CtxWithJson<typeof claudeCodeRefreshNowBody, '/:id'>) => {
   const id = c.req.param('id');
   const existing = await getRepo().upstreams.getById(id);
-  if (existing?.provider !== 'claude-code') {
+  if (existing?.kind !== 'claude-code') {
     return c.json({ error: 'Claude Code upstream not found' }, 404);
   }
 
@@ -1221,7 +1221,7 @@ export const claudeCodeProbeQuota = async (c: CtxWithJson<typeof claudeCodeProbe
   // still answers under inference-only scopes (sub2api hits it identically
   // for setup tokens), so we don't gate by tokenKind. The provider gate is
   // the only relevant filter.
-  if (existing.provider !== 'claude-code') {
+  if (existing.kind !== 'claude-code') {
     return c.json({ error: 'Quota probe is only supported for claude-code upstreams' }, 400);
   }
 

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -35,7 +35,7 @@ const copilotConfig = {
 };
 
 const createBody = (overrides: Record<string, unknown> = {}) => ({
-  provider: 'custom',
+  kind: 'custom',
   name: 'Test custom upstream',
   config: customConfig,
   flag_overrides: {},
@@ -59,7 +59,7 @@ test('POST /api/upstreams creates custom upstreams and redacts bearer tokens', a
 
   assertEquals(resp.status, 201);
   const created = (await resp.json()) as JsonObject;
-  assertEquals(created.provider, 'custom');
+  assertEquals(created.kind, 'custom');
   assertEquals(created.config.apiKey, undefined);
   assertEquals(created.config.apiKeySet, true);
   assertEquals(created.config.baseUrl, 'https://custom.example.com');
@@ -100,15 +100,15 @@ test('POST /api/upstreams validates Azure models and redacts API keys', async ()
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
 
-  const invalid = await requestApp('/api/upstreams', authed(adminSession, createBody({ provider: 'azure', config: { ...azureConfig, models: [] } })));
+  const invalid = await requestApp('/api/upstreams', authed(adminSession, createBody({ kind: 'azure', config: { ...azureConfig, models: [] } })));
   assertEquals(invalid.status, 400);
   const invalidBody = (await invalid.json()) as { error?: string };
   assertEquals(invalidBody.error?.includes('models must be a non-empty array'), true);
 
-  const createdResp = await requestApp('/api/upstreams', authed(adminSession, createBody({ provider: 'azure', name: 'Azure', config: azureConfig })));
+  const createdResp = await requestApp('/api/upstreams', authed(adminSession, createBody({ kind: 'azure', name: 'Azure', config: azureConfig })));
   assertEquals(createdResp.status, 201);
   const created = (await createdResp.json()) as JsonObject;
-  assertEquals(created.provider, 'azure');
+  assertEquals(created.kind, 'azure');
   assertEquals(created.config.apiKey, undefined);
   assertEquals(created.config.apiKeySet, true);
   assertEquals(created.config.endpoint, 'https://example.openai.azure.com');
@@ -126,13 +126,13 @@ test('POST /api/upstreams creates Copilot upstream rows with redacted GitHub tok
   const created = await withMockedFetch(
     () => jsonResponse({ error: 'forbidden' }, 403),
     async () => {
-      const resp = await requestApp('/api/upstreams', authed(adminSession, createBody({ provider: 'copilot', name: 'Copilot', config: copilotConfig })));
+      const resp = await requestApp('/api/upstreams', authed(adminSession, createBody({ kind: 'copilot', name: 'Copilot', config: copilotConfig })));
       assertEquals(resp.status, 201);
       const body = (await resp.json()) as JsonObject;
       return body;
     },
   );
-  assertEquals(created.provider, 'copilot');
+  assertEquals(created.kind, 'copilot');
   assertEquals(created.config.githubToken, undefined);
   assertEquals(created.config.githubTokenSet, true);
   assertEquals(created.config.user.id, 12345);
@@ -141,7 +141,7 @@ test('POST /api/upstreams creates Copilot upstream rows with redacted GitHub tok
   assertEquals((stored?.config as Record<string, unknown>).githubToken, 'ghu_secret');
 });
 
-test('PATCH /api/upstreams rejects provider changes and preserves the row', async () => {
+test('PATCH /api/upstreams rejects kind changes and preserves the row', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
 
@@ -154,12 +154,12 @@ test('PATCH /api/upstreams rejects provider changes and preserves the row', asyn
       'content-type': 'application/json',
       'x-floway-session': adminSession,
     },
-    body: JSON.stringify({ provider: 'azure' }),
+    body: JSON.stringify({ kind: 'azure' }),
   });
 
   assertEquals(patch.status, 400);
-  assertEquals(((await patch.json()) as { error?: string }).error, 'provider cannot be changed');
-  assertEquals((await repo.upstreams.getById(created.id))?.provider, 'custom');
+  assertEquals(((await patch.json()) as { error?: string }).error, 'kind cannot be changed');
+  assertEquals((await repo.upstreams.getById(created.id))?.kind, 'custom');
 });
 
 test('PATCH /api/upstreams preserves omitted secrets and re-warms the models cache', async () => {
@@ -211,7 +211,7 @@ test('PATCH /api/upstreams keeps Azure as a single endpoint config', async () =>
   await repo.upstreams.deleteAll();
   await repo.upstreams.save({
     id: 'up_azure_single_endpoint',
-    provider: 'azure',
+    kind: 'azure',
     name: 'Azure Single Endpoint',
     enabled: true,
     sortOrder: 0,
@@ -258,7 +258,7 @@ test('GET /api/upstreams attaches models-cache freshness to every row', async ()
   // Three upstreams cover the three cache states: no row, warm row, warm row
   // with a follow-up failure annotated via setLastError.
   const baseRow = {
-    provider: 'custom' as const,
+    kind: 'custom' as const,
     enabled: true,
     sortOrder: 0,
     createdAt: '2026-06-01T00:00:00.000Z',
@@ -317,7 +317,7 @@ test('GET /api/upstream-options returns the minimal picker shape to admin and no
   const { repo, adminSession, apiKey } = await setupAppTest();
   await repo.upstreams.save({
     id: 'up_disabled_custom',
-    provider: 'custom',
+    kind: 'custom',
     name: 'Disabled Custom',
     enabled: false,
     sortOrder: 5,
@@ -332,8 +332,8 @@ test('GET /api/upstream-options returns the minimal picker shape to admin and no
   });
 
   const expected = [
-    { id: 'up_copilot', name: 'GitHub Copilot (tester)', provider: 'copilot', enabled: true },
-    { id: 'up_disabled_custom', name: 'Disabled Custom', provider: 'custom', enabled: false },
+    { id: 'up_copilot', name: 'GitHub Copilot (tester)', kind: 'copilot', enabled: true },
+    { id: 'up_disabled_custom', name: 'Disabled Custom', kind: 'custom', enabled: false },
   ];
 
   const adminResp = await requestApp('/api/upstream-options', { headers: { 'x-floway-session': adminSession } });
@@ -346,7 +346,7 @@ test('GET /api/upstream-options returns the minimal picker shape to admin and no
   assertEquals(userBody, expected);
   // No secret-bearing or operator-only fields leak through this endpoint.
   for (const row of userBody) {
-    assertEquals(Object.keys(row).sort(), ['enabled', 'id', 'name', 'provider']);
+    assertEquals(Object.keys(row).sort(), ['enabled', 'id', 'kind', 'name']);
   }
 });
 
@@ -363,7 +363,7 @@ test('POST /api/upstreams/fetch-models fetches a draft custom upstream model lis
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { provider: 'custom', config: customConfig }));
+      const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { kind: 'custom', config: customConfig }));
       assertEquals(resp.status, 200);
       const body = (await resp.json()) as { data: Array<Record<string, unknown>> };
       assertEquals(body.data.map(m => m.id), ['gpt-a', 'gpt-b']);
@@ -377,7 +377,7 @@ test('POST /api/upstreams/fetch-models rejects calls that supply a saved upstrea
   await repo.upstreams.deleteAll();
   await repo.upstreams.save({
     id: 'up_stored_secret',
-    provider: 'custom',
+    kind: 'custom',
     name: 'Stored Secret Custom',
     enabled: true,
     sortOrder: 0,
@@ -395,7 +395,7 @@ test('POST /api/upstreams/fetch-models rejects calls that supply a saved upstrea
   // (the SWR-cached path); fetch-models stays draft-only.
   const resp = await requestApp(
     '/api/upstreams/fetch-models',
-    authed(adminSession, { provider: 'custom', id: 'up_stored_secret', config: { ...customConfig, apiKey: '' } }),
+    authed(adminSession, { kind: 'custom', id: 'up_stored_secret', config: { ...customConfig, apiKey: '' } }),
   );
   assertEquals(resp.status, 400);
   const body = (await resp.json()) as { error: { message: string; type: string } };
@@ -433,7 +433,7 @@ test('POST /api/upstreams/fetch-models projects an ollama draft into UpstreamMod
     },
     async () => {
       const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, {
-        provider: 'ollama',
+        kind: 'ollama',
         config: { baseUrl: 'https://ollama.com', apiKey: 'ollama_test' },
       }));
       assertEquals(resp.status, 200);
@@ -462,7 +462,7 @@ test('POST /api/upstreams/fetch-models surfaces upstream model-listing failures 
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { provider: 'custom', config: customConfig }));
+      const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { kind: 'custom', config: customConfig }));
       assertEquals(resp.status, 502);
       const body = (await resp.json()) as { error: { message: string; type: string } };
       assertEquals(body.error.type, 'api_error');
@@ -483,7 +483,7 @@ test('POST /api/upstreams/fetch-models surfaces an ollama /api/tags failure as 5
     },
     async () => {
       const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, {
-        provider: 'ollama',
+        kind: 'ollama',
         config: { baseUrl: 'https://ollama.com', apiKey: 'ollama_test' },
       }));
       assertEquals(resp.status, 502);
@@ -498,7 +498,7 @@ test('POST /api/upstreams/fetch-models rejects a malformed draft config with 400
 
   // Blank token with no id and no stored secret to substitute: the runtime
   // assert rejects the empty apiKey, surfaced as a 400 validation error.
-  const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { provider: 'custom', config: { ...customConfig, apiKey: '' } }));
+  const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { kind: 'custom', config: { ...customConfig, apiKey: '' } }));
   assertEquals(resp.status, 400);
   const body = (await resp.json()) as { error: string };
   assertEquals(body.error.includes('apiKey'), true);
@@ -509,7 +509,7 @@ test('GET /api/upstreams/:id/models?refresh=true forces a fresh upstream fetch',
   await repo.upstreams.deleteAll();
   await repo.upstreams.save({
     id: 'up_refresh',
-    provider: 'custom',
+    kind: 'custom',
     name: 'Refresh Custom',
     enabled: true,
     sortOrder: 0,
@@ -561,7 +561,7 @@ test('GET /api/upstreams/:id/models resolves a saved upstream catalog and 404s f
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
 
-  const created = (await (await requestApp('/api/upstreams', authed(adminSession, createBody({ provider: 'azure', name: 'Az', config: azureConfig })))).json()) as { id: string };
+  const created = (await (await requestApp('/api/upstreams', authed(adminSession, createBody({ kind: 'azure', name: 'Az', config: azureConfig })))).json()) as { id: string };
 
   const resp = await requestApp(`/api/upstreams/${created.id}/models`, { headers: { 'x-floway-session': adminSession } });
   assertEquals(resp.status, 200);
@@ -645,7 +645,7 @@ test('POST /api/upstreams/fetch-models without an id still serves draft preview'
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { provider: 'custom', config: customConfig }));
+      const resp = await requestApp('/api/upstreams/fetch-models', authed(adminSession, { kind: 'custom', config: customConfig }));
       assertEquals(resp.status, 200);
       const body = (await resp.json()) as { data: Array<Record<string, unknown>> };
       assertEquals(body.data.map(m => m.id), ['draft-only']);
@@ -716,8 +716,8 @@ test('POST /api/upstreams/codex-import (callback) exchanges the SPA-supplied ver
         authed(adminSession, { name: 'ChatGPT Codex', callback: { code: 'AUTH_CODE', verifier: 'TEST_VERIFIER' } }),
       );
       assertEquals(resp.status, 201);
-      const created = (await resp.json()) as { provider: string; state: { accounts: Array<{ refresh_token_set: boolean }> } };
-      assertEquals(created.provider, 'codex');
+      const created = (await resp.json()) as { kind: string; state: { accounts: Array<{ refresh_token_set: boolean }> } };
+      assertEquals(created.kind, 'codex');
       assertEquals(created.state.accounts[0].refresh_token_set, true);
     },
   );
@@ -730,7 +730,7 @@ test('POST /api/upstreams/codex-import (auth_json) creates a codex upstream with
   const resp = await requestApp('/api/upstreams/codex-import', authed(adminSession, codexAuthJsonImport()));
   assertEquals(resp.status, 201);
   const created = (await resp.json()) as JsonObject;
-  assertEquals(created.provider, 'codex');
+  assertEquals(created.kind, 'codex');
   assertEquals(created.config.accounts[0].email, 'alice@example.com');
   assertEquals(created.config.accounts[0].chatgptAccountId, 'acc_test');
   assertEquals(created.config.accounts[0].planType, 'plus');
@@ -945,8 +945,8 @@ test('POST /api/upstreams/claude-code-import (callback) exchanges the SPA-suppli
         authed(adminSession, { name: 'Claude Code', callback: { code: 'AUTH_CODE', verifier: 'TEST_VERIFIER', state: 'TEST_STATE' } }),
       );
       assertEquals(resp.status, 201);
-      const created = (await resp.json()) as { provider: string; state: { accounts: Array<{ refreshTokenSet: boolean; accessToken: { expiresAt: number } | null }> } };
-      assertEquals(created.provider, 'claude-code');
+      const created = (await resp.json()) as { kind: string; state: { accounts: Array<{ refreshTokenSet: boolean; accessToken: { expiresAt: number } | null }> } };
+      assertEquals(created.kind, 'claude-code');
       assertEquals(created.state.accounts[0].refreshTokenSet, true);
       assertEquals(typeof created.state.accounts[0].accessToken?.expiresAt, 'number');
     },
@@ -966,7 +966,7 @@ test('POST /api/upstreams/claude-code-import (credentials_json) creates a row wi
       );
       assertEquals(resp.status, 201);
       const created = (await resp.json()) as JsonObject;
-      assertEquals(created.provider, 'claude-code');
+      assertEquals(created.kind, 'claude-code');
       assertEquals(created.config.accounts[0].email, 'alice@example.com');
       assertEquals(created.config.accounts[0].accountUuid, 'acc-uuid-1');
       // CLI subscriptionType + rateLimitTier verbatim from the persisted
@@ -1073,7 +1073,7 @@ test('POST /api/upstreams rejects a direct claude-code create with a redirect me
   const { adminSession } = await setupAppTest();
 
   const resp = await requestApp('/api/upstreams', authed(adminSession, {
-    provider: 'claude-code',
+    kind: 'claude-code',
     name: 'Claude Code',
     config: {},
   }));
@@ -1789,11 +1789,11 @@ test('POST /api/upstreams/claude-code-setup-token-import (callback) creates a se
       );
       assertEquals(resp.status, 201);
       const created = (await resp.json()) as {
-        id: string; provider: string;
+        id: string; kind: string;
         config: { accounts: Array<{ email: string | null; accountUuid: string }> };
         state: { accounts: Array<{ tokenKind: string; refreshTokenSet: boolean; accessToken: { expiresAt: number } | null }> };
       };
-      assertEquals(created.provider, 'claude-code');
+      assertEquals(created.kind, 'claude-code');
       assertEquals(created.state.accounts[0].tokenKind, 'setup-token');
       // No refresh token on the wire view — the serializer surfaces presence
       // as `refreshTokenSet`. For setup-token it's always false.

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -8,7 +8,7 @@ export interface ModelsCacheStatus {
 
 export interface SerializedUpstreamRecord {
   id: string;
-  provider: UpstreamProviderKind;
+  kind: UpstreamProviderKind;
   name: string;
   enabled: boolean;
   sort_order: number;
@@ -24,7 +24,7 @@ export interface SerializedUpstreamRecord {
   // route handler. Both inner values are null on a row that has never been
   // warmed.
   modelsCache?: ModelsCacheStatus;
-  // Present only for provider === 'codex'.
+  // Present only for kind === 'codex'.
   codex_quota?: CodexQuotaSnapshot | null;
 }
 
@@ -36,11 +36,11 @@ const hasSecret = (value: unknown): boolean => typeof value === 'string' && valu
 
 const assertAccountsArray = (upstream: UpstreamRecord, accounts: unknown): Record<string, unknown>[] => {
   if (!Array.isArray(accounts)) {
-    throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed accounts: expected array`);
+    throw new Error(`Upstream ${upstream.id} (${upstream.kind}) has malformed accounts: expected array`);
   }
   return accounts.map((account, index) => {
     if (!isRecord(account)) {
-      throw new Error(`Upstream ${upstream.id} (${upstream.provider}) account[${index}] is malformed: expected object`);
+      throw new Error(`Upstream ${upstream.id} (${upstream.kind}) account[${index}] is malformed: expected object`);
     }
     return account;
   });
@@ -49,18 +49,18 @@ const assertAccountsArray = (upstream: UpstreamRecord, accounts: unknown): Recor
 const serializeOpaqueRecord = (upstream: UpstreamRecord, field: string, value: unknown): Record<string, unknown> | null => {
   if (value === null) return null;
   if (!isRecord(value)) {
-    throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed ${field}: expected object or null`);
+    throw new Error(`Upstream ${upstream.id} (${upstream.kind}) has malformed ${field}: expected object or null`);
   }
   return clone(value);
 };
 
 const redactedConfig = (upstream: UpstreamRecord): unknown => {
   if (!isRecord(upstream.config)) {
-    throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed config: expected object`);
+    throw new Error(`Upstream ${upstream.id} (${upstream.kind}) has malformed config: expected object`);
   }
   const config = upstream.config;
 
-  switch (upstream.provider) {
+  switch (upstream.kind) {
   case 'custom':
     return {
       ...(config.baseUrl !== undefined ? { baseUrl: clone(config.baseUrl) } : {}),
@@ -110,7 +110,7 @@ const redactedConfig = (upstream: UpstreamRecord): unknown => {
       apiKeySet: hasSecret(config.apiKey),
     };
   default: {
-    const exhaustive: never = upstream.provider;
+    const exhaustive: never = upstream.kind;
     throw new Error(`Unknown upstream provider for redaction: ${String(exhaustive)}`);
   }
   }
@@ -119,11 +119,11 @@ const redactedConfig = (upstream: UpstreamRecord): unknown => {
 const redactedState = (upstream: UpstreamRecord): unknown => {
   if (upstream.state === null || upstream.state === undefined) return null;
   if (!isRecord(upstream.state)) {
-    throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed state: expected object`);
+    throw new Error(`Upstream ${upstream.id} (${upstream.kind}) has malformed state: expected object`);
   }
   const state = upstream.state;
 
-  switch (upstream.provider) {
+  switch (upstream.kind) {
   case 'codex':
     return {
       accounts: assertAccountsArray(upstream, state.accounts).map(a => ({
@@ -142,7 +142,7 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
           ? null
           : isRecord(a.accessToken)
             ? { expiresAt: clone(a.accessToken.expiresAt), refreshedAt: clone(a.accessToken.refreshedAt) }
-            : (() => { throw new Error(`Upstream ${upstream.id} (${upstream.provider}) has malformed accessToken: expected object or null`); })();
+            : (() => { throw new Error(`Upstream ${upstream.id} (${upstream.kind}) has malformed accessToken: expected object or null`); })();
         return {
           ...(a.accountUuid !== undefined ? { accountUuid: clone(a.accountUuid) } : {}),
           ...(a.tokenKind !== undefined ? { tokenKind: clone(a.tokenKind) } : {}),
@@ -173,7 +173,7 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
     // These providers have no autonomous state.
     return null;
   default: {
-    const exhaustive: never = upstream.provider;
+    const exhaustive: never = upstream.kind;
     throw new Error(`Unknown upstream provider for state redaction: ${String(exhaustive)}`);
   }
   }
@@ -184,7 +184,7 @@ const serializeBase = (
   payload: { config: unknown; state: unknown },
 ): SerializedUpstreamRecord => ({
   id: upstream.id,
-  provider: upstream.provider,
+  kind: upstream.kind,
   name: upstream.name,
   enabled: upstream.enabled,
   sort_order: upstream.sortOrder,

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -8,7 +8,7 @@ const timestamp = '2026-04-29T00:00:00.000Z';
 
 const custom: UpstreamRecord = {
   id: 'up_custom_test',
-  provider: 'custom',
+  kind: 'custom',
   name: 'Custom Upstream',
   enabled: true,
   sortOrder: 10,
@@ -34,7 +34,7 @@ test('upstreamRecordToJson redacts custom bearer token inside config', () => {
   const config = result.config as Record<string, unknown>;
 
   assertEquals(result.id, 'up_custom_test');
-  assertEquals(result.provider, 'custom');
+  assertEquals(result.kind, 'custom');
   assertEquals(result.sort_order, 10);
   assertEquals(result.created_at, timestamp);
   assertEquals(result.updated_at, timestamp);
@@ -52,7 +52,7 @@ test('upstreamRecordToJson redacts Azure API keys inside config', () => {
   const result = upstreamRecordToJson({
     ...custom,
     id: 'up_azure_test',
-    provider: 'azure',
+    kind: 'azure',
     config: {
       endpoint: 'https://example.openai.azure.com',
       apiKey: 'az-secret',
@@ -61,7 +61,7 @@ test('upstreamRecordToJson redacts Azure API keys inside config', () => {
   });
   const config = result.config as Record<string, unknown>;
 
-  assertEquals(result.provider, 'azure');
+  assertEquals(result.kind, 'azure');
   assertEquals(config.endpoint, 'https://example.openai.azure.com');
   assertEquals(config.apiKey, undefined);
   assertEquals(config.apiKeySet, true);
@@ -72,7 +72,7 @@ test('upstreamRecordToJson redacts Copilot GitHub token inside config and expose
   const result = upstreamRecordToJson({
     ...custom,
     id: 'up_copilot_test',
-    provider: 'copilot',
+    kind: 'copilot',
     config: {
       githubToken: 'ghu_secret',
       user: {
@@ -89,7 +89,7 @@ test('upstreamRecordToJson redacts Copilot GitHub token inside config and expose
   const config = result.config as Record<string, unknown>;
   const state = result.state as Record<string, unknown>;
 
-  assertEquals(result.provider, 'copilot');
+  assertEquals(result.kind, 'copilot');
   assertEquals(config.githubToken, undefined);
   assertEquals(config.githubTokenSet, true);
   assertEquals(config.accountType, undefined);
@@ -107,7 +107,7 @@ test('upstreamRecordToJson serializes a Copilot row with state=null without thro
   const result = upstreamRecordToJson({
     ...custom,
     id: 'up_copilot_fresh',
-    provider: 'copilot',
+    kind: 'copilot',
     config: {
       githubToken: 'ghu_secret',
       user: { id: 200, login: 'fresh', name: null, avatar_url: 'https://example.com/fresh.png' },
@@ -115,7 +115,7 @@ test('upstreamRecordToJson serializes a Copilot row with state=null without thro
     state: null,
   });
 
-  assertEquals(result.provider, 'copilot');
+  assertEquals(result.kind, 'copilot');
   // A freshly imported Copilot row that hasn't completed its first token
   // exchange yet has no state at all — the dashboard renders the generic
   // 'copilot' badge in that case rather than a per-tier label.
@@ -126,7 +126,7 @@ test('upstreamRecordToJson serializes a Copilot row whose state lacks copilotTok
   const result = upstreamRecordToJson({
     ...custom,
     id: 'up_copilot_no_token',
-    provider: 'copilot',
+    kind: 'copilot',
     config: {
       githubToken: 'ghu_secret',
       user: { id: 201, login: 'no-token', name: null, avatar_url: 'https://example.com/n.png' },
@@ -153,7 +153,7 @@ test('upstreamRecordToFullJson includes provider config secrets for export', () 
 
 const claudeCodeBase = (overrides: { config?: unknown; state?: unknown }): UpstreamRecord => ({
   id: 'up_cc_test',
-  provider: 'claude-code',
+  kind: 'claude-code',
   name: 'Claude Code',
   enabled: true,
   sortOrder: 0,
@@ -169,7 +169,7 @@ const claudeCodeBase = (overrides: { config?: unknown; state?: unknown }): Upstr
 
 const codexBase = (overrides: { config?: unknown; state?: unknown }): UpstreamRecord => ({
   id: 'up_cx_test',
-  provider: 'codex',
+  kind: 'codex',
   name: 'Codex',
   enabled: true,
   sortOrder: 0,

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -12,7 +12,7 @@ import { createUpstreamLatencyRecorder } from '../shared/upstream-telemetry.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ChatCompletionsMessage, ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { type ProviderCandidate, type ExecuteResult } from '@floway-dev/provider';
+import { type ModelCandidate, type ExecuteResult } from '@floway-dev/provider';
 import { translateChatCompletionsViaMessages, translateChatCompletionsViaResponses } from '@floway-dev/translate';
 import { chatCompletionsViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -23,7 +23,7 @@ export const chatCompletionsTarget = chatTargetPicker(['chat-completions', 'mess
 export interface ChatCompletionsAttemptArgs {
   readonly payload: ChatCompletionsPayload;
   readonly ctx: ChatGatewayCtx;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly headers: Headers;
 }
 
@@ -75,7 +75,7 @@ export const chatCompletionsAttempt = {
 const rewriteOrRenderChatCompletionsFailure = async (
   payload: ChatCompletionsPayload,
   store: StatefulResponsesStore,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
 ): Promise<{ payload: ChatCompletionsPayload; failure?: undefined } | { payload?: undefined; failure: ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>> & { type: 'api-error' } }> => {
   try {
     const rewrittenMessages = await rewriteStoredResponsesItemsForCandidate(
@@ -106,12 +106,12 @@ const rewriteOrRenderChatCompletionsFailure = async (
 const callChatCompletionsAsExecuteResult = async (
   payload: ChatCompletionsPayload,
   ctx: ChatGatewayCtx,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
   headers: Headers,
 ): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
   const { model: _model, ...body } = payload;
   const recorder = createUpstreamLatencyRecorder();
-  const providerResult = await candidate.provider.provider.callChatCompletions(
+  const providerResult = await candidate.provider.instance.callChatCompletions(
     candidate.model,
     body,
     ctx.abortSignal,

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
@@ -83,7 +83,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: overrides.endpoints ? stubUpstreamModel({ endpoints: overrides.endpoints }) : stubUpstreamModel(),

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
@@ -9,7 +9,7 @@ import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_chat_completions_attempt_test';
@@ -74,7 +74,7 @@ const makeCandidate = (overrides: {
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({
     callChatCompletions: overrides.callChatCompletions,
@@ -84,7 +84,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: overrides.endpoints ? stubUpstreamModel({ endpoints: overrides.endpoints }) : stubUpstreamModel(),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
@@ -7,10 +7,10 @@ import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { ApiKey, User } from '../../../repo/types.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
-import { type ProviderCandidate, directFetcher, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
   return {
@@ -27,7 +27,7 @@ const { chatCompletionsHttp } = await import('./http.ts');
 
 const API_KEY_ID = 'key_chat_completions_http_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -102,13 +102,13 @@ const makeCandidate = (overrides: {
   upstream?: string;
   endpoints?: ModelEndpoints;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({ callChatCompletions: overrides.callChatCompletions });
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
@@ -107,7 +107,7 @@ const makeCandidate = (overrides: {
   const provider = stubProvider({ callChatCompletions: overrides.callChatCompletions });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -22,7 +22,7 @@ const stubCtx: ChatGatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -27,7 +27,7 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['demote-interleaved-system-to-user']),
 ): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -27,7 +27,7 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/include-usage-stream-options_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/include-usage-stream-options_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -24,7 +24,7 @@ const okEvents = () => Promise.resolve(eventResult((async function* () {})(), te
 
 const invocation = (payload: ChatCompletionsPayload): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate(),
+  candidate: stubModelCandidate(),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/normalize-usage_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/normalize-usage_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -23,7 +23,7 @@ const stubCtx: ChatGatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload = { model: 'test-model', messages: [] }): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate(),
+  candidate: stubModelCandidate(),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 type DeepseekReasoningDelta = ChatCompletionsStreamEvent['choices'][number]['delta'] & {
   reasoning_content?: string;
@@ -27,7 +27,7 @@ const stubCtx: ChatGatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -23,7 +23,7 @@ const stubCtx: ChatGatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-kimi'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -22,7 +22,7 @@ const stubCtx: ChatGatewayCtx = {
 
 const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ChatCompletionsInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'chat-completions',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/routing.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/routing.ts
@@ -2,12 +2,12 @@ import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { chatCompletionsViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 export const planChatCompletionsRouting = async (input: {
   readonly payload: ChatCompletionsPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ModelCandidate[];
   readonly ctx: ChatGatewayCtx;
 }): Promise<RoutingDecision> =>
   await classifyResponsesItemAffinity({

--- a/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
@@ -32,7 +32,7 @@ const candidateFor = (upstream: string): ModelCandidate => {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: modelProvider,
       supportsResponsesItemReference: true,
     },

--- a/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/routing_test.ts
@@ -7,7 +7,7 @@ import { createStoredResponsesItemId } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
@@ -25,7 +25,7 @@ const makeCtx = (): ChatGatewayCtx => ({
   store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
-const candidateFor = (upstream: string): ProviderCandidate => {
+const candidateFor = (upstream: string): ModelCandidate => {
   const upstreamModel = stubUpstreamModel();
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([upstreamModel]),
@@ -33,7 +33,7 @@ const candidateFor = (upstream: string): ProviderCandidate => {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider: modelProvider,
+      disabledPublicModelIds: [], modelPrefix: null, instance: modelProvider,
       supportsResponsesItemReference: true,
     },
     model: upstreamModel,

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -6,12 +6,12 @@ import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
-import { type ProviderCandidate, directFetcher, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 // Mock the candidates seam so each test hands the serve exactly the
 // provider candidates it wants.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
   return {
@@ -28,7 +28,7 @@ const { chatCompletionsServe } = await import('./serve.ts');
 
 const API_KEY_ID = 'key_chat_completions_serve_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -82,7 +82,7 @@ const makeCandidate = (overrides: {
   upstream?: string;
   endpoints?: ModelEndpoints;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({
     callChatCompletions: overrides.callChatCompletions,
@@ -90,7 +90,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -89,7 +89,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -11,7 +11,7 @@ import { traverseTranslation } from '../shared/translate-traverse.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
-import { type ProviderCandidate, plainResult, type ExecuteResult, type GeminiInvocation, type PlainResult } from '@floway-dev/provider';
+import { type ModelCandidate, plainResult, type ExecuteResult, type GeminiInvocation, type PlainResult } from '@floway-dev/provider';
 import { translateGeminiViaChatCompletions, translateGeminiViaMessages, translateGeminiViaResponses } from '@floway-dev/translate';
 
 // Gemini has no native upstream target in the provider API; prefer Chat
@@ -23,14 +23,14 @@ export const geminiCountTokensTarget = chatTargetPicker(['messages']);
 export interface GeminiAttemptGenerateArgs {
   readonly payload: GeminiPayload;
   readonly ctx: ChatGatewayCtx;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly headers: Headers;
 }
 
 export interface GeminiAttemptCountTokensArgs {
   readonly payload: GeminiPayload;
   readonly ctx: ChatGatewayCtx;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly headers: Headers;
 }
 

--- a/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
@@ -10,7 +10,7 @@ import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_gemini_attempt_test';
@@ -89,7 +89,7 @@ const makeCandidate = (overrides: {
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({
     callMessages: overrides.callMessages,
@@ -100,7 +100,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: overrides.endpoints ? stubUpstreamModel({ endpoints: overrides.endpoints }) : stubUpstreamModel(),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
@@ -99,7 +99,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: overrides.endpoints ? stubUpstreamModel({ endpoints: overrides.endpoints }) : stubUpstreamModel(),

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -116,7 +116,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel({ endpoints }),

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -8,10 +8,10 @@ import type { ApiKey, User } from '../../../repo/types.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import { type ProviderCandidate, directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
   return {
@@ -28,7 +28,7 @@ const { geminiHttp } = await import('./http.ts');
 
 const API_KEY_ID = 'key_gemini_http_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -96,7 +96,7 @@ const makeCandidate = (overrides: {
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const targetApi = overrides.targetApi ?? 'chat-completions';
   // When the test fixes `endpoints` directly, use it verbatim — that lets a
@@ -117,7 +117,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel({ endpoints }),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-safety-settings_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-safety-settings_test.ts
@@ -6,7 +6,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -25,7 +25,7 @@ const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate(),
+  candidate: stubModelCandidate(),
   targetApi: 'messages',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-part-fields_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-part-fields_test.ts
@@ -6,7 +6,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -25,7 +25,7 @@ const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate(),
+  candidate: stubModelCandidate(),
   targetApi: 'messages',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-tools_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/strip-unsupported-tools_test.ts
@@ -6,7 +6,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -25,7 +25,7 @@ const okEvents = (): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> =>
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate(),
+  candidate: stubModelCandidate(),
   targetApi: 'messages',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/gemini/interceptors/suppress-thought-parts_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/interceptors/suppress-thought-parts_test.ts
@@ -6,7 +6,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, eventResult, type GeminiInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -22,7 +22,7 @@ const stubCtx: ChatGatewayCtx = {
 
 const invocation = (payload: GeminiPayload): GeminiInvocation => ({
   payload,
-  candidate: stubProviderCandidate(),
+  candidate: stubModelCandidate(),
   targetApi: 'messages',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/gemini/routing.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/routing.ts
@@ -2,14 +2,14 @@ import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { geminiViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 export type GeminiRoutingDecision = RoutingDecision;
 
 export const planGeminiRouting = async (input: {
   readonly payload: GeminiPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ModelCandidate[];
   readonly ctx: ChatGatewayCtx;
 }): Promise<GeminiRoutingDecision> =>
   await classifyResponsesItemAffinity({

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -9,10 +9,10 @@ import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
   return {
@@ -29,7 +29,7 @@ const { geminiServe } = await import('./serve.ts');
 
 const API_KEY_ID = 'key_gemini_serve_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -110,7 +110,7 @@ const makeCandidate = (overrides: {
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const targetApi = overrides.targetApi ?? 'chat-completions';
   // The gemini serve layer picks the target from model.endpoints (chat-completions
@@ -133,7 +133,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel({ endpoints }),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -132,7 +132,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel({ endpoints }),

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -14,7 +14,7 @@ import { createUpstreamLatencyRecorder } from '../shared/upstream-telemetry.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesMessage, MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ProviderCandidate, ExecuteResult, PlainResult } from '@floway-dev/provider';
+import type { ModelCandidate, ExecuteResult, PlainResult } from '@floway-dev/provider';
 import { translateMessagesViaChatCompletions, translateMessagesViaResponses } from '@floway-dev/translate';
 import { messagesViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -29,14 +29,14 @@ export const messagesCountTokensTarget = chatTargetPicker(['messages']);
 export interface MessagesAttemptGenerateArgs {
   readonly payload: MessagesPayload;
   readonly ctx: ChatGatewayCtx;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly headers: Headers;
 }
 
 export interface MessagesAttemptCountTokensArgs {
   readonly payload: MessagesPayload;
   readonly ctx: ChatGatewayCtx;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly headers: Headers;
 }
 
@@ -57,7 +57,7 @@ export const messagesAttempt = {
       if (targetApi === 'messages') {
         const { model: _model, ...body } = invocation.payload;
         const recorder = createUpstreamLatencyRecorder();
-        const providerResult = await candidate.provider.provider.callMessages(
+        const providerResult = await candidate.provider.instance.callMessages(
           candidate.model,
           body,
           ctx.abortSignal,
@@ -109,7 +109,7 @@ export const messagesAttempt = {
     const recorder = createUpstreamLatencyRecorder();
     const response = await runInterceptors(invocation, ctx, messagesCountTokensInterceptors, async () => {
       const { model: _model, ...body } = invocation.payload;
-      const { response } = await candidate.provider.provider.callMessagesCountTokens(
+      const { response } = await candidate.provider.instance.callMessagesCountTokens(
         candidate.model,
         body,
         ctx.abortSignal,
@@ -135,7 +135,7 @@ export const messagesAttempt = {
 const rewriteOrRenderMessagesFailure = async (
   payload: MessagesPayload,
   store: StatefulResponsesStore,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
 ): Promise<{ payload: MessagesPayload; failure?: undefined } | { payload?: undefined; failure: ExecuteResult<ProtocolFrame<MessagesStreamEvent>> & { type: 'api-error' } }> => {
   try {
     const rewrittenMessages = await rewriteStoredResponsesItemsForCandidate(

--- a/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
@@ -76,7 +76,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: overrides.endpoints ? stubUpstreamModel({ endpoints: overrides.endpoints }) : stubUpstreamModel(),

--- a/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
@@ -9,7 +9,7 @@ import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-comp
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assertEquals, assertExists, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_messages_attempt_test';
@@ -66,7 +66,7 @@ const makeCandidate = (overrides: {
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({
     callMessages: overrides.callMessages,
@@ -77,7 +77,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: overrides.endpoints ? stubUpstreamModel({ endpoints: overrides.endpoints }) : stubUpstreamModel(),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -7,10 +7,10 @@ import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { ApiKey, User } from '../../../repo/types.ts';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import { type ProviderCandidate, directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderStreamResult, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
   return {
@@ -27,7 +27,7 @@ const { messagesHttp } = await import('./http.ts');
 
 const API_KEY_ID = 'key_messages_http_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -104,7 +104,7 @@ const makeCandidate = (overrides: {
   endpoints?: ModelEndpoints;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({
     callMessages: overrides.callMessages,
@@ -113,7 +113,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -112,7 +112,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -30,7 +30,7 @@ interface InvocationOptions {
 
 const invocation = (payload: MessagesPayload, { flagOn = true }: InvocationOptions = {}): MessagesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({
+  candidate: stubModelCandidate({
     model: {
       endpoints: { messages: {} },
       enabledFlags: flagOn ? new Set(['demote-interleaved-system-to-user']) : new Set(),

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { stubProviderCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
+import { stubModelCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -29,7 +29,7 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): MessagesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({
+  candidate: stubModelCandidate({
     model: { endpoints: { messages: {} }, enabledFlags },
   }),
   targetApi: 'messages',

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -30,7 +30,7 @@ interface InvocationOptions {
 
 const invocation = (payload: MessagesPayload, { flagOn = true }: InvocationOptions = {}): MessagesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({
+  candidate: stubModelCandidate({
     model: {
       endpoints: { messages: {} },
       enabledFlags: flagOn ? new Set(['strip-billing-attribution']) : new Set(),

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
@@ -30,7 +30,7 @@ import type {
   MessagesToolResultContentBlock,
   MessagesUserContentBlock,
 } from '@floway-dev/protocols/messages';
-import { assertEquals, assertExists, assertRejects, stubProviderCandidate } from '@floway-dev/test-utils';
+import { assertEquals, assertExists, assertRejects, stubModelCandidate } from '@floway-dev/test-utils';
 
 const testTelemetryModelIdentity = {
   model: 'test-model',
@@ -41,7 +41,7 @@ const testTelemetryModelIdentity = {
 
 const invocation = (payload: MessagesPayload): MessagesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({
+  candidate: stubModelCandidate({
     model: {
       endpoints: { messages: {} },
       enabledFlags: new Set(['messages-web-search-shim']),

--- a/packages/gateway/src/data-plane/chat/messages/routing.ts
+++ b/packages/gateway/src/data-plane/chat/messages/routing.ts
@@ -2,14 +2,14 @@ import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { messagesViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 export type MessagesRoutingDecision = RoutingDecision;
 
 export const planMessagesRouting = async (input: {
   readonly payload: MessagesPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ModelCandidate[];
   readonly ctx: ChatGatewayCtx;
 }): Promise<MessagesRoutingDecision> =>
   await classifyResponsesItemAffinity({

--- a/packages/gateway/src/data-plane/chat/messages/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/routing_test.ts
@@ -7,7 +7,7 @@ import { createStoredResponsesItemId } from '../responses/items/format.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
@@ -25,7 +25,7 @@ const makeCtx = (): ChatGatewayCtx => ({
   store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
-const candidateFor = (upstream: string): ProviderCandidate => {
+const candidateFor = (upstream: string): ModelCandidate => {
   const upstreamModel = stubUpstreamModel();
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([upstreamModel]),
@@ -33,7 +33,7 @@ const candidateFor = (upstream: string): ProviderCandidate => {
   return {
     provider: {
       upstream, providerKind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider: modelProvider,
+      disabledPublicModelIds: [], modelPrefix: null, instance: modelProvider,
       supportsResponsesItemReference: true,
     },
     model: upstreamModel,

--- a/packages/gateway/src/data-plane/chat/messages/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/routing_test.ts
@@ -32,7 +32,7 @@ const candidateFor = (upstream: string): ModelCandidate => {
   });
   return {
     provider: {
-      upstream, providerKind: 'custom', name: upstream,
+      upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: modelProvider,
       supportsResponsesItemReference: true,
     },

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -7,10 +7,10 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, defaultsForProvider, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, defaultsForProvider, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
   return {
@@ -27,7 +27,7 @@ const { messagesServe } = await import('./serve.ts');
 
 const API_KEY_ID = 'key_messages_serve_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -119,12 +119,12 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 const makeCandidate = (overrides: {
   upstream?: string;
   endpoints?: ModelEndpoints;
-  providerKind?: ProviderCandidate['provider']['providerKind'];
+  providerKind?: ModelCandidate['provider']['providerKind'];
   enabledFlags?: ReadonlySet<string>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const providerKind = overrides.providerKind ?? 'custom';
   const provider = stubProvider({
@@ -135,7 +135,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, providerKind, name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel({
       ...(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -119,14 +119,14 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 const makeCandidate = (overrides: {
   upstream?: string;
   endpoints?: ModelEndpoints;
-  providerKind?: ModelCandidate['provider']['providerKind'];
+  kind?: ModelCandidate['provider']['kind'];
   enabledFlags?: ReadonlySet<string>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
 } = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
-  const providerKind = overrides.providerKind ?? 'custom';
+  const kind = overrides.kind ?? 'custom';
   const provider = stubProvider({
     callMessages: overrides.callMessages,
     callResponses: overrides.callResponses,
@@ -134,7 +134,7 @@ const makeCandidate = (overrides: {
   });
   return {
     provider: {
-      upstream, providerKind, name: upstream,
+      upstream, kind, name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel({
@@ -394,7 +394,7 @@ test('claude-code candidate preserves x-anthropic-billing-header system block th
   queueCandidates([
     makeCandidate({
       upstream: 'up_cc',
-      providerKind: 'claude-code',
+      kind: 'claude-code',
       enabledFlags: claudeCodeDefaults,
       callMessages,
     }),
@@ -449,7 +449,7 @@ test('copilot candidate strips x-anthropic-billing-header system block via the d
   queueCandidates([
     makeCandidate({
       upstream: 'up_co',
-      providerKind: 'copilot',
+      kind: 'copilot',
       enabledFlags: copilotDefaults,
       callMessages,
     }),

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -18,7 +18,7 @@ import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
 import { type ResponsesPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction, type ResponsesInvocation } from '@floway-dev/provider';
+import { type ModelCandidate, eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction, type ResponsesInvocation } from '@floway-dev/provider';
 import { translateResponsesViaChatCompletions, translateResponsesViaMessages } from '@floway-dev/translate';
 
 // `/v1/responses` generate prefers the native Responses target, then the
@@ -32,7 +32,7 @@ export interface ResponsesAttemptInvokeArgs {
   readonly payload: ResponsesPayload;
   readonly action: ResponsesAction;
   readonly ctx: ChatGatewayCtx;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly headers: Headers;
 }
 
@@ -180,7 +180,7 @@ type RewriteOutcome =
 const rewriteOrRenderFailure = async (
   payload: ResponsesPayload,
   store: StatefulResponsesStore,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
 ): Promise<RewriteOutcome> => {
   try {
     return await rewriteResponsesItemsForCandidate(payload, store, candidate);
@@ -229,7 +229,7 @@ const dispatchResponses = async (
       // provider can decide for itself (every provider's streaming call
       // forces stream=true anyway).
       const { model: _model, stream: _stream, store: _store, ...body } = invocation.payload;
-      const providerResult = await candidate.provider.provider.callResponses(
+      const providerResult = await candidate.provider.instance.callResponses(
         candidate.model,
         body,
         invocation.action,
@@ -239,7 +239,7 @@ const dispatchResponses = async (
       return await providerResponsesResultToExecuteResult(providerResult, candidate, targetApi, ctx, recorder);
     }
     const { model: _model, ...body } = invocation.payload;
-    const providerResult = await candidate.provider.provider.callResponses(
+    const providerResult = await candidate.provider.instance.callResponses(
       candidate.model,
       body,
       invocation.action,
@@ -293,7 +293,7 @@ const dispatchResponses = async (
 // the provider executed.
 const providerResponsesResultToExecuteResult = async (
   providerResult: ProviderResponsesResult,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
   targetApi: ChatTargetApi,
   ctx: ChatGatewayCtx,
   recorder: ReturnType<typeof createUpstreamLatencyRecorder>,

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -11,7 +11,7 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions, type UpstreamModel } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions, type UpstreamModel } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_attempt_test';
@@ -56,7 +56,7 @@ const makeProviderEvents = async function* (events: readonly ResponsesStreamEven
   yield doneFrame();
 };
 
-const makeCandidate = (callResponses: (model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions) => Promise<ProviderResponsesResult>): ProviderCandidate => {
+const makeCandidate = (callResponses: (model: UpstreamModel, body: Omit<ResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions) => Promise<ProviderResponsesResult>): ModelCandidate => {
   const provider = stubProvider({ callResponses });
   return {
     provider: {
@@ -65,7 +65,7 @@ const makeCandidate = (callResponses: (model: UpstreamModel, body: Omit<Response
       name: 'up_test',
       disabledPublicModelIds: [],
       modelPrefix: null,
-      provider,
+      instance: provider,
       supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(),
@@ -371,10 +371,10 @@ test('generate inherits invocation headers across translation to Messages', asyn
       };
     },
   });
-  const candidate: ProviderCandidate = {
+  const candidate: ModelCandidate = {
     provider: {
       upstream: 'up_test', providerKind: 'custom', name: 'up_test',
-      disabledPublicModelIds: [], modelPrefix: null, provider: messagesProvider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: messagesProvider, supportsResponsesItemReference: true,
     },
     model: upstreamModel,
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -61,7 +61,7 @@ const makeCandidate = (callResponses: (model: UpstreamModel, body: Omit<Response
   return {
     provider: {
       upstream: 'up_test',
-      providerKind: 'custom',
+      kind: 'custom',
       name: 'up_test',
       disabledPublicModelIds: [],
       modelPrefix: null,
@@ -373,7 +373,7 @@ test('generate inherits invocation headers across translation to Messages', asyn
   });
   const candidate: ModelCandidate = {
     provider: {
-      upstream: 'up_test', providerKind: 'custom', name: 'up_test',
+      upstream: 'up_test', kind: 'custom', name: 'up_test',
       disabledPublicModelIds: [], modelPrefix: null, instance: messagesProvider, supportsResponsesItemReference: true,
     },
     model: upstreamModel,

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -114,7 +114,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream,
-      providerKind: 'custom',
+      kind: 'custom',
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -8,12 +8,12 @@ import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { ApiKey, StoredResponsesItem, User } from '../../../repo/types.ts';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, directFetcher, type ProviderResponsesResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 // Mock the candidates seam so each test hands the http entry exactly the
 // provider candidates it wants. Mirrors the pattern from serve_test.ts.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 const seenModels: string[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
@@ -32,7 +32,7 @@ const { responsesHttp } = await import('./http.ts');
 
 const API_KEY_ID = 'key_http_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -106,7 +106,7 @@ const makeCandidate = (overrides: {
   upstream?: string;
   endpoints?: ModelEndpoints;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({
     callResponses: overrides.callResponses,
@@ -118,7 +118,7 @@ const makeCandidate = (overrides: {
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,
-      provider,
+      instance: provider,
       supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, eventResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { stubProviderCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
+import { stubModelCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -23,7 +23,7 @@ const stubCtx: ChatGatewayCtx = {
 const invocation = (): ResponsesInvocation => ({
   payload: { model: 'gpt-test', input: 'hi' } as ResponsesPayload,
   action: 'generate',
-  candidate: stubProviderCandidate(),
+  candidate: stubModelCandidate(),
   targetApi: 'responses',
   headers: new Headers(),
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -7,7 +7,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -27,7 +27,7 @@ const makeInvocation = (
 ): ResponsesInvocation => ({
   payload: { model: 'test-model', input: [], ...payload } as ResponsesPayload,
   action: options.action ?? 'generate',
-  candidate: stubProviderCandidate({
+  candidate: stubModelCandidate({
     model: { enabledFlags: new Set(options.flagOn === false ? [] : ['responses-compact-shim']) },
   }),
   targetApi: options.targetApi ?? 'responses',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -32,7 +32,7 @@ const okEvents = () =>
 
 const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
   headers: new Headers(),
   action: 'generate',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -35,7 +35,7 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['demote-interleaved-system-to-user']),
 ): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
   headers: new Headers(),
   action: 'generate',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -35,7 +35,7 @@ const invocation = (
   enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
   headers: new Headers(),
   action: 'generate',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const makePayload = (): ResponsesPayload => ({
   model: 'gpt-test',
@@ -25,7 +25,7 @@ const makePayload = (): ResponsesPayload => ({
 
 const makeInvocation = (payload: ResponsesPayload): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags: new Set(['retry-cyber-policy']) } }),
+  candidate: stubModelCandidate({ model: { enabledFlags: new Set(['retry-cyber-policy']) } }),
   targetApi: 'responses',
   headers: new Headers(),
   action: 'generate',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -311,10 +311,10 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
     provider: {
       // Tests don't care about provider identity here; the shim reads
       // targetApi off the invocation and enabledFlags off the candidate's
-      // model. Use `never` to skip the full ModelProviderInstance literal.
+      // model. Use `never` to skip the full Provider literal.
       upstream: 'test-upstream', providerKind: 'custom', name: 'test',
       disabledPublicModelIds: [], modelPrefix: null,
-      provider: {} as never, supportsResponsesItemReference: false,
+      instance: {} as never, supportsResponsesItemReference: false,
     },
     model: {
       id: 'claude-x', limits: {}, kind: 'chat',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -312,7 +312,7 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
       // Tests don't care about provider identity here; the shim reads
       // targetApi off the invocation and enabledFlags off the candidate's
       // model. Use `never` to skip the full Provider literal.
-      upstream: 'test-upstream', providerKind: 'custom', name: 'test',
+      upstream: 'test-upstream', kind: 'custom', name: 'test',
       disabledPublicModelIds: [], modelPrefix: null,
       instance: {} as never, supportsResponsesItemReference: false,
     },

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -40,7 +40,7 @@ const defaultCandidates = vi.hoisted(() => () => [{
     disabledPublicModelIds: [],
     modelPrefix: null,
     supportsResponsesItemReference: false,
-    provider: {
+    instance: {
       getPricingForModelKey: () => null,
       callImagesGenerations: async (_model: unknown, body: Record<string, unknown>, _signal: unknown, opts: { recordUpstreamLatency: <T>(p: Promise<T>) => Promise<T> }) => {
         stub.generationsCalls.push(body);
@@ -135,7 +135,7 @@ const makeCtx = (input: unknown[], action: 'generate' | 'edit' | 'auto' = 'auto'
     provider: {
       upstream: 'test-upstream', providerKind: 'custom', name: 'test',
       disabledPublicModelIds: [], modelPrefix: null,
-      provider: {} as never, supportsResponsesItemReference: false,
+      instance: {} as never, supportsResponsesItemReference: false,
     },
     model: {
       id: 'm', limits: {}, kind: 'chat',
@@ -176,7 +176,7 @@ beforeEach(async () => {
   // "unknown upstream id: u".
   await repo.upstreams.save({
     id: 'u',
-    provider: 'custom',
+    kind: 'custom',
     name: 'mock-image',
     enabled: true,
     sortOrder: 0,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -35,7 +35,7 @@ const stub = vi.hoisted((): BackendStub => ({ generationsCalls: [], editsForms: 
 const defaultCandidates = vi.hoisted(() => () => [{
   provider: {
     upstream: 'u',
-    providerKind: 'custom',
+    kind: 'custom',
     name: 'mock-image',
     disabledPublicModelIds: [],
     modelPrefix: null,
@@ -133,7 +133,7 @@ const scriptedRun = (turns: ProtocolFrame<ResponsesStreamEvent>[][]) => {
 const makeCtx = (input: unknown[], action: 'generate' | 'edit' | 'auto' = 'auto', extraTool: Record<string, unknown> = {}): ResponsesInvocation => ({
   candidate: {
     provider: {
-      upstream: 'test-upstream', providerKind: 'custom', name: 'test',
+      upstream: 'test-upstream', kind: 'custom', name: 'test',
       disabledPublicModelIds: [], modelPrefix: null,
       instance: {} as never, supportsResponsesItemReference: false,
     },
@@ -376,7 +376,7 @@ test('resolveImageCandidate renders model_not_supported when image-kind candidat
   stub.nextResolutionOverride = {
     candidates: [{
       provider: {
-        upstream: 'u', providerKind: 'custom', name: 'wrong-endpoint',
+        upstream: 'u', kind: 'custom', name: 'wrong-endpoint',
         disabledPublicModelIds: [], modelPrefix: null,
         supportsResponsesItemReference: false,
         provider: { getPricingForModelKey: () => null },

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -18,7 +18,7 @@ import type {
   ResponsesPayload,
   ResponsesTool,
 } from '@floway-dev/protocols/responses';
-import type { Fetcher, ModelProviderInstance, PerformanceTelemetryContext, ProviderCandidate, UpstreamModel } from '@floway-dev/provider';
+import type { Fetcher, Provider, PerformanceTelemetryContext, ModelCandidate, UpstreamModel } from '@floway-dev/provider';
 
 export const SHIM_TOOL_NAME = 'image_generation';
 
@@ -460,14 +460,14 @@ interface ShimState {
   imageDispatchCount: number;
 }
 
-const recordImageUsage = (state: ShimState, provider: ModelProviderInstance, model: UpstreamModel, modelKey: string, responseBody: unknown): void => {
+const recordImageUsage = (state: ShimState, provider: Provider, model: UpstreamModel, modelKey: string, responseBody: unknown): void => {
   const usage = tokenUsageFromImagesBody(responseBody);
   if (usage === null) return;
   const promise = recordTokenUsage(state.apiKeyId, {
     model: model.id,
     upstream: provider.upstream,
     modelKey,
-    cost: provider.provider.getPricingForModelKey(modelKey) ?? null,
+    cost: provider.instance.getPricingForModelKey(modelKey) ?? null,
   }, usage).catch((error: unknown) => {
     console.error('Failed to record image generation usage:', error);
   });
@@ -537,7 +537,7 @@ const serverError = (e: unknown): ImageError => ({
 const resolveImageCandidate = async (
   isEdit: boolean,
   state: ShimState,
-): Promise<{ ok: true; candidate: ProviderCandidate } | { ok: false; error: ImageError }> => {
+): Promise<{ ok: true; candidate: ModelCandidate } | { ok: false; error: ImageError }> => {
   const endpointKey = isEdit ? 'imagesEdits' : 'imagesGenerations';
   const endpointPath = isEdit ? '/images/edits' : '/images/generations';
   let resolution;
@@ -631,7 +631,7 @@ export const parseRetryAfterMs = (headers: Headers): number | null => {
 // unread body — intermediate failed responses are drained inside the loop so
 // the underlying socket can be reused while we sleep.
 const issueImageCall = async (
-  provider: ModelProviderInstance,
+  provider: Provider,
   model: UpstreamModel,
   fetcher: Fetcher,
   prompt: string,
@@ -643,8 +643,8 @@ const issueImageCall = async (
   for (let attempt = 0; ; attempt++) {
     const recorder = createUpstreamLatencyRecorder();
     const { response, modelKey } = await (isEdit
-      ? provider.provider.callImagesEdits(model, buildEditsForm(prompt, state.config, sources, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() })
-      : provider.provider.callImagesGenerations(model, buildGenerationsBody(prompt, state.config, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() }));
+      ? provider.instance.callImagesEdits(model, buildEditsForm(prompt, state.config, sources, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() })
+      : provider.instance.callImagesGenerations(model, buildGenerationsBody(prompt, state.config, stream), state.downstreamAbortSignal, { fetcher, recordUpstreamLatency: recorder.record, waitUntil: state.backgroundScheduler, headers: new Headers() }));
     const context: PerformanceTelemetryContext = {
       keyId: state.apiKeyId,
       model: model.id,
@@ -675,7 +675,7 @@ const issueImageCall = async (
 // outcome. Transport/backend failures become `{ok:false}` rather than
 // throwing, so the caller always produces a terminal image item.
 const consumeImageResponse = async (
-  provider: ModelProviderInstance,
+  provider: Provider,
   model: UpstreamModel,
   modelKey: string,
   response: Response,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -33,7 +33,7 @@ const makeCtx = (payload: Partial<ResponsesPayload>): ResponsesInvocation => ({
     provider: {
       upstream: 'test-upstream', providerKind: 'custom', name: 'test',
       disabledPublicModelIds: [], modelPrefix: null,
-      provider: {} as never, supportsResponsesItemReference: false,
+      instance: {} as never, supportsResponsesItemReference: false,
     },
     model: {
       id: 'm', limits: {}, kind: 'chat',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -31,7 +31,7 @@ const PNG_B64 = 'aGVsbG8='; // "hello" — any decodable base64 works for source
 const makeCtx = (payload: Partial<ResponsesPayload>): ResponsesInvocation => ({
   candidate: {
     provider: {
-      upstream: 'test-upstream', providerKind: 'custom', name: 'test',
+      upstream: 'test-upstream', kind: 'custom', name: 'test',
       disabledPublicModelIds: [], modelPrefix: null,
       instance: {} as never, supportsResponsesItemReference: false,
     },

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -32,7 +32,7 @@ const okEvents = () =>
 
 const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
   headers: new Headers(),
   action: 'generate',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
-import { assertEquals, stubProviderCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',
@@ -32,7 +32,7 @@ const okEvents = () =>
 
 const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ResponsesInvocation => ({
   payload,
-  candidate: stubProviderCandidate({ model: { enabledFlags } }),
+  candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
   headers: new Headers(),
   action: 'generate',

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
@@ -4,7 +4,7 @@ import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import type { ChatServeFailure } from '../../shared/errors.ts';
 import type { RoutingDecision } from '../../shared/routing.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 type StoredResponsesAffinity = 'forcing' | 'portable' | 'downgradable' | 'non_affinity';
@@ -99,9 +99,9 @@ const collectStoredResponsesItemRefs = async <TSourceItems>(
 };
 
 const orderCandidatesByStoredResponsesAffinity = (
-  candidates: readonly ProviderCandidate[],
+  candidates: readonly ModelCandidate[],
   preferredUpstreamIds: ReadonlySet<string>,
-): readonly ProviderCandidate[] => {
+): readonly ModelCandidate[] => {
   const preferred = [...preferredUpstreamIds].reverse();
   if (preferred.length === 0) return candidates;
 
@@ -117,7 +117,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems>(input: {
   sourceItems: TSourceItems;
   view: ResponsesItemsView<TSourceItems>;
   store: StatefulResponsesStore;
-  candidates: readonly ProviderCandidate[];
+  candidates: readonly ModelCandidate[];
   // Items the caller will stage as inputs after the affinity walk; passed
   // here so `loadInputItems` can pre-load any stored row whose content hash
   // matches one of them. Without this, a duplicate user message resent on

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
@@ -7,14 +7,14 @@ import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 const API_KEY_ID = 'key_affinity_test';
 
-const candidate = (upstream: string, supportsResponsesItemReference = true): ProviderCandidate => {
+const candidate = (upstream: string, supportsResponsesItemReference = true): ModelCandidate => {
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
   });
@@ -25,7 +25,7 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Pro
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,
-      provider: modelProvider,
+      instance: modelProvider,
       supportsResponsesItemReference,
     },
     model: stubUpstreamModel(),
@@ -64,7 +64,7 @@ const storedRow = (
 
 const classifyItems = async (
   sourceItems: readonly ResponsesInputItem[],
-  candidates: readonly ProviderCandidate[],
+  candidates: readonly ModelCandidate[],
 ) => {
   const store = createNonResponsesSourceStore(API_KEY_ID);
   return await classifyResponsesItemAffinity({

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
@@ -21,7 +21,7 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Mod
   return {
     provider: {
       upstream,
-      providerKind: 'custom',
+      kind: 'custom',
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -3,7 +3,7 @@ import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import { throwChatServeFailure } from '../../shared/errors.ts';
 import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 const isUpstreamOwned = (row: StoredResponsesItem): row is StoredResponsesItem & { upstreamId: string } =>
@@ -25,7 +25,7 @@ const itemWithId = (item: ResponsesInputItem, id: string): ResponsesInputItem =>
 const rewriteItemForCandidate = (
   item: ResponsesInputItem,
   row: StoredResponsesItem,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
 ): ResponsesInputItem | null => {
   // An `item_reference` whose stored row has no inline payload can only
   // travel as a reference on the wire; a provider that doesn't support
@@ -86,7 +86,7 @@ export interface RewrittenResponsesPayload {
 const rewriteOneItemAgainstStore = (
   item: ResponsesInputItem,
   store: StatefulResponsesStore,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
   hashByEncryptedContent: ReadonlyMap<string, string>,
   references: RewrittenResponsesReference[],
 ): ResponsesInputItem | null => {
@@ -105,7 +105,7 @@ const rewriteOneItemAgainstStore = (
 export const rewriteResponsesItemsForCandidate = async (
   payload: ResponsesPayload,
   store: StatefulResponsesStore,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
 ): Promise<RewrittenResponsesPayload> => {
   if (typeof payload.input === 'string') return { payload, references: [] };
 
@@ -129,7 +129,7 @@ export const rewriteStoredResponsesItemsForCandidate = async <TSourceItems>(
   sourceItems: TSourceItems,
   view: ResponsesItemsView<TSourceItems>,
   store: StatefulResponsesStore,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
 ): Promise<TSourceItems> => {
   // Pre-compute encrypted_content hashes so the per-item walk is a single
   // synchronous lookup instead of re-hashing on every visit.

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -22,7 +22,7 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Mod
   return {
     provider: {
       upstream,
-      providerKind: 'custom',
+      kind: 'custom',
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -8,14 +8,14 @@ import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assert, assertEquals, assertFalse } from '@floway-dev/test-utils';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 const API_KEY_ID = 'key_rewrite_test';
 
-const candidate = (upstream: string, supportsResponsesItemReference = true): ProviderCandidate => {
+const candidate = (upstream: string, supportsResponsesItemReference = true): ModelCandidate => {
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
   });
@@ -26,7 +26,7 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Pro
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,
-      provider: modelProvider,
+      instance: modelProvider,
       supportsResponsesItemReference,
     },
     model: stubUpstreamModel(),
@@ -74,7 +74,7 @@ const makePayload = (input: ResponsesInputItem[]): ResponsesPayload => ({
 
 const rewrite = async (
   input: ResponsesInputItem[],
-  cand: ProviderCandidate,
+  cand: ModelCandidate,
 ): Promise<ResponsesInputItem[]> => {
   const store = createNonResponsesSourceStore(API_KEY_ID);
   await store.loadInputItems({ sourceItems: input, view: responsesItemsView });

--- a/packages/gateway/src/data-plane/chat/responses/routing.ts
+++ b/packages/gateway/src/data-plane/chat/responses/routing.ts
@@ -2,12 +2,12 @@ import { classifyResponsesItemAffinity } from './items/affinity.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { RoutingDecision } from '../shared/routing.ts';
 import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 export const planResponsesRouting = async (input: {
   readonly payload: ResponsesPayload;
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ModelCandidate[];
   readonly ctx: ChatGatewayCtx;
 }): Promise<RoutingDecision> => {
   // A bare-string input is wrapped into a synthetic user message for staging;

--- a/packages/gateway/src/data-plane/chat/responses/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/routing_test.ts
@@ -33,7 +33,7 @@ const candidateFor = (upstream: string): ModelCandidate => {
   return {
     provider: {
       upstream,
-      providerKind: 'custom',
+      kind: 'custom',
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,

--- a/packages/gateway/src/data-plane/chat/responses/routing_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/routing_test.ts
@@ -8,7 +8,7 @@ import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../repo/types.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assertEquals } from '@floway-dev/test-utils';
 
@@ -26,7 +26,7 @@ const makeCtx = (): ChatGatewayCtx => ({
   store: createNonResponsesSourceStore(API_KEY_ID),
 });
 
-const candidateFor = (upstream: string): ProviderCandidate => {
+const candidateFor = (upstream: string): ModelCandidate => {
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([stubUpstreamModel()]),
   });
@@ -37,7 +37,7 @@ const candidateFor = (upstream: string): ProviderCandidate => {
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,
-      provider: modelProvider,
+      instance: modelProvider,
       supportsResponsesItemReference: true,
     },
     model: stubUpstreamModel(),

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -7,7 +7,7 @@ import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ProviderCandidate, ExecuteResult } from '@floway-dev/provider';
+import type { ModelCandidate, ExecuteResult } from '@floway-dev/provider';
 
 // Thrown when a request names a `previous_response_id` that the store cannot
 // resolve. The HTTP/WS entry layer catches this and renders the OpenAI-shaped
@@ -74,7 +74,7 @@ const stageUserInputItems = async (input: ResponsesPayload['input'], store: Stat
 
 export type ResponsesServePlan =
   | { readonly kind: 'failure'; readonly result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> }
-  | { readonly kind: 'ready'; readonly prepared: ResponsesPayload; readonly candidate: ProviderCandidate };
+  | { readonly kind: 'ready'; readonly prepared: ResponsesPayload; readonly candidate: ModelCandidate };
 
 // Runs the shared serve-side prep both `responsesServe.generate` and
 // `responsesServe.compact` need before dispatching to `responsesAttempt`:

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -113,7 +113,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream,
-      providerKind: 'custom',
+      kind: 'custom',
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -10,7 +10,7 @@ import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-comp
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ProviderCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 // `enumerateModelCandidates` is the only seam between serve and the
@@ -20,7 +20,7 @@ import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-d
 // `sawModel` defaults to true when at least one candidate was queued; the
 // `model-missing` failure tests queue an empty list and expect `sawModel:
 // false` so the serve renders 404 rather than 400.
-const candidatesQueue: { readonly candidates: readonly ProviderCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
+const candidatesQueue: { readonly candidates: readonly ModelCandidate[]; readonly sawModel: boolean; readonly failedUpstreams: readonly string[] }[] = [];
 vi.mock('../../providers/registry.ts', async importOriginal => {
   const original = await importOriginal<typeof import('../../providers/registry.ts')>();
   return {
@@ -38,7 +38,7 @@ const { expandPreviousResponseId } = await import('./serve-prep.ts');
 
 const API_KEY_ID = 'key_serve_test';
 
-const queueCandidates = (candidates: readonly ProviderCandidate[], sawModel = candidates.length > 0): void => {
+const queueCandidates = (candidates: readonly ModelCandidate[], sawModel = candidates.length > 0): void => {
   candidatesQueue.push({ candidates, sawModel, failedUpstreams: [] });
 };
 
@@ -103,7 +103,7 @@ const makeCandidate = (overrides: {
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
-} = {}): ProviderCandidate => {
+} = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
   const provider = stubProvider({
     callResponses: overrides.callResponses,
@@ -117,7 +117,7 @@ const makeCandidate = (overrides: {
       name: upstream,
       disabledPublicModelIds: [],
       modelPrefix: null,
-      provider,
+      instance: provider,
       supportsResponsesItemReference: true,
     },
     // Default keeps stubUpstreamModel's three-endpoint map intact; tests that

--- a/packages/gateway/src/data-plane/chat/shared/attempt-helpers.ts
+++ b/packages/gateway/src/data-plane/chat/shared/attempt-helpers.ts
@@ -2,7 +2,7 @@ import type { GatewayCtx } from './gateway-ctx.ts';
 import { recordUpstreamHttpFailure, upstreamPerformanceContext, withUpstreamTelemetry } from './upstream-telemetry.ts';
 import { requireRecordedDurationMs, type UpstreamLatencyRecorder } from '../../shared/telemetry/performance.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
-import { eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderCandidate, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
+import { eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ModelCandidate, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
 
 // Per-protocol chat-target picker. Serve calls `canServe` to filter
 // candidates whose upstream wire cannot satisfy any preferred target;
@@ -54,18 +54,18 @@ export const chatTargetPicker = (preference: readonly ChatTargetApi[]): ChatTarg
 // (`or/gpt-4o` or `gpt-4o`). Usage and performance aggregates therefore key on
 // the canonical upstream id, and a dashboard slice over `model` rolls up both
 // surfaces of the same upstream model under one row.
-export const telemetryModelIdentity = (candidate: ProviderCandidate, modelKey: string): TelemetryModelIdentity => ({
+export const telemetryModelIdentity = (candidate: ModelCandidate, modelKey: string): TelemetryModelIdentity => ({
   model: candidate.model.id,
   upstream: candidate.provider.upstream,
   modelKey,
-  cost: candidate.provider.provider.getPricingForModelKey(modelKey),
+  cost: candidate.provider.instance.getPricingForModelKey(modelKey),
 });
 
 // Per-call UpstreamCallOptions for the chosen candidate; see
 // UpstreamCallOptions in `@floway-dev/provider` for the contract on each
 // field, especially header ownership.
 export const buildUpstreamCallOptions = (
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
   ctx: GatewayCtx,
   recordUpstreamLatency: UpstreamCallOptions['recordUpstreamLatency'],
   headers: Headers,
@@ -89,7 +89,7 @@ export const buildUpstreamCallOptions = (
 // — and so doesn't consult the recorder.
 export const providerStreamResultToExecuteResult = async <TEvent>(
   providerResult: ProviderStreamResult<TEvent>,
-  candidate: ProviderCandidate,
+  candidate: ModelCandidate,
   targetApi: ChatTargetApi,
   ctx: GatewayCtx,
   recorder: UpstreamLatencyRecorder,

--- a/packages/gateway/src/data-plane/chat/shared/attempt-helpers_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/attempt-helpers_test.ts
@@ -16,7 +16,7 @@ const testScheduler = (promise: Promise<unknown>): void => {
 // Azure resolves its catalog without HTTP, giving deterministic candidates.
 const azureUpstream = (id: string, sortOrder: number, modelIds: string[], endpoints: ModelEndpoints): UpstreamRecord => ({
   id,
-  provider: 'azure',
+  kind: 'azure',
   name: id,
   enabled: true,
   sortOrder,

--- a/packages/gateway/src/data-plane/chat/shared/routing.ts
+++ b/packages/gateway/src/data-plane/chat/shared/routing.ts
@@ -1,6 +1,6 @@
 import type { ChatServeFailure } from './errors.ts';
-import type { ProviderCandidate } from '@floway-dev/provider';
+import type { ModelCandidate } from '@floway-dev/provider';
 
 export type RoutingDecision =
-  | { readonly kind: 'success'; readonly candidates: readonly ProviderCandidate[] }
+  | { readonly kind: 'success'; readonly candidates: readonly ModelCandidate[] }
   | { readonly kind: 'failure'; readonly failure: ChatServeFailure };

--- a/packages/gateway/src/data-plane/chat/shared/upstream-telemetry.ts
+++ b/packages/gateway/src/data-plane/chat/shared/upstream-telemetry.ts
@@ -1,7 +1,7 @@
 import type { GatewayCtx } from './gateway-ctx.ts';
 import { recordPerformanceError, recordPerformanceLatency } from '../../shared/telemetry/performance.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ChatTargetApi, PerformanceTelemetryContext, ProviderCandidate } from '@floway-dev/provider';
+import type { ChatTargetApi, PerformanceTelemetryContext, ModelCandidate } from '@floway-dev/provider';
 
 export { createUpstreamLatencyRecorder } from '../../shared/telemetry/performance.ts';
 
@@ -10,7 +10,7 @@ type TerminalKind = 'success' | 'failure';
 // The full telemetry context for one upstream call: request-scoped dimensions
 // (keyId, stream, runtimeLocation) come off the gateway ctx, the model
 // dimensions off the chosen candidate plus the upstream-reported model key.
-export const upstreamPerformanceContext = (ctx: GatewayCtx, candidate: ProviderCandidate, modelKey: string): PerformanceTelemetryContext => ({
+export const upstreamPerformanceContext = (ctx: GatewayCtx, candidate: ModelCandidate, modelKey: string): PerformanceTelemetryContext => ({
   keyId: ctx.apiKeyId,
   model: candidate.model.id,
   upstream: candidate.provider.upstream,

--- a/packages/gateway/src/data-plane/completions/serve.ts
+++ b/packages/gateway/src/data-plane/completions/serve.ts
@@ -104,7 +104,7 @@ export const completions = async (c: Context): Promise<Response> => {
     kind: 'chat',
     modelServesEndpoint: model => model.endpoints.completions !== undefined,
     call: (provider, model, opts) =>
-      provider.provider.callCompletions(model, upstreamBody, ctx.abortSignal, opts),
+      provider.instance.callCompletions(model, upstreamBody, ctx.abortSignal, opts),
     response: request.wantsStream
       ? { format: 'sse', transformFrame, settleUsage }
       : {

--- a/packages/gateway/src/data-plane/embeddings/serve.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve.ts
@@ -63,7 +63,7 @@ export const embeddings = async (c: Context): Promise<Response> => {
     modelServesEndpoint: model => model.endpoints.embeddings !== undefined,
     call: async (provider, model, opts) => {
       const { model: _model, ...body } = request.body;
-      return await provider.provider.callEmbeddings(model, body, undefined, opts);
+      return await provider.instance.callEmbeddings(model, body, undefined, opts);
     },
     response: { format: 'json', extractBilling: tokenUsageFromEmbeddingsBody },
   });

--- a/packages/gateway/src/data-plane/images/serve.ts
+++ b/packages/gateway/src/data-plane/images/serve.ts
@@ -62,7 +62,7 @@ export const imagesGenerations = async (c: Context): Promise<Response> => {
     modelServesEndpoint: model => model.endpoints.imagesGenerations !== undefined,
     call: (provider, model, opts) => {
       const { model: _model, ...body } = request.body;
-      return provider.provider.callImagesGenerations(model, body, undefined, opts);
+      return provider.instance.callImagesGenerations(model, body, undefined, opts);
     },
     response: { format: 'json', extractBilling: tokenUsageFromImagesBody },
   });
@@ -103,7 +103,7 @@ export const imagesEdits = async (c: Context): Promise<Response> => {
     kind: 'image',
     modelServesEndpoint: model => model.endpoints.imagesEdits !== undefined,
     call: (provider, model, opts) => {
-      // ModelProvider.callImagesEdits takes ownership of the FormData and
+      // ProviderInstance.callImagesEdits takes ownership of the FormData and
       // appends the upstream-specific model/deployment id; allocate a fresh
       // copy per candidate so the contract holds even if cross-candidate
       // fallback is ever extended to try a second match. File-blob entries
@@ -113,7 +113,7 @@ export const imagesEdits = async (c: Context): Promise<Response> => {
         if (name === 'model') continue;
         passthrough.append(name, value);
       }
-      return provider.provider.callImagesEdits(model, passthrough, undefined, opts);
+      return provider.instance.callImagesEdits(model, passthrough, undefined, opts);
     },
     response: { format: 'json', extractBilling: tokenUsageFromImagesBody },
   });

--- a/packages/gateway/src/data-plane/images/serve_test.ts
+++ b/packages/gateway/src/data-plane/images/serve_test.ts
@@ -173,7 +173,7 @@ test('/v1/images/edits forwards a multipart request through an Azure model and r
   clearInProcessCopilotTokenCache();
   await repo.upstreams.save({
     id: 'az-image',
-    provider: 'azure',
+    kind: 'azure',
     name: 'azure-images',
     enabled: true,
     sortOrder: 1,

--- a/packages/gateway/src/data-plane/models/serve_test.ts
+++ b/packages/gateway/src/data-plane/models/serve_test.ts
@@ -81,7 +81,6 @@ test('/v1/models returns merged model list from Copilot and custom upstreams', a
           limits?: Record<string, number>;
           capabilities?: unknown;
           provider?: unknown;
-          providerKind?: unknown;
           providers?: unknown;
           providerData?: unknown;
           endpoints?: unknown;
@@ -116,7 +115,6 @@ test('/v1/models returns merged model list from Copilot and custom upstreams', a
       for (const model of body.data) {
         // Provider / upstream identity is hidden on the public surface.
         assertEquals(model.provider, undefined);
-        assertEquals(model.providerKind, undefined);
         assertEquals(model.providers, undefined);
         assertEquals(model.providerData, undefined);
         assertEquals(model.endpoints, undefined);

--- a/packages/gateway/src/data-plane/providers/azure/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/azure/provider_test.ts
@@ -28,7 +28,7 @@ const azureRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord =>
 
   return {
     id: 'up_azure',
-    provider: 'azure',
+    kind: 'azure',
     name: 'Azure Resource',
     enabled: true,
     sortOrder: 0,
@@ -46,7 +46,7 @@ const azureRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord =>
 
 test('createAzureProvider projects configured models into upstream models', async () => {
   const instance = createAzureProvider(azureRecord({ flagOverrides: { 'vendor-kimi': true } }));
-  const models = await instance.provider.getProvidedModels(directFetcher);
+  const models = await instance.instance.getProvidedModels(directFetcher);
 
   assertEquals(instance.upstream, 'up_azure');
   assertEquals(instance.name, 'Azure Resource');
@@ -74,7 +74,7 @@ test('createAzureProvider projects configured models into upstream models', asyn
 
 test('createAzureProvider sends upstream model ids in OpenAI-shaped request bodies and model keys', async () => {
   const instance = createAzureProvider(azureRecord());
-  const [model] = await instance.provider.getProvidedModels(directFetcher);
+  const [model] = await instance.instance.getProvidedModels(directFetcher);
   const seen: Array<{ url: string; body: Record<string, unknown> }> = [];
 
   await withMockedFetch(
@@ -86,9 +86,9 @@ test('createAzureProvider sends upstream model ids in OpenAI-shaped request bodi
       return sseResponse();
     },
     async () => {
-      const chat = await instance.provider.callChatCompletions(model, { messages: [{ role: 'user', content: 'hello' }] }, undefined, noopUpstreamCallOptions());
-      const responses = await instance.provider.callResponses(model, { input: 'hello' }, 'generate', undefined, noopUpstreamCallOptions());
-      const embeddings = await instance.provider.callEmbeddings(model, { input: 'hello' }, undefined, noopUpstreamCallOptions());
+      const chat = await instance.instance.callChatCompletions(model, { messages: [{ role: 'user', content: 'hello' }] }, undefined, noopUpstreamCallOptions());
+      const responses = await instance.instance.callResponses(model, { input: 'hello' }, 'generate', undefined, noopUpstreamCallOptions());
+      const embeddings = await instance.instance.callEmbeddings(model, { input: 'hello' }, undefined, noopUpstreamCallOptions());
 
       assertEquals(chat.modelKey, 'gpt-prod');
       assertEquals(responses.modelKey, 'gpt-prod');
@@ -130,7 +130,7 @@ test('createAzureProvider supports Azure AI cross-provider models with explicit 
       },
     }),
   );
-  const [chatModel, responsesModel] = await instance.provider.getProvidedModels(directFetcher);
+  const [chatModel, responsesModel] = await instance.instance.getProvidedModels(directFetcher);
   const seen: Array<{ url: string; apiKey: string | null; body: Record<string, unknown> }> = [];
 
   assertEquals(chatModel.id, 'deepseek-v4-pro');
@@ -148,8 +148,8 @@ test('createAzureProvider supports Azure AI cross-provider models with explicit 
       return sseResponse();
     },
     async () => {
-      const chat = await instance.provider.callChatCompletions(chatModel, { messages: [{ role: 'user', content: 'hello' }] }, undefined, noopUpstreamCallOptions());
-      const responses = await instance.provider.callResponses(responsesModel, { input: 'hello' }, 'generate', undefined, noopUpstreamCallOptions());
+      const chat = await instance.instance.callChatCompletions(chatModel, { messages: [{ role: 'user', content: 'hello' }] }, undefined, noopUpstreamCallOptions());
+      const responses = await instance.instance.callResponses(responsesModel, { input: 'hello' }, 'generate', undefined, noopUpstreamCallOptions());
       assertEquals(chat.modelKey, 'deepseek-v4-pro');
       assertEquals(responses.modelKey, 'gpt-5.4-pro');
     },
@@ -193,7 +193,7 @@ test('createAzureProvider supports native Azure Anthropic Messages models', asyn
       },
     }),
   );
-  const [model] = await instance.provider.getProvidedModels(directFetcher);
+  const [model] = await instance.instance.getProvidedModels(directFetcher);
   const seen: Array<{ url: string; xApiKey: string | null; body: Record<string, unknown>; beta: string | null }> = [];
 
   assertEquals(model.id, 'claude-public');
@@ -210,8 +210,8 @@ test('createAzureProvider supports native Azure Anthropic Messages models', asyn
       return sseResponse();
     },
     async () => {
-      const messages = await instance.provider.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hello' }] }, undefined, { ...noopUpstreamCallOptions(), headers: new Headers({ 'anthropic-beta': 'context-1m' }) });
-      const count = await instance.provider.callMessagesCountTokens(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hello' }] }, undefined, noopUpstreamCallOptions());
+      const messages = await instance.instance.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hello' }] }, undefined, { ...noopUpstreamCallOptions(), headers: new Headers({ 'anthropic-beta': 'context-1m' }) });
+      const count = await instance.instance.callMessagesCountTokens(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hello' }] }, undefined, noopUpstreamCallOptions());
       assertEquals(messages.modelKey, 'claude-prod');
       assertEquals(count.modelKey, 'claude-prod');
     },
@@ -243,7 +243,7 @@ test('createAzureProvider forwards inbound anthropic-beta header through opts.he
       },
     }),
   );
-  const [model] = await instance.provider.getProvidedModels(directFetcher);
+  const [model] = await instance.instance.getProvidedModels(directFetcher);
   const seen: Array<string | null> = [];
 
   await withMockedFetch(
@@ -255,12 +255,12 @@ test('createAzureProvider forwards inbound anthropic-beta header through opts.he
       // The data plane plumbs the inbound `anthropic-beta` header straight
       // through `opts.headers`. Azure has no boundary filter, so whatever
       // arrives on `opts.headers` is what the wire sees.
-      await instance.provider.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, { ...noopUpstreamCallOptions(), headers: new Headers({ 'anthropic-beta': 'context-1m-2025-08-07,interleaved-thinking-2025-05-14' }) });
-      await instance.provider.callMessagesCountTokens(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, { ...noopUpstreamCallOptions(), headers: new Headers({ 'anthropic-beta': 'context-1m-2025-08-07' }) });
+      await instance.instance.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, { ...noopUpstreamCallOptions(), headers: new Headers({ 'anthropic-beta': 'context-1m-2025-08-07,interleaved-thinking-2025-05-14' }) });
+      await instance.instance.callMessagesCountTokens(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, { ...noopUpstreamCallOptions(), headers: new Headers({ 'anthropic-beta': 'context-1m-2025-08-07' }) });
       // No beta header → no header on the wire (the regression guard for the
       // pre-86ef9aa drop).
-      await instance.provider.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, noopUpstreamCallOptions());
-      await instance.provider.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, noopUpstreamCallOptions());
+      await instance.instance.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, noopUpstreamCallOptions());
+      await instance.instance.callMessages(model, { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }, undefined, noopUpstreamCallOptions());
     },
   );
 
@@ -286,7 +286,7 @@ test('createAzureProvider applies per-model flag overrides on top of the upstrea
       },
     }),
   );
-  const models = await instance.provider.getProvidedModels(directFetcher);
+  const models = await instance.instance.getProvidedModels(directFetcher);
   const d1 = models.find(model => (model.providerData as { upstreamModelId: string }).upstreamModelId === 'd1');
   const d2 = models.find(model => (model.providerData as { upstreamModelId: string }).upstreamModelId === 'd2');
   if (!d1 || !d2) throw new Error('expected both models');
@@ -315,7 +315,7 @@ test('createAzureProvider skips the per-model layer when flagOverrides.enabled i
       },
     }),
   );
-  const [model] = await instance.provider.getProvidedModels(directFetcher);
+  const [model] = await instance.instance.getProvidedModels(directFetcher);
 
   assertEquals(model.enabledFlags.has('vendor-deepseek'), true);
 });
@@ -341,7 +341,7 @@ test('createAzureProvider attaches cost field from model config', async () => {
       },
     }),
   );
-  const models = await instance.provider.getProvidedModels(directFetcher);
+  const models = await instance.instance.getProvidedModels(directFetcher);
   assertEquals(models[0].cost, { input: 2.5, output: 15, input_cache_read: 0.25 });
   assertEquals(models[1].cost, undefined);
 });
@@ -366,15 +366,15 @@ test('createAzureProvider getPricingForModelKey resolves by upstream model id', 
       },
     }),
   );
-  assertEquals(instance.provider.getPricingForModelKey('gpt-prod'), { input: 2.5, output: 15 });
-  assertEquals(instance.provider.getPricingForModelKey('gpt-small'), null);
-  assertEquals(instance.provider.getPricingForModelKey('unknown'), null);
+  assertEquals(instance.instance.getPricingForModelKey('gpt-prod'), { input: 2.5, output: 15 });
+  assertEquals(instance.instance.getPricingForModelKey('gpt-small'), null);
+  assertEquals(instance.instance.getPricingForModelKey('unknown'), null);
 });
 
 test('createAzureProvider exposes image models and routes generations with api-version=preview', async () => {
   const record: UpstreamRecord = {
     id: 'az-image',
-    provider: 'azure',
+    kind: 'azure',
     name: 'azure-images',
     enabled: true,
     sortOrder: 0,
@@ -404,7 +404,7 @@ test('createAzureProvider exposes image models and routes generations with api-v
       return new Response(JSON.stringify({ data: [{ b64_json: 'x' }], usage: { input_tokens: 1, output_tokens: 2 } }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
     },
     async () => {
-      const provider = createAzureProvider(record).provider;
+      const provider = createAzureProvider(record).instance;
       const models = await provider.getProvidedModels(directFetcher);
       assertEquals(models[0].kind, 'image');
       assertEquals(models[0].endpoints, { imagesGenerations: {}, imagesEdits: {} });
@@ -421,7 +421,7 @@ test('createAzureProvider exposes image models and routes generations with api-v
 test('createAzureProvider callImagesEdits posts multipart with model replaced by upstream model id and api-version=preview', async () => {
   const record: UpstreamRecord = {
     id: 'az-image',
-    provider: 'azure',
+    kind: 'azure',
     name: 'azure-images',
     enabled: true,
     sortOrder: 0,
@@ -451,7 +451,7 @@ test('createAzureProvider callImagesEdits posts multipart with model replaced by
       return new Response(JSON.stringify({ data: [{ b64_json: 'x' }], usage: { input_tokens: 3, output_tokens: 4 } }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
     },
     async () => {
-      const provider = createAzureProvider(record).provider;
+      const provider = createAzureProvider(record).instance;
       const models = await provider.getProvidedModels(directFetcher);
       const form = new FormData();
       form.append('prompt', 'replace sky');

--- a/packages/gateway/src/data-plane/providers/custom/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/custom/provider_test.ts
@@ -8,7 +8,7 @@ import { jsonResponse, noopUpstreamCallOptions, sseResponse, withMockedFetch, as
 
 const baseRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => ({
   id: 'up_custom_test',
-  provider: 'custom',
+  kind: 'custom',
   name: 'Custom Test',
   enabled: true,
   sortOrder: 0,
@@ -30,7 +30,7 @@ const baseRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => 
 
 test('Custom provider forces stream=true for streaming endpoints and leaves count-tokens/embeddings alone', async () => {
   const instance = createCustomProvider(baseRecord());
-  const provider = instance.provider;
+  const provider = instance.instance;
   const bodies: Record<string, Record<string, unknown>> = {};
 
   assertEquals(instance.supportsResponsesItemReference, true);
@@ -103,7 +103,7 @@ test('Custom provider uses configured endpoints regardless of per-model hints in
           apiKey: 'sk-test',
           endpoints: { chatCompletions: {} },
         },
-      })).provider;
+      })).instance;
       const [model] = await provider.getProvidedModels(directFetcher);
       assertEquals(model.endpoints, { chatCompletions: {} });
       assertEquals(model.kind, 'chat');
@@ -128,7 +128,7 @@ test('Custom provider projects display_name / created / limits / cost from a Flo
     }),
     async () => {
       const instance = createCustomProvider(baseRecord({ id: 'up_custom_rich' }));
-      const [model] = await instance.provider.getProvidedModels(directFetcher);
+      const [model] = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(model.display_name, 'Rich Model');
       assertEquals(model.created, Math.floor(Date.parse('2026-04-01T00:00:00Z') / 1000));
       assertEquals(model.limits.max_output_tokens, 8192);
@@ -137,11 +137,11 @@ test('Custom provider projects display_name / created / limits / cost from a Flo
       assertEquals(model.cost?.output, 15);
       assertEquals(model.cost?.input_cache_read, 0.3);
 
-      const pricing = instance.provider.getPricingForModelKey('m-rich');
+      const pricing = instance.instance.getPricingForModelKey('m-rich');
       assertEquals(pricing?.input, 3);
       assertEquals(pricing?.output, 15);
 
-      assertEquals(instance.provider.getPricingForModelKey('unknown'), null);
+      assertEquals(instance.instance.getPricingForModelKey('unknown'), null);
     },
   );
 });
@@ -152,7 +152,7 @@ test('Custom provider falls back to `name` when display_name is missing (loose O
   await withMockedFetch(
     () => jsonResponse({ object: 'list', data: [{ id: 'm-named', name: 'Named Model' }] }),
     async () => {
-      const [model] = await createCustomProvider(baseRecord({ id: 'up_custom_named' })).provider.getProvidedModels(directFetcher);
+      const [model] = await createCustomProvider(baseRecord({ id: 'up_custom_named' })).instance.getProvidedModels(directFetcher);
       assertEquals(model.display_name, 'Named Model');
     },
   );
@@ -172,7 +172,7 @@ test('Custom provider projects gpt-image-* models with kind=image and both image
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const provider = createCustomProvider(record).provider;
+      const provider = createCustomProvider(record).instance;
       const models = await provider.getProvidedModels(directFetcher);
       assertEquals(models.length, 1);
       assertEquals(models[0].id, 'gpt-image-2-2026-04-21');
@@ -199,7 +199,7 @@ test('Custom provider callImagesGenerations posts JSON with model re-injected', 
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const provider = createCustomProvider(record).provider;
+      const provider = createCustomProvider(record).instance;
       const models = await provider.getProvidedModels(directFetcher);
       const result = await provider.callImagesGenerations(models[0], { prompt: 'hi' }, undefined, noopUpstreamCallOptions());
       assertEquals(result.modelKey, 'gpt-image-2');
@@ -228,7 +228,7 @@ test('Custom provider callImagesEdits forwards multipart body with model field a
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const provider = createCustomProvider(record).provider;
+      const provider = createCustomProvider(record).instance;
       const models = await provider.getProvidedModels(directFetcher);
       const form = new FormData();
       form.append('prompt', 'add a kite');
@@ -269,7 +269,7 @@ test('Custom provider with modelsFetch disabled serves only manual models and ne
             },
           ],
         },
-      })).provider;
+      })).instance;
 
       const models = await provider.getProvidedModels(directFetcher);
       assertEquals(models.length, 1);
@@ -322,7 +322,7 @@ test('Custom provider with a manual override sharing an upstream id wins over th
             },
           ],
         },
-      })).provider;
+      })).instance;
 
       const models = await provider.getProvidedModels(directFetcher);
       // [manual, ...autoFiltered] — the upstream 'shared' copy is dropped.
@@ -345,7 +345,7 @@ test('Custom provider with a manual override sharing an upstream id wins over th
 
 test('Custom provider forwards inbound anthropic-beta header through opts.headers', async () => {
   const instance = createCustomProvider(baseRecord());
-  const provider = instance.provider;
+  const provider = instance.instance;
   const seen: Array<string | null> = [];
 
   await withMockedFetch(

--- a/packages/gateway/src/data-plane/providers/models-cache.ts
+++ b/packages/gateway/src/data-plane/providers/models-cache.ts
@@ -1,6 +1,6 @@
 import { getRepo } from '../../repo/index.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
-import type { Fetcher, ModelProviderInstance, UpstreamModel } from '@floway-dev/provider';
+import type { Fetcher, Provider, UpstreamModel } from '@floway-dev/provider';
 
 // Soft TTL: a fetched row is served verbatim within this window with no
 // upstream call. Past SOFT but within HARD, the stored row is still served
@@ -45,12 +45,12 @@ const memoInFlight = (
 const errorMessage = (err: unknown): string => err instanceof Error ? err.message : String(err);
 
 const runFetch = async (
-  instance: ModelProviderInstance,
+  instance: Provider,
   fetcher: Fetcher,
   key: string,
 ): Promise<UpstreamModel[]> => {
   try {
-    const models = [...await instance.provider.getProvidedModels(fetcher)];
+    const models = [...await instance.instance.getProvidedModels(fetcher)];
     await getRepo().modelsCache.put(key, { fetchedAt: Date.now(), models });
     return models;
   } catch (err) {
@@ -63,7 +63,7 @@ const runFetch = async (
 };
 
 export const fetchUpstreamModelsCached = async (
-  instance: ModelProviderInstance,
+  instance: Provider,
   opts: ModelsCacheFetchOptions,
 ): Promise<UpstreamModel[]> => {
   const { scheduler, fetcher, force } = opts;

--- a/packages/gateway/src/data-plane/providers/models-cache_test.ts
+++ b/packages/gateway/src/data-plane/providers/models-cache_test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { clearInFlightForTesting, fetchUpstreamModelsCached } from './models-cache.ts';
 import { initRepo } from '../../repo/index.ts';
 import { InMemoryRepo } from '../../repo/memory.ts';
-import { directFetcher, type ModelProviderInstance, type UpstreamModel } from '@floway-dev/provider';
+import { directFetcher, type Provider, type UpstreamModel } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
 const aModel = (id: string): UpstreamModel => stubUpstreamModel({ id });
@@ -11,14 +11,14 @@ const aModel = (id: string): UpstreamModel => stubUpstreamModel({ id });
 const stubInstance = (
   upstreamId: string,
   fetchFn: () => Promise<UpstreamModel[]>,
-): ModelProviderInstance => ({
+): Provider => ({
   upstream: upstreamId,
   providerKind: 'custom',
   name: upstreamId,
   disabledPublicModelIds: [],
   modelPrefix: null,
   supportsResponsesItemReference: false,
-  provider: stubProvider({ getProvidedModels: fetchFn }),
+  instance: stubProvider({ getProvidedModels: fetchFn }),
 });
 
 const setupRepo = (): InMemoryRepo => {

--- a/packages/gateway/src/data-plane/providers/models-cache_test.ts
+++ b/packages/gateway/src/data-plane/providers/models-cache_test.ts
@@ -13,7 +13,7 @@ const stubInstance = (
   fetchFn: () => Promise<UpstreamModel[]>,
 ): Provider => ({
   upstream: upstreamId,
-  providerKind: 'custom',
+  kind: 'custom',
   name: upstreamId,
   disabledPublicModelIds: [],
   modelPrefix: null,

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -3,7 +3,7 @@ import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import { type ModelEndpointKey, type ModelEndpoints, type ModelKind, kindForEndpoints } from '@floway-dev/protocols/common';
-import { isAbortError, type InternalModel, type Fetcher, type ModelProviderInstance, type ProviderCandidate, type UpstreamModel, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import { isAbortError, type InternalModel, type Fetcher, type Provider, type ModelCandidate, type UpstreamModel, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
 import { createAzureProvider } from '@floway-dev/provider-azure';
 import { createClaudeCodeProvider } from '@floway-dev/provider-claude-code';
 import { createCodexProvider } from '@floway-dev/provider-codex';
@@ -16,7 +16,7 @@ interface ProviderModelsResult {
   // Reverse index: every upstream instance that emitted an entry under the
   // given public id, in enumeration order. The control-plane catalog
   // endpoint reads this to render `upstreams: [{kind, id, name}]` per row.
-  upstreamsByPublicId: Map<string, ModelProviderInstance[]>;
+  upstreamsByPublicId: Map<string, Provider[]>;
   sawSuccess: boolean;
   lastError: unknown;
   // Upstream names whose catalog fetch rejected this round, in the same
@@ -27,7 +27,7 @@ interface ProviderModelsResult {
 
 const NO_UPSTREAM_CONFIGURED_MESSAGE = 'No upstream provider configured — connect GitHub Copilot or add a Custom/Azure upstream in the dashboard';
 
-type ProviderFactory = (record: UpstreamRecord) => ModelProviderInstance | Promise<ModelProviderInstance>;
+type ProviderFactory = (record: UpstreamRecord) => Provider | Promise<Provider>;
 
 const providerFactories: Record<UpstreamProviderKind, ProviderFactory> = {
   copilot: createCopilotProvider,
@@ -38,8 +38,8 @@ const providerFactories: Record<UpstreamProviderKind, ProviderFactory> = {
   ollama: createOllamaProvider,
 };
 
-export const createProviderInstance = (record: UpstreamRecord): ModelProviderInstance | Promise<ModelProviderInstance> =>
-  providerFactories[record.provider](record);
+export const createProviderInstance = (record: UpstreamRecord): Provider | Promise<Provider> =>
+  providerFactories[record.kind](record);
 
 // The upstream scope is a required argument across the catalog-assembly chain
 // (this, getModels) so a caller can never omit it and silently receive the
@@ -47,7 +47,7 @@ export const createProviderInstance = (record: UpstreamRecord): ModelProviderIns
 // leak. Pass `null` to deliberately request every enabled upstream.
 export const listModelProviders = async (
   upstreamFilter: readonly string[] | null,
-): Promise<ModelProviderInstance[]> => {
+): Promise<Provider[]> => {
   const upstreams = await getRepo().upstreams.list();
   const enabledById = new Map<string, UpstreamRecord>();
   const knownIds = new Set<string>();
@@ -74,9 +74,9 @@ export const listModelProviders = async (
     selection = [...enabledById.values()];
   }
 
-  const providers: ModelProviderInstance[] = [];
+  const providers: Provider[] = [];
   for (const upstream of selection) {
-    const factory = providerFactories[upstream.provider];
+    const factory = providerFactories[upstream.kind];
     providers.push(await factory(upstream));
   }
 
@@ -110,8 +110,8 @@ const catalogFromUpstreamModel = (upstreamModel: UpstreamModel): InternalModel =
 // upstream chips without re-walking the catalog.
 const mergeIntoCatalog = (
   byId: Map<string, InternalModel>,
-  upstreamsByPublicId: Map<string, ModelProviderInstance[]>,
-  instance: ModelProviderInstance,
+  upstreamsByPublicId: Map<string, Provider[]>,
+  instance: Provider,
   surfacedModel: UpstreamModel,
   publicId: string,
 ): void => {
@@ -136,12 +136,12 @@ const mergeIntoCatalog = (
 };
 
 const collectProviderModels = async (
-  providers: readonly ModelProviderInstance[],
+  providers: readonly Provider[],
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<ProviderModelsResult> => {
   const byId = new Map<string, InternalModel>();
-  const upstreamsByPublicId = new Map<string, ModelProviderInstance[]>();
+  const upstreamsByPublicId = new Map<string, Provider[]>();
   let sawSuccess = false;
   let lastError: unknown = null;
   const failedUpstreams: string[] = [];
@@ -151,7 +151,7 @@ const collectProviderModels = async (
   // the SOFT-fresh row without an upstream round trip, so the parallel walk
   // is cheap on the warm path and bounded by `max(per-upstream fetch)` on
   // the cold path.
-  const fetchOne = (instance: ModelProviderInstance) =>
+  const fetchOne = (instance: Provider) =>
     fetchUpstreamModelsCached(instance, {
       scheduler,
       fetcher: fetcherForUpstream(instance.upstream),
@@ -256,7 +256,7 @@ export const getModels = async (
   upstreamFilter: readonly string[] | null,
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
-): Promise<{ models: InternalModel[]; upstreamsByPublicId: Map<string, ModelProviderInstance[]>; failedUpstreams: readonly string[] }> => {
+): Promise<{ models: InternalModel[]; upstreamsByPublicId: Map<string, Provider[]>; failedUpstreams: readonly string[] }> => {
   const providers = await listModelProviders(upstreamFilter);
   if (providers.length === 0) {
     throw new Error(NO_UPSTREAM_CONFIGURED_MESSAGE);
@@ -290,12 +290,12 @@ export const getModels = async (
 // catalog regardless of kind, so the caller can distinguish
 // "id is unknown to this upstream" from "id exists but wrong kind".
 const enumerateOneUpstreamCandidates = async (
-  provider: ModelProviderInstance,
+  provider: Provider,
   modelId: string,
   kind: ModelKind,
   fetcher: Fetcher,
   scheduler: BackgroundScheduler,
-): Promise<{ candidates: ProviderCandidate[]; sawAnyId: boolean }> => {
+): Promise<{ candidates: ModelCandidate[]; sawAnyId: boolean }> => {
   const cfg = provider.modelPrefix;
   const lookupIds: string[] = [];
   if (cfg === null) {
@@ -310,7 +310,7 @@ const enumerateOneUpstreamCandidates = async (
 
   const providedModels = await fetchUpstreamModelsCached(provider, { scheduler, fetcher });
   const disabled = new Set(provider.disabledPublicModelIds);
-  const candidates: ProviderCandidate[] = [];
+  const candidates: ModelCandidate[] = [];
   let sawAnyId = false;
   for (const lookupId of lookupIds) {
     const match = providedModels.find(m => m.id === lookupId && !disabled.has(m.id));
@@ -336,11 +336,11 @@ const enumerateOneUpstreamCandidates = async (
 export const enumerateRealModelCandidates = async (
   modelId: string,
   kind: ModelKind,
-  providers: readonly ModelProviderInstance[],
+  providers: readonly Provider[],
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<{
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ModelCandidate[];
   readonly sawAnyId: boolean;
   readonly failedUpstreams: readonly string[];
 }> => {
@@ -348,7 +348,7 @@ export const enumerateRealModelCandidates = async (
     enumerateOneUpstreamCandidates(provider, modelId, kind, fetcherForUpstream(provider.upstream), scheduler)));
 
   const failedUpstreams: string[] = [];
-  const candidates: ProviderCandidate[] = [];
+  const candidates: ModelCandidate[] = [];
   let sawAnyId = false;
   for (const [index, result] of settled.entries()) {
     if (result.status === 'rejected') {
@@ -411,7 +411,7 @@ export const enumerateModelCandidates = async ({
   // honoured at dial time.
   currentColo: string;
 }): Promise<{
-  readonly candidates: readonly ProviderCandidate[];
+  readonly candidates: readonly ModelCandidate[];
   readonly sawModel: boolean;
   readonly failedUpstreams: readonly string[];
 }> => {

--- a/packages/gateway/src/data-plane/providers/registry_test.ts
+++ b/packages/gateway/src/data-plane/providers/registry_test.ts
@@ -92,7 +92,7 @@ test('listModelProviders creates enabled provider instances with upstream row id
   await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_custom', sortOrder: 1 }));
   await repo.upstreams.save({
     id: 'up_azure',
-    provider: 'azure',
+    kind: 'azure',
     name: 'Azure Resource',
     enabled: true,
     sortOrder: 2,
@@ -385,7 +385,7 @@ test('disabledPublicModelIds hides models from the catalog and routing, per upst
 
   const azureUpstream = (over: { id: string; sortOrder: number; models: { upstreamModelId: string; publicModelId?: string }[]; disabledPublicModelIds: string[] }) => ({
     id: over.id,
-    provider: 'azure' as const,
+    kind: 'azure' as const,
     name: over.id,
     enabled: true,
     sortOrder: over.sortOrder,
@@ -444,7 +444,7 @@ test('enumerateRealModelCandidates rejects a model id disabled on that upstream 
   await repo.upstreams.deleteAll();
   await repo.upstreams.save({
     id: 'up_x',
-    provider: 'azure',
+    kind: 'azure',
     name: 'X',
     enabled: true,
     sortOrder: 1,

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -27,7 +27,7 @@ import { enumerateModelCandidates } from '../providers/registry.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import { doneFrame, eventFrame, type ModelKind, parseSSEStream, parseTargetStreamFrames, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { httpResponseToResponse, ProviderModelsUnavailableError, toInternalDebugError } from '@floway-dev/provider';
-import type { ModelProviderInstance, ProviderCallResult, UpstreamCallOptions, UpstreamModel } from '@floway-dev/provider';
+import type { Provider, ProviderCallResult, UpstreamCallOptions, UpstreamModel } from '@floway-dev/provider';
 
 // Headers we forward verbatim from a successful upstream response, plus
 // content-type with an application/json fallback when the upstream omitted
@@ -113,7 +113,7 @@ interface PassthroughServeContext {
   // swallowed. `opts` carries the per-call hooks the gateway threads in
   // (the recordUpstreamLatency wrapper for the upstream_success metric);
   // the callback forwards it verbatim to the chosen provider call method.
-  readonly call: (provider: ModelProviderInstance, model: UpstreamModel, opts: UpstreamCallOptions) => Promise<ProviderCallResult>;
+  readonly call: (provider: Provider, model: UpstreamModel, opts: UpstreamCallOptions) => Promise<ProviderCallResult>;
   readonly response: PassthroughResponseHandling;
 }
 
@@ -170,7 +170,7 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
         model: candidate.model.id,
         upstream: candidate.provider.upstream,
         modelKey,
-        cost: candidate.provider.provider.getPricingForModelKey(modelKey),
+        cost: candidate.provider.instance.getPricingForModelKey(modelKey),
       };
       const performanceContext: PerformanceTelemetryContext = {
         keyId: ctx.apiKeyId,

--- a/packages/gateway/src/dial/per-request_test.ts
+++ b/packages/gateway/src/dial/per-request_test.ts
@@ -19,7 +19,7 @@ const COPILOT_CONFIG = {
 
 const upstream = (id: string, proxyFallbackList: ProxyFallbackEntry[]) => ({
   id,
-  provider: 'copilot' as const,
+  kind: 'copilot' as const,
   name: id,
   enabled: true,
   sortOrder: 0,

--- a/packages/gateway/src/dump/accumulator.ts
+++ b/packages/gateway/src/dump/accumulator.ts
@@ -92,7 +92,7 @@ const resolveUpstreamRef = async (id: string | null): Promise<DumpUpstreamRef | 
   if (!id) return null;
   const upstream = await getRepo().upstreams.getById(id);
   if (!upstream) return null;
-  return { id: upstream.id, name: upstream.name, kind: upstream.provider };
+  return { id: upstream.id, name: upstream.name, kind: upstream.kind };
 };
 
 export class DumpAccumulator {

--- a/packages/gateway/src/repo/proxies_test.ts
+++ b/packages/gateway/src/repo/proxies_test.ts
@@ -19,7 +19,7 @@ const REPO_BACKENDS: Array<readonly [string, () => Promise<Repo>]> = [
 
 const upstreamFixture = (id: string, proxyFallbackList: ProxyFallbackEntry[]): UpstreamRecord => ({
   id,
-  provider: 'custom',
+  kind: 'custom',
   name: id,
   enabled: true,
   sortOrder: 0,

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -1166,7 +1166,7 @@ class SqlUpstreamRepo implements UpstreamRepo {
       )
       .bind(
         upstream.id,
-        upstream.provider,
+        upstream.kind,
         upstream.name,
         upstream.enabled ? 1 : 0,
         upstream.sortOrder,
@@ -1238,7 +1238,7 @@ const toUpstreamRecord = (row: UpstreamRow): UpstreamRecord => {
 
   return {
     id: row.id,
-    provider: assertUpstreamProviderKind(row.provider),
+    kind: assertUpstreamProviderKind(row.provider),
     name: row.name,
     enabled: row.enabled !== 0,
     sortOrder: row.sort_order,

--- a/packages/gateway/src/repo/sql_test.ts
+++ b/packages/gateway/src/repo/sql_test.ts
@@ -8,7 +8,7 @@ import { assertEquals } from '@floway-dev/test-utils';
 const goodAccount = { chatgptAccountId: 'aid', refresh_token: 'rt_v1', state: 'active' as const, state_updated_at: '2026-01-01T00:00:00Z' };
 const baseRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => ({
   id: 'up_test',
-  provider: 'codex',
+  kind: 'codex',
   name: 'Codex Test',
   enabled: true,
   sortOrder: 0,

--- a/packages/gateway/src/repo/upstreams_test.ts
+++ b/packages/gateway/src/repo/upstreams_test.ts
@@ -8,7 +8,7 @@ import type { SqlDatabase } from '@floway-dev/platform';
 import type { UpstreamRecord } from '@floway-dev/provider';
 import { assert, assertEquals, assertRejects } from '@floway-dev/test-utils';
 
-const upstream = (overrides: Partial<UpstreamRecord> & Pick<UpstreamRecord, 'id' | 'provider' | 'createdAt' | 'sortOrder'>): UpstreamRecord => ({
+const upstream = (overrides: Partial<UpstreamRecord> & Pick<UpstreamRecord, 'id' | 'kind' | 'createdAt' | 'sortOrder'>): UpstreamRecord => ({
   name: overrides.id,
   enabled: true,
   updatedAt: overrides.createdAt,
@@ -26,7 +26,7 @@ test('memory upstream repo saves, lists, updates, deletes, and clears rows', asy
 
   const custom = upstream({
     id: 'up_custom_a',
-    provider: 'custom',
+    kind: 'custom',
     name: 'Custom A',
     sortOrder: 2,
     createdAt: '2026-05-21T10:00:02.000Z',
@@ -34,7 +34,7 @@ test('memory upstream repo saves, lists, updates, deletes, and clears rows', asy
   });
   const copilot = upstream({
     id: 'up_copilot_a',
-    provider: 'copilot',
+    kind: 'copilot',
     name: 'Copilot A',
     sortOrder: 1,
     createdAt: '2026-05-21T10:00:03.000Z',
@@ -42,7 +42,7 @@ test('memory upstream repo saves, lists, updates, deletes, and clears rows', asy
   });
   const azure = upstream({
     id: 'up_azure_a',
-    provider: 'azure',
+    kind: 'azure',
     name: 'Azure A',
     sortOrder: 1,
     createdAt: '2026-05-21T10:00:01.000Z',
@@ -98,7 +98,7 @@ test('memory upstream repo deeply clones configs and flag overrides at the repo 
   const repo = new InMemoryRepo().upstreams;
   const original = upstream({
     id: 'up_custom_clone',
-    provider: 'custom',
+    kind: 'custom',
     sortOrder: 0,
     createdAt: '2026-05-21T10:00:00.000Z',
     config: {
@@ -143,7 +143,7 @@ test('memory upstream repo sorts flag overrides by key when saving rows', async 
   await repo.save(
     upstream({
       id: 'up_copilot_fixes',
-      provider: 'copilot',
+      kind: 'copilot',
       sortOrder: 0,
       createdAt: '2026-05-21T10:00:00.000Z',
       flagOverrides: { 'z-fix': true, 'a-fix': false, 'm-fix': true },
@@ -157,7 +157,7 @@ test('memory upstream repo sorts flag overrides by key when saving rows', async 
 const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
   const custom = upstream({
     id: 'up_custom_sql',
-    provider: 'custom',
+    kind: 'custom',
     name: 'Custom SQL',
     sortOrder: 2,
     createdAt: '2026-05-21T10:00:02.000Z',
@@ -168,7 +168,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
   });
   const copilot = upstream({
     id: 'up_copilot_sql',
-    provider: 'copilot',
+    kind: 'copilot',
     name: 'Copilot SQL',
     sortOrder: 1,
     createdAt: '2026-05-21T10:00:03.000Z',
@@ -177,7 +177,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
   });
   const azure = upstream({
     id: 'up_azure_sql',
-    provider: 'azure',
+    kind: 'azure',
     name: 'Azure SQL',
     sortOrder: 1,
     createdAt: '2026-05-21T10:00:01.000Z',
@@ -373,7 +373,7 @@ test('SQL upstream repo round-trips a non-null model_prefix', async () => {
   const now = new Date().toISOString();
   const record: UpstreamRecord = {
     id: 'up_prefix_rt',
-    provider: 'custom',
+    kind: 'custom',
     name: 'Prefix Round-Trip',
     enabled: true,
     sortOrder: 0,

--- a/packages/gateway/src/test-helpers.ts
+++ b/packages/gateway/src/test-helpers.ts
@@ -53,7 +53,7 @@ export const buildCopilotUpstreamRecord = (githubAccount: CopilotAccountFixture,
 
   return {
     id: 'up_copilot',
-    provider: 'copilot',
+    kind: 'copilot',
     name: githubAccount.user.login ? `GitHub Copilot (${githubAccount.user.login})` : 'GitHub Copilot',
     enabled: true,
     sortOrder: 0,
@@ -80,7 +80,7 @@ export const buildCustomUpstreamRecord = (overrides: Partial<UpstreamRecord> = {
 
   return {
     id: 'up_custom',
-    provider: 'custom',
+    kind: 'custom',
     name: 'Custom Provider',
     enabled: true,
     sortOrder: 100,

--- a/packages/provider-azure/src/config.ts
+++ b/packages/provider-azure/src/config.ts
@@ -8,7 +8,7 @@ export interface AzureUpstreamConfig {
 }
 
 export type AzureUpstreamRecord = UpstreamRecord & {
-  provider: 'azure';
+  kind: 'azure';
   config: AzureUpstreamConfig;
 };
 
@@ -62,7 +62,7 @@ const azureEndpointField = (value: unknown, label: string): string => {
 };
 
 export const assertAzureUpstreamRecord = (record: UpstreamRecord): AzureUpstreamRecord => {
-  if (record.provider !== 'azure') throw new Error(`Expected azure upstream record, got ${record.provider}`);
+  if (record.kind !== 'azure') throw new Error(`Expected azure upstream record, got ${record.kind}`);
   if (!isRecord(record.config)) throw new Error('Malformed azure upstream config: config must be an object');
 
   const models = modelsField(record.config.models, 'azure');
@@ -76,7 +76,7 @@ export const assertAzureUpstreamRecord = (record: UpstreamRecord): AzureUpstream
 
   return {
     ...record,
-    provider: 'azure',
+    kind: 'azure',
     config,
   };
 };

--- a/packages/provider-azure/src/config_test.ts
+++ b/packages/provider-azure/src/config_test.ts
@@ -6,7 +6,7 @@ import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 const baseRecord: UpstreamRecord = {
   id: 'up_azure',
-  provider: 'azure',
+  kind: 'azure',
   name: 'Azure Resource',
   enabled: true,
   sortOrder: 0,
@@ -34,7 +34,7 @@ test('assertAzureUpstreamRecord validates Azure opaque config strictly', () => {
     () =>
       assertAzureUpstreamRecord({
         ...baseRecord,
-        provider: 'custom',
+        kind: 'custom',
       }),
     Error,
     'Expected azure upstream record, got custom',

--- a/packages/provider-azure/src/fetch_test.ts
+++ b/packages/provider-azure/src/fetch_test.ts
@@ -16,7 +16,7 @@ import { assertEquals, withMockedFetch } from '@floway-dev/test-utils';
 
 const baseRecord: UpstreamRecord = {
   id: 'up_azure',
-  provider: 'azure',
+  kind: 'azure',
   name: 'Azure Resource',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -4,13 +4,13 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { type ModelProvider, type ModelProviderInstance, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord, defaultsForProvider, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
+import { type ProviderInstance, type Provider, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord, defaultsForProvider, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
 
 const providerData = (model: UpstreamModel): { upstreamModelId: string } => model.providerData as { upstreamModelId: string };
 
 type AzureTypedFetch = (config: ReturnType<typeof assertAzureUpstreamRecord>['config'], init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>;
 
-export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstance => {
+export const createAzureProvider = (record: UpstreamRecord): Provider => {
   const azure = assertAzureUpstreamRecord(record);
 
   const callStreaming = <TEvent>(
@@ -41,7 +41,7 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
     return { response, modelKey: upstreamModelId };
   };
 
-  const provider: ModelProvider = {
+  const instance: ProviderInstance = {
     getProvidedModels() {
       return Promise.resolve(azure.config.models.map(model => {
         const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
@@ -110,7 +110,7 @@ export const createAzureProvider = (record: UpstreamRecord): ModelProviderInstan
     name: azure.name,
     disabledPublicModelIds: azure.disabledPublicModelIds,
     modelPrefix: azure.modelPrefix,
-    provider,
+    instance,
     supportsResponsesItemReference: true,
   };
 };

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -106,7 +106,7 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
 
   return {
     upstream: azure.id,
-    providerKind: 'azure',
+    kind: 'azure',
     name: azure.name,
     disabledPublicModelIds: azure.disabledPublicModelIds,
     modelPrefix: azure.modelPrefix,

--- a/packages/provider-claude-code/src/access-token-cache_test.ts
+++ b/packages/provider-claude-code/src/access-token-cache_test.ts
@@ -25,7 +25,7 @@ const baseConfig: ClaudeCodeUpstreamConfig = {
 
 const makeRecord = (state: ClaudeCodeUpstreamState): UpstreamRecord => ({
   id: upstreamId,
-  provider: 'claude-code',
+  kind: 'claude-code',
   name: 'Claude Code',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-claude-code/src/config.ts
+++ b/packages/provider-claude-code/src/config.ts
@@ -38,7 +38,7 @@ export interface ClaudeCodeUpstreamConfig {
 }
 
 export type ClaudeCodeUpstreamRecord = UpstreamRecord & {
-  provider: 'claude-code';
+  kind: 'claude-code';
   config: ClaudeCodeUpstreamConfig;
 };
 
@@ -92,8 +92,8 @@ function assertClaudeCodeUpstreamConfig(value: unknown): asserts value is Claude
 }
 
 export function assertClaudeCodeUpstreamRecord(record: UpstreamRecord): asserts record is ClaudeCodeUpstreamRecord {
-  if (record.provider !== 'claude-code') {
-    throw new TypeError(`Expected provider 'claude-code', got '${record.provider}'`);
+  if (record.kind !== 'claude-code') {
+    throw new TypeError(`Expected provider 'claude-code', got '${record.kind}'`);
   }
   assertClaudeCodeUpstreamConfig(record.config);
 }

--- a/packages/provider-claude-code/src/config_test.ts
+++ b/packages/provider-claude-code/src/config_test.ts
@@ -12,7 +12,7 @@ const goodAccount = {
 const good = { accounts: [goodAccount] };
 
 const wrap = (config: unknown): UpstreamRecord => ({
-  id: 'up', provider: 'claude-code', name: 'n', enabled: true, sortOrder: 0,
+  id: 'up', kind: 'claude-code', name: 'n', enabled: true, sortOrder: 0,
   createdAt: '', updatedAt: '', config: config as UpstreamRecord['config'], state: null,
   flagOverrides: {}, disabledPublicModelIds: [], proxyFallbackList: [], modelPrefix: null,
 });
@@ -64,7 +64,7 @@ describe('assertClaudeCodeUpstreamRecord (config validation)', () => {
 describe('assertClaudeCodeUpstreamRecord (record-level checks)', () => {
   test('rejects non-claude-code record', () => {
     const record: UpstreamRecord = {
-      id: 'up', provider: 'copilot', name: 'n', enabled: true, sortOrder: 0,
+      id: 'up', kind: 'copilot', name: 'n', enabled: true, sortOrder: 0,
       createdAt: '', updatedAt: '', config: {}, state: null,
       flagOverrides: {}, disabledPublicModelIds: [], proxyFallbackList: [], modelPrefix: null,
     };

--- a/packages/provider-claude-code/src/fetch_test.ts
+++ b/packages/provider-claude-code/src/fetch_test.ts
@@ -52,7 +52,7 @@ const freshAccessTokenEntry: ClaudeCodeAccessTokenEntry = {
 
 const makeRecord = (state: ClaudeCodeUpstreamState): UpstreamRecord => ({
   id: upstreamId,
-  provider: 'claude-code',
+  kind: 'claude-code',
   name: 'CC',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-claude-code/src/provider.ts
+++ b/packages/provider-claude-code/src/provider.ts
@@ -12,19 +12,19 @@ import {
   defaultsForProvider,
   getProviderRepo,
   resolveEffectiveFlags,
-  type ModelProvider,
-  type ModelProviderInstance,
+  type ProviderInstance,
+  type Provider,
   type ProviderStreamResult,
   type UpstreamRecord,
 } from '@floway-dev/provider';
 
-export const createClaudeCodeProvider = async (record: UpstreamRecord): Promise<ModelProviderInstance> => {
+export const createClaudeCodeProvider = async (record: UpstreamRecord): Promise<Provider> => {
   assertClaudeCodeUpstreamRecord(record);
   assertClaudeCodeUpstreamState(record.state);
 
   const enabledFlags = resolveEffectiveFlags(defaultsForProvider('claude-code'), [record.flagOverrides]);
 
-  const provider: ModelProvider = {
+  const instance: ProviderInstance = {
     // Catalog refresh mints an access token and hits /v1/models on every
     // dispatcher poll. `ensureClaudeCodeAccessToken` flips the row to
     // `refresh_failed` and throws `ClaudeCodeOAuthSessionTerminatedError`
@@ -104,7 +104,7 @@ export const createClaudeCodeProvider = async (record: UpstreamRecord): Promise<
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
-    provider,
+    instance,
     supportsResponsesItemReference: false,
   };
 };

--- a/packages/provider-claude-code/src/provider.ts
+++ b/packages/provider-claude-code/src/provider.ts
@@ -100,7 +100,7 @@ export const createClaudeCodeProvider = async (record: UpstreamRecord): Promise<
 
   return {
     upstream: record.id,
-    providerKind: 'claude-code',
+    kind: 'claude-code',
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -138,9 +138,9 @@ describe('createClaudeCodeProvider — factory surface', () => {
     expect(instance.instance.getPricingForModelKey('unknown-id')).toBeNull();
   });
 
-  test('providerKind is "claude-code" and supportsResponsesItemReference is false', async () => {
+  test('kind is "claude-code" and supportsResponsesItemReference is false', async () => {
     const instance = await createClaudeCodeProvider(currentRecord);
-    expect(instance.providerKind).toBe('claude-code');
+    expect(instance.kind).toBe('claude-code');
     expect(instance.supportsResponsesItemReference).toBe(false);
     expect(instance.upstream).toBe(upstreamId);
   });

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -42,7 +42,7 @@ const activeAccount: ClaudeCodeAccountCredential = {
 
 const makeRecord = (state: ClaudeCodeUpstreamState): UpstreamRecord => ({
   id: upstreamId,
-  provider: 'claude-code',
+  kind: 'claude-code',
   name: 'CC',
   enabled: true,
   sortOrder: 0,
@@ -109,7 +109,7 @@ describe('createClaudeCodeProvider — factory surface', () => {
   test('getProvidedModels mirrors the live /v1/models catalog under public aliases', async () => {
     stubModelsListFetch();
     const instance = await createClaudeCodeProvider(currentRecord);
-    const models = await instance.provider.getProvidedModels(noopUpstreamCallOptions().fetcher);
+    const models = await instance.instance.getProvidedModels(noopUpstreamCallOptions().fetcher);
     expect(models.map(m => m.id)).toEqual([
       'claude-fable-5',
       'claude-opus-4-7',
@@ -125,7 +125,7 @@ describe('createClaudeCodeProvider — factory surface', () => {
     // stays empty regardless of the other providers' defaults.
     stubModelsListFetch();
     const instance = await createClaudeCodeProvider(currentRecord);
-    const models = await instance.provider.getProvidedModels(noopUpstreamCallOptions().fetcher);
+    const models = await instance.instance.getProvidedModels(noopUpstreamCallOptions().fetcher);
     for (const m of models) {
       expect(m.enabledFlags.has('strip-billing-attribution')).toBe(false);
     }
@@ -133,9 +133,9 @@ describe('createClaudeCodeProvider — factory surface', () => {
 
   test('getPricingForModelKey wires through the pricing table (keyed by dated upstream id)', async () => {
     const instance = await createClaudeCodeProvider(currentRecord);
-    expect(instance.provider.getPricingForModelKey('claude-sonnet-4-5-20250929'))
+    expect(instance.instance.getPricingForModelKey('claude-sonnet-4-5-20250929'))
       .toEqual(pricingForClaudeCodeModelKey('claude-sonnet-4-5-20250929'));
-    expect(instance.provider.getPricingForModelKey('unknown-id')).toBeNull();
+    expect(instance.instance.getPricingForModelKey('unknown-id')).toBeNull();
   });
 
   test('providerKind is "claude-code" and supportsResponsesItemReference is false', async () => {
@@ -151,7 +151,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
     const instance = await createClaudeCodeProvider(currentRecord);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
 
-    await instance.provider.callMessages(
+    await instance.instance.callMessages(
       upstreamModel,
       { max_tokens: 16, messages: [{ role: 'user', content: 'hello' }] },
       undefined,
@@ -178,7 +178,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
 
     const userId = JSON.stringify({ device_id: 'd'.repeat(32), account_uuid: '', session_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' });
-    await instance.provider.callMessages(
+    await instance.instance.callMessages(
       upstreamModel,
       {
         max_tokens: 16,
@@ -213,7 +213,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
     const instance = await createClaudeCodeProvider(currentRecord);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
 
-    await instance.provider.callMessages(
+    await instance.instance.callMessages(
       upstreamModel,
       { max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
       undefined,

--- a/packages/provider-codex/src/access-token-cache_test.ts
+++ b/packages/provider-codex/src/access-token-cache_test.ts
@@ -16,7 +16,7 @@ const upstreamId = 'up_a';
 
 const makeRecord = (state: CodexUpstreamState): UpstreamRecord => ({
   id: upstreamId,
-  provider: 'codex',
+  kind: 'codex',
   name: 'Codex',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-codex/src/config.ts
+++ b/packages/provider-codex/src/config.ts
@@ -20,7 +20,7 @@ export interface CodexUpstreamConfig {
 }
 
 export type CodexUpstreamRecord = UpstreamRecord & {
-  provider: 'codex';
+  kind: 'codex';
   config: CodexUpstreamConfig;
 };
 
@@ -66,8 +66,8 @@ function assertCodexUpstreamConfig(value: unknown): asserts value is CodexUpstre
 }
 
 export function assertCodexUpstreamRecord(record: UpstreamRecord): asserts record is CodexUpstreamRecord {
-  if (record.provider !== 'codex') {
-    throw new TypeError(`Expected provider 'codex', got '${record.provider}'`);
+  if (record.kind !== 'codex') {
+    throw new TypeError(`Expected provider 'codex', got '${record.kind}'`);
   }
   assertCodexUpstreamConfig(record.config);
 }

--- a/packages/provider-codex/src/config_test.ts
+++ b/packages/provider-codex/src/config_test.ts
@@ -7,7 +7,7 @@ const goodAccount = { email: 'a@b.com', chatgptAccountId: 'a', chatgptUserId: 'u
 const good = { accounts: [goodAccount] };
 
 const wrap = (config: unknown): UpstreamRecord => ({
-  id: 'up', provider: 'codex', name: 'n', enabled: true, sortOrder: 0,
+  id: 'up', kind: 'codex', name: 'n', enabled: true, sortOrder: 0,
   createdAt: '', updatedAt: '', config: config as UpstreamRecord['config'], state: null,
   flagOverrides: {}, disabledPublicModelIds: [], proxyFallbackList: [], modelPrefix: null,
 });
@@ -40,7 +40,7 @@ describe('assertCodexUpstreamRecord (config validation)', () => {
 describe('assertCodexUpstreamRecord (record-level checks)', () => {
   test('rejects non-codex record', () => {
     const record: UpstreamRecord = {
-      id: 'up', provider: 'copilot', name: 'n', enabled: true, sortOrder: 0,
+      id: 'up', kind: 'copilot', name: 'n', enabled: true, sortOrder: 0,
       createdAt: '', updatedAt: '', config: {}, state: null,
       flagOverrides: {}, disabledPublicModelIds: [], proxyFallbackList: [], modelPrefix: null,
     };

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -26,7 +26,7 @@ const farFutureAccessToken: CodexAccessTokenEntry = {
 
 const makeRecord = (state: CodexUpstreamState): UpstreamRecord => ({
   id: upstreamId,
-  provider: 'codex',
+  kind: 'codex',
   name: 'Codex',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-codex/src/interceptors/responses/action-pivot_test.ts
+++ b/packages/provider-codex/src/interceptors/responses/action-pivot_test.ts
@@ -36,7 +36,7 @@ const farFutureMs = Date.now() + 24 * 60 * 60 * 1000;
 
 const baseRecord: UpstreamRecord = {
   id: 'up_codex_pivot',
-  provider: 'codex',
+  kind: 'codex',
   name: 'Codex (pivot tester)',
   enabled: true,
   sortOrder: 0,
@@ -90,7 +90,7 @@ test('Codex terminal dispatches on post-chain ctx.action (interceptor flip gener
   // Generate-shaped body — carries tools, reasoning, temperature, etc. None
   // of these are allowed on /responses/compact. The pivot above flips action
   // to 'compact'; the terminal must narrow the body before sending upstream.
-  const result = await instance.provider.callResponses(
+  const result = await instance.instance.callResponses(
     { id: 'gpt-5.4', display_name: 'gpt-5.4', kind: 'chat', limits: {}, endpoints: { responses: {} }, enabledFlags: new Set() },
     {
       input: [{ type: 'message', role: 'user', content: 'hi' }],

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -148,7 +148,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Provi
 
   return {
     upstream: record.id,
-    providerKind: 'codex',
+    kind: 'codex',
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -9,9 +9,9 @@ import { pricingForCodexModelKey } from './pricing.ts';
 import { assertCodexUpstreamState, type CodexUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import { toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { defaultsForProvider, getProviderRepo, resolveEffectiveFlags, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { defaultsForProvider, getProviderRepo, resolveEffectiveFlags, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
 
-export const createCodexProvider = async (record: UpstreamRecord): Promise<ModelProviderInstance> => {
+export const createCodexProvider = async (record: UpstreamRecord): Promise<Provider> => {
   assertCodexUpstreamRecord(record);
   assertCodexUpstreamState(record.state);
   const config: CodexUpstreamConfig = record.config;
@@ -68,7 +68,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
 
   const effects: CodexCallEffects = { persistRefreshTokenRotation, persistTerminalState };
 
-  const provider: ModelProvider = {
+  const instance: ProviderInstance = {
     getProvidedModels: async fetcher => {
       // A model-list refresh is the first thing a brand-new Codex upstream
       // does, and it is the only place outside the data plane that mints an
@@ -152,7 +152,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Model
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
-    provider,
+    instance,
     supportsResponsesItemReference: false,
   };
 };

--- a/packages/provider-codex/src/provider_test.ts
+++ b/packages/provider-codex/src/provider_test.ts
@@ -71,7 +71,7 @@ const oauthTokenResponse = (overrides: Partial<{ access_token: string; refresh_t
 describe('createCodexProvider', () => {
   test('returns an instance carrying provider kind and identity', async () => {
     const instance = await createCodexProvider(baseRecord);
-    expect(instance.providerKind).toBe('codex');
+    expect(instance.kind).toBe('codex');
     expect(instance.upstream).toBe('up_codex');
     expect(instance.name).toBe('Codex Plus');
     expect(instance.supportsResponsesItemReference).toBe(false);

--- a/packages/provider-codex/src/provider_test.ts
+++ b/packages/provider-codex/src/provider_test.ts
@@ -11,7 +11,7 @@ const freshAccessToken: CodexAccessTokenEntry = { token: 'at', expiresAt: farFut
 
 const baseRecord: UpstreamRecord = {
   id: 'up_codex',
-  provider: 'codex',
+  kind: 'codex',
   name: 'Codex Plus',
   enabled: true,
   sortOrder: 0,
@@ -80,7 +80,7 @@ describe('createCodexProvider', () => {
   test('getProvidedModels uses the cached access token when fresh and surfaces every catalog entry', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(modelsResponse());
     const instance = await createCodexProvider(baseRecord);
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     // Provider surfaces both visible and hidden upstream models — operators
     // can dispatch to `codex-auto-review` even though ChatGPT's UI hides it.
     expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review']);
@@ -98,7 +98,7 @@ describe('createCodexProvider', () => {
       throw new Error(`unexpected fetch ${url}`);
     });
     const instance = await createCodexProvider(baseRecord);
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review']);
     const urls = fetchSpy.mock.calls.map(c => typeof c[0] === 'string' ? c[0] : (c[0] as URL | Request).toString());
     expect(urls.some(u => u.includes('/oauth/token'))).toBe(true);
@@ -115,7 +115,7 @@ describe('createCodexProvider', () => {
   test('getProvidedModels propagates catalog fetch failures', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('upstream down', { status: 502 }));
     const instance = await createCodexProvider(baseRecord);
-    await expect(instance.provider.getProvidedModels(directFetcher)).rejects.toThrow(/Codex \/models fetch failed/);
+    await expect(instance.instance.getProvidedModels(directFetcher)).rejects.toThrow(/Codex \/models fetch failed/);
   });
 
   test('getProvidedModels propagates OAuth refresh failures', async () => {
@@ -126,7 +126,7 @@ describe('createCodexProvider', () => {
       throw new Error(`unexpected fetch ${url}`);
     });
     const instance = await createCodexProvider(baseRecord);
-    await expect(instance.provider.getProvidedModels(directFetcher)).rejects.toThrow(/Codex OAuth session terminated/);
+    await expect(instance.instance.getProvidedModels(directFetcher)).rejects.toThrow(/Codex OAuth session terminated/);
   });
 
   test('getProvidedModels resolves operator flag overrides into every UpstreamModel', async () => {
@@ -141,7 +141,7 @@ describe('createCodexProvider', () => {
       flagOverrides: { 'responses-web-search-shim': true },
     };
     const instance = await createCodexProvider(recordWithOverride);
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     for (const m of models) {
       expect(m.enabledFlags.has('responses-web-search-shim')).toBe(true);
     }
@@ -150,7 +150,7 @@ describe('createCodexProvider', () => {
   test('callResponses round-trips through fetch transport', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
     const instance = await createCodexProvider(baseRecord);
-    const result = await instance.provider.callResponses(
+    const result = await instance.instance.callResponses(
       { id: 'gpt-5.4', display_name: 'gpt-5.4', kind: 'chat', limits: {}, endpoints: { responses: {} }, enabledFlags: new Set() },
       { input: [{ type: 'message', role: 'user', content: 'hi' }], stream: true },
       'generate',
@@ -164,7 +164,7 @@ describe('createCodexProvider', () => {
   test('callResponses re-reads state per request (operator re-import takes effect)', async () => {
     getByIdSpy.mockResolvedValueOnce({ ...baseRecord, state: { accounts: [{ chatgptAccountId: 'acc', refresh_token: 'rt_v1', state: 'session_terminated', state_updated_at: '2026-01-02T00:00:00Z', accessToken: null, quotaSnapshot: null }] } as CodexUpstreamState });
     const instance = await createCodexProvider(baseRecord);
-    const result = await instance.provider.callResponses(
+    const result = await instance.instance.callResponses(
       { id: 'gpt-5.4', display_name: 'gpt-5.4', kind: 'chat', limits: {}, endpoints: { responses: {} }, enabledFlags: new Set() },
       { input: [], stream: true },
       'generate',
@@ -187,7 +187,7 @@ describe('createCodexProvider', () => {
     const model = { id: 'gpt-5.4', display_name: 'gpt-5.4', kind: 'chat', limits: {}, endpoints: { responses: {} }, enabledFlags: new Set<string>() };
     // @ts-expect-error: each method has a different body type; we only assert
     // the synthetic 405 envelope is what comes back.
-    const result = await instance.provider[method](model, {}, undefined, noopUpstreamCallOptions()) as { response: Response };
+    const result = await instance.instance[method](model, {}, undefined, noopUpstreamCallOptions()) as { response: Response };
     expect(result.response.status).toBe(405);
     const body = await result.response.json() as { error: { type: string; message: string } };
     expect(body.error.type).toBe('method_not_allowed');

--- a/packages/provider-codex/src/quota_test.ts
+++ b/packages/provider-codex/src/quota_test.ts
@@ -16,7 +16,7 @@ const upstreamId = 'up_a';
 
 const makeRecord = (state: CodexUpstreamState): UpstreamRecord => ({
   id: upstreamId,
-  provider: 'codex',
+  kind: 'codex',
   name: 'Codex',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-copilot/src/auth_test.ts
+++ b/packages/provider-copilot/src/auth_test.ts
@@ -13,7 +13,7 @@ const installRepoAndClearCache = async () => {
   let state: unknown = null;
   const stub: UpstreamRecord = {
     id: UPSTREAM_ID,
-    provider: 'copilot',
+    kind: 'copilot',
     name: 'auth-test',
     enabled: true,
     sortOrder: 0,

--- a/packages/provider-copilot/src/config.ts
+++ b/packages/provider-copilot/src/config.ts
@@ -13,7 +13,7 @@ export interface CopilotUpstreamConfig {
 }
 
 export type CopilotUpstreamRecord = UpstreamRecord & {
-  provider: 'copilot';
+  kind: 'copilot';
   config: CopilotUpstreamConfig;
 };
 
@@ -45,11 +45,11 @@ const copilotUserField = (value: unknown): CopilotUpstreamUser => {
 };
 
 export const assertCopilotUpstreamRecord = (record: UpstreamRecord): CopilotUpstreamRecord => {
-  if (record.provider !== 'copilot') throw new Error(`Expected copilot upstream record, got ${record.provider}`);
+  if (record.kind !== 'copilot') throw new Error(`Expected copilot upstream record, got ${record.kind}`);
   if (!isRecord(record.config)) throw new Error('Malformed copilot upstream config: config must be an object');
   return {
     ...record,
-    provider: 'copilot',
+    kind: 'copilot',
     config: {
       githubToken: stringField(record.config.githubToken, 'githubToken'),
       user: copilotUserField(record.config.user),

--- a/packages/provider-copilot/src/fetch-models_test.ts
+++ b/packages/provider-copilot/src/fetch-models_test.ts
@@ -10,7 +10,7 @@ const installRepoAndConfig = async () => {
   const githubToken = `ghu_${crypto.randomUUID().replace(/-/g, '')}`;
   const stub: UpstreamRecord = {
     id,
-    provider: 'copilot',
+    kind: 'copilot',
     name: 'fetch-models-test',
     enabled: true,
     sortOrder: 0,

--- a/packages/provider-copilot/src/interceptors/responses/action-pivot_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/action-pivot_test.ts
@@ -39,7 +39,7 @@ type UpstreamRecord = import('@floway-dev/provider').UpstreamRecord;
 test('Copilot provider terminal dispatches on post-chain ctx.action (interceptor flip compact→generate routes to the streaming generate path)', async () => {
   const upstream: UpstreamRecord = {
     id: 'up_copilot_pivot',
-    provider: 'copilot',
+    kind: 'copilot',
     name: 'Copilot (pivot tester)',
     enabled: true,
     sortOrder: 0,
@@ -65,7 +65,7 @@ test('Copilot provider terminal dispatches on post-chain ctx.action (interceptor
   clearInProcessCopilotTokenCache();
 
   const instance = await createCopilotProvider(upstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
 
   let responsesBody: Record<string, unknown> | undefined;
   await withMockedFetch(

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -20,7 +20,7 @@ import { parseChatCompletionsStream, type ChatCompletionsPayload, type ChatCompl
 import { type ModelEndpointKey, type ModelEndpoints, type ProtocolFrame, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseAnthropicBetaHeader, parseMessagesStream, type MessagesPayload, type MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
-import { COMPACTION_TRIGGER, compactionResponse, eventResult, getProviderRepo, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, defaultsForProvider, resolveEffectiveFlags, type ExecuteResult, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
+import { COMPACTION_TRIGGER, compactionResponse, eventResult, getProviderRepo, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, defaultsForProvider, resolveEffectiveFlags, type ExecuteResult, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CopilotProviderData {
   rawModels: CopilotRawModel[];
@@ -164,7 +164,7 @@ const finalizeCopilotModels = (rawModels: CopilotRawModel[], enabledFlags: Reado
   return models;
 };
 
-export const createCopilotProvider = async (record: UpstreamRecord): Promise<ModelProviderInstance> => {
+export const createCopilotProvider = async (record: UpstreamRecord): Promise<Provider> => {
   const copilot = assertCopilotUpstreamRecord(record);
   const upstreamConfig = { id: copilot.id, githubToken: copilot.config.githubToken };
   // Computed once: only the upstream layer applies for this provider kind
@@ -266,7 +266,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
     throw new Error(`Copilot boundary chain produced unexpected ExecuteResult shape '${result.type}'`);
   };
 
-  const provider: ModelProvider = {
+  const instance: ProviderInstance = {
     getProvidedModels: async fetcher => {
       const fresh = await getProviderRepo().upstreams.getById(copilot.id);
       if (!fresh) throw new Error(`Copilot upstream ${copilot.id} disappeared mid-request`);
@@ -454,7 +454,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Mod
     name: copilot.name,
     disabledPublicModelIds: copilot.disabledPublicModelIds,
     modelPrefix: copilot.modelPrefix,
-    provider,
+    instance,
     supportsResponsesItemReference: false,
   };
 };

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -450,7 +450,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Pro
 
   return {
     upstream: copilot.id,
-    providerKind: 'copilot',
+    kind: 'copilot',
     name: copilot.name,
     disabledPublicModelIds: copilot.disabledPublicModelIds,
     modelPrefix: copilot.modelPrefix,

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -14,7 +14,7 @@ const buildCopilotUpstream = (overrides: Partial<UpstreamRecord> = {}): Upstream
   const { config: overrideConfig, ...rest } = overrides;
   return {
     id: 'up_copilot',
-    provider: 'copilot',
+    kind: 'copilot',
     name: 'GitHub Copilot (tester)',
     enabled: true,
     sortOrder: 0,
@@ -123,7 +123,7 @@ const copilotModels = (models: CopilotModelFixture[]) => ({
 test('Copilot provider exposes the highest-priority non-Claude endpoint', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
 
   assertEquals(instance.supportsResponsesItemReference, false);
 
@@ -170,7 +170,7 @@ test('Copilot provider exposes the highest-priority non-Claude endpoint', async 
 test('Copilot provider exposes only Responses for Claude when available', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
 
   await withMockedFetch(
     request => {
@@ -219,7 +219,7 @@ test('Copilot provider exposes only Responses for Claude when available', async 
 test('Copilot provider owns the claude-* Messages capability workaround', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   let upstreamBody: Record<string, unknown> | undefined;
 
   await withMockedFetch(
@@ -273,7 +273,7 @@ test('Copilot provider owns the claude-* Messages capability workaround', async 
 test('Copilot provider selects raw variants that support the target endpoint', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   let responsesBody: Record<string, unknown> | undefined;
 
   await withMockedFetch(
@@ -336,7 +336,7 @@ test('Copilot provider runs the Responses boundary chain on the compact path', a
   // still comes back through `compactionResponse`.
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   let responsesBody: Record<string, unknown> | undefined;
   let visionHeader: string | null = null;
   let initiatorHeader: string | null = null;
@@ -433,7 +433,7 @@ test('Copilot provider exposes its default flag set via UpstreamModel.enabledFla
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const models = await instance.provider.getProvidedModels(directFetcher);
+      const models = await instance.instance.getProvidedModels(directFetcher);
       const model = models[0];
       if (!model) throw new Error('expected at least one Copilot model in test fixture');
       assertEquals(model.enabledFlags.has('retry-cyber-policy'), true);
@@ -445,7 +445,7 @@ test('Copilot provider exposes its default flag set via UpstreamModel.enabledFla
 test('Copilot provider forces stream=true for streaming endpoints and leaves count-tokens/embeddings alone', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   const bodies: Record<string, Record<string, unknown>> = {};
 
   await withMockedFetch(
@@ -511,12 +511,12 @@ test('Copilot provider forces stream=true for streaming endpoints and leaves cou
 test('Copilot provider sets copilot-vision-request when an image is nested inside tool_result.content', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   const visionHeaders: (string | null)[] = [];
 
   // The vision-detection interceptor runs inside `provider.callMessages`, so
   // it must walk into nested `tool_result.content` to find the image.
-  const driveMessages = async (model: Awaited<ReturnType<typeof instance.provider.getProvidedModels>>[number], body: Omit<MessagesPayload, 'model'>): Promise<void> => {
+  const driveMessages = async (model: Awaited<ReturnType<typeof instance.instance.getProvidedModels>>[number], body: Omit<MessagesPayload, 'model'>): Promise<void> => {
     await provider.callMessages(model, body, undefined, noopUpstreamCallOptions());
   };
 
@@ -600,7 +600,7 @@ test('Copilot Messages boundary chain does NOT fire on the Chat Completions wire
   // which has no Messages-source headers in it.
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   const observedInteractionType: (string | null)[] = [];
 
   await withMockedFetch(
@@ -664,7 +664,7 @@ test('Copilot provider persists merged known-models view via saveState CAS keyed
     },
     async () => {
       const instance = await createCopilotProvider(copilotUpstream);
-      const result = await instance.provider.getProvidedModels(directFetcher);
+      const result = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(result.map(m => m.id), ['m1']);
     },
   );
@@ -708,7 +708,7 @@ test('Copilot provider persists known-models even when the token-mint write adva
     },
     async () => {
       const instance = await createCopilotProvider(copilotUpstream);
-      await instance.provider.getProvidedModels(directFetcher);
+      await instance.instance.getProvidedModels(directFetcher);
     },
   );
 
@@ -741,9 +741,9 @@ test('Copilot provider accumulates known-models across calls so a model dropped 
     },
     async () => {
       const instance = await createCopilotProvider(copilotUpstream);
-      const first = await instance.provider.getProvidedModels(directFetcher);
+      const first = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(first.map(m => m.id), ['m1']);
-      const second = await instance.provider.getProvidedModels(directFetcher);
+      const second = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(second.map(m => m.id).sort(), ['m1', 'm2']);
     },
   );
@@ -771,7 +771,7 @@ test('Copilot provider throws when the upstream fetch fails — no in-provider f
     },
     async () => {
       const instance = await createCopilotProvider(harness.copilotUpstream);
-      await assertRejects(() => instance.provider.getProvidedModels(directFetcher));
+      await assertRejects(() => instance.instance.getProvidedModels(directFetcher));
     },
   );
 });
@@ -782,7 +782,7 @@ test('Copilot provider throws "disappeared mid-request" when the upstream row va
   harness.overrideGetById(async () => null);
 
   await assertRejects(
-    () => instance.provider.getProvidedModels(directFetcher),
+    () => instance.instance.getProvidedModels(directFetcher),
     Error,
     'Copilot upstream up_copilot disappeared mid-request',
   );
@@ -804,7 +804,7 @@ test('Copilot provider accepts a losing CAS write and still returns the freshly 
     },
     async () => {
       const instance = await createCopilotProvider(harness.copilotUpstream);
-      const result = await instance.provider.getProvidedModels(directFetcher);
+      const result = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(result.map(m => m.id), ['m1']);
     },
   );
@@ -829,7 +829,7 @@ test('Copilot provider swallows a saveState throw so a transient persistence hic
     },
     async () => {
       const instance = await createCopilotProvider(harness.copilotUpstream);
-      const result = await instance.provider.getProvidedModels(directFetcher);
+      const result = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(result.map(m => m.id), ['m1']);
     },
   );
@@ -901,7 +901,7 @@ const fastModelCatalog = () =>
 test('Copilot provider routes speed=fast to the -fast raw variant and stamps usage.speed on the way out', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   let upstreamBody: Record<string, unknown> | undefined;
 
   await withMockedFetch(
@@ -958,7 +958,7 @@ test('Copilot provider routes speed=fast to the -fast raw variant and stamps usa
 test('Copilot provider returns HTTP 400 invalid_request_error when speed=fast hits a model without a -fast variant', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   let messagesHit = false;
 
   await withMockedFetch(
@@ -1006,7 +1006,7 @@ test('Copilot provider returns HTTP 400 invalid_request_error when speed=fast hi
 test('Copilot provider passes unknown speed values to the upstream verbatim so the upstream owns rejecting them', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  const provider = instance.provider;
+  const provider = instance.instance;
   let upstreamBody: Record<string, unknown> | undefined;
 
   await withMockedFetch(
@@ -1075,7 +1075,7 @@ const copilotModelsWithCapabilities = (models: CopilotModelCapabilityFixture[]) 
 const getModelsWithCapabilities = async (fixtures: CopilotModelCapabilityFixture[]) => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = await createCopilotProvider(copilotUpstream);
-  let models: Awaited<ReturnType<typeof instance.provider.getProvidedModels>> = [];
+  let models: Awaited<ReturnType<typeof instance.instance.getProvidedModels>> = [];
 
   await withMockedFetch(
     request => {
@@ -1087,7 +1087,7 @@ const getModelsWithCapabilities = async (fixtures: CopilotModelCapabilityFixture
       if (url.pathname === '/models') return jsonResponse(copilotModelsWithCapabilities(fixtures));
       throw new Error(`Unhandled fetch ${request.url}`);
     },
-    async () => { models = await instance.provider.getProvidedModels(directFetcher); },
+    async () => { models = await instance.instance.getProvidedModels(directFetcher); },
   );
 
   return models;

--- a/packages/provider-custom/src/config.ts
+++ b/packages/provider-custom/src/config.ts
@@ -64,7 +64,7 @@ export type CustomUpstreamConfig =
   | (CustomUpstreamConfigBase & { authStyle: 'bearer' | 'anthropic'; apiKey: string });
 
 export type CustomUpstreamRecord = UpstreamRecord & {
-  provider: 'custom';
+  kind: 'custom';
   config: CustomUpstreamConfig;
 };
 
@@ -142,7 +142,7 @@ const modelsFetchField = (value: unknown): CustomModelsFetch => {
 };
 
 export const assertCustomUpstreamRecord = (record: UpstreamRecord): CustomUpstreamRecord => {
-  if (record.provider !== 'custom') throw new Error(`Expected custom upstream record, got ${record.provider}`);
+  if (record.kind !== 'custom') throw new Error(`Expected custom upstream record, got ${record.kind}`);
   if (!isRecord(record.config)) throw new Error('Malformed custom upstream config: config must be an object');
 
   const raw = record.config;
@@ -163,9 +163,9 @@ export const assertCustomUpstreamRecord = (record: UpstreamRecord): CustomUpstre
     if (raw.apiKey !== undefined) {
       throw new Error('Malformed custom upstream config: apiKey must not be present when authStyle is "none"');
     }
-    return { ...record, provider: 'custom', config: { ...base, authStyle } };
+    return { ...record, kind: 'custom', config: { ...base, authStyle } };
   }
 
   const apiKey = nonEmptyStringField(raw.apiKey, 'apiKey');
-  return { ...record, provider: 'custom', config: { ...base, authStyle, apiKey } };
+  return { ...record, kind: 'custom', config: { ...base, authStyle, apiKey } };
 };

--- a/packages/provider-custom/src/config_test.ts
+++ b/packages/provider-custom/src/config_test.ts
@@ -6,7 +6,7 @@ import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 const baseRecord: UpstreamRecord = {
   id: 'up_test',
-  provider: 'custom',
+  kind: 'custom',
   name: 'Test Custom',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-custom/src/fetch-models_test.ts
+++ b/packages/provider-custom/src/fetch-models_test.ts
@@ -6,7 +6,7 @@ import { assertEquals, jsonResponse, withMockedFetch } from '@floway-dev/test-ut
 
 const upstreamRecord = () => ({
   id: 'up_custom',
-  provider: 'custom' as const,
+  kind: 'custom' as const,
   name: 'Custom',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-custom/src/fetch_test.ts
+++ b/packages/provider-custom/src/fetch_test.ts
@@ -16,7 +16,7 @@ import { assertEquals, withMockedFetch } from '@floway-dev/test-utils';
 
 const baseRecord: UpstreamRecord = {
   id: 'up_test',
-  provider: 'custom',
+  kind: 'custom',
   name: 'Test Custom',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -221,7 +221,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
 
   return {
     upstream: record.id,
-    providerKind: 'custom',
+    kind: 'custom',
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -6,7 +6,7 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { publicModelId, resolveEffectiveFlags, defaultsForProvider, streamingProviderCall, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
+import { publicModelId, resolveEffectiveFlags, defaultsForProvider, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
 
 const rawModelIdOf = (model: UpstreamModel): string => model.providerData as string;
 
@@ -67,7 +67,7 @@ const finalizeCustomModels = (
   return models;
 };
 
-export const createCustomProvider = (record: UpstreamRecord): ModelProviderInstance => {
+export const createCustomProvider = (record: UpstreamRecord): Provider => {
   const { config } = assertCustomUpstreamRecord(record);
   const configuredEndpoints = config.endpoints;
   // Computed once for the auto-fetch layer: only the upstream layer applies to
@@ -170,7 +170,7 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     );
   };
 
-  const provider: ModelProvider = {
+  const instance: ProviderInstance = {
     getProvidedModels: async fetcher => {
       if (!config.modelsFetch.enabled) return manualModels;
       const response = await fetchCustomModels(config, fetcher);
@@ -225,7 +225,7 @@ export const createCustomProvider = (record: UpstreamRecord): ModelProviderInsta
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
-    provider,
+    instance,
     supportsResponsesItemReference: true,
   };
 };

--- a/packages/provider-custom/src/provider_test.ts
+++ b/packages/provider-custom/src/provider_test.ts
@@ -13,7 +13,7 @@ interface BuildOptions {
 
 const buildCustomUpstream = (options: BuildOptions = {}): UpstreamRecord => ({
   id: 'up_custom',
-  provider: 'custom',
+  kind: 'custom',
   name: 'Custom Provider',
   enabled: true,
   sortOrder: 0,
@@ -55,7 +55,7 @@ test('getProvidedModels returns only manual models and never fetches when models
       return jsonResponse({ object: 'list', data: [{ id: 'should-not-appear' }] });
     },
     async () => {
-      const models = await instance.provider.getProvidedModels(directFetcher);
+      const models = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(models.length, 1);
       assertEquals(models[0].id, 'manual-only');
     },
@@ -79,7 +79,7 @@ test('getProvidedModels merges manual models in front of auto-fetched models whe
   await withMockedFetch(
     () => jsonResponse({ object: 'list', data: [{ id: 'auto-1' }, { id: 'auto-2' }] }),
     async () => {
-      const models = await instance.provider.getProvidedModels(directFetcher);
+      const models = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(models.map(m => m.id), ['manual-extra', 'auto-1', 'auto-2']);
     },
   );
@@ -92,7 +92,7 @@ test('getProvidedModels rethrows when the upstream fetch fails — no fallback i
   await withMockedFetch(
     () => new Response('rate limited', { status: 429 }),
     async () => {
-      await assertRejects(() => instance.provider.getProvidedModels(directFetcher));
+      await assertRejects(() => instance.instance.getProvidedModels(directFetcher));
     },
   );
 });
@@ -108,11 +108,11 @@ test('getProvidedModels remembers pricing from the fetched response so getPricin
       data: [{ id: 'priced-model', cost: upstreamCost }],
     }),
     async () => {
-      await instance.provider.getProvidedModels(directFetcher);
+      await instance.instance.getProvidedModels(directFetcher);
     },
   );
 
-  const pricing = instance.provider.getPricingForModelKey('priced-model');
+  const pricing = instance.instance.getPricingForModelKey('priced-model');
   assertEquals(pricing, upstreamCost);
 });
 
@@ -140,11 +140,11 @@ test('A manual model whose upstreamModelId matches an auto-fetched id overrides 
       ],
     }),
     async () => {
-      const models = await instance.provider.getProvidedModels(directFetcher);
+      const models = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(models.map(m => m.id), ['shared-id', 'auto-only']);
       assertEquals(models[0].display_name, 'Manual Override');
     },
   );
 
-  assertEquals(instance.provider.getPricingForModelKey('shared-id'), manualCost);
+  assertEquals(instance.instance.getPricingForModelKey('shared-id'), manualCost);
 });

--- a/packages/provider-ollama/src/config.ts
+++ b/packages/provider-ollama/src/config.ts
@@ -29,7 +29,7 @@ export interface OllamaUpstreamConfig {
 }
 
 export type OllamaUpstreamRecord = UpstreamRecord & {
-  provider: 'ollama';
+  kind: 'ollama';
   config: OllamaUpstreamConfig;
 };
 
@@ -60,13 +60,13 @@ const apiKeyField = (value: unknown): string | undefined => {
 };
 
 export const assertOllamaUpstreamRecord = (record: UpstreamRecord): OllamaUpstreamRecord => {
-  if (record.provider !== 'ollama') throw new Error(`Expected ollama upstream record, got ${record.provider}`);
+  if (record.kind !== 'ollama') throw new Error(`Expected ollama upstream record, got ${record.kind}`);
   if (!isRecord(record.config)) throw new Error('Malformed ollama upstream config: config must be an object');
 
   const apiKey = apiKeyField(record.config.apiKey);
   return {
     ...record,
-    provider: 'ollama',
+    kind: 'ollama',
     config: {
       baseUrl: baseUrlField(record.config.baseUrl),
       ...(apiKey !== undefined ? { apiKey } : {}),

--- a/packages/provider-ollama/src/config_test.ts
+++ b/packages/provider-ollama/src/config_test.ts
@@ -7,7 +7,7 @@ import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 const baseRecord: UpstreamRecord = {
   id: 'up_ollama_test',
-  provider: 'ollama',
+  kind: 'ollama',
   name: 'Ollama Cloud',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-ollama/src/fetch-models_test.ts
+++ b/packages/provider-ollama/src/fetch-models_test.ts
@@ -7,7 +7,7 @@ import { assertEquals, assertRejects, jsonResponse, withMockedFetch } from '@flo
 
 const config: OllamaUpstreamConfig = assertOllamaUpstreamRecord({
   id: 'up_ollama',
-  provider: 'ollama',
+  kind: 'ollama',
   name: 'Ollama',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-ollama/src/fetch_test.ts
+++ b/packages/provider-ollama/src/fetch_test.ts
@@ -16,7 +16,7 @@ import { assertEquals, withMockedFetch } from '@floway-dev/test-utils';
 
 const baseRecord: UpstreamRecord = {
   id: 'up_ollama_test',
-  provider: 'ollama',
+  kind: 'ollama',
   name: 'Ollama',
   enabled: true,
   sortOrder: 0,

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -27,7 +27,7 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { publicModelId, resolveEffectiveFlags, defaultsForProvider, streamingProviderCall, type ModelProvider, type ModelProviderInstance, type ProviderCallResult, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
+import { publicModelId, resolveEffectiveFlags, defaultsForProvider, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamModel, type UpstreamRecord } from '@floway-dev/provider';
 
 // providerData carries the raw upstream id verbatim — the same value /api/tags
 // returns and the same value the gateway must send back on every inference
@@ -71,7 +71,7 @@ const finalizeOllamaModels = (
   return models;
 };
 
-export const createOllamaProvider = (record: UpstreamRecord): ModelProviderInstance => {
+export const createOllamaProvider = (record: UpstreamRecord): Provider => {
   const { config } = assertOllamaUpstreamRecord(record);
   const upstreamFlags = resolveEffectiveFlags(defaultsForProvider('ollama'), [record.flagOverrides]);
 
@@ -138,7 +138,7 @@ export const createOllamaProvider = (record: UpstreamRecord): ModelProviderInsta
   const rejectUnsupported = (capability: string) => () =>
     Promise.reject(new Error(`Ollama provider does not implement ${capability}`));
 
-  const provider: ModelProvider = {
+  const instance: ProviderInstance = {
     getProvidedModels: async fetcher => {
       const catalog = await fetchOllamaCatalog(config, fetcher);
       const auto = finalizeOllamaModels(
@@ -189,7 +189,7 @@ export const createOllamaProvider = (record: UpstreamRecord): ModelProviderInsta
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
-    provider,
+    instance,
     supportsResponsesItemReference: true,
   };
 };

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -185,7 +185,7 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
 
   return {
     upstream: record.id,
-    providerKind: 'ollama',
+    kind: 'ollama',
     name: record.name,
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,

--- a/packages/provider-ollama/src/provider_test.ts
+++ b/packages/provider-ollama/src/provider_test.ts
@@ -7,7 +7,7 @@ import { assertEquals, jsonResponse, withMockedFetch } from '@floway-dev/test-ut
 
 const buildRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => ({
   id: 'up_ollama',
-  provider: 'ollama',
+  kind: 'ollama',
   name: 'Ollama',
   enabled: true,
   sortOrder: 0,
@@ -56,7 +56,7 @@ const tagsAndShow = async (request: Request): Promise<Response> => {
 test('getProvidedModels surfaces chat models with all three OpenAI/Anthropic-compat endpoints', async () => {
   const instance = createOllamaProvider(buildRecord());
   await withMockedFetch(tagsAndShow, async () => {
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     const gptoss = models.find(m => m.id === 'gpt-oss:120b')!;
     assertEquals(gptoss.kind, 'chat');
     assertEquals(Object.keys(gptoss.endpoints).sort(), ['chatCompletions', 'completions', 'messages', 'responses']);
@@ -72,7 +72,7 @@ test('getProvidedModels surfaces chat models with all three OpenAI/Anthropic-com
 test('getProvidedModels routes embedding-capability models to kind=embedding with only the embeddings endpoint', async () => {
   const instance = createOllamaProvider(buildRecord());
   await withMockedFetch(tagsAndShow, async () => {
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     const embed = models.find(m => m.id === 'nomic-embed-text:latest')!;
     assertEquals(embed.kind, 'embedding');
     assertEquals(Object.keys(embed.endpoints), ['embeddings']);
@@ -93,7 +93,7 @@ test('getProvidedModels merges manual overrides in front of auto-fetched models 
     },
   }));
   await withMockedFetch(tagsAndShow, async () => {
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     // Manual entry appears first; the auto duplicate is filtered out so the
     // public id resolves to the manual entry's narrower endpoints map.
     assertEquals(models[0].id, 'gpt-oss:120b');
@@ -118,11 +118,11 @@ test('getPricingForModelKey resolves manual cost first, then falls back to the O
     },
   }));
   // Manual cost wins for the pinned id.
-  assertEquals(instance.provider.getPricingForModelKey('gpt-oss:120b'), { input: 99, output: 99 });
+  assertEquals(instance.instance.getPricingForModelKey('gpt-oss:120b'), { input: 99, output: 99 });
   // Unpinned model falls back to the table.
-  assertEquals(instance.provider.getPricingForModelKey('deepseek-v4-flash')?.input, 0.14);
+  assertEquals(instance.instance.getPricingForModelKey('deepseek-v4-flash')?.input, 0.14);
   // Unknown model returns null rather than fabricating a guess.
-  assertEquals(instance.provider.getPricingForModelKey('devstral-small-2:24b'), null);
+  assertEquals(instance.instance.getPricingForModelKey('devstral-small-2:24b'), null);
 });
 
 test('call* methods POST to /v1/<endpoint> with the upstream model id and Bearer header', async () => {
@@ -153,8 +153,8 @@ test('call* methods POST to /v1/<endpoint> with the upstream model id and Bearer
       return new Response('unexpected', { status: 500 });
     },
     async () => {
-      const [model] = await instance.provider.getProvidedModels(directFetcher);
-      const result = await instance.provider.callChatCompletions(
+      const [model] = await instance.instance.getProvidedModels(directFetcher);
+      const result = await instance.instance.callChatCompletions(
         model,
         { messages: [{ role: 'user', content: 'hi' }] },
         undefined,
@@ -174,7 +174,7 @@ test('call* methods POST to /v1/<endpoint> with the upstream model id and Bearer
 test('getProvidedModels populates chat from capabilities: gpt-oss thinking → effort, vision → modalities', async () => {
   const instance = createOllamaProvider(buildRecord());
   await withMockedFetch(tagsAndShow, async () => {
-    const models = await instance.provider.getProvidedModels(directFetcher);
+    const models = await instance.instance.getProvidedModels(directFetcher);
     const gptoss = models.find(m => m.id === 'gpt-oss:120b')!;
     assertEquals(gptoss.chat, {
       reasoning: { effort: { supported: ['low', 'medium', 'high'], default: 'medium' } },

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -3,7 +3,7 @@ export type {
   GeminiInvocation,
   ChatTargetApi,
   MessagesInvocation,
-  ProviderCandidate,
+  ModelCandidate,
   ResponsesInvocation,
 } from './invocation.ts';
 
@@ -42,8 +42,8 @@ export type { AddressableForm, ModelPrefixConfig } from './model-prefix.ts';
 export { MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX, normalizeModelPrefix } from './model-prefix.ts';
 
 export type {
-  ModelProvider,
-  ModelProviderInstance,
+  Provider,
+  ProviderInstance,
   ProviderCallResult,
   ProviderResponsesResult,
   ProviderStreamResult,

--- a/packages/provider/src/invocation.ts
+++ b/packages/provider/src/invocation.ts
@@ -1,6 +1,6 @@
 import type { UpstreamModel } from './model.ts';
 import type { Fetcher } from './options.ts';
-import type { ModelProviderInstance, ResponsesAction } from './provider.ts';
+import type { Provider, ResponsesAction } from './provider.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
@@ -11,15 +11,15 @@ export type ChatTargetApi = 'messages' | 'responses' | 'chat-completions';
 // One (provider, model) pair the resolver produced for an inbound id,
 // plus the per-request `Fetcher` minted for the provider's upstream. The
 // pair is the smallest unit the dispatch layer needs to make a wire call:
-// `provider.provider.callXxx(model, body, ...)` — upstream id / upstream
+// `provider.instance.callXxx(model, body, ...)` — upstream id / upstream
 // name / provider kind / capability flags come off `provider.*`, model id
 // / providerData / endpoints off `model.*`.
 //
 // Resolution narrows by `model.kind` only — choosing the inbound target
 // protocol from `model.endpoints` is the attempt layer's job, not part of
 // the candidate.
-export interface ProviderCandidate {
-  readonly provider: ModelProviderInstance;
+export interface ModelCandidate {
+  readonly provider: Provider;
   readonly model: UpstreamModel;
   readonly fetcher: Fetcher;
 }
@@ -33,7 +33,7 @@ export interface ProviderCandidate {
 // widening the provider call signature.
 export interface MessagesInvocation {
   payload: MessagesPayload;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
@@ -45,21 +45,21 @@ export interface ResponsesInvocation {
   // responses-compact-shim) and the gateway derives snapshot mode from the
   // post-chain action carried on the provider's tagged result.
   action: ResponsesAction;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
 export interface ChatCompletionsInvocation {
   payload: ChatCompletionsPayload;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }
 
 export interface GeminiInvocation {
   payload: GeminiPayload;
-  readonly candidate: ProviderCandidate;
+  readonly candidate: ModelCandidate;
   readonly targetApi: ChatTargetApi;
   readonly headers: Headers;
 }

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -21,7 +21,7 @@ export interface ProxyFallbackEntry {
 // `state` is gateway-managed runtime data.
 export interface UpstreamRecord {
   id: string;
-  provider: UpstreamProviderKind;
+  kind: UpstreamProviderKind;
   name: string;
   enabled: boolean;
   sortOrder: number;

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -21,7 +21,7 @@ export type ResponsesAction = 'generate' | 'compact';
 
 export interface Provider {
   upstream: string;
-  providerKind: UpstreamProviderKind;
+  kind: UpstreamProviderKind;
   name: string;
   // Public model ids the operator switched off for this upstream.
   disabledPublicModelIds: readonly string[];

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -19,7 +19,7 @@ import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@f
 // turn against the SUMMARIZATION_PROMPT).
 export type ResponsesAction = 'generate' | 'compact';
 
-export interface ModelProviderInstance {
+export interface Provider {
   upstream: string;
   providerKind: UpstreamProviderKind;
   name: string;
@@ -29,7 +29,7 @@ export interface ModelProviderInstance {
   // record so registry helpers — routing and listing — read it from the
   // instance instead of re-fetching the row. `null` keeps the bare-id behavior.
   modelPrefix: ModelPrefixConfig | null;
-  provider: ModelProvider;
+  instance: ProviderInstance;
   supportsResponsesItemReference: boolean;
 }
 
@@ -107,7 +107,7 @@ export interface UpstreamCallOptions {
   headers: Headers;
 }
 
-export interface ModelProvider {
+export interface ProviderInstance {
   // Catalog refresh fetches a single resource and never enters the per-request
   // latency budget, so it takes the per-upstream fetcher directly instead of
   // the broader `UpstreamCallOptions` bag the data-plane `call*` methods use.

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -9,4 +9,4 @@ export {
   assertThrows,
 } from './assert.ts';
 export { jsonResponse, sseResponse, withMockedFetch } from './mock-fetch.ts';
-export { noopUpstreamCallOptions, stubProvider, stubProviderCandidate, stubUpstreamModel, testTelemetryModelIdentity } from './stubs.ts';
+export { noopUpstreamCallOptions, stubProvider, stubModelCandidate, stubUpstreamModel, testTelemetryModelIdentity } from './stubs.ts';

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -60,7 +60,7 @@ export const stubProvider = (overrides: Partial<ProviderInstance> = {}): Provide
 export const stubModelCandidate = (overrides: { model?: Partial<UpstreamModel>; provider?: Provider } = {}): ModelCandidate => {
   const provider = overrides.provider ?? {
     upstream: 'test-upstream',
-    providerKind: 'custom',
+    kind: 'custom',
     name: 'Test Upstream',
     disabledPublicModelIds: [],
     modelPrefix: null,

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -1,4 +1,4 @@
-import { directFetcher, type ModelProvider, type ModelProviderInstance, type ProviderCandidate, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamModel } from '@floway-dev/provider';
+import { directFetcher, type ProviderInstance, type Provider, type ModelCandidate, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamModel } from '@floway-dev/provider';
 
 // No-op UpstreamCallOptions factory for tests calling provider methods
 // directly: identity recordUpstreamLatency satisfies the contract without
@@ -44,7 +44,7 @@ const autoWrap = <T>(impl: T | undefined): T | undefined => {
   }) as unknown as T;
 };
 
-export const stubProvider = (overrides: Partial<ModelProvider> = {}): ModelProvider => ({
+export const stubProvider = (overrides: Partial<ProviderInstance> = {}): ProviderInstance => ({
   getProvidedModels: overrides.getProvidedModels ?? (() => Promise.resolve([])),
   getPricingForModelKey: overrides.getPricingForModelKey ?? (() => null),
   callCompletions: autoWrap(overrides.callCompletions) ?? (() => Promise.reject(new Error('stubProvider.callCompletions was called'))),
@@ -57,14 +57,14 @@ export const stubProvider = (overrides: Partial<ModelProvider> = {}): ModelProvi
   callImagesEdits: autoWrap(overrides.callImagesEdits) ?? (() => Promise.reject(new Error('stubProvider.callImagesEdits was called'))),
 });
 
-export const stubProviderCandidate = (overrides: { model?: Partial<UpstreamModel>; provider?: ModelProviderInstance } = {}): ProviderCandidate => {
+export const stubModelCandidate = (overrides: { model?: Partial<UpstreamModel>; provider?: Provider } = {}): ModelCandidate => {
   const provider = overrides.provider ?? {
     upstream: 'test-upstream',
     providerKind: 'custom',
     name: 'Test Upstream',
     disabledPublicModelIds: [],
     modelPrefix: null,
-    provider: stubProvider(),
+    instance: stubProvider(),
     supportsResponsesItemReference: false,
   };
   return {


### PR DESCRIPTION
Renames across the provider/candidate vocabulary — packages-side technical types plus the dashboard's upstream-edit props — bundled because each clarifies which dimension a name carries (kind vs. instance vs. (provider, model) pair) and the shape only reads coherently as one set.

- **`UpstreamRecord.provider` → `.kind`.** The field discriminates upstream classes (`custom`, `azure`, `copilot`, `codex`, `claude-code`, `ollama`). Once the second rename below put a `Provider` object on the record, the discriminator's old name would have collided; the discriminator takes the cleaner name. The DB column stays `provider` and `sql.ts` adapts at the row→record boundary. `SearchUsageRecord.provider` and `SearchConfigRecord.provider` stay put — those name a search-provider in a different domain.
- **`ModelProviderInstance` → `Provider`; inner field `provider: ModelProvider` → `instance: ProviderInstance`.** The outer type is the per-upstream, resolver-facing object the candidate flow carries; the inner field is the wire-call implementation the dispatch layer reaches through. Each `apps/provider-*` factory returns `Provider`, and the wire-call object inside it is `instance: ProviderInstance`. Call sites read `candidate.provider.instance.callXxx(...)` for the six chat call methods plus `getProvidedModels` / `getPricingForModelKey`.
- **`ProviderCandidate` → `ModelCandidate`; `stubProviderCandidate` → `stubModelCandidate`.** A candidate represents a `(Provider, UpstreamModel)` pair; the model is the discriminant the resolver is selecting, so naming the pair after the model is more accurate than naming it after the provider.
- **`Provider.providerKind` → `Provider.kind`.** Same "outer type's name is enough context" logic as the record rename. `candidate.provider.kind` now reads the way `candidate.provider` does, and the field's type (`UpstreamProviderKind`) is unchanged.

Wire DTOs and zod schemas track the in-memory rename: `SerializedUpstreamRecord.kind`, the `createUpstreamBody` / `fetchModelsBody` discriminator, `updateUpstreamBody.kind`, the data-transfer import validator, and the dashboard's `UpstreamOption.kind` + `UpstreamRecord` discriminated union. The data-transfer import error message reads `` `kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}` `` — sourced from the same set the check consults, so the message can't drift out of sync when a new provider kind lands. There is no compat shim: existing export files keyed on `provider:` fail import, per the in-repo policy against in-code legacy-data handling.

The dashboard's upstream-edit cascade applies the same logic: `UpstreamConfigPanel.props.provider` → `.kind`, `UpstreamEditPage.props.initialProvider` → `.initialKind` (with its derived `activeProvider` computed → `activeKind`), and `FlagOverridesEditor.props.providerKind` → `.kind`. `ModelsPanel.props.flagProviderKind` stays — that component has `model.kind` in scope, so a disambiguating compound name still reads better than a bare `kind` that would collide. URL routing (`pages/dashboard/upstreams/new/[provider].vue`) stays as-is; the segment name is a public URL contract.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`