### PR TITLE
feat(web): expand chart legend series selection across dashboard

### DIFF
--- a/apps/web/src/components/charts/ChartSeriesControls.vue
+++ b/apps/web/src/components/charts/ChartSeriesControls.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import type { SeriesSelectionAction } from './series-selection.ts';
+
+defineProps<{
+  label: string;
+}>();
+
+const emit = defineEmits<{
+  select: [action: SeriesSelectionAction];
+}>();
+
+const buttonClass = 'shrink-0 rounded px-2 py-1 text-[11px] font-medium text-gray-500 transition-colors hover:bg-white/[0.06] hover:text-gray-300';
+</script>
+
+<template>
+  <div class="inline-flex items-center gap-1.5" :aria-label="label">
+    <span class="text-[11px] font-medium text-gray-500">Select</span>
+    <div class="inline-flex items-center gap-0.5 rounded-md border border-white/[0.06] bg-surface-800/70 p-0.5">
+      <button type="button" :class="buttonClass" @click="emit('select', 'all')">All</button>
+      <button type="button" :class="buttonClass" @click="emit('select', 'invert')">Invert</button>
+      <button type="button" :class="buttonClass" @click="emit('select', 'none')">None</button>
+    </div>
+  </div>
+</template>

--- a/apps/web/src/components/charts/series-selection.ts
+++ b/apps/web/src/components/charts/series-selection.ts
@@ -1,0 +1,57 @@
+import type { ChartConfiguration } from 'chart.js/auto';
+
+export type SeriesSelectionAction = 'all' | 'invert' | 'none';
+
+export const chartSeriesIds = (config: ChartConfiguration<'line'>): string[] =>
+  config.data.datasets.map(dataset => (dataset as unknown as { seriesId: string }).seriesId);
+
+// Chart.js filters events reaching plugins through the `events` list. `dblclick`
+// isn't in the default set, so we opt in here — otherwise `legend.onClick` never
+// sees the second click of a double-click isolation gesture.
+export const chartEventsWithDoubleClick: (keyof HTMLElementEventMap)[] = ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove', 'dblclick'];
+
+export const applySeriesSelection = (hidden: Set<string>, ids: readonly string[], action: SeriesSelectionAction) => {
+  if (action === 'all') {
+    hidden.clear();
+    return;
+  }
+  const nextHidden = action === 'none' ? ids : ids.filter(id => !hidden.has(id));
+  hidden.clear();
+  for (const id of nextHidden) hidden.add(id);
+};
+
+export const createSeriesIsolation = () => {
+  let exitCandidate: string | null = null;
+  return {
+    toggle(hidden: Set<string>, id: string) {
+      if (exitCandidate !== id) exitCandidate = null;
+      if (hidden.has(id)) hidden.delete(id);
+      else hidden.add(id);
+    },
+    isolateOrSelectAll(hidden: Set<string>, ids: readonly string[], id: string) {
+      const active = ids.filter(seriesId => !hidden.has(seriesId));
+      if ((active.length === 1 && active[0] === id) || exitCandidate === id) {
+        hidden.clear();
+        exitCandidate = null;
+        return;
+      }
+      hidden.clear();
+      for (const seriesId of ids) if (seriesId !== id) hidden.add(seriesId);
+      exitCandidate = id;
+    },
+  };
+};
+
+type SeriesIsolation = ReturnType<typeof createSeriesIsolation>;
+
+export const handleLegendClick = (
+  event: { native?: Event | null },
+  isolation: SeriesIsolation,
+  hidden: Set<string>,
+  ids: readonly string[],
+  id: string,
+) => {
+  const native = event.native;
+  if (native instanceof MouseEvent && (native.shiftKey || native.detail >= 2)) isolation.isolateOrSelectAll(hidden, ids, id);
+  else isolation.toggle(hidden, id);
+};

--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -7,7 +7,9 @@ import { computed, ref, watch, watchEffect } from 'vue';
 
 import { callApi, useApi } from '../../api/client.ts';
 import ChartCanvas from '../../components/charts/ChartCanvas.vue';
