### PR TITLE
refactor(flags): pivot per-model defaults to per-provider ownership

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -55,10 +55,6 @@ export interface UpstreamModelConfig {
   cost?: ModelPricing;
   flagOverrides?: { enabled: boolean; values: Record<string, boolean> };
   chat?: UpstreamChatConfig;
-  // Wire-only: provider-declared per-model default overlay (layer 2 of
-  // the flag resolver). Absent on rows the client synthesizes locally
-  // before save. All current manual-model providers emit an empty map.
-  providerFlagOverlay?: Record<string, boolean>;
 }
 
 export interface CustomModelsFetch {

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -55,6 +55,10 @@ export interface UpstreamModelConfig {
   cost?: ModelPricing;
   flagOverrides?: { enabled: boolean; values: Record<string, boolean> };
   chat?: UpstreamChatConfig;
+  // Wire-only: provider-declared per-model default overlay (layer 2 of
+  // the flag resolver). Absent on rows the client synthesizes locally
+  // before save. All current manual-model providers emit an empty map.
+  provider_default_overlay?: Record<string, boolean>;
 }
 
 export interface CustomModelsFetch {
@@ -282,6 +286,9 @@ interface UpstreamRecordBase {
   created_at: string;
   updated_at: string;
   flag_overrides: Record<string, boolean>;
+  // Provider-declared upstream-level default for every flag on this
+  // record. Fed into the flag editor's "Inherit → on/off" hint.
+  flag_defaults: Record<string, boolean>;
   // Public model ids switched off for this upstream. Hidden from the catalog and
   // unroutable, but their per-model metadata stays editable. May include ids no
   // longer present in the live model list.

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -16,12 +16,11 @@ import type {
   PublicModel,
   PublicModelLimits,
 } from '@floway-dev/protocols/common';
-import type { Flag as FlagDef, FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
+import type { FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
 import type { AddressableForm, ModelPrefixConfig } from '@floway-dev/provider/model-prefix';
 
 export type { BillingDimension, ModelEndpointKey, ModelEndpoints, ModelKind, ModelPricing };
 export type { AddressableForm, ModelPrefixConfig };
-export type { FlagDef };
 export type {
   AliasRules, AliasSelection, AliasTarget, AnnouncedMetadata, ChatAliasRules, ChatModelInfo, ModelAlias,
   PublicModel, PublicModelLimits,

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -16,11 +16,12 @@ import type {
   PublicModel,
   PublicModelLimits,
 } from '@floway-dev/protocols/common';
-import type { FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
+import type { Flag as FlagDef, FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
 import type { AddressableForm, ModelPrefixConfig } from '@floway-dev/provider/model-prefix';
 
 export type { BillingDimension, ModelEndpointKey, ModelEndpoints, ModelKind, ModelPricing };
 export type { AddressableForm, ModelPrefixConfig };
+export type { FlagDef };
 export type {
   AliasRules, AliasSelection, AliasTarget, AnnouncedMetadata, ChatAliasRules, ChatModelInfo, ModelAlias,
   PublicModel, PublicModelLimits,
@@ -348,12 +349,6 @@ export type UpstreamRecordEnvelope = {
 };
 
 export const toRecordEnvelope = (record: UpstreamRecord): UpstreamRecordEnvelope => ({ ...record });
-
-export interface FlagDef {
-  id: string;
-  label: string;
-  description: string;
-}
 
 // Importing the gateway's source-of-truth type as the actual definition (rather
 // than redeclaring the shape) makes any future field rename a compile error

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -56,11 +56,14 @@ export interface UpstreamModelConfig {
   // Layer 3 in the flag resolver, mutually exclusive by row kind:
   //   - flagOverrides: operator-declared per-model override on a
   //     manual row (persisted under upstreams.config.models[]).
+  //     Presence itself (undefined vs `{}`) toggles whether the row
+  //     opts into per-model overriding; individual flags are tri-state
+  //     via the editor (inherit / on / off).
   //   - flagOverridesAuto: provider-declared per-model default on an
   //     auto row (populated by reshapeModelForDashboard, never
   //     persisted). Read-only in the dashboard.
   // Exactly one of the two is populated on any given row.
-  flagOverrides?: { enabled: boolean; values: Record<string, boolean> };
+  flagOverrides?: Record<string, boolean>;
   flagOverridesAuto?: Record<string, boolean>;
   chat?: UpstreamChatConfig;
 }

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -53,7 +53,15 @@ export interface UpstreamModelConfig {
   display_name?: string;
   limits?: PublicModelLimits;
   cost?: ModelPricing;
+  // Layer 3 in the flag resolver, mutually exclusive by row kind:
+  //   - flagOverrides: operator-declared per-model override on a
+  //     manual row (persisted under upstreams.config.models[]).
+  //   - flagOverridesAuto: provider-declared per-model default on an
+  //     auto row (populated by reshapeModelForDashboard, never
+  //     persisted). Read-only in the dashboard.
+  // Exactly one of the two is populated on any given row.
   flagOverrides?: { enabled: boolean; values: Record<string, boolean> };
+  flagOverridesAuto?: Record<string, boolean>;
   chat?: UpstreamChatConfig;
 }
 

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -45,21 +45,7 @@ export interface UpstreamChatConfig {
   };
 }
 
-// Layer 3 in the flag resolver — exclusive by row kind. Encoded as a
-// union so `{ flagOverrides, flagOverridesAuto }` set together is a
-// compile error at every wire producer / consumer:
-//   - manual row: operator-declared per-model override stored under
-//     `upstreams.config.models[].flagOverrides`. Presence itself
-//     (undefined vs `{}`) toggles opt-in; individual flags are
-//     tri-state via the editor (inherit / on / off).
-//   - auto row: provider-declared per-model default projected onto
-//     `flagOverridesAuto` by reshapeModelForDashboard, never
-//     persisted, read-only in the dashboard.
-type FlagLayer3 =
-  | { flagOverrides?: Record<string, boolean>; flagOverridesAuto?: never }
-  | { flagOverrides?: never; flagOverridesAuto?: Record<string, boolean> };
-
-export type UpstreamModelConfig = {
+export interface UpstreamModelConfig {
   upstreamModelId: string;
   publicModelId?: string;
   kind: ModelKind;
@@ -68,7 +54,16 @@ export type UpstreamModelConfig = {
   limits?: PublicModelLimits;
   cost?: ModelPricing;
   chat?: UpstreamChatConfig;
-} & FlagLayer3;
+  // Layer 3 per-model flag map. On a manual row (from
+  // `upstreams.config.models[]`) this is the operator-declared
+  // override that PATCH writes back to the DB; on an auto row (from
+  // `POST /api/upstreams/list-models`, reshaped from `ProviderModel`
+  // by the backend) it is the provider's per-model rule as a live
+  // read-only projection. The shape is the same in both cases; the
+  // source and whether the row persists are carried by the enclosing
+  // `Row.kind` at consumption time, not by a wire discriminator.
+  flagOverrides?: Record<string, boolean>;
+}
 
 export interface CustomModelsFetch {
   enabled: boolean;

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -352,7 +352,6 @@ export interface FlagDef {
   id: string;
   label: string;
   description: string;
-  defaultFor: UpstreamProviderKind[];
 }
 
 // Importing the gateway's source-of-truth type as the actual definition (rather

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -62,8 +62,9 @@ export interface UpstreamModelConfig {
   // `POST /api/upstreams/list-models`, reshaped from `ProviderModel`
   // by the backend) it is the provider's per-model rule as a live
   // read-only projection. The shape is the same in both cases; the
-  // source and whether the row persists are carried by the enclosing
-  // `Row.kind` at consumption time, not by a wire discriminator.
+  // source (and whether the row persists) is not carried on the wire —
+  // the consuming UI knows it from which list it is iterating (the
+  // config models[] array vs. the list-models response).
   flagOverrides?: FlagOverrides;
 }
 

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -58,7 +58,7 @@ export interface UpstreamModelConfig {
   // Wire-only: provider-declared per-model default overlay (layer 2 of
   // the flag resolver). Absent on rows the client synthesizes locally
   // before save. All current manual-model providers emit an empty map.
-  provider_default_overlay?: Record<string, boolean>;
+  providerFlagOverlay?: Record<string, boolean>;
 }
 
 export interface CustomModelsFetch {

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -45,7 +45,21 @@ export interface UpstreamChatConfig {
   };
 }
 
-export interface UpstreamModelConfig {
+// Layer 3 in the flag resolver — exclusive by row kind. Encoded as a
+// union so `{ flagOverrides, flagOverridesAuto }` set together is a
+// compile error at every wire producer / consumer:
+//   - manual row: operator-declared per-model override stored under
+//     `upstreams.config.models[].flagOverrides`. Presence itself
+//     (undefined vs `{}`) toggles opt-in; individual flags are
+//     tri-state via the editor (inherit / on / off).
+//   - auto row: provider-declared per-model default projected onto
+//     `flagOverridesAuto` by reshapeModelForDashboard, never
+//     persisted, read-only in the dashboard.
+type FlagLayer3 =
+  | { flagOverrides?: Record<string, boolean>; flagOverridesAuto?: never }
+  | { flagOverrides?: never; flagOverridesAuto?: Record<string, boolean> };
+
+export type UpstreamModelConfig = {
   upstreamModelId: string;
   publicModelId?: string;
   kind: ModelKind;
@@ -53,20 +67,8 @@ export interface UpstreamModelConfig {
   display_name?: string;
   limits?: PublicModelLimits;
   cost?: ModelPricing;
-  // Layer 3 in the flag resolver, mutually exclusive by row kind:
-  //   - flagOverrides: operator-declared per-model override on a
-  //     manual row (persisted under upstreams.config.models[]).
-  //     Presence itself (undefined vs `{}`) toggles whether the row
-  //     opts into per-model overriding; individual flags are tri-state
-  //     via the editor (inherit / on / off).
-  //   - flagOverridesAuto: provider-declared per-model default on an
-  //     auto row (populated by reshapeModelForDashboard, never
-  //     persisted). Read-only in the dashboard.
-  // Exactly one of the two is populated on any given row.
-  flagOverrides?: Record<string, boolean>;
-  flagOverridesAuto?: Record<string, boolean>;
   chat?: UpstreamChatConfig;
-}
+} & FlagLayer3;
 
 export interface CustomModelsFetch {
   enabled: boolean;

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -16,6 +16,7 @@ import type {
   PublicModel,
   PublicModelLimits,
 } from '@floway-dev/protocols/common';
+import type { FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
 import type { AddressableForm, ModelPrefixConfig } from '@floway-dev/provider/model-prefix';
 
 export type { BillingDimension, ModelEndpointKey, ModelEndpoints, ModelKind, ModelPricing };
@@ -62,7 +63,7 @@ export interface UpstreamModelConfig {
   // read-only projection. The shape is the same in both cases; the
   // source and whether the row persists are carried by the enclosing
   // `Row.kind` at consumption time, not by a wire discriminator.
-  flagOverrides?: Record<string, boolean>;
+  flagOverrides?: FlagOverrides;
 }
 
 export interface CustomModelsFetch {
@@ -289,10 +290,10 @@ interface UpstreamRecordBase {
   sort_order: number;
   created_at: string;
   updated_at: string;
-  flag_overrides: Record<string, boolean>;
+  flag_overrides: FlagOverrides;
   // Provider-declared upstream-level default for every flag on this
   // record. Fed into the flag editor's "Inherit → on/off" hint.
-  flag_defaults: Record<string, boolean>;
+  flag_defaults: FlagDefaults;
   // Public model ids switched off for this upstream. Hidden from the catalog and
   // unroutable, but their per-model metadata stays editable. May include ids no
   // longer present in the live model list.

--- a/apps/web/src/components/settings/ImportSection.vue
+++ b/apps/web/src/components/settings/ImportSection.vue
@@ -20,7 +20,7 @@ interface ExportPayload {
 
 // The dashboard only round-trips the current export format. Older exports are
 // rejected rather than silently coerced.
-const EXPORT_VERSION = 6 as const;
+const EXPORT_VERSION = 7 as const;
 
 const api = useApi();
 

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -72,7 +72,7 @@ const pillClass = (state: TriState, selected: boolean, inheritedTo: 'on' | 'off'
         class="flex min-w-0 items-start justify-between gap-3 border-t border-white/[0.06] px-1 py-2.5"
       >
         <div class="min-w-0">
-          <span class="block break-words text-xs text-white">{{ flag.label || flag.id }}</span>
+          <span class="block break-words text-xs text-white">{{ flag.label }}</span>
           <span v-if="flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ flag.description }}</span>
         </div>
         <fieldset class="flex shrink-0 items-center gap-1 text-[11px]">

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -8,9 +8,10 @@
 import type { HTMLAttributes } from 'vue';
 
 import type { FlagDef } from '../../api/types.ts';
+import type { FlagDefaults, FlagId, FlagOverrides } from '@floway-dev/provider/flags';
 import { cn, OverlayScrollbars } from '@floway-dev/ui';
 
-const overrides = defineModel<Record<string, boolean>>({ required: true });
+const overrides = defineModel<FlagOverrides>({ required: true });
 
 const props = withDefaults(defineProps<{
   flags: FlagDef[];
@@ -18,8 +19,8 @@ const props = withDefaults(defineProps<{
   // `flag_defaults`). The editor falls through to this map for flags that
   // neither the operator's per-upstream override nor the per-model override
   // touched.
-  providerDefaults: Record<string, boolean>;
-  inheritedOverrides?: Record<string, boolean>;
+  providerDefaults: FlagDefaults;
+  inheritedOverrides?: FlagOverrides;
   namePrefix?: string;
   class?: HTMLAttributes['class'];
 }>(), {
@@ -30,21 +31,24 @@ const props = withDefaults(defineProps<{
 type TriState = 'inherit' | 'on' | 'off';
 
 const stateFor = (flagId: string): TriState => {
-  if (flagId in overrides.value) return overrides.value[flagId] ? 'on' : 'off';
+  const id = flagId as FlagId;
+  if (id in overrides.value) return overrides.value[id] ? 'on' : 'off';
   return 'inherit';
 };
 
 const setState = (flagId: string, next: TriState) => {
+  const id = flagId as FlagId;
   const copy = { ...overrides.value };
-  if (next === 'inherit') delete copy[flagId];
-  else copy[flagId] = next === 'on';
+  if (next === 'inherit') delete copy[id];
+  else copy[id] = next === 'on';
   overrides.value = copy;
 };
 
 const inheritedLabel = (flag: FlagDef): 'on' | 'off' => {
-  const inherited = props.inheritedOverrides[flag.id];
+  const id = flag.id as FlagId;
+  const inherited = props.inheritedOverrides[id];
   if (typeof inherited === 'boolean') return inherited ? 'on' : 'off';
-  return props.providerDefaults[flag.id] ? 'on' : 'off';
+  return props.providerDefaults[id] ? 'on' : 'off';
 };
 
 const stateLabel = (state: TriState, flag: FlagDef) => {

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -7,14 +7,13 @@
 
 import type { HTMLAttributes } from 'vue';
 
-import type { FlagDef } from '../../api/types.ts';
-import type { FlagDefaults, FlagId, FlagOverrides } from '@floway-dev/provider/flags';
+import type { Flag, FlagDefaults, FlagId, FlagOverrides } from '@floway-dev/provider/flags';
 import { cn, OverlayScrollbars } from '@floway-dev/ui';
 
 const overrides = defineModel<FlagOverrides>({ required: true });
 
 const props = withDefaults(defineProps<{
-  flags: FlagDef[];
+  flags: Flag[];
   // Provider-declared defaults for this upstream kind (from the record's
   // `flag_defaults`). The editor falls through to this map for flags that
   // neither the operator's per-upstream override nor the per-model override
@@ -44,14 +43,14 @@ const setState = (flagId: string, next: TriState) => {
   overrides.value = copy;
 };
 
-const inheritedLabel = (flag: FlagDef): 'on' | 'off' => {
+const inheritedLabel = (flag: Flag): 'on' | 'off' => {
   const id = flag.id as FlagId;
   const inherited = props.inheritedOverrides[id];
   if (typeof inherited === 'boolean') return inherited ? 'on' : 'off';
   return props.providerDefaults[id] ? 'on' : 'off';
 };
 
-const stateLabel = (state: TriState, flag: FlagDef) => {
+const stateLabel = (state: TriState, flag: Flag) => {
   if (state === 'inherit') return `Inherit: ${inheritedLabel(flag)}`;
   return state === 'on' ? 'On' : 'Off';
 };

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -14,10 +14,7 @@ const overrides = defineModel<FlagOverrides>({ required: true });
 
 const props = withDefaults(defineProps<{
   flags: Flag[];
-  // Provider-declared defaults for this upstream kind (from the record's
-  // `flag_defaults`). The editor falls through to this map for flags that
-  // neither the operator's per-upstream override nor the per-model override
-  // touched.
+  // Provider-declared defaults for this upstream kind (from the record's `flag_defaults`).
   providerDefaults: FlagDefaults;
   inheritedOverrides?: FlagOverrides;
   namePrefix?: string;

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -2,19 +2,23 @@
 // Tri-state flag editor: each flag is either Inherit, On, or Off. The
 // `inheritedOverrides` prop is what the "Inherit" pill should resolve to when
 // the flag has no explicit override at the level being edited — at the
-// upstream level that's the flag's defaultFor; at the model level that's the
-// upstream's effective value for the flag.
+// upstream level that's the provider-side default (`providerDefaults`); at
+// the model level that's the upstream's effective value for the flag.
 
 import type { HTMLAttributes } from 'vue';
 
-import type { FlagDef, UpstreamProviderKind } from '../../api/types.ts';
+import type { FlagDef } from '../../api/types.ts';
 import { cn, OverlayScrollbars } from '@floway-dev/ui';
 
 const overrides = defineModel<Record<string, boolean>>({ required: true });
 
 const props = withDefaults(defineProps<{
   flags: FlagDef[];
-  kind: UpstreamProviderKind;
+  // Provider-declared defaults for this upstream kind (from the record's
+  // `flag_defaults`). The editor falls through to this map for flags that
+  // neither the operator's per-upstream override nor the per-model override
+  // touched.
+  providerDefaults: Record<string, boolean>;
   inheritedOverrides?: Record<string, boolean>;
   namePrefix?: string;
   class?: HTMLAttributes['class'];
@@ -40,7 +44,7 @@ const setState = (flagId: string, next: TriState) => {
 const inheritedLabel = (flag: FlagDef): 'on' | 'off' => {
   const inherited = props.inheritedOverrides[flag.id];
   if (typeof inherited === 'boolean') return inherited ? 'on' : 'off';
-  return flag.defaultFor.includes(props.kind) ? 'on' : 'off';
+  return props.providerDefaults[flag.id] ? 'on' : 'off';
 };
 
 const stateLabel = (state: TriState, flag: FlagDef) => {

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -14,7 +14,6 @@ const overrides = defineModel<FlagOverrides>({ required: true });
 
 const props = withDefaults(defineProps<{
   flags: Flag[];
-  // Provider-declared defaults for this upstream kind (from the record's `flag_defaults`).
   providerDefaults: FlagDefaults;
   inheritedOverrides?: FlagOverrides;
   namePrefix?: string;

--- a/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
+++ b/apps/web/src/components/upstream-edit/FlagOverridesEditor.vue
@@ -17,10 +17,12 @@ const props = withDefaults(defineProps<{
   providerDefaults: FlagDefaults;
   inheritedOverrides?: FlagOverrides;
   namePrefix?: string;
+  readOnly?: boolean;
   class?: HTMLAttributes['class'];
 }>(), {
   inheritedOverrides: () => ({}),
   namePrefix: 'flag',
+  readOnly: false,
 });
 
 type TriState = 'inherit' | 'on' | 'off';
@@ -52,7 +54,9 @@ const stateLabel = (state: TriState, flag: Flag) => {
 };
 
 const pillClass = (state: TriState, selected: boolean, inheritedTo: 'on' | 'off') => {
-  if (!selected) return 'border-white/10 text-gray-500 hover:bg-white/5';
+  if (!selected) return props.readOnly
+    ? 'border-white/10 text-gray-600'
+    : 'border-white/10 text-gray-500 hover:bg-white/5';
   if (state === 'on') return 'border-accent-emerald/40 bg-accent-emerald/15 text-accent-emerald';
   if (state === 'off') return 'border-accent-rose/40 bg-accent-rose/15 text-accent-rose';
   return inheritedTo === 'on'
@@ -74,12 +78,12 @@ const pillClass = (state: TriState, selected: boolean, inheritedTo: 'on' | 'off'
           <span class="block break-words text-xs text-white">{{ flag.label }}</span>
           <span v-if="flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ flag.description }}</span>
         </div>
-        <fieldset class="flex shrink-0 items-center gap-1 text-[11px]">
+        <fieldset class="flex shrink-0 items-center gap-1 text-[11px]" :disabled="readOnly">
           <label
             v-for="state in (['inherit', 'on', 'off'] as TriState[])"
             :key="state"
-            class="flex cursor-pointer items-center gap-1 rounded border px-1.5 py-0.5 transition-colors"
-            :class="pillClass(state, stateFor(flag.id) === state, inheritedLabel(flag))"
+            class="flex items-center gap-1 rounded border px-1.5 py-0.5 transition-colors"
+            :class="[pillClass(state, stateFor(flag.id) === state, inheritedLabel(flag)), readOnly ? 'cursor-default' : 'cursor-pointer']"
           >
             <input
               type="radio"

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -7,17 +7,13 @@ import { defaultEndpointsForKind, publicIdOf, titleFor, type Row } from './model
 import type { AnnouncedMetadata, BillingDimension, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig } from '../../api/types.ts';
 import { parseOptionalNumber } from '../../utils/parse-optional-number.ts';
 import ChatMetadataEditor from '../shared/ChatMetadataEditor.vue';
-import type { Flag, FlagDefaults, FlagId, FlagOverrides } from '@floway-dev/provider/flags';
+import type { Flag, FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
 import { Button, Input, Select, Switch, Tooltip } from '@floway-dev/ui';
 
 const props = defineProps<{
   row: Row | null;
   flags: Flag[];
   upstreamFlagOverrides: FlagOverrides;
-  // Provider-declared upstream-level default for every flag on this
-  // upstream kind. The per-model editor's "Inherit" pill resolves via
-  // the upstream override (live-edited, `upstreamFlagOverrides`) if set,
-  // else falls through to this map.
   providerFlagDefaults: FlagDefaults;
   // "Upstream Model ID" for custom/copilot, "Deployment" for azure.
   upstreamIdLabel: string;
@@ -61,23 +57,6 @@ const PRICING_BY_KIND: Record<ModelKind, BillingDimension[]> = {
 const config = computed<UpstreamModelConfig | null>(() => props.row?.config ?? null);
 const editable = computed(() => props.row?.kind === 'manual');
 const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
-
-// Auto-row read-only flag view: resolve each flag through the three
-// layers (upstream default → operator upstream override → provider
-// per-model default) and label the winning source in one walk.
-// Mirrors the layer order the data plane applies in
-// `resolveEffectiveFlags` at request time, so what the dashboard shows
-// is exactly what the provider dispatches.
-const autoRowFlagState = (flagId: string): { on: boolean; source: string } => {
-  const id = flagId as FlagId;
-  const perModel = config.value?.flagOverrides?.[id];
-  if (perModel !== undefined) return { on: perModel, source: 'provider — this model' };
-  const upstreamOverride = props.upstreamFlagOverrides[id];
-  if (upstreamOverride !== undefined) return { on: upstreamOverride, source: 'upstream override' };
-  return { on: props.providerFlagDefaults[id], source: 'provider default' };
-};
-
-const autoFlagRows = computed(() => props.flags.map(flag => ({ flag, state: autoRowFlagState(flag.id) })));
 
 const patch = (next: Partial<UpstreamModelConfig>) => {
   if (!editable.value) return;
@@ -554,9 +533,8 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
 
         <section>
           <div class="mb-3 flex items-baseline gap-3">
-            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">{{ editable ? 'Override Feature Flags' : 'Effective Feature Flags' }}</h3>
+            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Feature Flags</h3>
             <span v-if="editable" class="text-[11px] text-gray-500">applied on top of upstream-level flags; <code class="font-mono">Inherit</code> reflects the upstream-resolved value</span>
-            <span v-else class="text-[11px] text-gray-500">resolved from upstream default → upstream override → provider per-model rule</span>
             <Switch
               v-if="editable"
               :model-value="config.flagOverrides !== undefined"
@@ -565,41 +543,19 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
             />
           </div>
           <FlagOverridesEditor
-            v-if="editable && config.flagOverrides !== undefined"
-            :model-value="config.flagOverrides"
+            v-if="!editable || config.flagOverrides !== undefined"
+            :model-value="config.flagOverrides ?? {}"
             :flags="flags"
             :provider-defaults="providerFlagDefaults"
             :inherited-overrides="upstreamFlagOverrides"
             :name-prefix="`${row.uiId}-flag`"
+            :read-only="!editable"
             class="max-h-72"
             @update:model-value="v => patch({ flagOverrides: v })"
           />
-          <p v-else-if="editable" class="text-[11px] text-gray-600">
+          <p v-else class="text-[11px] text-gray-600">
             Toggle on to override individual flags for this model only.
           </p>
-          <div v-else class="max-h-72 overflow-y-auto">
-            <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))]">
-              <div
-                v-for="row in autoFlagRows"
-                :key="row.flag.id"
-                class="flex min-w-0 items-start justify-between gap-3 border-t border-white/[0.06] px-1 py-2.5"
-              >
-                <div class="min-w-0">
-                  <span class="block break-words text-xs text-white">{{ row.flag.label }}</span>
-                  <span v-if="row.flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ row.flag.description }}</span>
-                </div>
-                <div class="flex shrink-0 flex-col items-end gap-0.5 text-[11px]">
-                  <span
-                    class="rounded border px-1.5 py-0.5"
-                    :class="row.state.on
-                      ? 'border-accent-emerald/40 bg-accent-emerald/15 text-accent-emerald'
-                      : 'border-accent-rose/40 bg-accent-rose/15 text-accent-rose'"
-                  >{{ row.state.on ? 'On' : 'Off' }}</span>
-                  <span class="text-[10px] text-gray-500">{{ row.state.source }}</span>
-                </div>
-              </div>
-            </div>
-          </div>
         </section>
 
       </div>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -137,6 +137,12 @@ const tierDrafts = ref<TierDraft[]>(tierDraftsFor(config.value?.cost));
 // without an extra click. An Add Tier click also auto-expands.
 const tierSectionExpanded = ref(tierDrafts.value.length > 0);
 
+// Preserve the operator's per-flag choices when they toggle the whole
+// override off then back on for the same row — otherwise a stray click
+// would clear the map they had built up. Reset on row change so a fresh
+// row starts empty.
+const lastFlagOverrides = ref<FlagOverrides>({});
+
 // Resync the local drafts whenever the active row changes (a different model's
 // cost replaces the working set). Edits within the same row leave the drafts
 // alone — `writeTierDrafts` writes both local state and stored cost in lockstep.
@@ -145,12 +151,6 @@ watch(() => props.row?.uiId, () => {
   tierSectionExpanded.value = tierDrafts.value.length > 0;
   lastFlagOverrides.value = {};
 });
-
-// Preserve the operator's per-flag choices when they toggle the whole
-// override off then back on for the same row — otherwise a stray click
-// would clear the map they had built up. Reset on row change so a fresh
-// row starts empty.
-const lastFlagOverrides = ref<FlagOverrides>({});
 
 const writeTierDrafts = (drafts: readonly TierDraft[]) => {
   if (!config.value) return;

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -71,7 +71,7 @@ const autoRowFlagState = (flagId: string): { on: boolean; source: string } => {
   const perModel = config.value?.flagOverridesAuto?.[flagId];
   if (perModel !== undefined) return { on: perModel, source: 'provider — this model' };
   const upstreamOverride = props.upstreamFlagOverrides[flagId];
-  if (upstreamOverride !== undefined) return { on: upstreamOverride, source: 'your upstream override' };
+  if (upstreamOverride !== undefined) return { on: upstreamOverride, source: 'upstream override' };
   return { on: props.providerFlagDefaults[flagId], source: 'provider default' };
 };
 
@@ -556,7 +556,7 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
           <div class="mb-3 flex items-baseline gap-3">
             <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">{{ editable ? 'Override Feature Flags' : 'Effective Feature Flags' }}</h3>
             <span v-if="editable" class="text-[11px] text-gray-500">applied on top of upstream-level flags; <code class="font-mono">Inherit</code> reflects the upstream-resolved value</span>
-            <span v-else class="text-[11px] text-gray-500">resolved from upstream default → your upstream override → provider per-model rule</span>
+            <span v-else class="text-[11px] text-gray-500">resolved from upstream default → upstream override → provider per-model rule</span>
             <Switch
               v-if="editable"
               :model-value="config.flagOverrides !== undefined"

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -4,15 +4,15 @@ import { computed, ref, watch } from 'vue';
 import EndpointsField from './EndpointsField.vue';
 import FlagOverridesEditor from './FlagOverridesEditor.vue';
 import { defaultEndpointsForKind, publicIdOf, titleFor, type Row } from './modelRows.ts';
-import type { AnnouncedMetadata, BillingDimension, FlagDef, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig } from '../../api/types.ts';
+import type { AnnouncedMetadata, BillingDimension, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig } from '../../api/types.ts';
 import { parseOptionalNumber } from '../../utils/parse-optional-number.ts';
 import ChatMetadataEditor from '../shared/ChatMetadataEditor.vue';
-import type { FlagDefaults, FlagId, FlagOverrides } from '@floway-dev/provider/flags';
+import type { Flag, FlagDefaults, FlagId, FlagOverrides } from '@floway-dev/provider/flags';
 import { Button, Input, Select, Switch, Tooltip } from '@floway-dev/ui';
 
 const props = defineProps<{
   row: Row | null;
-  flags: FlagDef[];
+  flags: Flag[];
   upstreamFlagOverrides: FlagOverrides;
   // Provider-declared upstream-level default for every flag on this
   // upstream kind. The per-model editor's "Inherit" pill resolves via

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -77,6 +77,8 @@ const autoRowFlagState = (flagId: string): { on: boolean; source: string } => {
   return { on: props.providerFlagDefaults[id], source: 'provider default' };
 };
 
+const autoFlagRows = computed(() => props.flags.map(flag => ({ flag, state: autoRowFlagState(flag.id) })));
+
 const patch = (next: Partial<UpstreamModelConfig>) => {
   if (!editable.value) return;
   emit('patch-config', next);
@@ -582,24 +584,22 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
           <div v-else class="max-h-72 overflow-y-auto">
             <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))]">
               <div
-                v-for="flag in flags"
-                :key="flag.id"
+                v-for="row in autoFlagRows"
+                :key="row.flag.id"
                 class="flex min-w-0 items-start justify-between gap-3 border-t border-white/[0.06] px-1 py-2.5"
               >
                 <div class="min-w-0">
-                  <span class="block break-words text-xs text-white">{{ flag.label }}</span>
-                  <span v-if="flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ flag.description }}</span>
+                  <span class="block break-words text-xs text-white">{{ row.flag.label }}</span>
+                  <span v-if="row.flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ row.flag.description }}</span>
                 </div>
                 <div class="flex shrink-0 flex-col items-end gap-0.5 text-[11px]">
-                  <template v-for="state in [autoRowFlagState(flag.id)]" :key="flag.id">
-                    <span
-                      class="rounded border px-1.5 py-0.5"
-                      :class="state.on
-                        ? 'border-accent-emerald/40 bg-accent-emerald/15 text-accent-emerald'
-                        : 'border-accent-rose/40 bg-accent-rose/15 text-accent-rose'"
-                    >{{ state.on ? 'On' : 'Off' }}</span>
-                    <span class="text-[10px] text-gray-500">{{ state.source }}</span>
-                  </template>
+                  <span
+                    class="rounded border px-1.5 py-0.5"
+                    :class="row.state.on
+                      ? 'border-accent-emerald/40 bg-accent-emerald/15 text-accent-emerald'
+                      : 'border-accent-rose/40 bg-accent-rose/15 text-accent-rose'"
+                  >{{ row.state.on ? 'On' : 'Off' }}</span>
+                  <span class="text-[10px] text-gray-500">{{ row.state.source }}</span>
                 </div>
               </div>
             </div>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
   // Provider-declared upstream-level default for every flag on this
   // upstream kind (layer 1 in the flag resolver). The per-model editor's
   // "Inherit" pill resolves via layer 3 (upstream override, live-edited)
-  // else the merge of layer 1 with this row's `provider_default_overlay`
+  // else the merge of layer 1 with this row's `providerFlagOverlay`
   // (layer 2, when the provider ships per-model defaults). All current
   // manual-model providers emit an empty layer 2, but the merge keeps the
   // component future-proof.
@@ -69,7 +69,7 @@ const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
 // prop above for the full layer semantics.
 const flagDefaultsForThisModel = computed<Record<string, boolean>>(() => ({
   ...props.providerFlagDefaults,
-  ...(config.value?.provider_default_overlay ?? {}),
+  ...(config.value?.providerFlagOverlay ?? {}),
 }));
 
 const patch = (next: Partial<UpstreamModelConfig>) => {

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -63,21 +63,16 @@ const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
 
 // Auto-row read-only flag view: resolve each flag through the three
 // layers (upstream default → operator upstream override → provider
-// per-model default) and label the source. Mirrors the layer order the
-// data plane applies in `resolveEffectiveFlags` at request time, so
-// what the dashboard shows is exactly what the provider dispatches.
-const autoRowFlagOn = (flagId: string): boolean => {
+// per-model default) and label the winning source in one walk.
+// Mirrors the layer order the data plane applies in
+// `resolveEffectiveFlags` at request time, so what the dashboard shows
+// is exactly what the provider dispatches.
+const autoRowFlagState = (flagId: string): { on: boolean; source: string } => {
   const perModel = config.value?.flagOverridesAuto?.[flagId];
-  if (perModel !== undefined) return perModel;
+  if (perModel !== undefined) return { on: perModel, source: 'provider — this model' };
   const upstreamOverride = props.upstreamFlagOverrides[flagId];
-  if (upstreamOverride !== undefined) return upstreamOverride;
-  return props.providerFlagDefaults[flagId];
-};
-
-const autoRowFlagSource = (flagId: string): string => {
-  if (config.value?.flagOverridesAuto?.[flagId] !== undefined) return 'provider — this model';
-  if (props.upstreamFlagOverrides[flagId] !== undefined) return 'your upstream override';
-  return 'provider default';
+  if (upstreamOverride !== undefined) return { on: upstreamOverride, source: 'your upstream override' };
+  return { on: props.providerFlagDefaults[flagId], source: 'provider default' };
 };
 
 const patch = (next: Partial<UpstreamModelConfig>) => {
@@ -582,13 +577,15 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
                   <span v-if="flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ flag.description }}</span>
                 </div>
                 <div class="flex shrink-0 flex-col items-end gap-0.5 text-[11px]">
-                  <span
-                    class="rounded border px-1.5 py-0.5"
-                    :class="autoRowFlagOn(flag.id)
-                      ? 'border-accent-emerald/40 bg-accent-emerald/15 text-accent-emerald'
-                      : 'border-accent-rose/40 bg-accent-rose/15 text-accent-rose'"
-                  >{{ autoRowFlagOn(flag.id) ? 'On' : 'Off' }}</span>
-                  <span class="text-[10px] text-gray-500">{{ autoRowFlagSource(flag.id) }}</span>
+                  <template v-for="state in [autoRowFlagState(flag.id)]" :key="flag.id">
+                    <span
+                      class="rounded border px-1.5 py-0.5"
+                      :class="state.on
+                        ? 'border-accent-emerald/40 bg-accent-emerald/15 text-accent-emerald'
+                        : 'border-accent-rose/40 bg-accent-rose/15 text-accent-rose'"
+                    >{{ state.on ? 'On' : 'Off' }}</span>
+                    <span class="text-[10px] text-gray-500">{{ state.source }}</span>
+                  </template>
                 </div>
               </div>
             </div>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -7,17 +7,18 @@ import { configOf, defaultEndpointsForKind, publicIdOf, titleFor, type Row } fro
 import type { AnnouncedMetadata, BillingDimension, FlagDef, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig } from '../../api/types.ts';
 import { parseOptionalNumber } from '../../utils/parse-optional-number.ts';
 import ChatMetadataEditor from '../shared/ChatMetadataEditor.vue';
+import type { FlagDefaults, FlagId, FlagOverrides } from '@floway-dev/provider/flags';
 import { Button, Input, Select, Switch, Tooltip } from '@floway-dev/ui';
 
 const props = defineProps<{
   row: Row | null;
   flags: FlagDef[];
-  upstreamFlagOverrides: Record<string, boolean>;
+  upstreamFlagOverrides: FlagOverrides;
   // Provider-declared upstream-level default for every flag on this
   // upstream kind. The per-model editor's "Inherit" pill resolves via
   // the upstream override (live-edited, `upstreamFlagOverrides`) if set,
   // else falls through to this map.
-  providerFlagDefaults: Record<string, boolean>;
+  providerFlagDefaults: FlagDefaults;
   // "Upstream Model ID" for custom/copilot, "Deployment" for azure.
   upstreamIdLabel: string;
   // True when this manual row's upstream id is fixed (seeded from an auto
@@ -68,11 +69,12 @@ const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
 // `resolveEffectiveFlags` at request time, so what the dashboard shows
 // is exactly what the provider dispatches.
 const autoRowFlagState = (flagId: string): { on: boolean; source: string } => {
-  const perModel = config.value?.flagOverrides?.[flagId];
+  const id = flagId as FlagId;
+  const perModel = config.value?.flagOverrides?.[id];
   if (perModel !== undefined) return { on: perModel, source: 'provider — this model' };
-  const upstreamOverride = props.upstreamFlagOverrides[flagId];
+  const upstreamOverride = props.upstreamFlagOverrides[id];
   if (upstreamOverride !== undefined) return { on: upstreamOverride, source: 'upstream override' };
-  return { on: props.providerFlagDefaults[flagId], source: 'provider default' };
+  return { on: props.providerFlagDefaults[id], source: 'provider default' };
 };
 
 const patch = (next: Partial<UpstreamModelConfig>) => {
@@ -146,7 +148,7 @@ watch(() => props.row?.uiId, () => {
 // override off then back on for the same row — otherwise a stray click
 // would clear the map they had built up. Reset on row change so a fresh
 // row starts empty.
-const lastFlagOverrides = ref<Record<string, boolean>>({});
+const lastFlagOverrides = ref<FlagOverrides>({});
 
 const writeTierDrafts = (drafts: readonly TierDraft[]) => {
   if (!config.value) return;
@@ -256,7 +258,7 @@ const toggleFlagOverridesEnabled = () => {
   }
 };
 
-const updateFlagOverrides = (values: Record<string, boolean>) => {
+const updateFlagOverrides = (values: FlagOverrides) => {
   patch({ flagOverrides: values });
 };
 

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -61,6 +61,25 @@ const config = computed<UpstreamModelConfig | null>(() => props.row ? configOf(p
 const editable = computed(() => props.row?.kind === 'manual');
 const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
 
+// Auto-row read-only flag view: resolve each flag through the three
+// layers (upstream default → operator upstream override → provider
+// per-model default) and label the source. Mirrors the layer order the
+// data plane applies in `resolveEffectiveFlags` at request time, so
+// what the dashboard shows is exactly what the provider dispatches.
+const autoRowFlagOn = (flagId: string): boolean => {
+  const perModel = config.value?.flagOverridesAuto?.[flagId];
+  if (perModel !== undefined) return perModel;
+  const upstreamOverride = props.upstreamFlagOverrides[flagId];
+  if (upstreamOverride !== undefined) return upstreamOverride;
+  return props.providerFlagDefaults[flagId] ?? false;
+};
+
+const autoRowFlagSource = (flagId: string): string => {
+  if (config.value?.flagOverridesAuto?.[flagId] !== undefined) return 'provider — this model';
+  if (props.upstreamFlagOverrides[flagId] !== undefined) return 'your upstream override';
+  return 'provider default';
+};
+
 const patch = (next: Partial<UpstreamModelConfig>) => {
   if (!editable.value) return;
   emit('patch-config', next);
@@ -528,15 +547,15 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
 
         <section>
           <div class="mb-3 flex items-baseline gap-3">
-            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">Override Feature Flags</h3>
-            <span class="text-[11px] text-gray-500">applied on top of upstream-level flags; <code class="font-mono">Inherit</code> reflects the upstream-resolved value</span>
+            <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-500">{{ editable ? 'Override Feature Flags' : 'Effective Feature Flags' }}</h3>
+            <span v-if="editable" class="text-[11px] text-gray-500">applied on top of upstream-level flags; <code class="font-mono">Inherit</code> reflects the upstream-resolved value</span>
+            <span v-else class="text-[11px] text-gray-500">resolved from upstream default → your upstream override → provider per-model rule</span>
             <Switch
               v-if="editable"
               :model-value="config.flagOverrides !== undefined"
               class="ml-auto"
               @update:model-value="toggleFlagOverridesEnabled"
             />
-            <Switch v-else :model-value="false" disabled class="ml-auto" />
           </div>
           <FlagOverridesEditor
             v-if="editable && config.flagOverrides !== undefined"
@@ -551,9 +570,29 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
           <p v-else-if="editable" class="text-[11px] text-gray-600">
             Toggle on to override individual flags for this model only.
           </p>
-          <p v-else class="text-[11px] text-gray-600">
-            Auto models inherit upstream flags. Switch to Manual to override per model.
-          </p>
+          <div v-else class="max-h-72 overflow-y-auto">
+            <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))]">
+              <div
+                v-for="flag in flags"
+                :key="flag.id"
+                class="flex min-w-0 items-start justify-between gap-3 border-t border-white/[0.06] px-1 py-2.5"
+              >
+                <div class="min-w-0">
+                  <span class="block break-words text-xs text-white">{{ flag.label || flag.id }}</span>
+                  <span v-if="flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ flag.description }}</span>
+                </div>
+                <div class="flex shrink-0 flex-col items-end gap-0.5 text-[11px]">
+                  <span
+                    class="rounded border px-1.5 py-0.5"
+                    :class="autoRowFlagOn(flag.id)
+                      ? 'border-accent-emerald/40 bg-accent-emerald/15 text-accent-emerald'
+                      : 'border-accent-rose/40 bg-accent-rose/15 text-accent-rose'"
+                  >{{ autoRowFlagOn(flag.id) ? 'On' : 'Off' }}</span>
+                  <span class="text-[10px] text-gray-500">{{ autoRowFlagSource(flag.id) }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
         </section>
 
       </div>

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -71,7 +71,7 @@ const autoRowFlagOn = (flagId: string): boolean => {
   if (perModel !== undefined) return perModel;
   const upstreamOverride = props.upstreamFlagOverrides[flagId];
   if (upstreamOverride !== undefined) return upstreamOverride;
-  return props.providerFlagDefaults[flagId] ?? false;
+  return props.providerFlagDefaults[flagId];
 };
 
 const autoRowFlagSource = (flagId: string): string => {
@@ -578,7 +578,7 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
                 class="flex min-w-0 items-start justify-between gap-3 border-t border-white/[0.06] px-1 py-2.5"
               >
                 <div class="min-w-0">
-                  <span class="block break-words text-xs text-white">{{ flag.label || flag.id }}</span>
+                  <span class="block break-words text-xs text-white">{{ flag.label }}</span>
                   <span v-if="flag.description" class="mt-0.5 block text-[11px] text-gray-500">{{ flag.description }}</span>
                 </div>
                 <div class="flex shrink-0 flex-col items-end gap-0.5 text-[11px]">

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -260,10 +260,6 @@ const toggleFlagOverridesEnabled = () => {
   }
 };
 
-const updateFlagOverrides = (values: FlagOverrides) => {
-  patch({ flagOverrides: values });
-};
-
 // ── Chat metadata ──────────────────────────────────────────────────────────
 
 // Mirror the shared editor's value shape: pull the model's `limits` +
@@ -576,7 +572,7 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
             :inherited-overrides="upstreamFlagOverrides"
             :name-prefix="`${row.uiId}-flag`"
             class="max-h-72"
-            @update:model-value="updateFlagOverrides"
+            @update:model-value="v => patch({ flagOverrides: v })"
           />
           <p v-else-if="editable" class="text-[11px] text-gray-600">
             Toggle on to override individual flags for this model only.

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -139,7 +139,14 @@ const tierSectionExpanded = ref(tierDrafts.value.length > 0);
 watch(() => props.row?.uiId, () => {
   tierDrafts.value = tierDraftsFor(config.value?.cost);
   tierSectionExpanded.value = tierDrafts.value.length > 0;
+  lastFlagOverrides.value = {};
 });
+
+// Preserve the operator's per-flag choices when they toggle the whole
+// override off then back on for the same row — otherwise a stray click
+// would clear the map they had built up. Reset on row change so a fresh
+// row starts empty.
+const lastFlagOverrides = ref<Record<string, boolean>>({});
 
 const writeTierDrafts = (drafts: readonly TierDraft[]) => {
   if (!config.value) return;
@@ -241,7 +248,12 @@ const moveTierDown = (index: number) => {
 
 const toggleFlagOverridesEnabled = () => {
   if (!editable.value || !config.value) return;
-  patch({ flagOverrides: config.value.flagOverrides !== undefined ? undefined : {} });
+  if (config.value.flagOverrides !== undefined) {
+    lastFlagOverrides.value = { ...config.value.flagOverrides };
+    patch({ flagOverrides: undefined });
+  } else {
+    patch({ flagOverrides: { ...lastFlagOverrides.value } });
+  }
 };
 
 const updateFlagOverrides = (values: Record<string, boolean>) => {

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from 'vue';
 
 import EndpointsField from './EndpointsField.vue';
 import FlagOverridesEditor from './FlagOverridesEditor.vue';
-import { configOf, defaultEndpointsForKind, publicIdOf, titleFor, type Row } from './modelRows.ts';
+import { defaultEndpointsForKind, publicIdOf, titleFor, type Row } from './modelRows.ts';
 import type { AnnouncedMetadata, BillingDimension, FlagDef, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig } from '../../api/types.ts';
 import { parseOptionalNumber } from '../../utils/parse-optional-number.ts';
 import ChatMetadataEditor from '../shared/ChatMetadataEditor.vue';
@@ -58,7 +58,7 @@ const PRICING_BY_KIND: Record<ModelKind, BillingDimension[]> = {
   image: ['input', 'input_image', 'output', 'output_image'],
 };
 
-const config = computed<UpstreamModelConfig | null>(() => props.row ? configOf(props.row) : null);
+const config = computed<UpstreamModelConfig | null>(() => props.row?.config ?? null);
 const editable = computed(() => props.row?.kind === 'manual');
 const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
 

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -14,12 +14,9 @@ const props = defineProps<{
   flags: FlagDef[];
   upstreamFlagOverrides: Record<string, boolean>;
   // Provider-declared upstream-level default for every flag on this
-  // upstream kind (layer 1 in the flag resolver). The per-model editor's
-  // "Inherit" pill resolves via layer 3 (upstream override, live-edited)
-  // else the merge of layer 1 with this row's `providerFlagOverlay`
-  // (layer 2, when the provider ships per-model defaults). All current
-  // manual-model providers emit an empty layer 2, but the merge keeps the
-  // component future-proof.
+  // upstream kind. The per-model editor's "Inherit" pill resolves via
+  // the upstream override (live-edited, `upstreamFlagOverrides`) if set,
+  // else falls through to this map.
   providerFlagDefaults: Record<string, boolean>;
   // "Upstream Model ID" for custom/copilot, "Deployment" for azure.
   upstreamIdLabel: string;
@@ -63,14 +60,6 @@ const PRICING_BY_KIND: Record<ModelKind, BillingDimension[]> = {
 const config = computed<UpstreamModelConfig | null>(() => props.row ? configOf(props.row) : null);
 const editable = computed(() => props.row?.kind === 'manual');
 const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
-
-// Merge of layer 1 (upstream default) with this row's layer 2 for
-// FlagOverridesEditor's inherit fallthrough. See the `providerFlagDefaults`
-// prop above for the full layer semantics.
-const flagDefaultsForThisModel = computed<Record<string, boolean>>(() => ({
-  ...props.providerFlagDefaults,
-  ...(config.value?.providerFlagOverlay ?? {}),
-}));
 
 const patch = (next: Partial<UpstreamModelConfig>) => {
   if (!editable.value) return;
@@ -557,7 +546,7 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
             v-if="editable && config.flagOverrides?.enabled"
             :model-value="config.flagOverrides?.values ?? {}"
             :flags="flags"
-            :provider-defaults="flagDefaultsForThisModel"
+            :provider-defaults="providerFlagDefaults"
             :inherited-overrides="upstreamFlagOverrides"
             :name-prefix="`${row.uiId}-flag`"
             class="max-h-72"

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -68,7 +68,7 @@ const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
 // `resolveEffectiveFlags` at request time, so what the dashboard shows
 // is exactly what the provider dispatches.
 const autoRowFlagState = (flagId: string): { on: boolean; source: string } => {
-  const perModel = config.value?.flagOverridesAuto?.[flagId];
+  const perModel = config.value?.flagOverrides?.[flagId];
   if (perModel !== undefined) return { on: perModel, source: 'provider — this model' };
   const upstreamOverride = props.upstreamFlagOverrides[flagId];
   if (upstreamOverride !== undefined) return { on: upstreamOverride, source: 'upstream override' };

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -227,15 +227,11 @@ const moveTierDown = (index: number) => {
 
 const toggleFlagOverridesEnabled = () => {
   if (!editable.value || !config.value) return;
-  if (config.value.flagOverrides?.enabled) {
-    patch({ flagOverrides: undefined });
-  } else {
-    patch({ flagOverrides: { enabled: true, values: { ...(config.value.flagOverrides?.values ?? {}) } } });
-  }
+  patch({ flagOverrides: config.value.flagOverrides !== undefined ? undefined : {} });
 };
 
 const updateFlagOverrides = (values: Record<string, boolean>) => {
-  patch({ flagOverrides: { enabled: true, values } });
+  patch({ flagOverrides: values });
 };
 
 // ── Chat metadata ──────────────────────────────────────────────────────────
@@ -536,15 +532,15 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
             <span class="text-[11px] text-gray-500">applied on top of upstream-level flags; <code class="font-mono">Inherit</code> reflects the upstream-resolved value</span>
             <Switch
               v-if="editable"
-              :model-value="config.flagOverrides?.enabled === true"
+              :model-value="config.flagOverrides !== undefined"
               class="ml-auto"
               @update:model-value="toggleFlagOverridesEnabled"
             />
             <Switch v-else :model-value="false" disabled class="ml-auto" />
           </div>
           <FlagOverridesEditor
-            v-if="editable && config.flagOverrides?.enabled"
-            :model-value="config.flagOverrides?.values ?? {}"
+            v-if="editable && config.flagOverrides !== undefined"
+            :model-value="config.flagOverrides"
             :flags="flags"
             :provider-defaults="providerFlagDefaults"
             :inherited-overrides="upstreamFlagOverrides"

--- a/apps/web/src/components/upstream-edit/ModelEditor.vue
+++ b/apps/web/src/components/upstream-edit/ModelEditor.vue
@@ -4,7 +4,7 @@ import { computed, ref, watch } from 'vue';
 import EndpointsField from './EndpointsField.vue';
 import FlagOverridesEditor from './FlagOverridesEditor.vue';
 import { configOf, defaultEndpointsForKind, publicIdOf, titleFor, type Row } from './modelRows.ts';
-import type { AnnouncedMetadata, BillingDimension, FlagDef, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig, UpstreamProviderKind } from '../../api/types.ts';
+import type { AnnouncedMetadata, BillingDimension, FlagDef, ModelKind, ModelPricing, UpstreamChatConfig, UpstreamModelConfig } from '../../api/types.ts';
 import { parseOptionalNumber } from '../../utils/parse-optional-number.ts';
 import ChatMetadataEditor from '../shared/ChatMetadataEditor.vue';
 import { Button, Input, Select, Switch, Tooltip } from '@floway-dev/ui';
@@ -13,7 +13,14 @@ const props = defineProps<{
   row: Row | null;
   flags: FlagDef[];
   upstreamFlagOverrides: Record<string, boolean>;
-  flagProviderKind: UpstreamProviderKind;
+  // Provider-declared upstream-level default for every flag on this
+  // upstream kind (layer 1 in the flag resolver). The per-model editor's
+  // "Inherit" pill resolves via layer 3 (upstream override, live-edited)
+  // else the merge of layer 1 with this row's `provider_default_overlay`
+  // (layer 2, when the provider ships per-model defaults). All current
+  // manual-model providers emit an empty layer 2, but the merge keeps the
+  // component future-proof.
+  providerFlagDefaults: Record<string, boolean>;
   // "Upstream Model ID" for custom/copilot, "Deployment" for azure.
   upstreamIdLabel: string;
   // True when this manual row's upstream id is fixed (seeded from an auto
@@ -56,6 +63,14 @@ const PRICING_BY_KIND: Record<ModelKind, BillingDimension[]> = {
 const config = computed<UpstreamModelConfig | null>(() => props.row ? configOf(props.row) : null);
 const editable = computed(() => props.row?.kind === 'manual');
 const rowKind = computed<ModelKind>(() => config.value?.kind ?? 'chat');
+
+// Merge of layer 1 (upstream default) with this row's layer 2 for
+// FlagOverridesEditor's inherit fallthrough. See the `providerFlagDefaults`
+// prop above for the full layer semantics.
+const flagDefaultsForThisModel = computed<Record<string, boolean>>(() => ({
+  ...props.providerFlagDefaults,
+  ...(config.value?.provider_default_overlay ?? {}),
+}));
 
 const patch = (next: Partial<UpstreamModelConfig>) => {
   if (!editable.value) return;
@@ -542,7 +557,7 @@ watch(isReasoningValid, valid => { emit('validity-change', valid); }, { immediat
             v-if="editable && config.flagOverrides?.enabled"
             :model-value="config.flagOverrides?.values ?? {}"
             :flags="flags"
-            :kind="flagProviderKind"
+            :provider-defaults="flagDefaultsForThisModel"
             :inherited-overrides="upstreamFlagOverrides"
             :name-prefix="`${row.uiId}-flag`"
             class="max-h-72"

--- a/apps/web/src/components/upstream-edit/ModelsPanel.vue
+++ b/apps/web/src/components/upstream-edit/ModelsPanel.vue
@@ -80,13 +80,13 @@ const reconcile = () => {
         placedManual.add(row.config);
       }
     } else {
-      const live = auto.find(a => a.upstreamModelId === row.auto.upstreamModelId);
+      const live = auto.find(a => a.upstreamModelId === row.config.upstreamModelId);
       if (live) {
         // Refresh the snapshot in place so a re-fetch updates read-only
         // metadata without disturbing the row's identity/position.
-        row.auto = live;
+        row.config = live;
         next.push(row);
-        placedAuto.add(row.auto.upstreamModelId);
+        placedAuto.add(row.config.upstreamModelId);
       }
     }
   }
@@ -101,7 +101,7 @@ const reconcile = () => {
 
   for (const a of auto) {
     if (!placedAuto.has(a.upstreamModelId)) {
-      next.push({ uiId: newUiId(), kind: 'auto', auto: a });
+      next.push({ uiId: newUiId(), kind: 'auto', config: a });
     }
   }
 
@@ -122,7 +122,7 @@ const selectedRow = computed<Row | null>(() =>
 
 const emitManual = () => {
   manualModels.value = rows.value
-    .filter((r): r is Extract<Row, { kind: 'manual' }> => r.kind === 'manual')
+    .filter(r => r.kind === 'manual')
     .map(r => r.config);
 };
 
@@ -152,7 +152,7 @@ const setMode = (uiId: string, mode: 'auto' | 'manual') => {
   if (mode === 'manual' && row.kind === 'auto') {
     // Seed an editable manual entry from the auto snapshot, keep the
     // position, and lock its upstreamModelId so it keeps shadowing the twin.
-    const config = seedFromAuto(row.auto);
+    const config = seedFromAuto(row.config);
     rows.value.splice(index, 1, { uiId, kind: 'manual', config });
     lockedUpstreamId.add(uiId);
     emitManual();
@@ -161,7 +161,7 @@ const setMode = (uiId: string, mode: 'auto' | 'manual') => {
     // the same uiId so the row keeps its position.
     lockedUpstreamId.delete(uiId);
     const twin = props.autoModels.find(a => a.upstreamModelId === row.config.upstreamModelId);
-    if (twin) rows.value.splice(index, 1, { uiId, kind: 'auto', auto: twin });
+    if (twin) rows.value.splice(index, 1, { uiId, kind: 'auto', config: twin });
     else rows.value.splice(index, 1);
     emitManual();
   }

--- a/apps/web/src/components/upstream-edit/ModelsPanel.vue
+++ b/apps/web/src/components/upstream-edit/ModelsPanel.vue
@@ -8,6 +8,7 @@ import ModelEditor from './ModelEditor.vue';
 import { newUiId, type Row, seedFromAuto } from './modelRows.ts';
 import ModelsGrid from './ModelsGrid.vue';
 import type { FlagDef, UpstreamModelConfig } from '../../api/types.ts';
+import type { FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
 import { Button } from '@floway-dev/ui';
 
 const manualModels = defineModel<UpstreamModelConfig[]>({ required: true });
@@ -20,8 +21,8 @@ const emit = defineEmits<{
 const props = withDefaults(defineProps<{
   autoModels?: UpstreamModelConfig[];
   flags: FlagDef[];
-  upstreamFlagOverrides: Record<string, boolean>;
-  providerFlagDefaults: Record<string, boolean>;
+  upstreamFlagOverrides: FlagOverrides;
+  providerFlagDefaults: FlagDefaults;
   upstreamIdLabel: string;
   // Fully read-only: no add, no mode switch, no editing.
   readOnly?: boolean;

--- a/apps/web/src/components/upstream-edit/ModelsPanel.vue
+++ b/apps/web/src/components/upstream-edit/ModelsPanel.vue
@@ -7,7 +7,7 @@ import { computed, reactive, ref, watch } from 'vue';
 import ModelEditor from './ModelEditor.vue';
 import { newUiId, type Row, seedFromAuto } from './modelRows.ts';
 import ModelsGrid from './ModelsGrid.vue';
-import type { FlagDef, UpstreamModelConfig, UpstreamProviderKind } from '../../api/types.ts';
+import type { FlagDef, UpstreamModelConfig } from '../../api/types.ts';
 import { Button } from '@floway-dev/ui';
 
 const manualModels = defineModel<UpstreamModelConfig[]>({ required: true });
@@ -21,7 +21,7 @@ const props = withDefaults(defineProps<{
   autoModels?: UpstreamModelConfig[];
   flags: FlagDef[];
   upstreamFlagOverrides: Record<string, boolean>;
-  flagProviderKind: UpstreamProviderKind;
+  providerFlagDefaults: Record<string, boolean>;
   upstreamIdLabel: string;
   // Fully read-only: no add, no mode switch, no editing.
   readOnly?: boolean;
@@ -308,7 +308,7 @@ watch(manualModels, () => {
         :row="selectedRow"
         :flags="flags"
         :upstream-flag-overrides="upstreamFlagOverrides"
-        :flag-provider-kind="flagProviderKind"
+        :provider-flag-defaults="providerFlagDefaults"
         :upstream-id-label="upstreamIdLabel"
         :is-upstream-id-locked="selectedRow !== null && lockedUpstreamId.has(selectedRow.uiId)"
         :has-auto-counterpart="selectedRow !== null && hasAutoCounterpart(selectedRow)"

--- a/apps/web/src/components/upstream-edit/ModelsPanel.vue
+++ b/apps/web/src/components/upstream-edit/ModelsPanel.vue
@@ -7,8 +7,8 @@ import { computed, reactive, ref, watch } from 'vue';
 import ModelEditor from './ModelEditor.vue';
 import { newUiId, type Row, seedFromAuto } from './modelRows.ts';
 import ModelsGrid from './ModelsGrid.vue';
-import type { FlagDef, UpstreamModelConfig } from '../../api/types.ts';
-import type { FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
+import type { UpstreamModelConfig } from '../../api/types.ts';
+import type { Flag, FlagDefaults, FlagOverrides } from '@floway-dev/provider/flags';
 import { Button } from '@floway-dev/ui';
 
 const manualModels = defineModel<UpstreamModelConfig[]>({ required: true });
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 
 const props = withDefaults(defineProps<{
   autoModels?: UpstreamModelConfig[];
-  flags: FlagDef[];
+  flags: Flag[];
   upstreamFlagOverrides: FlagOverrides;
   providerFlagDefaults: FlagDefaults;
   upstreamIdLabel: string;

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -14,11 +14,12 @@ import OllamaConfigPanel from './OllamaConfigPanel.vue';
 import ProxyFallbackListPanel from './ProxyFallbackListPanel.vue';
 import type { FlagDef, ModelPrefixConfig, ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 import { providerBadgeClass, providerMeta } from '../upstreams/provider-meta.ts';
+import type { FlagOverrides } from '@floway-dev/provider/flags';
 import { Input, Switch, TagCombobox } from '@floway-dev/ui';
 
 const name = defineModel<string>('name', { required: true });
 const enabled = defineModel<boolean>('enabled', { required: true });
-const flagOverrides = defineModel<Record<string, boolean>>('flagOverrides', { required: true });
+const flagOverrides = defineModel<FlagOverrides>('flagOverrides', { required: true });
 const disabledIds = defineModel<string[]>('disabledIds', { required: true });
 const customDraft = defineModel<CustomDraft>('custom', { required: true });
 const azureDraft = defineModel<AzureDraft>('azure', { required: true });

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -240,7 +240,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         <FlagOverridesEditor
           v-model="flagOverrides"
           :flags="flags"
-          :kind="kind"
+          :provider-defaults="draft.flag_defaults"
           name-prefix="upstream-flag"
           class="min-h-0 flex-1"
         />

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -12,9 +12,9 @@ import ModelPrefixEditor from './ModelPrefixEditor.vue';
 import ModelsCacheStatus from './ModelsCacheStatus.vue';
 import OllamaConfigPanel from './OllamaConfigPanel.vue';
 import ProxyFallbackListPanel from './ProxyFallbackListPanel.vue';
-import type { FlagDef, ModelPrefixConfig, ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
+import type { ModelPrefixConfig, ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 import { providerBadgeClass, providerMeta } from '../upstreams/provider-meta.ts';
-import type { FlagOverrides } from '@floway-dev/provider/flags';
+import type { Flag, FlagOverrides } from '@floway-dev/provider/flags';
 import { Input, Switch, TagCombobox } from '@floway-dev/ui';
 
 const name = defineModel<string>('name', { required: true });
@@ -31,7 +31,7 @@ const modelPrefix = defineModel<ModelPrefixConfig | null>('modelPrefix', { requi
 // through `patched` for the parent to merge.
 const props = defineProps<{
   draft: UpstreamRecord;
-  flags: FlagDef[];
+  flags: Flag[];
   customApiKeySet: boolean;
   azureApiKeySet: boolean;
   ollamaApiKeySet: boolean;

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -600,7 +600,7 @@ const workbenchStyle = computed(() => ({ '--right-pane-h': `${Math.ceil(rightCon
         :auto-models="autoForActive"
         :flags="flags"
         :upstream-flag-overrides="flagOverrides"
-        :flag-provider-kind="draft.kind"
+        :provider-flag-defaults="draft.flag_defaults"
         :upstream-id-label="upstreamIdLabelForActive"
         :read-only="draft.kind === 'copilot' || draft.kind === 'codex' || draft.kind === 'claude-code'"
         :all-manual="draft.kind === 'azure'"

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -25,6 +25,7 @@ import type { AzureUpstreamConfig, CustomRawModel, CustomUpstreamConfig, FlagDef
 import { toRecordEnvelope } from '../../api/types.ts';
 import { useRuntimeInfo } from '../../composables/useRuntimeInfo.ts';
 import { useUpstreamsStore } from '../../composables/useUpstreams.ts';
+import type { FlagOverrides } from '@floway-dev/provider/flags';
 import { Button } from '@floway-dev/ui';
 
 const props = defineProps<{
@@ -107,7 +108,7 @@ seedProviderDrafts();
 // getting it observes any patch merged in by a wizard.
 const name = computed<string>({ get: () => draft.value.name, set: v => { draft.value = { ...draft.value, name: v }; } });
 const enabled = computed<boolean>({ get: () => draft.value.enabled, set: v => { draft.value = { ...draft.value, enabled: v }; } });
-const flagOverrides = computed<Record<string, boolean>>({
+const flagOverrides = computed<FlagOverrides>({
   get: () => draft.value.flag_overrides,
   set: v => { draft.value = { ...draft.value, flag_overrides: v }; },
 });

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -487,7 +487,7 @@ const showCacheStatus = computed(() => !isCreate.value && draft.value.kind !== '
 const availableModelItems = computed<{ value: string; label: string }[]>(() => {
   const seen = new Set<string>();
   const items: { value: string; label: string }[] = [];
-  const collect = (list: UpstreamModelConfig[]) => {
+  const collect = (list: readonly UpstreamModelConfig[]) => {
     for (const m of list) {
       // `||` (not `??`) is intentional: a whitespace-only override should
       // not shadow the upstream id.

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -21,16 +21,16 @@ import {
 import ModelsPanel from './ModelsPanel.vue';
 import UpstreamConfigPanel from './UpstreamConfigPanel.vue';
 import { callApi, useApi } from '../../api/client.ts';
-import type { AzureUpstreamConfig, CustomRawModel, CustomUpstreamConfig, FlagDef, ModelEndpoints, OllamaUpstreamConfig, UpstreamModelConfig, UpstreamRecord } from '../../api/types.ts';
+import type { AzureUpstreamConfig, CustomRawModel, CustomUpstreamConfig, ModelEndpoints, OllamaUpstreamConfig, UpstreamModelConfig, UpstreamRecord } from '../../api/types.ts';
 import { toRecordEnvelope } from '../../api/types.ts';
 import { useRuntimeInfo } from '../../composables/useRuntimeInfo.ts';
 import { useUpstreamsStore } from '../../composables/useUpstreams.ts';
-import type { FlagOverrides } from '@floway-dev/provider/flags';
+import type { Flag, FlagOverrides } from '@floway-dev/provider/flags';
 import { Button } from '@floway-dev/ui';
 
 const props = defineProps<{
   initialRecord: UpstreamRecord;
-  flags: FlagDef[];
+  flags: Flag[];
 }>();
 
 const emit = defineEmits<{

--- a/apps/web/src/components/upstream-edit/modelRows.ts
+++ b/apps/web/src/components/upstream-edit/modelRows.ts
@@ -4,10 +4,6 @@ import type { ModelEndpointKey, ModelEndpoints, ModelKind, UpstreamModelConfig }
 // `manual` came from `upstreams.config.models[]` (persists on PATCH,
 // operator-editable); `auto` came from the live wire projection of
 // `POST /api/upstreams/list-models` (read-only, never persists).
-// Both flavours share `UpstreamModelConfig` — a manual row is what
-// `seedFromAuto` produces from an auto row, verbatim except for a
-// `defaultEndpointsForKind` fallback when the source endpoints map is
-// empty, so the type must accept the union already.
 export interface Row {
   uiId: string;
   kind: 'manual' | 'auto';
@@ -36,8 +32,6 @@ export const defaultEndpointsForKind = (kind: ModelKind, current: ModelEndpoints
 // metadata field, and pull the auto row's `flagOverrides` (the provider's
 // per-model rule) into the manual row's `flagOverrides` so the operator
 // starts from the same layer-3 state the provider was applying.
-// `defaultEndpointsForKind` fills in when the source has an empty
-// endpoints map, otherwise the auto endpoints ride through unchanged.
 export const seedFromAuto = (auto: UpstreamModelConfig): UpstreamModelConfig => {
   const kind = auto.kind;
   return {

--- a/apps/web/src/components/upstream-edit/modelRows.ts
+++ b/apps/web/src/components/upstream-edit/modelRows.ts
@@ -17,8 +17,6 @@ export interface Row {
 let nextUiId = 0;
 export const newUiId = () => `m${++nextUiId}`;
 
-export const configOf = (row: Row): UpstreamModelConfig => row.config;
-
 const CHAT_ENDPOINT_KEYS: ModelEndpointKey[] = ['completions', 'chatCompletions', 'responses', 'messages'];
 const IMAGE_ENDPOINT_KEYS: ModelEndpointKey[] = ['imagesGenerations', 'imagesEdits'];
 
@@ -62,17 +60,15 @@ export const seedFromAuto = (auto: UpstreamModelConfig): UpstreamModelConfig => 
 // backend publicModelId() so the toggle and the combobox key on the same id
 // the data plane filters by.
 export const publicIdOf = (row: Row): string => {
-  const c = configOf(row);
-  const configured = c.publicModelId?.trim();
+  const configured = row.config.publicModelId?.trim();
   if (configured) return configured;
-  return c.upstreamModelId;
+  return row.config.upstreamModelId;
 };
 
 export const titleFor = (row: Row): string => {
-  const c = configOf(row);
-  const display = c.display_name?.trim();
+  const display = row.config.display_name?.trim();
   if (display) return display;
-  const upstream = c.upstreamModelId.trim();
+  const upstream = row.config.upstreamModelId.trim();
   if (upstream) return upstream;
   return 'Untitled model';
 };

--- a/apps/web/src/components/upstream-edit/modelRows.ts
+++ b/apps/web/src/components/upstream-edit/modelRows.ts
@@ -1,14 +1,23 @@
 import type { ModelEndpointKey, ModelEndpoints, ModelKind, UpstreamModelConfig } from '../../api/types.ts';
 
-export type Row =
-  | { uiId: string; kind: 'manual'; config: UpstreamModelConfig }
-  | { uiId: string; kind: 'auto'; auto: UpstreamModelConfig };
+// A row's `kind` names the source of its `config`, not the shape:
+// `manual` came from `upstreams.config.models[]` (persists on PATCH,
+// operator-editable); `auto` came from the live wire projection of
+// `POST /api/upstreams/list-models` (read-only, never persists).
+// Both flavours share `UpstreamModelConfig` — a manual row is what
+// `seedFromAuto` produces from an auto row, verbatim except for a
+// `defaultEndpointsForKind` fallback when the source endpoints map is
+// empty, so the type must accept the union already.
+export interface Row {
+  uiId: string;
+  kind: 'manual' | 'auto';
+  config: UpstreamModelConfig;
+}
 
 let nextUiId = 0;
 export const newUiId = () => `m${++nextUiId}`;
 
-export const configOf = (row: Row): UpstreamModelConfig =>
-  row.kind === 'manual' ? row.config : row.auto;
+export const configOf = (row: Row): UpstreamModelConfig => row.config;
 
 const CHAT_ENDPOINT_KEYS: ModelEndpointKey[] = ['completions', 'chatCompletions', 'responses', 'messages'];
 const IMAGE_ENDPOINT_KEYS: ModelEndpointKey[] = ['imagesGenerations', 'imagesEdits'];
@@ -25,6 +34,12 @@ export const defaultEndpointsForKind = (kind: ModelKind, current: ModelEndpoints
   return kind === 'image' ? { imagesGenerations: {}, imagesEdits: {} } : { chatCompletions: {} };
 };
 
+// Crystallize an auto row's live projection into a manual row: copy every
+// metadata field, and pull the auto row's `flagOverrides` (the provider's
+// per-model rule) into the manual row's `flagOverrides` so the operator
+// starts from the same layer-3 state the provider was applying.
+// `defaultEndpointsForKind` fills in when the source has an empty
+// endpoints map, otherwise the auto endpoints ride through unchanged.
 export const seedFromAuto = (auto: UpstreamModelConfig): UpstreamModelConfig => {
   const kind = auto.kind;
   return {
@@ -38,6 +53,7 @@ export const seedFromAuto = (auto: UpstreamModelConfig): UpstreamModelConfig => 
     ...(auto.limits ? { limits: { ...auto.limits } } : {}),
     ...(auto.cost ? { cost: { ...auto.cost } } : {}),
     ...(auto.chat ? { chat: auto.chat } : {}),
+    ...(auto.flagOverrides ? { flagOverrides: { ...auto.flagOverrides } } : {}),
   };
 };
 

--- a/apps/web/src/composables/useUpstreams.ts
+++ b/apps/web/src/composables/useUpstreams.ts
@@ -1,11 +1,12 @@
 import { ref, shallowRef } from 'vue';
 
 import { callApi, useApi } from '../api/client.ts';
-import type { FlagDef, UpstreamRecord } from '../api/types.ts';
+import type { UpstreamRecord } from '../api/types.ts';
+import type { Flag } from '@floway-dev/provider/flags';
 
 // Module-scoped so Settings edits reflect on Models without a refetch.
 const upstreams = shallowRef<UpstreamRecord[] | null>(null);
-const flagCatalog = shallowRef<FlagDef[] | null>(null);
+const flagCatalog = shallowRef<Flag[] | null>(null);
 const loading = ref(false);
 
 export const useUpstreamsStore = () => {
@@ -16,7 +17,7 @@ export const useUpstreamsStore = () => {
     try {
       const [listRes, flagsRes] = await Promise.all([
         callApi<UpstreamRecord[]>(() => api.api.upstreams.$get()),
-        callApi<FlagDef[]>(() => api.api.upstreams.flags.$get()),
+        callApi<Flag[]>(() => api.api.upstreams.flags.$get()),
       ]);
       if (listRes.error) throw new Error(listRes.error.message);
       if (flagsRes.error) throw new Error(flagsRes.error.message);

--- a/packages/gateway/migrations/0049_flatten_model_flag_overrides.sql
+++ b/packages/gateway/migrations/0049_flatten_model_flag_overrides.sql
@@ -12,9 +12,12 @@
 --     passed through byte-for-byte.
 --
 -- Rebuild config.models via json_group_array(CASE …) so untouched entries
--- fall through the ELSE branch unchanged, and gate the outer UPDATE on
--- EXISTS(...) so rows that hold zero wrapped entries are not rewritten.
--- Idempotent: on a second pass every row lands in the ELSE branch.
+-- fall through the ELSE branch unchanged. The outer EXISTS gate is a
+-- perf hedge, not a correctness gate — rows that hold zero wrapped
+-- entries would just rewrite themselves to the same JSON, but skipping
+-- the rebuild avoids that write on every re-run. Idempotent: on a
+-- second pass every row lands in the ELSE branch, EXISTS returns false,
+-- nothing is written.
 
 UPDATE upstreams
 SET config_json = json_set(

--- a/packages/gateway/migrations/0049_flatten_model_flag_overrides.sql
+++ b/packages/gateway/migrations/0049_flatten_model_flag_overrides.sql
@@ -1,0 +1,46 @@
+-- Flatten UpstreamModelConfig.flagOverrides. The prior wire shape was
+-- `{ enabled: boolean, values: Record<string, boolean> }`; the new shape is
+-- `Record<string, boolean>` directly. `enabled: false` had the same layer-3
+-- effect as an absent field (skip the per-model layer entirely), so it
+-- collapses to unset — the presence of the field is now the sole toggle.
+--
+-- Rewrite per config.models[] entry:
+--   * `flagOverrides.enabled: true`  → replace flagOverrides with its
+--     inner `values` dict.
+--   * `flagOverrides.enabled: false` → drop flagOverrides entirely.
+--   * entries with no `.enabled` subkey (already-flat or absent) are
+--     passed through byte-for-byte.
+--
+-- Rebuild config.models via json_group_array(CASE …) so untouched entries
+-- fall through the ELSE branch unchanged, and gate the outer UPDATE on
+-- EXISTS(...) so rows that hold zero wrapped entries are not rewritten.
+-- Idempotent: on a second pass every row lands in the ELSE branch.
+
+UPDATE upstreams
+SET config_json = json_set(
+  config_json,
+  '$.models',
+  (
+    SELECT json_group_array(
+      CASE
+        WHEN json_extract(model.value, '$.flagOverrides.enabled') = 1
+        THEN json_set(
+          model.value,
+          '$.flagOverrides',
+          json_extract(model.value, '$.flagOverrides.values')
+        )
+        WHEN json_extract(model.value, '$.flagOverrides.enabled') = 0
+        THEN json_remove(model.value, '$.flagOverrides')
+        ELSE model.value
+      END
+    )
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+  )
+)
+WHERE json_valid(config_json)
+  AND json_type(config_json, '$.models') = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+    WHERE json_type(model.value, '$.flagOverrides.enabled') IS NOT NULL
+  );

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -49,7 +49,7 @@ interface SerializedProxy {
 }
 
 interface ExportPayload {
-  version: 6;
+  version: 7;
   exportedAt: string;
   data: {
     users: User[];
@@ -64,7 +64,7 @@ interface ExportPayload {
   };
 }
 
-const EXPORT_VERSION = 6;
+const EXPORT_VERSION = 7;
 const SEARCH_USAGE_HOUR_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}$/;
 const PERFORMANCE_METRIC_SCOPES = new Set<PerformanceMetricScope>(['request_total', 'upstream_success']);
 const UPSTREAM_PROVIDERS = new Set<UpstreamProviderKind>(ALL_PROVIDER_KINDS);

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -574,7 +574,7 @@ const parsePerformanceRecords = (value: unknown): { type: 'ok'; records: Perform
 // genuine misconfiguration and are not swallowed.
 const warmModelsCache = async (record: UpstreamRecord, c: Context): Promise<void> => {
   const scheduler = backgroundSchedulerFromContext(c);
-  const instance = await createProviderInstance(record);
+  const instance = createProviderInstance(record);
   const fetcher = (await createPerRequestFetcher(getCurrentColo(c.req.raw)))(record.id);
   try {
     await fetchUpstreamModelsCached(instance, { scheduler, fetcher, force: true });

--- a/packages/gateway/src/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes_test.ts
@@ -279,7 +279,7 @@ const doExport = async (app: Hono, includePerformance = false) => {
   return (await resp.json()) as Record<string, any>;
 };
 
-const doImport = async (app: Hono, mode: string, data: unknown, version: unknown = 6) => {
+const doImport = async (app: Hono, mode: string, data: unknown, version: unknown = 7) => {
   const resp = await app.request('/import', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -299,13 +299,13 @@ const latestImportData = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-test('export emits the v6 envelope with users and upstreams', async () => {
+test('export emits the v7 envelope with users and upstreams', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
 
   const result = await doExport(app);
 
-  assertEquals(result.version, 6);
+  assertEquals(result.version, 7);
   assertEquals(typeof result.exportedAt, 'string');
   assertEquals(result.data.users, [SEED_ADMIN]);
   assertEquals(result.data.apiKeys, []);
@@ -364,7 +364,7 @@ test('import rejects any version other than the current one before deleting data
   await repo.apiKeys.save(KEY_A);
   await repo.upstreams.save(CUSTOM_UPSTREAM);
 
-  const VERSION_ERROR = 'version must be 6 — older export formats are not supported; re-export from the current deployment';
+  const VERSION_ERROR = 'version must be 7 — older export formats are not supported; re-export from the current deployment';
   const priorVersion = await doImport(app, 'replace', { apiKeys: [] }, 3);
   const ancientVersion = await doImport(app, 'replace', { apiKeys: [] }, 1);
   const missingVersionResponse = await app.request('/import', {
@@ -711,7 +711,7 @@ test('import rejects legacy enabled_fixes payloads before mutating', async () =>
   assertEquals(await repo.upstreams.list(), [CUSTOM_UPSTREAM]);
 });
 
-test('import rejects missing latest-v6 arrays before clearing existing data', async () => {
+test('import rejects missing latest-v7 arrays before clearing existing data', async () => {
   const { app, repo } = setup();
   await repo.apiKeys.save(KEY_A);
   await repo.upstreams.save(CUSTOM_UPSTREAM);
@@ -737,14 +737,14 @@ test('import rejects missing latest-v6 arrays before clearing existing data', as
 test('import validates mode and data before mutating', async () => {
   const { app } = setup();
 
-  const invalidMode = await doImport(app, 'invalid', {}, 6);
+  const invalidMode = await doImport(app, 'invalid', {}, 7);
   const missingData = await app.request('/import', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ mode: 'replace', version: 6 }),
+    body: JSON.stringify({ mode: 'replace', version: 7 }),
   });
-  const missingUpstreams = await doImport(app, 'merge', {}, 6);
-  const emptyMerge = await doImport(app, 'merge', latestImportData(), 6);
+  const missingUpstreams = await doImport(app, 'merge', {}, 7);
+  const emptyMerge = await doImport(app, 'merge', latestImportData(), 7);
 
   assertEquals(invalidMode.status, 400);
   assertEquals(invalidMode.body.error, "mode must be 'merge' or 'replace'");
@@ -885,7 +885,7 @@ test('import replace wipes proxy_upstream_backoffs alongside the proxies it cool
   assertEquals(await repo.proxyBackoffs.listAll(), []);
 });
 
-test('v6 export/import round-trips users and per-key user_id', async () => {
+test('v7 export/import round-trips users and per-key user_id', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
   await repo.users.save(USER_BOB);
@@ -893,10 +893,10 @@ test('v6 export/import round-trips users and per-key user_id', async () => {
   await repo.apiKeys.save({ ...KEY_B, userId: USER_BOB.id });
 
   const exportResult = await doExport(app);
-  assertEquals(exportResult.version, 6);
+  assertEquals(exportResult.version, 7);
   assertEquals(exportResult.data.users.map((u: any) => u.id).sort(), [SEED_ADMIN.id, USER_BOB.id]);
 
-  const result = await doImport(app, 'replace', exportResult.data, 6);
+  const result = await doImport(app, 'replace', exportResult.data, 7);
   assertEquals(result.status, 200);
   assertEquals(result.body.imported.users, 2);
   assertEquals(result.body.imported.apiKeys, 2);
@@ -907,7 +907,7 @@ test('v6 export/import round-trips users and per-key user_id', async () => {
   assertEquals(restoredKey?.userId, USER_BOB.id);
 });
 
-test('v6 import rejects api_keys whose user_id does not appear in the payload', async () => {
+test('v7 import rejects api_keys whose user_id does not appear in the payload', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
 
@@ -919,13 +919,13 @@ test('v6 import rejects api_keys whose user_id does not appear in the payload', 
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 6);
+  }, 7);
 
   assertEquals(result.status, 400);
   assertEquals(result.body.error, 'invalid apiKeys at index 0: user_id 99 does not match any user in the payload');
 });
 
-test('v6 import rejects malformed users (bad username, bad password_hash)', async () => {
+test('v7 import rejects malformed users (bad username, bad password_hash)', async () => {
   const { app } = setup();
 
   const badUsername = await doImport(app, 'replace', {
@@ -936,7 +936,7 @@ test('v6 import rejects malformed users (bad username, bad password_hash)', asyn
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 6);
+  }, 7);
   assertEquals(badUsername.status, 400);
   assertEquals(String(badUsername.body.error).startsWith('invalid users at index 0:'), true);
 
@@ -948,7 +948,7 @@ test('v6 import rejects malformed users (bad username, bad password_hash)', asyn
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 6);
+  }, 7);
   assertEquals(badHash.status, 400);
   assertEquals(String(badHash.body.error).includes('passwordHash'), true);
 });
@@ -970,7 +970,7 @@ test('import rejects a pre-accounts v3 export instead of coercing its legacy api
   }, 3);
 
   assertEquals(result.status, 400);
-  assertEquals(String(result.body.error).includes('version must be 6'), true);
+  assertEquals(String(result.body.error).includes('version must be 7'), true);
   // Rejected at the version gate, before touching any data.
   assertEquals(await repo.apiKeys.list(), [KEY_A]);
   assertEquals((await repo.users.list()).map(u => u.id), [SEED_ADMIN.id]);
@@ -991,7 +991,7 @@ test('replace-mode import clears sessions before writing users', async () => {
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 6);
+  }, 7);
 
   assertEquals(result.status, 200);
   // No public listAll on sessions; create a fresh session and check the
@@ -1000,7 +1000,7 @@ test('replace-mode import clears sessions before writing users', async () => {
   assertEquals(await repo.sessions.deleteByUserId(USER_BOB.id), 0);
 });
 
-test('v6 import rejects users[i].upstreamIds === undefined', async () => {
+test('v7 import rejects users[i].upstreamIds === undefined', async () => {
   const { app } = setup();
   const result = await doImport(app, 'replace', {
     users: [SEED_ADMIN, { ...USER_BOB, upstreamIds: undefined }],
@@ -1010,12 +1010,12 @@ test('v6 import rejects users[i].upstreamIds === undefined', async () => {
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 6);
+  }, 7);
   assertEquals(result.status, 400);
   expect(result.body.error).toMatch(/upstreamIds/);
 });
 
-test('v6 import rejects users[i].deletedAt of non-string non-null type', async () => {
+test('v7 import rejects users[i].deletedAt of non-string non-null type', async () => {
   const { app } = setup();
   const result = await doImport(app, 'replace', {
     users: [SEED_ADMIN, { ...USER_BOB, deletedAt: 42 }],
@@ -1025,12 +1025,12 @@ test('v6 import rejects users[i].deletedAt of non-string non-null type', async (
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 6);
+  }, 7);
   assertEquals(result.status, 400);
   expect(result.body.error).toMatch(/deletedAt/);
 });
 
-test('v6 replace import refuses payload missing user 1', async () => {
+test('v7 replace import refuses payload missing user 1', async () => {
   const { app } = setup();
   const result = await doImport(app, 'replace', {
     users: [USER_BOB],
@@ -1040,12 +1040,12 @@ test('v6 replace import refuses payload missing user 1', async () => {
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 6);
+  }, 7);
   assertEquals(result.status, 400);
   expect(result.body.error).toMatch(/user 1/);
 });
 
-test('a full v6 export re-imports verbatim — the export→import round trip is closed', async () => {
+test('a full v7 export re-imports verbatim — the export→import round trip is closed', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
   await repo.users.save(USER_BOB);
@@ -1065,12 +1065,12 @@ test('a full v6 export re-imports verbatim — the export→import round trip is
   await repo.searchConfig.save(config);
 
   const exported = await doExport(app, true);
-  assertEquals(exported.version, 6);
+  assertEquals(exported.version, 7);
 
   // Replace-import the export's own `data`, verbatim. If the export emits any
   // shape the import parser rejects, this 400s — the round trip is the
   // invariant, so this test fails the moment the two sides drift.
-  const result = await doImport(app, 'replace', exported.data, 6);
+  const result = await doImport(app, 'replace', exported.data, 7);
   assertEquals(result.status, 200);
   assertEquals(result.body.imported, { users: 2, apiKeys: 2, upstreams: 4, proxies: 0, usage: 2, searchUsage: 2, performance: 2 });
 
@@ -1104,7 +1104,7 @@ test('any data bearing a historical version is rejected on the version gate, bef
   for (const version of [1, 2, 3, 4, 5]) {
     const result = await doImport(app, 'replace', wellFormed, version);
     assertEquals(result.status, 400);
-    assertEquals(String(result.body.error).includes('version must be 6'), true);
+    assertEquals(String(result.body.error).includes('version must be 7'), true);
   }
 
   // Nothing was touched — the version gate runs before any delete or write.
@@ -1195,7 +1195,7 @@ test('replace-mode import surfaces a purgeAll failure', async () => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      mode: 'replace', version: 6, data: latestImportData({
+      mode: 'replace', version: 7, data: latestImportData({
         apiKeys: [{ ...KEY_A, dumpRetentionSeconds: 3600 }],
       }),
     }),
@@ -1213,7 +1213,7 @@ test('merge-mode retention transition surfaces a purgeAll failure', async () => 
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      mode: 'merge', version: 6, data: latestImportData({
+      mode: 'merge', version: 7, data: latestImportData({
         apiKeys: [{ ...KEY_A, dumpRetentionSeconds: null }],
       }),
     }),

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -18,11 +18,9 @@
 import { z } from 'zod';
 
 import { normalizeDisabledPublicModelIds } from '../repo/disabled-public-models.ts';
-import { MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX, OPTIONAL_FLAGS, parseFlagOverridesWire } from '@floway-dev/provider';
+import { MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX, parseFlagOverridesWire } from '@floway-dev/provider';
 
 // --- shared atoms ---
-
-const knownFlagIds = new Set<string>(OPTIONAL_FLAGS.map(f => f.id));
 
 // Reuse the runtime parseFlagOverridesWire so unknown-id and type errors
 // carry the canonical messages. z.unknown() → transform keeps the
@@ -35,11 +33,6 @@ const flagOverridesSchema = z.unknown().transform((value, ctx): Record<string, b
     return z.NEVER;
   }
 });
-
-const flagOverrideValuesSchema = z.record(z.string(), z.boolean()).refine(
-  overrides => Object.keys(overrides).every(id => knownFlagIds.has(id)),
-  'Unknown flag id in model flag overrides',
-);
 
 // Like flag_overrides, the disabled-models field normalizes at the API edge so a
 // create/update response echoes exactly what gets persisted (trimmed, de-duped).
@@ -146,10 +139,7 @@ const upstreamModelSchema = z.object({
     // rate, so every dimension inherits base pricing.
     tiers: z.record(z.string().min(1), z.object(pricingDimensionShape)).optional(),
   }).optional(),
-  flagOverrides: z.object({
-    enabled: z.boolean(),
-    values: flagOverrideValuesSchema,
-  }).optional(),
+  flagOverrides: flagOverridesSchema.optional(),
   limits: limitsSchema.optional(),
   chat: chatSchema.optional(),
 }).refine(

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -613,7 +613,7 @@ export const updateAliasBody = aliasBodyCore.superRefine(aliasBodyRulesRefinemen
 // --- data transfer ---
 
 export const importBody = z.object({
-  version: z.literal(6, { error: 'version must be 6 — older export formats are not supported; re-export from the current deployment' }),
+  version: z.literal(7, { error: 'version must be 7 — older export formats are not supported; re-export from the current deployment' }),
   mode: z.enum(['merge', 'replace'], { error: "mode must be 'merge' or 'replace'" }),
   data: z.unknown().optional(),
 });

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -18,14 +18,14 @@
 import { z } from 'zod';
 
 import { normalizeDisabledPublicModelIds } from '../repo/disabled-public-models.ts';
-import { MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX, parseFlagOverridesWire } from '@floway-dev/provider';
+import { type FlagOverrides, MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX, parseFlagOverridesWire } from '@floway-dev/provider';
 
 // --- shared atoms ---
 
 // Reuse the runtime parseFlagOverridesWire so unknown-id and type errors
 // carry the canonical messages. z.unknown() → transform keeps the
-// schema-validated output typed as Record<string, boolean> for the RPC client.
-const flagOverridesSchema = z.unknown().transform((value, ctx): Record<string, boolean> => {
+// schema-validated output typed as FlagOverrides for the RPC client.
+const flagOverridesSchema = z.unknown().transform((value, ctx): FlagOverrides => {
   try {
     return parseFlagOverridesWire(value);
   } catch (e) {

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -920,8 +920,6 @@ const reshapeModelForDashboard = (model: ProviderModel): Record<string, unknown>
     ...(Object.keys(model.limits).length > 0 ? { limits: model.limits } : {}),
     ...(model.cost ? { cost: model.cost } : {}),
     ...(model.chat ? { chat: model.chat } : {}),
-    // Per-model deviation from upstream flag defaults; absent when the
-    // model has none.
     ...(model.flagOverrides ? { flagOverrides: model.flagOverrides } : {}),
   };
 };

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -920,10 +920,8 @@ const reshapeModelForDashboard = (model: ProviderModel): Record<string, unknown>
     ...(Object.keys(model.limits).length > 0 ? { limits: model.limits } : {}),
     ...(model.cost ? { cost: model.cost } : {}),
     ...(model.chat ? { chat: model.chat } : {}),
-    // The dashboard's auto-row flag view reads this to render "provider
-    // forces X on for this model" pills. Absent = no per-model
-    // deviation from the upstream default; the auto view falls back to
-    // upstream defaults + upstream overrides.
+    // Per-model deviation from upstream flag defaults; absent when the
+    // model has none.
     ...(model.flagOverridesAuto && Object.keys(model.flagOverridesAuto).length > 0 ? { flagOverridesAuto: model.flagOverridesAuto } : {}),
   };
 };

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -922,7 +922,7 @@ const reshapeModelForDashboard = (model: ProviderModel): Record<string, unknown>
     ...(model.chat ? { chat: model.chat } : {}),
     // Per-model deviation from upstream flag defaults; absent when the
     // model has none.
-    ...(model.flagOverridesAuto && Object.keys(model.flagOverridesAuto).length > 0 ? { flagOverridesAuto: model.flagOverridesAuto } : {}),
+    ...(model.flagOverridesAuto ? { flagOverridesAuto: model.flagOverridesAuto } : {}),
   };
 };
 

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -922,7 +922,7 @@ const reshapeModelForDashboard = (model: ProviderModel): Record<string, unknown>
     ...(model.chat ? { chat: model.chat } : {}),
     // Per-model deviation from upstream flag defaults; absent when the
     // model has none.
-    ...(model.flagOverridesAuto ? { flagOverridesAuto: model.flagOverridesAuto } : {}),
+    ...(model.flagOverrides ? { flagOverrides: model.flagOverrides } : {}),
   };
 };
 

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -920,6 +920,11 @@ const reshapeModelForDashboard = (model: ProviderModel): Record<string, unknown>
     ...(Object.keys(model.limits).length > 0 ? { limits: model.limits } : {}),
     ...(model.cost ? { cost: model.cost } : {}),
     ...(model.chat ? { chat: model.chat } : {}),
+    // The dashboard's auto-row flag view reads this to render "provider
+    // forces X on for this model" pills. Absent = no per-model
+    // deviation from the upstream default; the auto view falls back to
+    // upstream defaults + upstream overrides.
+    ...(model.flagOverridesAuto && Object.keys(model.flagOverridesAuto).length > 0 ? { flagOverridesAuto: model.flagOverridesAuto } : {}),
   };
 };
 

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -159,7 +159,7 @@ const normalizeModelPrefixField = (input: unknown): ValidationResult<ModelPrefix
 // genuine misconfiguration that the operator must see.
 const warmModelsCache = async (record: UpstreamRecord, c: Context): Promise<void> => {
   const scheduler = backgroundSchedulerFromContext(c);
-  const instance = await createProviderInstance(record);
+  const instance = createProviderInstance(record);
   const fetcher = (await createPerRequestFetcher(getCurrentColo(c.req.raw)))(record.id);
   try {
     await fetchUpstreamModelsCached(instance, { scheduler, fetcher, force: true });
@@ -982,7 +982,7 @@ export const listModels = async (c: CtxWithJson<typeof listModelsBody>) => {
     // Force through the SWR cache when the record is persisted so the
     // side-effect refresh keeps the data-plane cache in step; otherwise
     // live-fetch without any caching.
-    const instance = await createProviderInstance(synthRecord);
+    const instance = createProviderInstance(synthRecord);
     const models = record.id !== ''
       ? await fetchUpstreamModelsCached(instance, { scheduler, fetcher, force: true })
       : await instance.instance.getProvidedModels(fetcher);

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -17,8 +17,8 @@ import { fetchGitHubUser, pollGitHubDeviceFlow, startGitHubDeviceFlow, type GitH
 import type { claudeCodeOauthAuthorizeUrlBody, claudeCodeOauthExchangeBody, claudeCodeOauthRefreshBody, claudeCodeProbeBody, claudeCodeSetupTokenAuthorizeUrlBody, claudeCodeSetupTokenExchangeBody, codexOauthAuthorizeUrlBody, codexOauthExchangeBody, codexOauthRefreshBody, copilotOauthDeviceLoginPollBody, copilotQuotaBody, createUpstreamBody, listModelsBody, updateUpstreamBody } from '../schemas.ts';
 import { copilotConfigField, type CopilotUpstreamConfig, isRecord } from '../shared/field-validators.ts';
 import {
-  getFlagCatalog,
   normalizeModelPrefix,
+  OPTIONAL_FLAGS,
   ProviderModelsUnavailableError,
   ALL_PROVIDER_KINDS,
   type Fetcher,
@@ -211,7 +211,7 @@ export const listUpstreamOptions = async (c: Context) => {
     })));
 };
 
-export const listOptionalFlags = (c: Context) => c.json(getFlagCatalog());
+export const listOptionalFlags = (c: Context) => c.json(OPTIONAL_FLAGS);
 
 const isValidProviderKind = (value: unknown): value is UpstreamProviderKind =>
   typeof value === 'string' && (ALL_PROVIDER_KINDS as readonly string[]).includes(value);

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -453,11 +453,6 @@ test('GET /api/upstreams/flags returns the flag catalog and requires admin auth'
   const sample = catalog.find(e => e.id === 'vendor-kimi');
   assertEquals(typeof sample?.label, 'string');
   assertEquals(typeof sample?.description, 'string');
-  // Neither defaults nor appliesTo travel on the per-flag entry any more —
-  // defaults live per-record on `SerializedUpstreamRecord.flag_defaults`.
-  // Guard against silent reintroduction of either on the catalog row.
-  assertEquals('defaultFor' in sample!, false);
-  assertEquals('appliesTo' in sample!, false);
 
   const forbidden = await requestApp('/api/upstreams/flags', { method: 'GET', headers: { 'x-api-key': apiKey.key } });
   assertEquals(forbidden.status, 403);

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -393,8 +393,11 @@ test('GET /api/upstreams/flags returns the flag catalog and requires admin auth'
   const catalog = (await resp.json()) as Array<Record<string, unknown>>;
   const sample = catalog.find(e => e.id === 'vendor-kimi');
   assertEquals(typeof sample?.label, 'string');
-  assertEquals(Array.isArray(sample!.defaultFor), true);
-  // appliesTo is not part of the catalog shape; guard against silent re-introduction.
+  assertEquals(typeof sample?.description, 'string');
+  // Neither defaults nor appliesTo travel on the per-flag entry any more —
+  // defaults live per-record on `SerializedUpstreamRecord.flag_defaults`.
+  // Guard against silent reintroduction of either on the catalog row.
+  assertEquals('defaultFor' in sample!, false);
   assertEquals('appliesTo' in sample!, false);
 
   const forbidden = await requestApp('/api/upstreams/flags', { method: 'GET', headers: { 'x-api-key': apiKey.key } });
@@ -2076,16 +2079,41 @@ test('GET /api/upstreams/blueprint rejects an unknown kind with 400', async () =
 test('GET /api/upstreams/blueprint serves blank credentials without running the runtime asserts', async () => {
   const { adminSession } = await setupAppTest();
 
-  // The custom / azure / ollama blueprints carry blank credentials + empty
-  // model lists that assertXxxUpstreamRecord would reject on the save
-  // path. The blueprint route bypasses those asserts so the SPA can render
-  // an empty draft to edit.
+  // Blueprints are shape-complete synthetic-but-schema-valid rows that ride
+  // through the standard serialization pipeline (including provider factory
+  // for `flag_defaults`). The SPA discards everything except `flag_defaults`
+  // and lets the user fill the actual config in from an empty draft. Custom
+  // uses `authStyle: 'none'` so the assert accepts an absent apiKey; azure
+  // carries a single placeholder model since its assert rejects empty
+  // model lists. The blueprint travels through `upstreamRecordToFullJson`,
+  // so credentials come through verbatim (empty strings, not `*Set` bools).
   const custom = (await (await requestApp('/api/upstreams/blueprint?kind=custom', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
-  assertEquals(custom.config.apiKey, '');
+  assertEquals(custom.config.authStyle, 'none');
+  assertEquals('apiKey' in custom.config, false);
   const azure = (await (await requestApp('/api/upstreams/blueprint?kind=azure', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
-  assertEquals(azure.config.models, []);
+  assertEquals(Array.isArray(azure.config.models), true);
   const ollama = (await (await requestApp('/api/upstreams/blueprint?kind=ollama', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
   assertEquals(ollama.config.apiKey, '');
+
+  // Every provider kind must reach a 200 — the blueprint's synthetic record
+  // has to satisfy that kind's `assertXxxUpstream{Record,State}` on its way
+  // through the provider factory. `flag_defaults` on the wire is the whole
+  // point of routing through the factory; assert it lands on every kind.
+  for (const kind of ['copilot', 'custom', 'azure', 'codex', 'claude-code', 'ollama']) {
+    const preview = (await (await requestApp(`/api/upstreams/blueprint?kind=${kind}`, { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
+    assertEquals(typeof preview.flag_defaults['strip-billing-attribution'], 'boolean');
+  }
+
+  // Spot-check the two provider-computed decisions we care about at the
+  // wire boundary. copilot keeps `strip-billing-attribution` on so the
+  // Claude Code billing block never reaches its OpenAI-compatible upstream
+  // prompt cache; claude-code keeps it off so plan-tier attribution reaches
+  // Anthropic verbatim.
+  const copilotPreview = (await (await requestApp('/api/upstreams/blueprint?kind=copilot', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
+  assertEquals(copilotPreview.flag_defaults['strip-billing-attribution'], true);
+  assertEquals(copilotPreview.flag_defaults['demote-interleaved-system-to-user'], false);
+  const ccPreview = (await (await requestApp('/api/upstreams/blueprint?kind=claude-code', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
+  assertEquals(ccPreview.flag_defaults['strip-billing-attribution'], false);
 });
 
 test('GET /api/upstreams/:id returns the full unredacted record so the edit page can post it back to action endpoints', async () => {

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -339,7 +339,7 @@ test('PATCH /api/upstreams keeps Azure as a single endpoint config', async () =>
   });
 });
 
-test('PATCH /api/upstreams round-trips a flat per-model flagOverrides map and rejects the legacy wrapped shape', async () => {
+test('PATCH /api/upstreams round-trips a flat per-model flagOverrides map', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
   await repo.upstreams.save({
@@ -379,23 +379,6 @@ test('PATCH /api/upstreams round-trips a flat per-model flagOverrides map and re
   const storedFlat = await repo.upstreams.getById('up_azure_flag_overrides');
   const modelsFlat = (storedFlat?.config as { models: { flagOverrides?: unknown }[] }).models;
   assertEquals(modelsFlat[0].flagOverrides, { 'vendor-deepseek': true });
-
-  // The pre-flatten wire shape is no longer accepted; the schema rejects the
-  // legacy `{ enabled, values }` envelope with a canonical error.
-  const patchWrapped = await requestApp('/api/upstreams/up_azure_flag_overrides', {
-    method: 'PATCH',
-    headers: { 'content-type': 'application/json', 'x-floway-session': adminSession },
-    body: JSON.stringify({
-      config: {
-        models: [{
-          upstreamModelId: 'gpt-prod',
-          endpoints: { chatCompletions: {} },
-          flagOverrides: { enabled: true, values: { 'vendor-deepseek': true } },
-        }],
-      },
-    }),
-  });
-  assertEquals(patchWrapped.status, 400);
 });
 
 test('GET /api/upstreams attaches models-cache freshness to every row', async () => {

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -339,6 +339,65 @@ test('PATCH /api/upstreams keeps Azure as a single endpoint config', async () =>
   });
 });
 
+test('PATCH /api/upstreams round-trips a flat per-model flagOverrides map and rejects the legacy wrapped shape', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+  await repo.upstreams.save({
+    id: 'up_azure_flag_overrides',
+    kind: 'azure',
+    name: 'Azure Per-Model Flags',
+    enabled: true,
+    sortOrder: 0,
+    createdAt: '2026-07-08T00:00:00.000Z',
+    updatedAt: '2026-07-08T00:00:00.000Z',
+    flagOverrides: {},
+    disabledPublicModelIds: [],
+    proxyFallbackList: [],
+    modelPrefix: null,
+    config: {
+      endpoint: 'https://example.openai.azure.com/openai/v1',
+      apiKey: 'az-secret',
+      models: [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }],
+    },
+    state: null,
+  });
+
+  const patchFlat = await requestApp('/api/upstreams/up_azure_flag_overrides', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json', 'x-floway-session': adminSession },
+    body: JSON.stringify({
+      config: {
+        models: [{
+          upstreamModelId: 'gpt-prod',
+          endpoints: { chatCompletions: {} },
+          flagOverrides: { 'vendor-deepseek': true },
+        }],
+      },
+    }),
+  });
+  assertEquals(patchFlat.status, 200);
+  const storedFlat = await repo.upstreams.getById('up_azure_flag_overrides');
+  const modelsFlat = (storedFlat?.config as { models: { flagOverrides?: unknown }[] }).models;
+  assertEquals(modelsFlat[0].flagOverrides, { 'vendor-deepseek': true });
+
+  // The pre-flatten wire shape is no longer accepted; the schema rejects the
+  // legacy `{ enabled, values }` envelope with a canonical error.
+  const patchWrapped = await requestApp('/api/upstreams/up_azure_flag_overrides', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json', 'x-floway-session': adminSession },
+    body: JSON.stringify({
+      config: {
+        models: [{
+          upstreamModelId: 'gpt-prod',
+          endpoints: { chatCompletions: {} },
+          flagOverrides: { enabled: true, values: { 'vendor-deepseek': true } },
+        }],
+      },
+    }),
+  });
+  assertEquals(patchWrapped.status, 400);
+});
+
 test('GET /api/upstreams attaches models-cache freshness to every row', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -2076,29 +2076,26 @@ test('GET /api/upstreams/blueprint rejects an unknown kind with 400', async () =
   assertEquals(resp.status, 400);
 });
 
-test('GET /api/upstreams/blueprint serves blank credentials without running the runtime asserts', async () => {
+test('GET /api/upstreams/blueprint serves a pure-blank record with provider flag defaults filled in', async () => {
   const { adminSession } = await setupAppTest();
 
-  // Blueprints are shape-complete synthetic-but-schema-valid rows that ride
-  // through the standard serialization pipeline (including provider factory
-  // for `flag_defaults`). The SPA discards everything except `flag_defaults`
-  // and lets the user fill the actual config in from an empty draft. Custom
-  // uses `authStyle: 'none'` so the assert accepts an absent apiKey; azure
-  // carries a single placeholder model since its assert rejects empty
-  // model lists. The blueprint travels through `upstreamRecordToFullJson`,
-  // so credentials come through verbatim (empty strings, not `*Set` bools).
+  // Blueprints are pure-blank shape-complete records; the SPA discards
+  // everything except `flag_defaults` and lets the operator fill the
+  // actual config in from an empty draft. Serialization is a static
+  // registry lookup so no provider asserter runs against the blank.
+  // The blueprint travels through `upstreamRecordToFullJson`, so
+  // credentials come through verbatim (empty strings, not `*Set` bools).
   const custom = (await (await requestApp('/api/upstreams/blueprint?kind=custom', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
-  assertEquals(custom.config.authStyle, 'none');
-  assertEquals('apiKey' in custom.config, false);
+  assertEquals(custom.config.authStyle, 'bearer');
+  assertEquals(custom.config.apiKey, '');
   const azure = (await (await requestApp('/api/upstreams/blueprint?kind=azure', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
-  assertEquals(Array.isArray(azure.config.models), true);
+  assertEquals(azure.config.models, []);
   const ollama = (await (await requestApp('/api/upstreams/blueprint?kind=ollama', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
   assertEquals(ollama.config.apiKey, '');
 
-  // Every provider kind must reach a 200 — the blueprint's synthetic record
-  // has to satisfy that kind's `assertXxxUpstream{Record,State}` on its way
-  // through the provider factory. `flag_defaults` on the wire is the whole
-  // point of routing through the factory; assert it lands on every kind.
+  // `flag_defaults` on the wire is the whole point of the blueprint;
+  // assert it lands on every kind so the dashboard's "Inherit → on/off"
+  // pill has data to render before Save.
   for (const kind of ['copilot', 'custom', 'azure', 'codex', 'claude-code', 'ollama']) {
     const preview = (await (await requestApp(`/api/upstreams/blueprint?kind=${kind}`, { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
     assertEquals(typeof preview.flag_defaults['strip-billing-attribution'], 'boolean');

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -1,4 +1,5 @@
-import type { ModelPrefixConfig, ProxyFallbackEntry, UpstreamProviderKind, UpstreamRecord } from '@floway-dev/provider';
+import { createProviderInstance } from '../../data-plane/providers/registry.ts';
+import { publicModelId, type FlagDefaults, type FlagOverrides, type ModelPrefixConfig, type Provider, type ProviderModel, type ProxyFallbackEntry, type UpstreamModelConfig, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
 import type { CodexQuotaSnapshotMap } from '@floway-dev/provider-codex';
 
 export interface ModelsCacheStatus {
@@ -15,6 +16,11 @@ export interface SerializedUpstreamRecord {
   created_at: string;
   updated_at: string;
   flag_overrides: Record<string, boolean>;
+  // Provider-declared upstream-level flag defaults for this record.
+  // Filled from the provider's `defaultFlagsForUpstream()` — currently
+  // per-kind, but the wire is per-record so a future config-derived
+  // default can vary here without a shape change.
+  flag_defaults: FlagDefaults;
   disabled_public_model_ids: string[];
   proxy_fallback_list: ProxyFallbackEntry[];
   model_prefix: ModelPrefixConfig | null;
@@ -179,24 +185,57 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
   }
 };
 
+// Attach per-model `provider_default_overlay` (layer 2 of the flag
+// resolver) by asking the provider's `defaultFlagsForModel(model)` per
+// row. Uniformly `{}` today — no provider that supports manual model
+// configuration also implements the optional per-model method — but
+// routing through the instance keeps the invariant that
+// `ProviderInstance.defaultFlagsFor{Upstream,Model}` is the sole source
+// of flag defaults intact. When a future provider ships per-model
+// deltas, the map computation lands here automatically.
+const modelDraftFromConfig = (model: UpstreamModelConfig): Omit<ProviderModel, 'enabledFlags'> => ({
+  id: publicModelId(model),
+  kind: model.kind,
+  endpoints: model.endpoints,
+  limits: model.limits ?? {},
+  ...(model.display_name !== undefined ? { display_name: model.display_name } : {}),
+  ...(model.cost ? { cost: model.cost } : {}),
+  ...(model.chat ? { chat: model.chat } : {}),
+});
+
+const withProviderDefaultOverlay = (provider: Provider, models: unknown): unknown => {
+  if (!Array.isArray(models)) return models;
+  return models.map(m => {
+    if (!isRecord(m)) return m;
+    const overlay: FlagOverrides = provider.instance.defaultFlagsForModel?.(modelDraftFromConfig(m as unknown as UpstreamModelConfig)) ?? {};
+    return { ...m, provider_default_overlay: overlay };
+  });
+};
+
 const serializeBase = (
   upstream: UpstreamRecord,
   payload: { config: unknown; state: unknown },
-): SerializedUpstreamRecord => ({
-  id: upstream.id,
-  kind: upstream.kind,
-  name: upstream.name,
-  enabled: upstream.enabled,
-  sort_order: upstream.sortOrder,
-  created_at: upstream.createdAt,
-  updated_at: upstream.updatedAt,
-  flag_overrides: { ...upstream.flagOverrides },
-  disabled_public_model_ids: [...upstream.disabledPublicModelIds],
-  proxy_fallback_list: upstream.proxyFallbackList.map(entry => entry.colos === undefined ? { id: entry.id } : { id: entry.id, colos: [...entry.colos] }),
-  model_prefix: upstream.modelPrefix === null ? null : clone(upstream.modelPrefix),
-  config: payload.config,
-  state: payload.state,
-});
+): SerializedUpstreamRecord => {
+  const provider = createProviderInstance(upstream);
+  return {
+    id: upstream.id,
+    kind: upstream.kind,
+    name: upstream.name,
+    enabled: upstream.enabled,
+    sort_order: upstream.sortOrder,
+    created_at: upstream.createdAt,
+    updated_at: upstream.updatedAt,
+    flag_overrides: { ...upstream.flagOverrides },
+    flag_defaults: provider.instance.defaultFlagsForUpstream(),
+    disabled_public_model_ids: [...upstream.disabledPublicModelIds],
+    proxy_fallback_list: upstream.proxyFallbackList.map(entry => entry.colos === undefined ? { id: entry.id } : { id: entry.id, colos: [...entry.colos] }),
+    model_prefix: upstream.modelPrefix === null ? null : clone(upstream.modelPrefix),
+    config: isRecord(payload.config) && Array.isArray((payload.config as { models?: unknown }).models)
+      ? { ...payload.config, models: withProviderDefaultOverlay(provider, (payload.config as { models?: unknown }).models) }
+      : payload.config,
+    state: payload.state,
+  };
+};
 
 export const upstreamRecordToJson = (upstream: UpstreamRecord): SerializedUpstreamRecord =>
   serializeBase(upstream, { config: redactedConfig(upstream), state: redactedState(upstream) });
@@ -208,9 +247,12 @@ export const upstreamRecordToFullJson = (upstream: UpstreamRecord): SerializedUp
 // GET /api/upstreams/blueprint endpoint so the create page consumes the same
 // SerializedUpstreamRecord shape edit does — the front-end draft variable is
 // uniform across create and edit, and no write-path invariants have to be
-// satisfied. Field values are true blanks (empty strings, empty arrays),
-// matching what an editor sees before typing anything or completing any
-// OAuth flow.
+// satisfied. Every field value is a synthetic-but-schema-valid placeholder
+// so the blank passes every provider's `assertXxxUpstream{Record,State}` on
+// its way through `createProviderInstance` (needed to compute
+// `flag_defaults` via the provider's `defaultFlagsForUpstream()`); the
+// dashboard's create flow discards everything on this record except
+// `flag_defaults`.
 export const blueprintUpstreamRecord = (kind: UpstreamProviderKind): UpstreamRecord => {
   const base = {
     id: '',
@@ -226,17 +268,69 @@ export const blueprintUpstreamRecord = (kind: UpstreamProviderKind): UpstreamRec
   };
   switch (kind) {
   case 'copilot':
-    return { ...base, kind, config: { githubToken: '', user: { login: '', avatar_url: '', name: null, id: 0 } }, state: null };
+    return {
+      ...base, kind,
+      config: { githubToken: '', user: { login: 'preview', avatar_url: 'https://preview.invalid', name: null, id: 0 } },
+      state: null,
+    };
   case 'custom':
-    return { ...base, kind, config: { baseUrl: '', authStyle: 'bearer', apiKey: '', endpoints: {}, modelsFetch: { enabled: false }, models: [] }, state: null };
+    // authStyle: 'none' avoids the `apiKey` non-empty requirement that
+    // `authStyle: 'bearer'` imposes; the blank record is never actually
+    // dispatched against, so a "no auth" style is a valid placeholder.
+    return {
+      ...base, kind,
+      config: { baseUrl: 'https://preview.invalid', authStyle: 'none', endpoints: {}, modelsFetch: { enabled: false }, models: [] },
+      state: null,
+    };
   case 'azure':
-    return { ...base, kind, config: { endpoint: '', apiKey: '', models: [] }, state: null };
+    // Azure asserts a non-empty `apiKey` plus at least one model entry;
+    // the blank carries a placeholder for each so the assert passes.
+    return {
+      ...base, kind,
+      config: {
+        endpoint: 'https://preview.openai.azure.com/openai/v1',
+        apiKey: 'preview',
+        models: [{ upstreamModelId: 'preview', kind: 'chat', endpoints: { chatCompletions: {} } }],
+      },
+      state: null,
+    };
   case 'codex':
-    return { ...base, kind, config: { accounts: [] }, state: { accounts: [] } };
+    return {
+      ...base, kind,
+      config: { accounts: [{ email: 'preview', chatgptAccountId: 'preview', chatgptUserId: 'preview', planType: 'preview' }] },
+      state: {
+        accounts: [{
+          chatgptAccountId: 'preview',
+          refresh_token: 'preview',
+          state: 'active',
+          state_updated_at: '1970-01-01T00:00:00.000Z',
+          openaiDeviceId: 'preview',
+        }],
+      },
+    };
   case 'claude-code':
-    return { ...base, kind, config: { accounts: [] }, state: { accounts: [] } };
+    return {
+      ...base, kind,
+      config: { accounts: [{ email: 'preview', accountUuid: 'preview', organizationUuid: null, subscriptionType: null, rateLimitTier: null }] },
+      state: {
+        accounts: [{
+          accountUuid: 'preview',
+          tokenKind: 'oauth',
+          refreshToken: 'preview',
+          state: 'active',
+          stateUpdatedAt: '1970-01-01T00:00:00.000Z',
+          accessToken: null,
+          quotaSnapshot: null,
+          usageProbeSnapshot: null,
+        }],
+      },
+    };
   case 'ollama':
-    return { ...base, kind, config: { baseUrl: '', apiKey: '', models: [] }, state: null };
+    return {
+      ...base, kind,
+      config: { baseUrl: 'http://preview.invalid', apiKey: '', models: [] },
+      state: null,
+    };
   default: {
     const exhaustive: never = kind;
     throw new Error(`Unknown upstream provider kind: ${String(exhaustive)}`);

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -187,7 +187,8 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
 
 const serializeBase = (
   upstream: UpstreamRecord,
-  payload: { config: unknown; state: unknown },
+  config: unknown,
+  state: unknown,
 ): SerializedUpstreamRecord => ({
   id: upstream.id,
   kind: upstream.kind,
@@ -201,15 +202,15 @@ const serializeBase = (
   disabled_public_model_ids: [...upstream.disabledPublicModelIds],
   proxy_fallback_list: upstream.proxyFallbackList.map(entry => entry.colos === undefined ? { id: entry.id } : { id: entry.id, colos: [...entry.colos] }),
   model_prefix: upstream.modelPrefix === null ? null : clone(upstream.modelPrefix),
-  config: payload.config,
-  state: payload.state,
+  config,
+  state,
 });
 
 export const upstreamRecordToJson = (upstream: UpstreamRecord): SerializedUpstreamRecord =>
-  serializeBase(upstream, { config: redactedConfig(upstream), state: redactedState(upstream) });
+  serializeBase(upstream, redactedConfig(upstream), redactedState(upstream));
 
 export const upstreamRecordToFullJson = (upstream: UpstreamRecord): SerializedUpstreamRecord =>
-  serializeBase(upstream, { config: clone(upstream.config), state: clone(upstream.state) });
+  serializeBase(upstream, clone(upstream.config), clone(upstream.state));
 
 // Shape-complete UpstreamRecord blank for `kind`, never persisted. Serves the
 // GET /api/upstreams/blueprint endpoint so the create page consumes the same

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -1,5 +1,5 @@
-import { flagDefaultsForKind, flagDefaultsForModelByKind } from '../../data-plane/providers/registry.ts';
-import { publicModelId, type FlagDefaults, type FlagOverrides, type ModelPrefixConfig, type ProviderModel, type ProxyFallbackEntry, type UpstreamModelConfig, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import { flagDefaultsForKind } from '../../data-plane/providers/registry.ts';
+import { type FlagDefaults, type ModelPrefixConfig, type ProxyFallbackEntry, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
 import type { CodexQuotaSnapshotMap } from '@floway-dev/provider-codex';
 
 export interface ModelsCacheStatus {
@@ -185,30 +185,6 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
   }
 };
 
-// Attach per-model `providerFlagOverlay` (layer 2 of the flag resolver)
-// by asking the provider module's `getDefaultFlagsForModel` per row.
-// Uniformly `{}` today — no provider that supports manual model
-// configuration also implements per-model deltas — but routing through
-// the registry keeps the invariant that provider modules are the sole
-// source of flag defaults intact. When a future provider ships per-model
-// deltas, the map computation lands here automatically.
-const modelDraftFromConfig = (model: UpstreamModelConfig): Omit<ProviderModel, 'enabledFlags'> => ({
-  id: publicModelId(model),
-  kind: model.kind,
-  endpoints: model.endpoints,
-  limits: model.limits ?? {},
-  ...(model.display_name !== undefined ? { display_name: model.display_name } : {}),
-  ...(model.cost ? { cost: model.cost } : {}),
-  ...(model.chat ? { chat: model.chat } : {}),
-});
-
-const withProviderFlagOverlay = (kind: UpstreamProviderKind, models: readonly unknown[]): unknown[] =>
-  models.map(m => {
-    if (!isRecord(m)) return m;
-    const overlay: FlagOverrides = flagDefaultsForModelByKind(kind, modelDraftFromConfig(m as unknown as UpstreamModelConfig));
-    return { ...m, providerFlagOverlay: overlay };
-  });
-
 const serializeBase = (
   upstream: UpstreamRecord,
   payload: { config: unknown; state: unknown },
@@ -225,9 +201,7 @@ const serializeBase = (
   disabled_public_model_ids: [...upstream.disabledPublicModelIds],
   proxy_fallback_list: upstream.proxyFallbackList.map(entry => entry.colos === undefined ? { id: entry.id } : { id: entry.id, colos: [...entry.colos] }),
   model_prefix: upstream.modelPrefix === null ? null : clone(upstream.modelPrefix),
-  config: isRecord(payload.config) && Array.isArray((payload.config as { models?: unknown }).models)
-    ? { ...payload.config, models: withProviderFlagOverlay(upstream.kind, (payload.config as { models: unknown[] }).models) }
-    : payload.config,
+  config: payload.config,
   state: payload.state,
 });
 

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -1,5 +1,5 @@
 import { flagDefaultsForKind } from '../../data-plane/providers/registry.ts';
-import { type FlagDefaults, type FlagOverrides, type ModelPrefixConfig, type ProxyFallbackEntry, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import type { FlagDefaults, FlagOverrides, ModelPrefixConfig, ProxyFallbackEntry, UpstreamProviderKind, UpstreamRecord } from '@floway-dev/provider';
 import type { CodexQuotaSnapshotMap } from '@floway-dev/provider-codex';
 
 export interface ModelsCacheStatus {

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -218,8 +218,7 @@ export const upstreamRecordToFullJson = (upstream: UpstreamRecord): SerializedUp
 // uniform across create and edit, and no write-path invariants have to be
 // satisfied. Field values are true blanks (empty strings, empty arrays),
 // matching what an editor sees before typing anything or completing any
-// OAuth flow. The dashboard's create flow discards everything on this
-// record except `flag_defaults`.
+// OAuth flow.
 export const blueprintUpstreamRecord = (kind: UpstreamProviderKind): UpstreamRecord => {
   const base = {
     id: '',

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -16,10 +16,9 @@ export interface SerializedUpstreamRecord {
   created_at: string;
   updated_at: string;
   flag_overrides: FlagOverrides;
-  // Provider-declared upstream-level flag defaults for this record.
-  // Read from `ProviderModule.defaultFlags` — one map per kind, sent per
-  // record so the dashboard's "Inherit → on/off" pill renders each row
-  // without a second round trip.
+  // Sent per record (rather than a separate per-kind lookup) so the
+  // dashboard's "Inherit → on/off" pill renders each row without a
+  // second round trip.
   flag_defaults: FlagDefaults;
   disabled_public_model_ids: string[];
   proxy_fallback_list: ProxyFallbackEntry[];

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -185,7 +185,7 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
   }
 };
 
-// Attach per-model `provider_default_overlay` (layer 2 of the flag
+// Attach per-model `providerFlagOverlay` (layer 2 of the flag
 // resolver) by asking the provider's `defaultFlagsForModel(model)` per
 // row. Uniformly `{}` today — no provider that supports manual model
 // configuration also implements the optional per-model method — but
@@ -207,7 +207,7 @@ const withProviderDefaultOverlay = (provider: Provider, models: readonly unknown
   models.map(m => {
     if (!isRecord(m)) return m;
     const overlay: FlagOverrides = provider.instance.defaultFlagsForModel?.(modelDraftFromConfig(m as unknown as UpstreamModelConfig)) ?? {};
-    return { ...m, provider_default_overlay: overlay };
+    return { ...m, providerFlagOverlay: overlay };
   });
 
 const serializeBase = (

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -203,14 +203,12 @@ const modelDraftFromConfig = (model: UpstreamModelConfig): Omit<ProviderModel, '
   ...(model.chat ? { chat: model.chat } : {}),
 });
 
-const withProviderDefaultOverlay = (provider: Provider, models: unknown): unknown => {
-  if (!Array.isArray(models)) return models;
-  return models.map(m => {
+const withProviderDefaultOverlay = (provider: Provider, models: readonly unknown[]): unknown[] =>
+  models.map(m => {
     if (!isRecord(m)) return m;
     const overlay: FlagOverrides = provider.instance.defaultFlagsForModel?.(modelDraftFromConfig(m as unknown as UpstreamModelConfig)) ?? {};
     return { ...m, provider_default_overlay: overlay };
   });
-};
 
 const serializeBase = (
   upstream: UpstreamRecord,
@@ -231,7 +229,7 @@ const serializeBase = (
     proxy_fallback_list: upstream.proxyFallbackList.map(entry => entry.colos === undefined ? { id: entry.id } : { id: entry.id, colos: [...entry.colos] }),
     model_prefix: upstream.modelPrefix === null ? null : clone(upstream.modelPrefix),
     config: isRecord(payload.config) && Array.isArray((payload.config as { models?: unknown }).models)
-      ? { ...payload.config, models: withProviderDefaultOverlay(provider, (payload.config as { models?: unknown }).models) }
+      ? { ...payload.config, models: withProviderDefaultOverlay(provider, (payload.config as { models: unknown[] }).models) }
       : payload.config,
     state: payload.state,
   };

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -1,5 +1,5 @@
-import { createProviderInstance } from '../../data-plane/providers/registry.ts';
-import { publicModelId, type FlagDefaults, type FlagOverrides, type ModelPrefixConfig, type Provider, type ProviderModel, type ProxyFallbackEntry, type UpstreamModelConfig, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import { flagDefaultsForKind, flagDefaultsForModelByKind } from '../../data-plane/providers/registry.ts';
+import { publicModelId, type FlagDefaults, type FlagOverrides, type ModelPrefixConfig, type ProviderModel, type ProxyFallbackEntry, type UpstreamModelConfig, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
 import type { CodexQuotaSnapshotMap } from '@floway-dev/provider-codex';
 
 export interface ModelsCacheStatus {
@@ -185,13 +185,12 @@ const redactedState = (upstream: UpstreamRecord): unknown => {
   }
 };
 
-// Attach per-model `providerFlagOverlay` (layer 2 of the flag
-// resolver) by asking the provider's `defaultFlagsForModel(model)` per
-// row. Uniformly `{}` today — no provider that supports manual model
-// configuration also implements the optional per-model method — but
-// routing through the instance keeps the invariant that
-// `ProviderInstance.defaultFlagsFor{Upstream,Model}` is the sole source
-// of flag defaults intact. When a future provider ships per-model
+// Attach per-model `providerFlagOverlay` (layer 2 of the flag resolver)
+// by asking the provider module's `getDefaultFlagsForModel` per row.
+// Uniformly `{}` today — no provider that supports manual model
+// configuration also implements per-model deltas — but routing through
+// the registry keeps the invariant that provider modules are the sole
+// source of flag defaults intact. When a future provider ships per-model
 // deltas, the map computation lands here automatically.
 const modelDraftFromConfig = (model: UpstreamModelConfig): Omit<ProviderModel, 'enabledFlags'> => ({
   id: publicModelId(model),
@@ -203,37 +202,34 @@ const modelDraftFromConfig = (model: UpstreamModelConfig): Omit<ProviderModel, '
   ...(model.chat ? { chat: model.chat } : {}),
 });
 
-const withProviderDefaultOverlay = (provider: Provider, models: readonly unknown[]): unknown[] =>
+const withProviderFlagOverlay = (kind: UpstreamProviderKind, models: readonly unknown[]): unknown[] =>
   models.map(m => {
     if (!isRecord(m)) return m;
-    const overlay: FlagOverrides = provider.instance.defaultFlagsForModel?.(modelDraftFromConfig(m as unknown as UpstreamModelConfig)) ?? {};
+    const overlay: FlagOverrides = flagDefaultsForModelByKind(kind, modelDraftFromConfig(m as unknown as UpstreamModelConfig));
     return { ...m, providerFlagOverlay: overlay };
   });
 
 const serializeBase = (
   upstream: UpstreamRecord,
   payload: { config: unknown; state: unknown },
-): SerializedUpstreamRecord => {
-  const provider = createProviderInstance(upstream);
-  return {
-    id: upstream.id,
-    kind: upstream.kind,
-    name: upstream.name,
-    enabled: upstream.enabled,
-    sort_order: upstream.sortOrder,
-    created_at: upstream.createdAt,
-    updated_at: upstream.updatedAt,
-    flag_overrides: { ...upstream.flagOverrides },
-    flag_defaults: provider.instance.defaultFlagsForUpstream(),
-    disabled_public_model_ids: [...upstream.disabledPublicModelIds],
-    proxy_fallback_list: upstream.proxyFallbackList.map(entry => entry.colos === undefined ? { id: entry.id } : { id: entry.id, colos: [...entry.colos] }),
-    model_prefix: upstream.modelPrefix === null ? null : clone(upstream.modelPrefix),
-    config: isRecord(payload.config) && Array.isArray((payload.config as { models?: unknown }).models)
-      ? { ...payload.config, models: withProviderDefaultOverlay(provider, (payload.config as { models: unknown[] }).models) }
-      : payload.config,
-    state: payload.state,
-  };
-};
+): SerializedUpstreamRecord => ({
+  id: upstream.id,
+  kind: upstream.kind,
+  name: upstream.name,
+  enabled: upstream.enabled,
+  sort_order: upstream.sortOrder,
+  created_at: upstream.createdAt,
+  updated_at: upstream.updatedAt,
+  flag_overrides: { ...upstream.flagOverrides },
+  flag_defaults: flagDefaultsForKind(upstream.kind),
+  disabled_public_model_ids: [...upstream.disabledPublicModelIds],
+  proxy_fallback_list: upstream.proxyFallbackList.map(entry => entry.colos === undefined ? { id: entry.id } : { id: entry.id, colos: [...entry.colos] }),
+  model_prefix: upstream.modelPrefix === null ? null : clone(upstream.modelPrefix),
+  config: isRecord(payload.config) && Array.isArray((payload.config as { models?: unknown }).models)
+    ? { ...payload.config, models: withProviderFlagOverlay(upstream.kind, (payload.config as { models: unknown[] }).models) }
+    : payload.config,
+  state: payload.state,
+});
 
 export const upstreamRecordToJson = (upstream: UpstreamRecord): SerializedUpstreamRecord =>
   serializeBase(upstream, { config: redactedConfig(upstream), state: redactedState(upstream) });
@@ -245,12 +241,10 @@ export const upstreamRecordToFullJson = (upstream: UpstreamRecord): SerializedUp
 // GET /api/upstreams/blueprint endpoint so the create page consumes the same
 // SerializedUpstreamRecord shape edit does — the front-end draft variable is
 // uniform across create and edit, and no write-path invariants have to be
-// satisfied. Every field value is a synthetic-but-schema-valid placeholder
-// so the blank passes every provider's `assertXxxUpstream{Record,State}` on
-// its way through `createProviderInstance` (needed to compute
-// `flag_defaults` via the provider's `defaultFlagsForUpstream()`); the
-// dashboard's create flow discards everything on this record except
-// `flag_defaults`.
+// satisfied. Field values are true blanks (empty strings, empty arrays),
+// matching what an editor sees before typing anything or completing any
+// OAuth flow. The dashboard's create flow discards everything on this
+// record except `flag_defaults`.
 export const blueprintUpstreamRecord = (kind: UpstreamProviderKind): UpstreamRecord => {
   const base = {
     id: '',
@@ -266,69 +260,17 @@ export const blueprintUpstreamRecord = (kind: UpstreamProviderKind): UpstreamRec
   };
   switch (kind) {
   case 'copilot':
-    return {
-      ...base, kind,
-      config: { githubToken: '', user: { login: 'preview', avatar_url: 'https://preview.invalid', name: null, id: 0 } },
-      state: null,
-    };
+    return { ...base, kind, config: { githubToken: '', user: { login: '', avatar_url: '', name: null, id: 0 } }, state: null };
   case 'custom':
-    // authStyle: 'none' avoids the `apiKey` non-empty requirement that
-    // `authStyle: 'bearer'` imposes; the blank record is never actually
-    // dispatched against, so a "no auth" style is a valid placeholder.
-    return {
-      ...base, kind,
-      config: { baseUrl: 'https://preview.invalid', authStyle: 'none', endpoints: {}, modelsFetch: { enabled: false }, models: [] },
-      state: null,
-    };
+    return { ...base, kind, config: { baseUrl: '', authStyle: 'bearer', apiKey: '', endpoints: {}, modelsFetch: { enabled: false }, models: [] }, state: null };
   case 'azure':
-    // Azure asserts a non-empty `apiKey` plus at least one model entry;
-    // the blank carries a placeholder for each so the assert passes.
-    return {
-      ...base, kind,
-      config: {
-        endpoint: 'https://preview.openai.azure.com/openai/v1',
-        apiKey: 'preview',
-        models: [{ upstreamModelId: 'preview', kind: 'chat', endpoints: { chatCompletions: {} } }],
-      },
-      state: null,
-    };
+    return { ...base, kind, config: { endpoint: '', apiKey: '', models: [] }, state: null };
   case 'codex':
-    return {
-      ...base, kind,
-      config: { accounts: [{ email: 'preview', chatgptAccountId: 'preview', chatgptUserId: 'preview', planType: 'preview' }] },
-      state: {
-        accounts: [{
-          chatgptAccountId: 'preview',
-          refresh_token: 'preview',
-          state: 'active',
-          state_updated_at: '1970-01-01T00:00:00.000Z',
-          openaiDeviceId: 'preview',
-        }],
-      },
-    };
+    return { ...base, kind, config: { accounts: [] }, state: { accounts: [] } };
   case 'claude-code':
-    return {
-      ...base, kind,
-      config: { accounts: [{ email: 'preview', accountUuid: 'preview', organizationUuid: null, subscriptionType: null, rateLimitTier: null }] },
-      state: {
-        accounts: [{
-          accountUuid: 'preview',
-          tokenKind: 'oauth',
-          refreshToken: 'preview',
-          state: 'active',
-          stateUpdatedAt: '1970-01-01T00:00:00.000Z',
-          accessToken: null,
-          quotaSnapshot: null,
-          usageProbeSnapshot: null,
-        }],
-      },
-    };
+    return { ...base, kind, config: { accounts: [] }, state: { accounts: [] } };
   case 'ollama':
-    return {
-      ...base, kind,
-      config: { baseUrl: 'http://preview.invalid', apiKey: '', models: [] },
-      state: null,
-    };
+    return { ...base, kind, config: { baseUrl: '', apiKey: '', models: [] }, state: null };
   default: {
     const exhaustive: never = kind;
     throw new Error(`Unknown upstream provider kind: ${String(exhaustive)}`);

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -17,9 +17,9 @@ export interface SerializedUpstreamRecord {
   updated_at: string;
   flag_overrides: Record<string, boolean>;
   // Provider-declared upstream-level flag defaults for this record.
-  // Filled from the provider's `defaultFlagsForUpstream()` — currently
-  // per-kind, but the wire is per-record so a future config-derived
-  // default can vary here without a shape change.
+  // Read from `ProviderModule.defaultFlags` — one map per kind, sent per
+  // record so the dashboard's "Inherit → on/off" pill renders each row
+  // without a second round trip.
   flag_defaults: FlagDefaults;
   disabled_public_model_ids: string[];
   proxy_fallback_list: ProxyFallbackEntry[];

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -1,5 +1,5 @@
 import { flagDefaultsForKind } from '../../data-plane/providers/registry.ts';
-import { type FlagDefaults, type ModelPrefixConfig, type ProxyFallbackEntry, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import { type FlagDefaults, type FlagOverrides, type ModelPrefixConfig, type ProxyFallbackEntry, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
 import type { CodexQuotaSnapshotMap } from '@floway-dev/provider-codex';
 
 export interface ModelsCacheStatus {
@@ -15,7 +15,7 @@ export interface SerializedUpstreamRecord {
   sort_order: number;
   created_at: string;
   updated_at: string;
-  flag_overrides: Record<string, boolean>;
+  flag_overrides: FlagOverrides;
   // Provider-declared upstream-level flag defaults for this record.
   // Read from `ProviderModule.defaultFlags` — one map per kind, sent per
   // record so the dashboard's "Inherit → on/off" pill renders each row
@@ -228,7 +228,7 @@ export const blueprintUpstreamRecord = (kind: UpstreamProviderKind): UpstreamRec
     sortOrder: 0,
     createdAt: '',
     updatedAt: '',
-    flagOverrides: {} as Record<string, boolean>,
+    flagOverrides: {} as FlagOverrides,
     disabledPublicModelIds: [] as string[],
     proxyFallbackList: [] as ProxyFallbackEntry[],
     modelPrefix: null,

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -45,7 +45,7 @@ test('upstreamRecordToJson redacts custom bearer token inside config', () => {
   assertEquals(config.apiKeySet, true);
   assertEquals(config.endpoints, { chatCompletions: {}, responses: {} });
   assertEquals(config.modelsFetch, { enabled: true, endpoint: '/models' });
-  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, providerFlagOverlay: {} }]);
+  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }]);
 });
 
 test('upstreamRecordToJson redacts Azure API keys inside config', () => {
@@ -65,7 +65,7 @@ test('upstreamRecordToJson redacts Azure API keys inside config', () => {
   assertEquals(config.endpoint, 'https://example.openai.azure.com');
   assertEquals(config.apiKey, undefined);
   assertEquals(config.apiKeySet, true);
-  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, providerFlagOverlay: {} }]);
+  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }]);
 });
 
 test('upstreamRecordToJson redacts Copilot GitHub token inside config and exposes the state baseUrl', () => {

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -45,7 +45,7 @@ test('upstreamRecordToJson redacts custom bearer token inside config', () => {
   assertEquals(config.apiKeySet, true);
   assertEquals(config.endpoints, { chatCompletions: {}, responses: {} });
   assertEquals(config.modelsFetch, { enabled: true, endpoint: '/models' });
-  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }]);
+  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, provider_default_overlay: {} }]);
 });
 
 test('upstreamRecordToJson redacts Azure API keys inside config', () => {
@@ -65,7 +65,7 @@ test('upstreamRecordToJson redacts Azure API keys inside config', () => {
   assertEquals(config.endpoint, 'https://example.openai.azure.com');
   assertEquals(config.apiKey, undefined);
   assertEquals(config.apiKeySet, true);
-  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} } }]);
+  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, provider_default_overlay: {} }]);
 });
 
 test('upstreamRecordToJson redacts Copilot GitHub token inside config and exposes the state baseUrl', () => {

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -45,7 +45,7 @@ test('upstreamRecordToJson redacts custom bearer token inside config', () => {
   assertEquals(config.apiKeySet, true);
   assertEquals(config.endpoints, { chatCompletions: {}, responses: {} });
   assertEquals(config.modelsFetch, { enabled: true, endpoint: '/models' });
-  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, provider_default_overlay: {} }]);
+  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, providerFlagOverlay: {} }]);
 });
 
 test('upstreamRecordToJson redacts Azure API keys inside config', () => {
@@ -65,7 +65,7 @@ test('upstreamRecordToJson redacts Azure API keys inside config', () => {
   assertEquals(config.endpoint, 'https://example.openai.azure.com');
   assertEquals(config.apiKey, undefined);
   assertEquals(config.apiKeySet, true);
-  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, provider_default_overlay: {} }]);
+  assertEquals(config.models, [{ upstreamModelId: 'gpt-prod', endpoints: { chatCompletions: {} }, providerFlagOverlay: {} }]);
 });
 
 test('upstreamRecordToJson redacts Copilot GitHub token inside config and exposes the state baseUrl', () => {

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-developer-to-system_test.ts
@@ -5,7 +5,7 @@ import type { ChatCompletionsInvocation } from './types.ts';
 import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -21,7 +21,7 @@ const stubCtx: ChatGatewayCtx = {
   store: createNonResponsesSourceStore('test-key'),
 };
 
-const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ChatCompletionsInvocation => ({
+const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<FlagId> = new Set(['demote-developer-to-system'])): ChatCompletionsInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),
   targetApi: 'chat-completions',

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/demote-interleaved-system-to-user_test.ts
@@ -5,7 +5,7 @@ import type { ChatCompletionsInvocation } from './types.ts';
 import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -25,7 +25,7 @@ const okEvents = () => Promise.resolve(eventResult((async function* () {})(), te
 
 const invocation = (
   payload: ChatCompletionsPayload,
-  enabledFlags: ReadonlySet<string> = new Set(['demote-interleaved-system-to-user']),
+  enabledFlags: ReadonlySet<FlagId> = new Set(['demote-interleaved-system-to-user']),
 ): ChatCompletionsInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -5,7 +5,7 @@ import type { ChatCompletionsInvocation } from './types.ts';
 import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -25,7 +25,7 @@ const okEvents = () => Promise.resolve(eventResult((async function* () {})(), te
 
 const invocation = (
   payload: ChatCompletionsPayload,
-  enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
+  enabledFlags: ReadonlySet<FlagId> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): ChatCompletionsInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import { type ExecuteResult, eventResult } from '@floway-dev/provider';
+import { type ExecuteResult, eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 type DeepseekReasoningDelta = ChatCompletionsStreamEvent['choices'][number]['delta'] & {
@@ -26,7 +26,7 @@ const stubCtx: ChatGatewayCtx = {
   store: createNonResponsesSourceStore('test-key'),
 };
 
-const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ChatCompletionsInvocation => ({
+const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<FlagId> = new Set(['vendor-deepseek'])): ChatCompletionsInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),
   targetApi: 'chat-completions',

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import { type ExecuteResult, eventResult } from '@floway-dev/provider';
+import { type ExecuteResult, eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -22,7 +22,7 @@ const stubCtx: ChatGatewayCtx = {
   store: createNonResponsesSourceStore('test-key'),
 };
 
-const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-kimi'])): ChatCompletionsInvocation => ({
+const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<FlagId> = new Set(['vendor-kimi'])): ChatCompletionsInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),
   targetApi: 'chat-completions',

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/vendor-qwen-normalize_test.ts
@@ -5,7 +5,7 @@ import { withVendorQwenChatCompletionsNormalize } from './vendor-qwen-normalize.
 import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -21,7 +21,7 @@ const stubCtx: ChatGatewayCtx = {
   store: createNonResponsesSourceStore('test-key'),
 };
 
-const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ChatCompletionsInvocation => ({
+const invocation = (payload: ChatCompletionsPayload, enabledFlags: ReadonlySet<FlagId> = new Set(['vendor-qwen'])): ChatCompletionsInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),
   targetApi: 'chat-completions',

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -6,7 +6,7 @@ import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import { type ExecuteResult, eventResult } from '@floway-dev/provider';
+import { type ExecuteResult, eventResult, type FlagId } from '@floway-dev/provider';
 import { stubModelCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
 
 const stubCtx: ChatGatewayCtx = {
@@ -27,7 +27,7 @@ const okEvents = (): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> 
 
 const invocation = (
   payload: MessagesPayload,
-  enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
+  enabledFlags: ReadonlySet<FlagId> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): MessagesInvocation => ({
   payload,
   candidate: stubModelCandidate({

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { type AliasRules, doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions, type FlagId } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubInternalModel, stubProviderModel } from '@floway-dev/test-utils';
 
 // Mock the resolver seam so each test hands the serve exactly the provider
@@ -138,7 +138,7 @@ const makeCandidate = (overrides: {
   upstream?: string;
   endpoints?: ModelEndpoints;
   kind?: ModelCandidate['provider']['kind'];
-  enabledFlags?: ReadonlySet<string>;
+  enabledFlags?: ReadonlySet<FlagId>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
@@ -415,7 +415,7 @@ test('claude-code candidate preserves x-anthropic-billing-header system block th
   // Match the `strip-billing-attribution: false` decision the claude-code
   // provider ships (see provider-claude-code/src/defaults.ts): the plan-tier
   // block must reach Anthropic verbatim.
-  const claudeCodeDefaults: ReadonlySet<string> = new Set();
+  const claudeCodeDefaults: ReadonlySet<FlagId> = new Set();
 
   const billingBlock = 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;\ncc_entrypoint=cli';
 
@@ -471,7 +471,7 @@ test('copilot candidate strips x-anthropic-billing-header system block via the d
 
   // Match `strip-billing-attribution: true` on the copilot provider default
   // (see provider-copilot/src/defaults.ts).
-  const copilotDefaults: ReadonlySet<string> = new Set(['strip-billing-attribution']);
+  const copilotDefaults: ReadonlySet<FlagId> = new Set(['strip-billing-attribution']);
 
   const billingBlock = 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;';
 

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -7,7 +7,7 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { type AliasRules, doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ModelCandidate, defaultsForProvider, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubInternalModel, stubProviderModel } from '@floway-dev/test-utils';
 
 // Mock the resolver seam so each test hands the serve exactly the provider
@@ -412,11 +412,10 @@ test('countTokens filters out candidates whose endpoints do not satisfy the mess
 test('claude-code candidate preserves x-anthropic-billing-header system block through the interceptor chain', async () => {
   installRepo();
 
-  // Pre-confirm the flag catalog is wired the expected way; an edit that
-  // adds 'claude-code' to defaultFor by mistake should fail at setup, not
-  // silently pass on a stripped body.
-  const claudeCodeDefaults = defaultsForProvider('claude-code');
-  assertEquals(claudeCodeDefaults.has('strip-billing-attribution'), false);
+  // Match the `strip-billing-attribution: false` decision the claude-code
+  // provider ships (see provider-claude-code/src/defaults.ts): the plan-tier
+  // block must reach Anthropic verbatim.
+  const claudeCodeDefaults: ReadonlySet<string> = new Set();
 
   const billingBlock = 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;\ncc_entrypoint=cli';
 
@@ -470,8 +469,9 @@ test('claude-code candidate preserves x-anthropic-billing-header system block th
 test('copilot candidate strips x-anthropic-billing-header system block via the default-on flag', async () => {
   installRepo();
 
-  const copilotDefaults = defaultsForProvider('copilot');
-  assertEquals(copilotDefaults.has('strip-billing-attribution'), true);
+  // Match `strip-billing-attribution: true` on the copilot provider default
+  // (see provider-copilot/src/defaults.ts).
+  const copilotDefaults: ReadonlySet<string> = new Set(['strip-billing-attribution']);
 
   const billingBlock = 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;';
 

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -11,7 +11,7 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type ModelCandidate, directFetcher, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
+import { type ModelCandidate, directFetcher, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions, type FlagId } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubInternalModel, stubProviderModel } from '@floway-dev/test-utils';
 import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -60,7 +60,7 @@ const makeProviderEvents = async function* (events: readonly ResponsesStreamEven
 
 const makeCandidate = (
   callResponses: (model: ProviderModel, body: Omit<ResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions) => Promise<ProviderResponsesResult>,
-  enabledFlags: ReadonlySet<string> = new Set<string>(),
+  enabledFlags: ReadonlySet<FlagId> = new Set<FlagId>(),
 ): ModelCandidate => {
   const provider = stubProvider({ callResponses });
   const upstream = 'up_test';

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -5,7 +5,7 @@ import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -32,7 +32,7 @@ const okEvents = () =>
     ),
   );
 
-const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['demote-developer-to-system'])): ResponsesInvocation => ({
+const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<FlagId> = new Set(['demote-developer-to-system'])): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),
   targetApi: 'responses',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -5,7 +5,7 @@ import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -34,7 +34,7 @@ const okEvents = () =>
 
 const invocation = (
   payload: CanonicalResponsesPayload,
-  enabledFlags: ReadonlySet<string> = new Set(['demote-interleaved-system-to-user']),
+  enabledFlags: ReadonlySet<FlagId> = new Set(['demote-interleaved-system-to-user']),
 ): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -5,7 +5,7 @@ import type { ResponsesInvocation } from './types.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -34,7 +34,7 @@ const okEvents = () =>
 
 const invocation = (
   payload: CanonicalResponsesPayload,
-  enabledFlags: ReadonlySet<string> = new Set(['disable-reasoning-on-forced-tool-choice']),
+  enabledFlags: ReadonlySet<FlagId> = new Set(['disable-reasoning-on-forced-tool-choice']),
 ): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -42,7 +42,7 @@ import type {
   ResponsesToolChoice,
   ResponsesWebSearchAction,
 } from '@floway-dev/protocols/responses';
-import { type EventResult, type ExecuteResult } from '@floway-dev/provider';
+import { type EventResult, type ExecuteResult, type FlagId } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse, stubModelCandidate } from '@floway-dev/test-utils';
 import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -303,7 +303,7 @@ const makeStubDeps = (overrides: DepsOverrides = {}): {
 
 interface InvocationOverrides {
   targetApi?: 'responses' | 'messages' | 'chat-completions';
-  enabledFlags?: ReadonlySet<string>;
+  enabledFlags?: ReadonlySet<FlagId>;
   payload?: Partial<ResponsesPayload>;
 }
 
@@ -444,7 +444,7 @@ test('shim no-ops when targetApi=responses and flag is off', async () => {
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation({
     targetApi: 'responses',
-    enabledFlags: new Set<string>(),
+    enabledFlags: new Set<FlagId>(),
   });
   const originalPayload = inv.payload;
   const script = scriptedRun([messageTurn('hi back')]);
@@ -463,7 +463,7 @@ test('shim activates when targetApi=responses and flag is on', async () => {
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation({
     targetApi: 'responses',
-    enabledFlags: new Set<string>(['responses-web-search-shim']),
+    enabledFlags: new Set<FlagId>(['responses-web-search-shim']),
   });
   const script = scriptedRun([messageTurn('done')]);
 
@@ -477,7 +477,7 @@ test('shim activates when targetApi=responses and flag is on', async () => {
 test('shim activates when targetApi=messages and flag is off', async () => {
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation({ targetApi: 'messages', enabledFlags: new Set<string>() });
+  const inv = makeInvocation({ targetApi: 'messages', enabledFlags: new Set<FlagId>() });
   const script = scriptedRun([messageTurn('done')]);
 
   await runShimAndDrain(shim, inv, makeGatewayCtx(), script.run);
@@ -488,7 +488,7 @@ test('shim activates when targetApi=messages and flag is off', async () => {
 test('shim activates when targetApi=chat-completions and flag is off', async () => {
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
-  const inv = makeInvocation({ targetApi: 'chat-completions', enabledFlags: new Set<string>() });
+  const inv = makeInvocation({ targetApi: 'chat-completions', enabledFlags: new Set<FlagId>() });
   const script = scriptedRun([messageTurn('done')]);
 
   await runShimAndDrain(shim, inv, makeGatewayCtx(), script.run);
@@ -3874,7 +3874,7 @@ test('responses target with flag on: function_call_output is plain-text formatte
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation({
     targetApi: 'responses',
-    enabledFlags: new Set<string>(['responses-web-search-shim']),
+    enabledFlags: new Set<FlagId>(['responses-web-search-shim']),
   });
   const script = scriptedRun([
     searchCallTurn(0, 'call_1', 'q1'),

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -8,7 +8,7 @@ import type { ResponsesInvocation } from '../types.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { type EventResult, type ExecuteResult } from '@floway-dev/provider';
+import { type EventResult, type ExecuteResult, type FlagId } from '@floway-dev/provider';
 import { assert, assertEquals, stubModelCandidate } from '@floway-dev/test-utils';
 
 // Dirty integration harness: mock the model registry so the image backend is a
@@ -64,7 +64,7 @@ const defaultCandidates = vi.hoisted(() => () => [{
       u: {
         id: 'gpt-image-2', limits: {}, kind: 'image',
         endpoints: { imagesGenerations: {}, imagesEdits: {} },
-        enabledFlags: new Set<string>(),
+        enabledFlags: new Set<FlagId>(),
       },
     },
   },

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -5,7 +5,7 @@ import { withVendorDeepseekResponsesNormalize } from './vendor-deepseek-normaliz
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -32,7 +32,7 @@ const okEvents = () =>
     ),
   );
 
-const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-deepseek'])): ResponsesInvocation => ({
+const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<FlagId> = new Set(['vendor-deepseek'])): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),
   targetApi: 'responses',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -5,7 +5,7 @@ import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { createNonResponsesSourceStore } from '../items/store.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
-import { eventResult } from '@floway-dev/provider';
+import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
 import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -32,7 +32,7 @@ const okEvents = () =>
     ),
   );
 
-const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<string> = new Set(['vendor-qwen'])): ResponsesInvocation => ({
+const invocation = (payload: CanonicalResponsesPayload, enabledFlags: ReadonlySet<FlagId> = new Set(['vendor-qwen'])): ResponsesInvocation => ({
   payload,
   candidate: stubModelCandidate({ enabledFlags }),
   targetApi: 'responses',

--- a/packages/gateway/src/data-plane/providers/azure/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/azure/provider_test.ts
@@ -282,7 +282,7 @@ test('createAzureProvider applies per-model flag overrides on top of the upstrea
           {
             upstreamModelId: 'd2',
             endpoints: { chatCompletions: {} },
-            flagOverrides: { enabled: true, values: { 'vendor-deepseek': false, 'vendor-kimi': true } },
+            flagOverrides: { 'vendor-deepseek': false, 'vendor-kimi': true },
           },
         ],
       },
@@ -299,7 +299,7 @@ test('createAzureProvider applies per-model flag overrides on top of the upstrea
   assertEquals(d2.enabledFlags.has('vendor-kimi'), true);
 });
 
-test('createAzureProvider skips the per-model layer when flagOverrides.enabled is false', async () => {
+test('createAzureProvider respects upstream override when per-model flagOverrides is empty', async () => {
   const instance = createAzureProvider(
     azureRecord({
       flagOverrides: { 'vendor-deepseek': true },
@@ -311,7 +311,7 @@ test('createAzureProvider skips the per-model layer when flagOverrides.enabled i
           {
             upstreamModelId: 'd1',
             endpoints: { chatCompletions: {} },
-            flagOverrides: { enabled: false, values: { 'vendor-deepseek': false } },
+            flagOverrides: {},
           },
         ],
       },

--- a/packages/gateway/src/data-plane/providers/flags-resolve_test.ts
+++ b/packages/gateway/src/data-plane/providers/flags-resolve_test.ts
@@ -3,54 +3,55 @@ import { test } from 'vitest';
 import { resolveEffectiveFlags } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 
-test('flags-resolve: empty defaults and no layers → empty set', () => {
-  const set = resolveEffectiveFlags(new Set(), []);
+test('flags-resolve: no layers → empty set', () => {
+  const set = resolveEffectiveFlags([]);
   assertEquals([...set].sort(), []);
 });
 
-test('flags-resolve: provider defaults are always present', () => {
-  const set = resolveEffectiveFlags(new Set(['retry-cyber-policy']), []);
+test('flags-resolve: a layer with a true flag adds it', () => {
+  const set = resolveEffectiveFlags([{ 'retry-cyber-policy': true }]);
   assertEquals([...set].sort(), ['retry-cyber-policy']);
 });
 
-test('flags-resolve: defaults can be force-off by any layer', () => {
-  const set = resolveEffectiveFlags(
-    new Set(['retry-cyber-policy']),
-    [{ 'retry-cyber-policy': false }],
-  );
+test('flags-resolve: a later layer can force-off an earlier true', () => {
+  const set = resolveEffectiveFlags([
+    { 'retry-cyber-policy': true },
+    { 'retry-cyber-policy': false },
+  ]);
   assertEquals([...set].sort(), []);
 });
 
-test('flags-resolve: a later layer force-on re-adds a default an earlier layer removed', () => {
-  const set = resolveEffectiveFlags(
-    new Set(['retry-cyber-policy']),
-    [{ 'retry-cyber-policy': false }, { 'retry-cyber-policy': true }],
-  );
+test('flags-resolve: a still-later layer can force-on again', () => {
+  const set = resolveEffectiveFlags([
+    { 'retry-cyber-policy': true },
+    { 'retry-cyber-policy': false },
+    { 'retry-cyber-policy': true },
+  ]);
   assertEquals([...set].sort(), ['retry-cyber-policy']);
 });
 
-test('flags-resolve: upstream layer force-on adds a non-default flag', () => {
-  const set = resolveEffectiveFlags(new Set(), [{ 'vendor-deepseek': true }]);
+test('flags-resolve: upstream layer force-on adds a flag', () => {
+  const set = resolveEffectiveFlags([{ 'vendor-deepseek': true }]);
   assertEquals([...set].sort(), ['vendor-deepseek']);
 });
 
-test('flags-resolve: deployment layer can force-off a non-default flag enabled upstream', () => {
-  const set = resolveEffectiveFlags(
-    new Set(),
-    [{ 'vendor-deepseek': true }, { 'vendor-deepseek': false }],
-  );
+test('flags-resolve: model layer force-off wins over upstream force-on', () => {
+  const set = resolveEffectiveFlags([
+    { 'vendor-deepseek': true },
+    { 'vendor-deepseek': false },
+  ]);
   assertEquals([...set].sort(), []);
 });
 
-test('flags-resolve: deployment layer wins over upstream when both set the same flag', () => {
-  const set = resolveEffectiveFlags(
-    new Set(),
-    [{ 'vendor-qwen': false }, { 'vendor-qwen': true }],
-  );
+test('flags-resolve: later layer wins when both set the same flag', () => {
+  const set = resolveEffectiveFlags([
+    { 'vendor-qwen': false },
+    { 'vendor-qwen': true },
+  ]);
   assertEquals([...set].sort(), ['vendor-qwen']);
 });
 
 test('flags-resolve: undefined layers are skipped', () => {
-  const set = resolveEffectiveFlags(new Set(['retry-cyber-policy']), [undefined, undefined]);
+  const set = resolveEffectiveFlags([undefined, { 'retry-cyber-policy': true }, undefined]);
   assertEquals([...set].sort(), ['retry-cyber-policy']);
 });

--- a/packages/gateway/src/data-plane/providers/flags_test.ts
+++ b/packages/gateway/src/data-plane/providers/flags_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { defaultsForProvider, getFlagCatalog, isKnownFlagId } from '@floway-dev/provider';
+import { getFlagCatalog, isKnownFlagId } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 
 test('provider flags: catalog ids are unique', () => {
@@ -40,28 +40,5 @@ test('provider flags: every catalog entry has id, label, description string fiel
     assertEquals(typeof entry.label, 'string');
     assertEquals(typeof entry.description, 'string');
     assertEquals(entry.description.length > 0, true);
-    assertEquals(Array.isArray(entry.defaultFor), true);
   }
-});
-
-test('provider flags: defaultsForProvider returns the catalog-declared defaults', () => {
-  const copilotDefaults = [...defaultsForProvider('copilot')].sort();
-  assertEquals(copilotDefaults, ['messages-web-search-shim', 'responses-image-generation-shim', 'responses-web-search-shim', 'retry-cyber-policy', 'strip-billing-attribution']);
-  const azureDefaults = [...defaultsForProvider('azure')].sort();
-  assertEquals(azureDefaults, ['messages-web-search-shim', 'responses-image-generation-shim', 'responses-web-search-shim', 'strip-billing-attribution']);
-  assertEquals([...defaultsForProvider('custom')].sort(), ['messages-web-search-shim', 'responses-image-generation-shim', 'responses-web-search-shim', 'strip-billing-attribution']);
-  // ollama gets responses-compact-shim by default (no native /v1/responses/compact endpoint).
-  assertEquals([...defaultsForProvider('ollama')].sort(), ['messages-web-search-shim', 'responses-compact-shim', 'responses-image-generation-shim', 'responses-web-search-shim', 'strip-billing-attribution']);
-  assertEquals([...defaultsForProvider('codex')].sort(), ['strip-billing-attribution']);
-  // claude-code gets responses-compact-shim by default (Messages-only — any
-  // Responses request that reaches a claude-code candidate needs the shim to
-  // simulate compaction; the alternative is a hard reject from the provider).
-  assertEquals([...defaultsForProvider('claude-code')].sort(), ['responses-compact-shim']);
-});
-
-test('provider flags: defaultsForProvider memoizes the set per provider kind', () => {
-  assertEquals(defaultsForProvider('copilot') === defaultsForProvider('copilot'), true);
-  assertEquals(defaultsForProvider('azure') === defaultsForProvider('azure'), true);
-  assertEquals(defaultsForProvider('custom') === defaultsForProvider('custom'), true);
-  assertEquals(defaultsForProvider('claude-code') === defaultsForProvider('claude-code'), true);
 });

--- a/packages/gateway/src/data-plane/providers/flags_test.ts
+++ b/packages/gateway/src/data-plane/providers/flags_test.ts
@@ -1,25 +1,25 @@
 import { test } from 'vitest';
 
-import { getFlagCatalog, isKnownFlagId } from '@floway-dev/provider';
+import { isKnownFlagId, OPTIONAL_FLAGS } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 
 test('provider flags: catalog ids are unique', () => {
   const ids = new Set<string>();
-  for (const entry of getFlagCatalog()) {
+  for (const entry of OPTIONAL_FLAGS) {
     assertEquals(ids.has(entry.id), false);
     ids.add(entry.id);
   }
 });
 
 test('provider flags: every catalog entry has a non-empty label', () => {
-  for (const entry of getFlagCatalog()) {
+  for (const entry of OPTIONAL_FLAGS) {
     assertEquals(typeof entry.label, 'string');
     assertEquals(entry.label.length > 0, true);
   }
 });
 
 test('provider flags: isKnownFlagId agrees with catalog', () => {
-  for (const entry of getFlagCatalog()) {
+  for (const entry of OPTIONAL_FLAGS) {
     assertEquals(isKnownFlagId(entry.id), true);
   }
   assertEquals(isKnownFlagId('nonexistent-flag'), false);
@@ -28,13 +28,13 @@ test('provider flags: isKnownFlagId agrees with catalog', () => {
 const FLAG_ID_PATTERN = /^[a-z][a-z0-9-]+$/;
 
 test('provider flags: every catalog id is kebab-case', () => {
-  for (const entry of getFlagCatalog()) {
+  for (const entry of OPTIONAL_FLAGS) {
     assertEquals(FLAG_ID_PATTERN.test(entry.id), true, `id ${entry.id} must be kebab-case`);
   }
 });
 
 test('provider flags: every catalog entry has id, label, description string fields', () => {
-  for (const entry of getFlagCatalog()) {
+  for (const entry of OPTIONAL_FLAGS) {
     assertEquals(typeof entry.id, 'string');
     assertEquals(entry.id.length > 0, true);
     assertEquals(typeof entry.label, 'string');

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -43,14 +43,10 @@ const providerFactories: Record<UpstreamProviderKind, ProviderFactory> = {
   ollama: createOllamaProvider,
 };
 
-// Provider construction is synchronous: every factory just captures the
-// record and returns closures. Any I/O the provider needs (token refresh,
-// state persistence, model catalog fetch) happens on demand inside the
-// per-request methods, never at factory time. Keeping this sync lets the
-// serializer route flag defaults through the ProviderInstance methods
-// without threading async through every caller, and — via the invariant
-// that ProviderInstance is the ONLY source of flag defaults — prevents
-// parallel per-kind lookup maps from reappearing.
+// Provider factories only capture the record and return closures; any
+// I/O they need (token refresh, state persistence, model catalog fetch)
+// happens on demand inside the per-request methods, never at factory
+// time.
 export const createProviderInstance = (record: UpstreamRecord): Provider =>
   providerFactories[record.kind](record);
 

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -30,8 +30,6 @@ interface ProviderModelsResult {
   failedUpstreams: string[];
 }
 
-// Dispatch table: every static per-kind answer the gateway needs from a
-// provider hangs off `ProviderModule`.
 const providersByKind: Record<UpstreamProviderKind, ProviderModule> = {
   copilot: copilotProvider,
   custom: customProvider,
@@ -88,7 +86,7 @@ export const listModelProviders = async (
 // The provider model is stored verbatim under that entry so dispatch hands
 // the same reference back to the provider's `callXxx`.
 const internalModelFromProviderModel = (providerModel: ProviderModel, upstreamId: string): InternalModel => {
-  const { providerData, enabledFlags, endpoints, ...metadata } = providerModel;
+  const { providerData, enabledFlags, flagOverrides, endpoints, ...metadata } = providerModel;
   return {
     ...metadata,
     endpoints: { ...endpoints },

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -7,13 +7,13 @@ import { getRepo } from '../../repo/index.ts';
 import type { ModelAliasRecord } from '../../repo/types.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import { type ModelKind, kindForEndpoints } from '@floway-dev/protocols/common';
-import { isAbortError, type Fetcher, type InternalModel, type ModelCandidate, type Provider, type ProviderModel, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
-import { createAzureProvider } from '@floway-dev/provider-azure';
-import { createClaudeCodeProvider } from '@floway-dev/provider-claude-code';
-import { createCodexProvider } from '@floway-dev/provider-codex';
-import { createCopilotProvider } from '@floway-dev/provider-copilot';
-import { createCustomProvider } from '@floway-dev/provider-custom';
-import { createOllamaProvider } from '@floway-dev/provider-ollama';
+import { isAbortError, type Fetcher, type FlagDefaults, type FlagOverrides, type InternalModel, type ModelCandidate, type Provider, type ProviderModel, type ProviderModule, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import { azureProvider } from '@floway-dev/provider-azure';
+import { claudeCodeProvider } from '@floway-dev/provider-claude-code';
+import { codexProvider } from '@floway-dev/provider-codex';
+import { copilotProvider } from '@floway-dev/provider-copilot';
+import { customProvider } from '@floway-dev/provider-custom';
+import { ollamaProvider } from '@floway-dev/provider-ollama';
 
 interface ProviderModelsResult {
   models: InternalModel[];
@@ -32,23 +32,41 @@ interface ProviderModelsResult {
 
 const NO_UPSTREAM_CONFIGURED_MESSAGE = 'No upstream provider configured — connect GitHub Copilot or add a Custom/Azure upstream in the dashboard';
 
-type ProviderFactory = (record: UpstreamRecord) => Provider;
-
-const providerFactories: Record<UpstreamProviderKind, ProviderFactory> = {
-  copilot: createCopilotProvider,
-  custom: createCustomProvider,
-  azure: createAzureProvider,
-  codex: createCodexProvider,
-  'claude-code': createClaudeCodeProvider,
-  ollama: createOllamaProvider,
+// Single kind→module dispatch table. Every static answer the gateway needs
+// from a provider (instance factory, flag defaults, per-model flag
+// overlay) reads off the same object; adding a new dispatch slot means a
+// new field on `ProviderModule`, not a parallel per-kind map.
+const providersByKind: Record<UpstreamProviderKind, ProviderModule> = {
+  copilot: copilotProvider,
+  custom: customProvider,
+  azure: azureProvider,
+  codex: codexProvider,
+  'claude-code': claudeCodeProvider,
+  ollama: ollamaProvider,
 };
+
+export const providerModuleForKind = (kind: UpstreamProviderKind): ProviderModule => providersByKind[kind];
 
 // Provider factories only capture the record and return closures; any
 // I/O they need (token refresh, state persistence, model catalog fetch)
 // happens on demand inside the per-request methods, never at factory
 // time.
 export const createProviderInstance = (record: UpstreamRecord): Provider =>
-  providerFactories[record.kind](record);
+  providersByKind[record.kind].create(record);
+
+// Flag defaults for a fresh upstream of `kind`, read off the same module
+// object. Serializer, dashboard flag-defaults endpoint, and any future
+// caller share one lookup.
+export const flagDefaultsForKind = (kind: UpstreamProviderKind): FlagDefaults =>
+  providersByKind[kind].defaultFlags;
+
+// Per-model flag deltas layered on top of `flagDefaultsForKind`. Returns
+// {} when the provider has no per-model opinion (only Copilot implements
+// this today; see COPILOT_DEFAULT_FLAGS + defaultFlagsForCopilotModel).
+export const flagDefaultsForModelByKind = (
+  kind: UpstreamProviderKind,
+  model: Omit<ProviderModel, 'enabledFlags'>,
+): FlagOverrides => providersByKind[kind].getDefaultFlagsForModel?.(model) ?? {};
 
 // The upstream scope is a required argument across the catalog-assembly chain
 // (this, getModels) so a caller can never omit it and silently receive the
@@ -85,8 +103,7 @@ export const listModelProviders = async (
 
   const providers: Provider[] = [];
   for (const upstream of selection) {
-    const factory = providerFactories[upstream.kind];
-    providers.push(factory(upstream));
+    providers.push(providersByKind[upstream.kind].create(upstream));
   }
 
   return providers;

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -32,7 +32,7 @@ interface ProviderModelsResult {
 
 const NO_UPSTREAM_CONFIGURED_MESSAGE = 'No upstream provider configured — connect GitHub Copilot or add a Custom/Azure upstream in the dashboard';
 
-type ProviderFactory = (record: UpstreamRecord) => Provider | Promise<Provider>;
+type ProviderFactory = (record: UpstreamRecord) => Provider;
 
 const providerFactories: Record<UpstreamProviderKind, ProviderFactory> = {
   copilot: createCopilotProvider,
@@ -43,7 +43,15 @@ const providerFactories: Record<UpstreamProviderKind, ProviderFactory> = {
   ollama: createOllamaProvider,
 };
 
-export const createProviderInstance = (record: UpstreamRecord): Provider | Promise<Provider> =>
+// Provider construction is synchronous: every factory just captures the
+// record and returns closures. Any I/O the provider needs (token refresh,
+// state persistence, model catalog fetch) happens on demand inside the
+// per-request methods, never at factory time. Keeping this sync lets the
+// serializer route flag defaults through the ProviderInstance methods
+// without threading async through every caller, and — via the invariant
+// that ProviderInstance is the ONLY source of flag defaults — prevents
+// parallel per-kind lookup maps from reappearing.
+export const createProviderInstance = (record: UpstreamRecord): Provider =>
   providerFactories[record.kind](record);
 
 // The upstream scope is a required argument across the catalog-assembly chain
@@ -82,7 +90,7 @@ export const listModelProviders = async (
   const providers: Provider[] = [];
   for (const upstream of selection) {
     const factory = providerFactories[upstream.kind];
-    providers.push(await factory(upstream));
+    providers.push(factory(upstream));
   }
 
   return providers;

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -30,10 +30,8 @@ interface ProviderModelsResult {
   failedUpstreams: string[];
 }
 
-// Single kind→module dispatch table. Every static answer the gateway
-// needs from a provider (instance factory, flag defaults) reads off
-// the same object; adding a new dispatch slot means a new field on
-// `ProviderModule`, not a parallel per-kind map.
+// Dispatch table: every static per-kind answer the gateway needs from a
+// provider hangs off `ProviderModule`.
 const providersByKind: Record<UpstreamProviderKind, ProviderModule> = {
   copilot: copilotProvider,
   custom: customProvider,
@@ -43,10 +41,6 @@ const providersByKind: Record<UpstreamProviderKind, ProviderModule> = {
   ollama: ollamaProvider,
 };
 
-// Provider factories only capture the record and return closures; any
-// I/O they need (token refresh, state persistence, model catalog fetch)
-// happens on demand inside the per-request methods, never at factory
-// time.
 export const createProviderInstance = (record: UpstreamRecord): Provider =>
   providersByKind[record.kind].create(record);
 

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -50,9 +50,6 @@ const providersByKind: Record<UpstreamProviderKind, ProviderModule> = {
 export const createProviderInstance = (record: UpstreamRecord): Provider =>
   providersByKind[record.kind].create(record);
 
-// Flag defaults for a fresh upstream of `kind`, read off the same module
-// object. Serializer, dashboard flag-defaults endpoint, and any future
-// caller share one lookup.
 export const flagDefaultsForKind = (kind: UpstreamProviderKind): FlagDefaults =>
   providersByKind[kind].defaultFlags;
 
@@ -89,12 +86,7 @@ export const listModelProviders = async (
     selection = [...enabledById.values()];
   }
 
-  const providers: Provider[] = [];
-  for (const upstream of selection) {
-    providers.push(createProviderInstance(upstream));
-  }
-
-  return providers;
+  return selection.map(createProviderInstance);
 };
 
 // Lift a provider-emitted `ProviderModel` into an `InternalModel`, seeding

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -45,8 +45,6 @@ const providersByKind: Record<UpstreamProviderKind, ProviderModule> = {
   ollama: ollamaProvider,
 };
 
-export const providerModuleForKind = (kind: UpstreamProviderKind): ProviderModule => providersByKind[kind];
-
 // Provider factories only capture the record and return closures; any
 // I/O they need (token refresh, state persistence, model catalog fetch)
 // happens on demand inside the per-request methods, never at factory

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -7,7 +7,7 @@ import { getRepo } from '../../repo/index.ts';
 import type { ModelAliasRecord } from '../../repo/types.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import { type ModelKind, kindForEndpoints } from '@floway-dev/protocols/common';
-import { isAbortError, type Fetcher, type FlagDefaults, type FlagOverrides, type InternalModel, type ModelCandidate, type Provider, type ProviderModel, type ProviderModule, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import { isAbortError, type Fetcher, type FlagDefaults, type InternalModel, type ModelCandidate, type Provider, type ProviderModel, type ProviderModule, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
 import { azureProvider } from '@floway-dev/provider-azure';
 import { claudeCodeProvider } from '@floway-dev/provider-claude-code';
 import { codexProvider } from '@floway-dev/provider-codex';
@@ -59,14 +59,6 @@ export const createProviderInstance = (record: UpstreamRecord): Provider =>
 // caller share one lookup.
 export const flagDefaultsForKind = (kind: UpstreamProviderKind): FlagDefaults =>
   providersByKind[kind].defaultFlags;
-
-// Per-model flag deltas layered on top of `flagDefaultsForKind`. Returns
-// {} when the provider has no per-model opinion (only Copilot implements
-// this today; see COPILOT_DEFAULT_FLAGS + defaultFlagsForCopilotModel).
-export const flagDefaultsForModelByKind = (
-  kind: UpstreamProviderKind,
-  model: Omit<ProviderModel, 'enabledFlags'>,
-): FlagOverrides => providersByKind[kind].getDefaultFlagsForModel?.(model) ?? {};
 
 // The upstream scope is a required argument across the catalog-assembly chain
 // (this, getModels) so a caller can never omit it and silently receive the

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -30,12 +30,10 @@ interface ProviderModelsResult {
   failedUpstreams: string[];
 }
 
-const NO_UPSTREAM_CONFIGURED_MESSAGE = 'No upstream provider configured — connect GitHub Copilot or add a Custom/Azure upstream in the dashboard';
-
-// Single kind→module dispatch table. Every static answer the gateway needs
-// from a provider (instance factory, flag defaults, per-model flag
-// overlay) reads off the same object; adding a new dispatch slot means a
-// new field on `ProviderModule`, not a parallel per-kind map.
+// Single kind→module dispatch table. Every static answer the gateway
+// needs from a provider (instance factory, flag defaults) reads off
+// the same object; adding a new dispatch slot means a new field on
+// `ProviderModule`, not a parallel per-kind map.
 const providersByKind: Record<UpstreamProviderKind, ProviderModule> = {
   copilot: copilotProvider,
   custom: customProvider,
@@ -93,7 +91,7 @@ export const listModelProviders = async (
 
   const providers: Provider[] = [];
   for (const upstream of selection) {
-    providers.push(providersByKind[upstream.kind].create(upstream));
+    providers.push(createProviderInstance(upstream));
   }
 
   return providers;
@@ -283,7 +281,7 @@ export const getModelsFromProviders = async (
   scheduler: BackgroundScheduler,
 ): Promise<{ models: InternalModel[]; upstreamsByPublicId: Map<string, Provider[]>; failedUpstreams: readonly string[] }> => {
   if (providers.length === 0) {
-    throw new Error(NO_UPSTREAM_CONFIGURED_MESSAGE);
+    throw new Error('No upstream provider configured — connect GitHub Copilot or add a Custom/Azure upstream in the dashboard');
   }
 
   const { models, upstreamsByPublicId, sawSuccess, lastError, failedUpstreams } = await collectProviderModels(providers, fetcherForUpstream, scheduler);

--- a/packages/gateway/src/repo/upstreams_test.ts
+++ b/packages/gateway/src/repo/upstreams_test.ts
@@ -69,7 +69,7 @@ test('memory upstream repo saves, lists, updates, deletes, and clears rows', asy
     createdAt: '2099-01-01T00:00:00.000Z',
     updatedAt: '2026-05-21T10:00:04.000Z',
     config: { nested: { value: 'updated' }, endpoints: { responses: {} } },
-    flagOverrides: { 'retry-tool-use': true },
+    flagOverrides: { 'retry-cyber-policy': true },
     disabledPublicModelIds: [],
   });
   await repo.save(updatedCustom);
@@ -107,16 +107,16 @@ test('memory upstream repo deeply clones configs and flag overrides at the repo 
         headers: ['authorization'],
       },
     },
-    flagOverrides: { 'z-fix': true, 'a-fix': true },
+    flagOverrides: { 'vendor-deepseek': true, 'demote-developer-to-system': true },
     disabledPublicModelIds: [],
   });
 
   await repo.save(original);
-  original.flagOverrides['mutated-after-save'] = true;
+  original.flagOverrides['strip-billing-attribution'] = true;
   (original.config as { nested: { headers: string[] } }).nested.headers.push('mutated-after-save');
 
   const saved = await repo.getById('up_custom_clone');
-  assertEquals(saved?.flagOverrides, { 'a-fix': true, 'z-fix': true });
+  assertEquals(saved?.flagOverrides, { 'demote-developer-to-system': true, 'vendor-deepseek': true });
   assertEquals(saved?.config, {
     nested: {
       baseUrl: 'https://example.test/v1',
@@ -125,10 +125,10 @@ test('memory upstream repo deeply clones configs and flag overrides at the repo 
   });
 
   const listed = await repo.list();
-  listed[0].flagOverrides['mutated-after-list'] = true;
+  listed[0].flagOverrides['responses-web-search-shim'] = true;
   (listed[0].config as { nested: { headers: string[] } }).nested.headers.push('mutated-after-list');
 
-  assertEquals((await repo.getById('up_custom_clone'))?.flagOverrides, { 'a-fix': true, 'z-fix': true });
+  assertEquals((await repo.getById('up_custom_clone'))?.flagOverrides, { 'demote-developer-to-system': true, 'vendor-deepseek': true });
   assertEquals((await repo.getById('up_custom_clone'))?.config, {
     nested: {
       baseUrl: 'https://example.test/v1',
@@ -146,12 +146,12 @@ test('memory upstream repo sorts flag overrides by key when saving rows', async 
       kind: 'copilot',
       sortOrder: 0,
       createdAt: '2026-05-21T10:00:00.000Z',
-      flagOverrides: { 'z-fix': true, 'a-fix': false, 'm-fix': true },
+      flagOverrides: { 'vendor-deepseek': true, 'demote-developer-to-system': false, 'messages-web-search-shim': true },
       disabledPublicModelIds: [],
     }),
   );
 
-  assertEquals((await repo.getById('up_copilot_fixes'))?.flagOverrides, { 'a-fix': false, 'm-fix': true, 'z-fix': true });
+  assertEquals((await repo.getById('up_copilot_fixes'))?.flagOverrides, { 'demote-developer-to-system': false, 'messages-web-search-shim': true, 'vendor-deepseek': true });
 });
 
 const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
@@ -163,7 +163,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     createdAt: '2026-05-21T10:00:02.000Z',
     updatedAt: '2026-05-21T10:00:02.000Z',
     config: { baseUrl: 'https://custom.example/v1', authStyle: 'bearer', apiKey: 'sk-custom', endpoints: { chatCompletions: {} } },
-    flagOverrides: { 'z-fix': true, 'a-fix': true },
+    flagOverrides: { 'vendor-deepseek': true, 'demote-developer-to-system': true },
     disabledPublicModelIds: [],
   });
   const copilot = upstream({
@@ -193,7 +193,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     (await repo.list()).map(row => row.id),
     ['up_azure_sql', 'up_copilot_sql', 'up_custom_sql'],
   );
-  assertEquals((await repo.getById('up_custom_sql'))?.flagOverrides, { 'a-fix': true, 'z-fix': true });
+  assertEquals((await repo.getById('up_custom_sql'))?.flagOverrides, { 'demote-developer-to-system': true, 'vendor-deepseek': true });
   assertEquals(await repo.getById('missing'), null);
 
   await repo.save({
@@ -204,7 +204,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     createdAt: '2099-01-01T00:00:00.000Z',
     updatedAt: '2026-05-21T10:00:04.000Z',
     config: { baseUrl: 'https://updated.example/v1', authStyle: 'bearer', apiKey: 'sk-updated', endpoints: { responses: {} } },
-    flagOverrides: { 'm-fix': true, 'a-fix': true },
+    flagOverrides: { 'messages-web-search-shim': true, 'demote-developer-to-system': true },
     disabledPublicModelIds: [],
   });
   assertEquals(

--- a/packages/gateway/src/shared/upstream/model-config_test.ts
+++ b/packages/gateway/src/shared/upstream/model-config_test.ts
@@ -13,7 +13,7 @@ test('modelsField parses a full model entry', () => {
         display_name: 'GPT Prod',
         limits: { max_context_window_tokens: 128000, max_output_tokens: 4096 },
         cost: { input: 2.5, output: 15, input_cache_read: 0.25, input_cache_write: 3.75 },
-        flagOverrides: { enabled: true, values: { 'vendor-deepseek': false } },
+        flagOverrides: { 'vendor-deepseek': false },
       },
     ],
     'azure',
@@ -28,7 +28,7 @@ test('modelsField parses a full model entry', () => {
       display_name: 'GPT Prod',
       limits: { max_context_window_tokens: 128000, max_output_tokens: 4096 },
       cost: { input: 2.5, output: 15, input_cache_read: 0.25, input_cache_write: 3.75 },
-      flagOverrides: { enabled: true, values: { 'vendor-deepseek': false } },
+      flagOverrides: { 'vendor-deepseek': false },
     },
   ]);
 });
@@ -128,7 +128,7 @@ test('modelsField rejects cost with a negative input', () => {
   );
 });
 
-test('modelsField rejects a non-boolean flagOverrides.enabled', () => {
+test('modelsField rejects a non-object flagOverrides', () => {
   assertThrows(
     () =>
       modelsField(
@@ -136,13 +136,13 @@ test('modelsField rejects a non-boolean flagOverrides.enabled', () => {
           {
             upstreamModelId: 'gpt-prod',
             endpoints: { chatCompletions: {} },
-            flagOverrides: { enabled: 'yes', values: {} },
+            flagOverrides: 'not-an-object',
           },
         ],
         'azure',
       ),
     Error,
-    'Malformed azure models[0].flagOverrides.enabled: must be a boolean',
+    'Malformed azure models[0].flagOverrides: must be an object',
   );
 });
 
@@ -154,12 +154,12 @@ test('modelsField rejects flagOverrides with an unknown flag id', () => {
           {
             upstreamModelId: 'gpt-prod',
             endpoints: { chatCompletions: {} },
-            flagOverrides: { enabled: true, values: { 'made-up-flag': true } },
+            flagOverrides: { 'made-up-flag': true },
           },
         ],
         'azure',
       ),
     Error,
-    'Malformed azure models[0].flagOverrides.values: unknown flag ids: made-up-flag',
+    'Malformed azure models[0].flagOverrides: unknown flag ids: made-up-flag',
   );
 });

--- a/packages/provider-azure/src/config_test.ts
+++ b/packages/provider-azure/src/config_test.ts
@@ -142,16 +142,13 @@ test('assertAzureUpstreamRecord round-trips per-model flagOverrides', () => {
         {
           upstreamModelId: 'gpt-5',
           endpoints: { chatCompletions: {} },
-          flagOverrides: { enabled: true, values: { 'vendor-kimi': true, 'vendor-deepseek': false } },
+          flagOverrides: { 'vendor-kimi': true, 'vendor-deepseek': false },
         },
       ],
     },
   });
 
-  assertEquals(parsed.config.models[0].flagOverrides, {
-    enabled: true,
-    values: { 'vendor-kimi': true, 'vendor-deepseek': false },
-  });
+  assertEquals(parsed.config.models[0].flagOverrides, { 'vendor-kimi': true, 'vendor-deepseek': false });
 });
 
 test('assertAzureUpstreamRecord rejects malformed per-model flagOverrides', () => {
@@ -165,13 +162,13 @@ test('assertAzureUpstreamRecord rejects malformed per-model flagOverrides', () =
             {
               upstreamModelId: 'gpt-prod',
               endpoints: { chatCompletions: {} },
-              flagOverrides: { enabled: 'yes', values: {} },
+              flagOverrides: 'not-an-object',
             },
           ],
         },
       }),
     Error,
-    'azure models[0].flagOverrides.enabled: must be a boolean',
+    'azure models[0].flagOverrides: must be an object',
   );
 
   assertThrows(
@@ -184,13 +181,13 @@ test('assertAzureUpstreamRecord rejects malformed per-model flagOverrides', () =
             {
               upstreamModelId: 'gpt-prod',
               endpoints: { chatCompletions: {} },
-              flagOverrides: { enabled: true, values: { 'vendor-deepseek': 'on' } },
+              flagOverrides: { 'vendor-deepseek': 'on' },
             },
           ],
         },
       }),
     Error,
-    'azure models[0].flagOverrides.values.vendor-deepseek: must be a boolean',
+    'azure models[0].flagOverrides.vendor-deepseek: must be a boolean',
   );
 });
 
@@ -205,13 +202,13 @@ test('assertAzureUpstreamRecord rejects per-model flagOverrides with unknown fla
             {
               upstreamModelId: 'gpt-prod',
               endpoints: { chatCompletions: {} },
-              flagOverrides: { enabled: true, values: { 'made-up-flag': true } },
+              flagOverrides: { 'made-up-flag': true },
             },
           ],
         },
       }),
     Error,
-    'azure models[0].flagOverrides.values: unknown flag ids: made-up-flag',
+    'azure models[0].flagOverrides: unknown flag ids: made-up-flag',
   );
 });
 
@@ -226,13 +223,13 @@ test('assertAzureUpstreamRecord reports all unknown per-model flag ids in one er
             {
               upstreamModelId: 'gpt-prod',
               endpoints: { chatCompletions: {} },
-              flagOverrides: { enabled: true, values: { 'made-up-flag': true, 'another-typo': false } },
+              flagOverrides: { 'made-up-flag': true, 'another-typo': false },
             },
           ],
         },
       }),
     Error,
-    'azure models[0].flagOverrides.values: unknown flag ids: made-up-flag, another-typo',
+    'azure models[0].flagOverrides: unknown flag ids: made-up-flag, another-typo',
   );
 });
 

--- a/packages/provider-azure/src/defaults.ts
+++ b/packages/provider-azure/src/defaults.ts
@@ -1,0 +1,18 @@
+import type { FlagDefaults } from '@floway-dev/provider';
+
+// Exhaustive flag defaults for Azure OpenAI upstreams.
+export const AZURE_DEFAULT_FLAGS: FlagDefaults = {
+  'vendor-deepseek': false,
+  'vendor-qwen': false,
+  'vendor-kimi': false,
+  'retry-cyber-policy': false,
+  'messages-web-search-shim': true,
+  'responses-web-search-shim': true,
+  'responses-image-generation-shim': true,
+  // Azure exposes native /responses/compact.
+  'responses-compact-shim': false,
+  'disable-reasoning-on-forced-tool-choice': false,
+  'demote-interleaved-system-to-user': false,
+  'demote-developer-to-system': false,
+  'strip-billing-attribution': true,
+};

--- a/packages/provider-azure/src/defaults.ts
+++ b/packages/provider-azure/src/defaults.ts
@@ -1,6 +1,5 @@
 import type { FlagDefaults } from '@floway-dev/provider';
 
-// Exhaustive flag defaults for Azure OpenAI upstreams.
 export const AZURE_DEFAULT_FLAGS: FlagDefaults = {
   'vendor-deepseek': false,
   'vendor-qwen': false,

--- a/packages/provider-azure/src/index.ts
+++ b/packages/provider-azure/src/index.ts
@@ -1,3 +1,12 @@
+import { AZURE_DEFAULT_FLAGS } from './defaults.ts';
+import { createAzureProvider } from './provider.ts';
+import type { ProviderModule } from '@floway-dev/provider';
+
+export const azureProvider: ProviderModule = {
+  create: createAzureProvider,
+  defaultFlags: AZURE_DEFAULT_FLAGS,
+};
+
 export { createAzureProvider } from './provider.ts';
 export {
   assertAzureUpstreamRecord,

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -1,10 +1,11 @@
 import { assertAzureUpstreamRecord } from './config.ts';
+import { AZURE_DEFAULT_FLAGS } from './defaults.ts';
 import { azureFetchChatCompletions, azureFetchCompletions, azureFetchEmbeddings, azureFetchImagesEdits, azureFetchImagesGenerations, azureFetchMessages, azureFetchMessagesCountTokens, azureFetchResponses, azureFetchResponsesCompact } from './fetch.ts';
 import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completions';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { type ProviderInstance, type Provider, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord, defaultsForProvider, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
+import { type ProviderInstance, type Provider, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
 
 const upstreamModelIdOf = (model: ProviderModel): string => (model.providerData as { upstreamModelId: string }).upstreamModelId;
 
@@ -42,10 +43,11 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
   };
 
   const instance: ProviderInstance = {
+    defaultFlagsForUpstream: () => AZURE_DEFAULT_FLAGS,
     getProvidedModels() {
       return Promise.resolve(azure.config.models.map(model => {
         const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
-        const effective = resolveEffectiveFlags(defaultsForProvider('azure'), [azure.flagOverrides, modelLayer]);
+        const effective = resolveEffectiveFlags([AZURE_DEFAULT_FLAGS, azure.flagOverrides, modelLayer]);
         const endpoints = model.endpoints;
         return {
           id: publicModelId(model),

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -45,7 +45,7 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
   const instance: ProviderInstance = {
     getProvidedModels() {
       return Promise.resolve(azure.config.models.map(model => {
-        const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
+        const modelLayer = model.flagOverrides;
         const effective = resolveEffectiveFlags([AZURE_DEFAULT_FLAGS, azure.flagOverrides, modelLayer]);
         const endpoints = model.endpoints;
         return {

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -43,7 +43,6 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
   };
 
   const instance: ProviderInstance = {
-    defaultFlagsForUpstream: () => AZURE_DEFAULT_FLAGS,
     getProvidedModels() {
       return Promise.resolve(azure.config.models.map(model => {
         const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -45,8 +45,7 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
   const instance: ProviderInstance = {
     getProvidedModels() {
       return Promise.resolve(azure.config.models.map(model => {
-        const modelLayer = model.flagOverrides;
-        const effective = resolveEffectiveFlags([AZURE_DEFAULT_FLAGS, azure.flagOverrides, modelLayer]);
+        const effective = resolveEffectiveFlags([AZURE_DEFAULT_FLAGS, azure.flagOverrides, model.flagOverrides]);
         const endpoints = model.endpoints;
         return {
           id: publicModelId(model),

--- a/packages/provider-claude-code/src/defaults.ts
+++ b/packages/provider-claude-code/src/defaults.ts
@@ -1,0 +1,29 @@
+import type { FlagDefaults } from '@floway-dev/provider';
+
+// Exhaustive flag defaults for Claude.ai (Claude Code) subscription
+// upstreams.
+//
+// * Hosted-tool shims stay off — Claude Code's Messages passthrough
+//   forwards caller bytes verbatim, so a gateway-side shim would silently
+//   rewrite a request the operator deliberately let through unchanged.
+// * `responses-compact-shim` defaults on: Anthropic Messages has no
+//   /responses/compact concept, and the shim is what synthesizes a
+//   `response.compaction` envelope for callers that expect one.
+// * `strip-billing-attribution` defaults off: the `x-anthropic-billing-header:`
+//   block from Claude Code clients IS the input Anthropic reads to bill
+//   the request against the user's subscription. Stripping it here would
+//   route billing away from the user's plan.
+export const CLAUDE_CODE_DEFAULT_FLAGS: FlagDefaults = {
+  'vendor-deepseek': false,
+  'vendor-qwen': false,
+  'vendor-kimi': false,
+  'retry-cyber-policy': false,
+  'messages-web-search-shim': false,
+  'responses-web-search-shim': false,
+  'responses-image-generation-shim': false,
+  'responses-compact-shim': true,
+  'disable-reasoning-on-forced-tool-choice': false,
+  'demote-interleaved-system-to-user': false,
+  'demote-developer-to-system': false,
+  'strip-billing-attribution': false,
+};

--- a/packages/provider-claude-code/src/index.ts
+++ b/packages/provider-claude-code/src/index.ts
@@ -1,3 +1,12 @@
+import { CLAUDE_CODE_DEFAULT_FLAGS } from './defaults.ts';
+import { createClaudeCodeProvider } from './provider.ts';
+import type { ProviderModule } from '@floway-dev/provider';
+
+export const claudeCodeProvider: ProviderModule = {
+  create: createClaudeCodeProvider,
+  defaultFlags: CLAUDE_CODE_DEFAULT_FLAGS,
+};
+
 export * from './config.ts';
 export * from './state.ts';
 export * from './constants.ts';

--- a/packages/provider-claude-code/src/models.ts
+++ b/packages/provider-claude-code/src/models.ts
@@ -16,7 +16,7 @@
 import { CLAUDE_CODE_HEADERS_SONNET_OPUS } from './headers.ts';
 import { pricingForClaudeCodeModelKey } from './pricing.ts';
 import type { ClaudeCodeProviderData } from './types.ts';
-import type { Fetcher, ProviderModel, UpstreamChatModelConfig } from '@floway-dev/provider';
+import type { Fetcher, FlagId, ProviderModel, UpstreamChatModelConfig } from '@floway-dev/provider';
 
 const ANTHROPIC_MODELS_ENDPOINT = 'https://api.anthropic.com/v1/models?limit=100';
 
@@ -189,7 +189,7 @@ export const chatFromCapabilities = (
 
 export const buildClaudeCodeCatalog = (
   apiModels: readonly ClaudeCodeApiModel[],
-  enabledFlags: ReadonlySet<string>,
+  enabledFlags: ReadonlySet<FlagId>,
 ): ProviderModel[] => apiModels.map(api => {
   const alias = aliasFromApiId(api.id);
   const cost = pricingForClaudeCodeModelKey(api.id);

--- a/packages/provider-claude-code/src/models_test.ts
+++ b/packages/provider-claude-code/src/models_test.ts
@@ -8,6 +8,7 @@ import {
 } from './models.ts';
 import { pricingForClaudeCodeModelKey } from './pricing.ts';
 import type { ClaudeCodeProviderData } from './types.ts';
+import type { FlagId } from '@floway-dev/provider';
 
 const SAMPLE_API_MODELS: ClaudeCodeApiModel[] = [
   { id: 'claude-fable-5', display_name: 'Claude Fable 5', max_input_tokens: 1_000_000 },
@@ -155,7 +156,7 @@ describe('chatFromCapabilities', () => {
 });
 
 describe('buildClaudeCodeCatalog', () => {
-  const models = buildClaudeCodeCatalog(SAMPLE_API_MODELS, new Set<string>());
+  const models = buildClaudeCodeCatalog(SAMPLE_API_MODELS, new Set<FlagId>());
 
   test('publishes each model under its public alias (date-stripped where applicable)', () => {
     expect(models.map(m => m.id)).toEqual([
@@ -201,7 +202,7 @@ describe('buildClaudeCodeCatalog', () => {
   });
 
   test('forwards the supplied enabledFlags set onto every model', () => {
-    const flags = new Set(['custom-flag-a', 'custom-flag-b']);
+    const flags: ReadonlySet<FlagId> = new Set(['demote-developer-to-system', 'retry-cyber-policy']);
     const built = buildClaudeCodeCatalog(SAMPLE_API_MODELS, flags);
     for (const m of built) {
       expect(m.enabledFlags).toBe(flags);

--- a/packages/provider-claude-code/src/provider.ts
+++ b/packages/provider-claude-code/src/provider.ts
@@ -1,5 +1,6 @@
 import { ensureClaudeCodeAccessToken } from './access-token-cache.ts';
 import { assertClaudeCodeUpstreamRecord } from './config.ts';
+import { CLAUDE_CODE_DEFAULT_FLAGS } from './defaults.ts';
 import { isClaudeCodeShapedRequest } from './detection.ts';
 import { detectHaikuProbe, callClaudeCodeMessages } from './fetch.ts';
 import { claudeCodeMessagesChain, type ClaudeCodeMessagesBoundaryCtx } from './interceptors/messages/index.ts';
@@ -9,7 +10,6 @@ import { assertClaudeCodeUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import {
-  defaultsForProvider,
   getProviderRepo,
   resolveEffectiveFlags,
   type ProviderInstance,
@@ -18,13 +18,14 @@ import {
   type UpstreamRecord,
 } from '@floway-dev/provider';
 
-export const createClaudeCodeProvider = async (record: UpstreamRecord): Promise<Provider> => {
+export const createClaudeCodeProvider = (record: UpstreamRecord): Provider => {
   assertClaudeCodeUpstreamRecord(record);
   assertClaudeCodeUpstreamState(record.state);
 
-  const enabledFlags = resolveEffectiveFlags(defaultsForProvider('claude-code'), [record.flagOverrides]);
+  const enabledFlags = resolveEffectiveFlags([CLAUDE_CODE_DEFAULT_FLAGS, record.flagOverrides]);
 
   const instance: ProviderInstance = {
+    defaultFlagsForUpstream: () => CLAUDE_CODE_DEFAULT_FLAGS,
     // Catalog refresh mints an access token and hits /v1/models on every
     // dispatcher poll. `ensureClaudeCodeAccessToken` flips the row to
     // `refresh_failed` and throws `ClaudeCodeOAuthSessionTerminatedError`

--- a/packages/provider-claude-code/src/provider.ts
+++ b/packages/provider-claude-code/src/provider.ts
@@ -25,7 +25,6 @@ export const createClaudeCodeProvider = (record: UpstreamRecord): Provider => {
   const enabledFlags = resolveEffectiveFlags([CLAUDE_CODE_DEFAULT_FLAGS, record.flagOverrides]);
 
   const instance: ProviderInstance = {
-    defaultFlagsForUpstream: () => CLAUDE_CODE_DEFAULT_FLAGS,
     // Catalog refresh mints an access token and hits /v1/models on every
     // dispatcher poll. `ensureClaudeCodeAccessToken` flips the row to
     // `refresh_failed` and throws `ClaudeCodeOAuthSessionTerminatedError`

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -4,7 +4,7 @@ import { buildClaudeCodeCatalog, type ClaudeCodeApiModel } from './models.ts';
 import { pricingForClaudeCodeModelKey } from './pricing.ts';
 import { createClaudeCodeProvider } from './provider.ts';
 import type { ClaudeCodeAccessTokenEntry, ClaudeCodeAccountCredential, ClaudeCodeUpstreamState } from './state.ts';
-import { initProviderRepo, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { initProviderRepo, type FlagId, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions } from '@floway-dev/test-utils';
 
 const upstreamId = 'up_cc_provider';
@@ -22,7 +22,7 @@ const API_MODELS: ClaudeCodeApiModel[] = [
 
 // The catalog builder emits a `ProviderModel` per API row (with the dated
 // upstream id on providerData); pick the entry the messages-routing tests want.
-const sonnetProviderModel = buildClaudeCodeCatalog(API_MODELS, new Set<string>())
+const sonnetProviderModel = buildClaudeCodeCatalog(API_MODELS, new Set<FlagId>())
   .find(m => m.id === 'claude-sonnet-4-5')!;
 
 const activeAccount: ClaudeCodeAccountCredential = {

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -121,13 +121,16 @@ describe('createClaudeCodeProvider — factory surface', () => {
   });
 
   test('getProvidedModels stamps the effective flag set onto every model', async () => {
-    // claude-code has zero declared flag defaults — verify the effective set
-    // stays empty regardless of the other providers' defaults.
+    // claude-code's provider defaults leave `strip-billing-attribution` off
+    // (Anthropic reads the block to bill against the user's plan) and turn
+    // `responses-compact-shim` on (Messages has no native compact wire).
+    // Both should be reflected on every emitted model's enabledFlags.
     stubModelsListFetch();
     const instance = createClaudeCodeProvider(currentRecord);
     const models = await instance.instance.getProvidedModels(noopUpstreamCallOptions().fetcher);
     for (const m of models) {
       expect(m.enabledFlags.has('strip-billing-attribution')).toBe(false);
+      expect(m.enabledFlags.has('responses-compact-shim')).toBe(true);
     }
   });
 

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -108,7 +108,7 @@ const stubModelsListFetch = (): ReturnType<typeof vi.spyOn> => vi.spyOn(globalTh
 describe('createClaudeCodeProvider — factory surface', () => {
   test('getProvidedModels mirrors the live /v1/models catalog under public aliases', async () => {
     stubModelsListFetch();
-    const instance = await createClaudeCodeProvider(currentRecord);
+    const instance = createClaudeCodeProvider(currentRecord);
     const models = await instance.instance.getProvidedModels(noopUpstreamCallOptions().fetcher);
     expect(models.map(m => m.id)).toEqual([
       'claude-fable-5',
@@ -124,7 +124,7 @@ describe('createClaudeCodeProvider — factory surface', () => {
     // claude-code has zero declared flag defaults — verify the effective set
     // stays empty regardless of the other providers' defaults.
     stubModelsListFetch();
-    const instance = await createClaudeCodeProvider(currentRecord);
+    const instance = createClaudeCodeProvider(currentRecord);
     const models = await instance.instance.getProvidedModels(noopUpstreamCallOptions().fetcher);
     for (const m of models) {
       expect(m.enabledFlags.has('strip-billing-attribution')).toBe(false);
@@ -132,14 +132,14 @@ describe('createClaudeCodeProvider — factory surface', () => {
   });
 
   test('getPricingForModelKey wires through the pricing table (keyed by dated upstream id)', async () => {
-    const instance = await createClaudeCodeProvider(currentRecord);
+    const instance = createClaudeCodeProvider(currentRecord);
     expect(instance.instance.getPricingForModelKey('claude-sonnet-4-5-20250929'))
       .toEqual(pricingForClaudeCodeModelKey('claude-sonnet-4-5-20250929'));
     expect(instance.instance.getPricingForModelKey('unknown-id')).toBeNull();
   });
 
   test('kind is "claude-code" and supportsResponsesItemReference is false', async () => {
-    const instance = await createClaudeCodeProvider(currentRecord);
+    const instance = createClaudeCodeProvider(currentRecord);
     expect(instance.kind).toBe('claude-code');
     expect(instance.supportsResponsesItemReference).toBe(false);
     expect(instance.upstream).toBe(upstreamId);
@@ -148,7 +148,7 @@ describe('createClaudeCodeProvider — factory surface', () => {
 
 describe('createClaudeCodeProvider — callMessages routes through chain', () => {
   test('unshaped request runs the re-mimicry chain (3-block system, pinned UA, metadata.user_id)', async () => {
-    const instance = await createClaudeCodeProvider(currentRecord);
+    const instance = createClaudeCodeProvider(currentRecord);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
 
     await instance.instance.callMessages(
@@ -174,7 +174,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
   });
 
   test('shaped request preserves caller-supplied system + headers (chain skipped)', async () => {
-    const instance = await createClaudeCodeProvider(currentRecord);
+    const instance = createClaudeCodeProvider(currentRecord);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
 
     const userId = JSON.stringify({ device_id: 'd'.repeat(32), account_uuid: '', session_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' });
@@ -210,7 +210,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
   });
 
   test('CC UA but a payload that fails the strict shape gate still runs the chain', async () => {
-    const instance = await createClaudeCodeProvider(currentRecord);
+    const instance = createClaudeCodeProvider(currentRecord);
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
 
     await instance.instance.callMessages(

--- a/packages/provider-codex/src/defaults.ts
+++ b/packages/provider-codex/src/defaults.ts
@@ -1,6 +1,5 @@
 import type { FlagDefaults } from '@floway-dev/provider';
 
-// Exhaustive flag defaults for ChatGPT Codex (subscription) upstreams.
 export const CODEX_DEFAULT_FLAGS: FlagDefaults = {
   'vendor-deepseek': false,
   'vendor-qwen': false,

--- a/packages/provider-codex/src/defaults.ts
+++ b/packages/provider-codex/src/defaults.ts
@@ -1,7 +1,6 @@
 import type { FlagDefaults } from '@floway-dev/provider';
 
 // Exhaustive flag defaults for ChatGPT Codex (subscription) upstreams.
-// Codex has no hosted-tool concept, so the three shim flags stay off.
 export const CODEX_DEFAULT_FLAGS: FlagDefaults = {
   'vendor-deepseek': false,
   'vendor-qwen': false,

--- a/packages/provider-codex/src/defaults.ts
+++ b/packages/provider-codex/src/defaults.ts
@@ -1,0 +1,18 @@
+import type { FlagDefaults } from '@floway-dev/provider';
+
+// Exhaustive flag defaults for ChatGPT Codex (subscription) upstreams.
+// Codex has no hosted-tool concept, so the three shim flags stay off.
+export const CODEX_DEFAULT_FLAGS: FlagDefaults = {
+  'vendor-deepseek': false,
+  'vendor-qwen': false,
+  'vendor-kimi': false,
+  'retry-cyber-policy': false,
+  'messages-web-search-shim': false,
+  'responses-web-search-shim': false,
+  'responses-image-generation-shim': false,
+  'responses-compact-shim': false,
+  'disable-reasoning-on-forced-tool-choice': false,
+  'demote-interleaved-system-to-user': false,
+  'demote-developer-to-system': false,
+  'strip-billing-attribution': true,
+};

--- a/packages/provider-codex/src/index.ts
+++ b/packages/provider-codex/src/index.ts
@@ -1,3 +1,12 @@
+import { CODEX_DEFAULT_FLAGS } from './defaults.ts';
+import { createCodexProvider } from './provider.ts';
+import type { ProviderModule } from '@floway-dev/provider';
+
+export const codexProvider: ProviderModule = {
+  create: createCodexProvider,
+  defaultFlags: CODEX_DEFAULT_FLAGS,
+};
+
 export * from './access-token-cache.ts';
 export * from './auth/import.ts';
 export * from './auth/oauth.ts';

--- a/packages/provider-codex/src/interceptors/responses/action-pivot_test.ts
+++ b/packages/provider-codex/src/interceptors/responses/action-pivot_test.ts
@@ -86,7 +86,7 @@ test('Codex terminal dispatches on post-chain ctx.action (interceptor flip gener
     throw new Error(`unexpected fetch ${url}`);
   });
 
-  const instance = await createCodexProvider(baseRecord);
+  const instance = createCodexProvider(baseRecord);
   // Generate-shaped body — carries tools, reasoning, temperature, etc. None
   // of these are allowed on /responses/compact. The pivot above flips action
   // to 'compact'; the terminal must narrow the body before sending upstream.

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -6,7 +6,7 @@ import {
   CODEX_USER_AGENT,
 } from './constants.ts';
 import { pricingForCodexModelKey } from './pricing.ts';
-import { type Fetcher, type ProviderModel, type UpstreamChatModelConfig } from '@floway-dev/provider';
+import { type Fetcher, type FlagId, type ProviderModel, type UpstreamChatModelConfig } from '@floway-dev/provider';
 
 export interface CodexRawModel {
   id: string;
@@ -101,7 +101,7 @@ const assertRawModel = (value: unknown): CodexRawModel => {
 // `enabledFlags` is the upstream-resolved flag set (provider defaults
 // merged with the row's `flagOverrides`); it propagates per-model so
 // downstream interceptors can read the effective set without re-resolving.
-export const codexRawToProviderModel = (raw: CodexRawModel, enabledFlags: ReadonlySet<string>): ProviderModel => {
+export const codexRawToProviderModel = (raw: CodexRawModel, enabledFlags: ReadonlySet<FlagId>): ProviderModel => {
   const cost = pricingForCodexModelKey(raw.id);
   const chat: UpstreamChatModelConfig = {};
   if (raw.input_modalities && raw.input_modalities.length > 0) {

--- a/packages/provider-codex/src/models_test.ts
+++ b/packages/provider-codex/src/models_test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { CODEX_CLI_VERSION, CODEX_ORIGINATOR, CODEX_USER_AGENT } from './constants.ts';
 import { codexRawToProviderModel, fetchCodexCatalog } from './models.ts';
 import { resolveEffectivePricing } from '@floway-dev/protocols/common';
-import { directFetcher } from '@floway-dev/provider';
+import { directFetcher, type FlagId } from '@floway-dev/provider';
 
 const okJson = (body: unknown): Response => new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
 
@@ -116,7 +116,7 @@ describe('codexRawToProviderModel', () => {
   // The mapper just threads `enabledFlags` through onto the produced model;
   // these unit tests exercise the rest of the shape with the empty set, and
   // a dedicated test asserts the threading.
-  const noFlags: ReadonlySet<string> = new Set();
+  const noFlags: ReadonlySet<FlagId> = new Set();
 
   test('shapes raw → ProviderModel with responses-only endpoint and per-request context window', () => {
     const m = codexRawToProviderModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 }, noFlags);
@@ -175,7 +175,7 @@ describe('codexRawToProviderModel', () => {
   });
 
   test('threads the supplied enabledFlags onto the produced model', () => {
-    const flags: ReadonlySet<string> = new Set(['responses-web-search-shim']);
+    const flags: ReadonlySet<FlagId> = new Set(['responses-web-search-shim']);
     const m = codexRawToProviderModel({ id: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 272000 }, flags);
     expect(m.enabledFlags).toBe(flags);
   });

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -70,7 +70,6 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
   const effects: CodexCallEffects = { persistRefreshTokenRotation, persistTerminalState };
 
   const instance: ProviderInstance = {
-    defaultFlagsForUpstream: () => CODEX_DEFAULT_FLAGS,
     getProvidedModels: async fetcher => {
       // A model-list refresh is the first thing a brand-new Codex upstream
       // does, and it is the only place outside the data plane that mints an

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -1,6 +1,7 @@
 import { ensureCodexAccessToken, mintCodexAccessToken } from './access-token-cache.ts';
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import { assertCodexUpstreamRecord, type CodexUpstreamConfig } from './config.ts';
+import { CODEX_DEFAULT_FLAGS } from './defaults.ts';
 import { callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from './fetch.ts';
 import { CODEX_RESPONSES_BOUNDARY } from './interceptors/responses/index.ts';
 import type { ResponsesBoundaryCtx } from './interceptors/responses/types.ts';
@@ -9,9 +10,9 @@ import { pricingForCodexModelKey } from './pricing.ts';
 import { assertCodexUpstreamState, type CodexUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import { toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { defaultsForProvider, getProviderRepo, resolveEffectiveFlags, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { getProviderRepo, resolveEffectiveFlags, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
 
-export const createCodexProvider = async (record: UpstreamRecord): Promise<Provider> => {
+export const createCodexProvider = (record: UpstreamRecord): Provider => {
   assertCodexUpstreamRecord(record);
   assertCodexUpstreamState(record.state);
   const config: CodexUpstreamConfig = record.config;
@@ -24,7 +25,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Provi
   // (no per-model override layer). Threaded into every ProviderModel emitted
   // by getProvidedModels so interceptors can read the effective flag set
   // without re-resolving.
-  const enabledFlags = resolveEffectiveFlags(defaultsForProvider('codex'), [record.flagOverrides]);
+  const enabledFlags = resolveEffectiveFlags([CODEX_DEFAULT_FLAGS, record.flagOverrides]);
 
   // Re-read upstream state on every request rather than capturing the record's
   // state at construction. Refresh-token rotation, terminal-state transitions,
@@ -69,6 +70,7 @@ export const createCodexProvider = async (record: UpstreamRecord): Promise<Provi
   const effects: CodexCallEffects = { persistRefreshTokenRotation, persistTerminalState };
 
   const instance: ProviderInstance = {
+    defaultFlagsForUpstream: () => CODEX_DEFAULT_FLAGS,
     getProvidedModels: async fetcher => {
       // A model-list refresh is the first thing a brand-new Codex upstream
       // does, and it is the only place outside the data plane that mints an

--- a/packages/provider-codex/src/provider_test.ts
+++ b/packages/provider-codex/src/provider_test.ts
@@ -70,7 +70,7 @@ const oauthTokenResponse = (overrides: Partial<{ access_token: string; refresh_t
 
 describe('createCodexProvider', () => {
   test('returns an instance carrying provider kind and identity', async () => {
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     expect(instance.kind).toBe('codex');
     expect(instance.upstream).toBe('up_codex');
     expect(instance.name).toBe('Codex Plus');
@@ -79,7 +79,7 @@ describe('createCodexProvider', () => {
 
   test('getProvidedModels uses the cached access token when fresh and surfaces every catalog entry', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(modelsResponse());
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     const models = await instance.instance.getProvidedModels(directFetcher);
     // Provider surfaces both visible and hidden upstream models — operators
     // can dispatch to `codex-auto-review` even though ChatGPT's UI hides it.
@@ -97,7 +97,7 @@ describe('createCodexProvider', () => {
       if (url.includes('/codex/models')) return modelsResponse();
       throw new Error(`unexpected fetch ${url}`);
     });
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     const models = await instance.instance.getProvidedModels(directFetcher);
     expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review']);
     const urls = fetchSpy.mock.calls.map(c => typeof c[0] === 'string' ? c[0] : (c[0] as URL | Request).toString());
@@ -114,7 +114,7 @@ describe('createCodexProvider', () => {
 
   test('getProvidedModels propagates catalog fetch failures', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('upstream down', { status: 502 }));
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     await expect(instance.instance.getProvidedModels(directFetcher)).rejects.toThrow(/Codex \/models fetch failed/);
   });
 
@@ -125,7 +125,7 @@ describe('createCodexProvider', () => {
       if (url.includes('/oauth/token')) return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400, headers: new Headers({ 'content-type': 'application/json' }) });
       throw new Error(`unexpected fetch ${url}`);
     });
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     await expect(instance.instance.getProvidedModels(directFetcher)).rejects.toThrow(/Codex OAuth session terminated/);
   });
 
@@ -140,7 +140,7 @@ describe('createCodexProvider', () => {
       ...baseRecord,
       flagOverrides: { 'responses-web-search-shim': true },
     };
-    const instance = await createCodexProvider(recordWithOverride);
+    const instance = createCodexProvider(recordWithOverride);
     const models = await instance.instance.getProvidedModels(directFetcher);
     for (const m of models) {
       expect(m.enabledFlags.has('responses-web-search-shim')).toBe(true);
@@ -149,7 +149,7 @@ describe('createCodexProvider', () => {
 
   test('callResponses round-trips through fetch transport', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     const result = await instance.instance.callResponses(
       stubProviderModel({ id: 'gpt-5.4', display_name: 'gpt-5.4', endpoints: { responses: {} } }),
       { input: [{ type: 'message', role: 'user', content: 'hi' }], stream: true },
@@ -163,7 +163,7 @@ describe('createCodexProvider', () => {
 
   test('callResponses re-reads state per request (operator re-import takes effect)', async () => {
     getByIdSpy.mockResolvedValueOnce({ ...baseRecord, state: { accounts: [{ chatgptAccountId: 'acc', refresh_token: 'rt_v1', state: 'session_terminated', state_updated_at: '2026-01-02T00:00:00Z', openaiDeviceId: '11111111-2222-4333-8444-555555555555', accessToken: null, quotaSnapshot: null }] } as CodexUpstreamState });
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     const result = await instance.instance.callResponses(
       stubProviderModel({ id: 'gpt-5.4', display_name: 'gpt-5.4', endpoints: { responses: {} } }),
       { input: [], stream: true },
@@ -183,7 +183,7 @@ describe('createCodexProvider', () => {
     'callMessagesCountTokens',
     'callMessages',
   ] as const)('%s returns a synthetic 405 (data plane never dispatches these to Codex)', async method => {
-    const instance = await createCodexProvider(baseRecord);
+    const instance = createCodexProvider(baseRecord);
     const model = stubProviderModel({ id: 'gpt-5.4', display_name: 'gpt-5.4', endpoints: { responses: {} } });
     // @ts-expect-error: each method has a different body type; we only assert
     // the synthetic 405 envelope is what comes back.

--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -1,0 +1,115 @@
+import type { FlagDefaults, FlagOverrides, ProviderModel } from '@floway-dev/provider';
+
+// Exhaustive flag defaults for GitHub Copilot upstreams. Provider-wide
+// defaults; per-Claude-model deltas live in `defaultFlagsForCopilotModel`
+// below.
+export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
+  'vendor-deepseek': false,
+  'vendor-qwen': false,
+  'vendor-kimi': false,
+  // Copilot occasionally serves a cyber_policy 4xx from the upstream that
+  // clears on retry; the flag defaults on for Copilot to swallow the
+  // transient class without operator intervention.
+  'retry-cyber-policy': true,
+  'messages-web-search-shim': true,
+  'responses-web-search-shim': true,
+  'responses-image-generation-shim': true,
+  // Copilot exposes a native /responses/compact wire.
+  'responses-compact-shim': false,
+  'disable-reasoning-on-forced-tool-choice': false,
+  // Upstream default is off; Claude models below 4.8 flip it on via the
+  // per-model default. See `defaultFlagsForCopilotModel` for the empirical
+  // basis.
+  'demote-interleaved-system-to-user': false,
+  'demote-developer-to-system': false,
+  'strip-billing-attribution': true,
+};
+
+// Extract `[major, minor]` from a Copilot Claude model id. Copilot's ids
+// keep vendor version numbers as `<family>-<major>.<minor>`
+// (e.g. `claude-opus-4.8`, `claude-sonnet-4.6`, `claude-haiku-4.5`) or
+// just `<family>-<major>` for whole-number releases
+// (e.g. `claude-sonnet-5`). The `minor` slot defaults to 0 when absent so
+// tuple comparison works uniformly.
+const parseClaudeVersion = (id: string): readonly [number, number] | null => {
+  const m = /^claude-(?:opus|sonnet|haiku)-(\d+)(?:\.(\d+))?$/.exec(id);
+  return m ? [Number(m[1]), Number(m[2] ?? 0)] as const : null;
+};
+
+// True when the model id names a Claude release whose Anthropic Messages
+// wire accepts inline `role:'system'` (i.e., a mid-conversation system
+// turn placed between assistant/user turns rather than in the top-level
+// `system` field).
+//
+// # Empirical evidence
+//
+// Copilot's Claude model catalog is served through both AWS Bedrock and
+// Google Vertex, with the choice made per-request by Copilot's own load
+// balancer. Only Bedrock has shipped Anthropic's mid-conversation-system
+// feature; Vertex still validates against the pre-feature role enum
+// `user | assistant` and rejects `role:'system'` outright with:
+//
+//     Unexpected role "system". The Messages API accepts a top-level
+//     `system` parameter, not "system" as an input message role.
+//
+// The `anthropic-beta: mid-conversation-system-2026-04-07` header does
+// NOT unlock this on Vertex — Vertex returns
+// `Unexpected value for the 'anthropic-beta' header` when it appears.
+// On Bedrock the header is a no-op (the feature is GA there for models
+// that have it).
+//
+// So the operative question is: given a public model id, does the
+// Copilot LB route to Bedrock deterministically enough that we can
+// leave inline system on, or is the model split across backends where
+// we must demote to avoid random Vertex-side 400s?
+//
+// We ran a two-day cron-driven probe (Jun 26 → Jun 28 2026, session
+// `56030d79-c7dc-4d2f-a1af-8edef05522fa`) that hit the Copilot
+// enterprise endpoint from two accounts (personal + GHE) every 30
+// minutes with a Shape E payload
+// (`[user, assistant, system, user]` + the beta header) against every
+// Claude model then in the catalog. The classifier keyed on
+// `request_id`: `req_vrtx_*` = Vertex; bare `req_*` = Bedrock
+// (Copilot forwards AWS `InvokeModel` calls whose ids never carry the
+// `bdrk_` infix Anthropic's own SDK wrapper adds). Where Copilot
+// stripped the id, backend was recovered from validator wording —
+// `Unexpected role "system"` = Vertex legacy, `messages.N: role
+// 'system' must ...` = Bedrock mid-conv validator.
+//
+// After 40h / 1150 samples the distribution was:
+//
+//     | model              | Bedrock | Vertex | Bedrock% |
+//     | claude-opus-4.8    |     163 |      0 |     100% |
+//     | claude-opus-4.7    |      82 |     82 |      50% |
+//     | claude-sonnet-4.6  |      46 |    117 |      28% |
+//     | claude-opus-4.6    |      14 |    150 |       9% |
+//     | claude-haiku-4.5   |      18 |    146 |      11% |
+//     | claude-opus-4.5    |       0 |    164 |       0% |
+//     | claude-sonnet-4.5  |       0 |    163 |       0% |
+//
+// A follow-up 80-sample probe (Jul 3 2026) covered the newly-released
+// `claude-sonnet-5`; 80/80 = 100% Bedrock across both accounts. The
+// version-threshold hypothesis — Anthropic released mid-conv system on
+// Bedrock alongside the 4.8 line and every subsequent release ships
+// Bedrock-only routing — held; the equivalent check for older models
+// showed no Bedrock-favoring drift versus the earlier probe. The
+// backend selection is also account-independent (both accounts agreed
+// within ±5% on every non-4.8 model, and 100% on 4.8 / sonnet-5).
+//
+// Threshold conclusion: `>= 4.8`. This includes `claude-opus-4.8` and
+// every 5.x release (which trivially exceeds `[4, 8]`); everything at
+// 4.7 or below stays demoted.
+const supportsInlineSystem = (id: string): boolean => {
+  const v = parseClaudeVersion(id);
+  return v !== null && (v[0] > 4 || (v[0] === 4 && v[1] >= 8));
+};
+
+// Per-model default flag deltas for Copilot. Only Claude models below
+// 4.8 opt into `demote-interleaved-system-to-user`; every other flag
+// inherits from `COPILOT_DEFAULT_FLAGS`. Operator overrides on the DB
+// row still layer on top of this result.
+export const defaultFlagsForCopilotModel = (model: Omit<ProviderModel, 'enabledFlags'>): FlagOverrides => {
+  if (!model.id.startsWith('claude-')) return {};
+  if (supportsInlineSystem(model.id)) return {};
+  return { 'demote-interleaved-system-to-user': true };
+};

--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -25,22 +25,16 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
   'strip-billing-attribution': true,
 };
 
-// Parse the version tuple from a Claude model id, using dash-separated
-// minor form (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`)
-// — the shape copilotPublicModelId emits and finalizeCopilotModels
-// hands us here. Whole-number releases (`claude-sonnet-5`) drop the
-// minor slot, which defaults to 0 so tuple comparison works uniformly.
-// Also accepts the dotted form (`claude-opus-4.8`) so raw upstream ids
-// route the same way; the resolver never asserts a specific separator.
-const parseClaudeVersion = (id: string): readonly [number, number] | null => {
-  const m = /^claude-(?:opus|sonnet|haiku)-(\d+)(?:[.-](\d+))?$/.exec(id);
-  return m ? [Number(m[1]), Number(m[2] ?? 0)] as const : null;
-};
-
 // True when the model id names a Claude release whose Anthropic Messages
 // wire accepts inline `role:'system'` (i.e., a mid-conversation system
 // turn placed between assistant/user turns rather than in the top-level
 // `system` field).
+//
+// The id-family regex accepts both the dash-separated minor form
+// (`claude-opus-4-8`, the shape copilotPublicModelId emits) and the
+// dotted form (`claude-opus-4.8`, seen on raw upstream ids). Whole-
+// number releases drop the minor slot; missing minor is treated as 0
+// so the version comparison works uniformly.
 //
 // # Empirical evidence
 //
@@ -101,8 +95,11 @@ const parseClaudeVersion = (id: string): readonly [number, number] | null => {
 // every 5.x release (which trivially exceeds `[4, 8]`); everything at
 // 4.7 or below stays demoted.
 const supportsInlineSystem = (id: string): boolean => {
-  const v = parseClaudeVersion(id);
-  return v !== null && (v[0] > 4 || (v[0] === 4 && v[1] >= 8));
+  const m = /^claude-(?:opus|sonnet|haiku)-(\d+)(?:[.-](\d+))?$/.exec(id);
+  if (!m) return false;
+  const major = Number(m[1]);
+  const minor = Number(m[2] ?? 0);
+  return major > 4 || (major === 4 && minor >= 8);
 };
 
 // Per-model default flag deltas for Copilot. Only Claude models below

--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -30,11 +30,14 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
 // turn placed between assistant/user turns rather than in the top-level
 // `system` field).
 //
-// The id-family regex accepts both the dash-separated minor form
-// (`claude-opus-4-8`, the shape copilotPublicModelId emits) and the
-// dotted form (`claude-opus-4.8`, seen on raw upstream ids). Whole-
-// number releases drop the minor slot; missing minor is treated as 0
-// so the version comparison works uniformly.
+// The id-family regex accepts any `claude-<family>-<major>[[.-]<minor>]`
+// shape — the version number is the sole gate, family names are opaque
+// (Anthropic ships new sub-families on their own schedule; the historical
+// catalog is opus/sonnet/haiku but a future `claude-<newfamily>-<N.M>`
+// routes the same way). Both dash-separated minor form (`claude-opus-4-8`,
+// the shape copilotPublicModelId emits) and dotted form (`claude-opus-4.8`,
+// seen on raw upstream ids) are accepted; whole-number releases drop the
+// minor slot, missing minor is treated as 0.
 //
 // # Empirical evidence
 //
@@ -95,7 +98,7 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
 // every 5.x release (which trivially exceeds `[4, 8]`); everything at
 // 4.7 or below stays demoted.
 const supportsInlineSystem = (id: string): boolean => {
-  const m = /^claude-(?:opus|sonnet|haiku)-(\d+)(?:[.-](\d+))?$/.exec(id);
+  const m = /^claude-[a-z]+-(\d+)(?:[.-](\d+))?$/.exec(id);
   if (!m) return false;
   const major = Number(m[1]);
   const minor = Number(m[2] ?? 0);

--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -25,14 +25,15 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
   'strip-billing-attribution': true,
 };
 
-// Extract `[major, minor]` from a Copilot Claude model id. Copilot's ids
-// keep vendor version numbers as `<family>-<major>.<minor>`
-// (e.g. `claude-opus-4.8`, `claude-sonnet-4.6`, `claude-haiku-4.5`) or
-// just `<family>-<major>` for whole-number releases
-// (e.g. `claude-sonnet-5`). The `minor` slot defaults to 0 when absent so
-// tuple comparison works uniformly.
+// Parse the version tuple from a Claude model id, using dash-separated
+// minor form (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`)
+// — the shape copilotPublicModelId emits and finalizeCopilotModels
+// hands us here. Whole-number releases (`claude-sonnet-5`) drop the
+// minor slot, which defaults to 0 so tuple comparison works uniformly.
+// Also accepts the dotted form (`claude-opus-4.8`) so raw upstream ids
+// route the same way; the resolver never asserts a specific separator.
 const parseClaudeVersion = (id: string): readonly [number, number] | null => {
-  const m = /^claude-(?:opus|sonnet|haiku)-(\d+)(?:\.(\d+))?$/.exec(id);
+  const m = /^claude-(?:opus|sonnet|haiku)-(\d+)(?:[.-](\d+))?$/.exec(id);
   return m ? [Number(m[1]), Number(m[2] ?? 0)] as const : null;
 };
 

--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -58,9 +58,9 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
 // leave inline system on, or is the model split across backends where
 // we must demote to avoid random Vertex-side 400s?
 //
-// We ran a two-day cron-driven probe (Jun 26 → Jun 28 2026, session
-// `56030d79-c7dc-4d2f-a1af-8edef05522fa`) that hit the Copilot
-// enterprise endpoint from two accounts (personal + GHE) every 30
+// We ran a two-day cron-driven probe (Jun 26 → Jun 28 2026) that hit
+// the Copilot enterprise endpoint from two accounts (personal + GHE)
+// every 30
 // minutes with a Shape E payload
 // (`[user, assistant, system, user]` + the beta header) against every
 // Claude model then in the catalog. The classifier keyed on

--- a/packages/provider-copilot/src/defaults_test.ts
+++ b/packages/provider-copilot/src/defaults_test.ts
@@ -49,8 +49,8 @@ test('defaultFlagsForCopilotModel returns empty for non-Claude ids', () => {
 test('defaultFlagsForCopilotModel falls back to demote-on when a Claude id fails version parsing', () => {
   // Safer than defaulting off — a Claude family name we don't recognize
   // might route through Vertex, which still rejects inline system turns.
-  // Only a positive parseClaudeVersion match with a `>= 4.8` tuple flips
-  // the overlay to empty.
+  // Only a positive supportsInlineSystem match (regex + `>= 4.8` version
+  // tuple) flips the overlay to empty.
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus')), OVERLAY_ON);
   assertEquals(defaultFlagsForCopilotModel(model('claude-unknown-4-7')), OVERLAY_ON);
 });

--- a/packages/provider-copilot/src/defaults_test.ts
+++ b/packages/provider-copilot/src/defaults_test.ts
@@ -20,12 +20,15 @@ const OVERLAY_OFF = {} as const;
 // (finalizeCopilotModels routes them through copilotPublicModelId, which
 // rewrites `4.8` → `4-8`). Parsing must therefore accept dashes; whole-
 // number releases (`claude-sonnet-5`) skip the minor slot and count as
-// `[N, 0]`.
+// `[N, 0]`. Sub-family names are treated as opaque — the version tuple
+// is the sole gate, so a future `claude-<newfamily>-<N.M>` routes the
+// same way as opus/sonnet/haiku.
 test('defaultFlagsForCopilotModel forces demote on Claude < 4.8', () => {
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus-4-7')), OVERLAY_ON);
   assertEquals(defaultFlagsForCopilotModel(model('claude-sonnet-4-6')), OVERLAY_ON);
   assertEquals(defaultFlagsForCopilotModel(model('claude-haiku-4-5')), OVERLAY_ON);
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus-3-5')), OVERLAY_ON);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-newfamily-4-7')), OVERLAY_ON);
 });
 
 test('defaultFlagsForCopilotModel leaves demote inherited for Claude >= 4.8', () => {
@@ -33,6 +36,7 @@ test('defaultFlagsForCopilotModel leaves demote inherited for Claude >= 4.8', ()
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus-5-0')), OVERLAY_OFF);
   assertEquals(defaultFlagsForCopilotModel(model('claude-sonnet-5')), OVERLAY_OFF);
   assertEquals(defaultFlagsForCopilotModel(model('claude-haiku-6')), OVERLAY_OFF);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-newfamily-5-0')), OVERLAY_OFF);
 });
 
 test('defaultFlagsForCopilotModel accepts dotted minor form for forward-compat', () => {
@@ -46,11 +50,11 @@ test('defaultFlagsForCopilotModel returns empty for non-Claude ids', () => {
   assertEquals(defaultFlagsForCopilotModel(model('o1-mini')), OVERLAY_OFF);
 });
 
-test('defaultFlagsForCopilotModel falls back to demote-on when a Claude id fails version parsing', () => {
-  // Safer than defaulting off — a Claude family name we don't recognize
+test('defaultFlagsForCopilotModel falls back to demote-on when a Claude id carries no version', () => {
+  // Safer than defaulting off — a Claude id we cannot version-parse
   // might route through Vertex, which still rejects inline system turns.
   // Only a positive supportsInlineSystem match (regex + `>= 4.8` version
   // tuple) flips the overlay to empty.
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus')), OVERLAY_ON);
-  assertEquals(defaultFlagsForCopilotModel(model('claude-unknown-4-7')), OVERLAY_ON);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-sonnet-4-5-20250929')), OVERLAY_ON);
 });

--- a/packages/provider-copilot/src/defaults_test.ts
+++ b/packages/provider-copilot/src/defaults_test.ts
@@ -1,0 +1,56 @@
+import { test } from 'vitest';
+
+import { defaultFlagsForCopilotModel } from './defaults.ts';
+import type { ProviderModel } from '@floway-dev/provider';
+import { assertEquals } from '@floway-dev/test-utils';
+
+// Minimal ProviderModel stand-in — defaultFlagsForCopilotModel only reads `id`,
+// so `kind`/`endpoints`/`limits` can be blank shape-satisfiers.
+const model = (id: string): Omit<ProviderModel, 'enabledFlags'> => ({
+  id,
+  kind: 'chat',
+  endpoints: {},
+  limits: {},
+});
+
+const OVERLAY_ON = { 'demote-interleaved-system-to-user': true } as const;
+const OVERLAY_OFF = {} as const;
+
+// Copilot's public model ids arrive here in dash-separated minor form
+// (finalizeCopilotModels routes them through copilotPublicModelId, which
+// rewrites `4.8` → `4-8`). Parsing must therefore accept dashes; whole-
+// number releases (`claude-sonnet-5`) skip the minor slot and count as
+// `[N, 0]`.
+test('defaultFlagsForCopilotModel forces demote on Claude < 4.8', () => {
+  assertEquals(defaultFlagsForCopilotModel(model('claude-opus-4-7')), OVERLAY_ON);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-sonnet-4-6')), OVERLAY_ON);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-haiku-4-5')), OVERLAY_ON);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-opus-3-5')), OVERLAY_ON);
+});
+
+test('defaultFlagsForCopilotModel leaves demote inherited for Claude >= 4.8', () => {
+  assertEquals(defaultFlagsForCopilotModel(model('claude-opus-4-8')), OVERLAY_OFF);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-opus-5-0')), OVERLAY_OFF);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-sonnet-5')), OVERLAY_OFF);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-haiku-6')), OVERLAY_OFF);
+});
+
+test('defaultFlagsForCopilotModel accepts dotted minor form for forward-compat', () => {
+  assertEquals(defaultFlagsForCopilotModel(model('claude-opus-4.7')), OVERLAY_ON);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-opus-4.8')), OVERLAY_OFF);
+});
+
+test('defaultFlagsForCopilotModel returns empty for non-Claude ids', () => {
+  assertEquals(defaultFlagsForCopilotModel(model('gpt-5')), OVERLAY_OFF);
+  assertEquals(defaultFlagsForCopilotModel(model('gpt-4o')), OVERLAY_OFF);
+  assertEquals(defaultFlagsForCopilotModel(model('o1-mini')), OVERLAY_OFF);
+});
+
+test('defaultFlagsForCopilotModel falls back to demote-on when a Claude id fails version parsing', () => {
+  // Safer than defaulting off — a Claude family name we don't recognize
+  // might route through Vertex, which still rejects inline system turns.
+  // Only a positive parseClaudeVersion match with a `>= 4.8` tuple flips
+  // the overlay to empty.
+  assertEquals(defaultFlagsForCopilotModel(model('claude-opus')), OVERLAY_ON);
+  assertEquals(defaultFlagsForCopilotModel(model('claude-unknown-4-7')), OVERLAY_ON);
+});

--- a/packages/provider-copilot/src/index.ts
+++ b/packages/provider-copilot/src/index.ts
@@ -7,7 +7,6 @@ export const copilotProvider: ProviderModule = {
   defaultFlags: COPILOT_DEFAULT_FLAGS,
 };
 
-export { createCopilotProvider } from './provider.ts';
 export {
   clearCopilotTokenCache,
   clearInProcessCopilotTokenCache,

--- a/packages/provider-copilot/src/index.ts
+++ b/packages/provider-copilot/src/index.ts
@@ -1,11 +1,10 @@
-import { COPILOT_DEFAULT_FLAGS, defaultFlagsForCopilotModel } from './defaults.ts';
+import { COPILOT_DEFAULT_FLAGS } from './defaults.ts';
 import { createCopilotProvider } from './provider.ts';
 import type { ProviderModule } from '@floway-dev/provider';
 
 export const copilotProvider: ProviderModule = {
   create: createCopilotProvider,
   defaultFlags: COPILOT_DEFAULT_FLAGS,
-  getDefaultFlagsForModel: defaultFlagsForCopilotModel,
 };
 
 export { createCopilotProvider } from './provider.ts';

--- a/packages/provider-copilot/src/index.ts
+++ b/packages/provider-copilot/src/index.ts
@@ -1,3 +1,13 @@
+import { COPILOT_DEFAULT_FLAGS, defaultFlagsForCopilotModel } from './defaults.ts';
+import { createCopilotProvider } from './provider.ts';
+import type { ProviderModule } from '@floway-dev/provider';
+
+export const copilotProvider: ProviderModule = {
+  create: createCopilotProvider,
+  defaultFlags: COPILOT_DEFAULT_FLAGS,
+  getDefaultFlagsForModel: defaultFlagsForCopilotModel,
+};
+
 export { createCopilotProvider } from './provider.ts';
 export {
   clearCopilotTokenCache,

--- a/packages/provider-copilot/src/interceptors/responses/action-pivot_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/action-pivot_test.ts
@@ -64,7 +64,7 @@ test('Copilot provider terminal dispatches on post-chain ctx.action (interceptor
   initImageProcessor(createInMemoryImageProcessor());
   clearInProcessCopilotTokenCache();
 
-  const instance = await createCopilotProvider(upstream);
+  const instance = createCopilotProvider(upstream);
   const provider = instance.instance;
 
   let responsesBody: Record<string, unknown> | undefined;

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -179,15 +179,12 @@ const finalizeCopilotModels = (
 export const createCopilotProvider = (record: UpstreamRecord): Provider => {
   const copilot = assertCopilotUpstreamRecord(record);
   const upstreamConfig = { id: copilot.id, githubToken: copilot.config.githubToken };
-  // Per-model flag resolution follows the shared layer order: provider
-  // upstream default → operator upstream override → per-model layer. For
-  // an auto (catalog-fetched) row like Copilot's the per-model layer is
-  // the provider's own model-specific default (`defaultFlagsForCopilotModel`
-  // — e.g. force demote-interleaved-system-to-user on for Claude < 4.8,
-  // whose Vertex backend rejects inline `role:'system'`). Placing it last
-  // means a technical necessity the provider knows about is not silently
-  // undone by an upstream-level operator toggle; operators who genuinely
-  // want to opt out switch the row to Manual and override there.
+  // Layer order: provider upstream default → operator upstream override
+  // → per-model default. Placing the per-model layer last keeps a
+  // technical necessity the provider knows about (see
+  // `defaultFlagsForCopilotModel`) from being silently undone by an
+  // operator upstream toggle; opting out means switching the row to
+  // Manual and overriding there.
   const resolveModelFlags = (draft: Omit<ProviderModel, 'enabledFlags'>): ReadonlySet<string> =>
     resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, copilot.flagOverrides, defaultFlagsForCopilotModel(draft)]);
 

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -168,14 +168,14 @@ const finalizeCopilotModels = (
     // rejects inline `role:'system'` for Claude < 4.8; see
     // `defaultFlagsForCopilotModel`) from being silently undone by the
     // operator's upstream toggle. The same per-model overlay is surfaced
-    // on `flagOverridesAuto` so the dashboard can show which flags the
+    // on `flagOverrides` so the dashboard can show which flags the
     // provider forces on this specific model.
-    const flagOverridesAuto = defaultFlagsForCopilotModel(draft);
-    const enabledFlags = resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, upstreamOverrides, flagOverridesAuto]);
+    const flagOverrides = defaultFlagsForCopilotModel(draft);
+    const enabledFlags = resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, upstreamOverrides, flagOverrides]);
     models.push({
       ...draft,
       enabledFlags,
-      ...(Object.keys(flagOverridesAuto).length > 0 ? { flagOverridesAuto } : {}),
+      ...(Object.keys(flagOverrides).length > 0 ? { flagOverrides } : {}),
     });
   }
   return models;

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -162,7 +162,16 @@ const finalizeCopilotModels = (
       providerData: { rawModels: variants } satisfies CopilotProviderData,
       ...(cost ? { cost } : {}),
     };
-    models.push({ ...draft, enabledFlags: resolveModelFlags(draft) });
+    // Surface the per-model layer that fed into `enabledFlags` so the
+    // dashboard's auto-row flag view can render "provider forces X on
+    // for this model" pills. Empty overlay → omit the field (no per-
+    // model deviation from the upstream default).
+    const flagOverridesAuto = defaultFlagsForCopilotModel(draft);
+    models.push({
+      ...draft,
+      enabledFlags: resolveModelFlags(draft),
+      ...(Object.keys(flagOverridesAuto).length > 0 ? { flagOverridesAuto } : {}),
+    });
   }
   return models;
 };

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -37,7 +37,7 @@ const copilotRawToProviderModel = (model: CopilotRawModel): Omit<ProviderModel, 
   if (model.capabilities?.limits?.max_context_window_tokens !== undefined) limits.max_context_window_tokens = model.capabilities.limits.max_context_window_tokens;
   if (model.capabilities?.limits?.max_prompt_tokens !== undefined) limits.max_prompt_tokens = model.capabilities.limits.max_prompt_tokens;
 
-  const partial: Omit<ProviderModel, 'kind' | 'endpoints' | 'providerData' | 'enabledFlags'> = {
+  const partial: Omit<ProviderModel, 'kind' | 'endpoints' | 'providerData' | 'enabledFlags' | 'flagOverrides'> = {
     id: model.id,
     limits,
   };

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -29,7 +29,9 @@ interface CopilotProviderData {
 
 // Project Copilot's raw `/models` shape into the slim provider-neutral fields.
 // kind/endpoints/providerData/enabledFlags are added by the caller because they
-// depend on Copilot's endpoint knowledge and the upstream-level flag layer.
+// depend on Copilot's endpoint knowledge and on the multi-layer flag resolution
+// (provider default + operator upstream override + per-model overlay);
+// `flagOverrides` is stamped on top when the per-model overlay is non-empty.
 const copilotRawToProviderModel = (model: CopilotRawModel): Omit<ProviderModel, 'kind' | 'endpoints' | 'providerData' | 'enabledFlags'> => {
   const limits: ProviderModel['limits'] = {};
   if (model.capabilities?.limits?.max_output_tokens !== undefined) limits.max_output_tokens = model.capabilities.limits.max_output_tokens;

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -170,13 +170,17 @@ const finalizeCopilotModels = (
 export const createCopilotProvider = (record: UpstreamRecord): Provider => {
   const copilot = assertCopilotUpstreamRecord(record);
   const upstreamConfig = { id: copilot.id, githubToken: copilot.config.githubToken };
-  // Per-model flag resolution: provider-wide defaults, then per-model
-  // deltas (Claude models below 4.8 get `demote-interleaved-system-to-user`
-  // — see `defaultFlagsForCopilotModel` for the empirical basis), then the
-  // operator's upstream-level override. Copilot has no per-model operator
-  // override layer.
+  // Per-model flag resolution follows the shared layer order: provider
+  // upstream default → operator upstream override → per-model layer. For
+  // an auto (catalog-fetched) row like Copilot's the per-model layer is
+  // the provider's own model-specific default (`defaultFlagsForCopilotModel`
+  // — e.g. force demote-interleaved-system-to-user on for Claude < 4.8,
+  // whose Vertex backend rejects inline `role:'system'`). Placing it last
+  // means a technical necessity the provider knows about is not silently
+  // undone by an upstream-level operator toggle; operators who genuinely
+  // want to opt out switch the row to Manual and override there.
   const resolveModelFlags = (draft: Omit<ProviderModel, 'enabledFlags'>): ReadonlySet<string> =>
-    resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, defaultFlagsForCopilotModel(draft), copilot.flagOverrides]);
+    resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, copilot.flagOverrides, defaultFlagsForCopilotModel(draft)]);
 
   const call = async (
     transport: (config: typeof upstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -274,8 +274,6 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
   };
 
   const instance: ProviderInstance = {
-    defaultFlagsForUpstream: () => COPILOT_DEFAULT_FLAGS,
-    defaultFlagsForModel: defaultFlagsForCopilotModel,
     getProvidedModels: async fetcher => {
       const fresh = await getProviderRepo().upstreams.getById(copilot.id);
       if (!fresh) throw new Error(`Copilot upstream ${copilot.id} disappeared mid-request`);

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -1,5 +1,6 @@
 import { chatFromCopilotRaw } from './chat-from-raw.ts';
 import { assertCopilotUpstreamRecord } from './config.ts';
+import { COPILOT_DEFAULT_FLAGS, defaultFlagsForCopilotModel } from './defaults.ts';
 import { fetchCopilotModels } from './fetch-models.ts';
 import { copilotFetchChatCompletions, copilotFetchEmbeddings, copilotFetchMessages, copilotFetchMessagesCountTokens, copilotFetchResponses } from './fetch.ts';
 import { COPILOT_CHATCOMPLETIONS_BOUNDARY } from './interceptors/chat-completions/index.ts';
@@ -20,7 +21,7 @@ import { parseChatCompletionsStream, type ChatCompletionsPayload, type ChatCompl
 import { type ModelEndpointKey, type ModelEndpoints, type ProtocolFrame, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseAnthropicBetaHeader, parseMessagesStream, type MessagesPayload, type MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
-import { COMPACTION_TRIGGER, compactionResponse, eventResult, getProviderRepo, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, defaultsForProvider, resolveEffectiveFlags, type ExecuteResult, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { COMPACTION_TRIGGER, compactionResponse, eventResult, getProviderRepo, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, resolveEffectiveFlags, type ExecuteResult, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CopilotProviderData {
   rawModels: CopilotRawModel[];
@@ -138,7 +139,10 @@ const copilotEmbeddingsBody = (body: Record<string, unknown>): Record<string, un
   return { ...body, input: [body.input] };
 };
 
-const finalizeCopilotModels = (rawModels: CopilotRawModel[], enabledFlags: ReadonlySet<string>): ProviderModel[] => {
+const finalizeCopilotModels = (
+  rawModels: CopilotRawModel[],
+  resolveModelFlags: (draft: Omit<ProviderModel, 'enabledFlags'>) => ReadonlySet<string>,
+): ProviderModel[] => {
   const merged = mergeClaudeVariants({ object: 'list', data: rawModels });
   const groups = new Map<string, CopilotRawModel[]>();
   for (const rawModel of rawModels) {
@@ -151,24 +155,28 @@ const finalizeCopilotModels = (rawModels: CopilotRawModel[], enabledFlags: Reado
     const variants = groups.get(mergedModel.id) ?? [mergedModel];
     const endpoints = copilotModelEndpoints(variants);
     const cost = pricingForCopilotPublicModelId(mergedModel.id);
-    models.push({
+    const draft: Omit<ProviderModel, 'enabledFlags'> = {
       ...copilotRawToProviderModel(mergedModel),
       kind: kindForEndpoints(endpoints),
       endpoints,
       providerData: { rawModels: variants } satisfies CopilotProviderData,
       ...(cost ? { cost } : {}),
-      enabledFlags,
-    });
+    };
+    models.push({ ...draft, enabledFlags: resolveModelFlags(draft) });
   }
   return models;
 };
 
-export const createCopilotProvider = async (record: UpstreamRecord): Promise<Provider> => {
+export const createCopilotProvider = (record: UpstreamRecord): Provider => {
   const copilot = assertCopilotUpstreamRecord(record);
   const upstreamConfig = { id: copilot.id, githubToken: copilot.config.githubToken };
-  // Computed once: only the upstream layer applies for this provider kind
-  // (no per-model override layer).
-  const upstreamFlags = resolveEffectiveFlags(defaultsForProvider('copilot'), [copilot.flagOverrides]);
+  // Per-model flag resolution: provider-wide defaults, then per-model
+  // deltas (Claude models below 4.8 get `demote-interleaved-system-to-user`
+  // — see `defaultFlagsForCopilotModel` for the empirical basis), then the
+  // operator's upstream-level override. Copilot has no per-model operator
+  // override layer.
+  const resolveModelFlags = (draft: Omit<ProviderModel, 'enabledFlags'>): ReadonlySet<string> =>
+    resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, defaultFlagsForCopilotModel(draft), copilot.flagOverrides]);
 
   const call = async (
     transport: (config: typeof upstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,
@@ -266,6 +274,8 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Pro
   };
 
   const instance: ProviderInstance = {
+    defaultFlagsForUpstream: () => COPILOT_DEFAULT_FLAGS,
+    defaultFlagsForModel: defaultFlagsForCopilotModel,
     getProvidedModels: async fetcher => {
       const fresh = await getProviderRepo().upstreams.getById(copilot.id);
       if (!fresh) throw new Error(`Copilot upstream ${copilot.id} disappeared mid-request`);
@@ -294,7 +304,7 @@ export const createCopilotProvider = async (record: UpstreamRecord): Promise<Pro
           console.warn(`Failed to persist Copilot known-models for ${copilot.id}:`, err);
         }
       }
-      return finalizeCopilotModels(projectKnownModels(merged, now), upstreamFlags);
+      return finalizeCopilotModels(projectKnownModels(merged, now), resolveModelFlags);
     },
     getPricingForModelKey: pricingForCopilotModelKey,
     // Copilot's catalog never declares endpoints.completions, so this

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -28,11 +28,10 @@ interface CopilotProviderData {
 }
 
 // Project Copilot's raw `/models` shape into the slim provider-neutral fields.
-// kind/endpoints/providerData/enabledFlags are added by the caller because they
-// depend on Copilot's endpoint knowledge and on the multi-layer flag resolution
-// (provider default + operator upstream override + per-model overlay);
-// `flagOverrides` is stamped on top when the per-model overlay is non-empty.
-const copilotRawToProviderModel = (model: CopilotRawModel): Omit<ProviderModel, 'kind' | 'endpoints' | 'providerData' | 'enabledFlags'> => {
+// kind/endpoints/providerData/enabledFlags/flagOverrides are set by the caller
+// because they depend on Copilot's endpoint knowledge and the multi-layer
+// flag resolution.
+const copilotRawToProviderModel = (model: CopilotRawModel): Omit<ProviderModel, 'kind' | 'endpoints' | 'providerData' | 'enabledFlags' | 'flagOverrides'> => {
   const limits: ProviderModel['limits'] = {};
   if (model.capabilities?.limits?.max_output_tokens !== undefined) limits.max_output_tokens = model.capabilities.limits.max_output_tokens;
   if (model.capabilities?.limits?.max_context_window_tokens !== undefined) limits.max_context_window_tokens = model.capabilities.limits.max_context_window_tokens;

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -21,7 +21,7 @@ import { parseChatCompletionsStream, type ChatCompletionsPayload, type ChatCompl
 import { type ModelEndpointKey, type ModelEndpoints, type ProtocolFrame, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseAnthropicBetaHeader, parseMessagesStream, type MessagesPayload, type MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
-import { COMPACTION_TRIGGER, compactionResponse, eventResult, getProviderRepo, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, resolveEffectiveFlags, type ExecuteResult, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { COMPACTION_TRIGGER, compactionResponse, eventResult, getProviderRepo, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, resolveEffectiveFlags, type ExecuteResult, type FlagOverrides, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CopilotProviderData {
   rawModels: CopilotRawModel[];
@@ -141,7 +141,7 @@ const copilotEmbeddingsBody = (body: Record<string, unknown>): Record<string, un
 
 const finalizeCopilotModels = (
   rawModels: CopilotRawModel[],
-  resolveModelFlags: (draft: Omit<ProviderModel, 'enabledFlags'>) => ReadonlySet<string>,
+  upstreamOverrides: FlagOverrides,
 ): ProviderModel[] => {
   const merged = mergeClaudeVariants({ object: 'list', data: rawModels });
   const groups = new Map<string, CopilotRawModel[]>();
@@ -162,14 +162,19 @@ const finalizeCopilotModels = (
       providerData: { rawModels: variants } satisfies CopilotProviderData,
       ...(cost ? { cost } : {}),
     };
-    // Surface the per-model layer that fed into `enabledFlags` so the
-    // dashboard's auto-row flag view can render "provider forces X on
-    // for this model" pills. Empty overlay → omit the field (no per-
-    // model deviation from the upstream default).
+    // Layer order: provider upstream default → operator upstream override
+    // → per-model provider default. Placing the per-model layer last
+    // keeps a technical necessity the provider knows about (Vertex
+    // rejects inline `role:'system'` for Claude < 4.8; see
+    // `defaultFlagsForCopilotModel`) from being silently undone by the
+    // operator's upstream toggle. The same per-model overlay is surfaced
+    // on `flagOverridesAuto` so the dashboard can show which flags the
+    // provider forces on this specific model.
     const flagOverridesAuto = defaultFlagsForCopilotModel(draft);
+    const enabledFlags = resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, upstreamOverrides, flagOverridesAuto]);
     models.push({
       ...draft,
-      enabledFlags: resolveModelFlags(draft),
+      enabledFlags,
       ...(Object.keys(flagOverridesAuto).length > 0 ? { flagOverridesAuto } : {}),
     });
   }
@@ -179,14 +184,6 @@ const finalizeCopilotModels = (
 export const createCopilotProvider = (record: UpstreamRecord): Provider => {
   const copilot = assertCopilotUpstreamRecord(record);
   const upstreamConfig = { id: copilot.id, githubToken: copilot.config.githubToken };
-  // Layer order: provider upstream default → operator upstream override
-  // → per-model default. Placing the per-model layer last keeps a
-  // technical necessity the provider knows about (see
-  // `defaultFlagsForCopilotModel`) from being silently undone by an
-  // operator upstream toggle; opting out means switching the row to
-  // Manual and overriding there.
-  const resolveModelFlags = (draft: Omit<ProviderModel, 'enabledFlags'>): ReadonlySet<string> =>
-    resolveEffectiveFlags([COPILOT_DEFAULT_FLAGS, copilot.flagOverrides, defaultFlagsForCopilotModel(draft)]);
 
   const call = async (
     transport: (config: typeof upstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,
@@ -312,7 +309,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
           console.warn(`Failed to persist Copilot known-models for ${copilot.id}:`, err);
         }
       }
-      return finalizeCopilotModels(projectKnownModels(merged, now), resolveModelFlags);
+      return finalizeCopilotModels(projectKnownModels(merged, now), copilot.flagOverrides);
     },
     getPricingForModelKey: pricingForCopilotModelKey,
     // Copilot's catalog never declares endpoints.completions, so this

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -122,7 +122,7 @@ const copilotModels = (models: CopilotModelFixture[]) => ({
 
 test('Copilot provider exposes the highest-priority non-Claude endpoint', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
 
   assertEquals(instance.supportsResponsesItemReference, false);
@@ -169,7 +169,7 @@ test('Copilot provider exposes the highest-priority non-Claude endpoint', async 
 
 test('Copilot provider exposes only Responses for Claude when available', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
 
   await withMockedFetch(
@@ -218,7 +218,7 @@ test('Copilot provider exposes only Responses for Claude when available', async 
 
 test('Copilot provider owns the claude-* Messages capability workaround', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   let upstreamBody: Record<string, unknown> | undefined;
 
@@ -272,7 +272,7 @@ test('Copilot provider owns the claude-* Messages capability workaround', async 
 
 test('Copilot provider selects raw variants that support the target endpoint', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   let responsesBody: Record<string, unknown> | undefined;
 
@@ -335,7 +335,7 @@ test('Copilot provider runs the Responses boundary chain on the compact path', a
   // derivers reach the wire request headers, and the compact-shaped envelope
   // still comes back through `compactionResponse`.
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   let responsesBody: Record<string, unknown> | undefined;
   let visionHeader: string | null = null;
@@ -408,7 +408,7 @@ test('Copilot provider exposes its default flag set via ProviderModel.enabledFla
     flagOverrides: { 'messages-web-search-shim': true },
     disabledPublicModelIds: [],
   });
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
 
   assertEquals(instance.upstream, 'up_copilot');
   assertEquals(instance.name, copilotUpstream.name);
@@ -444,7 +444,7 @@ test('Copilot provider exposes its default flag set via ProviderModel.enabledFla
 
 test('Copilot provider forces stream=true for streaming endpoints and leaves count-tokens/embeddings alone', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   const bodies: Record<string, Record<string, unknown>> = {};
 
@@ -511,7 +511,7 @@ test('Copilot provider forces stream=true for streaming endpoints and leaves cou
 
 test('Copilot provider sets copilot-vision-request when an image is nested inside tool_result.content', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   const visionHeaders: (string | null)[] = [];
 
@@ -600,7 +600,7 @@ test('Copilot Messages boundary chain does NOT fire on the Chat Completions wire
   // chat-completions wire — that path runs `COPILOT_CHATCOMPLETIONS_BOUNDARY`,
   // which has no Messages-source headers in it.
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   const observedInteractionType: (string | null)[] = [];
 
@@ -664,7 +664,7 @@ test('Copilot provider persists merged known-models view via saveState CAS keyed
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const instance = await createCopilotProvider(copilotUpstream);
+      const instance = createCopilotProvider(copilotUpstream);
       const result = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(result.map(m => m.id), ['m1']);
     },
@@ -708,7 +708,7 @@ test('Copilot provider persists known-models even when the token-mint write adva
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const instance = await createCopilotProvider(copilotUpstream);
+      const instance = createCopilotProvider(copilotUpstream);
       await instance.instance.getProvidedModels(directFetcher);
     },
   );
@@ -741,7 +741,7 @@ test('Copilot provider accumulates known-models across calls so a model dropped 
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const instance = await createCopilotProvider(copilotUpstream);
+      const instance = createCopilotProvider(copilotUpstream);
       const first = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(first.map(m => m.id), ['m1']);
       const second = await instance.instance.getProvidedModels(directFetcher);
@@ -771,7 +771,7 @@ test('Copilot provider throws when the upstream fetch fails — no in-provider f
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const instance = await createCopilotProvider(harness.copilotUpstream);
+      const instance = createCopilotProvider(harness.copilotUpstream);
       await assertRejects(() => instance.instance.getProvidedModels(directFetcher));
     },
   );
@@ -779,7 +779,7 @@ test('Copilot provider throws when the upstream fetch fails — no in-provider f
 
 test('Copilot provider throws "disappeared mid-request" when the upstream row vanishes between construction and call', async () => {
   const harness = await setupCopilotTest();
-  const instance = await createCopilotProvider(harness.copilotUpstream);
+  const instance = createCopilotProvider(harness.copilotUpstream);
   harness.overrideGetById(async () => null);
 
   await assertRejects(
@@ -804,7 +804,7 @@ test('Copilot provider accepts a losing CAS write and still returns the freshly 
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const instance = await createCopilotProvider(harness.copilotUpstream);
+      const instance = createCopilotProvider(harness.copilotUpstream);
       const result = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(result.map(m => m.id), ['m1']);
     },
@@ -829,7 +829,7 @@ test('Copilot provider swallows a saveState throw so a transient persistence hic
       throw new Error(`Unhandled fetch ${request.url}`);
     },
     async () => {
-      const instance = await createCopilotProvider(harness.copilotUpstream);
+      const instance = createCopilotProvider(harness.copilotUpstream);
       const result = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(result.map(m => m.id), ['m1']);
     },
@@ -901,7 +901,7 @@ const fastModelCatalog = () =>
 
 test('Copilot provider routes speed=fast to the -fast raw variant and stamps usage.speed on the way out', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   let upstreamBody: Record<string, unknown> | undefined;
 
@@ -958,7 +958,7 @@ test('Copilot provider routes speed=fast to the -fast raw variant and stamps usa
 
 test('Copilot provider returns HTTP 400 invalid_request_error when speed=fast hits a model without a -fast variant', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   let messagesHit = false;
 
@@ -1006,7 +1006,7 @@ test('Copilot provider returns HTTP 400 invalid_request_error when speed=fast hi
 
 test('Copilot provider passes unknown speed values to the upstream verbatim so the upstream owns rejecting them', async () => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
   let upstreamBody: Record<string, unknown> | undefined;
 
@@ -1075,7 +1075,7 @@ const copilotModelsWithCapabilities = (models: CopilotModelCapabilityFixture[]) 
 
 const getModelsWithCapabilities = async (fixtures: CopilotModelCapabilityFixture[]) => {
   const { copilotUpstream } = await setupCopilotTest();
-  const instance = await createCopilotProvider(copilotUpstream);
+  const instance = createCopilotProvider(copilotUpstream);
   let models: Awaited<ReturnType<typeof instance.instance.getProvidedModels>> = [];
 
   await withMockedFetch(

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -442,6 +442,60 @@ test('Copilot provider exposes its default flag set via ProviderModel.enabledFla
   );
 });
 
+test('per-model provider default beats operator upstream override — Claude < 4.8 stays demoted even when the upstream flag is off', async () => {
+  const { copilotUpstream } = await setupCopilotTest({
+    // Operator flipped the upstream-wide flag off. Provider says
+    // Claude < 4.8 must stay demoted (its Vertex backend rejects
+    // inline `role:'system'`), and the per-model layer sits after the
+    // upstream override in the resolve chain, so the provider judgment
+    // wins for the affected model while every other model honors the
+    // operator setting.
+    flagOverrides: { 'demote-interleaved-system-to-user': false },
+  });
+  const instance = createCopilotProvider(copilotUpstream);
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') {
+        return jsonResponse(['1.110.1']);
+      }
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({
+          token: 'copilot-access-token',
+          expires_at: 4102444800,
+          refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
+        });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([
+          { id: 'claude-opus-4.6', supported_endpoints: ['/chat/completions'] },
+          { id: 'claude-opus-4.8', supported_endpoints: ['/chat/completions'] },
+          { id: 'gpt-test', supported_endpoints: ['/chat/completions'] },
+        ]));
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const models = await instance.instance.getProvidedModels(directFetcher);
+      const claude46 = models.find(m => m.id === 'claude-opus-4-6');
+      const claude48 = models.find(m => m.id === 'claude-opus-4-8');
+      const gpt = models.find(m => m.id === 'gpt-test');
+      if (!claude46 || !claude48 || !gpt) throw new Error('expected all three models in the emitted catalog');
+      // Per-model layer forces demote on for Claude < 4.8, even though
+      // the operator upstream override said off.
+      assertEquals(claude46.enabledFlags.has('demote-interleaved-system-to-user'), true);
+      // No per-model rule for Claude >= 4.8; the operator upstream
+      // override wins on this row.
+      assertEquals(claude48.enabledFlags.has('demote-interleaved-system-to-user'), false);
+      // Non-Claude ids never get a per-model rule; operator setting
+      // stands.
+      assertEquals(gpt.enabledFlags.has('demote-interleaved-system-to-user'), false);
+    },
+  );
+});
+
 test('Copilot provider forces stream=true for streaming endpoints and leaves count-tokens/embeddings alone', async () => {
   const { copilotUpstream } = await setupCopilotTest();
   const instance = createCopilotProvider(copilotUpstream);

--- a/packages/provider-custom/src/defaults.ts
+++ b/packages/provider-custom/src/defaults.ts
@@ -1,0 +1,24 @@
+import type { FlagDefaults } from '@floway-dev/provider';
+
+// Exhaustive flag defaults for custom (generic OpenAI-compatible) upstreams.
+export const CUSTOM_DEFAULT_FLAGS: FlagDefaults = {
+  'vendor-deepseek': false,
+  'vendor-qwen': false,
+  'vendor-kimi': false,
+  'retry-cyber-policy': false,
+  'messages-web-search-shim': true,
+  'responses-web-search-shim': true,
+  'responses-image-generation-shim': true,
+  // Custom targets are OpenAI-compatible and typically expose a native
+  // /responses/compact endpoint (or don't need compaction at all), so the
+  // shim stays off by default. Operator can turn it on for a specific
+  // upstream that lacks native compact.
+  'responses-compact-shim': false,
+  'disable-reasoning-on-forced-tool-choice': false,
+  'demote-interleaved-system-to-user': false,
+  'demote-developer-to-system': false,
+  // `x-anthropic-billing-header:` from Claude Code clients is meaningful
+  // only to the Anthropic subscription endpoint; strip it here so it
+  // does not pollute the OpenAI-compatible upstream's prompt-cache key.
+  'strip-billing-attribution': true,
+};

--- a/packages/provider-custom/src/index.ts
+++ b/packages/provider-custom/src/index.ts
@@ -1,3 +1,12 @@
+import { CUSTOM_DEFAULT_FLAGS } from './defaults.ts';
+import { createCustomProvider } from './provider.ts';
+import type { ProviderModule } from '@floway-dev/provider';
+
+export const customProvider: ProviderModule = {
+  create: createCustomProvider,
+  defaultFlags: CUSTOM_DEFAULT_FLAGS,
+};
+
 export { createCustomProvider } from './provider.ts';
 export { assertCustomUpstreamRecord } from './config.ts';
 export { fetchCustomModels } from './fetch-models.ts';

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -1,4 +1,5 @@
 import { assertCustomUpstreamRecord, type CustomUpstreamConfig } from './config.ts';
+import { CUSTOM_DEFAULT_FLAGS } from './defaults.ts';
 import { fetchCustomModels, type CustomModelsResponse, type CustomRawModel } from './fetch-models.ts';
 import { customFetchChatCompletions, customFetchCompletions, customFetchEmbeddings, customFetchImagesEdits, customFetchImagesGenerations, customFetchMessages, customFetchMessagesCountTokens, customFetchResponses, customFetchResponsesCompact } from './fetch.ts';
 import { inferEndpointsFromModelId } from './infer-endpoints.ts';
@@ -6,7 +7,7 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { publicModelId, resolveEffectiveFlags, defaultsForProvider, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 const rawModelIdOf = (model: ProviderModel): string => model.providerData as string;
 
@@ -73,13 +74,13 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
   // Computed once for the auto-fetch layer: only the upstream layer applies to
   // auto models (no per-model override layer). Manual models layer their own
   // flag overrides on top, resolved per-model below.
-  const upstreamFlags = resolveEffectiveFlags(defaultsForProvider('custom'), [record.flagOverrides]);
+  const upstreamFlags = resolveEffectiveFlags([CUSTOM_DEFAULT_FLAGS, record.flagOverrides]);
 
   // Manual models always emit.
   const overriddenIds = new Set(config.models.map(m => m.upstreamModelId));
   const manualModels: ProviderModel[] = config.models.map(model => {
     const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
-    const enabledFlags = resolveEffectiveFlags(defaultsForProvider('custom'), [record.flagOverrides, modelLayer]);
+    const enabledFlags = resolveEffectiveFlags([CUSTOM_DEFAULT_FLAGS, record.flagOverrides, modelLayer]);
     const endpoints = model.endpoints;
     const internal: ProviderModel = {
       id: publicModelId(model),
@@ -172,6 +173,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
   };
 
   const instance: ProviderInstance = {
+    defaultFlagsForUpstream: () => CUSTOM_DEFAULT_FLAGS,
     getProvidedModels: async fetcher => {
       if (!config.modelsFetch.enabled) return manualModels;
       const response = await fetchCustomModels(config, fetcher);

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -112,24 +112,9 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
   //      for auto-fetched models on every isolate that started cold against
   //      a SOFT-fresh cache row.
   const pricingByRawId = new Map<string, ModelPricing>();
-  const rememberPricingFromResponse = (response: CustomModelsResponse): void => {
-    pricingByRawId.clear();
-    for (const raw of response.data) {
-      if (raw.id && raw.cost) pricingByRawId.set(raw.id, raw.cost);
-    }
-  };
   const rememberPricingForModel = (model: ProviderModel): void => {
     if (model.cost) pricingByRawId.set(rawModelIdOf(model), model.cost);
   };
-
-  // Drop any auto-fetched model whose id is pinned by a manual override so the
-  // manual copy is the only one emitted for that id.
-  const autoFromResponse = (response: CustomModelsResponse): ProviderModel[] => {
-    const filtered: CustomModelsResponse = { data: response.data.filter(raw => !overriddenIds.has(raw.id)) };
-    return finalizeCustomModels(filtered, configuredEndpoints, upstreamFlags);
-  };
-
-  const withManual = (auto: ProviderModel[]): ProviderModel[] => [...manualModels, ...auto];
 
   const call = (
     transport: (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,
@@ -175,8 +160,19 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     getProvidedModels: async fetcher => {
       if (!config.modelsFetch.enabled) return manualModels;
       const response = await fetchCustomModels(config, fetcher);
-      rememberPricingFromResponse(response);
-      return withManual(autoFromResponse(response));
+      // Populate the raw-id→cost cache so a dispatch coming through the
+      // SWR cache path (which hands the provider a rebuilt ProviderModel
+      // without going through getProvidedModels again) can still resolve
+      // per-model pricing for telemetry — without it, cold isolates would
+      // report null cost until the next catalog fetch.
+      pricingByRawId.clear();
+      for (const raw of response.data) {
+        if (raw.id && raw.cost) pricingByRawId.set(raw.id, raw.cost);
+      }
+      // Drop any auto-fetched model whose id is pinned by a manual
+      // override so the manual copy is the only one emitted for that id.
+      const filtered: CustomModelsResponse = { data: response.data.filter(raw => !overriddenIds.has(raw.id)) };
+      return [...manualModels, ...finalizeCustomModels(filtered, configuredEndpoints, upstreamFlags)];
     },
     getPricingForModelKey: modelKey => manualPricingByUpstreamId.get(modelKey) ?? pricingByRawId.get(modelKey) ?? null,
     callCompletions: (model, body, signal, opts) => call(customFetchCompletions, model, body, signal, opts.headers, opts),

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -173,7 +173,6 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
   };
 
   const instance: ProviderInstance = {
-    defaultFlagsForUpstream: () => CUSTOM_DEFAULT_FLAGS,
     getProvidedModels: async fetcher => {
       if (!config.modelsFetch.enabled) return manualModels;
       const response = await fetchCustomModels(config, fetcher);

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -160,11 +160,6 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     getProvidedModels: async fetcher => {
       if (!config.modelsFetch.enabled) return manualModels;
       const response = await fetchCustomModels(config, fetcher);
-      // Populate the raw-id→cost cache so a dispatch coming through the
-      // SWR cache path (which hands the provider a rebuilt ProviderModel
-      // without going through getProvidedModels again) can still resolve
-      // per-model pricing for telemetry — without it, cold isolates would
-      // report null cost until the next catalog fetch.
       pricingByRawId.clear();
       for (const raw of response.data) {
         if (raw.id && raw.cost) pricingByRawId.set(raw.id, raw.cost);

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -7,7 +7,7 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type FlagId, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 const rawModelIdOf = (model: ProviderModel): string => model.providerData as string;
 
@@ -51,7 +51,7 @@ const autoModelEndpoints = (model: CustomRawModel, configured: ModelEndpoints): 
 const finalizeCustomModels = (
   response: CustomModelsResponse,
   configuredEndpoints: ModelEndpoints,
-  enabledFlags: ReadonlySet<string>,
+  enabledFlags: ReadonlySet<FlagId>,
 ): ProviderModel[] => {
   const models: ProviderModel[] = [];
   for (const rawModel of response.data) {

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -79,8 +79,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
   // Manual models always emit.
   const overriddenIds = new Set(config.models.map(m => m.upstreamModelId));
   const manualModels: ProviderModel[] = config.models.map(model => {
-    const modelLayer = model.flagOverrides;
-    const enabledFlags = resolveEffectiveFlags([CUSTOM_DEFAULT_FLAGS, record.flagOverrides, modelLayer]);
+    const enabledFlags = resolveEffectiveFlags([CUSTOM_DEFAULT_FLAGS, record.flagOverrides, model.flagOverrides]);
     const endpoints = model.endpoints;
     const internal: ProviderModel = {
       id: publicModelId(model),

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -79,7 +79,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
   // Manual models always emit.
   const overriddenIds = new Set(config.models.map(m => m.upstreamModelId));
   const manualModels: ProviderModel[] = config.models.map(model => {
-    const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
+    const modelLayer = model.flagOverrides;
     const enabledFlags = resolveEffectiveFlags([CUSTOM_DEFAULT_FLAGS, record.flagOverrides, modelLayer]);
     const endpoints = model.endpoints;
     const internal: ProviderModel = {

--- a/packages/provider-ollama/src/defaults.ts
+++ b/packages/provider-ollama/src/defaults.ts
@@ -8,7 +8,6 @@ export const OLLAMA_DEFAULT_FLAGS: FlagDefaults = {
   'messages-web-search-shim': true,
   'responses-web-search-shim': true,
   'responses-image-generation-shim': true,
-  // Ollama exposes no native /responses/compact, so the shim stays on.
   'responses-compact-shim': true,
   'disable-reasoning-on-forced-tool-choice': false,
   'demote-interleaved-system-to-user': false,

--- a/packages/provider-ollama/src/defaults.ts
+++ b/packages/provider-ollama/src/defaults.ts
@@ -1,6 +1,5 @@
 import type { FlagDefaults } from '@floway-dev/provider';
 
-// Exhaustive flag defaults for Ollama upstreams (self-hosted daemon or ollama.com).
 export const OLLAMA_DEFAULT_FLAGS: FlagDefaults = {
   'vendor-deepseek': false,
   'vendor-qwen': false,

--- a/packages/provider-ollama/src/defaults.ts
+++ b/packages/provider-ollama/src/defaults.ts
@@ -1,0 +1,19 @@
+import type { FlagDefaults } from '@floway-dev/provider';
+
+// Exhaustive flag defaults for Ollama upstreams (self-hosted daemon or
+// ollama.com). Ollama exposes no native /responses/compact so the shim
+// stays on by default.
+export const OLLAMA_DEFAULT_FLAGS: FlagDefaults = {
+  'vendor-deepseek': false,
+  'vendor-qwen': false,
+  'vendor-kimi': false,
+  'retry-cyber-policy': false,
+  'messages-web-search-shim': true,
+  'responses-web-search-shim': true,
+  'responses-image-generation-shim': true,
+  'responses-compact-shim': true,
+  'disable-reasoning-on-forced-tool-choice': false,
+  'demote-interleaved-system-to-user': false,
+  'demote-developer-to-system': false,
+  'strip-billing-attribution': true,
+};

--- a/packages/provider-ollama/src/defaults.ts
+++ b/packages/provider-ollama/src/defaults.ts
@@ -1,8 +1,6 @@
 import type { FlagDefaults } from '@floway-dev/provider';
 
-// Exhaustive flag defaults for Ollama upstreams (self-hosted daemon or
-// ollama.com). Ollama exposes no native /responses/compact so the shim
-// stays on by default.
+// Exhaustive flag defaults for Ollama upstreams (self-hosted daemon or ollama.com).
 export const OLLAMA_DEFAULT_FLAGS: FlagDefaults = {
   'vendor-deepseek': false,
   'vendor-qwen': false,
@@ -11,6 +9,7 @@ export const OLLAMA_DEFAULT_FLAGS: FlagDefaults = {
   'messages-web-search-shim': true,
   'responses-web-search-shim': true,
   'responses-image-generation-shim': true,
+  // Ollama exposes no native /responses/compact, so the shim stays on.
   'responses-compact-shim': true,
   'disable-reasoning-on-forced-tool-choice': false,
   'demote-interleaved-system-to-user': false,

--- a/packages/provider-ollama/src/index.ts
+++ b/packages/provider-ollama/src/index.ts
@@ -1,2 +1,11 @@
+import { OLLAMA_DEFAULT_FLAGS } from './defaults.ts';
+import { createOllamaProvider } from './provider.ts';
+import type { ProviderModule } from '@floway-dev/provider';
+
+export const ollamaProvider: ProviderModule = {
+  create: createOllamaProvider,
+  defaultFlags: OLLAMA_DEFAULT_FLAGS,
+};
+
 export { createOllamaProvider } from './provider.ts';
 export { assertOllamaUpstreamRecord, type OllamaUpstreamConfig, type OllamaUpstreamRecord } from './config.ts';

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -20,6 +20,7 @@
 
 import { chatFromOllamaRaw } from './chat-from-raw.ts';
 import { assertOllamaUpstreamRecord, type OllamaUpstreamConfig } from './config.ts';
+import { OLLAMA_DEFAULT_FLAGS } from './defaults.ts';
 import { fetchOllamaCatalog, type OllamaCatalog } from './fetch-models.ts';
 import { ollamaFetchChatCompletions, ollamaFetchCompletions, ollamaFetchEmbeddings, ollamaFetchMessages, ollamaFetchMessagesCountTokens, ollamaFetchResponses, ollamaFetchResponsesCompact } from './fetch.ts';
 import { pricingForOllamaModelKey } from './pricing.ts';
@@ -27,7 +28,7 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { publicModelId, resolveEffectiveFlags, defaultsForProvider, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 // providerData carries the raw upstream id verbatim — the same value /api/tags
 // returns and the same value the gateway must send back on every inference call.
@@ -72,14 +73,14 @@ const finalizeOllamaModels = (
 
 export const createOllamaProvider = (record: UpstreamRecord): Provider => {
   const { config } = assertOllamaUpstreamRecord(record);
-  const upstreamFlags = resolveEffectiveFlags(defaultsForProvider('ollama'), [record.flagOverrides]);
+  const upstreamFlags = resolveEffectiveFlags([OLLAMA_DEFAULT_FLAGS, record.flagOverrides]);
 
   // Manual overrides always emit, regardless of whether the upstream catalog
   // fetch succeeds. Same shape and merge precedence as the custom provider.
   const overriddenIds = new Set(config.models.map(m => m.upstreamModelId));
   const manualModels: ProviderModel[] = config.models.map(model => {
     const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
-    const enabledFlags = resolveEffectiveFlags(defaultsForProvider('ollama'), [record.flagOverrides, modelLayer]);
+    const enabledFlags = resolveEffectiveFlags([OLLAMA_DEFAULT_FLAGS, record.flagOverrides, modelLayer]);
     const endpoints = model.endpoints;
     const internal: ProviderModel = {
       id: publicModelId(model),
@@ -138,6 +139,7 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
     Promise.reject(new Error(`Ollama provider does not implement ${capability}`));
 
   const instance: ProviderInstance = {
+    defaultFlagsForUpstream: () => OLLAMA_DEFAULT_FLAGS,
     getProvidedModels: async fetcher => {
       const catalog = await fetchOllamaCatalog(config, fetcher);
       const auto = finalizeOllamaModels(

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -28,7 +28,7 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type FlagId, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 // providerData carries the raw upstream id verbatim — the same value /api/tags
 // returns and the same value the gateway must send back on every inference call.
@@ -45,7 +45,7 @@ const endpointsForCapabilities = (capabilities: ReadonlySet<string>): ModelEndpo
 
 const finalizeOllamaModels = (
   catalog: OllamaCatalog,
-  enabledFlags: ReadonlySet<string>,
+  enabledFlags: ReadonlySet<FlagId>,
 ): ProviderModel[] => {
   const models: ProviderModel[] = [];
   for (const raw of catalog.data) {

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -79,7 +79,7 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
   // fetch succeeds. Same shape and merge precedence as the custom provider.
   const overriddenIds = new Set(config.models.map(m => m.upstreamModelId));
   const manualModels: ProviderModel[] = config.models.map(model => {
-    const modelLayer = model.flagOverrides?.enabled ? model.flagOverrides.values : undefined;
+    const modelLayer = model.flagOverrides;
     const enabledFlags = resolveEffectiveFlags([OLLAMA_DEFAULT_FLAGS, record.flagOverrides, modelLayer]);
     const endpoints = model.endpoints;
     const internal: ProviderModel = {

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -79,8 +79,7 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
   // fetch succeeds. Same shape and merge precedence as the custom provider.
   const overriddenIds = new Set(config.models.map(m => m.upstreamModelId));
   const manualModels: ProviderModel[] = config.models.map(model => {
-    const modelLayer = model.flagOverrides;
-    const enabledFlags = resolveEffectiveFlags([OLLAMA_DEFAULT_FLAGS, record.flagOverrides, modelLayer]);
+    const enabledFlags = resolveEffectiveFlags([OLLAMA_DEFAULT_FLAGS, record.flagOverrides, model.flagOverrides]);
     const endpoints = model.endpoints;
     const internal: ProviderModel = {
       id: publicModelId(model),

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -139,7 +139,6 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
     Promise.reject(new Error(`Ollama provider does not implement ${capability}`));
 
   const instance: ProviderInstance = {
-    defaultFlagsForUpstream: () => OLLAMA_DEFAULT_FLAGS,
     getProvidedModels: async fetcher => {
       const catalog = await fetchOllamaCatalog(config, fetcher);
       const auto = finalizeOllamaModels(

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": { "import": "./src/index.ts", "types": "./src/index.ts" },
+    "./flags": { "import": "./src/flags.ts", "types": "./src/flags.ts" },
     "./model-prefix": { "import": "./src/model-prefix.ts", "types": "./src/model-prefix.ts" }
   },
   "scripts": {

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -112,9 +112,10 @@ export type FlagDefaults = Readonly<Record<FlagId, boolean>>;
 // this layer (including flags seeded by earlier layers — the operator or
 // per-model default explicitly opted out).
 //
-// Used by operator override storage (`UpstreamRecord.flagOverrides`,
-// per-model `flagOverrides.values`) and by the per-model default deltas
-// a provider computes inside its `create` — see
+// Used by operator override storage (upstream-level
+// `UpstreamRecord.flagOverrides`, per-model
+// `UpstreamModelConfig.flagOverrides`) and by the per-model default
+// deltas a provider computes inside its `create` — see
 // `defaultFlagsForCopilotModel` for the current example.
 export type FlagOverrides = Partial<Record<FlagId, boolean>>;
 
@@ -150,7 +151,7 @@ export const parseFlagOverridesWire = (value: unknown): FlagOverrides => {
 //   2. Operator upstream override (`UpstreamRecord.flagOverrides`)
 //   3. Per-model layer — provider's per-model default for auto rows
 //      (`defaultFlagsForCopilotModel(model)`), operator's per-model
-//      override for manual rows (`UpstreamModelConfig.flagOverrides.values`).
+//      override for manual rows (`UpstreamModelConfig.flagOverrides`).
 //      Never both, since an auto/manual row cannot be the other.
 //
 // Placing per-model last lets provider-declared technical necessities

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -11,16 +11,19 @@
 // gateway's OpenAI-canonical request and response shape into the vendor's
 // wire dialect; with no vendor flag set, behavior defaults to the OpenAI
 // standard and no vendor rewrite runs.
-
-import type { UpstreamProviderKind } from './model.ts';
-import { ALL_PROVIDER_KINDS } from './model.ts';
+//
+// Defaults are NOT declared in this catalog. Each provider owns the
+// decision of which flags default on for its own upstream (and, when
+// per-model differentiation matters, per model). The pivot keeps
+// vendor-specific knowledge inside the provider package that talks to
+// that vendor — the central catalog only describes identity, label, and
+// UI copy. See `ProviderInstance.defaultFlagsForUpstream` and
+// `defaultFlagsForModel` in `provider.ts`.
 
 export interface Flag {
   id: string;
   label: string;
   description: string;
-  // Provider kinds that turn this flag on by default.
-  defaultFor: readonly UpstreamProviderKind[];
 }
 
 export const OPTIONAL_FLAGS = [
@@ -28,114 +31,92 @@ export const OPTIONAL_FLAGS = [
     id: 'vendor-deepseek',
     label: 'Vendor: DeepSeek',
     description: "Pick this when the upstream serves DeepSeek's chat completions API. The gateway translates between OpenAI canonical and DeepSeek's dialect: assistant reasoning rides on `reasoning_content` instead of `reasoning_text`; disabling reasoning uses a top-level `thinking: { type: 'disabled' }` instead of `reasoning_effort: 'none'`; cache hit/miss tokens normalise to OpenAI's `prompt_tokens_details.cached_tokens`; and structured-output `json_schema` requests are downgraded to `json_object` because DeepSeek doesn't accept schemas.",
-    defaultFor: [],
   },
   {
     id: 'vendor-qwen',
     label: 'Vendor: Qwen',
     description: "Pick this when the upstream serves Qwen's (Alibaba Model Studio) chat completions API. The gateway rewrites a 'no reasoning' request to Qwen's top-level `enable_thinking: false` field instead of `reasoning_effort`.",
-    defaultFor: [],
   },
   {
     id: 'vendor-kimi',
     label: 'Vendor: Kimi',
     description: "Pick this when the upstream serves Kimi's (Moonshot) chat completions API. The gateway normalises Kimi's flat `cached_tokens` usage field back to OpenAI's `prompt_tokens_details.cached_tokens`.",
-    defaultFor: [],
   },
   {
     id: 'retry-cyber-policy',
     label: 'Retry on upstream cyber-policy block',
     description: 'Retry cyber_policy 4xx errors from the upstream (up to 10 attempts).',
-    defaultFor: ['copilot'],
   },
-  // The three shim flags default on for every upstream kind that runs
-  // operator-shaped traffic through translation. They are off by default on
-  // `codex` (no hosted tools at all) and on `claude-code` (the shaped-
-  // passthrough path forwards caller bytes verbatim, so a gateway-side shim
-  // would silently rewrite a request the operator deliberately let through
-  // unchanged).
   {
     id: 'messages-web-search-shim',
     label: 'Messages web search shim',
     description: "Execute Anthropic native Messages web search through the gateway's configured search provider instead of forwarding it to the upstream. (When a client Messages request is routed to a non-Messages backend, the shim always runs regardless of this flag, because those targets cannot carry Anthropic server tools.)",
-    defaultFor: ALL_PROVIDER_KINDS.filter(p => !['codex', 'claude-code'].includes(p)),
   },
   {
     id: 'responses-web-search-shim',
     label: 'Responses web search shim',
     description: "Execute the Responses `web_search` hosted tool through the gateway's configured search provider instead of forwarding it to a Responses upstream. (When a Responses request is routed to a non-Responses backend, the shim always runs regardless of this flag, because those targets cannot carry hosted web_search.)",
-    defaultFor: ALL_PROVIDER_KINDS.filter(p => !['codex', 'claude-code'].includes(p)),
   },
   {
     id: 'responses-image-generation-shim',
     label: 'Responses image generation shim',
     description: "Execute the Responses `image_generation` hosted tool through the gateway's image-capable upstream (gpt-image-*) instead of forwarding it to a Responses upstream. The orchestrator model calls a generated function tool; the shim drives the standalone /images/{generations,edits} backend and synthesizes the native image_generation_call lifecycle. (When a Responses request is routed to a non-Responses backend, the shim always runs regardless of this flag, because those targets cannot carry the hosted image_generation tool.)",
-    defaultFor: ALL_PROVIDER_KINDS.filter(p => !['codex', 'claude-code'].includes(p)),
   },
   {
     id: 'responses-compact-shim',
     label: 'Responses compact shim',
-    description: "Simulate `response.compaction` against upstreams that don't expose a native compact wire. The shim swaps a compact request's instructions for the Codex SUMMARIZATION_PROMPT, runs a normal generate turn, and packs the upstream's summary back into a synthetic compaction envelope. Default on for `claude-code` and `ollama` (no native compaction); default off for `codex`, `copilot`, `azure`, `custom` (each has a native compact wire).",
-    defaultFor: ['claude-code', 'ollama'],
+    description: "Simulate `response.compaction` against upstreams that don't expose a native compact wire. The shim swaps a compact request's instructions for the Codex SUMMARIZATION_PROMPT, runs a normal generate turn, and packs the upstream's summary back into a synthetic compaction envelope.",
   },
   {
     id: 'disable-reasoning-on-forced-tool-choice',
     label: 'Disable reasoning when caller forces a tool',
     description: "Disable reasoning in the outbound request when the caller forces a specific tool. Emits the gateway's canonical 'no reasoning' sentinel; the active Vendor flag (if any) translates that into the vendor's wire form.",
-    defaultFor: [],
   },
   {
     id: 'demote-interleaved-system-to-user',
     label: 'Demote interleaved system messages to user',
     description: "Pick this when the upstream rejects `role: 'system'` after the first non-system message (e.g. DeepSeek-R1). The leading contiguous run of system messages is preserved; any later inline system message has its role rewritten to `user`, with content kept verbatim. For Anthropic Messages — where `payload.system` is conceptually the only first-position system slot — every inline `role: 'system'` message is demoted unconditionally.",
-    defaultFor: [],
   },
   {
     id: 'demote-developer-to-system',
     label: 'Demote developer role to system',
     description: "Rewrite messages with role 'developer' to role 'system' for upstreams that do not recognise the developer role.",
-    defaultFor: [],
   },
-  // The `x-anthropic-billing-header:` line the Claude Code CLI injects is a
-  // literal `cch=00000;` placeholder, not a per-request hash — Anthropic's
-  // subscription endpoint reads the placeholder block itself to attribute
-  // billing. So strip it on every non-Anthropic upstream (it would only
-  // pollute their prompt-cache key) and keep it only on `claude-code`,
-  // where the same block is what bills the request against the user's plan.
   {
     id: 'strip-billing-attribution',
     label: 'Strip Claude Code billing attribution from system prompt',
-    description: "Remove `x-anthropic-billing-header:` lines from the request's system prompt before forwarding upstream. Default on for every upstream kind except `claude-code` — the block is irrelevant to non-Anthropic upstreams and only pollutes their prompt-cache key. Default off for `claude-code`, where the same block is the input Anthropic uses to bill the request against the user's plan.",
-    defaultFor: ALL_PROVIDER_KINDS.filter(p => p !== 'claude-code'),
+    description: "Remove `x-anthropic-billing-header:` lines from the request's system prompt before forwarding upstream. The block is irrelevant to non-Anthropic upstreams and only pollutes their prompt-cache key. On `claude-code`, the same block is the input Anthropic uses to bill the request against the user's plan and must be preserved.",
   },
 ] as const satisfies readonly Flag[];
 
-export type OptionalFlagId = (typeof OPTIONAL_FLAGS)[number]['id'];
+export type FlagId = (typeof OPTIONAL_FLAGS)[number]['id'];
 
 const KNOWN_IDS = new Set<string>(OPTIONAL_FLAGS.map(f => f.id));
 
 export const getFlagCatalog = (): readonly Flag[] => OPTIONAL_FLAGS;
 
-export const isKnownFlagId = (id: string): id is OptionalFlagId => KNOWN_IDS.has(id);
+export const isKnownFlagId = (id: string): id is FlagId => KNOWN_IDS.has(id);
 
-// Provider-default flag set. Computed from the catalog's `defaultFor` field.
+// A provider's full opinion on every flag: `true` = default on for this
+// upstream, `false` = default off. The Record shape enforces exhaustiveness
+// at compile time — adding a new flag to the catalog is a type error until
+// every provider decides its default.
+export type FlagDefaults = Readonly<Record<FlagId, boolean>>;
+
+// Tri-state override or partial-default layer. Absent key = inherit from the
+// previous layer. `true` = force-on at this layer. `false` = force-off at
+// this layer (including flags seeded by earlier layers — the operator or
+// per-model default explicitly opted out).
 //
-// Memoized because the catalog is module-constant and providers may call
-// this on a per-request hot path; cache the read-only result set per
-// provider kind.
-const DEFAULTS_CACHE = new Map<UpstreamProviderKind, ReadonlySet<string>>();
-export const defaultsForProvider = (kind: UpstreamProviderKind): ReadonlySet<string> => {
-  let cached = DEFAULTS_CACHE.get(kind);
-  if (!cached) {
-    cached = new Set(OPTIONAL_FLAGS.filter(f => (f.defaultFor as readonly string[]).includes(kind)).map(f => f.id));
-    DEFAULTS_CACHE.set(kind, cached);
-  }
-  return cached;
-};
+// Used both by operator override storage (`UpstreamRecord.flagOverrides`,
+// per-model `flagOverrides.values`) and by
+// `ProviderInstance.defaultFlagsForModel` for per-model default deltas
+// atop the upstream default.
+export type FlagOverrides = Partial<Record<FlagId, boolean>>;
 
 // Validate a wire-form flag_overrides object. Throws on malformed shape;
 // returns a sorted, validated record of known flag ids to booleans.
-export const parseFlagOverridesWire = (value: unknown): Record<string, boolean> => {
+export const parseFlagOverridesWire = (value: unknown): FlagOverrides => {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('flag_overrides must be an object of { flagId: boolean }');
   }
@@ -150,29 +131,27 @@ export const parseFlagOverridesWire = (value: unknown): Record<string, boolean> 
     result[id] = on;
   }
   if (unknown.length > 0) throw new Error(`Unknown flag_overrides ids: ${unknown.join(', ')}`);
-  const sorted: Record<string, boolean> = {};
-  for (const id of Object.keys(result).sort()) sorted[id] = result[id];
+  const sorted: FlagOverrides = {};
+  for (const id of Object.keys(result).sort() as FlagId[]) sorted[id] = result[id];
   return sorted;
 };
 
-// Tri-state override map. Absent key = inherit from the parent layer.
-// `true` = force-on at this layer. `false` = force-off at this layer (including
-// flags seeded by provider defaults — admins explicitly toggled Off to opt out).
-export type FlagOverrides = Record<string, boolean>;
-
-// Reduce a sequence of override layers atop the provider defaults to the
-// effective enabled set. Layers are applied left-to-right; a later layer's
-// explicit `true` re-enables a previously-off flag, and an explicit `false`
-// overrides any earlier `true` (and any default seed). An `undefined` layer
-// is skipped entirely.
+// Reduce ordered flag layers to the effective enabled set. Layers apply
+// left-to-right; a later layer's explicit `true` re-enables a previously-off
+// flag, an explicit `false` overrides any earlier `true`, and an absent key
+// inherits the previous layer's decision. `undefined` layers are skipped.
+//
+// The typical call site walks provider defaults first, then per-model
+// defaults, then operator overrides — but the function itself doesn't
+// distinguish; the layer order is the caller's choice.
 export const resolveEffectiveFlags = (
-  providerDefaults: ReadonlySet<string>,
-  layers: readonly (FlagOverrides | undefined)[],
-): ReadonlySet<string> => {
-  const effective = new Set<string>(providerDefaults);
+  layers: readonly (FlagOverrides | FlagDefaults | undefined)[],
+): ReadonlySet<FlagId> => {
+  const effective = new Set<FlagId>();
   for (const layer of layers) {
     if (!layer) continue;
     for (const [id, on] of Object.entries(layer)) {
+      if (!isKnownFlagId(id)) continue;
       if (on) effective.add(id);
       else effective.delete(id);
     }

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -151,8 +151,6 @@ export const validateFlagOverridesRecord = (value: unknown, msg: FlagOverridesEr
   return sorted;
 };
 
-// Validate a wire-form flag_overrides object. Throws on malformed shape;
-// returns a sorted, validated record of known flag ids to booleans.
 export const parseFlagOverridesWire = (value: unknown): FlagOverrides =>
   validateFlagOverridesRecord(value, {
     notObject: 'flag_overrides must be an object of { flagId: boolean }',

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -17,8 +17,12 @@
 // per-model differentiation matters, per model). Vendor-specific
 // knowledge lives inside the provider package that talks to that
 // vendor — the central catalog only describes identity, label, and
-// UI copy. See `ProviderInstance.defaultFlagsForUpstream` and
-// `defaultFlagsForModel` in `provider.ts`.
+// UI copy. See `ProviderModule.defaultFlags` in `provider.ts` for the
+// module surface, and each provider package's `defaults.ts` for the
+// per-kind constants themselves. Per-model deltas — where the same
+// provider forms a different opinion for individual models — are
+// provider-internal: `createXxxProvider` computes them once and
+// stakes the result into `ProviderModel.enabledFlags`.
 
 export interface Flag {
   id: string;
@@ -108,10 +112,10 @@ export type FlagDefaults = Readonly<Record<FlagId, boolean>>;
 // this layer (including flags seeded by earlier layers — the operator or
 // per-model default explicitly opted out).
 //
-// Used both by operator override storage (`UpstreamRecord.flagOverrides`,
-// per-model `flagOverrides.values`) and by
-// `ProviderInstance.defaultFlagsForModel` for per-model default deltas
-// atop the upstream default.
+// Used by operator override storage (`UpstreamRecord.flagOverrides`,
+// per-model `flagOverrides.values`) and by the per-model default deltas
+// a provider computes inside its `create` — see
+// `defaultFlagsForCopilotModel` for the current example.
 export type FlagOverrides = Partial<Record<FlagId, boolean>>;
 
 // Validate a wire-form flag_overrides object. Throws on malformed shape;

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -97,8 +97,6 @@ export type FlagId = (typeof OPTIONAL_FLAGS)[number]['id'];
 
 const KNOWN_IDS = new Set<string>(OPTIONAL_FLAGS.map(f => f.id));
 
-export const getFlagCatalog = (): readonly Flag[] => OPTIONAL_FLAGS;
-
 export const isKnownFlagId = (id: string): id is FlagId => KNOWN_IDS.has(id);
 
 // A provider's full opinion on every flag: `true` = default on for this

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -117,21 +117,21 @@ export type FlagDefaults = Readonly<Record<FlagId, boolean>>;
 // `defaultFlagsForCopilotModel`.
 export type FlagOverrides = Partial<Record<FlagId, boolean>>;
 
-// Caller-supplied wording for validateFlagOverridesRecord errors — each
-// entry point keeps its canonical operator-facing message.
-export interface FlagOverridesErrorMessages {
-  readonly notObject: string;
-  readonly notBoolean: (id: string) => string;
-  readonly unknownIds: (ids: readonly string[]) => string;
-}
-
 // Shape validator + canonicalizer shared by every entry point that
 // takes a "flag id → boolean" map from an untrusted source
 // (wire-form `parseFlagOverridesWire`, per-model
 // `flagOverridesField`). Rejects non-object payloads, non-boolean
 // values, and unknown flag ids; returns a copy with keys sorted
 // lexicographically so equal maps round-trip to identical JSON.
-export const validateFlagOverridesRecord = (value: unknown, msg: FlagOverridesErrorMessages): FlagOverrides => {
+// `msg` lets each caller keep its canonical operator-facing wording.
+export const validateFlagOverridesRecord = (
+  value: unknown,
+  msg: {
+    readonly notObject: string;
+    readonly notBoolean: (id: string) => string;
+    readonly unknownIds: (ids: readonly string[]) => string;
+  },
+): FlagOverrides => {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error(msg.notObject);
   }

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -180,7 +180,7 @@ export const parseFlagOverridesWire = (value: unknown): FlagOverrides =>
 // The function itself doesn't enforce this order; each provider's
 // `createXxx` composes its layer list in this shape.
 export const resolveEffectiveFlags = (
-  layers: readonly (FlagOverrides | FlagDefaults | undefined)[],
+  layers: readonly (FlagOverrides | undefined)[],
 ): ReadonlySet<FlagId> => {
   const effective = new Set<FlagId>();
   for (const layer of layers) {

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -145,9 +145,22 @@ export const parseFlagOverridesWire = (value: unknown): FlagOverrides => {
 // flag, an explicit `false` overrides any earlier `true`, and an absent key
 // inherits the previous layer's decision. `undefined` layers are skipped.
 //
-// The typical call site walks provider defaults first, then per-model
-// defaults, then operator overrides — but the function itself doesn't
-// distinguish; the layer order is the caller's choice.
+// Canonical layer order across every provider:
+//   1. Provider upstream default (per-kind constant)
+//   2. Operator upstream override (`UpstreamRecord.flagOverrides`)
+//   3. Per-model layer — provider's per-model default for auto rows
+//      (`defaultFlagsForCopilotModel(model)`), operator's per-model
+//      override for manual rows (`UpstreamModelConfig.flagOverrides.values`).
+//      Never both, since an auto/manual row cannot be the other.
+//
+// Placing per-model last lets provider-declared technical necessities
+// (e.g. Copilot forcing demote-interleaved-system-to-user on for
+// Claude < 4.8, whose Vertex backend rejects inline `role:'system'`)
+// survive an upstream-wide operator override. Operators who genuinely
+// want to opt out of a provider's per-model call switch the row to
+// Manual and override there — explicit and visible in the dashboard.
+// The function itself doesn't enforce this order; each provider's
+// `createXxx` composes its layer list in this shape.
 export const resolveEffectiveFlags = (
   layers: readonly (FlagOverrides | FlagDefaults | undefined)[],
 ): ReadonlySet<FlagId> => {

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -14,9 +14,9 @@
 //
 // Defaults are NOT declared in this catalog. Each provider owns the
 // decision of which flags default on for its own upstream (and, when
-// per-model differentiation matters, per model). The pivot keeps
-// vendor-specific knowledge inside the provider package that talks to
-// that vendor — the central catalog only describes identity, label, and
+// per-model differentiation matters, per model). Vendor-specific
+// knowledge lives inside the provider package that talks to that
+// vendor — the central catalog only describes identity, label, and
 // UI copy. See `ProviderInstance.defaultFlagsForUpstream` and
 // `defaultFlagsForModel` in `provider.ts`.
 

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -119,27 +119,48 @@ export type FlagDefaults = Readonly<Record<FlagId, boolean>>;
 // `defaultFlagsForCopilotModel` for the current example.
 export type FlagOverrides = Partial<Record<FlagId, boolean>>;
 
-// Validate a wire-form flag_overrides object. Throws on malformed shape;
-// returns a sorted, validated record of known flag ids to booleans.
-export const parseFlagOverridesWire = (value: unknown): FlagOverrides => {
+// Shape validator + canonicalizer shared by every entry point that
+// takes a "flag id → boolean" map from an untrusted source
+// (wire-form `parseFlagOverridesWire`, per-model
+// `flagOverridesField`). Rejects non-object payloads, non-boolean
+// values, and unknown flag ids; returns a copy with keys sorted
+// lexicographically so equal maps round-trip to identical JSON.
+// Error message format is caller-driven so each entry point keeps
+// its canonical operator-facing wording.
+export interface FlagOverridesErrorMessages {
+  readonly notObject: string;
+  readonly notBoolean: (id: string) => string;
+  readonly unknownIds: (ids: readonly string[]) => string;
+}
+
+export const validateFlagOverridesRecord = (value: unknown, msg: FlagOverridesErrorMessages): FlagOverrides => {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('flag_overrides must be an object of { flagId: boolean }');
+    throw new Error(msg.notObject);
   }
   const result: Record<string, boolean> = {};
   const unknown: string[] = [];
   for (const [id, on] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof on !== 'boolean') throw new Error(`flag_overrides.${id} must be a boolean`);
+    if (typeof on !== 'boolean') throw new Error(msg.notBoolean(id));
     if (!isKnownFlagId(id)) {
       unknown.push(id);
       continue;
     }
     result[id] = on;
   }
-  if (unknown.length > 0) throw new Error(`Unknown flag_overrides ids: ${unknown.join(', ')}`);
+  if (unknown.length > 0) throw new Error(msg.unknownIds(unknown));
   const sorted: FlagOverrides = {};
   for (const id of Object.keys(result).sort() as FlagId[]) sorted[id] = result[id];
   return sorted;
 };
+
+// Validate a wire-form flag_overrides object. Throws on malformed shape;
+// returns a sorted, validated record of known flag ids to booleans.
+export const parseFlagOverridesWire = (value: unknown): FlagOverrides =>
+  validateFlagOverridesRecord(value, {
+    notObject: 'flag_overrides must be an object of { flagId: boolean }',
+    notBoolean: id => `flag_overrides.${id} must be a boolean`,
+    unknownIds: ids => `Unknown flag_overrides ids: ${ids.join(', ')}`,
+  });
 
 // Reduce ordered flag layers to the effective enabled set. Layers apply
 // left-to-right; a later layer's explicit `true` re-enables a previously-off

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -114,8 +114,16 @@ export type FlagDefaults = Readonly<Record<FlagId, boolean>>;
 // `UpstreamRecord.flagOverrides`, per-model
 // `UpstreamModelConfig.flagOverrides`) and by the per-model default
 // deltas a provider computes inside its `create` — see
-// `defaultFlagsForCopilotModel` for the current example.
+// `defaultFlagsForCopilotModel`.
 export type FlagOverrides = Partial<Record<FlagId, boolean>>;
+
+// Caller-supplied wording for validateFlagOverridesRecord errors — each
+// entry point keeps its canonical operator-facing message.
+export interface FlagOverridesErrorMessages {
+  readonly notObject: string;
+  readonly notBoolean: (id: string) => string;
+  readonly unknownIds: (ids: readonly string[]) => string;
+}
 
 // Shape validator + canonicalizer shared by every entry point that
 // takes a "flag id → boolean" map from an untrusted source
@@ -123,14 +131,6 @@ export type FlagOverrides = Partial<Record<FlagId, boolean>>;
 // `flagOverridesField`). Rejects non-object payloads, non-boolean
 // values, and unknown flag ids; returns a copy with keys sorted
 // lexicographically so equal maps round-trip to identical JSON.
-// Error message format is caller-driven so each entry point keeps
-// its canonical operator-facing wording.
-export interface FlagOverridesErrorMessages {
-  readonly notObject: string;
-  readonly notBoolean: (id: string) => string;
-  readonly unknownIds: (ids: readonly string[]) => string;
-}
-
 export const validateFlagOverridesRecord = (value: unknown, msg: FlagOverridesErrorMessages): FlagOverrides => {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error(msg.notObject);

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -187,8 +187,7 @@ export const resolveEffectiveFlags = (
   const effective = new Set<FlagId>();
   for (const layer of layers) {
     if (!layer) continue;
-    for (const [id, on] of Object.entries(layer)) {
-      if (!isKnownFlagId(id)) continue;
+    for (const [id, on] of Object.entries(layer) as [FlagId, boolean][]) {
       if (on) effective.add(id);
       else effective.delete(id);
     }

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -47,6 +47,7 @@ export type {
   Provider,
   ProviderInstance,
   ProviderCallResult,
+  ProviderModule,
   ProviderResponsesResult,
   ProviderStreamResult,
   ResponsesAction,

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -64,10 +64,9 @@ export {
   httpResponseToResponse,
 } from './models-fetch.ts';
 
-export type { Flag, FlagOverrides, OptionalFlagId } from './flags.ts';
+export type { Flag, FlagDefaults, FlagId, FlagOverrides } from './flags.ts';
 export {
   OPTIONAL_FLAGS,
-  defaultsForProvider,
   getFlagCatalog,
   isKnownFlagId,
   parseFlagOverridesWire,

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -76,7 +76,6 @@ export {
 
 export type {
   UpstreamModelConfig,
-  UpstreamModelFlagOverrides,
   UpstreamModelLimits,
   Modality,
   UpstreamChatModelConfig,

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -68,7 +68,6 @@ export {
 export type { Flag, FlagDefaults, FlagId, FlagOverrides } from './flags.ts';
 export {
   OPTIONAL_FLAGS,
-  getFlagCatalog,
   isKnownFlagId,
   parseFlagOverridesWire,
   resolveEffectiveFlags,

--- a/packages/provider/src/invocation_test.ts
+++ b/packages/provider/src/invocation_test.ts
@@ -5,7 +5,7 @@ import { providerModelOf } from './invocation.ts';
 import { assertEquals, assertThrows, stubModelCandidate, stubProvider, stubProviderModel } from '@floway-dev/test-utils';
 
 test('providerModelOf returns the ProviderModel keyed on the candidate provider upstream, verbatim', () => {
-  const providerModel = stubProviderModel({ id: 'gpt-9', enabledFlags: new Set(['flag-a']) });
+  const providerModel = stubProviderModel({ id: 'gpt-9', enabledFlags: new Set(['retry-cyber-policy']) });
   const candidate = stubModelCandidate({
     model: {
       id: 'gpt-9',
@@ -16,7 +16,7 @@ test('providerModelOf returns the ProviderModel keyed on the candidate provider 
   const resolved = providerModelOf(candidate);
 
   assertEquals(resolved, providerModel);
-  assertEquals(resolved.enabledFlags, new Set(['flag-a']));
+  assertEquals(resolved.enabledFlags, new Set(['retry-cyber-policy']));
 });
 
 test('providerModelOf throws when the candidate names an upstream missing from providerModels', () => {

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -29,10 +29,10 @@ export interface UpstreamModelConfig {
   // Layer 3 in resolveEffectiveFlags for a manual row: operator-declared
   // per-model override, applied on top of the upstream default +
   // operator upstream override. Absent / `{}` = no per-model override
-  // (pure inherit). The auto-row counterpart is `ProviderModel.
-  // flagOverridesAuto`, projected onto the wire by
-  // reshapeModelForDashboard — the two are mutually exclusive by row
-  // kind, since a config.models[] entry is always operator-authored.
+  // (pure inherit). The auto-row counterpart is
+  // `ProviderModel.flagOverrides` — same field name, occupies the same
+  // layer-3 slot, but sourced from the provider's per-model rule
+  // rather than an operator-authored config row.
   flagOverrides?: Record<string, boolean>;
 }
 

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -10,11 +10,6 @@ export interface UpstreamModelLimits {
   max_output_tokens?: number;
 }
 
-export interface UpstreamModelFlagOverrides {
-  enabled: boolean;
-  values: Record<string, boolean>;
-}
-
 // The catalog-side name for the wire chat metadata. Shape lives in
 // @floway-dev/protocols/common so PublicModel.chat and the upstream catalog
 // share a single declaration.
@@ -31,7 +26,14 @@ export interface UpstreamModelConfig {
   // Floway-internal (camelCase, not surfaced on PublicModel).
   upstreamModelId: string;
   publicModelId?: string;
-  flagOverrides?: UpstreamModelFlagOverrides;
+  // Layer 3 in resolveEffectiveFlags for a manual row: operator-declared
+  // per-model override, applied on top of the upstream default +
+  // operator upstream override. Absent / `{}` = no per-model override
+  // (pure inherit). The auto-row counterpart is `ProviderModel.
+  // flagOverridesAuto`, projected onto the wire by
+  // reshapeModelForDashboard — the two are mutually exclusive by row
+  // kind, since a config.models[] entry is always operator-authored.
+  flagOverrides?: Record<string, boolean>;
 }
 
 // The public catalog id a model is exposed under: an explicit override when set,
@@ -98,15 +100,13 @@ export const limitsField = (value: unknown, label: string): UpstreamModelLimits 
   };
 };
 
-export const flagOverridesField = (value: unknown, label: string): UpstreamModelFlagOverrides | undefined => {
+export const flagOverridesField = (value: unknown, label: string): Record<string, boolean> | undefined => {
   if (value === undefined) return undefined;
   if (!isRecord(value)) throw new Error(`Malformed ${label}: must be an object`);
-  if (typeof value.enabled !== 'boolean') throw new Error(`Malformed ${label}.enabled: must be a boolean`);
-  if (!isRecord(value.values)) throw new Error(`Malformed ${label}.values: must be an object`);
   const unknown: string[] = [];
   const values: Record<string, boolean> = {};
-  for (const [id, on] of Object.entries(value.values)) {
-    if (typeof on !== 'boolean') throw new Error(`Malformed ${label}.values.${id}: must be a boolean`);
+  for (const [id, on] of Object.entries(value)) {
+    if (typeof on !== 'boolean') throw new Error(`Malformed ${label}.${id}: must be a boolean`);
     if (!isKnownFlagId(id)) {
       unknown.push(id);
       continue;
@@ -114,9 +114,9 @@ export const flagOverridesField = (value: unknown, label: string): UpstreamModel
     values[id] = on;
   }
   if (unknown.length > 0) {
-    throw new Error(`Malformed ${label}.values: unknown flag ids: ${unknown.join(', ')}`);
+    throw new Error(`Malformed ${label}: unknown flag ids: ${unknown.join(', ')}`);
   }
-  return { enabled: value.enabled, values };
+  return values;
 };
 
 const nonNegativeNumberField = (value: unknown, label: string): number => {

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -1,4 +1,4 @@
-import { isKnownFlagId } from './flags.ts';
+import { validateFlagOverridesRecord } from './flags.ts';
 import { BILLING_DIMENSIONS, type BillingDimension, type ChatModelInfo, type ModelEndpointKey, type ModelEndpoints, type ModelKind, type Modality, type ModelPricing } from '@floway-dev/protocols/common';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 
@@ -102,27 +102,11 @@ export const limitsField = (value: unknown, label: string): UpstreamModelLimits 
 
 export const flagOverridesField = (value: unknown, label: string): Record<string, boolean> | undefined => {
   if (value === undefined) return undefined;
-  if (!isRecord(value)) throw new Error(`Malformed ${label}: must be an object`);
-  const unknown: string[] = [];
-  const values: Record<string, boolean> = {};
-  for (const [id, on] of Object.entries(value)) {
-    if (typeof on !== 'boolean') throw new Error(`Malformed ${label}.${id}: must be a boolean`);
-    if (!isKnownFlagId(id)) {
-      unknown.push(id);
-      continue;
-    }
-    values[id] = on;
-  }
-  if (unknown.length > 0) {
-    throw new Error(`Malformed ${label}: unknown flag ids: ${unknown.join(', ')}`);
-  }
-  // Sort keys lexicographically so two rows with the same flag set round-trip
-  // to byte-identical JSON regardless of the caller's insertion order —
-  // matches `parseFlagOverridesWire`'s canonicalization for the sibling
-  // upstream-level `flagOverrides` column.
-  const sorted: Record<string, boolean> = {};
-  for (const id of Object.keys(values).sort()) sorted[id] = values[id];
-  return sorted;
+  return validateFlagOverridesRecord(value, {
+    notObject: `Malformed ${label}: must be an object`,
+    notBoolean: id => `Malformed ${label}.${id}: must be a boolean`,
+    unknownIds: ids => `Malformed ${label}: unknown flag ids: ${ids.join(', ')}`,
+  });
 };
 
 const nonNegativeNumberField = (value: unknown, label: string): number => {

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -1,4 +1,4 @@
-import { validateFlagOverridesRecord } from './flags.ts';
+import { type FlagOverrides, validateFlagOverridesRecord } from './flags.ts';
 import { BILLING_DIMENSIONS, type BillingDimension, type ChatModelInfo, type ModelEndpointKey, type ModelEndpoints, type ModelKind, type Modality, type ModelPricing } from '@floway-dev/protocols/common';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 
@@ -33,7 +33,7 @@ export interface UpstreamModelConfig {
   // `ProviderModel.flagOverrides` — same field name, occupies the same
   // layer-3 slot, but sourced from the provider's per-model rule
   // rather than an operator-authored config row.
-  flagOverrides?: Record<string, boolean>;
+  flagOverrides?: FlagOverrides;
 }
 
 // The public catalog id a model is exposed under: an explicit override when set,
@@ -100,7 +100,7 @@ export const limitsField = (value: unknown, label: string): UpstreamModelLimits 
   };
 };
 
-export const flagOverridesField = (value: unknown, label: string): Record<string, boolean> | undefined => {
+export const flagOverridesField = (value: unknown, label: string): FlagOverrides | undefined => {
   if (value === undefined) return undefined;
   return validateFlagOverridesRecord(value, {
     notObject: `Malformed ${label}: must be an object`,

--- a/packages/provider/src/model-config.ts
+++ b/packages/provider/src/model-config.ts
@@ -116,7 +116,13 @@ export const flagOverridesField = (value: unknown, label: string): Record<string
   if (unknown.length > 0) {
     throw new Error(`Malformed ${label}: unknown flag ids: ${unknown.join(', ')}`);
   }
-  return values;
+  // Sort keys lexicographically so two rows with the same flag set round-trip
+  // to byte-identical JSON regardless of the caller's insertion order —
+  // matches `parseFlagOverridesWire`'s canonicalization for the sibling
+  // upstream-level `flagOverrides` column.
+  const sorted: Record<string, boolean> = {};
+  for (const id of Object.keys(values).sort()) sorted[id] = values[id];
+  return sorted;
 };
 
 const nonNegativeNumberField = (value: unknown, label: string): number => {

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -142,21 +142,21 @@ export interface InternalAliasedFrom {
 export interface ProviderModel extends ModelMetadata {
   providerData?: unknown;
   enabledFlags: ReadonlySet<string>;
-  // Provider's per-model default flag delta relative to its upstream-level
-  // default map, as a sparse override — only entries where the provider's
-  // per-model call differs from the upstream default are present, with
-  // `true`/`false` for on/off. Absent when the provider has no per-model
-  // deviation from its upstream default; when present, the map is non-empty.
-  // Populated only for providers with a per-model rule (Copilot's Claude
-  // < 4.8 demote clause is the current example); other providers leave it
-  // undefined.
+  // Provider's per-model flag call as a sparse override — each entry
+  // states the provider's opinion for that flag on this specific
+  // model, in `true`/`false` on/off form. Absent when the provider
+  // has no per-model call on this model; when present, the map is
+  // non-empty (producers elide empty overlays before emission).
+  // Populated only for providers with a per-model rule (Copilot's
+  // Claude < 4.8 demote clause is the current example); other
+  // providers leave it undefined.
   //
-  // The data plane consumes the already-resolved `enabledFlags` and never
-  // re-layers this. The field exists so the dashboard's auto-row flag view
-  // can render a per-flag pill showing which flags the provider itself
-  // forces on this specific model — reshapeModelForDashboard projects it
-  // onto the wire as the auto-row counterpart to the operator's
-  // `UpstreamModelConfig.flagOverrides`, and the two are mutually
-  // exclusive by row kind.
+  // The data plane consumes the already-resolved `enabledFlags` and
+  // never re-layers this. The field exists so the dashboard's
+  // auto-row flag view can render a per-flag pill showing which flags
+  // the provider itself calls on this specific model —
+  // reshapeModelForDashboard projects it onto the wire as the auto-row
+  // counterpart to the operator's `UpstreamModelConfig.flagOverrides`,
+  // and the two are mutually exclusive by row kind.
   flagOverridesAuto?: FlagOverrides;
 }

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -144,11 +144,11 @@ export interface ProviderModel extends ModelMetadata {
   enabledFlags: ReadonlySet<FlagId>;
   // Provider's per-model flag call as a sparse override — each entry
   // states the provider's opinion for that flag on this specific
-  // model, in `true`/`false` on/off form. Absent when the provider
-  // has no per-model call on this model; when present, the map is
-  // non-empty (producers elide empty overlays before emission).
-  // Populated only for providers with a per-model rule (Copilot's
-  // Claude < 4.8 demote clause is the current example); other
+  // model. Absent when the provider has no per-model call on this
+  // model; when present, the map is non-empty (producers elide empty
+  // overlays before emission). Populated only for providers with a
+  // per-model rule (Copilot's Claude < 4.8 demote clause is the current
+  // example); other
   // providers leave it undefined.
   //
   // The data plane consumes the already-resolved `enabledFlags` and

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -145,18 +145,18 @@ export interface ProviderModel extends ModelMetadata {
   // Provider's per-model default flag delta relative to its upstream-level
   // default map, as a sparse override — only entries where the provider's
   // per-model call differs from the upstream default are present, with
-  // `true`/`false` for on/off. Absent, `undefined`, or `{}` means "no
-  // per-model deviation from the upstream default." Populated only for
-  // providers with a per-model rule (Copilot's Claude < 4.8 demote
-  // clause is the current example); other providers leave it undefined.
+  // `true`/`false` for on/off. Absent when the provider has no per-model
+  // deviation from its upstream default; when present, the map is non-empty.
+  // Populated only for providers with a per-model rule (Copilot's Claude
+  // < 4.8 demote clause is the current example); other providers leave it
+  // undefined.
   //
-  // Mirrors the per-model layer the provider fed into `enabledFlags` at
-  // construction time. The data plane consumes the already-resolved
-  // `enabledFlags` and never re-layers this. The field exists so the
-  // dashboard's auto-row flag view can render a per-flag pill showing
-  // which flags the provider itself forces on this specific model —
-  // reshapeModelForDashboard projects it onto the wire as the auto-row
-  // counterpart to the operator's `UpstreamModelConfig.flagOverrides`,
-  // and the two are mutually exclusive by row kind.
+  // The data plane consumes the already-resolved `enabledFlags` and never
+  // re-layers this. The field exists so the dashboard's auto-row flag view
+  // can render a per-flag pill showing which flags the provider itself
+  // forces on this specific model — reshapeModelForDashboard projects it
+  // onto the wire as the auto-row counterpart to the operator's
+  // `UpstreamModelConfig.flagOverrides`, and the two are mutually
+  // exclusive by row kind.
   flagOverridesAuto?: FlagOverrides;
 }

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -148,8 +148,7 @@ export interface ProviderModel extends ModelMetadata {
   // model; when present, the map is non-empty (producers elide empty
   // overlays before emission). Populated only for providers with a
   // per-model rule (Copilot's Claude < 4.8 demote clause is the current
-  // example); other
-  // providers leave it undefined.
+  // example); other providers leave it undefined.
   //
   // The data plane consumes the already-resolved `enabledFlags` and
   // never re-layers this. The field exists so the dashboard's

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -32,7 +32,7 @@ export interface UpstreamRecord {
   // Runtime state managed by the gateway autonomous flows; null when a
   // provider has no autonomous state.
   state: unknown;
-  flagOverrides: Record<string, boolean>;
+  flagOverrides: FlagOverrides;
   // Public model ids the operator switched off for this upstream. Orthogonal to
   // every per-model metadata field and uniform across provider kinds: a disabled
   // id is hidden from the catalog and unroutable, but its row metadata stays

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -136,7 +136,7 @@ export interface InternalAliasedFrom {
 // per-provider wire carrier — Copilot's raw variant list, Claude Code's dated
 // upstream id, ...), `enabledFlags` (the effective flag set for the model
 // on the emitting upstream, already resolved through every layer), and
-// `flagOverridesAuto` (optional dashboard-only view of the per-model layer
+// `flagOverrides` (optional dashboard-only view of the per-model layer
 // that fed into `enabledFlags`). Providers only ever see their own emission —
 // the surrounding `InternalModel` map is assembled by the registry.
 export interface ProviderModel extends ModelMetadata {
@@ -156,7 +156,9 @@ export interface ProviderModel extends ModelMetadata {
   // auto-row flag view can render a per-flag pill showing which flags
   // the provider itself calls on this specific model —
   // reshapeModelForDashboard projects it onto the wire as the auto-row
-  // counterpart to the operator's `UpstreamModelConfig.flagOverrides`,
-  // and the two are mutually exclusive by row kind.
-  flagOverridesAuto?: FlagOverrides;
+  // counterpart to the operator-authored
+  // `UpstreamModelConfig.flagOverrides` on manual rows. The two
+  // occupy the same layer-3 slot; the source is carried by the
+  // enclosing row type (auto vs manual), not by the field name.
+  flagOverrides?: FlagOverrides;
 }

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -1,4 +1,4 @@
-import type { FlagOverrides } from './flags.ts';
+import type { FlagId, FlagOverrides } from './flags.ts';
 import type { UpstreamChatModelConfig } from './model-config.ts';
 import type { ModelPrefixConfig } from './model-prefix.ts';
 import type { AliasSelection, AliasTarget, ModelKind, ModelEndpoints, ModelPricing } from '@floway-dev/protocols/common';
@@ -141,7 +141,7 @@ export interface InternalAliasedFrom {
 // the surrounding `InternalModel` map is assembled by the registry.
 export interface ProviderModel extends ModelMetadata {
   providerData?: unknown;
-  enabledFlags: ReadonlySet<string>;
+  enabledFlags: ReadonlySet<FlagId>;
   // Provider's per-model flag call as a sparse override — each entry
   // states the provider's opinion for that flag on this specific
   // model, in `true`/`false` on/off form. Absent when the provider

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -1,3 +1,4 @@
+import type { FlagOverrides } from './flags.ts';
 import type { UpstreamChatModelConfig } from './model-config.ts';
 import type { ModelPrefixConfig } from './model-prefix.ts';
 import type { AliasSelection, AliasTarget, ModelKind, ModelEndpoints, ModelPricing } from '@floway-dev/protocols/common';
@@ -133,10 +134,29 @@ export interface InternalAliasedFrom {
 // the shape every provider's `callXxx(model, ...)` takes at dispatch time.
 // Carries the same metadata as `InternalModel` plus `providerData` (the opaque
 // per-provider wire carrier — Copilot's raw variant list, Claude Code's dated
-// upstream id, ...) and `enabledFlags` (the effective flag set for the model
-// on the emitting upstream). Providers only ever see their own emission —
+// upstream id, ...), `enabledFlags` (the effective flag set for the model
+// on the emitting upstream, already resolved through every layer), and
+// `flagOverridesAuto` (optional dashboard-only view of the per-model layer
+// that fed into `enabledFlags`). Providers only ever see their own emission —
 // the surrounding `InternalModel` map is assembled by the registry.
 export interface ProviderModel extends ModelMetadata {
   providerData?: unknown;
   enabledFlags: ReadonlySet<string>;
+  // Provider's per-model default flag delta relative to its upstream-level
+  // default map, as a sparse override — only entries where the provider's
+  // per-model call differs from the upstream default are present, with
+  // `true`/`false` for on/off. Absent, `undefined`, or `{}` means "no
+  // per-model deviation from the upstream default." Populated only for
+  // providers with a per-model rule (Copilot's Claude < 4.8 demote
+  // clause is the current example); other providers leave it undefined.
+  //
+  // Mirrors the per-model layer the provider fed into `enabledFlags` at
+  // construction time. The data plane consumes the already-resolved
+  // `enabledFlags` and never re-layers this. The field exists so the
+  // dashboard's auto-row flag view can render a per-flag pill showing
+  // which flags the provider itself forces on this specific model —
+  // reshapeModelForDashboard projects it onto the wire as the auto-row
+  // counterpart to the operator's `UpstreamModelConfig.flagOverrides`,
+  // and the two are mutually exclusive by row kind.
+  flagOverridesAuto?: FlagOverrides;
 }

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -1,3 +1,4 @@
+import type { FlagDefaults, FlagOverrides } from './flags.ts';
 import type { ModelPrefixConfig } from './model-prefix.ts';
 import type { ProviderModel, UpstreamProviderKind } from './model.ts';
 import type { Fetcher } from './options.ts';
@@ -108,6 +109,21 @@ export interface UpstreamCallOptions {
 }
 
 export interface ProviderInstance {
+  // Provider's declaration of the default value for every flag when this
+  // upstream is created. Exhaustive: `FlagDefaults` is a full record over
+  // every catalog flag, so adding a new flag to the catalog is a type
+  // error until every provider decides its own default. This replaces the
+  // catalog-side `defaultFor` mechanism so vendor-specific knowledge lives
+  // in the provider package that talks to that vendor.
+  defaultFlagsForUpstream(): FlagDefaults;
+  // Per-model deltas on top of `defaultFlagsForUpstream()`. Optional: only
+  // providers whose models legitimately differ (e.g. Copilot routes
+  // different Claude versions to Bedrock vs Vertex, and only Bedrock
+  // accepts inline `role:'system'`) need to implement this. Returns
+  // a partial map: absent keys inherit from the upstream default; explicit
+  // `true`/`false` overrides. Operator overrides on the DB row still layer
+  // on top of the result.
+  defaultFlagsForModel?(model: Omit<ProviderModel, 'enabledFlags'>): FlagOverrides;
   // Catalog refresh fetches a single resource and never enters the per-request
   // latency budget, so it takes the per-upstream fetcher directly instead of
   // the broader `UpstreamCallOptions` bag the data-plane `call*` methods use.

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -1,4 +1,4 @@
-import type { FlagDefaults, FlagOverrides } from './flags.ts';
+import type { FlagDefaults } from './flags.ts';
 import type { ModelPrefixConfig } from './model-prefix.ts';
 import type { ProviderModel, UpstreamProviderKind, UpstreamRecord } from './model.ts';
 import type { Fetcher } from './options.ts';
@@ -142,10 +142,10 @@ export interface ProviderInstance {
 }
 
 // Static, module-shaped surface each provider package exports. The gateway
-// registry keeps a Record<UpstreamProviderKind, ProviderModule> and every
-// kind→X dispatch (instance construction, flag defaults, per-model flag
-// overlay) reads its answer off the same object. Adding a new dispatch
-// slot means a field here, not a parallel per-kind map.
+// registry keeps a Record<UpstreamProviderKind, ProviderModule> so every
+// kind→X dispatch (instance construction, flag defaults) reads its answer
+// off the same object. Adding a new dispatch slot means a field here, not
+// a parallel per-kind map.
 export interface ProviderModule {
   // Instance factory: capture the record and return closures. Sync — any
   // I/O the provider needs (token refresh, state persistence, catalog
@@ -155,14 +155,12 @@ export interface ProviderModule {
   // Exhaustive default map over every catalog flag id for a fresh
   // upstream of this kind. Vendor-specific knowledge lives in the
   // provider package that talks to that vendor; the central catalog only
-  // describes identity, label, and UI copy.
+  // describes identity, label, and UI copy. Per-model deltas — e.g.
+  // Copilot's demote-interleaved-system-to-user on Claude < 4.8, which
+  // Bedrock accepts inline and Vertex does not — are a provider-internal
+  // concern: the provider's `create` computes them once against the raw
+  // model list and stakes the result into `ProviderModel.enabledFlags`,
+  // which the data plane reads directly. No cross-provider generalization
+  // has warranted lifting them into a separate module slot.
   defaultFlags: FlagDefaults;
-  // Per-model deltas on top of `defaultFlags`. Optional: only providers
-  // whose models legitimately differ (e.g. Copilot routes different
-  // Claude versions to Bedrock vs Vertex, and only Bedrock accepts
-  // inline `role:'system'`) need to implement this. Returns a partial
-  // map: absent keys inherit from the upstream default; explicit
-  // true/false overrides. Operator overrides on the DB row still layer
-  // on top of the result.
-  getDefaultFlagsForModel?: (model: Omit<ProviderModel, 'enabledFlags'>) => FlagOverrides;
 }

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -153,8 +153,6 @@ export interface ProviderModule {
   // returned ProviderInstance.
   create: (record: UpstreamRecord) => Provider;
   // Exhaustive default map over every catalog flag id for a fresh
-  // upstream of this kind. Vendor-specific knowledge lives in the
-  // provider package that talks to that vendor; the central catalog only
-  // describes identity, label, and UI copy.
+  // upstream of this kind; see each provider package's `defaults.ts`.
   defaultFlags: FlagDefaults;
 }

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -1,6 +1,6 @@
 import type { FlagDefaults, FlagOverrides } from './flags.ts';
 import type { ModelPrefixConfig } from './model-prefix.ts';
-import type { ProviderModel, UpstreamProviderKind } from './model.ts';
+import type { ProviderModel, UpstreamProviderKind, UpstreamRecord } from './model.ts';
 import type { Fetcher } from './options.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import type { ModelPricing, ProtocolFrame } from '@floway-dev/protocols/common';
@@ -109,21 +109,6 @@ export interface UpstreamCallOptions {
 }
 
 export interface ProviderInstance {
-  // Provider's declaration of the default value for every flag when this
-  // upstream is created. Exhaustive: `FlagDefaults` is a full record over
-  // every catalog flag, so adding a new flag to the catalog is a type
-  // error until every provider decides its own default. Vendor-specific
-  // flag knowledge lives in the provider package that talks to that
-  // vendor.
-  defaultFlagsForUpstream(): FlagDefaults;
-  // Per-model deltas on top of `defaultFlagsForUpstream()`. Optional: only
-  // providers whose models legitimately differ (e.g. Copilot routes
-  // different Claude versions to Bedrock vs Vertex, and only Bedrock
-  // accepts inline `role:'system'`) need to implement this. Returns
-  // a partial map: absent keys inherit from the upstream default; explicit
-  // `true`/`false` overrides. Operator overrides on the DB row still layer
-  // on top of the result.
-  defaultFlagsForModel?(model: Omit<ProviderModel, 'enabledFlags'>): FlagOverrides;
   // Catalog refresh fetches a single resource and never enters the per-request
   // latency budget, so it takes the per-upstream fetcher directly instead of
   // the broader `UpstreamCallOptions` bag the data-plane `call*` methods use.
@@ -154,4 +139,30 @@ export interface ProviderInstance {
   // the upstream-specific model/deployment id). Callers must allocate a
   // fresh FormData per call.
   callImagesEdits(model: ProviderModel, body: FormData, signal: AbortSignal | undefined, opts: UpstreamCallOptions): Promise<ProviderCallResult>;
+}
+
+// Static, module-shaped surface each provider package exports. The gateway
+// registry keeps a Record<UpstreamProviderKind, ProviderModule> and every
+// kind→X dispatch (instance construction, flag defaults, per-model flag
+// overlay) reads its answer off the same object. Adding a new dispatch
+// slot means a field here, not a parallel per-kind map.
+export interface ProviderModule {
+  // Instance factory: capture the record and return closures. Sync — any
+  // I/O the provider needs (token refresh, state persistence, catalog
+  // fetch) happens on demand inside the per-request methods on the
+  // returned ProviderInstance.
+  create: (record: UpstreamRecord) => Provider;
+  // Exhaustive default map over every catalog flag id for a fresh
+  // upstream of this kind. Vendor-specific knowledge lives in the
+  // provider package that talks to that vendor; the central catalog only
+  // describes identity, label, and UI copy.
+  defaultFlags: FlagDefaults;
+  // Per-model deltas on top of `defaultFlags`. Optional: only providers
+  // whose models legitimately differ (e.g. Copilot routes different
+  // Claude versions to Bedrock vs Vertex, and only Bedrock accepts
+  // inline `role:'system'`) need to implement this. Returns a partial
+  // map: absent keys inherit from the upstream default; explicit
+  // true/false overrides. Operator overrides on the DB row still layer
+  // on top of the result.
+  getDefaultFlagsForModel?: (model: Omit<ProviderModel, 'enabledFlags'>) => FlagOverrides;
 }

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -155,12 +155,6 @@ export interface ProviderModule {
   // Exhaustive default map over every catalog flag id for a fresh
   // upstream of this kind. Vendor-specific knowledge lives in the
   // provider package that talks to that vendor; the central catalog only
-  // describes identity, label, and UI copy. Per-model deltas — e.g.
-  // Copilot's demote-interleaved-system-to-user on Claude < 4.8, which
-  // Bedrock accepts inline and Vertex does not — are a provider-internal
-  // concern: the provider's `create` computes them once against the raw
-  // model list and stakes the result into `ProviderModel.enabledFlags`,
-  // which the data plane reads directly. No cross-provider generalization
-  // has warranted lifting them into a separate module slot.
+  // describes identity, label, and UI copy.
   defaultFlags: FlagDefaults;
 }

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -112,9 +112,9 @@ export interface ProviderInstance {
   // Provider's declaration of the default value for every flag when this
   // upstream is created. Exhaustive: `FlagDefaults` is a full record over
   // every catalog flag, so adding a new flag to the catalog is a type
-  // error until every provider decides its own default. This replaces the
-  // catalog-side `defaultFor` mechanism so vendor-specific knowledge lives
-  // in the provider package that talks to that vendor.
+  // error until every provider decides its own default. Vendor-specific
+  // flag knowledge lives in the provider package that talks to that
+  // vendor.
   defaultFlagsForUpstream(): FlagDefaults;
   // Per-model deltas on top of `defaultFlagsForUpstream()`. Optional: only
   // providers whose models legitimately differ (e.g. Copilot routes

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -1,4 +1,4 @@
-import { directFetcher, type InternalModel, type ProviderInstance, type Provider, type ProviderModel, type ModelCandidate, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
+import { directFetcher, type FlagId, type InternalModel, type ProviderInstance, type Provider, type ProviderModel, type ModelCandidate, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
 
 // No-op UpstreamCallOptions factory for tests calling provider methods
 // directly: identity recordUpstreamLatency satisfies the contract without
@@ -24,7 +24,7 @@ export const stubProviderModel = (overrides: Partial<ProviderModel> = {}): Provi
   limits: {},
   kind: 'chat',
   endpoints: { chatCompletions: {}, responses: {}, messages: {} },
-  enabledFlags: new Set<string>(),
+  enabledFlags: new Set<FlagId>(),
   ...overrides,
 });
 
@@ -98,7 +98,7 @@ export const stubProvider = (overrides: Partial<ProviderInstance> = {}): Provide
 export const stubModelCandidate = (overrides: {
   model?: Partial<Omit<InternalModel, 'aliasedFrom' | 'providerModels'>> & { readonly providerModels?: Record<string, ProviderModel> };
   provider?: Provider;
-  enabledFlags?: ReadonlySet<string>;
+  enabledFlags?: ReadonlySet<FlagId>;
   providerData?: unknown;
 } = {}): ModelCandidate => {
   const provider = overrides.provider ?? {
@@ -122,7 +122,7 @@ export const stubModelCandidate = (overrides: {
     limits: outerMeta.limits,
     kind: outerMeta.kind,
     endpoints: outerMeta.endpoints,
-    enabledFlags: overrides.enabledFlags ?? new Set<string>(),
+    enabledFlags: overrides.enabledFlags ?? new Set<FlagId>(),
     ...(overrides.providerData !== undefined ? { providerData: overrides.providerData } : {}),
   });
   return {

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -75,6 +75,21 @@ const autoWrap = <T>(impl: T | undefined): T | undefined => {
 };
 
 export const stubProvider = (overrides: Partial<ProviderInstance> = {}): ProviderInstance => ({
+  defaultFlagsForUpstream: overrides.defaultFlagsForUpstream ?? (() => ({
+    'vendor-deepseek': false,
+    'vendor-qwen': false,
+    'vendor-kimi': false,
+    'retry-cyber-policy': false,
+    'messages-web-search-shim': false,
+    'responses-web-search-shim': false,
+    'responses-image-generation-shim': false,
+    'responses-compact-shim': false,
+    'disable-reasoning-on-forced-tool-choice': false,
+    'demote-interleaved-system-to-user': false,
+    'demote-developer-to-system': false,
+    'strip-billing-attribution': false,
+  })),
+  ...(overrides.defaultFlagsForModel ? { defaultFlagsForModel: overrides.defaultFlagsForModel } : {}),
   getProvidedModels: overrides.getProvidedModels ?? (() => Promise.resolve([])),
   getPricingForModelKey: overrides.getPricingForModelKey ?? (() => null),
   callCompletions: autoWrap(overrides.callCompletions) ?? (() => Promise.reject(new Error('stubProvider.callCompletions was called'))),

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -75,21 +75,6 @@ const autoWrap = <T>(impl: T | undefined): T | undefined => {
 };
 
 export const stubProvider = (overrides: Partial<ProviderInstance> = {}): ProviderInstance => ({
-  defaultFlagsForUpstream: overrides.defaultFlagsForUpstream ?? (() => ({
-    'vendor-deepseek': false,
-    'vendor-qwen': false,
-    'vendor-kimi': false,
-    'retry-cyber-policy': false,
-    'messages-web-search-shim': false,
-    'responses-web-search-shim': false,
-    'responses-image-generation-shim': false,
-    'responses-compact-shim': false,
-    'disable-reasoning-on-forced-tool-choice': false,
-    'demote-interleaved-system-to-user': false,
-    'demote-developer-to-system': false,
-    'strip-billing-attribution': false,
-  })),
-  ...(overrides.defaultFlagsForModel ? { defaultFlagsForModel: overrides.defaultFlagsForModel } : {}),
   getProvidedModels: overrides.getProvidedModels ?? (() => Promise.resolve([])),
   getPricingForModelKey: overrides.getPricingForModelKey ?? (() => null),
   callCompletions: autoWrap(overrides.callCompletions) ?? (() => Promise.reject(new Error('stubProvider.callCompletions was called'))),


### PR DESCRIPTION
## Summary

Pivots per-model flag defaults from a central catalog to per-provider ownership so the flag surface stays consistent whichever provider is emitting a model.

**Flag resolution.** `resolveEffectiveFlags` composes three ordered layers: provider defaults (`ProviderModule.defaultFlags` — one exhaustive `FlagDefaults` map per provider kind), operator upstream override (`UpstreamRecord.flagOverrides`), and a per-model layer. The per-model layer is mutually exclusive by row source: on an **auto** row it is the provider's per-model rule (`ProviderModel.flagOverrides`, populated only by providers that have one — today Copilot for Claude < 4.8); on a **manual** row it is the operator-declared per-model override (`UpstreamModelConfig.flagOverrides`). Placing the per-model layer last lets a provider's technical necessities (e.g. Copilot demoting `role:'system'` on Vertex-routed Claude releases) survive an upstream-wide operator toggle; operators who genuinely want to opt out flip the row to Manual and override there — explicit and visible in the dashboard.

**Copilot's per-model rule.** `defaultFlagsForCopilotModel` returns `{ 'demote-interleaved-system-to-user': true }` for any `claude-*` id whose version tuple is `< 4.8`. The empirical basis is inlined at the callsite: a two-day cron probe (40h / 1150 samples) plus a follow-up sweep on `claude-sonnet-5` — every release at 4.8 or later routes 100% Bedrock (where mid-conversation-system is GA); everything below is a Bedrock/Vertex mix where inline `role:'system'` risks a Vertex-side 400. Sub-family names are treated as opaque — the version tuple is the sole gate — so a future `claude-<newfamily>-<N.M>` routes the same way.

**Wire shape.** `UpstreamModelConfig.flagOverrides` flattens from `{enabled, values}` to `Record<string, boolean>` — `enabled: false` was always semantically equivalent to "no layer-3 override", now spelled by field absence. `FlagOverrides = Partial<Record<FlagId, boolean>>` / `FlagDefaults = Readonly<Record<FlagId, boolean>>` / `FlagId` all export through the new `@floway-dev/provider/flags` subpath and thread as a single strict type through provider → gateway → web. `SerializedUpstreamRecord` grows `flag_defaults` so the dashboard's "Inherit → on/off" pill renders each row without a second round trip. `GET /api/upstreams/flags` drops the retired `defaultFor` field. Data-transfer `EXPORT_VERSION` bumps 6 → 7 so pre-branch dumps are rejected at the version gate before touching data.

**Dashboard.** Model Editor auto rows now render the same `FlagOverridesEditor` the upstream level and manual-model rows use, in read-only mode — the tri-state Inherit / On / Off pills resolve the full three-layer walk with source-preserving colors, so operators can see for each model exactly what a provider will dispatch. Switching an auto row to Manual seeds `flagOverrides` from the provider's per-model rule, so a Copilot Claude < 4.8 row starts with `{ 'demote-interleaved-system-to-user': true }` visible as the operator's editable baseline. Toggling the per-model override off then back on preserves the last-set map.

**Migration.** `0049_flatten_model_flag_overrides.sql` rewrites every `config.models[].flagOverrides` in-place: `{enabled: true, values}` becomes `values`; `{enabled: false, ...}` is dropped. Idempotent — a second run's `EXISTS` gate finds no wrapped shape and no-ops.

**Provider factory.** `ProviderModule.create` is now synchronous — the three OAuth-family providers no longer defer any I/O to construction — and every registry / control-plane callsite drops the stale `await`.

## Test plan

- [x] `pnpm run typecheck` clean (19 / 19 projects)
- [x] `pnpm run lint` clean
- [x] `pnpm run test` passes (326 files / 3830 tests)
- [x] Backend wire: `GET /api/upstreams` returns per-record `flag_defaults` matching each provider kind's map (Copilot retry-cyber-policy on / strip-billing on, Azure retry off, Ollama compact-shim on, …)
- [x] Backend wire: `POST /api/upstreams/list-models` on Copilot stamps `flagOverrides: { 'demote-interleaved-system-to-user': true }` on Claude < 4.8 auto rows (`claude-opus-4-7`, `claude-sonnet-4-5`) and omits the field entirely on Claude >= 4.8 rows (`claude-opus-4-8`, `claude-sonnet-5`)
- [x] Migration 0049 applies cleanly to local D1 and against a prod-imported snapshot (`pnpm run db:migrate`)
- [x] `POST /api/import` with `version: 6` returns 400 `version must be 7 — older export formats are not supported; re-export from the current deployment` before mutating any data
- [x] Data-plane end-to-end: `POST /v1/messages` on Copilot for `claude-opus-4-7` with payload `[user, assistant, system, user]` returns 200 (Bedrock `msg_bdrk_*` id) — the demote interceptor rewrote the inline system to user before dispatch
- [x] Data-plane end-to-end: same payload for `claude-opus-4-8` returns 400 `messages.2: role 'system' must follow a 'user' message…` — demote does not engage, the raw inline system reaches the upstream verbatim
- [ ] Dashboard: on the Copilot upstream, select an auto `claude-opus-4-7` row; Feature Flags block renders the read-only editor with `demote-interleaved-system-to-user` at Inherit-on colour, other flags matching upstream defaults
- [ ] Dashboard: switch a Copilot Claude < 4.8 auto row to Manual; the seeded config carries `flagOverrides: { 'demote-interleaved-system-to-user': true }` and the editor reflects it as an explicit On
- [ ] Dashboard: on a Copilot manual row, toggle the per-model override off then on — the previously set flag choices come back rather than resetting to empty