### PR TITLE
feat(web): add chart series selection controls

### DIFF
--- a/apps/web/src/components/charts/ChartSeriesControls.vue
+++ b/apps/web/src/components/charts/ChartSeriesControls.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { SeriesSelectionAction } from './series-selection.ts';
+
+defineProps<{
+  label: string;
+}>();
+
+const emit = defineEmits<{
+  select: [action: SeriesSelectionAction];
+}>();
+
+const buttonClass = 'shrink-0 rounded px-2 py-1 text-[11px] font-medium text-gray-500 transition-colors hover:bg-white/[0.06] hover:text-gray-300';
+</script>
+
+<template>
+  <div class="inline-flex items-center gap-1.5" :aria-label="label">
+    <span class="text-[11px] font-medium text-gray-500">Select</span>
+    <div class="inline-flex items-center gap-0.5 rounded-md border border-white/[0.06] bg-surface-800/70 p-0.5">
+      <button type="button" :class="buttonClass" @click="emit('select', 'all')">All</button>
+      <button type="button" :class="buttonClass" @click="emit('select', 'invert')">Invert</button>
+      <button type="button" :class="buttonClass" @click="emit('select', 'none')">None</button>
+    </div>
+  </div>
+</template>

--- a/apps/web/src/components/charts/series-selection.ts
+++ b/apps/web/src/components/charts/series-selection.ts
@@ -1,0 +1,64 @@
+import type { ChartConfiguration } from 'chart.js/auto';
+
+export interface SeriesTaggedDataset {
+  seriesId?: string;
+}
+
+export type SeriesSelectionAction = 'all' | 'invert' | 'none';
+
+export const chartSeriesIds = (config: ChartConfiguration<'line'>): string[] => config.data.datasets
+  .map(dataset => (dataset as SeriesTaggedDataset).seriesId)
+  .filter((id): id is string => typeof id === 'string');
+
+export const datasetSeriesIds = (datasets: readonly unknown[]): string[] => datasets
+  .map(dataset => (dataset as SeriesTaggedDataset).seriesId)
+  .filter((id): id is string => typeof id === 'string');
+
+export const chartEventsWithDoubleClick: (keyof HTMLElementEventMap)[] = ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove', 'dblclick'];
+
+export const applySeriesSelection = (hidden: Set<string>, ids: readonly string[], action: SeriesSelectionAction) => {
+  if (action === 'all') {
+    hidden.clear();
+    return;
+  }
+  const nextHidden = action === 'none' ? ids : ids.filter(id => !hidden.has(id));
+  hidden.clear();
+  for (const id of nextHidden) hidden.add(id);
+};
+
+const activeSeriesIds = (hidden: Set<string>, ids: readonly string[]): string[] => ids.filter(id => !hidden.has(id));
+
+export class SeriesIsolationController {
+  private exitCandidate: string | null = null;
+
+  toggle(hidden: Set<string>, id: string) {
+    if (this.exitCandidate !== id) this.exitCandidate = null;
+    if (hidden.has(id)) hidden.delete(id);
+    else hidden.add(id);
+  }
+
+  isolateOrSelectAll(hidden: Set<string>, ids: readonly string[], id: string) {
+    const active = activeSeriesIds(hidden, ids);
+    if ((active.length === 1 && active[0] === id) || this.exitCandidate === id) {
+      hidden.clear();
+      this.exitCandidate = null;
+      return;
+    }
+    hidden.clear();
+    for (const seriesId of ids) if (seriesId !== id) hidden.add(seriesId);
+    this.exitCandidate = id;
+  }
+}
+
+export const handleLegendClick = (
+  event: { native?: Event | null },
+  controller: SeriesIsolationController,
+  hidden: Set<string>,
+  ids: readonly string[],
+  id: string,
+) => {
+  const native = event.native;
+  if (native instanceof MouseEvent && native.shiftKey) controller.isolateOrSelectAll(hidden, ids, id);
+  else if (native instanceof MouseEvent && (native.detail & 1) === 0) controller.isolateOrSelectAll(hidden, ids, id);
+  else controller.toggle(hidden, id);
+};

--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -7,7 +7,9 @@ import { computed, ref, watch, watchEffect } from 'vue';
 
 import { callApi, useApi } from '../../api/client.ts';
 import ChartCanvas from '../../components/charts/ChartCanvas.vue';
+import ChartSeriesControls from '../../components/charts/ChartSeriesControls.vue';
 import { chartColor, chartFont, chartXAxisTick, dashboardBuckets, dashboardRangeQuery, type DashboardRange } from '../../components/charts/dashboard-chart.ts';
+import { applySeriesSelection, chartEventsWithDoubleClick, chartSeriesIds, datasetSeriesIds, handleLegendClick, SeriesIsolationController, type SeriesTaggedDataset } from '../../components/charts/series-selection.ts';
 import { useAuthStore } from '../../stores/auth.ts';
 import { OverlayScrollbars, Spinner } from '@floway-dev/ui';
 
