### PR TITLE
refactor(serve): iterate candidates on attempt failure

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -2,8 +2,9 @@ import { chatCompletionsAttempt, chatCompletionsTarget } from './attempt.ts';
 import { renderChatCompletionsFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import { isAttemptSuccess, noViableCandidateFailure } from '../shared/errors.ts';
+import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
+import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ExecuteResult } from '@floway-dev/provider';
@@ -41,12 +42,10 @@ export const chatCompletionsServe = {
     // transient 5xx/429/network failures. When the list is exhausted, the
     // most recent failure is forwarded verbatim so the client still sees
     // real upstream telemetry rather than a synthetic envelope.
-    let lastFailure: ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>> | undefined;
-    for (const candidate of decision.candidates) {
-      const result = await chatCompletionsAttempt.generate({ payload, ctx, candidate, headers });
-      if (isAttemptSuccess(result)) return result;
-      lastFailure = result;
-    }
-    return lastFailure!;
+    return await iterateChatCandidates(
+      decision.candidates,
+      'chatCompletionsServe.generate',
+      candidate => chatCompletionsAttempt.generate({ payload, ctx, candidate, headers }),
+    );
   },
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -2,7 +2,7 @@ import { chatCompletionsAttempt, chatCompletionsTarget } from './attempt.ts';
 import { renderChatCompletionsFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import { noViableCandidateFailure } from '../shared/errors.ts';
+import { isAttemptSuccess, noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
@@ -33,13 +33,20 @@ export const chatCompletionsServe = {
       candidates: viable,
     });
     if (decision.kind === 'failure') return renderChatCompletionsFailure(decision.failure);
+    if (decision.candidates.length === 0) return renderChatCompletionsFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams));
 
-    // Any non-throwing attempt result — events, api-error, or
-    // internal-error — IS the answer for this request: an upstream 4xx/5xx
-    // from the first viable candidate is final, not a hint to try another
-    // upstream.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) return renderChatCompletionsFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams));
-    return await chatCompletionsAttempt.generate({ payload, ctx, candidate, headers });
+    // Try each narrowed candidate in order. A successful attempt (SSE
+    // stream opened) is the final answer; an api-error or internal-error
+    // from one candidate falls through to the next so the gateway absorbs
+    // transient 5xx/429/network failures. When the list is exhausted, the
+    // most recent failure is forwarded verbatim so the client still sees
+    // real upstream telemetry rather than a synthetic envelope.
+    let lastFailure: ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>> | undefined;
+    for (const candidate of decision.candidates) {
+      const result = await chatCompletionsAttempt.generate({ payload, ctx, candidate, headers });
+      if (isAttemptSuccess(result)) return result;
+      lastFailure = result;
+    }
+    return lastFailure!;
   },
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -150,7 +150,7 @@ test('generate filters out candidates that do not expose any chat-completions-ta
   assertEquals(callChatCompletions.mock.calls.length, 0);
 });
 
