### PR TITLE
fix(auth): normalize empty credential sources so blanks don't shadow valid keys

### DIFF
--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -74,12 +74,26 @@ export const authMiddleware = async (c: AuthedContext, next: Next) => {
   await next();
 };
 
+// Normalize a present-but-empty / whitespace-only credential source to
+// undefined. '' is not nullish, so without this it would latch the `??`
+// fallback chain below and shadow a valid lower-priority credential — the
+// request then 401s with the real key never consulted. Non-standard clients
+// hit this: e.g. Xcode's Claude agent custom-endpoint workaround sends an
+// empty x-api-key alongside a real Authorization: Bearer. Trimming also
+// tolerates keys copy-pasted with stray surrounding whitespace.
+const presentOrUndefined = (v: string | null | undefined): string | undefined => {
+  const trimmed = v?.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
+};
+
 const extractApiKey = (c: Context): string | null => {
   const url = new URL(c.req.url);
-  return url.searchParams.get('key')
-    ?? c.req.header('x-api-key')
-    ?? c.req.header('x-goog-api-key')
-    ?? c.req.header('authorization')?.replace(/^Bearer\s+/i, '')
+  const bearer = c.req.header('authorization')?.replace(/^Bearer\s+/i, '');
+  return presentOrUndefined(url.searchParams.get('key'))
+    ?? presentOrUndefined(c.req.header('x-api-key'))
+    ?? presentOrUndefined(c.req.header('x-goog-api-key'))
+    ?? presentOrUndefined(bearer)
     ?? null;
 };
 

--- a/packages/gateway/src/middleware/auth_test.ts
+++ b/packages/gateway/src/middleware/auth_test.ts
@@ -95,3 +95,59 @@ test('API key whose owner was deleted is rejected', async () => {
   });
   assertEquals(response.status, 401);
 });
+
+// A present-but-empty higher-priority source must not shadow a valid
+// lower-priority credential. '' is not nullish, so the raw `??` chain used to
+// latch onto it and 401 the request without ever consulting the real key —
+// exactly what non-standard clients (e.g. Xcode's Claude agent custom-endpoint
+// workaround) trigger by sending an empty x-api-key alongside a real Bearer.
+test('empty x-api-key does not shadow a valid Authorization: Bearer', async () => {
+  const { apiKey } = await setupAppTest();
+  const app = authTestApp();
+  const response = await app.request('/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'x-api-key': '', authorization: `Bearer ${apiKey.key}` },
+  });
+  assertEquals(response.status, 200);
+  assertEquals(await response.text(), 'ok');
+});
+
+test('empty ?key= query does not shadow a valid x-goog-api-key', async () => {
+  const { apiKey } = await setupAppTest();
+  const app = authTestApp();
+  const response = await app.request('/v1beta/models/gemini-test:generateContent?key=', {
+    method: 'POST',
+    headers: { 'x-goog-api-key': apiKey.key },
+  });
+  assertEquals(response.status, 200);
+});
+
+test('whitespace-only x-api-key falls through to a valid Bearer', async () => {
+  const { apiKey } = await setupAppTest();
+  const app = authTestApp();
+  const response = await app.request('/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'x-api-key': '   ', authorization: `Bearer ${apiKey.key}` },
+  });
+  assertEquals(response.status, 200);
+});
+
+test('a key with stray surrounding whitespace is trimmed and accepted', async () => {
+  const { apiKey } = await setupAppTest();
+  const app = authTestApp();
+  const response = await app.request('/v1beta/models/gemini-test:generateContent', {
+    method: 'POST',
+    headers: { 'x-goog-api-key': `  ${apiKey.key}  ` },
+  });
+  assertEquals(response.status, 200);
+});
+
+test('Authorization: Bearer with no value is rejected', async () => {
+  await setupAppTest();
+  const app = authTestApp();
+  const response = await app.request('/v1/chat/completions', {
+    method: 'POST',
+    headers: { authorization: 'Bearer ' },
+  });
+  assertEquals(response.status, 401);
+});


### PR DESCRIPTION
## Summary

Data-plane auth's `extractApiKey` (`packages/gateway/src/middleware/auth.ts`) pulls the API key through a `??` fallback chain: `?key=` → `x-api-key` → `x-goog-api-key` → `Authorization: Bearer`.

`??` only falls through on `null`/`undefined`, **not on an empty string `''`**. Hono's `c.req.header()` returns `''` (a string, not `undefined`) for a header that is present but empty. So any present-but-empty higher-priority source latches the chain onto `''` and shadows an otherwise-valid lower-priority credential. `''` is also falsy, so control reaches `if (!rawKey) return 401` and the request ends in **401 Unauthorized** — the real key is never looked up.

This is triggered by non-standard clients: e.g. Xcode's Claude agent custom-endpoint workaroud ([Xcode Claude Code integration with third-party APIs](https://gist.github.com/zoltan-magyar/be846eb36cf5ee33c882ef5f932b754b)) sends an empty `x-api-key` alongside a real `Authorization: Bearer xxxxx`, and the empty header shadows the Bearer token.

## Fix

- Add a local `presentOrUndefined` helper that normalizes present-but-empty / whitespace-only values to `undefined` (and trims), so the `??` chain skips blanks and falls through to the next real credential — and tolerates keys pasted with stray surrounding whitespace.
- Route every source in `extractApiKey` through the helper.
- Preserve the existing lenient behavior of accepting a bare key in `Authorization` (no `Bearer ` prefix); the session-token extraction is intentionally left unchanged (out of scope).

## Tests

Five regression cases added to `auth_test.ts`:

- empty `x-api-key` + valid Bearer → 200 (the primary regression, covering the Xcode case)
- empty `?key=` + valid `x-goog-api-key` → 200
- whitespace-only `x-api-key` → falls through to Bearer → 200
- key with stray surrounding whitespace → trimmed and accepted → 200
- `Authorization: Bearer ` (empty value) alone → still 401

## Verification

- `pnpm --filter @floway-dev/gateway exec vitest run src/middleware/auth_test.ts` → 10/10 pass
- `pnpm run test` → 3554/3554 pass
- `pnpm run lint` → pass
- `pnpm run typecheck` → pass
