### PR TITLE
fix(aliases): reject rules that combine adaptive=true with budget_tokens

### DIFF
--- a/apps/web/src/components/alias-edit/AliasTargetRow.vue
+++ b/apps/web/src/components/alias-edit/AliasTargetRow.vue
@@ -74,7 +74,15 @@ const adaptiveSelect = computed<AdaptiveSelect>(() => {
   return 'auto';
 });
 const setAdaptive = (raw: AdaptiveSelect | undefined) => {
-  patchReasoning({ adaptive: raw === 'on' ? true : raw === 'off' ? false : undefined });
+  // Switching to `on` clears any sibling budget_tokens in the same patch:
+  // adaptive mode auto-determines the budget, so the pinned value would be
+  // silently discarded downstream (and the control-plane schema rejects the
+  // combination on save).
+  if (raw === 'on') {
+    patchReasoning({ adaptive: true, budget_tokens: undefined });
+    return;
+  }
+  patchReasoning({ adaptive: raw === 'off' ? false : undefined });
 };
 const setVerbosity = (raw: string) => {
   const next = { ...target.value.rules };

--- a/apps/web/src/components/alias-edit/AliasTargetRow_test.ts
+++ b/apps/web/src/components/alias-edit/AliasTargetRow_test.ts
@@ -1,12 +1,11 @@
-import { mount } from '@vue/test-utils';
+import { mount, type VueWrapper } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { nextTick } from 'vue';
-
-import { Select } from '@floway-dev/ui';
 
 import AliasTargetRow from './AliasTargetRow.vue';
 import { buildRealModel } from '../../api/test-fixtures.ts';
 import type { AliasTarget, ControlPlaneModel } from '../../api/types.ts';
+import { Select } from '@floway-dev/ui';
 
 const target = (over: Partial<AliasTarget> = {}): AliasTarget => ({
   target_model_id: 'gpt-5',
@@ -96,14 +95,13 @@ describe('AliasTargetRow', () => {
     await w.find('button[aria-label="Toggle target row"]').trigger('click');
     await nextTick();
 
-    // The chat rule body renders two Selects (target-id combobox uses
-    // Combobox, not Select; the remaining Selects here are Adaptive and
-    // Selection — but Selection lives on the parent, so within one row the
-    // only Select is Adaptive). Pick by current model-value to be robust.
-    const selects = w.findAllComponents(Select);
-    const adaptive = selects.find(s => s.props('modelValue') === 'auto');
-    expect(adaptive).toBeDefined();
-    await adaptive!.vm.$emit('update:modelValue', 'on');
+    // The chat rule body has one Select (Adaptive); target-id uses Combobox
+    // and Selection lives on the parent dialog, so findComponent is safe.
+    // Cast is necessary because Select is a generic SFC whose type args
+    // don't flow through findComponent's overloads.
+    const adaptive = w.findComponent(Select) as unknown as VueWrapper<Record<string, unknown>>;
+    expect(adaptive.exists()).toBe(true);
+    adaptive.vm.$emit('update:modelValue', 'on');
     await nextTick();
 
     const events = w.emitted<[AliasTarget]>('update:modelValue') ?? [];

--- a/apps/web/src/components/alias-edit/AliasTargetRow_test.ts
+++ b/apps/web/src/components/alias-edit/AliasTargetRow_test.ts
@@ -2,6 +2,8 @@ import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { nextTick } from 'vue';
 
+import { Select } from '@floway-dev/ui';
+
 import AliasTargetRow from './AliasTargetRow.vue';
 import { buildRealModel } from '../../api/test-fixtures.ts';
 import type { AliasTarget, ControlPlaneModel } from '../../api/types.ts';
@@ -85,5 +87,29 @@ describe('AliasTargetRow', () => {
     const html = w.html();
     expect(html).toContain('text-amber-300');
     expect(html).toContain('low, medium');
+  });
+
+  it('clears budget_tokens when adaptive is switched to on', async () => {
+    const w = mountRow({
+      modelValue: { target_model_id: 'gpt-5', rules: { reasoning: { budget_tokens: 4096 } } },
+    });
+    await w.find('button[aria-label="Toggle target row"]').trigger('click');
+    await nextTick();
+
+    // The chat rule body renders two Selects (target-id combobox uses
+    // Combobox, not Select; the remaining Selects here are Adaptive and
+    // Selection — but Selection lives on the parent, so within one row the
+    // only Select is Adaptive). Pick by current model-value to be robust.
+    const selects = w.findAllComponents(Select);
+    const adaptive = selects.find(s => s.props('modelValue') === 'auto');
+    expect(adaptive).toBeDefined();
+    await adaptive!.vm.$emit('update:modelValue', 'on');
+    await nextTick();
+
+    const events = w.emitted<[AliasTarget]>('update:modelValue') ?? [];
+    expect(events.length).toBeGreaterThan(0);
+    const latest = events[events.length - 1][0];
+    expect(latest.rules.reasoning?.adaptive).toBe(true);
+    expect(latest.rules.reasoning?.budget_tokens).toBeUndefined();
   });
 });

--- a/apps/web/src/components/alias-edit/warnings.ts
+++ b/apps/web/src/components/alias-edit/warnings.ts
@@ -61,6 +61,17 @@ export const computeRuleWarnings = (
     }
   }
 
+  // Cross-field: adaptive mode auto-determines the budget on the wire, so a
+  // sibling budget_tokens on the same rule would be silently discarded at
+  // overlay time — the control-plane schema also rejects this combination,
+  // so the warning surfaces it earlier in the editor.
+  if (rules.reasoning?.adaptive === true && rules.reasoning?.budget_tokens !== undefined) {
+    out.push({
+      field: 'reasoning.budget_tokens',
+      message: 'Adaptive reasoning auto-determines the budget — this value is ignored. Remove it or turn Adaptive off.',
+    });
+  }
+
   if (rules.reasoning?.adaptive === true && reasoning?.adaptive !== true) {
     out.push({ field: 'reasoning.adaptive', message: 'Target does not advertise adaptive reasoning.' });
   }

--- a/apps/web/src/components/alias-edit/warnings.ts
+++ b/apps/web/src/components/alias-edit/warnings.ts
@@ -50,6 +50,19 @@ export const computeRuleWarnings = (
     }
   }
 
+  // Cross-field structural check runs before the catalog-range check so
+  // `warningFor` (which returns the first hit per field) surfaces the
+  // actionable "these two fields conflict" hint over the softer
+  // "target doesn't advertise this feature" advisory. Adaptive mode
+  // auto-determines the budget on the wire; the control-plane schema
+  // also rejects this combination.
+  if (rules.reasoning?.adaptive === true && rules.reasoning?.budget_tokens !== undefined) {
+    out.push({
+      field: 'reasoning.budget_tokens',
+      message: 'Adaptive reasoning auto-determines the budget — this value is ignored. Remove it or turn Adaptive off.',
+    });
+  }
+
   if (rules.reasoning?.budget_tokens !== undefined) {
     const range = reasoning?.budget_tokens;
     if (range === undefined) {
@@ -59,17 +72,6 @@ export const computeRuleWarnings = (
       if (range.min !== undefined && n < range.min) out.push({ field: 'reasoning.budget_tokens', message: `Below target minimum (${range.min}).` });
       if (range.max !== undefined && n > range.max) out.push({ field: 'reasoning.budget_tokens', message: `Above target maximum (${range.max}).` });
     }
-  }
-
-  // Cross-field: adaptive mode auto-determines the budget on the wire, so a
-  // sibling budget_tokens on the same rule would be silently discarded at
-  // overlay time — the control-plane schema also rejects this combination,
-  // so the warning surfaces it earlier in the editor.
-  if (rules.reasoning?.adaptive === true && rules.reasoning?.budget_tokens !== undefined) {
-    out.push({
-      field: 'reasoning.budget_tokens',
-      message: 'Adaptive reasoning auto-determines the budget — this value is ignored. Remove it or turn Adaptive off.',
-    });
   }
 
   if (rules.reasoning?.adaptive === true && reasoning?.adaptive !== true) {

--- a/apps/web/src/components/alias-edit/warnings_test.ts
+++ b/apps/web/src/components/alias-edit/warnings_test.ts
@@ -91,6 +91,22 @@ describe('computeRuleWarnings', () => {
     expect(w[0].field).toBe('reasoning.adaptive');
   });
 
+  it('flags a rule that combines adaptive=true with budget_tokens (cross-field)', () => {
+    const advertisesAdaptive = realModel({
+      id: 'gpt-5',
+      chat: {
+        reasoning: {
+          budget_tokens: { min: 100, max: 8000 },
+          adaptive: true,
+        },
+      },
+    });
+    const w = computeRuleWarnings({ reasoning: { adaptive: true, budget_tokens: 4096 } }, advertisesAdaptive);
+    const budgetWarning = w.find(x => x.field === 'reasoning.budget_tokens');
+    expect(budgetWarning).toBeDefined();
+    expect(budgetWarning!.message).toContain('Adaptive');
+  });
+
   it('flags reasoning at all when the target lacks reasoning metadata', () => {
     const noReasoning = realModel({ id: 'gpt-5', chat: {} });
     const w = computeRuleWarnings({ reasoning: { effort: 'low' } }, noReasoning);

--- a/packages/gateway/src/control-plane/model-aliases/routes_test.ts
+++ b/packages/gateway/src/control-plane/model-aliases/routes_test.ts
@@ -251,3 +251,46 @@ test('POST /api/aliases rejects unknown reasoning fields on a chat target with 4
   );
   assertEquals(resp.status, 400);
 });
+
+test('POST /api/aliases rejects reasoning that combines adaptive=true with budget_tokens (400)', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.modelAliases.deleteAll();
+
+  const resp = await requestApp(
+    '/api/aliases',
+    authed(adminSession, baseBody({
+      targets: [{ target_model_id: 'gpt-5.4', rules: { reasoning: { adaptive: true, budget_tokens: 4096 } } }],
+    })),
+  );
+  assertEquals(resp.status, 400);
+  const body = (await resp.json()) as { error?: string };
+  assertEquals(body.error?.includes('adaptive'), true);
+  assertEquals(body.error?.includes('budget_tokens'), true);
+});
+
+test('PUT /api/aliases/:name rejects an update that pairs adaptive=true with budget_tokens (400)', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.modelAliases.deleteAll();
+  await requestApp('/api/aliases', authed(adminSession, baseBody()));
+
+  const resp = await requestApp(
+    '/api/aliases/gpt-fast',
+    putAuthed(adminSession, baseBody({
+      targets: [{ target_model_id: 'gpt-5.4', rules: { reasoning: { adaptive: true, budget_tokens: 4096 } } }],
+    })),
+  );
+  assertEquals(resp.status, 400);
+});
+
+test('POST /api/aliases accepts adaptive=false alongside budget_tokens (force non-adaptive + pinned budget)', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.modelAliases.deleteAll();
+
+  const resp = await requestApp(
+    '/api/aliases',
+    authed(adminSession, baseBody({
+      targets: [{ target_model_id: 'gpt-5.4', rules: { reasoning: { adaptive: false, budget_tokens: 4096 } } }],
+    })),
+  );
+  assertEquals(resp.status, 201);
+});

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -607,7 +607,17 @@ const chatAliasReasoningSchema = z.object({
   budget_tokens: z.number().int().nonnegative().optional(),
   adaptive: z.boolean().optional(),
   summary: z.string().min(1).optional(),
-}).strict();
+}).strict().refine(
+  // `adaptive` and a pinned `budget_tokens` are mutually exclusive on the
+  // Messages wire — `thinking.type` is one of `adaptive` or `enabled`, and
+  // only the `enabled` branch carries a `budget_tokens`. Storing both on the
+  // same rule would silently discard the budget at overlay time.
+  r => !(r.adaptive === true && r.budget_tokens !== undefined),
+  {
+    message: 'reasoning.adaptive=true cannot be combined with reasoning.budget_tokens — adaptive mode auto-determines the budget',
+    path: ['budget_tokens'],
+  },
+);
 
 const chatAliasRulesSchema = z.object({
   reasoning: chatAliasReasoningSchema.optional(),


### PR DESCRIPTION
## Summary

- `chatAliasReasoningSchema` accepted `{ adaptive: true, budget_tokens: N }` even though the two fields target mutually exclusive branches of the Anthropic Messages `thinking` block — `type: 'adaptive' | 'enabled'`, and only `enabled` carries a `budget_tokens`. `applyRulesToUpstreamMessages` picks the adaptive branch and never reads the rule's own `budget_tokens`, so operators who stored both saw the pinned value silently discarded on every wire hop.
- Add a cross-field `refine` on the reasoning sub-schema so writes fail with a message naming both fields. Existing DB rows continue to load and run under the tolerant runtime path (`apply-rules.ts` unchanged; `apply-rules_test.ts:172-176` still exercises the legacy shape as a read-tolerance contract).
- Mirror the constraint in the alias editor: `computeRuleWarnings` emits the cross-field hint before the catalog-range advisory so the actionable warning wins the first-hit-per-field display, and switching Adaptive to \`On\` clears any sibling \`budget_tokens\` in the same patch so the operator cannot construct a rule the server will reject on save.

Complements #153, which strips a client-set \`body.thinking.budget_tokens\` when an adaptive rule fires. #153 fixes the wire-side leak from client input; this PR closes the operator-side leak from stored rule values.

## Test plan

- [x] \`pnpm --filter @floway-dev/gateway run typecheck\` clean
- [x] \`pnpm --filter @floway-dev/web run typecheck\` clean
- [x] \`pnpm run lint\` clean
- [x] \`pnpm --filter @floway-dev/gateway exec vitest run\` — 1647 tests pass, including three new POST/PUT rejection cases and one \`adaptive: false + budget_tokens\` positive
- [x] \`pnpm --filter @floway-dev/web exec vitest run src/components/alias-edit/\` — 43 tests pass, including new \`computeRuleWarnings\` cross-field case and \`AliasTargetRow\` auto-clear case
- [x] Chrome DevTools walk-through (dev:node + Vite):
  - Fill budget=4096 then switch Adaptive to \`On\` → input clears immediately
  - Inject \`{adaptive:true,budget_tokens:4096}\` into DB, reload, edit → amber cross-field warning renders under the budget input
  - Save the invalid combination anyway → dashboard rose banner shows the refine message verbatim