-test('generate stops at the first candidate even when it yields an upstream error', async () => {
+test('generate falls through to the next candidate when the first yields an upstream error', async () => {
   installRepo();
   const firstError = new Response(JSON.stringify({ error: { message: 'nope' } }), {
     status: 502, headers: new Headers({ 'content-type': 'application/json' }),
@@ -172,12 +172,34 @@ test('generate stops at the first candidate even when it yields an upstream erro
     headers: new Headers(),
   });
 
-  // An upstream error from the first candidate IS the final answer — the
-  // gateway does not retry on a different upstream just because the first one
-  // produced an HTTP error.
-  assertEquals(result.type, 'api-error');
+  // The narrowed candidate list exists exactly so a transient upstream
+  // failure (5xx/429/network) on one entry rolls over to the next. The
+  // second candidate's success is the request's final answer.
+  assertEquals(result.type, 'events');
   assertEquals(firstCall.mock.calls.length, 1);
-  assertEquals(secondCall.mock.calls.length, 0);
+  assertEquals(secondCall.mock.calls.length, 1);
+});
+
+test('generate surfaces the last upstream error verbatim when every candidate fails', async () => {
+  installRepo();
+  const firstError = new Response('first', { status: 503 });
+  const lastError = new Response(JSON.stringify({ error: { message: 'last' } }), {
+    status: 502, headers: new Headers({ 'content-type': 'application/json' }),
+  });
+  queueCandidates([
+    makeCandidate({ upstream: 'up_a', callChatCompletions: async () => ({ ok: false, response: firstError, modelKey: 'first-key' }) }),
+    makeCandidate({ upstream: 'up_b', callChatCompletions: async () => ({ ok: false, response: lastError, modelKey: 'last-key' }) }),
+  ]);
+
+  const result = await chatCompletionsServe.generate({
+    payload: makePayload(),
+    ctx: makeGatewayCtx(),
+    headers: new Headers(),
+  });
+
+  assertEquals(result.type, 'api-error');
+  if (result.type !== 'api-error') throw new Error('unreachable');
+  assertEquals(result.status, 502);
 });
 
 test('generate is a routing no-op when the payload carries no reasoning carriers (degenerate path)', async () => {

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -2,7 +2,7 @@ import { geminiAttempt, geminiCountTokensTarget, geminiGenerateTarget } from './
 import { renderGeminiFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import { noViableCandidateFailure } from '../shared/errors.ts';
+import { isAttemptSuccess, noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
@@ -44,14 +44,15 @@ export const geminiServe = {
       candidates: viable,
     });
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'generate');
+    if (decision.candidates.length === 0) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'generate');
 
-    // Any non-throwing attempt result — events, api-error, or
-    // internal-error — IS the answer for this request: an upstream 4xx/5xx
-    // from the first viable candidate is final, not a hint to try another
-    // upstream.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'generate');
-    return await geminiAttempt.generate({ payload, ctx, candidate, headers });
+    let lastFailure: ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | undefined;
+    for (const candidate of decision.candidates) {
+      const result = await geminiAttempt.generate({ payload, ctx, candidate, headers });
+      if (isAttemptSuccess(result)) return result;
+      lastFailure = result;
+    }
+    return lastFailure!;
   },
 
   countTokens: async (args: GeminiServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | PlainResult> => {
@@ -71,12 +72,14 @@ export const geminiServe = {
       candidates: viable,
     });
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'countTokens');
+    if (decision.candidates.length === 0) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'countTokens');
 
-    // PlainResult always represents a final response — both 2xx and upstream
-    // errors come back as a `plain` envelope, so the first candidate's result
-    // is the answer. Provider-level transport errors throw and propagate.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'countTokens');
-    return await geminiAttempt.countTokens({ payload, ctx, candidate, headers });
+    let lastFailure: ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | PlainResult | undefined;
+    for (const candidate of decision.candidates) {
+      const result = await geminiAttempt.countTokens({ payload, ctx, candidate, headers });
+      if (isAttemptSuccess(result)) return result;
+      lastFailure = result;
+    }
+    return lastFailure!;
   },
 };

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -2,8 +2,9 @@ import { geminiAttempt, geminiCountTokensTarget, geminiGenerateTarget } from './
 import { renderGeminiFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import { isAttemptSuccess, noViableCandidateFailure } from '../shared/errors.ts';
+import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
+import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
@@ -46,13 +47,11 @@ export const geminiServe = {
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'generate');
     if (decision.candidates.length === 0) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'generate');
 
-    let lastFailure: ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | undefined;
-    for (const candidate of decision.candidates) {
-      const result = await geminiAttempt.generate({ payload, ctx, candidate, headers });
-      if (isAttemptSuccess(result)) return result;
-      lastFailure = result;
-    }
-    return lastFailure!;
+    return await iterateChatCandidates(
+      decision.candidates,
+      'geminiServe.generate',
+      candidate => geminiAttempt.generate({ payload, ctx, candidate, headers }),
+    );
   },
 
   countTokens: async (args: GeminiServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | PlainResult> => {
@@ -74,12 +73,10 @@ export const geminiServe = {
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'countTokens');
     if (decision.candidates.length === 0) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'countTokens');
 
-    let lastFailure: ExecuteResult<ProtocolFrame<GeminiStreamEvent>> | PlainResult | undefined;
-    for (const candidate of decision.candidates) {
-      const result = await geminiAttempt.countTokens({ payload, ctx, candidate, headers });
-      if (isAttemptSuccess(result)) return result;
-      lastFailure = result;
-    }
-    return lastFailure!;
+    return await iterateChatCandidates(
+      decision.candidates,
+      'geminiServe.countTokens',
+      candidate => geminiAttempt.countTokens({ payload, ctx, candidate, headers }),
+    );
   },
 };

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -210,7 +210,7 @@ test('generate translates through Responses when only that endpoint is exposed',
   assertEquals(callResponses.mock.calls.length, 1);
 });
 
