### PR TITLE
refactor(passthrough): extract passthroughAttempt and drive both chat and passthrough serves through iterateCandidates

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -4,7 +4,7 @@ import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
+import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ExecuteResult } from '@floway-dev/provider';
@@ -42,7 +42,7 @@ export const chatCompletionsServe = {
     // transient 5xx/429/network failures. When the list is exhausted, the
     // most recent failure is forwarded verbatim so the client still sees
     // real upstream telemetry rather than a synthetic envelope.
-    return await iterateChatCandidates(
+    return await iterateCandidates(
       decision.candidates,
       'chatCompletionsServe.generate',
       candidate => chatCompletionsAttempt.generate({ payload, ctx, candidate, headers }),

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -1,10 +1,10 @@
 import { chatCompletionsAttempt, chatCompletionsTarget } from './attempt.ts';
 import { renderChatCompletionsFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
+import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ExecuteResult } from '@floway-dev/provider';

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -4,7 +4,7 @@ import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
+import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
@@ -47,7 +47,7 @@ export const geminiServe = {
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'generate');
     if (decision.candidates.length === 0) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'generate');
 
-    return await iterateChatCandidates(
+    return await iterateCandidates(
       decision.candidates,
       'geminiServe.generate',
       candidate => geminiAttempt.generate({ payload, ctx, candidate, headers }),
@@ -73,7 +73,7 @@ export const geminiServe = {
     if (decision.kind === 'failure') return renderGeminiFailure(decision.failure, 'countTokens');
     if (decision.candidates.length === 0) return renderGeminiFailure(noViableCandidateFailure(sawModel, model, failedUpstreams), 'countTokens');
 
-    return await iterateChatCandidates(
+    return await iterateCandidates(
       decision.candidates,
       'geminiServe.countTokens',
       candidate => geminiAttempt.countTokens({ payload, ctx, candidate, headers }),

--- a/packages/gateway/src/data-plane/chat/gemini/serve.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve.ts
@@ -1,10 +1,10 @@
 import { geminiAttempt, geminiCountTokensTarget, geminiGenerateTarget } from './attempt.ts';
 import { renderGeminiFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
+import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -1,10 +1,10 @@
 import { messagesAttempt, messagesGenerateTarget, messagesCountTokensTarget } from './attempt.ts';
 import { renderMessagesFailure } from './errors.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
+import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -4,7 +4,7 @@ import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { classifyResponsesItemAffinity } from '../responses/items/affinity.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
+import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ExecuteResult, PlainResult } from '@floway-dev/provider';
@@ -47,7 +47,7 @@ export const messagesServe = {
     // from one candidate falls through to the next so the gateway absorbs
     // transient 5xx/429/network failures. When the list is exhausted, the
     // most recent failure is forwarded verbatim.
-    return await iterateChatCandidates(
+    return await iterateCandidates(
       decision.candidates,
       'messagesServe.generate',
       candidate => messagesAttempt.generate({ payload, ctx, candidate, headers }),
@@ -73,7 +73,7 @@ export const messagesServe = {
     if (decision.kind === 'failure') return renderMessagesFailure(decision.failure, 'countTokens');
     if (decision.candidates.length === 0) return renderMessagesFailure(noViableCandidateFailure(sawModel, payload.model, failedUpstreams), 'countTokens');
 
-    return await iterateChatCandidates(
+    return await iterateCandidates(
       decision.candidates,
       'messagesServe.countTokens',
       candidate => messagesAttempt.countTokens({ payload, ctx, candidate, headers }),

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,8 +1,8 @@
 import { responsesAttempt } from './attempt.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
-import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { iterateCandidates } from '../../shared/iterate-candidates.ts';
+import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -2,7 +2,7 @@ import { responsesAttempt } from './attempt.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { iterateChatCandidates } from '../shared/iterate-candidates.ts';
+import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
@@ -29,7 +29,7 @@ export const responsesServe = {
     // final answer; per-candidate failures fall through so a transient
     // 5xx/429/network does not become the request's verdict when another
     // candidate can serve. The last failure surfaces verbatim on exhaustion.
-    return await iterateChatCandidates(
+    return await iterateCandidates(
       plan.candidates,
       'responsesServe.generate',
       candidate => responsesAttempt.generate({ payload: plan.prepared, ctx, candidate, headers }),
@@ -48,7 +48,7 @@ export const responsesServe = {
     // re-tags the result as compact on the way out.
     const plan = await prepareResponsesServePlan({ payload, ctx });
     if (plan.kind === 'failure') return plan.result;
-    return await iterateChatCandidates(
+    return await iterateCandidates(
       plan.candidates,
       'responsesServe.compact',
       candidate => responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate, headers }),

--- a/packages/gateway/src/data-plane/shared/iterate-candidates.ts
+++ b/packages/gateway/src/data-plane/shared/iterate-candidates.ts
@@ -11,7 +11,9 @@ import type { ModelCandidate } from '@floway-dev/provider';
 // through to the next candidate. 4xx is on the failure side — 429
 // (rate-limit) is the responsibility of the upstream that issued it, and
 // the gateway's candidate ordering exists to absorb that kind of
-// transient.
+// transient. Passthrough serves feed in an enlarged `plain` shape that
+// carries the raw upstream Response plus per-attempt telemetry alongside
+// the status; the success discriminant is unchanged.
 type IterableAttemptResult =
   | { readonly type: 'events' }
   | { readonly type: 'result' }
@@ -35,12 +37,13 @@ const isAttemptSuccess = (result: IterableAttemptResult): boolean => {
 // Tries each narrowed candidate in order and returns the first success. A
 // per-candidate failure falls through so a transient 5xx/429/network on
 // one upstream rolls over to the next; when the list is exhausted the
-// most recent failure is forwarded verbatim so clients still see real
-// upstream telemetry rather than a synthetic gateway envelope. Callers
-// are contractually required to hand in a non-empty candidate list — the
-// empty-candidate branch renders `noViableCandidateFailure` at each
-// caller's own protocol-shaped rendering site.
-export const iterateChatCandidates = async <T extends IterableAttemptResult>(
+// most recent failure is returned so callers can forward it verbatim and
+// clients still see real upstream telemetry rather than a synthetic
+// gateway envelope. Callers are contractually required to hand in a
+// non-empty candidate list — the empty-candidate branch renders each
+// caller's own protocol-shaped "no viable candidate" envelope at the
+// serve site.
+export const iterateCandidates = async <T extends IterableAttemptResult>(
   candidates: readonly ModelCandidate[],
   invocationLabel: string,
   attempt: (candidate: ModelCandidate) => Promise<T>,

--- a/packages/gateway/src/data-plane/shared/passthrough-attempt.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-attempt.ts
@@ -16,7 +16,6 @@ import type { PerformanceTelemetryContext } from './telemetry/performance.ts';
 import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, requireRecordedDurationMs } from './telemetry/performance.ts';
 import type { AuthedContext } from '../../middleware/auth.ts';
 import type { GatewayCtx } from '../chat/shared/gateway-ctx.ts';
-import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { ModelCandidate, Provider, ProviderCallResult, TelemetryModelIdentity, UpstreamCallOptions, UpstreamModel } from '@floway-dev/provider';
 
 // Enlarged `plain` shape: `iterateCandidates` reads `type` + `status`;
@@ -47,15 +46,6 @@ export interface PassthroughAttemptArgs {
   // internal-debug envelope.
   readonly call: (provider: Provider, model: UpstreamModel, opts: UpstreamCallOptions) => Promise<ProviderCallResult>;
 }
-
-const recordUpstreamPerformance = (
-  scheduler: BackgroundScheduler,
-  context: PerformanceTelemetryContext,
-  failed: boolean,
-  durationMs: number,
-): void => {
-  scheduler(failed ? recordPerformanceError(context, 'upstream_success') : recordPerformanceLatency(context, 'upstream_success', durationMs));
-};
 
 export const passthroughAttempt = async (args: PassthroughAttemptArgs): Promise<PassthroughAttemptResult> => {
   const { c, ctx, candidate, stream, call } = args;
@@ -88,7 +78,9 @@ export const passthroughAttempt = async (args: PassthroughAttemptArgs): Promise<
   // attempted upstream; request-perf and the dump's upstream attribution
   // wait until the serve loop picks its terminal candidate (2xx success
   // or last failure on exhaustion).
-  recordUpstreamPerformance(ctx.backgroundScheduler, performance, !response.ok, upstreamDurationMs);
+  ctx.backgroundScheduler(response.ok
+    ? recordPerformanceLatency(performance, 'upstream_success', upstreamDurationMs)
+    : recordPerformanceError(performance, 'upstream_success'));
   return {
     type: 'plain',
     status: response.status,

--- a/packages/gateway/src/data-plane/shared/passthrough-attempt.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-attempt.ts
@@ -21,17 +21,15 @@ import type { ModelCandidate, Provider, ProviderCallResult, TelemetryModelIdenti
 
 // Enlarged `plain` shape: `iterateCandidates` reads `type` + `status`;
 // the passthrough serve reads the rest to forward the response, attribute
-// dumps, and record request-total perf. The upstream id and per-attempt
-// perf context live on the result rather than on side-channel state
-// because the iterator only exposes the winning (or last-failed) result
-// back to the serve.
+// dumps, and record request-total perf. `identity` carries the upstream
+// id alongside the model/pricing metadata the dump and usage-record
+// paths already consume together.
 export interface PassthroughAttemptResult {
   readonly type: 'plain';
   readonly status: number;
   readonly response: Response;
   readonly performance: PerformanceTelemetryContext;
   readonly identity: TelemetryModelIdentity;
-  readonly upstream: string;
 }
 
 export interface PassthroughAttemptArgs {
@@ -97,6 +95,5 @@ export const passthroughAttempt = async (args: PassthroughAttemptArgs): Promise<
     response,
     performance,
     identity,
-    upstream: candidate.provider.upstream,
   };
 };

--- a/packages/gateway/src/data-plane/shared/passthrough-attempt.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-attempt.ts
@@ -1,0 +1,102 @@
+// Per-candidate passthrough attempt: does the upstream HTTP call for one
+// resolved candidate, records the upstream_success perf metric (success
+// or failure), and hands the serve loop back a `plain`-shaped result the
+// shared `iterateCandidates` iterator can drive.
+//
+// Chat protocols run each attempt through a translation + interceptor
+// stack that yields an `ExecuteResult` discriminated union. Passthrough
+// endpoints have no translation — the request body is forwarded to the
+// upstream's matching endpoint and the raw upstream Response is returned
+// verbatim. The `plain` discriminant is enlarged here to carry that
+// Response plus the per-call telemetry the serve site needs when it
+// forwards the winning attempt (2xx) or the last failure (exhausted).
+
+import { inboundHeadersForUpstream } from './inbound-headers.ts';
+import type { PerformanceTelemetryContext } from './telemetry/performance.ts';
+import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, requireRecordedDurationMs } from './telemetry/performance.ts';
+import type { AuthedContext } from '../../middleware/auth.ts';
+import type { GatewayCtx } from '../chat/shared/gateway-ctx.ts';
+import type { BackgroundScheduler } from '@floway-dev/platform';
+import type { ModelCandidate, Provider, ProviderCallResult, TelemetryModelIdentity, UpstreamCallOptions, UpstreamModel } from '@floway-dev/provider';
+
+// Enlarged `plain` shape: `iterateCandidates` reads `type` + `status`;
+// the passthrough serve reads the rest to forward the response, attribute
+// dumps, and record request-total perf. The upstream id and per-attempt
+// perf context live on the result rather than on side-channel state
+// because the iterator only exposes the winning (or last-failed) result
+// back to the serve.
+export interface PassthroughAttemptResult {
+  readonly type: 'plain';
+  readonly status: number;
+  readonly response: Response;
+  readonly performance: PerformanceTelemetryContext;
+  readonly identity: TelemetryModelIdentity;
+  readonly upstream: string;
+}
+
+export interface PassthroughAttemptArgs {
+  readonly c: AuthedContext;
+  readonly ctx: GatewayCtx;
+  readonly candidate: ModelCandidate;
+  // `true` when the passthrough serves an SSE stream (completions); flows
+  // through to `PerformanceTelemetryContext.stream` so per-model latency
+  // charts stay split by streaming vs one-shot semantics.
+  readonly stream: boolean;
+  // Performs the upstream HTTP call for the chosen (provider, model) pair.
+  // Delegated to the passthrough caller so each endpoint keeps its
+  // request-body shaping (`{ model: _, ...body }`) local. Any throw here
+  // is preserved and the serve layer turns it into a 502 with the
+  // internal-debug envelope.
+  readonly call: (provider: Provider, model: UpstreamModel, opts: UpstreamCallOptions) => Promise<ProviderCallResult>;
+}
+
+const recordUpstreamPerformance = (
+  scheduler: BackgroundScheduler,
+  context: PerformanceTelemetryContext,
+  failed: boolean,
+  durationMs: number,
+): void => {
+  scheduler(failed ? recordPerformanceError(context, 'upstream_success') : recordPerformanceLatency(context, 'upstream_success', durationMs));
+};
+
+export const passthroughAttempt = async (args: PassthroughAttemptArgs): Promise<PassthroughAttemptResult> => {
+  const { c, ctx, candidate, stream, call } = args;
+  const recorder = createUpstreamLatencyRecorder();
+  const { response, modelKey } = await call(candidate.provider, candidate.model, {
+    fetcher: candidate.fetcher,
+    recordUpstreamLatency: recorder.record,
+    waitUntil: ctx.backgroundScheduler,
+    headers: inboundHeadersForUpstream(c),
+  });
+  const upstreamDurationMs = requireRecordedDurationMs(recorder, 'passthrough upstream call');
+  // Telemetry keys on the upstream's bare catalog id (`model.id`); the
+  // user-facing error body echoes the inbound `model` and is the serve
+  // layer's job.
+  const identity: TelemetryModelIdentity = {
+    model: candidate.model.id,
+    upstream: candidate.provider.upstream,
+    modelKey,
+    cost: candidate.provider.instance.getPricingForModelKey(modelKey),
+  };
+  const performance: PerformanceTelemetryContext = {
+    keyId: ctx.apiKeyId,
+    model: identity.model,
+    upstream: identity.upstream,
+    modelKey: identity.modelKey,
+    stream,
+    runtimeLocation: ctx.runtimeLocation,
+  };
+  // Upstream-perf is recorded per attempt so the dashboard shows each
+  // attempted upstream; request-perf and the dump's upstream attribution
+  // wait until the serve loop picks its terminal candidate (2xx success
+  // or last failure on exhaustion).
+  recordUpstreamPerformance(ctx.backgroundScheduler, performance, !response.ok, upstreamDurationMs);
+  return {
+    type: 'plain',
+    status: response.status,
+    response,
+    performance,
+    identity,
+    upstream: candidate.provider.upstream,
+  };
+};

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -130,8 +130,6 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
     // family before they reach `modelServesEndpoint`. Iteration order
     // follows configured sort_order across upstreams, with the unprefixed
     // branch pushed before the prefixed one within a single upstream.
-    // Candidates are tried in turn; the first 2xx wins, transient
-    // failures (5xx/429/network) on one upstream roll over to the next.
     const { candidates, sawModel, failedUpstreams } = await enumerateModelCandidates({
       upstreamIds: ctx.upstreamIds,
       model,

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -180,14 +180,14 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
         return attempted;
       },
     );
-    const { response, performance: performanceContext, identity, upstream } = result;
+    const { response, performance: performanceContext, identity } = result;
 
     if (!response.ok) {
       // Exhausted — forward the last upstream response verbatim so clients
       // still see real upstream telemetry (status, retry-after, request-id,
       // ...) rather than a synthetic gateway envelope.
       recordRequestPerformance(ctx.backgroundScheduler, performanceContext, true, performance.now() - requestStartedAt);
-      ctx.dump?.error('upstream', upstream);
+      ctx.dump?.error('upstream', identity.upstream);
       return forwardUpstreamResponse(response);
     }
 

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -15,9 +15,10 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import type { PassthroughServeApiName } from './api-names.ts';
 import { appendFailedUpstreams } from './failed-upstreams.ts';
-import { inboundHeadersForUpstream } from './inbound-headers.ts';
+import { iterateCandidates } from './iterate-candidates.ts';
+import { passthroughAttempt } from './passthrough-attempt.ts';
 import type { PerformanceTelemetryContext } from './telemetry/performance.ts';
-import { createUpstreamLatencyRecorder, recordPerformanceError, recordPerformanceLatency, recordRequestPerformance, requireRecordedDurationMs } from './telemetry/performance.ts';
+import { recordRequestPerformance } from './telemetry/performance.ts';
 import { recordTokenUsage } from './telemetry/usage.ts';
 import type { AuthedContext } from '../../middleware/auth.ts';
 import type { TokenUsage } from '../../repo/types.ts';
@@ -58,15 +59,6 @@ const stageForwardedResponseHeaders = (c: Context, resp: Response): void => {
   for (const [name, value] of resp.headers.entries()) {
     if (isForwardedResponseHeader(name)) c.header(name, value);
   }
-};
-
-const recordUpstreamPerformance = (
-  scheduler: BackgroundScheduler,
-  context: PerformanceTelemetryContext,
-  failed: boolean,
-  durationMs: number,
-): void => {
-  scheduler(failed ? recordPerformanceError(context, 'upstream_success') : recordPerformanceLatency(context, 'upstream_success', durationMs));
 };
 
 // Fire-and-forget the usage record. A transient D1/KV failure here must not
@@ -124,6 +116,10 @@ export const passthroughApiError = (c: Context, message: string, status: Content
 export const passthroughServe = async (input: PassthroughServeContext): Promise<Response> => {
   const { c, ctx, sourceApi, model, kind, modelServesEndpoint, call, response: responseHandling } = input;
   const requestStartedAt = performance.now();
+  // Populated as attempts land so a throw from `passthroughAttempt` (or
+  // the response handling below) can still attribute request-perf to the
+  // most recent candidate the loop touched. A throw before any candidate
+  // fired leaves this undefined; the outer catch below is happy with that.
   let lastPerformance: PerformanceTelemetryContext | undefined;
 
   try {
@@ -148,165 +144,133 @@ export const passthroughServe = async (input: PassthroughServeContext): Promise<
       // `sawModel === false` means no upstream catalog knew the inbound id
       // at all (404); `sawModel === true` with zero candidates means the
       // id is known but every match was the wrong kind for this endpoint
-      // (400), which mirrors the per-candidate-endpoint-miss case below.
+      // (400), which mirrors the empty-viable case below.
       return sawModel
         ? passthroughApiError(c, appendFailedUpstreams(`Model ${model} does not support the ${sourceApi} endpoint.`, failedUpstreams), 400)
         : passthroughApiError(c, appendFailedUpstreams(`Model ${model} is not available on any configured upstream.`, failedUpstreams), 404);
     }
 
-    // Track the most recent candidate that produced a non-2xx response so
-    // it can be forwarded verbatim once the candidate list is exhausted.
-    // `lastFailedUpstream` is the upstream id attributed to the request in
-    // the dump and the request-perf record.
-    let lastFailedResponse: Response | undefined;
-    let lastFailedPerformance: PerformanceTelemetryContext | undefined;
-    let lastFailedUpstream: string | undefined;
-    let anyCandidateServedEndpoint = false;
-
-    for (const candidate of candidates) {
-      if (!modelServesEndpoint(candidate.model)) continue;
-      anyCandidateServedEndpoint = true;
-
-      const recorder = createUpstreamLatencyRecorder();
-      const { response, modelKey } = await call(candidate.provider, candidate.model, {
-        fetcher: candidate.fetcher,
-        recordUpstreamLatency: recorder.record,
-        waitUntil: ctx.backgroundScheduler,
-        headers: inboundHeadersForUpstream(c),
-      });
-      const upstreamDurationMs = requireRecordedDurationMs(recorder, 'passthrough upstream call');
-      // Telemetry keys on the upstream's bare catalog id (`model.id`);
-      // user-facing error bodies echo the inbound `model`.
-      const identity = {
-        model: candidate.model.id,
-        upstream: candidate.provider.upstream,
-        modelKey,
-        cost: candidate.provider.instance.getPricingForModelKey(modelKey),
-      };
-      const performanceContext: PerformanceTelemetryContext = {
-        keyId: ctx.apiKeyId,
-        ...identity,
-        stream: responseHandling.format === 'sse',
-        runtimeLocation: ctx.runtimeLocation,
-      };
-      lastPerformance = performanceContext;
-
-      if (!response.ok) {
-        // Non-2xx (4xx including 429, 5xx) — let the next candidate try.
-        // Upstream-perf is recorded per failed attempt so the dashboard
-        // shows each attempted upstream; request-perf and the dump's
-        // upstream attribution wait until the final candidate is chosen
-        // (success or the last failure).
-        recordUpstreamPerformance(ctx.backgroundScheduler, performanceContext, true, upstreamDurationMs);
-        lastFailedResponse = response;
-        lastFailedPerformance = performanceContext;
-        lastFailedUpstream = candidate.provider.upstream;
-        continue;
-      }
-
-      recordUpstreamPerformance(ctx.backgroundScheduler, performanceContext, false, upstreamDurationMs);
-
-      if (responseHandling.format === 'json') {
-        // A 2xx body that fails to parse must not 502 a client whose
-        // upstream call already succeeded; we skip usage extraction and
-        // log so missing rows stay traceable.
-        let parsed: unknown;
-        try {
-          parsed = await response.clone().json();
-        } catch (e) {
-          console.warn(`passthrough-serve: failed to parse 2xx upstream body for ${sourceApi}; usage row will be skipped`, e instanceof Error ? e.message : String(e));
-          parsed = undefined;
-        }
-        const usage = parsed !== undefined ? responseHandling.extractBilling(parsed) : null;
-        ctx.dump?.success(identity, usage);
-        if (usage) {
-          scheduleUsageRecord(ctx.backgroundScheduler, recordTokenUsage(ctx.apiKeyId, identity, usage));
-        }
-        recordRequestPerformance(ctx.backgroundScheduler, performanceContext, false, performance.now() - requestStartedAt);
-        return forwardUpstreamResponse(response);
-      }
-
-      // Hono's streamSSE owns the response — forwardable upstream
-      // headers must be staged on `c` *before* the streamSSE call so
-      // they survive its internal newResponse.
-      const upstreamBody = response.body;
-      if (!upstreamBody) {
-        ctx.dump?.failed(`${sourceApi} streaming upstream returned no body`);
-        recordRequestPerformance(ctx.backgroundScheduler, performanceContext, true, performance.now() - requestStartedAt);
-        // Preserve upstream correlation headers (x-request-id, cf-ray, ...)
-        // on the synthesized 502 so this rare edge case is still traceable.
-        stageForwardedResponseHeaders(c, response);
-        return passthroughApiError(c, 'Upstream returned a streaming response with no body.', 502);
-      }
-      stageForwardedResponseHeaders(c, response);
-      return streamSSE(c, async stream => {
-        let completion: StreamCompletion = 'error';
-        let streamError: unknown;
-        // Tracks whether the upstream's terminal (`done`) frame arrived
-        // before the writer settled. A client cancel after the terminal
-        // frame is graceful (upstream already finished its work); a
-        // mid-stream cancel or EOF without terminal is a real failure.
-        // Mirrors SourceStreamState.failedAfter on the chat endpoints.
-        let terminalFrameSeen = false;
-        try {
-          const frames = (async function* () {
-            const sseFramesIn = parseSSEStream(upstreamBody, { signal: ctx.abortSignal });
-            for await (const parsed of parseTargetStreamFrames<unknown>(sseFramesIn, { protocol: sourceApi })) {
-              const inputFrame: ProtocolFrame<unknown> = parsed.type === 'done' ? doneFrame() : eventFrame(parsed.data);
-              // Dump pre-transform, so forensics see upstream truth even
-              // when the caller drops a frame from the client-facing stream.
-              ctx.dump?.frame(inputFrame);
-              if (inputFrame.type === 'done') terminalFrameSeen = true;
-              const outputFrame = responseHandling.transformFrame(inputFrame);
-              if (outputFrame === null) continue;
-              yield outputFrame.type === 'done' ? sseFrame('[DONE]') : sseFrame(JSON.stringify(outputFrame.event));
-            }
-          })();
-          completion = await writeSSEFrames(stream, frames, {
-            keepAlive: { frame: sseCommentFrame('keepalive') },
-            downstreamAbortController: ctx.downstreamAbortController,
-          });
-        } catch (e) {
-          streamError = e;
-        } finally {
-          const usage = responseHandling.settleUsage();
-          const failed = streamError !== undefined || completion === 'error' || !terminalFrameSeen;
-          if (failed) {
-            ctx.dump?.failed(streamError ?? `${sourceApi} stream ended with completion=${completion}`);
-          } else {
-            ctx.dump?.success(identity, usage);
-          }
-          // Record any accumulated usage regardless of the failed flag —
-          // tokens already metered upstream should bill even when the
-          // downstream half of the round-trip turned out badly. The chat
-          // streaming endpoints follow the same rule.
-          if (usage) {
-            scheduleUsageRecord(ctx.backgroundScheduler, recordTokenUsage(ctx.apiKeyId, identity, usage));
-          }
-          recordRequestPerformance(ctx.backgroundScheduler, performanceContext, failed, performance.now() - requestStartedAt);
-        }
-      });
-    }
-
-    // Candidate list exhausted. Two terminal states:
-    //   - At least one candidate replied non-2xx → surface the most recent
-    //     upstream response verbatim (its status, headers, body), and
-    //     attribute the request-perf + dump to that upstream.
-    //   - No candidate served the endpoint at all → 400 (the model exists
-    //     for chat dispatch but no enabled upstream offers this endpoint).
-    if (lastFailedResponse !== undefined) {
-      recordRequestPerformance(ctx.backgroundScheduler, lastFailedPerformance, true, performance.now() - requestStartedAt);
-      ctx.dump?.error('upstream', lastFailedUpstream);
-      return forwardUpstreamResponse(lastFailedResponse);
-    }
-    if (!anyCandidateServedEndpoint) {
+    // Endpoint-level pre-filter: drop candidates whose upstream model
+    // exists for the requested kind but doesn't expose this endpoint's
+    // specific capability (e.g. an embeddings-kind model on an upstream
+    // that only exposes chat). An empty viable set is the same "model
+    // exists but no upstream serves this endpoint" 400 the empty-candidate
+    // branch above surfaces.
+    const viable = candidates.filter(c => modelServesEndpoint(c.model));
+    if (viable.length === 0) {
       ctx.dump?.error('gateway');
       return passthroughApiError(c, appendFailedUpstreams(`Model ${model} does not support the ${sourceApi} endpoint.`, failedUpstreams), 400);
     }
-    // `anyCandidateServedEndpoint=true` means the loop dispatched at least
-    // one attempt; every attempt either returned via the 2xx path above or
-    // recorded `lastFailedResponse`. There is no third state.
-    throw new Error('invariant broken: passthroughServe exhausted candidates with neither success nor failure');
+
+    // Iterate the viable list. Each candidate's attempt runs the upstream
+    // HTTP call and records `upstream_success` telemetry; the shared
+    // iterator returns the first 2xx or, on exhaustion, the last non-2xx
+    // result. Request-perf and dump attribution wait until this point so
+    // they land against the terminal candidate.
+    const result = await iterateCandidates(
+      viable,
+      'passthroughServe',
+      async candidate => {
+        const attempted = await passthroughAttempt({
+          c, ctx, candidate,
+          stream: responseHandling.format === 'sse',
+          call,
+        });
+        lastPerformance = attempted.performance;
+        return attempted;
+      },
+    );
+    const { response, performance: performanceContext, identity, upstream } = result;
+
+    if (!response.ok) {
+      // Exhausted — forward the last upstream response verbatim so clients
+      // still see real upstream telemetry (status, retry-after, request-id,
+      // ...) rather than a synthetic gateway envelope.
+      recordRequestPerformance(ctx.backgroundScheduler, performanceContext, true, performance.now() - requestStartedAt);
+      ctx.dump?.error('upstream', upstream);
+      return forwardUpstreamResponse(response);
+    }
+
+    if (responseHandling.format === 'json') {
+      // A 2xx body that fails to parse must not 502 a client whose
+      // upstream call already succeeded; we skip usage extraction and
+      // log so missing rows stay traceable.
+      let parsed: unknown;
+      try {
+        parsed = await response.clone().json();
+      } catch (e) {
+        console.warn(`passthrough-serve: failed to parse 2xx upstream body for ${sourceApi}; usage row will be skipped`, e instanceof Error ? e.message : String(e));
+        parsed = undefined;
+      }
+      const usage = parsed !== undefined ? responseHandling.extractBilling(parsed) : null;
+      ctx.dump?.success(identity, usage);
+      if (usage) {
+        scheduleUsageRecord(ctx.backgroundScheduler, recordTokenUsage(ctx.apiKeyId, identity, usage));
+      }
+      recordRequestPerformance(ctx.backgroundScheduler, performanceContext, false, performance.now() - requestStartedAt);
+      return forwardUpstreamResponse(response);
+    }
+
+    // Hono's streamSSE owns the response — forwardable upstream
+    // headers must be staged on `c` *before* the streamSSE call so
+    // they survive its internal newResponse.
+    const upstreamBody = response.body;
+    if (!upstreamBody) {
+      ctx.dump?.failed(`${sourceApi} streaming upstream returned no body`);
+      recordRequestPerformance(ctx.backgroundScheduler, performanceContext, true, performance.now() - requestStartedAt);
+      // Preserve upstream correlation headers (x-request-id, cf-ray, ...)
+      // on the synthesized 502 so this rare edge case is still traceable.
+      stageForwardedResponseHeaders(c, response);
+      return passthroughApiError(c, 'Upstream returned a streaming response with no body.', 502);
+    }
+    stageForwardedResponseHeaders(c, response);
+    return streamSSE(c, async stream => {
+      let completion: StreamCompletion = 'error';
+      let streamError: unknown;
+      // Tracks whether the upstream's terminal (`done`) frame arrived
+      // before the writer settled. A client cancel after the terminal
+      // frame is graceful (upstream already finished its work); a
+      // mid-stream cancel or EOF without terminal is a real failure.
+      // Mirrors SourceStreamState.failedAfter on the chat endpoints.
+      let terminalFrameSeen = false;
+      try {
+        const frames = (async function* () {
+          const sseFramesIn = parseSSEStream(upstreamBody, { signal: ctx.abortSignal });
+          for await (const parsed of parseTargetStreamFrames<unknown>(sseFramesIn, { protocol: sourceApi })) {
+            const inputFrame: ProtocolFrame<unknown> = parsed.type === 'done' ? doneFrame() : eventFrame(parsed.data);
+            // Dump pre-transform, so forensics see upstream truth even
+            // when the caller drops a frame from the client-facing stream.
+            ctx.dump?.frame(inputFrame);
+            if (inputFrame.type === 'done') terminalFrameSeen = true;
+            const outputFrame = responseHandling.transformFrame(inputFrame);
+            if (outputFrame === null) continue;
+            yield outputFrame.type === 'done' ? sseFrame('[DONE]') : sseFrame(JSON.stringify(outputFrame.event));
+          }
+        })();
+        completion = await writeSSEFrames(stream, frames, {
+          keepAlive: { frame: sseCommentFrame('keepalive') },
+          downstreamAbortController: ctx.downstreamAbortController,
+        });
+      } catch (e) {
+        streamError = e;
+      } finally {
+        const usage = responseHandling.settleUsage();
+        const failed = streamError !== undefined || completion === 'error' || !terminalFrameSeen;
+        if (failed) {
+          ctx.dump?.failed(streamError ?? `${sourceApi} stream ended with completion=${completion}`);
+        } else {
+          ctx.dump?.success(identity, usage);
+        }
+        // Record any accumulated usage regardless of the failed flag —
+        // tokens already metered upstream should bill even when the
+        // downstream half of the round-trip turned out badly. The chat
+        // streaming endpoints follow the same rule.
+        if (usage) {
+          scheduleUsageRecord(ctx.backgroundScheduler, recordTokenUsage(ctx.apiKeyId, identity, usage));
+        }
+        recordRequestPerformance(ctx.backgroundScheduler, performanceContext, failed, performance.now() - requestStartedAt);
+      }
+    });
   } catch (e) {
     if (e instanceof ProviderModelsUnavailableError) {
       const forwarded = httpResponseToResponse(e.httpResponse);


### PR DESCRIPTION
Chat protocols have an `attempt.ts` layer that returns an `ExecuteResult` discriminated union with `type:'events'|'result'|'plain'|'api-error'|'internal-error'`, which `iterateCandidates` consumes uniformly. Passthrough was doing the upstream call inline in `passthrough-serve.ts` — a per-candidate loop with three `lastFailedX` fields, an `anyCandidateServedEndpoint` guard, and its own per-attempt telemetry recording — so it couldn't feed the shared helper.

## The `passthroughAttempt` layer

`data-plane/shared/passthrough-attempt.ts` does one upstream call per candidate, records the `upstream_success` metric (success or failure), and returns an enlarged `plain` shape that satisfies `iterateCandidates`'s `IterableAttemptResult` while carrying the fields the serve site consumes on the terminal candidate:

```ts
{
  type: 'plain';
  status: number;         // read by iterateCandidates (2xx wins)
  response: Response;     // forwarded verbatim on both success and exhausted-failure
  performance: PerformanceTelemetryContext;
  identity: TelemetryModelIdentity;   // carries the upstream id for dump/usage attribution
}
```

The enlarged shape extends the union's `{type:'plain', status: number}` member with the extra fields the passthrough serve needs; structural typing keeps `iterateCandidates` happy while the serve reads the full result.

## Serve simplification

`passthrough-serve.ts`:

- Pre-filters candidates via `modelServesEndpoint`, folding the old `anyCandidateServedEndpoint` guard into a straight empty-viable check that surfaces the same 400 "Model X does not support the Y endpoint" envelope.
- Hands the viable list to `iterateCandidates(viable, 'passthroughServe', candidate => passthroughAttempt({...}))`.
- Branches on `result.response.ok`: 2xx runs the json / sse handling; non-2xx is the exhausted case forwarded verbatim with request-perf + dump attribution taken from `result.performance` / `result.identity.upstream`.

The three `lastFailedResponse` / `lastFailedPerformance` / `lastFailedUpstream` locals and the `invariant broken:` throw drop out of the file — the helper owns the exhaustion post-condition now.

## Naming

`iterateChatCandidates` in `chat/shared/iterate-candidates.ts` was renamed to `iterateCandidates` and hoisted to `data-plane/shared/iterate-candidates.ts`, since it's no longer chat-specific. The four chat serves and the passthrough serve import from the same place.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`