+import ChartSeriesControls from '../../components/charts/ChartSeriesControls.vue';
 import { chartColor, chartFont, chartXAxisTick, dashboardBuckets, dashboardRangeQuery, type DashboardRange } from '../../components/charts/dashboard-chart.ts';
+import { applySeriesSelection, chartEventsWithDoubleClick, chartSeriesIds, createSeriesIsolation, handleLegendClick } from '../../components/charts/series-selection.ts';
 import { useAuthStore } from '../../stores/auth.ts';
 import { OverlayScrollbars, Spinner } from '@floway-dev/ui';
 
@@ -67,6 +69,7 @@ const performanceChartView = ref<ChartView>('model');
 const performancePercentile = ref<PercentileKey>('p95Ms');
 const performanceModel = ref<string>('');
 const performanceView = ref<PerformanceView>(initialOverview.data.value.view);
+const hiddenPerformanceSeries = ref(new Set<string>());
 
 const overview = ref<PerformanceOverviewResponse>(initialOverview.data.value.overview);
 const performanceError = ref<string | null>(initialOverview.data.value.error);
@@ -113,6 +116,8 @@ watchEffect(() => {
   if (!options.includes(performanceModel.value)) performanceModel.value = options[0]!;
 });
 
+const performanceSeriesIsolation = createSeriesIsolation();
+
 const formatDuration = (ms: number | null) => {
   if (ms === null) return '—';
   if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)}m`;
@@ -135,6 +140,8 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
           const color = chartColor(i);
           return {
             label: group,
+            seriesId: group,
+            hidden: hiddenPerformanceSeries.value.has(group),
             data: bucketKeys.map(k => byBucket.get(k) ?? null),
             borderColor: color,
             backgroundColor: `${color}25`,
@@ -152,6 +159,8 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
         const color = chartColor(i);
         return {
           label: p.replace('Ms', ''),
+          seriesId: p,
+          hidden: hiddenPerformanceSeries.value.has(p),
           data: bucketKeys.map(k => byBucket.get(k) ?? null),
           borderColor: color,
           backgroundColor: `${color}25`,
@@ -172,6 +181,7 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
     type: 'line',
     data: { labels, datasets },
     options: {
+      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
@@ -180,6 +190,10 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
+          onClick: (event, legendItem) => {
+            const dataset = datasets[legendItem.datasetIndex!];
+            handleLegendClick(event, performanceSeriesIsolation, hiddenPerformanceSeries.value, datasets.map(d => d.seriesId), dataset.seriesId);
+          },
         },
         tooltip: {
           backgroundColor: 'rgba(12,16,21,0.95)',
@@ -217,6 +231,8 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
     },
   };
 });
+
+const performanceSeriesIds = computed(() => chartSeriesIds(chartConfig.value));
 
 const performanceSummary = computed(() => {
   const row = overview.value.summaryRows[0];
@@ -373,6 +389,9 @@ const performanceSummary = computed(() => {
         </div>
       </div>
 
+      <div class="mb-2 flex justify-end">
+        <ChartSeriesControls label="Performance series selection" @select="applySeriesSelection(hiddenPerformanceSeries, performanceSeriesIds, $event)" />
+      </div>
       <div style="height: 340px; position: relative;">
         <ChartCanvas :config="chartConfig" />
       </div>

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -8,7 +8,9 @@ import { computed, ref, watch } from 'vue';
 import { callApi, useApi, type ApiClient } from '../../api/client.ts';
 import type { BillingDimension } from '../../api/types.ts';
 import ChartCanvas from '../../components/charts/ChartCanvas.vue';
+import ChartSeriesControls from '../../components/charts/ChartSeriesControls.vue';
 import { bucketKeyForUtcHour, chartColor, chartFont, chartXAxisTick, dashboardBuckets, dashboardRangeQuery, type DashboardRange } from '../../components/charts/dashboard-chart.ts';
+import { applySeriesSelection, chartEventsWithDoubleClick, chartSeriesIds, createSeriesIsolation, handleLegendClick } from '../../components/charts/series-selection.ts';
 import UsageSummaryMetric from '../../components/usage/UsageSummaryMetric.vue';
 import { useModelsStore } from '../../composables/useModels.ts';
 import { useAuthStore } from '../../stores/auth.ts';
@@ -142,11 +144,6 @@ let usageRequestId = 0;
 const hiddenKeys = ref(new Set<string>());
 const hiddenModels = ref(new Set<string>());
 
-const toggleHidden = (set: Set<string>, id: string) => {
-  if (set.has(id)) set.delete(id);
-  else set.add(id);
-};
-
 const load = async () => {
   const requestId = ++usageRequestId;
   const requestedRange = tokenRange.value;
@@ -274,6 +271,10 @@ interface ChartEntry {
   label: string;
   colorSlot: number;
 }
+
+const keySeriesIsolation = createSeriesIsolation();
+const modelSeriesIsolation = createSeriesIsolation();
+const searchSeriesIsolation = createSeriesIsolation();
 
 const keyChartEntries = (
   presentKeyIds: readonly string[],
@@ -422,6 +423,7 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
         const color = chartColor(entry.colorSlot);
         return {
           label: entry.label,
+          seriesId: entry.id,
           data: datasetData,
           hidden: ownHidden.value.has(entry.id),
           borderColor: color,
@@ -436,6 +438,7 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
       }),
     },
     options: {
+      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
@@ -444,9 +447,10 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
-          onClick: (_event, legendItem) => {
-            const entry = datasetEntries[legendItem.datasetIndex ?? -1]?.entry;
-            if (entry) toggleHidden(ownHidden.value, entry.id);
+          onClick: (event, legendItem) => {
+            const entry = datasetEntries[legendItem.datasetIndex!].entry;
+            const isolation = groupKey === 'keyId' ? keySeriesIsolation : modelSeriesIsolation;
+            handleLegendClick(event, isolation, ownHidden.value, datasetEntries.map(({ entry }) => entry.id), entry.id);
           },
         },
         tooltip: {
@@ -494,6 +498,8 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
 
 const byKeyConfig = computed(() => buildStackedConfig('keyId'));
 const byModelConfig = computed(() => buildStackedConfig('model'));
+const byKeySeriesIds = computed(() => chartSeriesIds(byKeyConfig.value));
+const byModelSeriesIds = computed(() => chartSeriesIds(byModelConfig.value));
 
 const searchUsageActiveProvider = computed(() => {
   return searchData.value?.activeProvider ?? 'disabled';
@@ -525,6 +531,7 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
         const color = chartColor(entry.colorSlot);
         return {
           label: entry.label,
+          seriesId: entry.id,
           data: bucketKeys.map(k => groups.get(entry.id)?.get(k) ?? 0),
           hidden: hiddenKeys.value.has(entry.id),
           borderColor: color,
@@ -539,6 +546,7 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
       }),
     },
     options: {
+      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
@@ -547,9 +555,9 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
         legend: {
           position: 'bottom',
           labels: { color: '#9e9e9e', font: { size: 11, family: chartFont.sans }, boxWidth: 12, padding: 16, usePointStyle: true, pointStyle: 'circle' },
-          onClick: (_event, legendItem) => {
-            const entry = entries[legendItem.datasetIndex ?? -1];
-            if (entry) toggleHidden(hiddenKeys.value, entry.id);
+          onClick: (event, legendItem) => {
+            const entry = entries[legendItem.datasetIndex!];
+            handleLegendClick(event, searchSeriesIsolation, hiddenKeys.value, entries.map(entry => entry.id), entry.id);
           },
         },
         tooltip: {
@@ -571,6 +579,8 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
     },
   };
 });
+
+const searchByKeySeriesIds = computed(() => chartSeriesIds(searchByKeyConfig.value));
 
 const formatCost = (v: number) => {
   if (v >= 1) return `$${v.toFixed(2)}`;
@@ -635,12 +645,18 @@ const formatCost = (v: number) => {
         </OverlayScrollbars>
       </div>
 
+      <div class="mb-2 flex justify-end">
+        <ChartSeriesControls label="Token usage series selection" @select="applySeriesSelection(hiddenKeys, byKeySeriesIds, $event)" />
+      </div>
       <div style="height: 320px; position: relative;">
         <ChartCanvas :config="byKeyConfig" />
       </div>
 
       <div class="mt-6 pt-5 border-t border-white/5">
-        <span class="text-xs font-medium text-gray-500 uppercase tracking-widest mb-4 block">By Model</span>
+        <div class="flex items-center justify-between gap-3 mb-4">
+          <span class="text-xs font-medium text-gray-500 uppercase tracking-widest block">By Model</span>
+          <ChartSeriesControls label="Model usage series selection" @select="applySeriesSelection(hiddenModels, byModelSeriesIds, $event)" />
+        </div>
         <div style="height: 320px; position: relative;">
           <ChartCanvas :config="byModelConfig" />
         </div>
@@ -670,9 +686,12 @@ const formatCost = (v: number) => {
       </div>
 
       <div v-if="searchUsageActiveProvider !== 'disabled'" class="mt-6 pt-5 border-t border-white/5">
-        <div class="flex items-center gap-3 mb-4">
-          <span class="text-xs font-medium text-gray-500 uppercase tracking-widest block">Search Usage</span>
-          <Spinner v-if="searchUsageLoading" class="h-3.5 w-3.5 text-gray-500" />
+        <div class="flex items-center justify-between gap-3 mb-4">
+          <div class="flex items-center gap-3">
+            <span class="text-xs font-medium text-gray-500 uppercase tracking-widest block">Search Usage</span>
+            <Spinner v-if="searchUsageLoading" class="h-3.5 w-3.5 text-gray-500" />
+          </div>
+          <ChartSeriesControls label="Search usage series selection" @select="applySeriesSelection(hiddenKeys, searchByKeySeriesIds, $event)" />
         </div>
         <div style="height: 320px; position: relative;">
           <ChartCanvas :config="searchByKeyConfig" />


### PR DESCRIPTION
## Summary

The dashboard's **Performance** and **Token Usage** pages both render Chart.js line charts with legend-based series toggling, and each had grown its own copy of the "click a legend entry to hide/show that series" logic. This PR unifies that logic into a shared module, and while it's shared, adds two interactions users have been missing:

- **Isolate**: shift-click or double-click a legend entry to hide every other series (and click that same entry again to restore all).
- **Quick-select**: an **All / Invert / None** button group next to each chart.

## Shape

Two new files under `apps/web/src/components/charts/`:

- **`series-selection.ts`** — pure logic. Exports:
  - `chartSeriesIds(config)` — reads back the `seriesId` from each dataset on a `ChartConfiguration<'line'>`, so the button group's callback can act on the same id set the chart is currently drawing.
  - `applySeriesSelection(hidden, ids, action)` — the "All / Invert / None" reducer over a hidden `Set<string>`.
  - `createSeriesIsolation()` — closure returning `{ toggle, isolateOrSelectAll }`. `isolateOrSelectAll` closes over an "exit candidate" so a second click on an isolated series restores the full set.
  - `handleLegendClick(event, isolation, hidden, ids, id)` — event dispatcher: shift-click or `MouseEvent.detail >= 2` → isolate; plain click → toggle.
  - `chartEventsWithDoubleClick` — Chart.js filters events reaching plugins through the `events` list; `dblclick` isn't in the default set, so we opt in here.

- **`ChartSeriesControls.vue`** — the labeled "All / Invert / None" button group. `aria-label` per placement so screen readers can disambiguate multiple instances on one page.

## Rewire

Both pages now:

- Hold hidden state in a `Set<string>` keyed by `seriesId`. `performance.vue` namespaces its key by chart view (`model:<name>` / `percentile:<p>`) so By-Model and By-Percentile toggles stay independent and a model named e.g. `p95` cannot collide with the percentile line of the same name.
- Tag each dataset with a `seriesId` and derive `dataset.hidden` from the Set on every config rebuild — so the toggle survives the 60s poll and any range / scope / view switch that also goes through `load()`.
- Route `legend.onClick` through `handleLegendClick`.
- Render a `ChartSeriesControls` next to each chart (four instances total: performance chart, token-usage By-Key, By-Model, and Search-Usage).

## Test plan

- [x] `pnpm --filter @floway-dev/web run typecheck` passes
- [x] `pnpm run lint` passes