-test('generate stops at the first candidate even when it yields an upstream error', async () => {
+test('generate falls through to the next candidate when the first yields an upstream error', async () => {
   installRepo();
   const firstError = new Response(JSON.stringify({ error: { message: 'nope' } }), {
     status: 502, headers: new Headers({ 'content-type': 'application/json' }),
@@ -233,12 +233,12 @@ test('generate stops at the first candidate even when it yields an upstream erro
     headers: new Headers(),
   });
 
-  // An upstream error from the first candidate IS the final answer — the
-  // gateway does not retry on a different upstream just because the first one
-  // produced an HTTP error.
-  expectType(result, 'api-error');
+  // The narrowed candidate list exists exactly so a transient upstream
+  // failure (5xx/429/network) on one entry rolls over to the next. The
+  // second candidate's success is the request's final answer.
+  expectType(result, 'events');
   assertEquals(firstCall.mock.calls.length, 1);
-  assertEquals(secondCall.mock.calls.length, 0);
+  assertEquals(secondCall.mock.calls.length, 1);
 });
 
 test('generate is a routing no-op for a bare user-text request (degenerate path)', async () => {

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -2,7 +2,7 @@ import { messagesAttempt, messagesGenerateTarget, messagesCountTokensTarget } fr
 import { renderMessagesFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import { noViableCandidateFailure } from '../shared/errors.ts';
+import { isAttemptSuccess, noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -39,14 +39,20 @@ export const messagesServe = {
       candidates: viable,
     });
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'generate');
+    if (decision.candidates.length === 0) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'generate');
 
-    // Any non-throwing attempt result — events, api-error, or
-    // internal-error — IS the answer for this request: an upstream 4xx/5xx
-    // from the first viable candidate is final, not a hint to try another
-    // upstream.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'generate');
-    return await messagesAttempt.generate({ payload, ctx, candidate, headers });
+    // Try each narrowed candidate in order. A successful attempt (SSE
+    // stream opened) is the final answer; an api-error or internal-error
+    // from one candidate falls through to the next so the gateway absorbs
+    // transient 5xx/429/network failures. When the list is exhausted, the
+    // most recent failure is forwarded verbatim.
+    let lastFailure: ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | undefined;
+    for (const candidate of decision.candidates) {
+      const result = await messagesAttempt.generate({ payload, ctx, candidate, headers });
+      if (isAttemptSuccess(result)) return result;
+      lastFailure = result;
+    }
+    return lastFailure!;
   },
 
   countTokens: async (args: MessagesServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | PlainResult> => {
@@ -66,12 +72,14 @@ export const messagesServe = {
       candidates: viable,
     });
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'countTokens');
+    if (decision.candidates.length === 0) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'countTokens');
 
-    // PlainResult always represents a final response — both 2xx and upstream
-    // errors come back as a `plain` envelope, so the first candidate's result
-    // is the answer. Provider-level transport errors throw and propagate.
-    const [candidate] = decision.candidates;
-    if (candidate === undefined) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'countTokens');
-    return await messagesAttempt.countTokens({ payload, ctx, candidate, headers });
+    let lastFailure: ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | PlainResult | undefined;
+    for (const candidate of decision.candidates) {
+      const result = await messagesAttempt.countTokens({ payload, ctx, candidate, headers });
+      if (isAttemptSuccess(result)) return result;
+      lastFailure = result;
+    }
+    return lastFailure!;
   },
 };

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -2,8 +2,9 @@ import { messagesAttempt, messagesGenerateTarget, messagesCountTokensTarget } fr
 import { renderMessagesFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
-import { isAttemptSuccess, noViableCandidateFailure } from '../shared/errors.ts';
+import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
+import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
@@ -46,13 +47,11 @@ export const messagesServe = {
     // from one candidate falls through to the next so the gateway absorbs
     // transient 5xx/429/network failures. When the list is exhausted, the
     // most recent failure is forwarded verbatim.
-    let lastFailure: ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | undefined;
-    for (const candidate of decision.candidates) {
-      const result = await messagesAttempt.generate({ payload, ctx, candidate, headers });
-      if (isAttemptSuccess(result)) return result;
-      lastFailure = result;
-    }
-    return lastFailure!;
+    return await iterateChatCandidates(
+      decision.candidates,
+      'messagesServe.generate',
+      candidate => messagesAttempt.generate({ payload, ctx, candidate, headers }),
+    );
   },
 
   countTokens: async (args: MessagesServeCountTokensArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | PlainResult> => {
@@ -74,12 +73,10 @@ export const messagesServe = {
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'countTokens');
     if (decision.candidates.length === 0) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'countTokens');
 
-    let lastFailure: ExecuteResult<ProtocolFrame<MessagesStreamEvent>> | PlainResult | undefined;
-    for (const candidate of decision.candidates) {
-      const result = await messagesAttempt.countTokens({ payload, ctx, candidate, headers });
-      if (isAttemptSuccess(result)) return result;
-      lastFailure = result;
-    }
-    return lastFailure!;
+    return await iterateChatCandidates(
+      decision.candidates,
+      'messagesServe.countTokens',
+      candidate => messagesAttempt.countTokens({ payload, ctx, candidate, headers }),
+    );
   },
 };

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -210,7 +210,7 @@ test('generate translates through the Responses target when only that endpoint i
   assertEquals(callResponses.mock.calls.length, 1);
 });
 
