### PR TITLE
fix(web): show zero-token models in token/cost usage charts

### DIFF
--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -406,13 +406,20 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
   const entries = groupKey === 'keyId'
     ? keyChartEntries([...presentGroups], keyMetadataForTokenRecords(allRecords, data.value?.keys ?? []), data.value?.keys.map(k => k.id) ?? [...presentGroups])
     : modelChartEntries([...presentGroups]);
-  // Cross-filtering can leave a group with all-zero (or, for percent metrics,
-  // all-null) values. Drop those datasets outright — legend entry and line both
-  // gone — instead of rendering an inert flat line. The own-dimension hidden set
-  // is a separate, restorable user toggle and keeps its struck-through entry.
+  // A group can hold all-zero (or, for percent metrics, all-null) values under
+  // the current metric for two distinct reasons, and requests tells them apart:
+  // cross-filtering that emptied the group leaves requests at zero too (details
+  // aggregate the same cross-filtered records), whereas a group with real but
+  // zero-token traffic — e.g. an upstream that reports no usage — still has
+  // requests > 0. Keep the latter as a flat line at zero so it stays visible in
+  // the token/cost views; drop the former outright, legend entry and line both
+  // gone, instead of rendering an inert line for a group with no activity. Own-
+  // dimension hidden groups are a separate, restorable toggle kept struck-through.
+  // Percent metrics stay null-only: a ratio over zero tokens is undefined.
+  const hasRequests = (id: string) => bucketKeys.some(k => (details.get(k)?.get(id)?.requests ?? 0) > 0);
   const datasetEntries = entries
     .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)?.get(entry.id) ?? (isPercent ? null : 0)) }))
-    .filter(({ data }) => isPercent ? data.some(v => v !== null) : data.some(v => v !== 0));
+    .filter(({ entry, data }) => isPercent ? data.some(v => v !== null) : (data.some(v => v !== 0) || hasRequests(entry.id)));
   const labelWidth = datasetEntries.reduce((max, { entry }) => Math.max(max, entry.label.length), 0);
   return {
     type: 'line',

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -416,7 +416,7 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
   // get routed to a private stack so they sit at the axis. Percent metrics
   // fold in for free: their divide-by-zero case already lands as null.
   const datasetEntries = entries
-    .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)?.get(entry.id) ?? null) }))
+    .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)!.get(entry.id) ?? null) }))
     .filter(({ data }) => data.some(v => v !== null));
   const labelWidth = datasetEntries.reduce((max, { entry }) => Math.max(max, entry.label.length), 0);
   return {
@@ -446,7 +446,7 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
           tension: 0.3,
           fill: isPercent || zeroLine ? false : 'stack',
           spanGaps: isPercent,
-          stack: zeroLine ? 'zero' : 'main',
+          stack: zeroLine ? 'axis' : 'main',
         };
       }),
     },

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -427,6 +427,13 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
       labels,
       datasets: datasetEntries.map(({ entry, data: datasetData }) => {
         const color = chartColor(entry.colorSlot);
+        // A dataset kept only because its group has real requests — every
+        // selected-metric value is zero — would, when stacked onto the series
+        // below it, ride invisibly along that series' top edge rather than sit
+        // at zero. Give it a private stack group and drop the fill so it draws
+        // as a flat, hoverable line pinned to the axis. It contributes nothing
+        // to the main stack, so pulling it out leaves the real totals untouched.
+        const zeroLine = !isPercent && !datasetData.some(v => v !== 0);
         return {
           label: entry.label,
           data: datasetData,
@@ -437,8 +444,9 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
           pointRadius: 2,
           pointHoverRadius: 5,
           tension: 0.3,
-          fill: isPercent ? false : 'stack',
+          fill: isPercent || zeroLine ? false : 'stack',
           spanGaps: isPercent,
+          stack: zeroLine ? `zero-${entry.id}` : 'main',
         };
       }),
     },
@@ -464,7 +472,16 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
           bodyColor: '#b0bec5',
           padding: 12,
           bodyFont: { family: chartFont.mono, size: 11 },
