### PR TITLE
feat(usage): shift-click to isolate + invert-all button for chart legends

### DIFF
--- a/apps/web/src/components/charts/ChartFocusButton.vue
+++ b/apps/web/src/components/charts/ChartFocusButton.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+defineEmits<{ toggle: [] }>();
+</script>
+
+<template>
+  <button
+    type="button"
+    class="absolute bottom-2 right-2 inline-flex min-h-7 min-w-7 items-center justify-center rounded-md p-1 transition-colors text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]"
+    title="Invert selections"
+    @click="$emit('toggle')"
+  >
+    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="12" cy="12" r="3" />
+      <line x1="12" y1="2" x2="12" y2="5" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+      <line x1="2" y1="12" x2="5" y2="12" />
+      <line x1="19" y1="12" x2="22" y2="12" />
+    </svg>
+  </button>
+</template>

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -8,6 +8,7 @@ import { computed, ref, watch } from 'vue';
 import { callApi, useApi, type ApiClient } from '../../api/client.ts';
 import type { BillingDimension } from '../../api/types.ts';
 import ChartCanvas from '../../components/charts/ChartCanvas.vue';
+import ChartFocusButton from '../../components/charts/ChartFocusButton.vue';
 import { bucketKeyForUtcHour, chartColor, chartFont, chartXAxisTick, dashboardBuckets, dashboardRangeQuery, type DashboardRange } from '../../components/charts/dashboard-chart.ts';
 import UsageSummaryMetric from '../../components/usage/UsageSummaryMetric.vue';
 import { useModelsStore } from '../../composables/useModels.ts';
@@ -146,6 +147,21 @@ const toggleHidden = (set: Set<string>, id: string) => {
   if (set.has(id)) set.delete(id);
   else set.add(id);
 };
+
+const selectOnly = (set: Set<string>, keepId: string, ids: readonly string[]) => {
+  set.clear();
+  for (const id of ids) if (id !== keepId) set.add(id);
+};
+
+const invertAll = (set: Set<string>, ids: readonly string[]) => {
+  for (const id of ids) {
+    if (set.has(id)) set.delete(id);
+    else set.add(id);
+  }
+};
+
+const isShiftClick = (native: Event | null): boolean =>
+  !!native && (native as MouseEvent).shiftKey;
 
 const load = async () => {
   const requestId = ++usageRequestId;
@@ -389,7 +405,7 @@ const keyMetadataForTokenRecords = (records: readonly DisplayUsageRecord[], meta
   return map;
 };
 
-const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'line'> => {
+const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'line'> & { _entryIds: string[] } => {
   const allRecords = data.value?.records ?? [];
   const metric = tokenChartMetric.value;
   const isPercent = isPercentMetric(metric);
@@ -413,8 +429,10 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
   const datasetEntries = entries
     .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)?.get(entry.id) ?? (isPercent ? null : 0)) }))
     .filter(({ data }) => isPercent ? data.some(v => v !== null) : data.some(v => v !== 0));
+  const datasetIds = datasetEntries.map(d => d.entry.id);
   const labelWidth = datasetEntries.reduce((max, { entry }) => Math.max(max, entry.label.length), 0);
   return {
+    _entryIds: datasetIds,
     type: 'line',
     data: {
       labels,
@@ -444,9 +462,11 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
-          onClick: (_event, legendItem) => {
+          onClick: (event, legendItem) => {
             const entry = datasetEntries[legendItem.datasetIndex ?? -1]?.entry;
-            if (entry) toggleHidden(ownHidden.value, entry.id);
+            if (!entry) return;
+            if (isShiftClick(event.native)) selectOnly(ownHidden.value, entry.id, datasetIds);
+            else toggleHidden(ownHidden.value, entry.id);
           },
         },
         tooltip: {
@@ -499,7 +519,7 @@ const searchUsageActiveProvider = computed(() => {
   return searchData.value?.activeProvider ?? 'disabled';
 });
 
-const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
+const searchByKeyConfig = computed<ChartConfiguration<'line'> & { _entryIds: string[] }>(() => {
   const records = searchData.value?.records ?? [];
   const { keys: bucketKeys, labels } = buckets.value;
   const groups = new Map<string, Map<string, number>>();
@@ -517,7 +537,9 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
     presentGroups.add(r.keyId);
   }
   const entries = keyChartEntries([...presentGroups], meta, searchData.value?.keys.map(k => k.id) ?? [...presentGroups]);
+  const entryIds = entries.map(e => e.id);
   return {
+    _entryIds: entryIds,
     type: 'line',
     data: {
       labels,
@@ -547,9 +569,11 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
-          onClick: (_event, legendItem) => {
+          onClick: (event, legendItem) => {
             const entry = entries[legendItem.datasetIndex ?? -1];
-            if (entry) toggleHidden(hiddenKeys.value, entry.id);
+            if (!entry) return;
+            if (isShiftClick(event.native)) selectOnly(hiddenKeys.value, entry.id, entryIds);
+            else toggleHidden(hiddenKeys.value, entry.id);
           },
         },
         tooltip: {
@@ -637,12 +661,14 @@ const formatCost = (v: number) => {
 
       <div style="height: 320px; position: relative;">
         <ChartCanvas :config="byKeyConfig" />
+        <ChartFocusButton v-if="byKeyConfig.data.datasets.length > 1" @toggle="invertAll(hiddenKeys, byKeyConfig._entryIds)" />
       </div>
 
       <div class="mt-6 pt-5 border-t border-white/5">
         <span class="text-xs font-medium text-gray-500 uppercase tracking-widest mb-4 block">By Model</span>
         <div style="height: 320px; position: relative;">
           <ChartCanvas :config="byModelConfig" />
+          <ChartFocusButton v-if="byModelConfig.data.datasets.length > 1" @toggle="invertAll(hiddenModels, byModelConfig._entryIds)" />
         </div>
       </div>
 
@@ -676,6 +702,7 @@ const formatCost = (v: number) => {
         </div>
         <div style="height: 320px; position: relative;">
           <ChartCanvas :config="searchByKeyConfig" />
+          <ChartFocusButton v-if="searchByKeyConfig.data.datasets.length > 1" @toggle="invertAll(hiddenKeys, searchByKeyConfig._entryIds)" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Shift-click** a legend item to isolate it (hide every other line) — desktop power-user shortcut.
- **Invert-all button** (crosshair icon, bottom-right of each chart) flips the hidden/shown state of every legend item at once — works on both desktop and mobile.
- Both operations are **stateless and instantly reversible** — no mode to learn, no snapshot to manage.
- Button is hidden when a chart has ≤1 dataset (nothing to invert against).
- The button lives in a new `ChartFocusButton.vue` component to avoid triplicating the SVG.

## Test plan

- [x] Login as admin, navigate to Dashboard → Usage with ≥2 users having data
- [x] Verify normal legend click still toggles a single line
- [x] Shift-click a legend item → only that line remains visible, others hidden
- [x] Click the invert button → all legend items flip hidden↔shown
- [x] Click invert again → returns to previous state (reversible)
- [x] With cross-filtering active (hide a model), verify invert button only affects visible entries
- [x] On a fresh account with no data or single user → invert button should not appear
- [x] Mobile viewport: invert button is reachable and functional without shift-click