### PR TITLE
docs(agents): opaque-upstream principle for models and enum values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,103 +49,59 @@ here.
 
 ## Design Principle: Upstream Models And Field Values Are Opaque
 
-Floway assumes an upstream speaks the protocol declared for it (Chat
-Completions, Messages, Responses, Gemini, Embeddings, Images, Ollama).
-Beyond that, the model catalog the upstream serves and the exact enum
-values each protocol slot accepts are upstream-owned. Floway must not
-silently collapse that surface onto a fixed vendor family.
+Floway assumes each upstream speaks the protocol declared for it. The
+model catalog and the enum values in open-string protocol slots are
+upstream-owned; Floway must not silently collapse either onto a fixed
+vendor family.
 
-The rule has a permission side and a prohibition side, and the
-prohibition is narrower than a naive reading would suggest.
+Allowed:
 
-**Explicit model-specific branching is allowed.** Code MAY special-case
-a known id, a family regex, or a version threshold when the special
-case only fires on a match: `if (model.id === 'X') use special-caps`,
-`if (isOpus47Plus(id)) use high-res caps`, `if (isClaudeFamily(id))
-promote thinking display`. These are "handle THIS identified model
-differently" — vendor knowledge, and vendor knowledge lives in the code
-that talks to that vendor.
+- **Identified-model special cases** — `if (model.id === 'X')`,
+  `if (isOpus47Plus(id))`, `if (isClaudeFamily(id))`. Vendor knowledge
+  lives in the code that talks to that vendor.
+- **Provider-wide uniform defaults on a bounded scope** — e.g.,
+  `provider-ollama` advertising `reasoning.effort: { supported: ['low',
+  'medium', 'high'] }` for every thinking-capable Ollama model. The
+  scope is bounded by the provider itself.
+- **Metadata-first id-inference fallbacks.** Endpoint capability comes
+  from upstream metadata first (Copilot `supported_endpoints`, a
+  Floway-shaped upstream's `kind`, capabilities blocks, operator
+  override); a name-token or prefix fallback that fires AFTER the
+  metadata check is silent is fine, provided it lives in the provider
+  package that owns the workaround and — for upstream-bug workarounds
+  — carries a reference URL and a listing in the
+  `audit-copilot-workarounds` skill or equivalent.
+- **Client-tool-compat name filters.** Dashboard helpers that build a
+  config for a CLI which itself expects a name family (Claude Code CLI
+  expects `claude-*`, Codex CLI expects `gpt-5-*`) MAY filter that
+  picker by the same pattern. Mirroring the CLI's own expectation, not
+  Floway asserting an endpoint mapping. Scope must be the CLI setup
+  helper; general model pickers still read `endpoints` from the DTO.
 
-**Provider-wide uniform defaults are allowed on a bounded scope.** A
-provider package MAY expose one editorial default across every model it
-serves — e.g., `provider-ollama` advertising
-`reasoning.effort: { supported: ['low','medium','high'], default:
-'medium' }` for every Ollama model that declares `thinking`. The scope
-is bounded by the provider itself: Ollama can only serve Ollama, so
-"for every Ollama thinking-capable model" is a bounded editorial
-statement, not an unbounded narrowing.
+Forbidden — silent narrowing at wire / translate / control-plane
+boundaries. Open-string fields declared `| (string & {})` or bare
+`string` in `packages/protocols/` (`reasoning_effort`, `verbosity`,
+`service_tier`, `reasoning.summary`, `thinkingLevel`, `speed`, Messages
+`thinking.display`, …) MUST be forwarded verbatim: `z.string()` in
+control-plane schemas, direct pass-through in translators, no `switch`
+default that drops unknown values. The upstream owns the accept/reject
+decision. Cross-protocol synthesis between different shapes — Gemini
+`includeThoughts: true` ↔ Responses `summary`, Messages
+`thinking.type: 'enabled'` (no effort) ↔ Chat `reasoning_effort` — is
+legit translation, distinct from within-protocol enum gating.
 
