### PR TITLE
refactor(chat/responses): canonicalize input at the entry boundary

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -2,7 +2,6 @@ import { chatCompletionsInterceptors } from './interceptors/index.ts';
 import type { ChatCompletionsInvocation } from './interceptors/types.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
-import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../shared/attempt-helpers.ts';
@@ -61,7 +60,7 @@ export const chatCompletionsAttempt = {
           invocation.payload,
           p => translateChatCompletionsViaResponses(p, { model: candidate.model.id }),
           translated => responsesAttempt.generate({
-            payload: canonicalizeResponsesPayload(translated), ctx, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -14,6 +14,7 @@ import type { ChatCompletionsMessage, ChatCompletionsPayload, ChatCompletionsStr
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ModelCandidate, type ExecuteResult } from '@floway-dev/provider';
 import { translateChatCompletionsViaMessages, translateChatCompletionsViaResponses } from '@floway-dev/translate';
+import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { chatCompletionsViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 // `/v1/chat/completions` generate prefers a native Chat Completions target,
@@ -60,7 +61,7 @@ export const chatCompletionsAttempt = {
           invocation.payload,
           p => translateChatCompletionsViaResponses(p, { model: candidate.model.id }),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, candidate, headers: invocation.headers,
+            payload: canonicalizeResponsesPayload(translated), ctx, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -2,6 +2,7 @@ import { chatCompletionsInterceptors } from './interceptors/index.ts';
 import type { ChatCompletionsInvocation } from './interceptors/types.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
+import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../shared/attempt-helpers.ts';
@@ -14,7 +15,6 @@ import type { ChatCompletionsMessage, ChatCompletionsPayload, ChatCompletionsStr
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ModelCandidate, type ExecuteResult } from '@floway-dev/provider';
 import { translateChatCompletionsViaMessages, translateChatCompletionsViaResponses } from '@floway-dev/translate';
-import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { chatCompletionsViaResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 // `/v1/chat/completions` generate prefers a native Chat Completions target,

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -5,6 +5,7 @@ import { stripUnsupportedToolsFromPayload } from './interceptors/strip-unsupport
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
+import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { chatTargetPicker } from '../shared/attempt-helpers.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
@@ -62,7 +63,7 @@ export const geminiAttempt = {
           invocation.payload,
           p => translateGeminiViaResponses(p, transCtx),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, candidate, headers: invocation.headers,
+            payload: canonicalizeResponsesPayload(translated), ctx, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -5,7 +5,6 @@ import { stripUnsupportedToolsFromPayload } from './interceptors/strip-unsupport
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
-import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { chatTargetPicker } from '../shared/attempt-helpers.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
@@ -63,7 +62,7 @@ export const geminiAttempt = {
           invocation.payload,
           p => translateGeminiViaResponses(p, transCtx),
           translated => responsesAttempt.generate({
-            payload: canonicalizeResponsesPayload(translated), ctx, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -3,6 +3,7 @@ import type { MessagesInvocation } from './interceptors/types.ts';
 import { requireRecordedDurationMs } from '../../shared/telemetry/performance.ts';
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
+import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../shared/attempt-helpers.ts';
@@ -70,7 +71,7 @@ export const messagesAttempt = {
           invocation.payload,
           p => translateMessagesViaResponses(p, { model: candidate.model.id }),
           translated => responsesAttempt.generate({
-            payload: translated, ctx, candidate, headers: invocation.headers,
+            payload: canonicalizeResponsesPayload(translated), ctx, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -3,7 +3,6 @@ import type { MessagesInvocation } from './interceptors/types.ts';
 import { requireRecordedDurationMs } from '../../shared/telemetry/performance.ts';
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
-import { canonicalizeResponsesPayload } from '../responses/interceptors/types.ts';
 import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../shared/attempt-helpers.ts';
@@ -71,7 +70,7 @@ export const messagesAttempt = {
           invocation.payload,
           p => translateMessagesViaResponses(p, { model: candidate.model.id }),
           translated => responsesAttempt.generate({
-            payload: canonicalizeResponsesPayload(translated), ctx, candidate, headers: invocation.headers,
+            payload: translated, ctx, candidate, headers: invocation.headers,
           }),
         );
       }

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -1,5 +1,5 @@
 import { responsesInterceptors } from './interceptors/index.ts';
-import type { ResponsesAttemptResult } from './interceptors/types.ts';
+import type { CanonicalResponsesPayload, ResponsesAttemptResult, ResponsesInvocation } from './interceptors/types.ts';
 import { createStoredResponseId } from './items/format.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
 import { drainAsync, syntheticEventsFromResult, wrapResponsesOutputForStorage } from './items/output.ts';
@@ -17,8 +17,8 @@ import { createUpstreamLatencyRecorder, recordUpstreamHttpFailure, upstreamPerfo
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
-import { type ResponsesPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ModelCandidate, eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction, type ResponsesInvocation } from '@floway-dev/provider';
+import { type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { type ModelCandidate, eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction } from '@floway-dev/provider';
 import { translateResponsesViaChatCompletions, translateResponsesViaMessages } from '@floway-dev/translate';
 
 // `/v1/responses` generate prefers the native Responses target, then the
@@ -29,7 +29,7 @@ import { translateResponsesViaChatCompletions, translateResponsesViaMessages } f
 export const responsesTarget = chatTargetPicker(['responses', 'messages', 'chat-completions']);
 
 export interface ResponsesAttemptInvokeArgs {
-  readonly payload: ResponsesPayload;
+  readonly payload: CanonicalResponsesPayload;
   readonly action: ResponsesAction;
   readonly ctx: ChatGatewayCtx;
   readonly candidate: ModelCandidate;
@@ -95,7 +95,7 @@ export const responsesAttempt = {
     // here, after the rewrite has expanded any `item_reference` items
     // from the snapshot store, catches both the direct-echo and
     // store-replay paths in one place.
-    const normalized: ResponsesPayload = { ...rewritten.payload, input: normalizeAssistantInputText(rewritten.payload.input) };
+    const normalized: CanonicalResponsesPayload = { ...rewritten.payload, input: normalizeAssistantInputText(rewritten.payload.input) };
 
     const invocation: ResponsesInvocation = {
       payload: normalized,
@@ -178,7 +178,7 @@ type RewriteOutcome =
   | { readonly failure: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> };
 
 const rewriteOrRenderFailure = async (
-  payload: ResponsesPayload,
+  payload: CanonicalResponsesPayload,
   store: StatefulResponsesStore,
   candidate: ModelCandidate,
 ): Promise<RewriteOutcome> => {

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -1,5 +1,5 @@
 import { responsesInterceptors } from './interceptors/index.ts';
-import type { CanonicalResponsesPayload, ResponsesAttemptResult, ResponsesInvocation } from './interceptors/types.ts';
+import type { ResponsesAttemptResult, ResponsesInvocation } from './interceptors/types.ts';
 import { createStoredResponseId } from './items/format.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
 import { drainAsync, syntheticEventsFromResult, wrapResponsesOutputForStorage } from './items/output.ts';
@@ -20,6 +20,7 @@ import { collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/re
 import { type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction } from '@floway-dev/provider';
 import { translateResponsesViaChatCompletions, translateResponsesViaMessages } from '@floway-dev/translate';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // `/v1/responses` generate prefers the native Responses target, then the
 // translated Messages path, then the translated Chat Completions path. The

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -1,6 +1,7 @@
 import { test, vi } from 'vitest';
 
 import { responsesAttempt } from './attempt.ts';
+import type { CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createStoredResponsesItemId, isStoredResponseId } from './items/format.ts';
 import * as outputModule from './items/output.ts';
 import { createResponsesHttpStore, createNonResponsesSourceStore } from './items/store.ts';
@@ -28,9 +29,9 @@ const makeGatewayCtx = (store?: ChatGatewayCtx['store']): ChatGatewayCtx => ({
   store: store ?? createNonResponsesSourceStore(API_KEY_ID),
 });
 
-const makePayload = (overrides: Partial<ResponsesPayload> = {}): ResponsesPayload => ({
+const makePayload = (overrides: Partial<CanonicalResponsesPayload> = {}): CanonicalResponsesPayload => ({
   model: 'test-model',
-  input: 'hello',
+  input: [{ type: 'message', role: 'user', content: 'hello' }],
   ...overrides,
 });
 

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -1,7 +1,6 @@
 import { test, vi } from 'vitest';
 
 import { responsesAttempt } from './attempt.ts';
-import type { CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createStoredResponsesItemId, isStoredResponseId } from './items/format.ts';
 import * as outputModule from './items/output.ts';
 import { createResponsesHttpStore, createNonResponsesSourceStore } from './items/store.ts';
@@ -14,6 +13,7 @@ import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions, type UpstreamModel } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const API_KEY_ID = 'key_attempt_test';
 

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -1,5 +1,4 @@
 import { translatorInputErrorResult } from './errors.ts';
-import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createResponsesHttpStore } from './items/store.ts';
 import { respondResponses } from './respond.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
@@ -13,6 +12,7 @@ import { providerModelsUnavailableResponse } from '../shared/upstream-models-err
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
 import { TranslatorInputError } from '@floway-dev/translate';
+import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // Codex sends auto-review requests over the Responses wire API as a
 // `codex-auto-review` model id; rewrite at the entry so downstream routing,

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -1,4 +1,5 @@
 import { translatorInputErrorResult } from './errors.ts';
+import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createResponsesHttpStore } from './items/store.ts';
 import { respondResponses } from './respond.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
@@ -79,8 +80,10 @@ const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: Req
   return await respondWithInternalError(c, error, requestBody, ctx);
 };
 
-const parsePayload = (requestBody: RequestBody, stampReasoningEffort: boolean): ResponsesPayload =>
-  rewriteResponsesEntryModelAlias(JSON.parse(new TextDecoder().decode(requestBody.bytes)) as ResponsesPayload, stampReasoningEffort);
+const parsePayload = (requestBody: RequestBody, stampReasoningEffort: boolean): CanonicalResponsesPayload =>
+  canonicalizeResponsesPayload(
+    rewriteResponsesEntryModelAlias(JSON.parse(new TextDecoder().decode(requestBody.bytes)) as ResponsesPayload, stampReasoningEffort),
+  );
 
 export const responsesHttp = {
   generate: async (c: AuthedContext): Promise<Response> => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
@@ -1,13 +1,14 @@
 import { test } from 'vitest';
 
 import { withResponsesOutputItemsCanonicalized } from './canonicalize-output-items.ts';
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { stubModelCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
@@ -1,11 +1,12 @@
 import { test } from 'vitest';
 
 import { withResponsesOutputItemsCanonicalized } from './canonicalize-output-items.ts';
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ExecuteResult, eventResult, type ResponsesInvocation } from '@floway-dev/provider';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { stubModelCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -21,7 +22,7 @@ const stubCtx: ChatGatewayCtx = {
 };
 
 const invocation = (): ResponsesInvocation => ({
-  payload: { model: 'gpt-test', input: 'hi' } as ResponsesPayload,
+  payload: { model: 'gpt-test', input: [{ type: 'message' as const, role: 'user' as const, content: 'hi' }] } as CanonicalResponsesPayload,
   action: 'generate',
   candidate: stubModelCandidate(),
   targetApi: 'responses',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -45,7 +45,7 @@
 // untouched, so the operator can selectively turn the flag off for codex /
 // copilot / azure / custom upstreams that natively support compaction.
 
-import type { CanonicalResponsesPayload, ResponsesInterceptor, ResponsesInvocation } from './types.ts';
+import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
 import { decodeBase64UrlJson, encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import { isJsonObject } from '../../../../shared/json-helpers.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
@@ -53,6 +53,7 @@ import { syntheticEventsFromResult } from '../items/output.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // Vendored from openai/codex (Apache-2.0):
 // https://github.com/openai/codex/blob/ba2b67f9cda954bcdda43c2a65ac58e807b996bd/codex-rs/prompts/templates/compact/prompt.md

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -45,14 +45,14 @@
 // untouched, so the operator can selectively turn the flag off for codex /
 // copilot / azure / custom upstreams that natively support compaction.
 
-import type { ResponsesInterceptor } from './types.ts';
+import type { CanonicalResponsesPayload, ResponsesInterceptor, ResponsesInvocation } from './types.ts';
 import { decodeBase64UrlJson, encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import { isJsonObject } from '../../../../shared/json-helpers.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { syntheticEventsFromResult } from '../items/output.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ExecuteResult, ResponsesInvocation } from '@floway-dev/provider';
+import { collectResponsesProtocolEventsToResult, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ExecuteResult } from '@floway-dev/provider';
 
 // Vendored from openai/codex (Apache-2.0):
 // https://github.com/openai/codex/blob/ba2b67f9cda954bcdda43c2a65ac58e807b996bd/codex-rs/prompts/templates/compact/prompt.md
@@ -74,9 +74,7 @@ const isShimCompactionPayload = (value: unknown): value is ResponsesInputItem[] 
   Array.isArray(value) && value.every(item =>
     isJsonObject(item) && typeof (item as { type?: unknown }).type === 'string');
 
-export const expandShimCompactionItems = (payload: ResponsesPayload): ResponsesPayload => {
-  if (typeof payload.input === 'string') return payload;
-
+export const expandShimCompactionItems = (payload: CanonicalResponsesPayload): CanonicalResponsesPayload => {
   const rewritten: ResponsesInputItem[] = [];
   let changed = false;
   for (const item of payload.input) {
@@ -157,15 +155,9 @@ const buildCompactionEnvelope = (cmpId: string, summaryText: string, upstream: R
 const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGatewayCtx, run: ChainRun): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
   const originalPayload = ctx.payload;
 
-  // Materialize the user-supplied input (string or array) into Responses items,
-  // then strip compaction_trigger so the upstream sees a plain generate turn
-  // against SUMMARIZATION_PROMPT. The string branch matches the serve-prep
-  // precedent (responses/serve-prep.ts): a string `input` becomes one
-  // user-role message whose content is the original text.
-  const originalInputItems: ResponsesInputItem[] = typeof originalPayload.input === 'string'
-    ? [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: originalPayload.input }] }]
-    : originalPayload.input;
-  const historyItems = originalInputItems.filter(item => item.type !== 'compaction_trigger');
+  // Strip compaction_trigger so the upstream sees a plain generate turn
+  // against SUMMARIZATION_PROMPT.
+  const historyItems = originalPayload.input.filter(item => item.type !== 'compaction_trigger');
 
   // Anthropic Messages rejects assistant prefill — when the translated
   // conversation ends on an assistant message, the upstream returns 400
@@ -238,8 +230,8 @@ const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGate
 // CLI's RemoteCompactionV2 path that semantically requests compaction
 // through `action: 'generate'`. Exported so callers outside the shim
 // (attempt.ts's snapshot-mode derivation) can ask the same question.
-export const containsCompactionTrigger = (input: ResponsesPayload['input']): boolean =>
-  typeof input !== 'string' && input.some(item => item.type === 'compaction_trigger');
+export const containsCompactionTrigger = (input: readonly ResponsesInputItem[]): boolean =>
+  input.some(item => item.type === 'compaction_trigger');
 
 export const withResponsesCompactShim: ResponsesInterceptor = async (ctx, gatewayCtx, run) => {
   // The shim is engaged when the operator turned it on for this upstream,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 
 import { expandShimCompactionItems, withResponsesCompactShim } from './compact-shim.ts';
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import { encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
@@ -9,6 +9,7 @@ import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols
 import { collectResponsesProtocolEventsToResult, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -1,12 +1,13 @@
 import { test } from 'vitest';
 
 import { expandShimCompactionItems, withResponsesCompactShim } from './compact-shim.ts';
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import { encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { collectResponsesProtocolEventsToResult, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { eventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { eventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -25,7 +26,7 @@ const makeInvocation = (
   payload: Partial<ResponsesPayload> = {},
   options: { action?: 'generate' | 'compact'; flagOn?: boolean; targetApi?: 'responses' | 'messages' | 'chat-completions' } = {},
 ): ResponsesInvocation => ({
-  payload: { model: 'test-model', input: [], ...payload } as ResponsesPayload,
+  payload: { model: 'test-model', input: [], ...payload } as CanonicalResponsesPayload,
   action: options.action ?? 'generate',
   candidate: stubModelCandidate({
     model: { enabledFlags: new Set(options.flagOn === false ? [] : ['responses-compact-shim']) },
@@ -108,11 +109,6 @@ test('inbound: foreign compaction blob (valid base64url but wrong shape) round-t
   };
   const expanded = expandShimCompactionItems(original);
   assertEquals(expanded, original);
-});
-
-test('inbound: string input is returned unchanged', () => {
-  const result = expandShimCompactionItems({ model: 'm', input: 'plain string' });
-  assertEquals(result.input, 'plain string');
 });
 
 // ── Outbound summarization (withResponsesCompactShim) ────────────────────────
@@ -283,31 +279,6 @@ test('compact + flag on: upstream incomplete status propagates onto the synthesi
   const collected = await collectResponsesProtocolEventsToResult(result.events);
   assertEquals(collected.status, 'incomplete');
   assertEquals(collected.incomplete_details, { reason: 'max_output_tokens' });
-});
-
-test('compact + flag on: string input is materialized into one user-message item before the upstream call', async () => {
-  const inv = makeInvocation(
-    { input: 'a single string turn' as unknown as never },
-    { action: 'compact' },
-  );
-
-  let seenPayload: ResponsesPayload | undefined;
-  await withResponsesCompactShim(inv, stubCtx, () => {
-    seenPayload = inv.payload;
-    return fakeUpstreamRun('s')();
-  });
-  if (!seenPayload) throw new Error('expected the upstream call to fire');
-  // Without materialization the original string would have been dropped on
-  // the floor — the summarization turn would see an empty history and the
-  // synthesized envelope would condense nothing. The trailing item is the
-  // synthetic terminal-user nudge appended unconditionally (see Bug 2).
-  const items = seenPayload.input as Array<{ type: string; role?: string; content?: unknown }>;
-  assertEquals(items.length, 2);
-  assertEquals(items[0].type, 'message');
-  assertEquals(items[0].role, 'user');
-  const content = items[0].content as Array<{ type: string; text: string }>;
-  assertEquals(content[0].type, 'input_text');
-  assertEquals(content[0].text, 'a single string turn');
 });
 
 test('compact + flag on: compaction_trigger items are stripped before the upstream call', async () => {
@@ -534,7 +505,7 @@ test('round-trip: outbound synthesis then inbound expansion recovers the summary
 
   // Step 2: next turn echoes the compaction item back as an input item;
   // inbound expansion replaces it with the summary message.
-  const nextTurn: ResponsesPayload = {
+  const nextTurn: CanonicalResponsesPayload = {
     model: 'test-model',
     input: [
       { type: 'compaction', id: compactionItem.id ?? 'cmp_rt', encrypted_content: compactionItem.encrypted_content } as unknown as never,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -78,7 +78,6 @@ test('inbound: compaction item with a shim-encoded payload expands inline', () =
     ],
   });
 
-  if (typeof expanded.input === 'string') throw new Error('expected array input');
   assertEquals(expanded.input.length, 2);
   assertEquals(expanded.input[0], userItem);
   assertEquals(expanded.input[1], { type: 'message', role: 'user', content: 'new turn' });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system.ts
@@ -26,12 +26,10 @@ const downgradeRole = (item: ResponsesInputItem): ResponsesInputItem => {
 export const withDemoteDeveloperToSystem: ResponsesInterceptor = async (ctx, _request, run) => {
   if (!ctx.candidate.model.enabledFlags.has('demote-developer-to-system')) return await run();
 
-  if (Array.isArray(ctx.payload.input)) {
-    ctx.payload = {
-      ...ctx.payload,
-      input: ctx.payload.input.map(downgradeRole),
-    };
-  }
+  ctx.payload = {
+    ...ctx.payload,
+    input: ctx.payload.input.map(downgradeRole),
+  };
 
   return await run();
 };

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -1,11 +1,11 @@
 import { test } from 'vitest';
 
 import { withDemoteDeveloperToSystem } from './demote-developer-to-system.ts';
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -30,7 +30,7 @@ const okEvents = () =>
     ),
   );
 
-const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ResponsesInvocation => ({
+const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
@@ -86,18 +86,6 @@ test('leaves non-message input items untouched', async () => {
   assertEquals(items[0].role, 'user');
   assertEquals(items[1].type, 'function_call_output');
   assertEquals(items[2].role, 'system');
-});
-
-test('passes string input through unchanged', async () => {
-  const input = invocation({
-    model: 'deepseek-chat',
-    input: 'hello world',
-  });
-
-  const original = input.payload;
-  await withDemoteDeveloperToSystem(input, stubCtx, okEvents);
-
-  assertEquals(input.payload, original);
 });
 
 test('early-returns when flag is not set', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -1,12 +1,13 @@
 import { test } from 'vitest';
 
 import { withDemoteDeveloperToSystem } from './demote-developer-to-system.ts';
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user.ts
@@ -13,8 +13,6 @@ export const withInterleavedSystemDemotedToUser: ResponsesInterceptor = (ctx, _g
   if (!ctx.candidate.model.enabledFlags.has('demote-interleaved-system-to-user')) return run();
 
   const { input } = ctx.payload;
-  if (typeof input === 'string') return run();
-
   let crossedLeadingRun = false;
   for (let i = 0; i < input.length; i++) {
     const item = input[i];

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -1,11 +1,11 @@
 import { test } from 'vitest';
 
 import { withInterleavedSystemDemotedToUser } from './demote-interleaved-system-to-user.ts';
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -31,7 +31,7 @@ const okEvents = () =>
   );
 
 const invocation = (
-  payload: ResponsesPayload,
+  payload: CanonicalResponsesPayload,
   enabledFlags: ReadonlySet<string> = new Set(['demote-interleaved-system-to-user']),
 ): ResponsesInvocation => ({
   payload,
@@ -137,12 +137,4 @@ test('is a no-op for an empty input array', async () => {
   await withInterleavedSystemDemotedToUser(input, stubCtx, okEvents);
 
   assertEquals(input.payload.input, []);
-});
-
-test('is a no-op when input is a plain string', async () => {
-  const input = invocation({ model: 'm', input: 'hello' });
-
-  await withInterleavedSystemDemotedToUser(input, stubCtx, okEvents);
-
-  assertEquals(input.payload.input, 'hello');
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -1,12 +1,13 @@
 import { test } from 'vitest';
 
 import { withInterleavedSystemDemotedToUser } from './demote-interleaved-system-to-user.ts';
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -1,11 +1,11 @@
 import { test } from 'vitest';
 
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -31,7 +31,7 @@ const okEvents = () =>
   );
 
 const invocation = (
-  payload: ResponsesPayload,
+  payload: CanonicalResponsesPayload,
   enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): ResponsesInvocation => ({
   payload,
@@ -44,7 +44,7 @@ const invocation = (
 test('responses required tool_choice sets reasoning.effort to none', async () => {
   const input = invocation({
     model: 'm',
-    input: 'hi',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
     reasoning: { effort: 'high' },
     tool_choice: 'required',
   });
@@ -60,7 +60,7 @@ test('responses required tool_choice sets reasoning.effort to none', async () =>
 test('responses object tool_choice is forced', async () => {
   const input = invocation({
     model: 'm',
-    input: 'hi',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
     reasoning: { effort: 'high' },
     tool_choice: { type: 'custom', name: 'x' },
   });
@@ -74,7 +74,7 @@ test('responses non-forced tool_choice leaves reasoning untouched', async () => 
   for (const tool_choice of ['auto', 'none'] as const) {
     const input = invocation({
       model: 'm',
-      input: 'hi',
+      input: [{ type: 'message', role: 'user', content: 'hi' }],
       reasoning: { effort: 'high' },
       tool_choice,
     });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -1,12 +1,13 @@
 import { test } from 'vitest';
 
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -1,16 +1,17 @@
 import { test } from 'vitest';
 
 import { withCyberPolicyRetried } from './retry-cyber-policy.ts';
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { eventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
+import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { eventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
-const makePayload = (): ResponsesPayload => ({
+const makePayload = (): CanonicalResponsesPayload => ({
   model: 'gpt-test',
-  input: 'hi',
+  input: [{ type: 'message', role: 'user', content: 'hi' }],
   instructions: null,
   temperature: 1,
   top_p: null,
@@ -23,7 +24,7 @@ const makePayload = (): ResponsesPayload => ({
   parallel_tool_calls: true,
 });
 
-const makeInvocation = (payload: ResponsesPayload): ResponsesInvocation => ({
+const makeInvocation = (payload: CanonicalResponsesPayload): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ model: { enabledFlags: new Set(['retry-cyber-policy']) } }),
   targetApi: 'responses',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -1,13 +1,14 @@
 import { test } from 'vitest';
 
 import { withCyberPolicyRetried } from './retry-cyber-policy.ts';
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const makePayload = (): CanonicalResponsesPayload => ({
   model: 'gpt-test',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -1,6 +1,6 @@
 import { jsonrepair } from 'jsonrepair';
 
-import type { ResponsesInterceptor } from './types.ts';
+import type { CanonicalResponsesPayload, ResponsesInterceptor, ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { truncatePreservingCodePoints } from '../../shared/text.ts';
 import type { StatefulResponsesStore } from '../items/store.ts';
@@ -10,13 +10,12 @@ import type {
   ResponsesHostedTool,
   ResponsesInputItem,
   ResponsesOutputItem,
-  ResponsesPayload,
   ResponsesResult,
   ResponsesStreamEvent,
   ResponsesTool,
   ResponsesToolChoice,
 } from '@floway-dev/protocols/responses';
-import type { EventResultMetadata, ExecuteResult, ResponsesInvocation } from '@floway-dev/provider';
+import type { EventResultMetadata, ExecuteResult } from '@floway-dev/provider';
 
 export interface MergeUsage {
   input_tokens?: number;
@@ -917,7 +916,7 @@ async function* runMultiTurnLoop(args: {
         ...baseInput,
         ...materializeAccumulatedOutput(merge).map(item => item as ResponsesInputItem),
       ];
-      const nextPayload: ResponsesPayload = { ...ctx.payload, input: transformServerToolItems(nextCanonicalInput, active) };
+      const nextPayload: CanonicalResponsesPayload = { ...ctx.payload, input: transformServerToolItems(nextCanonicalInput, active) };
       if (loopState.remainingToolCalls !== undefined) {
         nextPayload.max_tool_calls = Math.max(0, loopState.remainingToolCalls);
       } else {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -1,6 +1,6 @@
 import { jsonrepair } from 'jsonrepair';
 
-import type { CanonicalResponsesPayload, ResponsesInterceptor, ResponsesInvocation } from './types.ts';
+import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { truncatePreservingCodePoints } from '../../shared/text.ts';
 import type { StatefulResponsesStore } from '../items/store.ts';
@@ -16,6 +16,7 @@ import type {
   ResponsesToolChoice,
 } from '@floway-dev/protocols/responses';
 import type { EventResultMetadata, ExecuteResult } from '@floway-dev/provider';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 export interface MergeUsage {
   input_tokens?: number;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -983,12 +983,9 @@ export const withResponsesServerToolShim = (
     ctx.payload = { ...ctx.payload, tool_choice: rewrittenToolChoice };
   }
 
-  const canonicalInput: ResponsesInputItem[] = Array.isArray(ctx.payload.input) ? ctx.payload.input : [{ type: 'message', role: 'user', content: ctx.payload.input }];
-  const inputArray = Array.isArray(ctx.payload.input) ? ctx.payload.input : undefined;
-  if (inputArray !== undefined) {
-    const nextInput = transformServerToolItems(inputArray, active);
-    if (nextInput !== inputArray) ctx.payload = { ...ctx.payload, input: nextInput };
-  }
+  const canonicalInput = ctx.payload.input;
+  const nextInput = transformServerToolItems(canonicalInput, active);
+  if (nextInput !== canonicalInput) ctx.payload = { ...ctx.payload, input: nextInput };
 
   const hostedActive = active.filter(
     (entry): entry is ActiveServerTool & { hosted: ServerToolHostedDispatch } =>

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -13,7 +13,7 @@ import {
   type UpstreamTerminal,
 } from './server-tool-shim.ts';
 import { SHIM_TOOL_NAME, webSearchServerTool } from './server-tools/web-search.ts';
-import type { CanonicalResponsesPayload, ResponsesInterceptor, ResponsesInvocation } from './types.ts';
+import type { ResponsesInterceptor, ResponsesInvocation } from './types.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import { resolveConfiguredWebSearchProvider } from '../../../tools/web-search/provider.ts';
@@ -44,6 +44,7 @@ import type {
 } from '@floway-dev/protocols/responses';
 import { directFetcher, type EventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const withResponsesWebSearchShim = withResponsesServerToolShim([webSearchServerTool]);
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -13,7 +13,7 @@ import {
   type UpstreamTerminal,
 } from './server-tool-shim.ts';
 import { SHIM_TOOL_NAME, webSearchServerTool } from './server-tools/web-search.ts';
-import type { ResponsesInterceptor } from './types.ts';
+import type { CanonicalResponsesPayload, ResponsesInterceptor, ResponsesInvocation } from './types.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import { resolveConfiguredWebSearchProvider } from '../../../tools/web-search/provider.ts';
@@ -42,7 +42,7 @@ import type {
   ResponsesToolChoice,
   ResponsesWebSearchAction,
 } from '@floway-dev/protocols/responses';
-import { directFetcher, type EventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { directFetcher, type EventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse } from '@floway-dev/test-utils';
 
 const withResponsesWebSearchShim = withResponsesServerToolShim([webSearchServerTool]);
@@ -336,7 +336,7 @@ const makeInvocation = (overrides: InvocationOverrides = {}): ResponsesInvocatio
     // assert the wire-item shape without `results`.
     include: ['web_search_call.results'],
     ...overrides.payload,
-  } as ResponsesPayload,
+  } as CanonicalResponsesPayload,
   headers: new Headers(),
   action: 'generate',
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -4,10 +4,11 @@ import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
 import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../../items/store.ts';
+import type { ResponsesInvocation } from '../types.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { directFetcher, type EventResult, type ExecuteResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { directFetcher, type EventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assert, assertEquals } from '@floway-dev/test-utils';
 
 // Dirty integration harness: mock the model registry so the image backend is a

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -15,7 +15,6 @@ import type {
   ResponsesInputImageGenerationCall,
   ResponsesInputItem,
   ResponsesOutputImageGenerationCall,
-  ResponsesPayload,
   ResponsesTool,
 } from '@floway-dev/protocols/responses';
 import type { Fetcher, Provider, PerformanceTelemetryContext, ModelCandidate, UpstreamModel } from '@floway-dev/provider';
@@ -346,8 +345,7 @@ export const synthesizeImageGenerationCallId = (): string =>
 // against the order received — and native flattens every image across messages
 // and tool results into this same forward order. Preserving declaration order
 // therefore makes "the Nth image" mean the same thing here as it does natively.
-export const collectImageSources = (input: ResponsesPayload['input']): ImageSource[] => {
-  if (!Array.isArray(input)) return [];
+export const collectImageSources = (input: readonly ResponsesInputItem[]): ImageSource[] => {
   const sources: ImageSource[] = [];
   const collectFromContent = (content: string | ResponsesInputContent[]): void => {
     if (!Array.isArray(content)) return;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -922,7 +922,7 @@ export const imageGenerationServerTool: ServerToolRegistration = (invocation, ga
 
   const tools = Array.isArray(invocation.payload.tools) ? invocation.payload.tools : [];
   const hasHostedTool = tools.some(isHostedImageGenerationTool);
-  const hasReplayInput = Array.isArray(invocation.payload.input) && invocation.payload.input.some(i => i.type === 'image_generation_call');
+  const hasReplayInput = invocation.payload.input.some(i => i.type === 'image_generation_call');
   if (!hasHostedTool && !hasReplayInput) return { type: 'inactive' };
 
   if (!hasHostedTool) {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -21,10 +21,11 @@ import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
 import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../../items/store.ts';
-import type { CanonicalResponsesPayload, ResponsesInvocation } from '../types.ts';
+import type { ResponsesInvocation } from '../types.ts';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
 import { directFetcher } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse, assertStringIncludes } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const PNG_B64 = 'aGVsbG8='; // "hello" — any decodable base64 works for source tests.
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -21,8 +21,9 @@ import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
 import type { ChatGatewayCtx } from '../../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../../items/store.ts';
+import type { CanonicalResponsesPayload, ResponsesInvocation } from '../types.ts';
 import type { ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
-import { directFetcher, type ResponsesInvocation } from '@floway-dev/provider';
+import { directFetcher } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse, assertStringIncludes } from '@floway-dev/test-utils';
 
 const PNG_B64 = 'aGVsbG8='; // "hello" — any decodable base64 works for source tests.
@@ -43,7 +44,7 @@ const makeCtx = (payload: Partial<ResponsesPayload>): ResponsesInvocation => ({
     fetcher: directFetcher,
   },
   targetApi: 'responses',
-  payload: { model: 'm', input: [], ...payload } as ResponsesPayload,
+  payload: { model: 'm', input: [], ...payload } as CanonicalResponsesPayload,
   headers: new Headers(),
   action: 'generate',
 });

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -246,10 +246,6 @@ test('collectImageSources skips http(s) image urls (remote fetch unsupported)', 
   assertEquals(collectImageSources(input).length, 0);
 });
 
-test('collectImageSources returns empty for a plain string input', () => {
-  assertEquals(collectImageSources('just text').length, 0);
-});
-
 test('collectImageSources reads tool-result images and preserves forward order', () => {
   const input: ResponsesInputItem[] = [
     { type: 'function_call_output', call_id: 'c1', output: [{ type: 'input_image', image_url: `data:image/png;base64,${PNG_B64}`, detail: 'auto' }] },

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -1312,7 +1312,7 @@ export const webSearchServerTool: ServerToolRegistration = (invocation, gatewayC
 
   const tools = Array.isArray(invocation.payload.tools) ? invocation.payload.tools : [];
   const hasHostedWebSearch = tools.some(isHostedWebSearchTool);
-  const hasReplayInput = Array.isArray(invocation.payload.input) && invocation.payload.input.some(i => i.type === 'web_search_call');
+  const hasReplayInput = invocation.payload.input.some(i => i.type === 'web_search_call');
   if (!hasHostedWebSearch && !hasReplayInput) return { type: 'inactive' };
 
   const prepared = prepareToolsForShim(tools);

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
@@ -2,32 +2,9 @@ import type { TokenUsage } from '../../../../repo/types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { Interceptor } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesInputItem, ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult, ResponsesInvocation as WireResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
-
-// Wire `ResponsesPayload.input` is `string | InputItem[]`. The HTTP/WS entries
-// normalize the wire string to a single synthetic user-role message before
-// any serve logic runs, so every reader past the entry sees array shape.
-// This is the gateway-internal narrowed view; the wire-shape `ResponsesPayload`
-// continues to live on the entry boundary, on provider-call bodies, and in
-// translate-package signatures (those interface with foreign wire shapes that
-// haven't been normalized).
-export type CanonicalResponsesPayload = Omit<ResponsesPayload, 'input'> & {
-  input: ResponsesInputItem[];
-};
-
-// Lifts a wire `ResponsesPayload` into the gateway's internal canonical form
-// by replacing a bare-string `input` with a single synthetic user-role
-// message. Used at every boundary that produces a wire payload destined for
-// the gateway's serve/attempt pipeline: the HTTP/WS entries on a fresh
-// request, and the translate package's `messages → responses` /
-// `gemini → responses` outputs flowing into `responsesAttempt`.
-export const canonicalizeResponsesPayload = (payload: ResponsesPayload): CanonicalResponsesPayload => ({
-  ...payload,
-  input: typeof payload.input === 'string'
-    ? [{ type: 'message', role: 'user', content: payload.input }]
-    : payload.input,
-});
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 export interface ResponsesInvocation extends Omit<WireResponsesInvocation, 'payload'> {
   payload: CanonicalResponsesPayload;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
@@ -2,8 +2,36 @@ import type { TokenUsage } from '../../../../repo/types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { Interceptor } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ExecuteResult, ResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
+import type { ResponsesInputItem, ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ExecuteResult, ResponsesInvocation as WireResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
+
+// Wire `ResponsesPayload.input` is `string | InputItem[]`. The HTTP/WS entries
+// normalize the wire string to a single synthetic user-role message before
+// any serve logic runs, so every reader past the entry sees array shape.
+// This is the gateway-internal narrowed view; the wire-shape `ResponsesPayload`
+// continues to live on the entry boundary, on provider-call bodies, and in
+// translate-package signatures (those interface with foreign wire shapes that
+// haven't been normalized).
+export type CanonicalResponsesPayload = Omit<ResponsesPayload, 'input'> & {
+  input: ResponsesInputItem[];
+};
+
+// Lifts a wire `ResponsesPayload` into the gateway's internal canonical form
+// by replacing a bare-string `input` with a single synthetic user-role
+// message. Used at every boundary that produces a wire payload destined for
+// the gateway's serve/attempt pipeline: the HTTP/WS entries on a fresh
+// request, and the translate package's `messages → responses` /
+// `gemini → responses` outputs flowing into `responsesAttempt`.
+export const canonicalizeResponsesPayload = (payload: ResponsesPayload): CanonicalResponsesPayload => ({
+  ...payload,
+  input: typeof payload.input === 'string'
+    ? [{ type: 'message', role: 'user', content: payload.input }]
+    : payload.input,
+});
+
+export interface ResponsesInvocation extends Omit<WireResponsesInvocation, 'payload'> {
+  payload: CanonicalResponsesPayload;
+}
 
 // The chain runner produces an event stream for both actions — the attempt
 // post-processes it into a single `response.compaction` envelope when the

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
@@ -18,7 +18,8 @@
 // Reference:
 // - https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
 
-import type { CanonicalResponsesPayload, ResponsesInterceptor } from './types.ts';
+import type { ResponsesInterceptor } from './types.ts';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 interface DeepseekDisableField {
   thinking?: { type: 'disabled' };

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
@@ -18,20 +18,19 @@
 // Reference:
 // - https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
 
-import type { ResponsesInterceptor } from './types.ts';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInterceptor } from './types.ts';
 
 interface DeepseekDisableField {
   thinking?: { type: 'disabled' };
 }
 
-type ResponsesPayloadWithDeepseekDisable = Omit<ResponsesPayload, 'reasoning'> & DeepseekDisableField;
+type CanonicalResponsesPayloadWithDeepseekDisable = Omit<CanonicalResponsesPayload, 'reasoning'> & DeepseekDisableField;
 
-const stripCanonicalReasoningSentinel = (payload: ResponsesPayload): ResponsesPayload => {
+const stripCanonicalReasoningSentinel = (payload: CanonicalResponsesPayload): CanonicalResponsesPayload => {
   if (payload.reasoning?.effort !== 'none') return payload;
   const { reasoning: _stripped, ...rest } = payload;
-  const out: ResponsesPayloadWithDeepseekDisable = { ...rest, thinking: { type: 'disabled' } };
-  return out as ResponsesPayload;
+  const out: CanonicalResponsesPayloadWithDeepseekDisable = { ...rest, thinking: { type: 'disabled' } };
+  return out as CanonicalResponsesPayload;
 };
 
 export const withVendorDeepseekResponsesNormalize: ResponsesInterceptor = async (ctx, _request, run) => {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -1,12 +1,13 @@
 import { test } from 'vitest';
 
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import { withVendorDeepseekResponsesNormalize } from './vendor-deepseek-normalize.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -1,11 +1,11 @@
 import { test } from 'vitest';
 
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import { withVendorDeepseekResponsesNormalize } from './vendor-deepseek-normalize.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -30,7 +30,7 @@ const okEvents = () =>
     ),
   );
 
-const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ResponsesInvocation => ({
+const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
@@ -41,7 +41,7 @@ const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string>
 test("vendor-deepseek translates canonical reasoning.effort: 'none' into top-level thinking:{type:'disabled'}", async () => {
   const input = invocation({
     model: 'deepseek-reasoner',
-    input: 'hi',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
     reasoning: { effort: 'none' },
   });
 
@@ -55,7 +55,7 @@ test("vendor-deepseek translates canonical reasoning.effort: 'none' into top-lev
 test('vendor-deepseek leaves a real reasoning.effort value untouched (only the none sentinel triggers the rewrite)', async () => {
   const input = invocation({
     model: 'deepseek-reasoner',
-    input: 'hi',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
     reasoning: { effort: 'high' },
   });
 
@@ -67,7 +67,7 @@ test('vendor-deepseek leaves a real reasoning.effort value untouched (only the n
 });
 
 test('vendor-deepseek early-returns when its flag is not set on the candidate', async () => {
-  const input = invocation({ model: 'deepseek-reasoner', input: 'hi', reasoning: { effort: 'none' } }, new Set());
+  const input = invocation({ model: 'deepseek-reasoner', input: [{ type: 'message', role: 'user', content: 'hi' }], reasoning: { effort: 'none' } }, new Set());
 
   await withVendorDeepseekResponsesNormalize(input, stubCtx, okEvents);
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
@@ -13,7 +13,8 @@
 // Reference:
 // - https://www.alibabacloud.com/help/en/model-studio/deep-thinking
 
-import type { CanonicalResponsesPayload, ResponsesInterceptor } from './types.ts';
+import type { ResponsesInterceptor } from './types.ts';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 export const withVendorQwenResponsesNormalize: ResponsesInterceptor = async (ctx, _request, run) => {
   if (!ctx.candidate.model.enabledFlags.has('vendor-qwen')) return await run();

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
@@ -13,15 +13,14 @@
 // Reference:
 // - https://www.alibabacloud.com/help/en/model-studio/deep-thinking
 
-import type { ResponsesInterceptor } from './types.ts';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInterceptor } from './types.ts';
 
 export const withVendorQwenResponsesNormalize: ResponsesInterceptor = async (ctx, _request, run) => {
   if (!ctx.candidate.model.enabledFlags.has('vendor-qwen')) return await run();
 
   if (ctx.payload.reasoning?.effort === 'none') {
     const { reasoning: _stripped, ...rest } = ctx.payload;
-    ctx.payload = { ...rest, enable_thinking: false } as ResponsesPayload;
+    ctx.payload = { ...rest, enable_thinking: false } as CanonicalResponsesPayload;
   }
 
   return await run();

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -1,12 +1,13 @@
 import { test } from 'vitest';
 
-import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
+import type { ResponsesInvocation } from './types.ts';
 import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx: ChatGatewayCtx = {
   apiKeyId: 'test-key',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -1,11 +1,11 @@
 import { test } from 'vitest';
 
+import type { CanonicalResponsesPayload, ResponsesInvocation } from './types.ts';
 import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
-import { eventResult, type ResponsesInvocation } from '@floway-dev/provider';
+import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -30,7 +30,7 @@ const okEvents = () =>
     ),
   );
 
-const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ResponsesInvocation => ({
+const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ model: { enabledFlags } }),
   targetApi: 'responses',
@@ -41,7 +41,7 @@ const invocation = (payload: ResponsesPayload, enabledFlags: ReadonlySet<string>
 test("vendor-qwen translates canonical reasoning.effort: 'none' into top-level enable_thinking:false", async () => {
   const input = invocation({
     model: 'qwen-max',
-    input: 'hi',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
     reasoning: { effort: 'none' },
   });
 
@@ -53,7 +53,7 @@ test("vendor-qwen translates canonical reasoning.effort: 'none' into top-level e
 });
 
 test('vendor-qwen leaves a real reasoning.effort value untouched (only the none sentinel triggers the rewrite)', async () => {
-  const input = invocation({ model: 'qwen-max', input: 'hi', reasoning: { effort: 'high' } });
+  const input = invocation({ model: 'qwen-max', input: [{ type: 'message', role: 'user', content: 'hi' }], reasoning: { effort: 'high' } });
 
   await withVendorQwenResponsesNormalize(input, stubCtx, okEvents);
 
@@ -63,7 +63,7 @@ test('vendor-qwen leaves a real reasoning.effort value untouched (only the none 
 });
 
 test('vendor-qwen early-returns when its flag is not set on the candidate', async () => {
-  const input = invocation({ model: 'qwen-max', input: 'hi', reasoning: { effort: 'none' } }, new Set());
+  const input = invocation({ model: 'qwen-max', input: [{ type: 'message', role: 'user', content: 'hi' }], reasoning: { effort: 'none' } }, new Set());
 
   await withVendorQwenResponsesNormalize(input, stubCtx, okEvents);
 

--- a/packages/gateway/src/data-plane/chat/responses/items/normalize-assistant-content.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/normalize-assistant-content.ts
@@ -12,7 +12,7 @@
 // content type. Only `role: 'assistant'` is rewritten; user/system/developer
 // messages keep `input_text` because that IS the correct type on those roles.
 
-import type { ResponsesInputContent, ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { ResponsesInputContent, ResponsesInputItem } from '@floway-dev/protocols/responses';
 
 const normalizeAssistantContentBlocks = (content: string | ResponsesInputContent[]): string | ResponsesInputContent[] => {
   if (typeof content === 'string') return content;
@@ -31,8 +31,7 @@ const normalizeItem = (item: ResponsesInputItem): ResponsesInputItem => {
   return next === item.content ? item : { ...item, content: next };
 };
 
-export const normalizeAssistantInputText = (input: ResponsesPayload['input']): ResponsesPayload['input'] => {
-  if (typeof input === 'string') return input;
+export const normalizeAssistantInputText = (input: ResponsesInputItem[]): ResponsesInputItem[] => {
   let mutated = false;
   const next = input.map(item => {
     const replaced = normalizeItem(item);

--- a/packages/gateway/src/data-plane/chat/responses/items/normalize-assistant-content_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/normalize-assistant-content_test.ts
@@ -59,7 +59,3 @@ test('rewrites every input_text block in a multi-block assistant message', () =>
     ],
   });
 });
-
-test('passes through string-typed payload.input verbatim', () => {
-  assertEquals(normalizeAssistantInputText('hello'), 'hello');
-});

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -2,10 +2,9 @@ import { createTemporaryResponsesItemId, hashResponsesItemEncryptedContent, resp
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import { throwChatServeFailure } from '../../shared/errors.ts';
-import type { CanonicalResponsesPayload } from '../interceptors/types.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ModelCandidate } from '@floway-dev/provider';
-import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+import type { CanonicalResponsesPayload, ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 const isUpstreamOwned = (row: StoredResponsesItem): row is StoredResponsesItem & { upstreamId: string } =>
   row.upstreamId !== null;

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -2,7 +2,8 @@ import { createTemporaryResponsesItemId, hashResponsesItemEncryptedContent, resp
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import { throwChatServeFailure } from '../../shared/errors.ts';
-import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload } from '../interceptors/types.ts';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ModelCandidate } from '@floway-dev/provider';
 import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -79,7 +80,7 @@ export interface RewrittenResponsesReference {
 }
 
 export interface RewrittenResponsesPayload {
-  readonly payload: ResponsesPayload;
+  readonly payload: CanonicalResponsesPayload;
   readonly references: ReadonlyArray<RewrittenResponsesReference>;
 }
 
@@ -103,12 +104,10 @@ const rewriteOneItemAgainstStore = (
 };
 
 export const rewriteResponsesItemsForCandidate = async (
-  payload: ResponsesPayload,
+  payload: CanonicalResponsesPayload,
   store: StatefulResponsesStore,
   candidate: ModelCandidate,
 ): Promise<RewrittenResponsesPayload> => {
-  if (typeof payload.input === 'string') return { payload, references: [] };
-
   // Pre-compute encrypted_content hashes so each item lookup is a single
   // synchronous map access rather than a fresh hash per item.
   const hashByEncryptedContent = await collectEncryptedContents(payload.input);

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -7,12 +7,11 @@ import { createNonResponsesSourceStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
-import type { CanonicalResponsesPayload } from '../interceptors/types.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assert, assertEquals, assertFalse } from '@floway-dev/test-utils';
-import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+import { responsesItemsView, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const API_KEY_ID = 'key_rewrite_test';
 

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -7,7 +7,8 @@ import { createNonResponsesSourceStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
-import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload } from '../interceptors/types.ts';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubUpstreamModel, assert, assertEquals, assertFalse } from '@floway-dev/test-utils';
@@ -67,7 +68,7 @@ const storedMessageId = (_label: string): string => createStoredResponsesItemId(
 const storedReasoningId = (_label: string): string => createStoredResponsesItemId('reasoning');
 const storedCompactionId = (_label: string): string => createStoredResponsesItemId('compaction');
 
-const makePayload = (input: ResponsesInputItem[]): ResponsesPayload => ({
+const makePayload = (input: ResponsesInputItem[]): CanonicalResponsesPayload => ({
   model: 'test-model',
   input,
 });
@@ -277,16 +278,6 @@ test('id-less encrypted_content with no stored match is a benign passthrough', a
   const rewritten = await rewrite(input, candidate('up_a'));
 
   assertEquals(rewritten, input);
-});
-
-test('string input is returned unchanged', async () => {
-  await insertRows([]);
-  const store = createNonResponsesSourceStore(API_KEY_ID);
-  const payload: ResponsesPayload = { model: 'test-model', input: 'plain text' };
-  const result = await rewriteResponsesItemsForCandidate(payload, store, candidate('up_a'));
-
-  assertEquals(result.payload, payload);
-  assertEquals(result.references, []);
 });
 
 test('id-less encrypted_content duplicate hash uses freshest stored row for rewrite', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -1,6 +1,5 @@
 import { responsesTarget } from './attempt.ts';
 import { renderResponsesFailure } from './errors.ts';
-import type { CanonicalResponsesPayload } from './interceptors/types.ts';
 import { classifyResponsesItemAffinity } from './items/affinity.ts';
 import type { StatefulResponsesStore } from './items/store.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
@@ -9,7 +8,7 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ModelCandidate, ExecuteResult } from '@floway-dev/provider';
-import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+import { responsesItemsView, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // Thrown when a request names a `previous_response_id` that the store cannot
 // resolve. The HTTP/WS entry layer catches this and renders the OpenAI-shaped

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -1,12 +1,13 @@
 import { responsesTarget } from './attempt.ts';
 import { renderResponsesFailure } from './errors.ts';
+import type { CanonicalResponsesPayload } from './interceptors/types.ts';
 import { classifyResponsesItemAffinity } from './items/affinity.ts';
 import type { StatefulResponsesStore } from './items/store.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ModelCandidate, ExecuteResult } from '@floway-dev/provider';
 import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -38,43 +39,28 @@ export class PreviousResponseNotFoundError extends Error {
 // translated payloads coming in from another protocol's attempt never carry
 // `previous_response_id`, so this prep runs in serve and not in attempt.
 export const expandPreviousResponseId = async (
-  payload: ResponsesPayload,
+  payload: CanonicalResponsesPayload,
   store: StatefulResponsesStore,
-): Promise<ResponsesPayload> => {
+): Promise<CanonicalResponsesPayload> => {
   const previousResponseId = payload.previous_response_id;
   if (previousResponseId === undefined || previousResponseId === null) return payload;
 
   const snapshot = await store.loadSnapshot(previousResponseId);
   if (snapshot === null) throw new PreviousResponseNotFoundError(previousResponseId);
 
-  const currentInput = typeof payload.input === 'string'
-    ? [{ type: 'message' as const, role: 'user' as const, content: payload.input }]
-    : [...payload.input];
-
   const { previous_response_id: _previous, ...rest } = payload;
   return {
     ...rest,
     input: [
       ...snapshot.itemIds.map(id => ({ type: 'item_reference' as const, id })),
-      ...currentInput,
+      ...payload.input,
     ],
   };
 };
 
-// A bare-string Responses `input` is wrapped into a synthetic user message
-// so staging and the affinity walk both see it as a real item. The affinity
-// walk still receives an empty `sourceItems` array since a string carries no
-// item references — only the staged form matters.
-const materializeInput = (input: ResponsesPayload['input']): {
-  readonly sourceItems: readonly ResponsesInputItem[];
-  readonly items: readonly ResponsesInputItem[];
-} => typeof input === 'string'
-  ? { sourceItems: [], items: [{ type: 'message', role: 'user', content: input }] }
-  : { sourceItems: input, items: input };
-
 export type ResponsesServePlan =
   | { readonly kind: 'failure'; readonly result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> }
-  | { readonly kind: 'ready'; readonly prepared: ResponsesPayload; readonly candidate: ModelCandidate };
+  | { readonly kind: 'ready'; readonly prepared: CanonicalResponsesPayload; readonly candidate: ModelCandidate };
 
 // Runs the shared serve-side prep both `responsesServe.generate` and
 // `responsesServe.compact` need before dispatching to `responsesAttempt`:
@@ -83,7 +69,7 @@ export type ResponsesServePlan =
 // rendered failure result when no candidate is viable so the caller can
 // surface it directly without re-deriving the model-error branch.
 export const prepareResponsesServePlan = async (args: {
-  readonly payload: ResponsesPayload;
+  readonly payload: CanonicalResponsesPayload;
   readonly ctx: ChatGatewayCtx;
 }): Promise<ResponsesServePlan> => {
   const { payload, ctx } = args;
@@ -97,13 +83,16 @@ export const prepareResponsesServePlan = async (args: {
     currentColo: ctx.currentColo,
   });
   const viable = enumerated.filter(c => responsesTarget.canServe(c.model.endpoints));
-  const { sourceItems, items: inputItemsToStage } = materializeInput(prepared.input);
   const decision = await classifyResponsesItemAffinity({
-    sourceItems,
+    sourceItems: prepared.input,
     view: responsesItemsView,
     store,
     candidates: viable,
-    inputItemsToStage,
+    // Hash-preload covers any user item carried directly on this turn — once
+    // `expandPreviousResponseId` has run, those are the items after the
+    // snapshot's item_reference prefix, which IS `payload.input` (verbatim,
+    // pre-expansion).
+    inputItemsToStage: payload.input,
   });
   if (decision.kind === 'failure') return { kind: 'failure', result: renderResponsesFailure(decision.failure) };
   // Stage the user-supplied input from the original payload — not the
@@ -111,8 +100,7 @@ export const prepareResponsesServePlan = async (args: {
   // up the new user items in addition to the prior snapshot history.
   // Runs after the affinity walk so any `item_reference` in user-supplied
   // input has its target row loaded.
-  const { items: itemsToStage } = materializeInput(payload.input);
-  await store.stageInputItems(itemsToStage);
+  await store.stageInputItems(payload.input);
   await store.refreshTouchedItems();
 
   // Any non-throwing attempt result — events, api-error, or

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,10 +1,11 @@
 import { responsesAttempt } from './attempt.ts';
-import type { CanonicalResponsesPayload, ResponsesAttemptResult } from './interceptors/types.ts';
+import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 export interface ResponsesServeGenerateArgs {
   readonly payload: CanonicalResponsesPayload;

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,19 +1,19 @@
 import { responsesAttempt } from './attempt.ts';
-import type { ResponsesAttemptResult } from './interceptors/types.ts';
+import type { CanonicalResponsesPayload, ResponsesAttemptResult } from './interceptors/types.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 
 export interface ResponsesServeGenerateArgs {
-  readonly payload: ResponsesPayload;
+  readonly payload: CanonicalResponsesPayload;
   readonly ctx: ChatGatewayCtx;
   readonly headers: Headers;
 }
 
 export interface ResponsesServeCompactArgs {
-  readonly payload: ResponsesPayload;
+  readonly payload: CanonicalResponsesPayload;
   readonly ctx: ChatGatewayCtx;
   readonly headers: Headers;
 }

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -1,5 +1,6 @@
 import { afterEach, test, vi } from 'vitest';
 
+import type { CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createStoredResponsesItemId } from './items/format.ts';
 import { createResponsesHttpStore, MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from './items/store.ts';
 import { initRepo } from '../../../repo/index.ts';
@@ -9,7 +10,7 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
 
@@ -62,9 +63,9 @@ const makeGatewayCtx = (store?: ChatGatewayCtx['store']): ChatGatewayCtx => ({
   store: store ?? createResponsesHttpStore(API_KEY_ID, true),
 });
 
-const makePayload = (overrides: Partial<ResponsesPayload> = {}): ResponsesPayload => ({
+const makePayload = (overrides: Partial<CanonicalResponsesPayload> = {}): CanonicalResponsesPayload => ({
   model: 'test-model',
-  input: 'hello',
+  input: [{ type: 'message', role: 'user', content: 'hello' }],
   ...overrides,
 });
 
@@ -72,7 +73,7 @@ const makePayload = (overrides: Partial<ResponsesPayload> = {}): ResponsesPayloa
 // compaction trigger or item_reference shapes the routing layer cares
 // about). Default to the kept-user-message the existing happy-path test
 // uses; override `input` when a test needs a different shape.
-const compactPayload = (overrides: Partial<ResponsesPayload> = {}): ResponsesPayload =>
+const compactPayload = (overrides: Partial<CanonicalResponsesPayload> = {}): CanonicalResponsesPayload =>
   makePayload({ input: [{ type: 'message', role: 'user', content: 'kept' }], ...overrides });
 
 const makeResponsesResult = (id = 'resp_test'): ResponsesResult => ({

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -407,7 +407,6 @@ test('expandPreviousResponseId prepends snapshot items and strips the previous_r
   );
 
   assertEquals(expanded.previous_response_id, undefined);
-  if (!Array.isArray(expanded.input)) throw new Error('expected expanded input array');
   assertEquals(expanded.input.length, 2);
   assertEquals(expanded.input[0], { type: 'item_reference', id: previousMessageId });
   assertEquals(expanded.input[1], { type: 'message', role: 'user', content: 'second turn' });
@@ -460,7 +459,6 @@ test('expandPreviousResponseId resolves snapshots from a non-repo-backed store',
     store,
   );
 
-  if (!Array.isArray(expanded.input)) throw new Error('expected expanded input array');
   assertEquals(expanded.input.length, 2);
   assertEquals(expanded.input[0], { type: 'item_reference', id });
 });

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -1,6 +1,5 @@
 import { afterEach, test, vi } from 'vitest';
 
-import type { CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createStoredResponsesItemId } from './items/format.ts';
 import { createResponsesHttpStore, MemoryStatefulResponsesBacking, LayeredStatefulResponsesStore } from './items/store.ts';
 import { initRepo } from '../../../repo/index.ts';
@@ -13,6 +12,7 @@ import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubUpstreamModel } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // `enumerateModelCandidates` is the only seam between serve and the
 // provider registry — mocking it directly keeps the serve tests narrow

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono';
 
-import type { CanonicalResponsesPayload } from './interceptors/types.ts';
+import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createResponsesWsSession } from './items/store.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
@@ -239,13 +239,9 @@ const responsesPayloadFromClientSource = (source: object): CanonicalResponsesPay
   if (typeof candidate.input !== 'string' && !Array.isArray(candidate.input)) {
     throw new WebSocketClientMessageError('response.create requires response.input to be a string or an array.');
   }
-  // Normalize the wire string to a single synthetic user message so every
-  // downstream reader operates on array-shaped input. See http.ts:parsePayload
-  // for the matching normalization on the HTTP entry.
-  const input = typeof candidate.input === 'string'
-    ? [{ type: 'message' as const, role: 'user' as const, content: candidate.input }]
-    : candidate.input;
-  return { ...source, input, stream: true } as CanonicalResponsesPayload;
+  // Feed the wire shape through the same canonicalization the HTTP entry uses,
+  // then stamp `stream: true` — the WS transport streams every turn.
+  return { ...canonicalizeResponsesPayload(source as ResponsesPayload), stream: true };
 };
 
 const respondResponsesWebSocket = async (input: {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono';
 
+import type { CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createResponsesWsSession } from './items/store.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
@@ -230,7 +231,7 @@ const validateClientMessage = (parsed: unknown): ResponsesWebSocketClientEvent =
   return parsed as ResponsesWebSocketClientEvent;
 };
 
-const responsesPayloadFromClientSource = (source: object): ResponsesPayload => {
+const responsesPayloadFromClientSource = (source: object): CanonicalResponsesPayload => {
   const candidate = source as { model?: unknown; input?: unknown };
   if (typeof candidate.model !== 'string' || candidate.model.length === 0) {
     throw new WebSocketClientMessageError('response.create requires response.model to be a non-empty string.');
@@ -238,7 +239,13 @@ const responsesPayloadFromClientSource = (source: object): ResponsesPayload => {
   if (typeof candidate.input !== 'string' && !Array.isArray(candidate.input)) {
     throw new WebSocketClientMessageError('response.create requires response.input to be a string or an array.');
   }
-  return { ...source, stream: true } as ResponsesPayload;
+  // Normalize the wire string to a single synthetic user message so every
+  // downstream reader operates on array-shaped input. See http.ts:parsePayload
+  // for the matching normalization on the HTTP entry.
+  const input = typeof candidate.input === 'string'
+    ? [{ type: 'message' as const, role: 'user' as const, content: candidate.input }]
+    : candidate.input;
+  return { ...source, input, stream: true } as CanonicalResponsesPayload;
 };
 
 const respondResponsesWebSocket = async (input: {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -1,6 +1,5 @@
 import type { Context } from 'hono';
 
-import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from './interceptors/types.ts';
 import { createResponsesWsSession } from './items/store.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
@@ -15,6 +14,7 @@ import { RESPONSES_MISSING_TERMINAL_MESSAGE } from '@floway-dev/protocols/respon
 import { isResponsesTerminalEvent, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { toInternalDebugError } from '@floway-dev/provider';
+import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 interface WorkerWebSocket extends WebSocket {
   accept(): void;

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -1,8 +1,9 @@
 import { chatCompletionsContentToResponsesInputContent, chatCompletionsContentToText } from '../shared/chat-completions-and-responses/content.ts';
 import { scalarToResponsesReasoningItem, translateChatCompletionsReasoningItems } from '../shared/chat-completions-and-responses/reasoning.ts';
+import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
-import type { ResponsesInputItem, ResponsesInputReasoning, ResponsesPayload, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import type { ResponsesInputItem, ResponsesInputReasoning, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool[] | null =>
   tools?.length
@@ -20,7 +21,7 @@ const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool
 const translateChatToolChoice = (choice?: ChatCompletionsPayload['tool_choice']): ResponsesToolChoice =>
   choice == null ? 'auto' : typeof choice === 'string' ? choice : { type: 'function', name: choice.function.name };
 
-export const translateChatCompletionsToResponses = (payload: ChatCompletionsPayload): ResponsesPayload => {
+export const translateChatCompletionsToResponses = (payload: ChatCompletionsPayload): CanonicalResponsesPayload => {
   const instructions: string[] = [];
   const input: ResponsesInputItem[] = [];
   let hoistSystemPrefix = true;

--- a/packages/translate/src/chat-completions-via-responses/translate.ts
+++ b/packages/translate/src/chat-completions-via-responses/translate.ts
@@ -1,11 +1,12 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
+import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 export const translateChatCompletionsViaResponses: TranslateTrip<
-  ChatCompletionsPayload, ChatCompletionsStreamEvent, ResponsesPayload, ResponsesStreamEvent
+  ChatCompletionsPayload, ChatCompletionsStreamEvent, CanonicalResponsesPayload, ResponsesStreamEvent
 > = async src => ({
   target: buildTargetRequest(src),
   events: translateToSourceEvents,

--- a/packages/translate/src/gemini-via-responses/request.ts
+++ b/packages/translate/src/gemini-via-responses/request.ts
@@ -13,9 +13,10 @@ import {
   type GeminiToolCallIds,
   geminiVisibleText,
 } from '../shared/gemini-via/gemini.ts';
+import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import type { GeminiContent, GeminiPayload, GeminiGenerationConfig, GeminiPart } from '@floway-dev/protocols/gemini';
-import type { ResponsesInputContent, ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
+import type { ResponsesInputContent, ResponsesInputItem, ResponsesTool } from '@floway-dev/protocols/responses';
 
 const flushPendingContent = (input: ResponsesInputItem[], pending: ResponsesInputContent[], role: 'user' | 'assistant'): void => {
   if (pending.length === 0) return;
@@ -118,7 +119,7 @@ const buildAssistantInputItems = (content: GeminiContent, turnIndex: number, unm
   return input;
 };
 
-const applyGenerationConfig = (request: ResponsesPayload, generationConfig?: GeminiGenerationConfig): void => {
+const applyGenerationConfig = (request: CanonicalResponsesPayload, generationConfig?: GeminiGenerationConfig): void => {
   if (!generationConfig) return;
 
   if (generationConfig.maxOutputTokens !== undefined) {
@@ -166,8 +167,8 @@ const buildTools = (payload: GeminiPayload): ResponsesTool[] | undefined => {
   return tools.length ? tools : undefined;
 };
 
-export const buildTargetRequest = (payload: GeminiPayload, model: string): ResponsesPayload => {
-  const request: ResponsesPayload = {
+export const buildTargetRequest = (payload: GeminiPayload, model: string): CanonicalResponsesPayload => {
+  const request: CanonicalResponsesPayload = {
     model,
     stream: true,
     input: [],

--- a/packages/translate/src/gemini-via-responses/translate.ts
+++ b/packages/translate/src/gemini-via-responses/translate.ts
@@ -1,11 +1,12 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
+import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 export const translateGeminiViaResponses: TranslateTrip<
-  GeminiPayload, GeminiStreamEvent, ResponsesPayload, ResponsesStreamEvent
+  GeminiPayload, GeminiStreamEvent, CanonicalResponsesPayload, ResponsesStreamEvent
 > = async (src, ctx) => ({
   target: buildTargetRequest(src, ctx.model),
   events: translateToSourceEvents,

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -2,6 +2,7 @@ import { openAiJsonSchemaCoreFromMessagesFormat } from '../shared/messages/struc
 import { messagesReasoningBlockToResponsesReasoning } from '../shared/messages-and-responses/reasoning.ts';
 import { resolveMessagesReasoningEffort } from '../shared/messages-via/reasoning-effort.ts';
 import { normalizeMessagesToolInputSchema } from '../shared/messages-via/tool-schema.ts';
+import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import {
   type MessagesAssistantMessage,
@@ -17,7 +18,7 @@ import {
   type MessagesUserMessage,
   type MessagesWebSearchToolResultBlock,
 } from '@floway-dev/protocols/messages';
-import type { ResponsesInputContent, ResponsesInputItem, ResponsesPayload, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import type { ResponsesInputContent, ResponsesInputItem, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 const flushPendingContent = (pending: ResponsesInputContent[], input: ResponsesInputItem[], role: 'user' | 'assistant'): void => {
   if (pending.length === 0) return;
@@ -229,7 +230,7 @@ const translateToolChoice = (toolChoice: MessagesPayload['tool_choice'], tools?:
   }
 };
 
-export const translateMessagesToResponses = (payload: MessagesPayload): ResponsesPayload => {
+export const translateMessagesToResponses = (payload: MessagesPayload): CanonicalResponsesPayload => {
   // Preserve the source `output_config.effort` value as-is, even if the chosen
   // Responses upstream may reject it. Translation stays pairwise and leaves
   // target-side validation to the selected upstream endpoint.

--- a/packages/translate/src/messages-via-responses/translate.ts
+++ b/packages/translate/src/messages-via-responses/translate.ts
@@ -1,11 +1,12 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
+import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 export const translateMessagesViaResponses: TranslateTrip<
-  MessagesPayload, MessagesStreamEvent, ResponsesPayload, ResponsesStreamEvent
+  MessagesPayload, MessagesStreamEvent, CanonicalResponsesPayload, ResponsesStreamEvent
 > = async src => ({
   target: buildTargetRequest(src),
   events: translateToSourceEvents,

--- a/packages/translate/src/shared/via-responses/responses-items.ts
+++ b/packages/translate/src/shared/via-responses/responses-items.ts
@@ -3,7 +3,32 @@ import { responsesReasoningToMessagesBlock, unpackReasoningSignature } from '../
 import type { ChatCompletionsReasoningItem, ChatCompletionsMessage } from '@floway-dev/protocols/chat-completions';
 import type { GeminiContent } from '@floway-dev/protocols/gemini';
 import type { MessagesAssistantContentBlock, MessagesMessage } from '@floway-dev/protocols/messages';
-import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+import type { ResponsesInputItem, ResponsesPayload } from '@floway-dev/protocols/responses';
+
+// Wire `ResponsesPayload.input` is `string | ResponsesInputItem[]`. The
+// gateway's canonical internal shape narrows it to array-only: every
+// consumer past the wire boundary (HTTP / WS entry canonicalization,
+// cross-protocol translation returning this type) sees a real item array.
+// The name is owned here because `*-via-responses` translators produce this
+// shape directly — their `buildTargetRequest` always constructs an array —
+// so the boundary between "wire" and "canonical" naturally sits at the
+// translator's return type.
+export type CanonicalResponsesPayload = Omit<ResponsesPayload, 'input'> & {
+  input: ResponsesInputItem[];
+};
+
+// Lifts a wire `ResponsesPayload` to canonical form by wrapping a bare-string
+// `input` into a single synthetic user-role message. Called at every wire
+// boundary that produces a `ResponsesPayload` destined for internal use — the
+// HTTP entry parsing a request body, and the WebSocket entry building a
+// payload from a client frame. Cross-protocol translators return
+// `CanonicalResponsesPayload` directly and do not need this step.
+export const canonicalizeResponsesPayload = (payload: ResponsesPayload): CanonicalResponsesPayload => ({
+  ...payload,
+  input: typeof payload.input === 'string'
+    ? [{ type: 'message', role: 'user', content: payload.input }]
+    : payload.input,
+});
 
 export type ResponsesItemMapper = (
   item: ResponsesInputItem,


### PR DESCRIPTION
Wire `ResponsesPayload.input` is `string | ResponsesInputItem[]`. Every Responses payload flowing through the gateway is narrowed to array-only immediately, so downstream code never has to reconcile the two shapes.

The canonical shape lives in `@floway-dev/translate/via-responses/responses-items` as `CanonicalResponsesPayload = Omit<ResponsesPayload, 'input'> & { input: ResponsesInputItem[] }`, and the one-line wire-to-canonical lift `canonicalizeResponsesPayload` lives next to it. Every gateway-internal signature — `ResponsesServeGenerateArgs`, `ResponsesServeCompactArgs`, `ResponsesAttemptInvokeArgs`, `ResponsesServePlan.prepared`, `RewrittenResponsesPayload`, `expandPreviousResponseId`, `normalizeAssistantInputText`, plus the gateway-side `ResponsesInvocation` — carries the canonical type. The provider-package `ResponsesInvocation` stays wire-shaped: providers speak the OpenAI wire, and the boundary sits at gateway↔provider.

The canonicalization boundary runs in two places, both at the wire edge:

- **Wire entries.** The Responses HTTP handler parses the request body through `canonicalizeResponsesPayload`, and the Responses WebSocket handler runs the same helper after validating the client frame's `input` shape (string or array). Both entries import the helper from translate.
- **Cross-protocol translators.** The `*-via-responses` translators (`messages`, `gemini`, `chat-completions`) declare `CanonicalResponsesPayload` as their `TgtPayload` and never emit a bare string. The gateway's translation attempts hand the translator output straight to `responsesAttempt.generate` with no lift call — the type IS canonical.

Every downstream string-branch and `Array.isArray(payload.input)` guard that only existed to reconcile the two shapes drops out: `expandPreviousResponseId`, `expandShimCompactionItems`, the compact-shim's `simulateCompaction` (previously materializing a bare string into `originalInputItems`), `containsCompactionTrigger`, `withInterleavedSystemDemotedToUser`, `withDemoteDeveloperToSystem`, `collectImageSources`, the server-tool-shim's `canonicalInput` / `inputArray` plumbing, and the `hasReplayInput` detection in both the web-search and image-generation server tools. `serve-prep.ts`'s `materializeInput` helper is gone — the affinity walk and staging pass see the same array. The corresponding obsolete tests (bare-string input paths, dead `if (typeof/isArray(...)) throw` guards in tests that call the now-narrowed helpers) go with them.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`