### PR TITLE
chore: ignore .pnpm-store

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 node_modules
+.pnpm-store
 **/node_modules
 **/dist
 .wrangler

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/superpowers
 apps/web/dist/
 .dev.vars
 .env
+.pnpm-store/
 /wrangler.jsonc
 
 # Local node-target dev runtime (sqlite db + uploaded files). One under the


### PR DESCRIPTION
This prevents AI agents or humans from accidentally including `.pnpm-store` into commits.