-**Metadata-first id-inference fallbacks are allowed when no metadata
-exists.** Endpoint capability comes from upstream metadata first —
-Copilot's `supported_endpoints`, a Floway-shaped upstream's `kind`,
-capabilities blocks on `/models`, or an operator override. When no such
-metadata is available (a plain OpenAI-compatible `/models` response
-carries no `kind`; Copilot's Anthropic-family entries under-report
-`/v1/messages`), a name-token or id-prefix heuristic that fires only
-AFTER the metadata check is fine as a Tier-N fallback. Any such
-fallback MUST (a) sit strictly below the metadata check (metadata wins
-if present), (b) live in the provider package that owns the workaround,
-(c) carry a comment explaining why metadata alone isn't sufficient, and
-(d) for upstream-bug workarounds, carry a reference URL and be listed
-in the `audit-copilot-workarounds` skill (or the equivalent
-provider-scoped audit) so it can be periodically re-checked.
+**Every vendor constant needs a reference URL** — image caps, effort→
+budget bin edges, canonical enum values, header sets, protocol quirks.
+Prose like "per Anthropic's vision docs" without a permalink doesn't
+count.
 
-**Client-tool-compat surfaces are allowed to filter by name family.**
-When Floway generates a config for a specific client tool that itself
-makes assumptions about model naming (Claude Code CLI expects
-Claude-family model ids, Codex CLI expects `gpt-5`-family ids), the
-dashboard helper that builds that config MAY filter the picker by the
-same name pattern the CLI expects. This is not Floway asserting an
-endpoint mapping — it is Floway mirroring the client tool's own
-expectations. Filtering must be scoped to the specific CLI setup
-helper; general model pickers must still read `endpoints` from the DTO.
-
-**Silent narrowing at a wire / translation / control-plane boundary is
-forbidden.** Concretely:
-
-- Open-string fields — `reasoning_effort`, `verbosity`, `service_tier`,
-  `reasoning.summary`, `thinkingLevel`, `speed`, Messages
-  `thinking.display`, and every other slot the wire types in
-  `packages/protocols/` declare as `| (string & {})` or bare `string`
-  — MUST be forwarded verbatim through translate layers, interceptors,
-  and control-plane Zod schemas. A `switch` whose `default:` returns
-  `undefined` is a violation; `z.enum([...])` on such a field is a
-  violation. Use `z.string()` in schemas and a direct pass-through in
-  translators, so the upstream owns the accept/reject decision.
-- A translation-layer synthesis of a "safe default" from a caller's
-  intent (mapping Gemini's `includeThoughts: true` to a specific
-  Responses `summary` string, mapping Messages `thinking.type:
-  'enabled'` without effort to a synthesized effort) MAY be necessary
-  when the source protocol expresses the same intent through a
-  different shape than the target does. That's cross-protocol
-  translation, distinct from within-protocol enum gating. It is not a
-  violation of this rule; when in doubt, prefer forwarding to
-  synthesis and let the upstream reject if it can't consume the
-  passthrough.
-
-**Reference URLs are required for vendor constants.** Any hardcoded
-value that comes from an upstream doc, spec, community convention, or
-wire capture (image caps, canonical enum values, header sets, protocol
-quirks, effort→budget bin edges) MUST carry a URL in a comment. Prose
-like "per Anthropic's vision docs" or "community convention" without a
-link doesn't count — the whole point of the reference is that a future
-reader can re-verify it against the source.
-
-Legit narrow exceptions to the "no naming assumption" language above:
-
-- **Per-provider pricing tables (`pricing.ts` in each `provider-*`).**
-  Pricing is inherently vendor-specific, the map returns null for
-  unknown keys, and no downstream code branches on the mapping.
-- **A provider's config discriminator naming its OWN provider kind**
-  (`kind: 'claude-code'`, `kind: 'copilot'`, …). Floway-internal
-  identifier, not an upstream model assumption.
-- **Vendor-locked provider packages (`provider-claude-code`,
-  `provider-codex`).** Subscription products serving a fixed vendor's
-  models under an OAuth client. Even inside those, name-based endpoint
-  or protocol-capability gating still needs the metadata-first
-  ordering; pricing and fixed-catalog request/header mimicry are OK,
-  and mimicry constants MUST be captured verbatim from a live wire
-  probe with a reference URL.
+Beyond the allowed patterns above, three carve-outs also fall outside
+the prohibition: per-provider pricing tables (`pricing.ts` — return
+null for unknown keys); provider config discriminators naming the OWN
+kind (`kind: 'claude-code'`); and vendor-locked provider packages
+(`provider-claude-code`, `provider-codex`) doing fixed-catalog
+request/header mimicry captured verbatim from a live wire probe with a
+reference URL.
 
 Stack: Hono on Web APIs, TypeScript, pnpm, Vitest. The dashboard is a
 Vue + Vite SPA. Cloudflare Workers is the production deployment target;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,106 @@ them. Code-level rules about error handling, comments, and style live in the
 global agent instructions and in ESLint config — read those, not a copy
 here.
 
