### PR TITLE
fix(web): keep performance chart legend filter across poll refresh

### DIFF
--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -73,6 +73,18 @@ const performanceError = ref<string | null>(initialOverview.data.value.error);
 const performanceLoading = ref(false);
 let performanceRequestId = 0;
 
+// Hidden-series state lives here, keyed by stable dataset label (model name in
+// the By-Model view; p50/p95/p99 in the By-Percentile view), so a legend toggle
+// survives the 60s poll. Chart.js's default legend stores visibility in its
+// internal per-dataset meta, which is discarded when `load()` rebuilds the
+// config with fresh dataset objects; re-deriving `hidden` from this Set instead
+// keeps the toggle stable across refreshes.
+const hiddenSeries = ref(new Set<string>());
+const toggleHiddenSeries = (label: string) => {
+  if (hiddenSeries.value.has(label)) hiddenSeries.value.delete(label);
+  else hiddenSeries.value.add(label);
+};
+
 const load = async () => {
   const requestId = ++performanceRequestId;
   const requestedRange = performanceRange.value;
@@ -136,6 +148,7 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
           return {
             label: group,
             data: bucketKeys.map(k => byBucket.get(k) ?? null),
+            hidden: hiddenSeries.value.has(group),
             borderColor: color,
             backgroundColor: `${color}25`,
             borderWidth: 2,
@@ -150,9 +163,11 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
     : (['p50Ms', 'p95Ms', 'p99Ms'] as PercentileKey[]).map((p, i) => {
         const byBucket = new Map(overview.value.series.filter(r => r.group === performanceModel.value).map(r => [r.bucket, r[p]]));
         const color = chartColor(i);
+        const label = p.replace('Ms', '');
         return {
-          label: p.replace('Ms', ''),
+          label,
           data: bucketKeys.map(k => byBucket.get(k) ?? null),
+          hidden: hiddenSeries.value.has(label),
           borderColor: color,
           backgroundColor: `${color}25`,
           borderWidth: 2,
@@ -180,6 +195,10 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
+          onClick: (_event, legendItem) => {
+            const label = datasets[legendItem.datasetIndex ?? -1]?.label;
+            if (label !== undefined) toggleHiddenSeries(label);
+          },
         },
         tooltip: {
           backgroundColor: 'rgba(12,16,21,0.95)',

--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -73,16 +73,19 @@ const performanceError = ref<string | null>(initialOverview.data.value.error);
 const performanceLoading = ref(false);
 let performanceRequestId = 0;
 
-// Hidden-series state lives here, keyed by stable dataset label (model name in
-// the By-Model view; p50/p95/p99 in the By-Percentile view), so a legend toggle
-// survives the 60s poll. Chart.js's default legend stores visibility in its
-// internal per-dataset meta, which is discarded when `load()` rebuilds the
-// config with fresh dataset objects; re-deriving `hidden` from this Set instead
-// keeps the toggle stable across refreshes.
+// Hidden-series state lives here, keyed by chart view plus stable dataset label
+// (`model:<name>` in the By-Model view; `percentile:<p>` in the By-Percentile
+// view), so a legend toggle survives the 60s poll and the range/scope/data-view
+// switches that also go through `load()`. Chart.js's default legend stores
+// visibility in its internal per-dataset meta, which is discarded when `load()`
+// rebuilds the config with fresh dataset objects; re-deriving `hidden` from this
+// Set instead keeps the toggle stable. Namespacing by chart view keeps the two
+// views' toggles independent and avoids a model named e.g. `p95` colliding with
+// the percentile line of the same name.
 const hiddenSeries = ref(new Set<string>());
-const toggleHiddenSeries = (label: string) => {
-  if (hiddenSeries.value.has(label)) hiddenSeries.value.delete(label);
-  else hiddenSeries.value.add(label);
+const toggleHiddenSeries = (key: string) => {
+  if (hiddenSeries.value.has(key)) hiddenSeries.value.delete(key);
+  else hiddenSeries.value.add(key);
 };
 
 const load = async () => {
@@ -134,6 +137,7 @@ const formatDuration = (ms: number | null) => {
 
 const chartConfig = computed<ChartConfiguration<'line'>>(() => {
   const { keys: bucketKeys, labels } = dashboardBuckets(loadedPerformanceRange.value, loadedAt.value);
+  const seriesKey = (label: string) => `${performanceChartView.value}:${label}`;
 
   const datasets = performanceChartView.value === 'model'
     ? (() => {
@@ -148,7 +152,7 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
           return {
             label: group,
             data: bucketKeys.map(k => byBucket.get(k) ?? null),
-            hidden: hiddenSeries.value.has(group),
+            hidden: hiddenSeries.value.has(seriesKey(group)),
             borderColor: color,
             backgroundColor: `${color}25`,
             borderWidth: 2,
@@ -167,7 +171,7 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
         return {
           label,
           data: bucketKeys.map(k => byBucket.get(k) ?? null),
-          hidden: hiddenSeries.value.has(label),
+          hidden: hiddenSeries.value.has(seriesKey(label)),
           borderColor: color,
           backgroundColor: `${color}25`,
           borderWidth: 2,
@@ -197,7 +201,7 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
           onClick: (_event, legendItem) => {
             const label = datasets[legendItem.datasetIndex ?? -1]?.label;
-            if (label !== undefined) toggleHiddenSeries(label);
+            if (label !== undefined) toggleHiddenSeries(seriesKey(label));
           },
         },
         tooltip: {


### PR DESCRIPTION
## Problem

On the dashboard **Performance** page, the chart auto-refreshes every 60s. After each refresh, any series the user had toggled off via the chart legend reappears — the legend filter resets. The **Usage** page does not have this bug.

## Root cause

The Performance legend used Chart.js's default `onClick`, which stores hidden-series visibility only inside Chart.js's internal per-`datasetIndex` meta — never in a Vue ref.

The 60s poll (`useIntervalFn` → `load()`) reassigns `overview.value`, recomputing `chartConfig` into a brand-new config with **fresh dataset objects**. `ChartCanvas` then runs `chart.data = next.data; chart.update('none')`. Chart.js matches metasets by dataset **object identity**, so the new objects get fresh metas with `hidden: null` and the legend toggle is discarded → every series becomes visible again.

The Usage page avoids this by lifting hidden state into refs, overriding `legend.onClick`, and re-deriving `dataset.hidden` from that state on every rebuild.

## Fix

Mirror the proven Usage-page pattern in `performance.vue`:

- Hold hidden-series state in a reactive `Set`.
- Add a custom `legend.onClick` that toggles the set.
- Re-derive each dataset's `hidden` from the set on every config rebuild.

The set is keyed by chart view plus label (`model:<name>` / `percentile:<p>`), so the By-Model and By-Percentile toggles stay independent and a model named e.g. `p95` cannot collide with the percentile line of the same name. The filter now survives the 60s poll as well as the range / scope / data-view switches that also go through `load()`.

## Verification

- `pnpm --filter @floway-dev/web run typecheck` ✅
- `pnpm run lint` ✅