### PR TITLE
fix(web): remove inline Spinner from Buttons that already have :loading

### DIFF
--- a/apps/web/src/components/keys/EditKeyDialog.vue
+++ b/apps/web/src/components/keys/EditKeyDialog.vue
@@ -8,7 +8,7 @@ import type { UpstreamOption } from '../../composables/useUpstreamOptions.ts';
 import { useAuthStore } from '../../stores/auth.ts';
 import { parseDuration } from '../../utils/parseDuration.ts';
 import UpstreamPicker, { type UpstreamPickerValue } from '../upstreams/UpstreamPicker.vue';
-import { Button, Dialog, Input, Select, Spinner } from '@floway-dev/ui';
+import { Button, Dialog, Input, Select } from '@floway-dev/ui';
 
 const open = defineModel<boolean>('open');
 
@@ -184,7 +184,6 @@ const save = async () => {
       <footer class="flex items-center justify-end gap-2">
         <Button variant="secondary" :disabled="saving" @click="open = false">Cancel</Button>
         <Button :loading="saving" @click="save">
-          <Spinner v-if="saving" class="size-3.5" />
           Save changes
         </Button>
       </footer>

--- a/apps/web/src/components/upstream-edit/ClaudeCodeAccountCard.vue
+++ b/apps/web/src/components/upstream-edit/ClaudeCodeAccountCard.vue
@@ -18,7 +18,7 @@ import { computed } from 'vue';
 import type { ClaudeCodeAccountCredentialSummary, ClaudeCodeAccountIdentity, ClaudeCodeQuotaWindow, UpstreamRecord } from '../../api/types.ts';
 import { formatClaudeCodeSubscriptionType } from '../../lib/claude-code-format.ts';
 import { providerSwatchClass } from '../upstreams/provider-meta.ts';
-import { Badge, Button, Spinner } from '@floway-dev/ui';
+import { Badge, Button } from '@floway-dev/ui';
 
 type ClaudeCodeUpstreamRecord = Extract<UpstreamRecord, { kind: 'claude-code' }>;
 
@@ -285,8 +285,7 @@ const probeFetchedAtIso = computed<string | null>(() => {
       <p v-if="!hasAnyWindow" class="text-xs text-gray-500">No quota snapshot yet. Click Refresh to call <code class="font-mono text-[11px]">/api/oauth/usage</code> or wait for the next Claude Code call to populate headers.</p>
       <p v-else class="text-[11px] uppercase tracking-wide text-gray-500">Rate-limit windows</p>
       <Button size="sm" variant="secondary" :loading="probing" :disabled="probing" @click="emit('refresh-quota')">
-        <Spinner v-if="probing" class="size-3.5" />
-        <i v-else class="i-lucide-refresh-cw size-3.5" />
+        <i v-if="!probing" class="i-lucide-refresh-cw size-3.5" />
         Refresh quota
       </Button>
     </div>

--- a/apps/web/src/components/upstream-edit/ClaudeCodeConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/ClaudeCodeConfigPanel.vue
@@ -7,7 +7,7 @@ import ClaudeCodeImportTabs from './ClaudeCodeImportTabs.vue';
 import { callApi, useApi } from '../../api/client.ts';
 import type { ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 import { clearPkce, deriveChallenge, generatePkce, parseCallbackPaste, peekStashedPkce, pkceStorageKey, recallPkce, stashPkce } from '../../lib/pkce.ts';
-import { Button, Spinner } from '@floway-dev/ui';
+import { Button } from '@floway-dev/ui';
 
 type ClaudeCodeUpstreamRecord = Extract<UpstreamRecord, { kind: 'claude-code' }>;
 
@@ -253,8 +253,7 @@ const refreshQuotaNow = async () => {
       <ClaudeCodeAccountCard :record="record" :probing="probing" @refresh-quota="refreshQuotaNow" />
       <div class="flex flex-wrap items-center gap-2">
         <Button v-if="refreshable" :loading="refreshing" @click="refreshTokenNow">
-          <Spinner v-if="refreshing" class="size-3.5" />
-          <i v-else class="i-lucide-refresh-cw size-3.5" />
+          <i v-if="!refreshing" class="i-lucide-refresh-cw size-3.5" />
           Refresh token now
         </Button>
         <Button variant="secondary" @click="reimportOpen = !reimportOpen">
@@ -286,7 +285,6 @@ const refreshQuotaNow = async () => {
       />
       <div class="flex justify-end">
         <Button :loading="submitting" @click="submit">
-          <Spinner v-if="submitting" class="size-3.5" />
           {{ mode === 'create' ? 'Import' : 'Re-import' }}
         </Button>
       </div>

--- a/apps/web/src/components/upstream-edit/CodexConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CodexConfigPanel.vue
@@ -7,7 +7,7 @@ import CodexImportTabs from './CodexImportTabs.vue';
 import { callApi, useApi } from '../../api/client.ts';
 import type { ProxyFallbackEntry, UpstreamRecord } from '../../api/types.ts';
 import { clearPkce, deriveChallenge, generatePkce, parseCallbackPaste, peekStashedPkce, pkceStorageKey, recallPkce, stashPkce } from '../../lib/pkce.ts';
-import { Button, Spinner } from '@floway-dev/ui';
+import { Button } from '@floway-dev/ui';
 
 type CodexUpstreamRecord = Extract<UpstreamRecord, { kind: 'codex' }>;
 
@@ -154,8 +154,7 @@ const refreshTokenNow = async () => {
       <CodexAccountCard :record="record" />
       <div class="flex flex-wrap items-center gap-2">
         <Button :loading="refreshing" @click="refreshTokenNow">
-          <Spinner v-if="refreshing" class="size-3.5" />
-          <i v-else class="i-lucide-refresh-cw size-3.5" />
+          <i v-if="!refreshing" class="i-lucide-refresh-cw size-3.5" />
           Refresh token now
         </Button>
         <Button variant="secondary" @click="reimportOpen = !reimportOpen">
@@ -183,7 +182,6 @@ const refreshTokenNow = async () => {
       <p v-if="pkceError" class="text-xs text-accent-rose">{{ pkceError }}</p>
       <div class="flex justify-end">
         <Button :loading="submitting" @click="submit">
-          <Spinner v-if="submitting" class="size-3.5" />
           {{ mode === 'create' ? 'Import' : 'Re-import' }}
         </Button>
       </div>

--- a/apps/web/src/components/users/UserDialog.vue
+++ b/apps/web/src/components/users/UserDialog.vue
@@ -6,7 +6,7 @@ import { callApi, useApi } from '../../api/client.ts';
 import type { UpstreamOption } from '../../composables/useUpstreamOptions.ts';
 import SecretInput from '../shared/SecretInput.vue';
 import UpstreamPicker, { type UpstreamPickerValue } from '../upstreams/UpstreamPicker.vue';
-import { Button, Dialog, Input, Spinner, Switch } from '@floway-dev/ui';
+import { Button, Dialog, Input, Switch } from '@floway-dev/ui';
 
 const open = defineModel<boolean>('open');
 
@@ -164,7 +164,6 @@ const submit = async () => {
       <footer class="flex items-center justify-end gap-2">
         <Button variant="secondary" type="button" :disabled="saving" @click="open = false">Cancel</Button>
         <Button :loading="saving" type="submit">
-          <Spinner v-if="saving" class="size-3.5" />
           {{ mode === 'create' ? 'Create user' : 'Save changes' }}
         </Button>
       </footer>


### PR DESCRIPTION
## Summary

The shared `Button` component in `packages/ui/src/Button.vue` already renders a `<Spinner>` when the `loading` prop is truthy. Seven call sites in `apps/web` also inserted their own `<Spinner v-if="X">` (or a `<Spinner>`/`<i>` toggle) inside the slot with the same predicate as `:loading`, so clicking those buttons showed two spinning icons side by side while the request was in flight.

This PR removes the redundant inline `<Spinner>` from each of those call sites. For the "refresh" variants that swap an icon for a spinner, it keeps the leading `<i>` icon and only renders it when *not* loading — Button's built-in Spinner already covers the loading state.

Affected components:

- `users/UserDialog.vue` — Create user / Save changes
- `keys/EditKeyDialog.vue` — Save changes
- `upstream-edit/ClaudeCodeAccountCard.vue` — Refresh quota
- `upstream-edit/ClaudeCodeConfigPanel.vue` — Refresh token now / Import / Re-import
- `upstream-edit/CodexConfigPanel.vue` — Refresh token now / Import / Re-import

## Test plan

- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] Verified visually in Chrome DevTools: with `fetch` artificially delayed to hold the loading state, `Save changes` in `UserDialog` now renders exactly one `.animate-spin` element (previously two).