### PR TITLE
fix(aliases): translate lost read-then-write races into 409

### DIFF
--- a/packages/gateway/src/control-plane/model-aliases/routes.ts
+++ b/packages/gateway/src/control-plane/model-aliases/routes.ts
@@ -13,6 +13,13 @@ import type { createAliasBody, updateAliasBody } from '../schemas.ts';
 const nextSortOrder = (existing: readonly ModelAliasRecord[]): number =>
   existing.reduce((acc, record) => Math.max(acc, record.sortOrder), -1) + 1;
 
+// Both D1 and node:sqlite raise a UNIQUE-constraint error naming the column;
+// the repo layer's alias INSERT / rename UPDATE lets that bubble up so the
+// route can translate a lost read-then-write race into a structured 409.
+const isAliasNameCollision = (err: unknown): boolean =>
+  err instanceof Error &&
+  err.message.includes('UNIQUE constraint failed: model_aliases.name');
+
 export const listAliases = async (c: Context) => {
   const records = await getRepo().modelAliases.list();
   return c.json(records.map(recordToWire));
@@ -22,11 +29,6 @@ export const createAlias = async (c: CtxWithJson<typeof createAliasBody>) => {
   const body = c.req.valid('json');
   const repo = getRepo();
 
-  const collision = await repo.modelAliases.getByName(body.name);
-  if (collision) {
-    return c.json({ error: `Alias ${body.name} already exists` }, 409);
-  }
-
   const existing = await repo.modelAliases.list();
   const now = new Date().toISOString();
   const record = wireToRecord(body, {
@@ -34,7 +36,12 @@ export const createAlias = async (c: CtxWithJson<typeof createAliasBody>) => {
     createdAt: now,
     updatedAt: now,
   });
-  await repo.modelAliases.insert(record);
+  try {
+    await repo.modelAliases.insert(record);
+  } catch (err) {
+    if (isAliasNameCollision(err)) return c.json({ error: `Alias ${body.name} already exists` }, 409);
+    throw err;
+  }
   return c.json(recordToWire(record), 201);
 };
 
@@ -46,11 +53,6 @@ export const updateAlias = async (c: CtxWithJson<typeof updateAliasBody>) => {
   const existing = await repo.modelAliases.getByName(oldName);
   if (!existing) return c.json({ error: 'Alias not found' }, 404);
 
-  if (body.name !== oldName) {
-    const collision = await repo.modelAliases.getByName(body.name);
-    if (collision) return c.json({ error: `Alias ${body.name} already exists` }, 409);
-  }
-
   const next = wireToRecord(body, {
     // Preserve the original sortOrder unless the client explicitly overrides
     // it; createdAt belongs to the row's first-seen instant and never moves.
@@ -58,7 +60,12 @@ export const updateAlias = async (c: CtxWithJson<typeof updateAliasBody>) => {
     createdAt: existing.createdAt,
     updatedAt: new Date().toISOString(),
   });
-  await repo.modelAliases.update(oldName, next);
+  try {
+    await repo.modelAliases.update(oldName, next);
+  } catch (err) {
+    if (isAliasNameCollision(err)) return c.json({ error: `Alias ${body.name} already exists` }, 409);
+    throw err;
+  }
   return c.json(recordToWire(next));
 };
 

--- a/packages/gateway/src/repo/memory.ts
+++ b/packages/gateway/src/repo/memory.ts
@@ -907,7 +907,7 @@ class MemoryModelAliasesRepo implements ModelAliasesRepo {
   }
 
   insert(record: ModelAliasRecord): Promise<void> {
-    if (this.store.has(record.name)) throw new Error(`alias ${record.name} already exists`);
+    if (this.store.has(record.name)) throw new Error('UNIQUE constraint failed: model_aliases.name');
     this.store.set(record.name, cloneModelAliasRecord(record));
     return Promise.resolve();
   }
@@ -915,7 +915,7 @@ class MemoryModelAliasesRepo implements ModelAliasesRepo {
   update(oldName: string, record: ModelAliasRecord): Promise<void> {
     if (!this.store.has(oldName)) throw new Error(`alias ${oldName} not found`);
     if (oldName !== record.name && this.store.has(record.name)) {
-      throw new Error(`alias ${record.name} already exists`);
+      throw new Error('UNIQUE constraint failed: model_aliases.name');
     }
     this.store.delete(oldName);
     this.store.set(record.name, cloneModelAliasRecord(record));

--- a/packages/gateway/src/repo/types.ts
+++ b/packages/gateway/src/repo/types.ts
@@ -294,13 +294,17 @@ export interface ModelAliasRecord {
 export interface ModelAliasesRepo {
   list(): Promise<ModelAliasRecord[]>;
   getByName(name: string): Promise<ModelAliasRecord | null>;
-  // Throws on primary-key collision so the route layer can surface a 409.
+  // Throws on primary-key collision. The thrown Error's message contains
+  // `UNIQUE constraint failed: model_aliases.name` — SQLite's own PK
+  // violation string — so the route layer can match on the message and
+  // surface a 409 without knowing which repo backend fired.
   insert(record: ModelAliasRecord): Promise<void>;
   // Replaces the row keyed by `oldName`. When oldName === record.name the
   // call is a plain UPDATE; when they differ this is a rename, executed as
   // INSERT(new) + DELETE(old) inside one transaction so dependent reads
   // stay consistent. Throws when `oldName` does not exist, or when the
-  // rename target already collides with a different row.
+  // rename target already collides with a different row (same
+  // `UNIQUE constraint failed: model_aliases.name` message as `insert`).
   update(oldName: string, record: ModelAliasRecord): Promise<void>;
   delete(name: string): Promise<boolean>;
   deleteAll(): Promise<void>;


### PR DESCRIPTION
## Summary

- `createAlias` / `updateAlias` used a `getByName` pre-check to gate a 409 response. Under a lost read-then-write race the pre-check passes but the subsequent `INSERT` / rename `UPDATE` hits the SQLite PK constraint (`UNIQUE constraint failed: model_aliases.name`), which surfaced as an unstructured 500 leaking the SQLite error string instead of the documented 409. The repo layer's own comment already declared the contract (`a PK collision bubbles up from the INSERT, which the route layer translates to 409`) but no `try/catch` existed. Drop the pre-check on the collision path and catch the underlying UNIQUE error at the route boundary — one round-trip fewer on the happy path, and the 409 contract holds even under a lost race.
- Align both repo backends on the same collision error message. The SQL backend already lets SQLite's raw string bubble up; the in-memory backend used to throw a generic `alias X already exists` message, which the route helper could not recognize. Both now throw `UNIQUE constraint failed: model_aliases.name`, and `ModelAliasesRepo`'s contract documents the shape as an invariant so future backends stay compatible.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck` clean
- [x] `pnpm exec eslint` on touched files clean
- [x] `pnpm --filter @floway-dev/gateway exec vitest run` — 1643 tests pass, including the existing `POST /api/aliases rejects a name collision with 409` and `PUT /api/aliases/:name rename collision returns 409` cases, which now exercise the `catch` path directly (backed by the aligned in-memory backend error message)