### PR TITLE
feat(codex): expose quota snapshots by active limit

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -165,6 +165,8 @@ export interface CodexQuotaSnapshot {
   ratelimited_until?: string;
 }
 
+export type CodexQuotaSnapshotMap = Record<string, CodexQuotaSnapshot>;
+
 // Claude Code identity + state shapes. Mirror the redacted projections in
 // packages/gateway/src/control-plane/upstreams/serialize.ts: refreshToken
 // lives in state and surfaces only as the boolean `refreshTokenSet`, and
@@ -302,7 +304,7 @@ export type UpstreamRecord =
   | (UpstreamRecordBase & { kind: 'custom'; config: CustomUpstreamConfig; state: null })
   | (UpstreamRecordBase & { kind: 'azure'; config: AzureUpstreamConfig; state: null })
   | (UpstreamRecordBase & { kind: 'copilot'; config: CopilotUpstreamConfig; state: CopilotUpstreamState | null })
-  | (UpstreamRecordBase & { kind: 'codex'; config: CodexUpstreamConfig; state: CodexUpstreamState | null; codex_quota?: CodexQuotaSnapshot | null })
+  | (UpstreamRecordBase & { kind: 'codex'; config: CodexUpstreamConfig; state: CodexUpstreamState | null; codex_quota?: CodexQuotaSnapshotMap | null })
   | (UpstreamRecordBase & { kind: 'claude-code'; config: ClaudeCodeUpstreamConfig; state: ClaudeCodeUpstreamState | null })
   | (UpstreamRecordBase & { kind: 'ollama'; config: OllamaUpstreamConfig; state: null });
 

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -140,8 +140,9 @@ const accountIdShort = computed(() => {
     <template v-if="quotaEntries.length">
       <div class="space-y-3">
         <section v-for="entry in quotaEntries" :key="entry.key" class="space-y-3 rounded-xl border border-white/[0.06] bg-surface-900/40 p-3">
-          <div class="flex flex-wrap items-center gap-2 text-[11px]">
-            <Badge tone="zinc" size="sm">active limit: {{ entry.label }}</Badge>
+          <div class="flex min-w-0 items-baseline justify-between gap-3">
+            <h4 class="min-w-0 truncate text-sm font-medium text-gray-200" :title="entry.label">{{ entry.label }}</h4>
+            <span class="shrink-0 text-[11px] uppercase tracking-wide text-gray-500">active limit</span>
           </div>
 
           <div class="space-y-3">

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -125,10 +125,10 @@ const accountIdShort = computed(() => {
         <p class="truncate text-sm font-medium text-white">{{ account.email }}</p>
         <div class="flex flex-wrap items-center gap-2 text-xs text-gray-400">
           <Badge tone="violet" size="sm" class="!uppercase tracking-wide">{{ account.planType }}</Badge>
-          <Badge v-if="accountCredits?.credits_balance !== undefined" tone="zinc" size="sm">
+          <Badge v-if="accountCredits?.credits_has_credits === false" tone="rose" size="sm">no credits</Badge>
+          <Badge v-else-if="accountCredits?.credits_balance !== undefined" tone="zinc" size="sm">
             credits: {{ accountCredits.credits_balance }}
           </Badge>
-          <Badge v-if="accountCredits?.credits_has_credits === false" tone="rose" size="sm">no credits</Badge>
           <span class="font-mono text-[11px] text-gray-500" :title="account.chatgptAccountId">{{ accountIdShort }}</span>
         </div>
       </div>

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -73,6 +73,15 @@ const quotaEntries = computed<QuotaEntryView[]>(() => {
     }));
 });
 
+const accountCredits = computed<CodexQuotaSnapshot | null>(() => {
+  const map = quotaMap.value;
+  if (!map) return null;
+  const withCredits = Object.values(map)
+    .filter(q => q.credits_balance !== undefined || q.credits_has_credits !== undefined)
+    .toSorted((a, b) => new Date(b.observed_at).getTime() - new Date(a.observed_at).getTime());
+  return withCredits[0] ?? null;
+});
+
 const badge = computed<{ tone: 'rose' | 'amber' | 'emerald'; label: string; detail?: string }>(() => {
   const c = credential.value;
   if (c?.state === 'session_terminated') {
@@ -116,6 +125,10 @@ const accountIdShort = computed(() => {
         <p class="truncate text-sm font-medium text-white">{{ account.email }}</p>
         <div class="flex flex-wrap items-center gap-2 text-xs text-gray-400">
           <Badge tone="violet" size="sm" class="!uppercase tracking-wide">{{ account.planType }}</Badge>
+          <Badge v-if="accountCredits?.credits_balance !== undefined" tone="zinc" size="sm">
+            credits: {{ accountCredits.credits_balance }}
+          </Badge>
+          <Badge v-if="accountCredits?.credits_has_credits === false" tone="rose" size="sm">no credits</Badge>
           <span class="font-mono text-[11px] text-gray-500" :title="account.chatgptAccountId">{{ accountIdShort }}</span>
         </div>
       </div>
@@ -129,10 +142,6 @@ const accountIdShort = computed(() => {
         <section v-for="entry in quotaEntries" :key="entry.key" class="space-y-3 rounded-xl border border-white/[0.06] bg-surface-900/40 p-3">
           <div class="flex flex-wrap items-center gap-2 text-[11px]">
             <Badge tone="zinc" size="sm">active limit: {{ entry.label }}</Badge>
-            <Badge v-if="entry.quota.credits_balance !== undefined" tone="zinc" size="sm">
-              credits: {{ entry.quota.credits_balance }}
-            </Badge>
-            <Badge v-if="entry.quota.credits_has_credits === false" tone="rose" size="sm">no credits</Badge>
           </div>
 
           <div class="space-y-3">

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -23,6 +23,7 @@ interface QuotaEntryView {
   key: string;
   label: string;
   quota: CodexQuotaSnapshot;
+  rateLimitedUntil: string | null;
   windows: QuotaWindowView[];
 }
 
@@ -57,15 +58,22 @@ const formatPercent = (n: number | undefined): string => {
   return `${Math.max(0, Math.min(100, Math.round(n)))}%`;
 };
 
+const futureTimestamp = (iso: string | undefined, now: number): string | null => {
+  if (typeof iso !== 'string') return null;
+  return new Date(iso).getTime() > now ? iso : null;
+};
+
 const quotaEntries = computed<QuotaEntryView[]>(() => {
   const map = quotaMap.value;
   if (!map) return [];
+  const now = Date.now();
   return Object.entries(map)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, quota]) => ({
       key,
       label: quota.active_limit ?? key,
       quota,
+      rateLimitedUntil: futureTimestamp(quota.ratelimited_until, now),
       windows: [
         { label: 'Primary window', percent: quota.primary_used_percent, resetAt: quota.primary_reset_after_at, windowMinutes: quota.primary_window_minutes },
         { label: 'Secondary window', percent: quota.secondary_used_percent, resetAt: quota.secondary_reset_after_at, windowMinutes: quota.secondary_window_minutes },
@@ -90,10 +98,9 @@ const badge = computed<{ tone: 'rose' | 'amber' | 'emerald'; label: string; deta
   if (c?.state === 'refresh_failed') {
     return { tone: 'rose', label: 'Refresh failed — re-import to recover', detail: c.state_message };
   }
-  const now = Date.now();
   const rateLimitedUntil = quotaEntries.value
-    .map(entry => entry.quota.ratelimited_until)
-    .filter((until): until is string => typeof until === 'string' && new Date(until).getTime() > now)
+    .map(entry => entry.rateLimitedUntil)
+    .filter((until): until is string => until !== null)
     .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
   if (rateLimitedUntil) {
     return { tone: 'rose', label: `Rate-limited until ${formatTimestamp(rateLimitedUntil)}` };
@@ -164,7 +171,7 @@ const accountIdShort = computed(() => {
           </div>
 
           <footer class="flex flex-wrap items-center gap-3 border-t border-white/[0.06] pt-3 text-[11px] text-gray-500">
-            <span v-if="entry.quota.ratelimited_until">rate-limited until {{ formatTimestamp(entry.quota.ratelimited_until) }}</span>
+            <span v-if="entry.rateLimitedUntil">rate-limited until {{ formatTimestamp(entry.rateLimitedUntil) }}</span>
             <span>observed {{ formatTimestamp(entry.quota.observed_at) }}</span>
           </footer>
         </section>

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -4,13 +4,27 @@
 
 import { computed } from 'vue';
 
-import type { CodexAccountCredentialState, CodexAccountIdentity, UpstreamRecord } from '../../api/types.ts';
+import type { CodexAccountCredentialState, CodexAccountIdentity, CodexQuotaSnapshot, UpstreamRecord } from '../../api/types.ts';
 import { providerSwatchClass } from '../upstreams/provider-meta.ts';
 import { Badge, Card } from '@floway-dev/ui';
 
 const props = defineProps<{
   record: UpstreamRecord;
 }>();
+
+interface QuotaWindowView {
+  label: string;
+  percent?: number;
+  resetAt?: string;
+  windowMinutes?: number;
+}
+
+interface QuotaEntryView {
+  key: string;
+  label: string;
+  quota: CodexQuotaSnapshot;
+  windows: QuotaWindowView[];
+}
 
 // Narrow once: this card only renders inside a codex upstream's edit page.
 // Pinning the narrow at the script-setup boundary lets every computed below
@@ -30,7 +44,7 @@ const credential = computed<CodexAccountCredentialState | null>(() => {
   return raw.accounts.find(a => a.chatgptAccountId === account.value.chatgptAccountId) ?? null;
 });
 
-const quota = computed(() => codexRecord.value.codex_quota ?? null);
+const quotaMap = computed(() => codexRecord.value.codex_quota ?? null);
 
 const formatTimestamp = (iso: string): string => {
   const d = new Date(iso);
@@ -43,6 +57,22 @@ const formatPercent = (n: number | undefined): string => {
   return `${Math.max(0, Math.min(100, Math.round(n)))}%`;
 };
 
+const quotaEntries = computed<QuotaEntryView[]>(() => {
+  const map = quotaMap.value;
+  if (!map) return [];
+  return Object.entries(map)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, quota]) => ({
+      key,
+      label: quota.active_limit ?? key,
+      quota,
+      windows: [
+        { label: 'Primary window', percent: quota.primary_used_percent, resetAt: quota.primary_reset_after_at, windowMinutes: quota.primary_window_minutes },
+        { label: 'Secondary window', percent: quota.secondary_used_percent, resetAt: quota.secondary_reset_after_at, windowMinutes: quota.secondary_window_minutes },
+      ],
+    }));
+});
+
 const badge = computed<{ tone: 'rose' | 'amber' | 'emerald'; label: string; detail?: string }>(() => {
   const c = credential.value;
   if (c?.state === 'session_terminated') {
@@ -51,11 +81,16 @@ const badge = computed<{ tone: 'rose' | 'amber' | 'emerald'; label: string; deta
   if (c?.state === 'refresh_failed') {
     return { tone: 'rose', label: 'Refresh failed — re-import to recover', detail: c.state_message };
   }
-  const until = quota.value?.ratelimited_until;
-  if (until && new Date(until).getTime() > Date.now()) {
-    return { tone: 'rose', label: `Rate-limited until ${formatTimestamp(until)}` };
+  const now = Date.now();
+  const rateLimitedUntil = quotaEntries.value
+    .map(entry => entry.quota.ratelimited_until)
+    .filter((until): until is string => typeof until === 'string' && new Date(until).getTime() > now)
+    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
+  if (rateLimitedUntil) {
+    return { tone: 'rose', label: `Rate-limited until ${formatTimestamp(rateLimitedUntil)}` };
   }
-  const usages = [quota.value?.primary_used_percent, quota.value?.secondary_used_percent]
+  const usages = quotaEntries.value
+    .flatMap(entry => [entry.quota.primary_used_percent, entry.quota.secondary_used_percent])
     .filter((v): v is number => typeof v === 'number');
   const heaviest = usages.length ? Math.max(...usages) : null;
   if (heaviest !== null && heaviest >= 80) {
@@ -68,15 +103,6 @@ const accountIdShort = computed(() => {
   const id = account.value.chatgptAccountId;
   if (id.length <= 18) return id;
   return `${id.slice(0, 8)}…${id.slice(-6)}`;
-});
-
-const windows = computed(() => {
-  const q = quota.value;
-  if (!q) return [];
-  return [
-    { label: 'Primary window', percent: q.primary_used_percent, resetAt: q.primary_reset_after_at, windowMinutes: q.primary_window_minutes },
-    { label: 'Secondary window', percent: q.secondary_used_percent, resetAt: q.secondary_reset_after_at, windowMinutes: q.secondary_window_minutes },
-  ];
 });
 </script>
 
@@ -98,39 +124,47 @@ const windows = computed(() => {
 
     <p v-if="badge.detail" class="text-xs text-gray-500">{{ badge.detail }}</p>
 
-    <template v-if="quota">
+    <template v-if="quotaEntries.length">
       <div class="space-y-3">
-        <div v-for="w in windows" :key="w.label" class="space-y-1">
-          <div class="flex items-baseline justify-between text-xs">
-            <span class="text-gray-300">{{ w.label }}</span>
-            <span class="text-gray-500">
-              {{ formatPercent(w.percent) }}<template v-if="w.windowMinutes"> · {{ w.windowMinutes }} min window</template>
-            </span>
+        <section v-for="entry in quotaEntries" :key="entry.key" class="space-y-3 rounded-xl border border-white/[0.06] bg-surface-900/40 p-3">
+          <div class="flex flex-wrap items-center gap-2 text-[11px]">
+            <Badge tone="zinc" size="sm">active limit: {{ entry.label }}</Badge>
+            <Badge v-if="entry.quota.credits_balance !== undefined" tone="zinc" size="sm">
+              credits: {{ entry.quota.credits_balance }}
+            </Badge>
+            <Badge v-if="entry.quota.credits_has_credits === false" tone="rose" size="sm">no credits</Badge>
           </div>
-          <div class="h-1.5 overflow-hidden rounded-full bg-surface-700">
-            <div
-              class="h-full bg-accent-violet transition-[width]"
-              :style="{ width: `${Math.max(0, Math.min(100, Math.round(w.percent ?? 0)))}%` }"
-            />
+
+          <div class="space-y-3">
+            <div v-for="w in entry.windows" :key="`${entry.key}:${w.label}`" class="space-y-1">
+              <div class="flex items-baseline justify-between text-xs">
+                <span class="text-gray-300">{{ w.label }}</span>
+                <span class="text-gray-500">
+                  {{ formatPercent(w.percent) }}<template v-if="w.windowMinutes"> · {{ w.windowMinutes }} min window</template>
+                </span>
+              </div>
+              <div class="h-1.5 overflow-hidden rounded-full bg-surface-700">
+                <div
+                  class="h-full bg-accent-violet transition-[width]"
+                  :style="{ width: `${Math.max(0, Math.min(100, Math.round(w.percent ?? 0)))}%` }"
+                />
+              </div>
+              <p v-if="w.resetAt" class="text-[11px] text-gray-500">Resets at {{ formatTimestamp(w.resetAt) }}</p>
+            </div>
           </div>
-          <p v-if="w.resetAt" class="text-[11px] text-gray-500">Resets at {{ formatTimestamp(w.resetAt) }}</p>
-        </div>
+
+          <footer class="flex flex-wrap items-center gap-3 border-t border-white/[0.06] pt-3 text-[11px] text-gray-500">
+            <span v-if="entry.quota.ratelimited_until">rate-limited until {{ formatTimestamp(entry.quota.ratelimited_until) }}</span>
+            <span>observed {{ formatTimestamp(entry.quota.observed_at) }}</span>
+          </footer>
+        </section>
       </div>
 
-      <div class="flex flex-wrap items-center gap-2 text-[11px]">
-        <Badge v-if="quota.active_limit" tone="zinc" size="sm">active limit: {{ quota.active_limit }}</Badge>
-        <Badge v-if="quota.credits_balance !== undefined" tone="zinc" size="sm">
-          credits: {{ quota.credits_balance }}
-        </Badge>
-        <Badge v-if="quota.credits_has_credits === false" tone="rose" size="sm">no credits</Badge>
-      </div>
-
-      <footer class="flex flex-wrap items-center gap-3 border-t border-white/[0.06] pt-3 text-[11px] text-gray-500">
-        <span v-if="credential?.state_updated_at">state updated {{ formatTimestamp(credential.state_updated_at) }}</span>
-        <span>observed {{ formatTimestamp(quota.observed_at) }}</span>
+      <footer v-if="credential?.state_updated_at" class="border-t border-white/[0.06] pt-3 text-[11px] text-gray-500">
+        state updated {{ formatTimestamp(credential.state_updated_at) }}
       </footer>
     </template>
 
-    <p v-else class="text-xs text-gray-500">No quota snapshot yet. Make a Codex call to populate.</p>
+    <p v-else class="text-xs text-gray-500">No quota snapshots yet. Make Codex calls to populate.</p>
   </Card>
 </template>

--- a/apps/web/src/components/upstream-edit/CodexAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/CodexAccountCard.vue
@@ -84,10 +84,17 @@ const quotaEntries = computed<QuotaEntryView[]>(() => {
 const accountCredits = computed<CodexQuotaSnapshot | null>(() => {
   const map = quotaMap.value;
   if (!map) return null;
-  const withCredits = Object.values(map)
-    .filter(q => q.credits_balance !== undefined || q.credits_has_credits !== undefined)
-    .toSorted((a, b) => new Date(b.observed_at).getTime() - new Date(a.observed_at).getTime());
-  return withCredits[0] ?? null;
+  let newest: CodexQuotaSnapshot | null = null;
+  let newestObservedAt = Number.NEGATIVE_INFINITY;
+  for (const quota of Object.values(map)) {
+    if (quota.credits_balance === undefined && quota.credits_has_credits === undefined) continue;
+    const observedAt = new Date(quota.observed_at).getTime();
+    if (observedAt > newestObservedAt) {
+      newest = quota;
+      newestObservedAt = observedAt;
+    }
+  }
+  return newest;
 });
 
 const badge = computed<{ tone: 'rose' | 'amber' | 'emerald'; label: string; detail?: string }>(() => {

--- a/packages/gateway/migrations/0048_codex_quota_snapshot_active_limit_map.sql
+++ b/packages/gateway/migrations/0048_codex_quota_snapshot_active_limit_map.sql
@@ -1,0 +1,33 @@
+-- Rebucket Codex quota snapshots written before active-limit bucketing landed.
+-- Old rows store one snapshot directly at accounts[0].quotaSnapshot:
+--   { "data": { "active_limit": "premium", ... }, "fetchedAt": 123 }
+--
+-- The current state contract stores snapshots keyed by active limit:
+--   { "premium": { "data": { "active_limit": "premium", ... }, "fetchedAt": 123 } }
+--
+-- Keep this as a data migration rather than a runtime legacy shape. The
+-- provider state validator accepts only the current map form.
+
+UPDATE upstreams
+SET state_json = json_set(
+  state_json,
+  '$.accounts[0].quotaSnapshot',
+  json_object(
+    CASE
+      WHEN json_type(state_json, '$.accounts[0].quotaSnapshot.data.active_limit') = 'text'
+        AND trim(json_extract(state_json, '$.accounts[0].quotaSnapshot.data.active_limit')) <> ''
+        AND trim(json_extract(state_json, '$.accounts[0].quotaSnapshot.data.active_limit')) NOT IN ('__proto__', 'constructor', 'prototype')
+      THEN trim(json_extract(state_json, '$.accounts[0].quotaSnapshot.data.active_limit'))
+      ELSE 'unknown'
+    END,
+    json_object(
+      'data', json(json_extract(state_json, '$.accounts[0].quotaSnapshot.data')),
+      'fetchedAt', json_extract(state_json, '$.accounts[0].quotaSnapshot.fetchedAt')
+    )
+  )
+)
+WHERE provider = 'codex'
+  AND state_json IS NOT NULL
+  AND json_type(state_json, '$.accounts[0].quotaSnapshot') = 'object'
+  AND json_type(state_json, '$.accounts[0].quotaSnapshot.fetchedAt') IN ('integer', 'real')
+  AND json_type(state_json, '$.accounts[0].quotaSnapshot.data') = 'object';

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -46,7 +46,7 @@ import {
   refreshClaudeCodeAccessToken,
 } from '@floway-dev/provider-claude-code';
 import {
-  type CodexQuotaSnapshot,
+  type CodexQuotaSnapshotMap,
   type CodexUpstreamConfig,
   type CodexUpstreamState,
   CODEX_AUTHORIZE_URL,
@@ -65,13 +65,13 @@ import { clearInProcessCopilotTokenCache, exchangeCopilotToken, readCopilotUpstr
 import { assertCustomUpstreamRecord, fetchCustomModels } from '@floway-dev/provider-custom';
 import { assertOllamaUpstreamRecord, createOllamaProvider } from '@floway-dev/provider-ollama';
 
-// Serialize for the HTTP response, attaching the live codex_quota snapshot
+// Serialize for the HTTP response, attaching the live codex_quota snapshot map
 // when the row is a Codex upstream and the SWR models-cache freshness for
 // every row. Keeps serialize.ts free of provider I/O and a global repo handle,
 // while ensuring every response shape carries the panels the dashboard
 // expects.
 const serializeForResponse = async (record: UpstreamRecord): Promise<SerializedUpstreamRecord> => {
-  let codexQuotaPromise: Promise<CodexQuotaSnapshot | null> | null = null;
+  let codexQuotaPromise: Promise<CodexQuotaSnapshotMap | null> | null = null;
   if (record.kind === 'codex') {
     assertCodexUpstreamRecord(record);
     codexQuotaPromise = getCodexQuota(record.id, record.config.accounts[0].chatgptAccountId);

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -1,5 +1,5 @@
 import type { ModelPrefixConfig, ProxyFallbackEntry, UpstreamProviderKind, UpstreamRecord } from '@floway-dev/provider';
-import type { CodexQuotaSnapshot } from '@floway-dev/provider-codex';
+import type { CodexQuotaSnapshotMap } from '@floway-dev/provider-codex';
 
 export interface ModelsCacheStatus {
   fetchedAt: number | null;
@@ -25,7 +25,7 @@ export interface SerializedUpstreamRecord {
   // warmed.
   modelsCache?: ModelsCacheStatus;
   // Present only for kind === 'codex'.
-  codex_quota?: CodexQuotaSnapshot | null;
+  codex_quota?: CodexQuotaSnapshotMap | null;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/gateway/src/repo/upstreams_test.ts
+++ b/packages/gateway/src/repo/upstreams_test.ts
@@ -646,6 +646,132 @@ test('migration 0047 backfills openaiDeviceId on legacy Codex rows and leaves po
   }
 });
 
+test('migration 0048 rebuckets legacy Codex quota snapshots by active limit', async () => {
+  const db = await createMigratedSqlJsDatabase();
+  try {
+    for (const filename of [...migrationSqlByFilename.keys()].filter(f => f >= '0010_unified_upstreams.sql' && f < '0048_codex_quota_snapshot_active_limit_map.sql').toSorted()) {
+      applySqlJsFile(db, filename);
+    }
+
+    db.run(`INSERT INTO upstreams (id, provider, name, enabled, sort_order, created_at, updated_at, config_json, state_json, flag_overrides, disabled_public_model_ids, proxy_fallback_list_json)
+            VALUES
+              ('up_codex_premium', 'codex', 'Codex Premium', 1, 0, '2026-06-05T00:00:00.000Z', '2026-06-05T00:00:00.000Z',
+                json_object('accounts', json_array(json_object('email', 'a@b.com', 'chatgptAccountId', 'acc-premium', 'chatgptUserId', 'usr', 'planType', 'plus'))),
+                json_object('accounts', json_array(json_object(
+                  'accessToken', NULL,
+                  'chatgptAccountId', 'acc-premium',
+                  'openaiDeviceId', '11111111-2222-4333-8444-555555555555',
+                  'quotaSnapshot', json_object(
+                    'data', json_object('active_limit', 'premium', 'observed_at', '2026-06-05T00:00:00.000Z', 'primary_used_percent', 42),
+                    'fetchedAt', 1700000000000
+                  ),
+                  'refresh_token', 'rt',
+                  'state', 'active',
+                  'state_updated_at', '2026-06-05T00:00:00.000Z'
+                ))),
+                '[]', '[]', '[]'),
+              ('up_codex_missing_limit', 'codex', 'Codex Missing Limit', 1, 1, '2026-06-05T00:00:00.000Z', '2026-06-05T00:00:00.000Z',
+                json_object('accounts', json_array(json_object('email', 'a@b.com', 'chatgptAccountId', 'acc-missing', 'chatgptUserId', 'usr', 'planType', 'plus'))),
+                json_object('accounts', json_array(json_object(
+                  'accessToken', NULL,
+                  'chatgptAccountId', 'acc-missing',
+                  'openaiDeviceId', '22222222-3333-4444-8555-666666666666',
+                  'quotaSnapshot', json_object(
+                    'data', json_object('observed_at', '2026-06-05T01:00:00.000Z'),
+                    'fetchedAt', 1700000001000
+                  ),
+                  'refresh_token', 'rt',
+                  'state', 'active',
+                  'state_updated_at', '2026-06-05T00:00:00.000Z'
+                ))),
+                '[]', '[]', '[]'),
+              ('up_codex_unsafe_limit', 'codex', 'Codex Unsafe Limit', 1, 2, '2026-06-05T00:00:00.000Z', '2026-06-05T00:00:00.000Z',
+                json_object('accounts', json_array(json_object('email', 'a@b.com', 'chatgptAccountId', 'acc-unsafe', 'chatgptUserId', 'usr', 'planType', 'plus'))),
+                json_object('accounts', json_array(json_object(
+                  'accessToken', NULL,
+                  'chatgptAccountId', 'acc-unsafe',
+                  'openaiDeviceId', '33333333-4444-4555-8666-777777777777',
+                  'quotaSnapshot', json_object(
+                    'data', json_object('active_limit', 'constructor', 'observed_at', '2026-06-05T02:00:00.000Z'),
+                    'fetchedAt', 1700000002000
+                  ),
+                  'refresh_token', 'rt',
+                  'state', 'active',
+                  'state_updated_at', '2026-06-05T00:00:00.000Z'
+                ))),
+                '[]', '[]', '[]'),
+              ('up_codex_map', 'codex', 'Codex Map', 1, 3, '2026-06-05T00:00:00.000Z', '2026-06-05T00:00:00.000Z',
+                json_object('accounts', json_array(json_object('email', 'a@b.com', 'chatgptAccountId', 'acc-map', 'chatgptUserId', 'usr', 'planType', 'plus'))),
+                json_object('accounts', json_array(json_object(
+                  'accessToken', NULL,
+                  'chatgptAccountId', 'acc-map',
+                  'openaiDeviceId', '44444444-5555-4666-8777-888888888888',
+                  'quotaSnapshot', json_object(
+                    'premium', json_object('data', json_object('active_limit', 'premium', 'observed_at', '2026-06-05T03:00:00.000Z'), 'fetchedAt', 1700000003000)
+                  ),
+                  'refresh_token', 'rt',
+                  'state', 'active',
+                  'state_updated_at', '2026-06-05T00:00:00.000Z'
+                ))),
+                '[]', '[]', '[]'),
+              ('up_custom', 'custom', 'Custom', 1, 4, '2026-06-05T00:00:00.000Z', '2026-06-05T00:00:00.000Z',
+                json_object('baseUrl', 'https://a.example/v1', 'apiKey', 'k', 'authStyle', 'bearer'),
+                json_object('accounts', json_array(json_object('quotaSnapshot', json_object('data', json_object('active_limit', 'premium'), 'fetchedAt', 1)))),
+                '[]', '[]', '[]')`);
+
+    applySqlJsFile(db, '0048_codex_quota_snapshot_active_limit_map.sql');
+
+    const rows = sqlJsRows<{ id: string; stateJson: string; snapshot: string }>(
+      db,
+      `SELECT
+        id,
+        state_json AS stateJson,
+        json_extract(state_json, '$.accounts[0].quotaSnapshot') AS snapshot
+       FROM upstreams
+       ORDER BY id`,
+    );
+    const snapshotFor = (id: string): unknown => JSON.parse(rows.find(r => r.id === id)!.snapshot);
+
+    assertEquals(snapshotFor('up_codex_premium'), {
+      premium: {
+        data: { active_limit: 'premium', observed_at: '2026-06-05T00:00:00.000Z', primary_used_percent: 42 },
+        fetchedAt: 1700000000000,
+      },
+    });
+    assertEquals(rows.find(r => r.id === 'up_codex_premium')!.stateJson, JSON.stringify({
+      accounts: [{
+        accessToken: null,
+        chatgptAccountId: 'acc-premium',
+        openaiDeviceId: '11111111-2222-4333-8444-555555555555',
+        quotaSnapshot: {
+          premium: {
+            data: { active_limit: 'premium', observed_at: '2026-06-05T00:00:00.000Z', primary_used_percent: 42 },
+            fetchedAt: 1700000000000,
+          },
+        },
+        refresh_token: 'rt',
+        state: 'active',
+        state_updated_at: '2026-06-05T00:00:00.000Z',
+      }],
+    }));
+    assertEquals(snapshotFor('up_codex_missing_limit'), {
+      unknown: { data: { observed_at: '2026-06-05T01:00:00.000Z' }, fetchedAt: 1700000001000 },
+    });
+    assertEquals(snapshotFor('up_codex_unsafe_limit'), {
+      unknown: { data: { active_limit: 'constructor', observed_at: '2026-06-05T02:00:00.000Z' }, fetchedAt: 1700000002000 },
+    });
+    assertEquals(snapshotFor('up_codex_map'), {
+      premium: { data: { active_limit: 'premium', observed_at: '2026-06-05T03:00:00.000Z' }, fetchedAt: 1700000003000 },
+    });
+    assertEquals(snapshotFor('up_custom'), {
+      data: { active_limit: 'premium' },
+      fetchedAt: 1,
+    });
+  } finally {
+    db.close();
+  }
+});
+
 type FakeUpstreamRow = {
   id: string;
   provider: string;

--- a/packages/gateway/src/repo/upstreams_test.ts
+++ b/packages/gateway/src/repo/upstreams_test.ts
@@ -646,7 +646,7 @@ test('migration 0047 backfills openaiDeviceId on legacy Codex rows and leaves po
   }
 });
 
-test('migration 0048 rebuckets legacy Codex quota snapshots by active limit', async () => {
+test('migration 0048 rebuckets Codex quota snapshots by active limit', async () => {
   const db = await createMigratedSqlJsDatabase();
   try {
     for (const filename of [...migrationSqlByFilename.keys()].filter(f => f >= '0010_unified_upstreams.sql' && f < '0048_codex_quota_snapshot_active_limit_map.sql').toSorted()) {
@@ -661,10 +661,12 @@ test('migration 0048 rebuckets legacy Codex quota snapshots by active limit', as
                   'accessToken', NULL,
                   'chatgptAccountId', 'acc-premium',
                   'openaiDeviceId', '11111111-2222-4333-8444-555555555555',
-                  'quotaSnapshot', json_object(
-                    'data', json_object('active_limit', 'premium', 'observed_at', '2026-06-05T00:00:00.000Z', 'primary_used_percent', 42),
-                    'fetchedAt', 1700000000000
-                  ),
+                  'quotaSnapshot', json_extract(json_object(
+                    'premium', json_object(
+                      'data', json_object('active_limit', 'premium', 'observed_at', '2026-06-05T00:00:00.000Z', 'primary_used_percent', 42),
+                      'fetchedAt', 1700000000000
+                    )
+                  ), '$.premium'),
                   'refresh_token', 'rt',
                   'state', 'active',
                   'state_updated_at', '2026-06-05T00:00:00.000Z'
@@ -676,10 +678,12 @@ test('migration 0048 rebuckets legacy Codex quota snapshots by active limit', as
                   'accessToken', NULL,
                   'chatgptAccountId', 'acc-missing',
                   'openaiDeviceId', '22222222-3333-4444-8555-666666666666',
-                  'quotaSnapshot', json_object(
-                    'data', json_object('observed_at', '2026-06-05T01:00:00.000Z'),
-                    'fetchedAt', 1700000001000
-                  ),
+                  'quotaSnapshot', json_extract(json_object(
+                    'unknown', json_object(
+                      'data', json_object('observed_at', '2026-06-05T01:00:00.000Z'),
+                      'fetchedAt', 1700000001000
+                    )
+                  ), '$.unknown'),
                   'refresh_token', 'rt',
                   'state', 'active',
                   'state_updated_at', '2026-06-05T00:00:00.000Z'
@@ -691,10 +695,12 @@ test('migration 0048 rebuckets legacy Codex quota snapshots by active limit', as
                   'accessToken', NULL,
                   'chatgptAccountId', 'acc-unsafe',
                   'openaiDeviceId', '33333333-4444-4555-8666-777777777777',
-                  'quotaSnapshot', json_object(
-                    'data', json_object('active_limit', 'constructor', 'observed_at', '2026-06-05T02:00:00.000Z'),
-                    'fetchedAt', 1700000002000
-                  ),
+                  'quotaSnapshot', json_extract(json_object(
+                    'unknown', json_object(
+                      'data', json_object('active_limit', 'constructor', 'observed_at', '2026-06-05T02:00:00.000Z'),
+                      'fetchedAt', 1700000002000
+                    )
+                  ), '$.unknown'),
                   'refresh_token', 'rt',
                   'state', 'active',
                   'state_updated_at', '2026-06-05T00:00:00.000Z'
@@ -716,7 +722,7 @@ test('migration 0048 rebuckets legacy Codex quota snapshots by active limit', as
                 '[]', '[]', '[]'),
               ('up_custom', 'custom', 'Custom', 1, 4, '2026-06-05T00:00:00.000Z', '2026-06-05T00:00:00.000Z',
                 json_object('baseUrl', 'https://a.example/v1', 'apiKey', 'k', 'authStyle', 'bearer'),
-                json_object('accounts', json_array(json_object('quotaSnapshot', json_object('data', json_object('active_limit', 'premium'), 'fetchedAt', 1)))),
+                json_object('accounts', json_array(json_object('quotaSnapshot', json_object('premium', json_object('data', json_object('active_limit', 'premium'), 'fetchedAt', 1))))),
                 '[]', '[]', '[]')`);
 
     applySqlJsFile(db, '0048_codex_quota_snapshot_active_limit_map.sql');
@@ -764,8 +770,7 @@ test('migration 0048 rebuckets legacy Codex quota snapshots by active limit', as
       premium: { data: { active_limit: 'premium', observed_at: '2026-06-05T03:00:00.000Z' }, fetchedAt: 1700000003000 },
     });
     assertEquals(snapshotFor('up_custom'), {
-      data: { active_limit: 'premium' },
-      fetchedAt: 1,
+      premium: { data: { active_limit: 'premium' }, fetchedAt: 1 },
     });
   } finally {
     db.close();

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -9,8 +9,6 @@ import {
 } from './constants.ts';
 import { sha256Uuid } from './ids.ts';
 import {
-  getCodexQuota,
-  isCodexRateLimited,
   parseCodexQuotaHeaders,
   putCodexQuota,
 } from './quota.ts';
@@ -76,17 +74,6 @@ const prepareCodexCall = async (opts: CodexBackendCallBase): Promise<{ ok: true;
 
   if (opts.account.state !== 'active') {
     return { ok: false, response: await wrapSynthetic(synthetic503(`Codex upstream is ${opts.account.state}`)) };
-  }
-
-  const now = new Date();
-  const quotaSnapshot = await getCodexQuota(opts.upstreamId, opts.account.chatgptAccountId);
-  if (isCodexRateLimited(quotaSnapshot, now)) {
-    return {
-      ok: false,
-      response: await wrapSynthetic(
-        synthetic429(`Codex upstream rate-limited until ${quotaSnapshot!.ratelimited_until!}`, quotaSnapshot!.ratelimited_until!, now),
-      ),
-    };
   }
 
   try {
@@ -497,14 +484,6 @@ const synthetic503 = (message: string): Response => new Response(JSON.stringify(
   status: 503,
   headers: { 'content-type': 'application/json' },
 });
-
-const synthetic429 = (message: string, retryAtIso: string, now: Date): Response => {
-  const retryAfterSeconds = Math.max(0, Math.ceil((new Date(retryAtIso).getTime() - now.getTime()) / 1000));
-  return new Response(JSON.stringify({ error: { type: 'codex_rate_limited', message, retry_at: retryAtIso } }), {
-    status: 429,
-    headers: { 'content-type': 'application/json', 'retry-after': String(retryAfterSeconds) },
-  });
-};
 
 // Codex backend serves SSE without setting `content-type: text/event-stream`
 // (observed in production: only x-codex-* + standard CDN headers come back).

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from './constants.ts';
 import { callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from './fetch.ts';
-import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotEntry, CodexUpstreamState } from './state.ts';
+import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotMapEntry, CodexUpstreamState } from './state.ts';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
 import { initProviderRepo, type Fetcher, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
@@ -51,7 +51,7 @@ const seedAccountState = (overrides: Partial<CodexAccountCredential>): void => {
   currentRecord = makeRecord({ accounts: [{ ...activeAccount, ...overrides }] });
 };
 
-const readQuotaEntry = (): CodexQuotaSnapshotEntry | null =>
+const readQuotaEntry = (): CodexQuotaSnapshotMapEntry | null =>
   (currentRecord.state as CodexUpstreamState).accounts[0].quotaSnapshot;
 
 // putCodexQuota fires-and-forgets via .catch(() => {}); yield to the task
@@ -109,24 +109,23 @@ describe('callCodexResponses — gates', () => {
       expect(await result.response.text()).toMatch(/session_terminated/);
     }
   });
-
-  test('refuses while rate-limited window is open', async () => {
-    vi.useFakeTimers().setSystemTime(new Date('2026-06-05T00:30:00.000Z'));
+  test('continues to upstream when a cached rate-limited quota snapshot is still open', async () => {
     seedAccountState({
+      accessToken: farFutureAccessToken,
       quotaSnapshot: {
-        fetchedAt: new Date('2026-06-05T00:00:00.000Z').getTime(),
-        data: { observed_at: '2026-06-05T00:00:00.000Z', ratelimited_until: '2026-06-05T01:00:00.000Z' },
+        premium: {
+          fetchedAt: new Date('2026-06-05T00:00:00.000Z').getTime(),
+          data: { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'premium', ratelimited_until: '2026-06-05T01:00:00.000Z' },
+        },
       },
     });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
     const result = await callCodexResponses({
       upstreamId, account: activeAccount,
       model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.response.status).toBe(429);
-      expect(result.response.headers.get('retry-after')).toBeTruthy();
-    }
+    expect(result.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -182,8 +181,8 @@ describe('callCodexResponses — upstream classification', () => {
     expect(result.ok).toBe(true);
     await flushMicrotasks();
     const stored = readQuotaEntry();
-    expect(stored?.data.primary_used_percent).toBe(42);
-    expect(stored?.data.ratelimited_until).toBeUndefined();
+    expect(stored?.premium.data.primary_used_percent).toBe(42);
+    expect(stored?.premium.data.ratelimited_until).toBeUndefined();
   });
 
   test('upstream body has store:false and stream:true forced even if caller passes otherwise', async () => {
@@ -665,6 +664,7 @@ describe('callCodexResponses — upstream classification', () => {
   test('429 → quota with ratelimited_until, return upstream 429', async () => {
     seedFreshAccessToken();
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorJson(429, { error: { type: 'usage_limit_reached', message: 'cap reached', resets_in_seconds: 7200 } }, {
+      'x-codex-active-limit': 'premium',
       'x-codex-primary-reset-after-seconds': '3600',
       'x-codex-secondary-reset-after-seconds': '7200',
     }));
@@ -676,7 +676,7 @@ describe('callCodexResponses — upstream classification', () => {
     if (!result.ok) expect(result.response.status).toBe(429);
     await flushMicrotasks();
     const stored = readQuotaEntry();
-    expect(stored?.data.ratelimited_until).toBeTruthy();
+    expect(stored?.premium.data.ratelimited_until).toBeTruthy();
   });
 
   test('5xx passes through without touching state', async () => {
@@ -773,20 +773,23 @@ describe('callCodexResponses — recorder contract', () => {
     expect(recorder.durationMs()).toBeGreaterThanOrEqual(0);
   });
 
-  test('rate-limited gate satisfies an enforcing recorder once', async () => {
-    vi.useFakeTimers().setSystemTime(new Date('2026-06-05T00:30:00.000Z'));
+  test('cached rate-limited quota does not synthetic-return before the upstream fetch', async () => {
     seedAccountState({
+      accessToken: farFutureAccessToken,
       quotaSnapshot: {
-        fetchedAt: new Date('2026-06-05T00:00:00.000Z').getTime(),
-        data: { observed_at: '2026-06-05T00:00:00.000Z', ratelimited_until: '2026-06-05T01:00:00.000Z' },
+        premium: {
+          fetchedAt: new Date('2026-06-05T00:00:00.000Z').getTime(),
+          data: { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'premium', ratelimited_until: '2026-06-05T01:00:00.000Z' },
+        },
       },
     });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
     const recorder = enforcingRecorder();
     const result = await callCodexResponses({
       upstreamId, account: activeAccount,
       model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: recorder.options,
     });
-    expect(result.ok).toBe(false);
+    expect(result.ok).toBe(true);
     expect(recorder.invocations()).toBe(1);
     expect(() => recorder.durationMs()).not.toThrow();
   });
@@ -921,6 +924,7 @@ describe('callCodexResponsesCompact', () => {
   test('429 → quota with ratelimited_until, return upstream 429', async () => {
     seedFreshAccessToken();
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorJson(429, { error: { type: 'usage_limit_reached', message: 'cap reached' } }, {
+      'x-codex-active-limit': 'premium',
       'x-codex-primary-reset-after-seconds': '3600',
       'x-codex-secondary-reset-after-seconds': '7200',
     }));
@@ -932,7 +936,7 @@ describe('callCodexResponsesCompact', () => {
     if (!result.ok) expect(result.response.status).toBe(429);
     await flushMicrotasks();
     const stored = readQuotaEntry();
-    expect(stored?.data.ratelimited_until).toBeTruthy();
+    expect(stored?.premium.data.ratelimited_until).toBeTruthy();
   });
 
   test('5xx passes through verbatim without touching state', async () => {

--- a/packages/provider-codex/src/quota.ts
+++ b/packages/provider-codex/src/quota.ts
@@ -1,4 +1,4 @@
-import { readCodexUpstreamState, type CodexQuotaSnapshotEntry, type CodexUpstreamState } from './state.ts';
+import { readCodexUpstreamState, type CodexQuotaSnapshotMapEntry, type CodexUpstreamState } from './state.ts';
 import { getProviderRepo } from '@floway-dev/provider';
 
 export interface CodexQuotaSnapshot {
@@ -20,6 +20,17 @@ export interface CodexQuotaSnapshot {
   // Present only when this snapshot was written as a result of a 429.
   ratelimited_until?: string;
 }
+
+export type CodexQuotaSnapshotMap = Record<string, CodexQuotaSnapshot>;
+
+export const CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT = 'unknown';
+
+const isUnsafeActiveLimitKey = (key: string): boolean => key === '__proto__' || key === 'constructor' || key === 'prototype';
+
+export const codexQuotaActiveLimitKey = (snapshot: CodexQuotaSnapshot): string => {
+  const key = snapshot.active_limit?.trim();
+  return key && !isUnsafeActiveLimitKey(key) ? key : CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT;
+};
 
 const TTL_FLOOR_MS = 24 * 60 * 60 * 1000;
 
@@ -96,29 +107,32 @@ const findAccountIndex = (state: CodexUpstreamState, accountId: string): number 
 const replaceAccountQuota = (
   state: CodexUpstreamState,
   index: number,
-  entry: CodexQuotaSnapshotEntry,
+  quotaSnapshot: CodexQuotaSnapshotMapEntry,
 ): CodexUpstreamState => ({
   ...state,
-  accounts: state.accounts.map((account, i) => (i === index ? { ...account, quotaSnapshot: entry } : account)),
+  accounts: state.accounts.map((account, i) => (i === index ? { ...account, quotaSnapshot } : account)),
 });
 
-// Returns the most recent snapshot when still within its computed TTL.
-// Stale snapshots read as null — the next upstream response will overwrite
-// them. state_json is unbounded, so freshness is gated inline by
+// Returns all fresh quota snapshots keyed by active limit. Stale buckets read as
+// absent — the next upstream response for that active limit will overwrite it.
+// state_json is unbounded, so freshness is gated inline by
 // computeCodexQuotaTtlMs.
 export const getCodexQuota = async (
   upstreamId: string,
   accountId: string,
-): Promise<CodexQuotaSnapshot | null> => {
+): Promise<CodexQuotaSnapshotMap | null> => {
   const fresh = await getProviderRepo().upstreams.getById(upstreamId);
   if (!fresh) return null;
   const state = readCodexUpstreamState(fresh.state);
   const account = state.accounts.find(a => a.chatgptAccountId === accountId);
   if (!account?.quotaSnapshot) return null;
   const now = new Date();
-  const ttlMs = computeCodexQuotaTtlMs(account.quotaSnapshot.data, now);
-  if (now.getTime() - account.quotaSnapshot.fetchedAt > ttlMs) return null;
-  return account.quotaSnapshot.data;
+  const freshSnapshots: CodexQuotaSnapshotMap = {};
+  for (const [key, entry] of Object.entries(account.quotaSnapshot)) {
+    const ttlMs = computeCodexQuotaTtlMs(entry.data, now);
+    if (now.getTime() - entry.fetchedAt <= ttlMs) freshSnapshots[key] = entry.data;
+  }
+  return Object.keys(freshSnapshots).length ? freshSnapshots : null;
 };
 
 export const putCodexQuota = async (
@@ -131,11 +145,8 @@ export const putCodexQuota = async (
   const state = readCodexUpstreamState(fresh.state);
   const idx = findAccountIndex(state, accountId);
   if (idx < 0) throw new Error(`putCodexQuota: Codex account ${accountId} not found in upstream ${upstreamId}`);
-  const next = replaceAccountQuota(state, idx, { fetchedAt: Date.now(), data: snapshot });
+  const currentQuota = state.accounts[idx].quotaSnapshot ?? {};
+  const nextQuota = { ...currentQuota, [codexQuotaActiveLimitKey(snapshot)]: { fetchedAt: Date.now(), data: snapshot } };
+  const next = replaceAccountQuota(state, idx, nextQuota);
   await getProviderRepo().upstreams.saveState(upstreamId, next, { expectedState: fresh.state });
-};
-
-export const isCodexRateLimited = (snapshot: CodexQuotaSnapshot | null, now: Date): boolean => {
-  if (!snapshot?.ratelimited_until) return false;
-  return new Date(snapshot.ratelimited_until).getTime() > now.getTime();
 };

--- a/packages/provider-codex/src/quota.ts
+++ b/packages/provider-codex/src/quota.ts
@@ -45,7 +45,9 @@ export const parseCodexQuotaHeaders = (headers: Headers, options: ParseCodexQuot
 
   const setString = (key: keyof CodexQuotaSnapshot, header: string): void => {
     const v = headers.get(header);
-    if (v !== null) assign[key] = v;
+    if (v === null) return;
+    const trimmed = v.trim();
+    if (trimmed !== '') assign[key] = trimmed;
   };
   const setNumber = (key: keyof CodexQuotaSnapshot, header: string): void => {
     const v = headers.get(header);

--- a/packages/provider-codex/src/quota_test.ts
+++ b/packages/provider-codex/src/quota_test.ts
@@ -100,10 +100,13 @@ describe('parseCodexQuotaHeaders', () => {
     expect(snapshot.ratelimited_until).toBe('2026-06-05T02:00:00.000Z');
   });
 
-  test('survives missing optional headers', () => {
+  test('normalizes string headers at the provider boundary', () => {
     const observedAt = new Date('2026-06-05T00:00:00.000Z');
-    const snapshot = parseCodexQuotaHeaders(new Headers({}), { now: observedAt, isRateLimited: false });
-    expect(snapshot).toEqual({ observed_at: '2026-06-05T00:00:00.000Z' });
+    const snapshot = parseCodexQuotaHeaders(new Headers({
+      'x-codex-active-limit': '  premium  ',
+      'x-codex-plan-type': '   ',
+    }), { now: observedAt, isRateLimited: false });
+    expect(snapshot).toEqual({ observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'premium' });
   });
 });
 

--- a/packages/provider-codex/src/quota_test.ts
+++ b/packages/provider-codex/src/quota_test.ts
@@ -1,14 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT,
+  codexQuotaActiveLimitKey,
   computeCodexQuotaTtlMs,
   getCodexQuota,
-  isCodexRateLimited,
   parseCodexQuotaHeaders,
   putCodexQuota,
   type CodexQuotaSnapshot,
 } from './quota.ts';
-import type { CodexQuotaSnapshotEntry, CodexUpstreamState } from './state.ts';
+import type { CodexQuotaSnapshotMapEntry, CodexUpstreamState } from './state.ts';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 
 const accountId = 'acc_1';
@@ -37,7 +38,7 @@ const baseAccount = {
   state_updated_at: '2026-06-01T00:00:00.000Z',
   openaiDeviceId: '11111111-2222-4333-8444-555555555555',
   accessToken: null,
-  quotaSnapshot: null as CodexQuotaSnapshotEntry | null,
+  quotaSnapshot: null as CodexQuotaSnapshotMapEntry | null,
 };
 
 let current: UpstreamRecord | null;
@@ -106,6 +107,18 @@ describe('parseCodexQuotaHeaders', () => {
   });
 });
 
+describe('codexQuotaActiveLimitKey', () => {
+  test('uses the active_limit when present', () => {
+    expect(codexQuotaActiveLimitKey({ observed_at: 'now', active_limit: 'codex_bengalfox' })).toBe('codex_bengalfox');
+  });
+
+  test('falls back to unknown when the active_limit is missing or blank', () => {
+    expect(codexQuotaActiveLimitKey({ observed_at: 'now' })).toBe(CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT);
+    expect(codexQuotaActiveLimitKey({ observed_at: 'now', active_limit: '   ' })).toBe(CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT);
+    expect(codexQuotaActiveLimitKey({ observed_at: 'now', active_limit: 'constructor' })).toBe(CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT);
+  });
+});
+
 describe('getCodexQuota', () => {
   test('returns null when the upstream row is missing', async () => {
     current = null;
@@ -116,17 +129,32 @@ describe('getCodexQuota', () => {
     expect(await getCodexQuota(upstreamId, accountId)).toBeNull();
   });
 
-  test('returns the snapshot data when fresh', async () => {
-    const snap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', primary_used_percent: 10 };
-    current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: { fetchedAt: Date.now(), data: snap } }] });
-    expect(await getCodexQuota(upstreamId, accountId)).toEqual(snap);
+  test('returns the quota map when buckets are fresh', async () => {
+    const snap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'premium', primary_used_percent: 10 };
+    current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: { premium: { fetchedAt: Date.now(), data: snap } } }] });
+    expect(await getCodexQuota(upstreamId, accountId)).toEqual({ premium: snap });
   });
 
-  test('returns null when the snapshot is past its TTL window', async () => {
+  test('returns null when every bucket is past its TTL window', async () => {
     const snap: CodexQuotaSnapshot = { observed_at: '2026-06-01T00:00:00.000Z' };
     const fetchedAt = Date.now() - 2 * 24 * 60 * 60 * 1000;
-    current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: { fetchedAt, data: snap } }] });
+    current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: { premium: { fetchedAt, data: snap } } }] });
     expect(await getCodexQuota(upstreamId, accountId)).toBeNull();
+  });
+
+  test('filters stale buckets independently', async () => {
+    const freshSnap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'fresh' };
+    const staleSnap: CodexQuotaSnapshot = { observed_at: '2026-06-01T00:00:00.000Z', active_limit: 'stale' };
+    current = makeRecord({
+      accounts: [{
+        ...baseAccount,
+        quotaSnapshot: {
+          fresh: { fetchedAt: Date.now(), data: freshSnap },
+          stale: { fetchedAt: Date.now() - 2 * 24 * 60 * 60 * 1000, data: staleSnap },
+        },
+      }],
+    });
+    expect(await getCodexQuota(upstreamId, accountId)).toEqual({ fresh: freshSnap });
   });
 
   test('returns null when the requested account is not in the pool', async () => {
@@ -135,16 +163,40 @@ describe('getCodexQuota', () => {
 });
 
 describe('putCodexQuota', () => {
-  test('persists the snapshot into the account slot via saveState', async () => {
-    const snap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', primary_used_percent: 42 };
+  test('persists the snapshot under its active limit via saveState', async () => {
+    const snap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'premium', primary_used_percent: 42 };
     await putCodexQuota(upstreamId, accountId, snap);
     expect(saveStateSpy).toHaveBeenCalledTimes(1);
     const [id, nextState, opts] = saveStateSpy.mock.calls[0];
     expect(id).toBe(upstreamId);
     const written = (nextState as CodexUpstreamState).accounts[0].quotaSnapshot;
-    expect(written?.data).toEqual(snap);
-    expect(typeof written?.fetchedAt).toBe('number');
+    expect(written?.premium?.data).toEqual(snap);
+    expect(typeof written?.premium?.fetchedAt).toBe('number');
     expect(opts.expectedState).toEqual({ accounts: [{ ...baseAccount }] });
+  });
+
+  test('preserves other active-limit buckets and replaces the matching bucket', async () => {
+    const premium: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'premium', primary_used_percent: 10 };
+    current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: { premium: { fetchedAt: 1, data: premium } } }] });
+    const bengalfox: CodexQuotaSnapshot = { observed_at: '2026-06-05T01:00:00.000Z', active_limit: 'codex_bengalfox', primary_used_percent: 20 };
+    await putCodexQuota(upstreamId, accountId, bengalfox);
+    let written = (current!.state as CodexUpstreamState).accounts[0].quotaSnapshot;
+    expect(written?.premium.data).toEqual(premium);
+    expect(written?.codex_bengalfox.data).toEqual(bengalfox);
+
+    const nextPremium: CodexQuotaSnapshot = { observed_at: '2026-06-05T02:00:00.000Z', active_limit: 'premium', primary_used_percent: 30 };
+    await putCodexQuota(upstreamId, accountId, nextPremium);
+    written = (current!.state as CodexUpstreamState).accounts[0].quotaSnapshot;
+    expect(Object.keys(written ?? {}).sort()).toEqual(['codex_bengalfox', 'premium']);
+    expect(written?.premium.data).toEqual(nextPremium);
+    expect(written?.codex_bengalfox.data).toEqual(bengalfox);
+  });
+
+  test('uses the unknown key when active_limit is absent', async () => {
+    const snap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', primary_used_percent: 42 };
+    await putCodexQuota(upstreamId, accountId, snap);
+    const written = (current!.state as CodexUpstreamState).accounts[0].quotaSnapshot;
+    expect(written?.unknown.data).toEqual(snap);
   });
 
   test('throws when the upstream disappeared mid-flight', async () => {
@@ -172,20 +224,5 @@ describe('computeCodexQuotaTtlMs', () => {
       primary_reset_after_at: '2026-06-08T00:00:00.000Z',
     };
     expect(computeCodexQuotaTtlMs(snap, now)).toBe(3 * 24 * 60 * 60 * 1000);
-  });
-});
-
-describe('isCodexRateLimited', () => {
-  test('true when ratelimited_until is in the future', () => {
-    expect(isCodexRateLimited({ observed_at: 'x', ratelimited_until: '2026-06-05T01:00:00.000Z' }, new Date('2026-06-05T00:00:00.000Z'))).toBe(true);
-  });
-  test('false when reset time has passed', () => {
-    expect(isCodexRateLimited({ observed_at: 'x', ratelimited_until: '2026-06-05T00:00:00.000Z' }, new Date('2026-06-05T01:00:00.000Z'))).toBe(false);
-  });
-  test('false when ratelimited_until absent', () => {
-    expect(isCodexRateLimited({ observed_at: 'x' }, new Date())).toBe(false);
-  });
-  test('false for null snapshot', () => {
-    expect(isCodexRateLimited(null, new Date())).toBe(false);
   });
 });

--- a/packages/provider-codex/src/state.ts
+++ b/packages/provider-codex/src/state.ts
@@ -18,11 +18,13 @@ export interface CodexAccessTokenEntry {
 
 // Most recent quota observation derived from upstream response headers.
 // `fetchedAt` is unix ms; `data` is the parsed snapshot, validated by quota.ts
-// at the boundary where it's read for dashboard display / rate-limit checks.
+// at the boundary where it's read for dashboard display.
 export interface CodexQuotaSnapshotEntry {
   fetchedAt: number;
   data: CodexQuotaSnapshot;
 }
+
+export type CodexQuotaSnapshotMapEntry = Record<string, CodexQuotaSnapshotEntry>;
 
 // One account's autonomous credential state, joined back to its identity in
 // CodexUpstreamConfig.accounts via `chatgptAccountId`.
@@ -50,7 +52,7 @@ export interface CodexAccountCredential {
   // normalizes absent → `null` on a shallow copy, so consumers can rely on
   // the typed `null` slot here.
   accessToken: CodexAccessTokenEntry | null;
-  quotaSnapshot: CodexQuotaSnapshotEntry | null;
+  quotaSnapshot: CodexQuotaSnapshotMapEntry | null;
 }
 
 // Account-pool state. v1 always carries exactly one entry; the asserter
@@ -128,6 +130,21 @@ const assertCodexQuotaSnapshotEntry = (value: unknown, where: string): void => {
   }
 };
 
+const isUnsafeMapKey = (key: string): boolean => key === '' || key === '__proto__' || key === 'constructor' || key === 'prototype';
+
+const assertCodexQuotaSnapshotMapEntry = (value: unknown, where: string): void => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(`${where} must be a plain object`);
+  }
+  const obj = value as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (isUnsafeMapKey(key)) {
+      throw new TypeError(`${where} has invalid active limit key '${key}'`);
+    }
+    assertCodexQuotaSnapshotEntry(obj[key], `${where}.${key}`);
+  }
+};
+
 const assertCodexAccountCredential = (value: unknown, where: string): void => {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new TypeError(`${where} must be a plain object`);
@@ -167,7 +184,7 @@ const assertCodexAccountCredential = (value: unknown, where: string): void => {
     assertCodexAccessTokenEntry(obj.accessToken, `${where}.accessToken`);
   }
   if (obj.quotaSnapshot !== undefined && obj.quotaSnapshot !== null) {
-    assertCodexQuotaSnapshotEntry(obj.quotaSnapshot, `${where}.quotaSnapshot`);
+    assertCodexQuotaSnapshotMapEntry(obj.quotaSnapshot, `${where}.quotaSnapshot`);
   }
 };
 

--- a/packages/provider-codex/src/state_test.ts
+++ b/packages/provider-codex/src/state_test.ts
@@ -77,19 +77,31 @@ describe('assertCodexUpstreamState', () => {
   test('accepts quotaSnapshot absent / null / populated', () => {
     expect(() => assertCodexUpstreamState({ accounts: [{ ...goodAccount, quotaSnapshot: null }] })).not.toThrow();
     expect(() => assertCodexUpstreamState({
-      accounts: [{ ...goodAccount, quotaSnapshot: { fetchedAt: 1_700_000_000_000, data: { observed_at: '2026-06-05T00:00:00Z' } } }],
+      accounts: [{
+        ...goodAccount,
+        quotaSnapshot: { premium: { fetchedAt: 1_700_000_000_000, data: { observed_at: '2026-06-05T00:00:00Z' } } },
+      }],
     })).not.toThrow();
   });
   test('rejects malformed quotaSnapshot', () => {
     expect(() => assertCodexUpstreamState({
-      accounts: [{ ...goodAccount, quotaSnapshot: { fetchedAt: 'soon', data: {} } }],
+      accounts: [{ ...goodAccount, quotaSnapshot: { premium: { fetchedAt: 'soon', data: {} } } }],
     })).toThrow(/fetchedAt/);
     expect(() => assertCodexUpstreamState({
-      accounts: [{ ...goodAccount, quotaSnapshot: { fetchedAt: 1, data: 'oops' } }],
+      accounts: [{ ...goodAccount, quotaSnapshot: { premium: { fetchedAt: 1, data: 'oops' } } }],
     })).toThrow(/data/);
     expect(() => assertCodexUpstreamState({
-      accounts: [{ ...goodAccount, quotaSnapshot: { fetchedAt: 1, data: {}, extra: 1 } }],
+      accounts: [{ ...goodAccount, quotaSnapshot: { premium: { fetchedAt: 1, data: {}, extra: 1 } } }],
     })).toThrow(/extra/);
+    expect(() => assertCodexUpstreamState({
+      accounts: [{ ...goodAccount, quotaSnapshot: { premium: 123 } }],
+    })).toThrow(/premium/);
+    expect(() => assertCodexUpstreamState({
+      accounts: [{ ...goodAccount, quotaSnapshot: { '': { fetchedAt: 1, data: {} } } }],
+    })).toThrow(/invalid active limit key/);
+    expect(() => assertCodexUpstreamState({
+      accounts: [{ ...goodAccount, quotaSnapshot: { constructor: { fetchedAt: 1, data: {} } } }],
+    })).toThrow(/invalid active limit key/);
   });
 
   test('rejects missing / empty openaiDeviceId', () => {
@@ -112,7 +124,7 @@ describe('readCodexUpstreamState', () => {
       accounts: [{
         ...goodAccount,
         accessToken: { token: 'at', expiresAt: 1_700_000_000_000, refreshedAt: '2026-06-05T00:00:00Z' },
-        quotaSnapshot: { fetchedAt: 1_700_000_000_000, data: { observed_at: '2026-06-05T00:00:00Z' } },
+        quotaSnapshot: { premium: { fetchedAt: 1_700_000_000_000, data: { observed_at: '2026-06-05T00:00:00Z' } } },
       }],
     };
     const out = readCodexUpstreamState(populated);


### PR DESCRIPTION
## Summary

Codex can return different `x-codex-active-limit` values for different routed model families. Previously Floway stored and exposed only one Codex quota snapshot per account, so a later response for one active limit overwrote the window usage observed for another.

This PR changes the control-plane upstream response consumed by the dashboard from one Codex quota snapshot to an `active_limit` keyed map:

```json
{
  "codex_quota": {
    "premium": {
      "observed_at": "...",
      "active_limit": "premium",
      "primary_used_percent": 42,
      "primary_window_minutes": 300
    },
    "codex_bengalfox": {
      "observed_at": "...",
      "active_limit": "codex_bengalfox",
      "primary_used_percent": 8,
      "primary_window_minutes": 300
    }
  }
}
```

The dashboard now renders one quota section per active limit, so operators can see each window independently.

## Changes

- Change Codex persisted quota state from a single snapshot entry to a map of:
  - `active_limit -> { fetchedAt, data }`
- Change the control-plane `codex_quota` response from one snapshot to:
  - `Record<string, CodexQuotaSnapshot>`
- Add migration `0048_codex_quota_snapshot_active_limit_map.sql` to rebucket existing stored snapshots.
- Normalize Codex quota string headers at the provider boundary:
  - trim string values
  - omit blank values
  - bucket missing/blank/unsafe active limits under `unknown`
- Update the Codex account card to:
  - render each active-limit bucket separately
  - show account-level credits from the newest quota snapshot carrying credits fields
  - hide expired `ratelimited_until` footer text
  - avoid `Array.prototype.toSorted()` for broader browser compatibility
- Keep the no-synthetic-Codex-429 behavior:
  - cached rate-limit snapshots are still stored and displayed
  - Floway no longer preemptively returns synthetic 429s from cached Codex quota state

## Notes / known tradeoff

`putCodexQuota` remains a best-effort background state write using the existing optimistic `saveState(..., { expectedState })` path.

That means two concurrent Codex responses for the same account but different active limits can race:

1. both read the same previous quota map,
2. each adds its own active-limit bucket,
3. one CAS write wins,
4. the other may return `updated: false` and its bucket can be missed for that response.

This does not affect request routing or upstream response behavior. The missing bucket should be repopulated by the next request that observes that active limit, and Codex calls are frequent enough that I left retry/merge-on-CAS-failure out of this PR to keep the change smaller.