+## Design Principle: Upstream Models And Field Values Are Opaque
+
+Floway assumes an upstream speaks the protocol declared for it (Chat
+Completions, Messages, Responses, Gemini, Embeddings, Images, Ollama).
+Beyond that, the model catalog the upstream serves and the exact enum
+values each protocol slot accepts are upstream-owned. Floway must not
+silently collapse that surface onto a fixed vendor family.
+
+The rule has a permission side and a prohibition side, and the
+prohibition is narrower than a naive reading would suggest.
+
+**Explicit model-specific branching is allowed.** Code MAY special-case
+a known id, a family regex, or a version threshold when the special
+case only fires on a match: `if (model.id === 'X') use special-caps`,
+`if (isOpus47Plus(id)) use high-res caps`, `if (isClaudeFamily(id))
+promote thinking display`. These are "handle THIS identified model
+differently" — vendor knowledge, and vendor knowledge lives in the code
+that talks to that vendor.
+
+**Provider-wide uniform defaults are allowed on a bounded scope.** A
+provider package MAY expose one editorial default across every model it
+serves — e.g., `provider-ollama` advertising
+`reasoning.effort: { supported: ['low','medium','high'], default:
+'medium' }` for every Ollama model that declares `thinking`. The scope
+is bounded by the provider itself: Ollama can only serve Ollama, so
+"for every Ollama thinking-capable model" is a bounded editorial
+statement, not an unbounded narrowing.
+
+**Metadata-first id-inference fallbacks are allowed when no metadata
+exists.** Endpoint capability comes from upstream metadata first —
+Copilot's `supported_endpoints`, a Floway-shaped upstream's `kind`,
+capabilities blocks on `/models`, or an operator override. When no such
+metadata is available (a plain OpenAI-compatible `/models` response
+carries no `kind`; Copilot's Anthropic-family entries under-report
+`/v1/messages`), a name-token or id-prefix heuristic that fires only
+AFTER the metadata check is fine as a Tier-N fallback. Any such
+fallback MUST (a) sit strictly below the metadata check (metadata wins
+if present), (b) live in the provider package that owns the workaround,
+(c) carry a comment explaining why metadata alone isn't sufficient, and
+(d) for upstream-bug workarounds, carry a reference URL and be listed
+in the `audit-copilot-workarounds` skill (or the equivalent
+provider-scoped audit) so it can be periodically re-checked.
+
+**Client-tool-compat surfaces are allowed to filter by name family.**
+When Floway generates a config for a specific client tool that itself
+makes assumptions about model naming (Claude Code CLI expects
+Claude-family model ids, Codex CLI expects `gpt-5`-family ids), the
+dashboard helper that builds that config MAY filter the picker by the
+same name pattern the CLI expects. This is not Floway asserting an
+endpoint mapping — it is Floway mirroring the client tool's own
+expectations. Filtering must be scoped to the specific CLI setup
+helper; general model pickers must still read `endpoints` from the DTO.
+
+**Silent narrowing at a wire / translation / control-plane boundary is
+forbidden.** Concretely:
+
+- Open-string fields — `reasoning_effort`, `verbosity`, `service_tier`,
+  `reasoning.summary`, `thinkingLevel`, `speed`, Messages
+  `thinking.display`, and every other slot the wire types in
+  `packages/protocols/` declare as `| (string & {})` or bare `string`
+  — MUST be forwarded verbatim through translate layers, interceptors,
+  and control-plane Zod schemas. A `switch` whose `default:` returns
+  `undefined` is a violation; `z.enum([...])` on such a field is a
+  violation. Use `z.string()` in schemas and a direct pass-through in
+  translators, so the upstream owns the accept/reject decision.
+- A translation-layer synthesis of a "safe default" from a caller's
+  intent (mapping Gemini's `includeThoughts: true` to a specific
+  Responses `summary` string, mapping Messages `thinking.type:
+  'enabled'` without effort to a synthesized effort) MAY be necessary
+  when the source protocol expresses the same intent through a
+  different shape than the target does. That's cross-protocol
+  translation, distinct from within-protocol enum gating. It is not a
+  violation of this rule; when in doubt, prefer forwarding to
+  synthesis and let the upstream reject if it can't consume the
+  passthrough.
+
+**Reference URLs are required for vendor constants.** Any hardcoded
+value that comes from an upstream doc, spec, community convention, or
+wire capture (image caps, canonical enum values, header sets, protocol
+quirks, effort→budget bin edges) MUST carry a URL in a comment. Prose
+like "per Anthropic's vision docs" or "community convention" without a
+link doesn't count — the whole point of the reference is that a future
+reader can re-verify it against the source.
+
+Legit narrow exceptions to the "no naming assumption" language above:
+
+- **Per-provider pricing tables (`pricing.ts` in each `provider-*`).**
+  Pricing is inherently vendor-specific, the map returns null for
+  unknown keys, and no downstream code branches on the mapping.
+- **A provider's config discriminator naming its OWN provider kind**
+  (`kind: 'claude-code'`, `kind: 'copilot'`, …). Floway-internal
+  identifier, not an upstream model assumption.
+- **Vendor-locked provider packages (`provider-claude-code`,
+  `provider-codex`).** Subscription products serving a fixed vendor's
+  models under an OAuth client. Even inside those, name-based endpoint
+  or protocol-capability gating still needs the metadata-first
+  ordering; pricing and fixed-catalog request/header mimicry are OK,
+  and mimicry constants MUST be captured verbatim from a live wire
+  probe with a reference URL.
+
 Stack: Hono on Web APIs, TypeScript, pnpm, Vitest. The dashboard is a
 Vue + Vite SPA. Cloudflare Workers is the production deployment target;
 Node.js (`node:sqlite` + `sharp` + filesystem) is a parallel deployment

