### PR TITLE
feat(docker): add Podman Quadlet units for systemd deployment

### DIFF
--- a/docker/systemd/README.md
+++ b/docker/systemd/README.md
@@ -1,0 +1,46 @@
+# Podman Quadlet (systemd) configurations
+
+Podman Quadlets allow you to manage containers as native systemd services. These configuration files allow you to deploy and auto-start Floway using systemd.
+
+## Rootless installation
+
+1. Install [Podman](https://podman.io).
+
+   Podman should be preinstalled on Red Hat systems, and can be installed on-demand on other systems.
+
+2. ```bash
+   mkdir -p ~/.config/containers/systemd/
+   cp floway-data.volume floway-server.container.example floway-web.container floway.pod ~/.config/containers/systemd/
+   ```
+
+3. Edit `~/.config/containers/systemd/floway-server.container.example` by replacing `<admin-secret>` with your desired admin key.
+
+4. ```bash
+   mv ~/.config/containers/systemd/floway-server.container.example ~/.config/containers/systemd/floway-server.container
+   loginctl enable-linger
+   systemctl --user daemon-reload
+   systemctl --user restart floway-server floway-web
+   ```
+
+5. Floway should be available at `http://localhost:18088`.
+
+## Root installation
+
+1. Install [Podman](https://podman.io).
+
+   Podman should be preinstalled on Red Hat systems, and can be installed on-demand on other systems.
+
+2. ```bash
+   sudo mkdir -p /etc/containers/systemd/
+   sudo cp floway-data.volume floway-server.container.example floway-web.container floway.pod /etc/containers/systemd/
+   ```
+
+3. Edit `/etc/containers/systemd/floway-server.container.example` by replacing `<admin-secret>` with your desired admin key.
+
+4. ```bash
+   sudo mv /etc/containers/systemd/floway-server.container.example /etc/containers/systemd/floway-server.container
+   sudo systemctl daemon-reload
+   sudo systemctl restart floway-server floway-web
+   ```
+
+5. Floway should be available at `http://localhost:18088`.

--- a/docker/systemd/floway-data.volume
+++ b/docker/systemd/floway-data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=floway-data

--- a/docker/systemd/floway-server.container.example
+++ b/docker/systemd/floway-server.container.example
@@ -1,0 +1,19 @@
+[Container]
+ContainerName=floway-server
+Environment="ADMIN_KEY=<admin-secret>" FLOWAY_DB_PATH=/data/floway.db FLOWAY_FILES_DIR=/data/files PORT=8788 RUNTIME_LOCATION=LOCAL
+HealthCmd=["node", "-e", "fetch('http://127.0.0.1:8788/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+HealthInterval=10s
+HealthOnFailure=stop
+HealthRetries=12
+HealthStartPeriod=15s
+HealthTimeout=5s
+Image=ghcr.io/menci/floway-server:latest
+Mount=type=volume,source=floway-data.volume,destination=/data
+Notify=healthy
+Pod=floway.pod
+
+# Auto-update
+Pull=newer
+
+[Service]
+Restart=always

--- a/docker/systemd/floway-web.container
+++ b/docker/systemd/floway-web.container
@@ -1,0 +1,18 @@
+[Unit]
+After=floway-server.service
+Requires=floway-server.service
+
+[Container]
+ContainerName=floway-web
+Image=ghcr.io/menci/floway-web:latest
+Pod=floway.pod
+
+# Auto-update
+Pull=newer
+
+[Service]
+Restart=always
+
+[Install]
+# Auto-start
+WantedBy=default.target

--- a/docker/systemd/floway.pod
+++ b/docker/systemd/floway.pod
@@ -1,0 +1,11 @@
+[Pod]
+AddHost=server:127.0.0.1
+
+# If you need to access host services (like Ollama on the host):
+AddHost=host.containers.internal:host-gateway
+
+# floway-server
+#PublishPort=8788:8788
+
+# floway-web
+PublishPort=18088:80


### PR DESCRIPTION
Podman Quadlets allow you to manage containers as native systemd services. These configuration files allow you to deploy and auto-start Floway using systemd.

By the way, Podman Quadlet is also recommended by [Open WebUI](https://docs.openwebui.com/getting-started/quick-start) as the preferred way for local deployment on systemd systems.