-test('generate stops at the first candidate even when it yields an upstream error', async () => {
+test('generate falls through to the next candidate when the first yields an upstream error', async () => {
   installRepo();
   const firstError = new Response(JSON.stringify({ error: { message: 'nope' } }), {
     status: 502, headers: new Headers({ 'content-type': 'application/json' }),
@@ -232,12 +232,31 @@ test('generate stops at the first candidate even when it yields an upstream erro
     headers: new Headers(),
   });
 
-  // An upstream error from the first candidate IS the final answer — the
-  // gateway does not retry on a different upstream just because the first one
-  // produced an HTTP error.
-  assertEquals(result.type, 'api-error');
+  // The narrowed candidate list exists exactly so a transient upstream
+  // failure (5xx/429/network) on one entry rolls over to the next. The
+  // second candidate's success is the request's final answer.
+  assertEquals(result.type, 'events');
   assertEquals(firstCall.mock.calls.length, 1);
-  assertEquals(secondCall.mock.calls.length, 0);
+  assertEquals(secondCall.mock.calls.length, 1);
+});
+
+test('generate surfaces the last upstream error verbatim when every candidate fails', async () => {
+  installRepo();
+  const firstError = new Response('first', { status: 503 });
+  const lastError = new Response('last', { status: 502 });
+  queueCandidates([
+    makeCandidate({ upstream: 'up_a', callMessages: async () => ({ ok: false, response: firstError, modelKey: 'first-key' }) }),
+    makeCandidate({ upstream: 'up_b', callMessages: async () => ({ ok: false, response: lastError, modelKey: 'last-key' }) }),
+  ]);
+
+  const result = await messagesServe.generate({
+    payload: makePayload(),
+    ctx: makeGatewayCtx(),
+    headers: new Headers(),
+  });
+
+  const failure = assertResultType(result, 'api-error');
+  assertEquals(failure.status, 502);
 });
 
 test('generate stops at the first candidate when the payload has no reasoning carriers to route on', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -59,14 +59,16 @@ export const expandPreviousResponseId = async (
 
 export type ResponsesServePlan =
   | { readonly kind: 'failure'; readonly result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> }
-  | { readonly kind: 'ready'; readonly prepared: CanonicalResponsesPayload; readonly candidate: ModelCandidate };
+  | { readonly kind: 'ready'; readonly prepared: CanonicalResponsesPayload; readonly candidates: readonly ModelCandidate[] };
 
 // Runs the shared serve-side prep both `responsesServe.generate` and
 // `responsesServe.compact` need before dispatching to `responsesAttempt`:
 // expand any `previous_response_id`, enumerate candidates, classify item
-// affinity, stage the user input, and pick the first candidate. Returns a
-// rendered failure result when no candidate is viable so the caller can
-// surface it directly without re-deriving the model-error branch.
+// affinity, stage the user input, and return the narrowed candidate list.
+// Returns a rendered failure result when no candidate is viable so the
+// caller can surface it directly without re-deriving the model-error
+// branch. The caller iterates the candidates — a successful attempt is the
+// final answer, a per-candidate failure falls through to the next entry.
 export const prepareResponsesServePlan = async (args: {
   readonly payload: CanonicalResponsesPayload;
   readonly ctx: ChatGatewayCtx;
@@ -102,16 +104,11 @@ export const prepareResponsesServePlan = async (args: {
   await store.stageInputItems(payload.input);
   await store.refreshTouchedItems();
 
-  // Any non-throwing attempt result — events, api-error, or
-  // internal-error — IS the answer for this request: an upstream 4xx/5xx
-  // from the first viable candidate is final, not a hint to try another
-  // upstream.
-  const [candidate] = decision.candidates;
-  if (candidate === undefined) {
+  if (decision.candidates.length === 0) {
     return {
       kind: 'failure',
       result: renderResponsesFailure(noViableCandidateFailure(sawModel, prepared.model, failedUpstreams)),
     };
   }
-  return { kind: 'ready', prepared, candidate };
+  return { kind: 'ready', prepared, candidates: decision.candidates };
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,8 +1,8 @@
 import { responsesAttempt } from './attempt.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
-import { isAttemptSuccess } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
+import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
@@ -29,13 +29,11 @@ export const responsesServe = {
     // final answer; per-candidate failures fall through so a transient
     // 5xx/429/network does not become the request's verdict when another
     // candidate can serve. The last failure surfaces verbatim on exhaustion.
-    let lastFailure: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> | undefined;
-    for (const candidate of plan.candidates) {
-      const result = await responsesAttempt.generate({ payload: plan.prepared, ctx, candidate, headers });
-      if (isAttemptSuccess(result)) return result;
-      lastFailure = result;
-    }
-    return lastFailure!;
+    return await iterateChatCandidates(
+      plan.candidates,
+      'responsesServe.generate',
+      candidate => responsesAttempt.generate({ payload: plan.prepared, ctx, candidate, headers }),
+    );
   },
 
   compact: async (args: ResponsesServeCompactArgs): Promise<ResponsesAttemptResult> => {
@@ -50,12 +48,10 @@ export const responsesServe = {
     // re-tags the result as compact on the way out.
     const plan = await prepareResponsesServePlan({ payload, ctx });
     if (plan.kind === 'failure') return plan.result;
-    let lastFailure: ResponsesAttemptResult | undefined;
-    for (const candidate of plan.candidates) {
-      const result = await responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate, headers });
-      if (isAttemptSuccess(result)) return result;
-      lastFailure = result;
-    }
-    return lastFailure!;
+    return await iterateChatCandidates(
+      plan.candidates,
+      'responsesServe.compact',
+      candidate => responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate, headers }),
+    );
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,6 +1,7 @@
 import { responsesAttempt } from './attempt.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
+import { isAttemptSuccess } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -24,7 +25,17 @@ export const responsesServe = {
     const { payload, ctx, headers } = args;
     const plan = await prepareResponsesServePlan({ payload, ctx });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.generate({ payload: plan.prepared, ctx, candidate: plan.candidate, headers });
+    // Iterate the narrowed candidates: success (SSE stream opened) is the
+    // final answer; per-candidate failures fall through so a transient
+    // 5xx/429/network does not become the request's verdict when another
+    // candidate can serve. The last failure surfaces verbatim on exhaustion.
+    let lastFailure: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> | undefined;
+    for (const candidate of plan.candidates) {
+      const result = await responsesAttempt.generate({ payload: plan.prepared, ctx, candidate, headers });
+      if (isAttemptSuccess(result)) return result;
+      lastFailure = result;
+    }
+    return lastFailure!;
   },
 
   compact: async (args: ResponsesServeCompactArgs): Promise<ResponsesAttemptResult> => {
@@ -39,6 +50,12 @@ export const responsesServe = {
     // re-tags the result as compact on the way out.
     const plan = await prepareResponsesServePlan({ payload, ctx });
     if (plan.kind === 'failure') return plan.result;
-    return await responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate: plan.candidate, headers });
+    let lastFailure: ResponsesAttemptResult | undefined;
+    for (const candidate of plan.candidates) {
+      const result = await responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate, headers });
+      if (isAttemptSuccess(result)) return result;
+      lastFailure = result;
+    }
+    return lastFailure!;
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -193,7 +193,7 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
   assertEquals(callResponses.mock.calls[0][2], 'compact');
 });
 
-test('generate stops at the first candidate even when it yields an upstream error', async () => {
+test('generate falls through to the next candidate when the first yields an upstream error', async () => {
   installRepo();
   const firstError = new Response(JSON.stringify({ error: { message: 'nope' } }), {
     status: 502, headers: new Headers({ 'content-type': 'application/json' }),
@@ -219,12 +219,12 @@ test('generate stops at the first candidate even when it yields an upstream erro
     headers: new Headers(),
   });
 
-  // An upstream error from the first candidate IS the final answer — the
-  // gateway does not retry on a different upstream just because the first one
-  // produced an HTTP error.
-  assertEquals(result.type, 'api-error');
+  // The narrowed candidate list exists exactly so a transient upstream
+  // failure (5xx/429/network) on one entry rolls over to the next. The
+  // second candidate's success is the request's final answer.
+  assertEquals(result.type, 'events');
   assertEquals(firstCall.mock.calls.length, 1);
-  assertEquals(secondCall.mock.calls.length, 0);
+  assertEquals(secondCall.mock.calls.length, 1);
 });
 
 test('generate renders model-missing when no candidates are available', async () => {

--- a/packages/gateway/src/data-plane/chat/shared/errors.ts
+++ b/packages/gateway/src/data-plane/chat/shared/errors.ts
@@ -41,3 +41,35 @@ export const noViableCandidateFailure = (
   sawModel
     ? { kind: 'model-unsupported', model, failedUpstreams }
     : { kind: 'model-missing', model, failedUpstreams };
+
+// A serve-layer attempt result counts as success when:
+//   - The SSE event stream actually opened (`type: 'events'`). Mid-stream
+//     failure is the upstream's responsibility from there on; a fresh
+//     attempt on a different upstream does not start once the client has
+//     begun consuming events.
+//   - The non-streaming envelope landed: `PlainResult` with a 2xx status,
+//     or the Responses-compact `{type:'result'}` envelope.
+// `api-error` and `internal-error` are failures: the serve loop falls
+// through to the next candidate. 4xx is on the failure side — 429
+// (rate-limit) is the responsibility of the upstream that issued it, and
+// the gateway's candidate ordering exists to absorb that kind of
+// transient.
+export const isAttemptSuccess = (
+  result:
+    | { readonly type: 'events' }
+    | { readonly type: 'result' }
+    | { readonly type: 'plain'; readonly status: number }
+    | { readonly type: 'api-error' }
+    | { readonly type: 'internal-error' },
+): boolean => {
+  switch (result.type) {
+  case 'events':
+  case 'result':
+    return true;
+  case 'plain':
+    return result.status >= 200 && result.status < 300;
+  case 'api-error':
+  case 'internal-error':
+    return false;
+  }
+};

--- a/packages/gateway/src/data-plane/chat/shared/errors.ts
+++ b/packages/gateway/src/data-plane/chat/shared/errors.ts
@@ -41,35 +41,3 @@ export const noViableCandidateFailure = (
   sawModel
     ? { kind: 'model-unsupported', model, failedUpstreams }
     : { kind: 'model-missing', model, failedUpstreams };
-
-// A serve-layer attempt result counts as success when:
-//   - The SSE event stream actually opened (`type: 'events'`). Mid-stream
-//     failure is the upstream's responsibility from there on; a fresh
-//     attempt on a different upstream does not start once the client has
-//     begun consuming events.
-//   - The non-streaming envelope landed: `PlainResult` with a 2xx status,
-//     or the Responses-compact `{type:'result'}` envelope.
-// `api-error` and `internal-error` are failures: the serve loop falls
-// through to the next candidate. 4xx is on the failure side — 429
-// (rate-limit) is the responsibility of the upstream that issued it, and
-// the gateway's candidate ordering exists to absorb that kind of
-// transient.
-export const isAttemptSuccess = (
-  result:
-    | { readonly type: 'events' }
-    | { readonly type: 'result' }
-    | { readonly type: 'plain'; readonly status: number }
-    | { readonly type: 'api-error' }
-    | { readonly type: 'internal-error' },
-): boolean => {
-  switch (result.type) {
-  case 'events':
-  case 'result':
-    return true;
-  case 'plain':
-    return result.status >= 200 && result.status < 300;
-  case 'api-error':
-  case 'internal-error':
-    return false;
-  }
-};

--- a/packages/gateway/src/data-plane/chat/shared/iterate-candidates.ts
+++ b/packages/gateway/src/data-plane/chat/shared/iterate-candidates.ts
@@ -1,0 +1,58 @@
+import type { ModelCandidate } from '@floway-dev/provider';
+
+// A serve-layer attempt result counts as success when:
+//   - The SSE event stream actually opened (`type: 'events'`). Mid-stream
+//     failure is the upstream's responsibility from there on; a fresh
+//     attempt on a different upstream does not start once the client has
+//     begun consuming events.
+//   - The non-streaming envelope landed: `PlainResult` with a 2xx status,
+//     or the Responses-compact `{type:'result'}` envelope.
+// `api-error` and `internal-error` are failures: the serve loop falls
+// through to the next candidate. 4xx is on the failure side — 429
+// (rate-limit) is the responsibility of the upstream that issued it, and
+// the gateway's candidate ordering exists to absorb that kind of
+// transient.
+type IterableAttemptResult =
+  | { readonly type: 'events' }
+  | { readonly type: 'result' }
+  | { readonly type: 'plain'; readonly status: number }
+  | { readonly type: 'api-error' }
+  | { readonly type: 'internal-error' };
+
+const isAttemptSuccess = (result: IterableAttemptResult): boolean => {
+  switch (result.type) {
+  case 'events':
+  case 'result':
+    return true;
+  case 'plain':
+    return result.status >= 200 && result.status < 300;
+  case 'api-error':
+  case 'internal-error':
+    return false;
+  }
+};
+
+// Tries each narrowed candidate in order and returns the first success. A
+// per-candidate failure falls through so a transient 5xx/429/network on
+// one upstream rolls over to the next; when the list is exhausted the
+// most recent failure is forwarded verbatim so clients still see real
+// upstream telemetry rather than a synthetic gateway envelope. Callers
+// are contractually required to hand in a non-empty candidate list — the
+// empty-candidate branch renders `noViableCandidateFailure` at each
+// caller's own protocol-shaped rendering site.
+export const iterateChatCandidates = async <T extends IterableAttemptResult>(
+  candidates: readonly ModelCandidate[],
+  invocationLabel: string,
+  attempt: (candidate: ModelCandidate) => Promise<T>,
+): Promise<T> => {
+  let lastFailure: T | undefined;
+  for (const candidate of candidates) {
+    const result = await attempt(candidate);
+    if (isAttemptSuccess(result)) return result;
+    lastFailure = result;
+  }
+  if (lastFailure === undefined) {
+    throw new Error(`invariant broken: ${invocationLabel} exhausted candidates with neither success nor failure`);
+  }
+  return lastFailure;
+};

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -134,7 +134,8 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
     // family before they reach `modelServesEndpoint`. Iteration order
     // follows configured sort_order across upstreams, with the unprefixed
     // branch pushed before the prefixed one within a single upstream.
-    // The first candidate whose `modelServesEndpoint` is true wins.
+    // Candidates are tried in turn; the first 2xx wins, transient
+    // failures (5xx/429/network) on one upstream roll over to the next.
     const { candidates, sawModel, failedUpstreams } = await enumerateModelCandidates({
       upstreamIds: ctx.upstreamIds,
       model,
@@ -153,8 +154,18 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
         : passthroughApiError(c, appendFailedUpstreams(`Model ${model} is not available on any configured upstream.`, failedUpstreams), 404);
     }
 
+    // Track the most recent candidate that produced a non-2xx response so
+    // it can be forwarded verbatim once the candidate list is exhausted.
+    // `lastFailedUpstream` is the upstream id attributed to the request in
+    // the dump and the request-perf record.
+    let lastFailedResponse: Response | undefined;
+    let lastFailedPerformance: PerformanceTelemetryContext | undefined;
+    let lastFailedUpstream: string | undefined;
+    let anyCandidateServedEndpoint = false;
+
     for (const candidate of candidates) {
       if (!modelServesEndpoint(candidate.model)) continue;
+      anyCandidateServedEndpoint = true;
 
       const recorder = createUpstreamLatencyRecorder();
       const { response, modelKey } = await call(candidate.provider, candidate.model, {
@@ -181,10 +192,16 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
       lastPerformance = performanceContext;
 
       if (!response.ok) {
+        // Non-2xx (4xx including 429, 5xx) — let the next candidate try.
+        // Upstream-perf is recorded per failed attempt so the dashboard
+        // shows each attempted upstream; request-perf and the dump's
+        // upstream attribution wait until the final candidate is chosen
+        // (success or the last failure).
         recordUpstreamPerformance(ctx.backgroundScheduler, performanceContext, true, upstreamDurationMs);
-        recordRequestPerformance(ctx.backgroundScheduler, performanceContext, true, performance.now() - requestStartedAt);
-        ctx.dump?.error('upstream', candidate.provider.upstream);
-        return forwardUpstreamResponse(response);
+        lastFailedResponse = response;
+        lastFailedPerformance = performanceContext;
+        lastFailedUpstream = candidate.provider.upstream;
+        continue;
       }
 
       recordUpstreamPerformance(ctx.backgroundScheduler, performanceContext, false, upstreamDurationMs);
@@ -271,8 +288,24 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
       });
     }
 
-    ctx.dump?.error('gateway');
-    return passthroughApiError(c, appendFailedUpstreams(`Model ${model} does not support the ${sourceApi} endpoint.`, failedUpstreams), 400);
+    // Candidate list exhausted. Two terminal states:
+    //   - At least one candidate replied non-2xx → surface the most recent
+    //     upstream response verbatim (its status, headers, body), and
+    //     attribute the request-perf + dump to that upstream.
+    //   - No candidate served the endpoint at all → 400 (the model exists
+    //     for chat dispatch but no enabled upstream offers this endpoint).
+    if (lastFailedResponse !== undefined) {
+      recordRequestPerformance(ctx.backgroundScheduler, lastFailedPerformance, true, performance.now() - requestStartedAt);
+      ctx.dump?.error('upstream', lastFailedUpstream);
+      return forwardUpstreamResponse(lastFailedResponse);
+    }
+    if (!anyCandidateServedEndpoint) {
+      ctx.dump?.error('gateway');
+      return passthroughApiError(c, appendFailedUpstreams(`Model ${model} does not support the ${sourceApi} endpoint.`, failedUpstreams), 400);
+    }
+    // Unreachable: anyCandidateServedEndpoint=true implies one candidate
+    // either succeeded (returned above) or failed (lastFailedResponse set).
+    throw new Error('passthrough-serve: loop exhausted with no success or failure response');
   } catch (e) {
     if (e instanceof ProviderModelsUnavailableError) {
       const forwarded = httpResponseToResponse(e.httpResponse);

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -303,9 +303,10 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
       ctx.dump?.error('gateway');
       return passthroughApiError(c, appendFailedUpstreams(`Model ${model} does not support the ${sourceApi} endpoint.`, failedUpstreams), 400);
     }
-    // Unreachable: anyCandidateServedEndpoint=true implies one candidate
-    // either succeeded (returned above) or failed (lastFailedResponse set).
-    throw new Error('passthrough-serve: loop exhausted with no success or failure response');
+    // `anyCandidateServedEndpoint=true` means the loop dispatched at least
+    // one attempt; every attempt either returned via the 2xx path above or
+    // recorded `lastFailedResponse`. There is no third state.
+    throw new Error('invariant broken: passthroughServe exhausted candidates with neither success nor failure');
   } catch (e) {
     if (e instanceof ProviderModelsUnavailableError) {
       const forwarded = httpResponseToResponse(e.httpResponse);

--- a/packages/gateway/src/data-plane/shared/passthrough-serve_test.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve_test.ts
@@ -180,3 +180,104 @@ test('passthrough-serve: response header allow-list forwards expected headers an
     },
   );
 });
+
+// Register two custom upstreams both exposing the same embedding model, so
+// the shared narrow phase produces a two-element candidate list ordered by
+// `sortOrder`. The passthrough loop must try `up_a` first (sortOrder 100)
+// and `up_b` second (sortOrder 200).
+const registerTwoEmbeddingsUpstreams = async (repo: Awaited<ReturnType<typeof setupAppTest>>['repo']): Promise<void> => {
+  await repo.upstreams.deleteAll();
+  clearInProcessCopilotTokenCache();
+  await repo.upstreams.save(buildCustomUpstreamRecord({
+    id: 'up_a', name: 'Upstream A', sortOrder: 100,
+    config: { baseUrl: 'https://up-a.example.com', authStyle: 'bearer', apiKey: 'sk-a', endpoints: {} },
+  }));
+  await repo.upstreams.save(buildCustomUpstreamRecord({
+    id: 'up_b', name: 'Upstream B', sortOrder: 200,
+    config: { baseUrl: 'https://up-b.example.com', authStyle: 'bearer', apiKey: 'sk-b', endpoints: {} },
+  }));
+};
+
+test('passthrough-serve: 5xx from the first candidate falls through to the next successful upstream', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  await registerTwoEmbeddingsUpstreams(repo);
+
+  let firstEmbeddingsCalls = 0;
+  let secondEmbeddingsCalls = 0;
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.pathname === '/v1/models') {
+        return jsonResponse({ object: 'list', data: [{ id: 'custom-embed-model' }] });
+      }
+      if (url.hostname === 'up-a.example.com' && url.pathname === '/v1/embeddings') {
+        firstEmbeddingsCalls += 1;
+        return new Response('upstream boom', { status: 503 });
+      }
+      if (url.hostname === 'up-b.example.com' && url.pathname === '/v1/embeddings') {
+        secondEmbeddingsCalls += 1;
+        return jsonResponse({
+          object: 'list',
+          model: 'custom-embed-model',
+          data: [{ object: 'embedding', index: 0, embedding: [0.25] }],
+          usage: { prompt_tokens: 2, total_tokens: 2 },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/embeddings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'custom-embed-model', input: 'hi' }),
+      });
+
+      assertEquals(response.status, 200);
+      const body = await response.json() as { data: Array<{ embedding: number[] }> };
+      assertEquals(body.data[0].embedding, [0.25]);
+      await flushAsyncWork();
+    },
+  );
+
+  assertEquals(firstEmbeddingsCalls, 1);
+  assertEquals(secondEmbeddingsCalls, 1);
+});
+
+test('passthrough-serve: when every candidate returns non-2xx the most recent upstream response is forwarded verbatim', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  await registerTwoEmbeddingsUpstreams(repo);
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.pathname === '/v1/models') {
+        return jsonResponse({ object: 'list', data: [{ id: 'custom-embed-model' }] });
+      }
+      if (url.hostname === 'up-a.example.com' && url.pathname === '/v1/embeddings') {
+        return new Response('first upstream unavailable', { status: 503 });
+      }
+      if (url.hostname === 'up-b.example.com' && url.pathname === '/v1/embeddings') {
+        return new Response(JSON.stringify({ error: { message: 'rate limited' } }), {
+          status: 429, headers: { 'content-type': 'application/json', 'retry-after': '17' },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/embeddings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey.key },
+        body: JSON.stringify({ model: 'custom-embed-model', input: 'hi' }),
+      });
+
+      // The last-attempted upstream's status, body, and allow-listed
+      // headers pass through unchanged so clients see real upstream
+      // telemetry — no synthetic gateway envelope.
+      assertEquals(response.status, 429);
+      assertEquals(response.headers.get('retry-after'), '17');
+      const body = await response.json() as { error: { message: string } };
+      assertEquals(body.error.message, 'rate limited');
+      await flushAsyncWork();
+    },
+  );
+});


### PR DESCRIPTION
`const [candidate] = candidates` violated the candidates abstraction: the narrow phase produces an ordered list where the first is best and the rest are fallbacks, and returning the first candidate's failure verbatim gave up the gateway's resilience.

Now: chat (messages / gemini / chat-completions / responses generate + countTokens + compact) and the passthrough scaffold (`/v1/completions`, `/v1/embeddings`, `/v1/images/*`) iterate the candidate list. A successful attempt — SSE stream opened for chat, 2xx for passthrough's `PlainResult` / `Response`, `{type:'result'}` envelope for Responses compact — is the request's final answer. An `api-error` or `internal-error` from one candidate falls through to the next, so a transient 5xx/429/network on one upstream rolls over. 4xx counts as failure too: 429 in particular is the responsibility of the upstream that issued it, and the candidate ordering exists exactly to absorb that. When the list is exhausted, the most recent failure is forwarded verbatim — same status, headers, body — so clients still see real upstream telemetry rather than a synthetic gateway envelope.

The chat side factors into a single `iterateChatCandidates(candidates, invocationLabel, attempt)` helper (`chat/shared/iterate-candidates.ts`); each of the seven chat serve sites collapses to a one-liner naming its own invocation label. The `isAttemptSuccess` predicate lives inside the helper — no serve site touches it directly — and the exhaustion branch throws `invariant broken: ${invocationLabel} exhausted candidates with neither success nor failure`, matching the phrasing `passthroughServe` and `collectProviderModels` use for the same shape of impossible-post-condition.

Affinity-narrowed cases (input carries an `item_reference` or a reasoning signature whose stored row names a single upstream) come out of `classifyResponsesItemAffinity` as a one-element list — iteration there degrades to single-pass dispatch, preserving the correctness invariant that a stored reference must reach the upstream that owns it.

Per-attempt upstream performance (`upstream_success`) is recorded on every candidate, success or failure, so the dashboard shows each attempted upstream's latency. Request-level performance, dump attribution, and usage rows are recorded once, against the candidate that produced the final answer (success or the last-failure).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`