--- a/packages/provider-copilot/src/interceptors/messages/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/messages/compress-images.ts
@@ -4,15 +4,21 @@ import type { MessagesImageBlock, MessagesMessage } from '@floway-dev/protocols/
 import { memoizedBase64Compressor } from '@floway-dev/provider';
 
 // Per-model image caps for the Claude (Messages) egress, measured from the real
-// /v1/messages generation path (count_tokens misreports the downscale here):
+// /v1/messages generation path (count_tokens misreports the downscale here).
+// Copilot's Messages endpoint is Anthropic-only by Copilot's own contract, so
+// the caps below are Anthropic's canonical vision limits:
 //
-// - Opus 4.7 was the first high-resolution Claude model (per Anthropic's vision
-//   docs); Opus 4.7 and 4.8 sample up to ~3.59 MP within a 2576px long edge.
+// - Opus 4.7 was the first high-resolution Claude model; Opus 4.7 and 4.8
+//   sample up to ~3.59 MP within a 2576px long edge.
 // - Opus 4.5 / 4.6 and the sonnet / haiku families use the standard ~1.18 MP /
 //   1568px cap.
 //
 // We threshold on the Opus version so future Opus releases inherit the high-res
 // tier; every non-Opus Claude model uses the standard cap.
+//
+// References:
+// - Anthropic vision docs: https://docs.claude.com/en/docs/build-with-claude/vision
+// - High-res Opus 4.7+ sampling: https://docs.claude.com/en/docs/build-with-claude/vision#evaluate-image-size
 const STANDARD_CLAUDE_CAPS: SizeCaps = { maxLongEdge: 1568, maxArea: 1_176_000 };
 
 const claudeImageCaps = (upstreamModelId: string): SizeCaps => {

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -89,12 +89,12 @@ const rawModelSupportsEndpoint = (model: CopilotRawModel, endpoint: ModelEndpoin
   return false;
 };
 
-const copilotModelEndpoints = (publicModel: CopilotRawModel, rawModels: readonly CopilotRawModel[]): ModelEndpoints => {
+const copilotModelEndpoints = (rawModels: readonly CopilotRawModel[]): ModelEndpoints => {
   if (rawModels.some(model => rawModelSupportsEndpoint(model, 'responses'))) {
     return { responses: {} };
   }
 
-  if (publicModel.id.startsWith('claude-') || rawModels.some(model => rawModelSupportsEndpoint(model, 'messages'))) {
+  if (rawModels.some(model => rawModelSupportsEndpoint(model, 'messages'))) {
     return { messages: {} };
   }
 
@@ -149,7 +149,7 @@ const finalizeCopilotModels = (rawModels: CopilotRawModel[], enabledFlags: Reado
   const models: ProviderModel[] = [];
   for (const mergedModel of merged.data) {
     const variants = groups.get(mergedModel.id) ?? [mergedModel];
-    const endpoints = copilotModelEndpoints(mergedModel, variants);
+    const endpoints = copilotModelEndpoints(variants);
     const cost = pricingForCopilotPublicModelId(mergedModel.id);
     models.push({
       ...copilotRawToProviderModel(mergedModel),

--- a/packages/translate/src/gemini-via-chat-completions/request_test.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request_test.ts
@@ -496,3 +496,11 @@ test('buildTargetRequest extends reasoning_effort enum to recognize xhigh and ma
   assertEquals(max.reasoning_effort, 'max');
   assertEquals(minimal.reasoning_effort, 'minimal');
 });
+
+test('buildTargetRequest forwards a vendor-specific thinkingLevel verbatim (no enum gate)', () => {
+  const turbo = buildTargetRequest(
+    { contents: [{ role: 'user', parts: [{ text: 'hi' }] }], generationConfig: { thinkingConfig: { thinkingLevel: 'turbo' } } },
+    'gpt-test',
+  );
+  assertEquals(turbo.reasoning_effort, 'turbo');
+});

--- a/packages/translate/src/shared/gemini-via/gemini.ts
+++ b/packages/translate/src/shared/gemini-via/gemini.ts
@@ -122,25 +122,25 @@ export const geminiFunctionResponsePart = (part: GeminiPart, ids: GeminiToolCall
 // mappers below return whatever Gemini surfaced for `thinkingLevel` /
 // derived from `thinkingBudget` verbatim.
 
-export const geminiThinkingLevelEffort = (thinkingConfig?: GeminiThinkingConfig): string | undefined => {
-  switch (thinkingConfig?.thinkingLevel) {
-  case 'minimal':
-    return 'minimal';
-  case 'low':
-    return 'low';
-  case 'medium':
-    return 'medium';
-  case 'high':
-    return 'high';
-  case 'xhigh':
-    return 'xhigh';
-  case 'max':
-    return 'max';
-  default:
-    return undefined;
-  }
-};
+export const geminiThinkingLevelEffort = (thinkingConfig?: GeminiThinkingConfig): string | undefined =>
+  thinkingConfig?.thinkingLevel;
 
+// Bucket Gemini's numeric `thinkingBudget` back onto the discrete
+// `reasoning_effort` axis when the target protocol has no numeric budget
+// slot (Chat Completions, Responses). Google publishes per-model
+// budget ranges but not effort-name thresholds; the 2048 / 8192 bin
+// edges below invert the community convention of using those same
+// numbers as the DEFAULT budget per effort tier — treating "medium's
+// default is 2048" as "budgets up to and including 2048 read as low
+// tier", and "high's default is 8192" as "budgets up to 8192 read as
+// medium tier".
+//
+// References:
+// - Google Gemini thinking config: https://ai.google.dev/gemini-api/docs/thinking
+// - AutoReview (community): `THINK_BUDGETS = { low: 512, medium: 2048, high: 8192 }`
+//   https://github.com/krzysztofdudek/AutoReview/blob/9bf2ede3a960f5215645bedba41c591829053f5c/scripts/lib/providers/google.mjs#L4
+// - LiteLLM (community): `DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET = 2048`
+//   https://github.com/BerriAI/litellm/blob/88e03e548716a45284597edf2b7f47a7e6a66d5f/litellm/constants.py#L184
 export const geminiReasoningEffort = (thinkingConfig?: GeminiThinkingConfig): string | null => {
   if (!thinkingConfig) return null;
 


### PR DESCRIPTION
## Summary

Documents the **opaque-upstream principle** in `AGENTS.md` and aligns four sites with it. The upstream API contract is limited to the declared protocol; the model catalog the upstream serves and the enum values in open-string protocol slots are upstream-owned. Silent narrowing at wire / translate / control-plane boundaries is forbidden. Identified-model special cases, provider-wide uniform defaults on a bounded scope, metadata-first id-inference fallbacks, and client-tool-compat name filters are allowed. Every vendor constant requires a reference URL.

## Code changes

- `packages/provider-copilot/src/provider.ts` — `copilotModelEndpoints` duplicated the `rawModelSupportsEndpoint` claude- workaround inline. The single workaround at line 84 (metadata-first fallback for Copilot's under-reported `/v1/messages`) is kept; the redundant clause and its now-unused `publicModel` argument are removed.
- `packages/provider-copilot/src/interceptors/messages/compress-images.ts` — Anthropic vision doc permalinks now anchor the standard / high-res Claude image caps (1568/1_176_000, 2576/3_588_000).
- `packages/translate/src/shared/gemini-via/gemini.ts` (`geminiThinkingLevelEffort`) — a six-case switch collapses to a direct pass-through so unknown Gemini `thinkingLevel` values survive translation. The file's own comment already promised the freeform behaviour; the switch was the drift.
- `packages/translate/src/shared/gemini-via/gemini.ts` (`geminiReasoningEffort`) — reference URLs for the 2048/8192 `thinkingBudget` bin edges (Google Gemini docs, AutoReview, LiteLLM community conventions), lost in an earlier refactor.

## What stays as-is (legit under principle)

Six other audit findings survive intentionally, each covered by an allowed pattern:

- `provider.ts:84` claude- messages fallback — metadata-first fallback for Copilot's under-reported `/v1/messages` (upstream metadata is silent; workaround is single-sourced and provider-scoped).
- `promote-thinking-display.ts` claude-version threshold — Copilot idle-boundary workaround with live-probe evidence and public bug references.
- `provider-ollama/chat-from-raw.ts` unconditional `['low','medium','high']` — provider-wide uniform default on the Ollama scope.
- `apps/web/src/components/keys/CliSnippet.vue` name-family filter — client-tool-compat: Claude Code CLI expects `claude-*`, Codex CLI expects `gpt-5-*`.
- `messages-via-chat-completions/request.ts` `speed → service_tier` — cross-protocol translation synthesis, distinct from within-protocol enum gating.
- `messages-via/reasoning-effort.ts` `'medium'` default — cross-protocol bridge: Messages `thinking.type: 'enabled'` has no effort axis, so a synthesized effort is the only way to route the intent onto Chat's `reasoning_effort`.

## Test plan

- [x] `pnpm run typecheck` — every package green
- [x] `pnpm run lint`
- [x] `pnpm run test` — 3778 tests green
- [x] Metadata-first Copilot claude- fallback covered by the pre-existing `claude-haiku-chat-listed` case in `packages/provider-copilot/src/provider_test.ts` (raw model advertises only `/chat/completions`; the provider still resolves `endpoints: { messages: {} }`)
- [x] Vendor-specific `thinkingLevel` passthrough covered by a new case in `packages/translate/src/gemini-via-chat-completions/request_test.ts` (`thinkingLevel: 'turbo'` → `reasoning_effort: 'turbo'` on the target)