-          filter: item => item.parsed.y !== null && (isPercent || item.parsed.y > 0),
+          // Keep a zero-valued row when the group actually served requests in
+          // this bucket, so a zero-token model's hover still reports its
+          // requests/cost; drop rows that are zero because nothing happened.
+          filter: item => {
+            if (item.parsed.y === null) return false;
+            if (isPercent || item.parsed.y > 0) return true;
+            const bucket = bucketKeys[item.dataIndex];
+            const entry = datasetEntries[item.datasetIndex]?.entry;
+            return bucket !== undefined && entry !== undefined && (details.get(bucket)?.get(entry.id)?.requests ?? 0) > 0;
+          },
           itemSort: (a, b) => Number(b.parsed.y ?? 0) - Number(a.parsed.y ?? 0),
           callbacks: {
             beforeBody: items => items.length ? tooltipHeader(labelWidth) : [],

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -406,20 +406,18 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
   const entries = groupKey === 'keyId'
     ? keyChartEntries([...presentGroups], keyMetadataForTokenRecords(allRecords, data.value?.keys ?? []), data.value?.keys.map(k => k.id) ?? [...presentGroups])
     : modelChartEntries([...presentGroups]);
-  // A group can hold all-zero (or, for percent metrics, all-null) values under
-  // the current metric for two distinct reasons, and requests tells them apart:
-  // cross-filtering that emptied the group leaves requests at zero too (details
-  // aggregate the same cross-filtered records), whereas a group with real but
-  // zero-token traffic — e.g. an upstream that reports no usage — still has
-  // requests > 0. Keep the latter as a flat line at zero so it stays visible in
-  // the token/cost views; drop the former outright, legend entry and line both
-  // gone, instead of rendering an inert line for a group with no activity. Own-
-  // dimension hidden groups are a separate, restorable toggle kept struck-through.
-  // Percent metrics stay null-only: a ratio over zero tokens is undefined.
-  const hasRequests = (id: string) => bucketKeys.some(k => (details.get(k)?.get(id)?.requests ?? 0) > 0);
+  // Split the two indistinguishable-by-value cases at the data layer: `null`
+  // means the group had no record in this bucket (cross-filtered out or the
+  // group never served here), `0` means a real record whose selected-metric
+  // value is zero — e.g. a zero-token upstream that reports no usage. The
+  // rest of the pipeline leans on that split: `spanGaps: false` gaps the line
+  // at null, stacked scales skip null instead of piling zeros onto neighbors,
+  // the tooltip filter drops null while keeping zero, and zero-only datasets
+  // get routed to a private stack so they sit at the axis. Percent metrics
+  // fold in for free: their divide-by-zero case already lands as null.
   const datasetEntries = entries
-    .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)?.get(entry.id) ?? (isPercent ? null : 0)) }))
-    .filter(({ entry, data }) => isPercent ? data.some(v => v !== null) : (data.some(v => v !== 0) || hasRequests(entry.id)));
+    .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)?.get(entry.id) ?? null) }))
+    .filter(({ data }) => data.some(v => v !== null));
   const labelWidth = datasetEntries.reduce((max, { entry }) => Math.max(max, entry.label.length), 0);
   return {
     type: 'line',
@@ -427,13 +425,15 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
       labels,
       datasets: datasetEntries.map(({ entry, data: datasetData }) => {
         const color = chartColor(entry.colorSlot);
-        // A dataset kept only because its group has real requests — every
-        // selected-metric value is zero — would, when stacked onto the series
-        // below it, ride invisibly along that series' top edge rather than sit
-        // at zero. Give it a private stack group and drop the fill so it draws
-        // as a flat, hoverable line pinned to the axis. It contributes nothing
-        // to the main stack, so pulling it out leaves the real totals untouched.
-        const zeroLine = !isPercent && !datasetData.some(v => v !== 0);
+        // A group whose every non-null value is zero — typically a zero-token
+        // upstream — still needs a visible presence in the token/cost views.
+        // Left on the main stack, its flat line would ride the top edge of
+        // the series below it rather than sit at zero. Route it to a private
+        // stack with no fill so it draws as a flat line pinned to the axis
+        // and contributes nothing to the main stack, so real totals are
+        // unchanged. Percent metrics never take this branch: their zero-total
+        // case is already encoded as null.
+        const zeroLine = !isPercent && !datasetData.some(v => v !== null && v !== 0);
         return {
           label: entry.label,
           data: datasetData,
@@ -446,7 +446,7 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
           tension: 0.3,
           fill: isPercent || zeroLine ? false : 'stack',
           spanGaps: isPercent,
-          stack: zeroLine ? `zero-${entry.id}` : 'main',
+          stack: zeroLine ? 'zero' : 'main',
         };
       }),
     },
@@ -472,16 +472,10 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
           bodyColor: '#b0bec5',
           padding: 12,
           bodyFont: { family: chartFont.mono, size: 11 },