@@ -67,6 +69,7 @@ const performanceChartView = ref<ChartView>('model');
 const performancePercentile = ref<PercentileKey>('p95Ms');
 const performanceModel = ref<string>('');
 const performanceView = ref<PerformanceView>(initialOverview.data.value.view);
+const hiddenPerformanceSeries = ref(new Set<string>());
 
 const overview = ref<PerformanceOverviewResponse>(initialOverview.data.value.overview);
 const performanceError = ref<string | null>(initialOverview.data.value.error);
@@ -113,6 +116,8 @@ watchEffect(() => {
   if (!options.includes(performanceModel.value)) performanceModel.value = options[0]!;
 });
 
+const performanceSeriesController = new SeriesIsolationController();
+
 const formatDuration = (ms: number | null) => {
   if (ms === null) return '—';
   if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)}m`;
@@ -135,6 +140,8 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
           const color = chartColor(i);
           return {
             label: group,
+            seriesId: group,
+            hidden: hiddenPerformanceSeries.value.has(group),
             data: bucketKeys.map(k => byBucket.get(k) ?? null),
             borderColor: color,
             backgroundColor: `${color}25`,
@@ -152,6 +159,8 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
         const color = chartColor(i);
         return {
           label: p.replace('Ms', ''),
+          seriesId: p,
+          hidden: hiddenPerformanceSeries.value.has(p),
           data: bucketKeys.map(k => byBucket.get(k) ?? null),
           borderColor: color,
           backgroundColor: `${color}25`,
@@ -172,6 +181,7 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
     type: 'line',
     data: { labels, datasets },
     options: {
+      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
@@ -180,6 +190,10 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
+          onClick: (event, legendItem) => {
+            const dataset = datasets[legendItem.datasetIndex ?? -1] as SeriesTaggedDataset | undefined;
+            if (dataset?.seriesId) handleLegendClick(event, performanceSeriesController, hiddenPerformanceSeries.value, datasetSeriesIds(datasets), dataset.seriesId);
+          },
         },
         tooltip: {
           backgroundColor: 'rgba(12,16,21,0.95)',
@@ -217,6 +231,8 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
     },
   };
 });
+
+const performanceSeriesIds = computed(() => chartSeriesIds(chartConfig.value));
 
 const performanceSummary = computed(() => {
   const row = overview.value.summaryRows[0];
@@ -373,6 +389,9 @@ const performanceSummary = computed(() => {
         </div>
       </div>
 
+      <div class="mb-2 flex justify-end">
+        <ChartSeriesControls label="Performance series selection" @select="applySeriesSelection(hiddenPerformanceSeries, performanceSeriesIds, $event)" />
+      </div>
       <div style="height: 340px; position: relative;">
         <ChartCanvas :config="chartConfig" />
       </div>

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -8,7 +8,9 @@ import { computed, ref, watch } from 'vue';
 import { callApi, useApi, type ApiClient } from '../../api/client.ts';
 import type { BillingDimension } from '../../api/types.ts';
 import ChartCanvas from '../../components/charts/ChartCanvas.vue';
+import ChartSeriesControls from '../../components/charts/ChartSeriesControls.vue';
 import { bucketKeyForUtcHour, chartColor, chartFont, chartXAxisTick, dashboardBuckets, dashboardRangeQuery, type DashboardRange } from '../../components/charts/dashboard-chart.ts';
+import { applySeriesSelection, chartEventsWithDoubleClick, chartSeriesIds, handleLegendClick, SeriesIsolationController } from '../../components/charts/series-selection.ts';
 import UsageSummaryMetric from '../../components/usage/UsageSummaryMetric.vue';
 import { useModelsStore } from '../../composables/useModels.ts';
 import { useAuthStore } from '../../stores/auth.ts';
@@ -142,11 +144,6 @@ let usageRequestId = 0;
 const hiddenKeys = ref(new Set<string>());
 const hiddenModels = ref(new Set<string>());
 
-const toggleHidden = (set: Set<string>, id: string) => {
-  if (set.has(id)) set.delete(id);
-  else set.add(id);
-};
-
 const load = async () => {
   const requestId = ++usageRequestId;
   const requestedRange = tokenRange.value;
@@ -274,6 +271,10 @@ interface ChartEntry {
   label: string;
   colorSlot: number;
 }
+
+const keySeriesController = new SeriesIsolationController();
+const modelSeriesController = new SeriesIsolationController();
+const searchSeriesController = new SeriesIsolationController();
 
 const keyChartEntries = (
   presentKeyIds: readonly string[],
@@ -422,6 +423,7 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
         const color = chartColor(entry.colorSlot);
         return {
           label: entry.label,
+          seriesId: entry.id,
           data: datasetData,
           hidden: ownHidden.value.has(entry.id),
           borderColor: color,
@@ -436,6 +438,7 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
       }),
     },
     options: {
+      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
@@ -444,9 +447,10 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
-          onClick: (_event, legendItem) => {
+          onClick: (event, legendItem) => {
             const entry = datasetEntries[legendItem.datasetIndex ?? -1]?.entry;
-            if (entry) toggleHidden(ownHidden.value, entry.id);
+            const controller = groupKey === 'keyId' ? keySeriesController : modelSeriesController;
+            if (entry) handleLegendClick(event, controller, ownHidden.value, datasetEntries.map(({ entry }) => entry.id), entry.id);
           },
         },
         tooltip: {
@@ -494,6 +498,8 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
 
 const byKeyConfig = computed(() => buildStackedConfig('keyId'));
 const byModelConfig = computed(() => buildStackedConfig('model'));
+const byKeySeriesIds = computed(() => chartSeriesIds(byKeyConfig.value));
+const byModelSeriesIds = computed(() => chartSeriesIds(byModelConfig.value));
 
 const searchUsageActiveProvider = computed(() => {
   return searchData.value?.activeProvider ?? 'disabled';
@@ -525,6 +531,7 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
         const color = chartColor(entry.colorSlot);
         return {
           label: entry.label,
+          seriesId: entry.id,
           data: bucketKeys.map(k => groups.get(entry.id)?.get(k) ?? 0),
           hidden: hiddenKeys.value.has(entry.id),
           borderColor: color,
@@ -539,6 +546,7 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
       }),
     },
     options: {
+      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
@@ -547,9 +555,9 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
-          onClick: (_event, legendItem) => {
+          onClick: (event, legendItem) => {
             const entry = entries[legendItem.datasetIndex ?? -1];
-            if (entry) toggleHidden(hiddenKeys.value, entry.id);
+            if (entry) handleLegendClick(event, searchSeriesController, hiddenKeys.value, entries.map(entry => entry.id), entry.id);
           },
         },
         tooltip: {
@@ -571,6 +579,8 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
     },
   };
 });
+
+const searchByKeySeriesIds = computed(() => chartSeriesIds(searchByKeyConfig.value));
 
 const formatCost = (v: number) => {
   if (v >= 1) return `$${v.toFixed(2)}`;
@@ -635,12 +645,18 @@ const formatCost = (v: number) => {
         </OverlayScrollbars>
       </div>
 
+      <div class="mb-2 flex justify-end">
+        <ChartSeriesControls label="Token usage series selection" @select="applySeriesSelection(hiddenKeys, byKeySeriesIds, $event)" />
+      </div>
       <div style="height: 320px; position: relative;">
         <ChartCanvas :config="byKeyConfig" />
       </div>
 
       <div class="mt-6 pt-5 border-t border-white/5">
-        <span class="text-xs font-medium text-gray-500 uppercase tracking-widest mb-4 block">By Model</span>
+        <div class="mb-4 flex items-center justify-between gap-3">
+          <span class="text-xs font-medium text-gray-500 uppercase tracking-widest block">By Model</span>
+          <ChartSeriesControls label="Model usage series selection" @select="applySeriesSelection(hiddenModels, byModelSeriesIds, $event)" />
+        </div>
         <div style="height: 320px; position: relative;">
           <ChartCanvas :config="byModelConfig" />
         </div>
@@ -670,9 +686,12 @@ const formatCost = (v: number) => {
       </div>
 
       <div v-if="searchUsageActiveProvider !== 'disabled'" class="mt-6 pt-5 border-t border-white/5">
-        <div class="flex items-center gap-3 mb-4">
-          <span class="text-xs font-medium text-gray-500 uppercase tracking-widest block">Search Usage</span>
-          <Spinner v-if="searchUsageLoading" class="h-3.5 w-3.5 text-gray-500" />
+        <div class="flex items-center justify-between gap-3 mb-4">
+          <div class="flex items-center gap-3">
+            <span class="text-xs font-medium text-gray-500 uppercase tracking-widest block">Search Usage</span>
+            <Spinner v-if="searchUsageLoading" class="h-3.5 w-3.5 text-gray-500" />
+          </div>
+          <ChartSeriesControls label="Search usage series selection" @select="applySeriesSelection(hiddenKeys, searchByKeySeriesIds, $event)" />
         </div>
         <div style="height: 320px; position: relative;">
           <ChartCanvas :config="searchByKeyConfig" />


### PR DESCRIPTION
This commit adds two new ways to interact with the Usage and Performance charts:
* “Select All / Invert / None” buttons.
* Double-click or shift-click a legend to show a specific series only. If that legend is the only active one, the same gesture exits show-only mode.

This pull request supersedes #138.

## Test plan

* [x] Create at least 3 users. Import at least 3 models. For the admin user, create at least 3 API keys.
* [x] Import mock Usage and Performance data to the database, or, use real-world data if available.
* [x] Verify the behavior of the “Select All / Invert / None” buttons by clicking each button after manually activating some legends.

Then, verify the shift-click and double-click behaviors:
* [x] Shift-click legend A to verify only series A is active.
* [x] Shift-click legend B to verity only series B is active.
* [x] Shift-click legend B again to verify all series are active.
* [x] Manually deselect all legends and select only legend C.
* [x] Shift-click legend C to verify all series are active.
* [x] Repeatedly shift-click a single legend multiple times to verify the correct toggle behavior.
* [x] Repeat the same tests using “double-click” instead of “shift-click.”
* [x] On a mobile device or a touchscreen device, repeat the same tests using “double-tap.”

Repeat the whole test on every Usage and Performance chart.