### PR TITLE
fix(aliases): strip client budget_tokens when adaptive rule fires

### DIFF
--- a/packages/gateway/src/data-plane/model-aliases/apply-rules.ts
+++ b/packages/gateway/src/data-plane/model-aliases/apply-rules.ts
@@ -60,7 +60,11 @@ export const applyRulesToUpstreamMessages = (body: MessagesPayload, rules: Alias
     const display = summary !== undefined ? mapSummaryToMessagesDisplay(summary) : undefined;
     const displayPart = display !== undefined ? { display } : {};
     if (adaptive === true) {
-      body.thinking = { ...body.thinking, type: 'adaptive', ...displayPart };
+      // Adaptive auto-determines the budget; strip any client-set
+      // `budget_tokens` so the alias rule's mode isn't accompanied by a
+      // sibling budget the operator didn't ask for.
+      const { budget_tokens: _drop, ...priorThinking } = body.thinking ?? {};
+      body.thinking = { ...priorThinking, type: 'adaptive', ...displayPart };
     } else if (budget_tokens !== undefined) {
       body.thinking = { ...body.thinking, type: 'enabled', budget_tokens, ...displayPart };
     } else if (display !== undefined) {

--- a/packages/gateway/src/data-plane/model-aliases/apply-rules_test.ts
+++ b/packages/gateway/src/data-plane/model-aliases/apply-rules_test.ts
@@ -175,6 +175,17 @@ test('messages: adaptive=true sets thinking.type=adaptive and ignores budget_tok
   assertEquals(body.thinking?.type, 'adaptive');
 });
 
+test('messages: adaptive=true strips a client-set budget_tokens from body.thinking', () => {
+  const body = msgPayload();
+  body.thinking = { type: 'enabled', budget_tokens: 5000 };
+  applyRulesToUpstreamMessages(body, { reasoning: { adaptive: true } });
+  assertEquals(body.thinking?.type, 'adaptive');
+  // The prior client budget must not leak into the adaptive block — adaptive
+  // auto-determines the budget and a sibling budget_tokens violates the
+  // rules-are-authoritative contract.
+  assertEquals((body.thinking as { budget_tokens?: number }).budget_tokens, undefined);
+});
+
 test('messages: serviceTier=fast maps to speed=fast (cross-protocol bridge)', () => {
   const body = msgPayload();
   applyRulesToUpstreamMessages(body, { serviceTier: 'fast' });


### PR DESCRIPTION
## Summary

- `applyRulesToUpstreamMessages` spread `body.thinking` verbatim into the adaptive-mode block, so a client-set `budget_tokens` survived onto the wire alongside `thinking.type = 'adaptive'`. Adaptive auto-determines the budget, so a sibling `budget_tokens` violates the rules-are-authoritative contract: the alias rule said "let the model decide," but the client's original request pinned a budget the operator never signed off on.
- Drop `budget_tokens` from `body.thinking` on the adaptive branch. The sibling `enabled` branch is untouched — its own `budget_tokens` reflects the rule the alias asked for, not a client leak.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck` clean
- [x] `pnpm exec eslint` on touched files clean
- [x] `pnpm --filter @floway-dev/gateway exec vitest run` — 1644 tests pass, including the new regression `messages: adaptive=true strips a client-set budget_tokens from body.thinking`