-          // Keep a zero-valued row when the group actually served requests in
-          // this bucket, so a zero-token model's hover still reports its
-          // requests/cost; drop rows that are zero because nothing happened.
-          filter: item => {
-            if (item.parsed.y === null) return false;
-            if (isPercent || item.parsed.y > 0) return true;
-            const bucket = bucketKeys[item.dataIndex];
-            const entry = datasetEntries[item.datasetIndex]?.entry;
-            return bucket !== undefined && entry !== undefined && (details.get(bucket)?.get(entry.id)?.requests ?? 0) > 0;
-          },
+          // Null = no record in this bucket (dropped). Zero = a real record
+          // whose metric value is zero (kept, so a zero-token upstream's
+          // hover still reports its requests/cost).
+          filter: item => item.parsed.y !== null,
           itemSort: (a, b) => Number(b.parsed.y ?? 0) - Number(a.parsed.y ?? 0),
           callbacks: {
             beforeBody: items => items.length ? tooltipHeader(labelWidth) : [],

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -406,18 +406,28 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
   const entries = groupKey === 'keyId'
     ? keyChartEntries([...presentGroups], keyMetadataForTokenRecords(allRecords, data.value?.keys ?? []), data.value?.keys.map(k => k.id) ?? [...presentGroups])
     : modelChartEntries([...presentGroups]);
-  // Split the two indistinguishable-by-value cases at the data layer: `null`
-  // means the group had no record in this bucket (cross-filtered out or the
-  // group never served here), `0` means a real record whose selected-metric
-  // value is zero — e.g. a zero-token upstream that reports no usage. The
-  // rest of the pipeline leans on that split: `spanGaps: false` gaps the line
-  // at null, stacked scales skip null instead of piling zeros onto neighbors,
-  // the tooltip filter drops null while keeping zero, and zero-only datasets
-  // get routed to a private stack so they sit at the axis. Percent metrics
-  // fold in for free: their divide-by-zero case already lands as null.
+  // A group can hold all-zero (or, for percent metrics, all-null) values under
+  // the current metric for two distinct reasons, and requests tells them apart:
+  // cross-filtering that emptied the group leaves requests at zero too (details
+  // aggregate the same cross-filtered records), whereas a group with real but
+  // zero-token traffic — e.g. an upstream that reports no usage — still has
+  // requests > 0. Keep the latter as a flat line at zero so it stays visible in
+  // the token/cost views; drop the former outright, legend entry and line both
+  // gone, instead of rendering an inert line for a group with no activity. Own-
+  // dimension hidden groups are a separate, restorable toggle kept struck-through.
+  // Percent metrics stay null-only: a ratio over zero tokens is undefined.
+  //
+  // Non-percent buckets fall back to `0` (not `null`) so every dataset carries
+  // a numeric value at every index — stacked line rendering then accumulates
+  // correctly and every series draws a continuous line all the way across the
+  // axis, edges included. `spanGaps` only stitches internal gaps, so leaving
+  // nulls in would leave the leading and trailing "no record" buckets unlit.
+  // The tooltip filter reaches back into `details.requests` to distinguish a
+  // synthesized 0 from a real zero-token record.
+  const hasRequests = (id: string) => bucketKeys.some(k => (details.get(k)?.get(id)?.requests ?? 0) > 0);
   const datasetEntries = entries
-    .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)!.get(entry.id) ?? null) }))
-    .filter(({ data }) => data.some(v => v !== null));
+    .map(entry => ({ entry, data: bucketKeys.map(k => values.get(k)!.get(entry.id) ?? (isPercent ? null : 0)) }))
+    .filter(({ entry, data }) => isPercent ? data.some(v => v !== null) : (data.some(v => v !== 0) || hasRequests(entry.id)));
   const labelWidth = datasetEntries.reduce((max, { entry }) => Math.max(max, entry.label.length), 0);
   return {
     type: 'line',
@@ -425,15 +435,13 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
       labels,
       datasets: datasetEntries.map(({ entry, data: datasetData }) => {
         const color = chartColor(entry.colorSlot);
-        // A group whose every non-null value is zero — typically a zero-token
-        // upstream — still needs a visible presence in the token/cost views.
-        // Left on the main stack, its flat line would ride the top edge of
-        // the series below it rather than sit at zero. Route it to a private
-        // stack with no fill so it draws as a flat line pinned to the axis
-        // and contributes nothing to the main stack, so real totals are
-        // unchanged. Percent metrics never take this branch: their zero-total
-        // case is already encoded as null.
-        const zeroLine = !isPercent && !datasetData.some(v => v !== null && v !== 0);
+        // A dataset kept only because its group has real requests — every
+        // selected-metric value is zero — would, when stacked onto the series
+        // below it, ride invisibly along that series' top edge rather than sit
+        // at zero. Give it a private stack group and drop the fill so it draws
+        // as a flat, hoverable line pinned to the axis. It contributes nothing
+        // to the main stack, so pulling it out leaves the real totals untouched.
+        const zeroLine = !isPercent && !datasetData.some(v => v !== 0);
         return {
           label: entry.label,
           data: datasetData,
@@ -447,6 +455,10 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
           fill: isPercent || zeroLine ? false : 'stack',
           spanGaps: isPercent,
           stack: zeroLine ? 'axis' : 'main',
+          // Zero-line series draw at y=0 and get painted over by any main-stack
+          // area whose bottom sits at the axis; render them last (lower `order`
+          // = drawn on top) so their flat line and points stay visible.
+          order: zeroLine ? -1 : 0,
         };
       }),
     },
@@ -472,10 +484,19 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
           bodyColor: '#b0bec5',
           padding: 12,
           bodyFont: { family: chartFont.mono, size: 11 },
-          // Null = no record in this bucket (dropped). Zero = a real record
-          // whose metric value is zero (kept, so a zero-token upstream's
-          // hover still reports its requests/cost).
-          filter: item => item.parsed.y !== null,
+          // Null y = no record in this bucket (dropped). A stacked-dataset zero
+          // may be either a real zero-token record or a synthesized fill for a
+          // no-record bucket — the latter must not appear in the tooltip, so
+          // reach back into `details.requests` to keep only rows where the
+          // group actually served requests.
+          filter: item => {
+            if (item.parsed.y === null) return false;
+            if (isPercent || item.parsed.y > 0) return true;
+            const bucket = bucketKeys[item.dataIndex];
+            const entry = datasetEntries[item.datasetIndex]?.entry;
+            return bucket !== undefined && entry !== undefined
+              && (details.get(bucket)?.get(entry.id)?.requests ?? 0) > 0;
+          },
           itemSort: (a, b) => Number(b.parsed.y ?? 0) - Number(a.parsed.y ?? 0),
           callbacks: {
             beforeBody: items => items.length ? tooltipHeader(labelWidth) : [],


### PR DESCRIPTION
## Summary

An upstream provider can produce requests that record no usage — every token dimension and cost stored as `0` — while still incrementing the request count. Such a model appeared in the **Requests** view of the usage charts but vanished from the token/cost views (e.g. the default **Total Tokens** view), making it look as if the model had no activity at all.

The data does distinguish the two cases: a model with real-but-zero-token traffic keeps `requests > 0`, whereas a model with genuinely no usage never appears in the records at all. A group emptied purely by cross-filtering also drops to zero requests, since requests aggregate the same cross-filtered records.

## Changes

- Keep a model in the token/cost (non-percent) charts when its selected-metric values are all zero but the group served requests in the range. Cross-filter-emptied groups (requests also zero) are still dropped, so no inert flat lines appear for genuinely absent activity.
- Render such a zero-token series as a flat, hoverable line pinned at zero: give it its own stack group with no fill so it no longer rides invisibly along the top edge of the series stacked below it. It contributes nothing to
  the main stack, so real totals are unchanged.
- Relax the tooltip filter to keep a zero-valued row whenever the group actually served requests in that bucket, so hovering a zero-token model still reports its requests/cost.

Percent metrics (cache hit / cached rate) are unchanged: a ratio over zero tokens is undefined, so those models stay excluded there.

## Renderer constraint

The initial fix substituted `?? 0` at the aggregate map. A subsequent refactor (e0f8b83e, ef9f82e4) swapped that for `?? null` to preserve a data-layer distinction between "no record in this bucket" and "real zero-token record"; a follow-up (1ae1dfc1) folds `?? 0` back for non-percent metrics because chart.js's stacked line renderer needs a numeric value at every index — under `y.stacked: true` a null pulls neighbors down to the axis instead of stacking on top of the running total, `spanGaps: false` gaps the line and its area fill collapses to the axis, and `spanGaps: true` stitches internal nulls but does not extend the line past the first or last non-null point, leaving leading and trailing "no record" buckets unlit. The `no-record vs real-zero` signal survives via the tooltip filter and dataset filter reading `details.requests` directly.

Two small pieces of the refactor stay on merit — a `!` type assertion (the aggregate map pre-populates the outer entry per bucketKey) and a shared `stack: 'axis'` group for every zero-line dataset (each contributes 0 to its stack, so a single shared stack renders identically). The shared stack needs one guardrail: `order: -1` on zero-line datasets, so the axis-level flat line paints on top of any main-stack area whose bottom sits at `y=0` instead of relying on per-stack draw ordering that the shared group loses.

## Verification

- `pnpm --filter @floway-dev/web run typecheck` and `eslint` pass.
- Manually verified in the dashboard against a mocked zero-token model: it now appears in the Total Tokens and Input Tokens views as a flat line at zero spanning the full x-axis (including leading/trailing "no record" buckets), and hovering its bucket shows `Req N, Cost $0, Total 0`. A sparsely-sampled non-zero model renders as one continuous stacked series across the whole axis, not disjoint fill lobes. Tooltip hovering a no-record bucket shows no phantom row for either kind of series.
