### PR TITLE
feat(flags): strip prompt_cache_key for upstreams that reject it

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
@@ -3,6 +3,7 @@ import { withInterleavedSystemDemotedToUser } from './demote-interleaved-system-
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
 import { withUsageStreamOptionsIncluded } from './include-usage-stream-options.ts';
 import { withUsageNormalized } from './normalize-usage.ts';
+import { withPromptCacheKeyStripped } from './strip-prompt-cache-key.ts';
 import type { ChatCompletionsInterceptor } from './types.ts';
 import { withVendorDeepseekChatCompletionsNormalize } from './vendor-deepseek-normalize.ts';
 import { withVendorKimiChatCompletionsNormalize } from './vendor-kimi-normalize.ts';
@@ -29,6 +30,11 @@ import { withVendorQwenChatCompletionsNormalize } from './vendor-qwen-normalize.
 //     `demote-interleaved-system-to-user`. Rewrites any `role: 'system'` that
 //     appears after the leading contiguous system run to `role: 'user'` so
 //     upstreams that reject mid-stream system messages still accept the body.
+//   - withPromptCacheKeyStripped: gated by `strip-prompt-cache-key`. Drops
+//     the top-level `prompt_cache_key` field for upstreams that reject it as
+//     an unknown argument (e.g. Azure DeepSeek). Runs before vendor
+//     normalizers so vendor-specific translation sees the already-stripped
+//     canonical payload.
 //   - withVendor*ChatCompletionsNormalize: gated by `vendor-<X>`. Registered
 //     LAST so that on the outbound path each gets the final say on the wire
 //     body and on the inbound path each gets the first say on the upstream
@@ -42,6 +48,7 @@ export const chatCompletionsInterceptors: readonly ChatCompletionsInterceptor[] 
   withReasoningDisabledOnForcedToolChoice,
   withDemoteDeveloperToSystem,
   withInterleavedSystemDemotedToUser,
+  withPromptCacheKeyStripped,
   withVendorDeepseekChatCompletionsNormalize,
   withVendorQwenChatCompletionsNormalize,
   withVendorKimiChatCompletionsNormalize,

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/strip-prompt-cache-key.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/strip-prompt-cache-key.ts
@@ -1,0 +1,16 @@
+import type { ChatCompletionsInterceptor } from './types.ts';
+import { providerModelOf } from '@floway-dev/provider';
+
+// Opt-in workaround for upstreams that reject `prompt_cache_key` as an unknown
+// request argument (e.g. Azure DeepSeek returns
+// `unrecognized_request_argument`). Drop the top-level field before the
+// request reaches the terminal. OpenAI-native and truly OpenAI-compatible
+// upstreams accept it for prefix-cache attribution, so removal only happens
+// under the flag.
+export const withPromptCacheKeyStripped: ChatCompletionsInterceptor = async (ctx, _gatewayCtx, run) => {
+  if (!providerModelOf(ctx.candidate).enabledFlags.has('strip-prompt-cache-key')) return await run();
+  if (ctx.payload.prompt_cache_key === undefined) return await run();
+  const { prompt_cache_key: _stripped, ...rest } = ctx.payload;
+  ctx.payload = rest;
+  return await run();
+};

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/strip-prompt-cache-key_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/strip-prompt-cache-key_test.ts
@@ -1,0 +1,66 @@
+import { test } from 'vitest';
+
+import { withPromptCacheKeyStripped } from './strip-prompt-cache-key.ts';
+import type { ChatCompletionsInvocation } from './types.ts';
+import { createNonResponsesSourceStore } from '../../responses/items/store.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
+import { eventResult, type FlagId } from '@floway-dev/provider';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+
+const stubCtx: ChatGatewayCtx = {
+  apiKeyId: 'test-key',
+  upstreamIds: null,
+  wantsStream: false,
+  runtimeLocation: 'TEST',
+  currentColo: 'TEST',
+  dump: null,
+  responseHeaders: new Headers(),
+  backgroundScheduler: () => {},
+  requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
+};
+
+const okEvents = () => Promise.resolve(eventResult((async function* () {})(), testTelemetryModelIdentity));
+
+const invocation = (
+  payload: ChatCompletionsPayload,
+  enabledFlags: ReadonlySet<FlagId> = new Set(['strip-prompt-cache-key']),
+): ChatCompletionsInvocation => ({
+  payload,
+  candidate: stubModelCandidate({ enabledFlags }),
+  targetApi: 'chat-completions',
+  headers: new Headers(),
+});
+
+test('drops top-level prompt_cache_key when the flag is on', async () => {
+  const input = invocation({
+    model: 'm',
+    messages: [],
+    prompt_cache_key: 'thread-42',
+  });
+
+  await withPromptCacheKeyStripped(input, stubCtx, okEvents);
+
+  assertEquals(Object.hasOwn(input.payload, 'prompt_cache_key'), false);
+});
+
+test('leaves the payload untouched when prompt_cache_key is absent', async () => {
+  const input = invocation({ model: 'm', messages: [] });
+  const before = input.payload;
+
+  await withPromptCacheKeyStripped(input, stubCtx, okEvents);
+
+  assertEquals(input.payload, before);
+});
+
+test('is a no-op when the flag is not set on the candidate', async () => {
+  const input = invocation(
+    { model: 'm', messages: [], prompt_cache_key: 'thread-42' },
+    new Set(),
+  );
+
+  await withPromptCacheKeyStripped(input, stubCtx, okEvents);
+
+  assertEquals(input.payload.prompt_cache_key, 'thread-42');
+});

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
@@ -7,6 +7,7 @@ import { withCyberPolicyRetried } from './retry-cyber-policy.ts';
 import { withResponsesServerToolShim } from './server-tool-shim.ts';
 import { imageGenerationServerTool } from './server-tools/image-generation.ts';
 import { webSearchServerTool } from './server-tools/web-search.ts';
+import { withPromptCacheKeyStripped } from './strip-prompt-cache-key.ts';
 import type { ResponsesInterceptor } from './types.ts';
 import { withVendorDeepseekResponsesNormalize } from './vendor-deepseek-normalize.ts';
 import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
@@ -36,6 +37,11 @@ import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 //     rewrites any `role: 'system'` message item that follows the leading
 //     contiguous system run to `role: 'user'` so upstreams that reject
 //     mid-stream system messages still accept the body.
+//   - withPromptCacheKeyStripped: gated by `strip-prompt-cache-key`. Drops
+//     the top-level `prompt_cache_key` field for upstreams that reject it
+//     as an unknown argument (e.g. Azure DeepSeek). Runs before vendor
+//     normalizers so vendor-specific translation sees the already-stripped
+//     canonical payload.
 //   - withVendor*ResponsesNormalize: gated by `vendor-<X>`. Registered after
 //     the demotion entries so each gets the final say on the outbound wire
 //     body.
@@ -56,6 +62,7 @@ export const responsesInterceptors: readonly ResponsesInterceptor[] = [
   withReasoningDisabledOnForcedToolChoice,
   withDemoteDeveloperToSystem,
   withInterleavedSystemDemotedToUser,
+  withPromptCacheKeyStripped,
   withVendorDeepseekResponsesNormalize,
   withVendorQwenResponsesNormalize,
   withResponsesOutputItemsCanonicalized,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/strip-prompt-cache-key.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/strip-prompt-cache-key.ts
@@ -1,0 +1,15 @@
+import type { ResponsesInterceptor } from './types.ts';
+import { providerModelOf } from '@floway-dev/provider';
+
+// Opt-in workaround for upstreams that reject `prompt_cache_key` as an unknown
+// request argument (e.g. Azure DeepSeek). Drop the top-level field before the
+// request reaches the terminal. OpenAI-native and truly OpenAI-compatible
+// Responses upstreams accept it for prefix-cache attribution, so removal only
+// happens under the flag.
+export const withPromptCacheKeyStripped: ResponsesInterceptor = async (ctx, _request, run) => {
+  if (!providerModelOf(ctx.candidate).enabledFlags.has('strip-prompt-cache-key')) return await run();
+  if (ctx.payload.prompt_cache_key === undefined) return await run();
+  const { prompt_cache_key: _stripped, ...rest } = ctx.payload;
+  ctx.payload = rest;
+  return await run();
+};

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/strip-prompt-cache-key_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/strip-prompt-cache-key_test.ts
@@ -1,0 +1,83 @@
+import { test } from 'vitest';
+
+import { withPromptCacheKeyStripped } from './strip-prompt-cache-key.ts';
+import type { ResponsesInvocation } from './types.ts';
+import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
+import { createNonResponsesSourceStore } from '../items/store.ts';
+import { doneFrame } from '@floway-dev/protocols/common';
+import { eventResult, type FlagId } from '@floway-dev/provider';
+import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+
+const stubCtx: ChatGatewayCtx = {
+  apiKeyId: 'test-key',
+  upstreamIds: null,
+  wantsStream: false,
+  runtimeLocation: 'TEST',
+  currentColo: 'TEST',
+  dump: null,
+  responseHeaders: new Headers(),
+  backgroundScheduler: () => {},
+  requestStartedAt: 0,
+  store: createNonResponsesSourceStore('test-key'),
+};
+
+const okEvents = () =>
+  Promise.resolve(
+    eventResult(
+      (async function* () {
+        yield doneFrame();
+      })(),
+      testTelemetryModelIdentity,
+    ),
+  );
+
+const invocation = (
+  payload: CanonicalResponsesPayload,
+  enabledFlags: ReadonlySet<FlagId> = new Set(['strip-prompt-cache-key']),
+): ResponsesInvocation => ({
+  payload,
+  candidate: stubModelCandidate({ enabledFlags }),
+  targetApi: 'responses',
+  headers: new Headers(),
+  action: 'generate',
+});
+
+test('drops top-level prompt_cache_key when the flag is on', async () => {
+  const input = invocation({
+    model: 'm',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
+    prompt_cache_key: 'thread-42',
+  });
+
+  await withPromptCacheKeyStripped(input, stubCtx, okEvents);
+
+  assertEquals(Object.hasOwn(input.payload, 'prompt_cache_key'), false);
+});
+
+test('leaves the payload untouched when prompt_cache_key is absent', async () => {
+  const input = invocation({
+    model: 'm',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
+  });
+  const before = input.payload;
+
+  await withPromptCacheKeyStripped(input, stubCtx, okEvents);
+
+  assertEquals(input.payload, before);
+});
+
+test('is a no-op when the flag is not set on the candidate', async () => {
+  const input = invocation(
+    {
+      model: 'm',
+      input: [{ type: 'message', role: 'user', content: 'hi' }],
+      prompt_cache_key: 'thread-42',
+    },
+    new Set(),
+  );
+
+  await withPromptCacheKeyStripped(input, stubCtx, okEvents);
+
+  assertEquals(input.payload.prompt_cache_key, 'thread-42');
+});

--- a/packages/provider-azure/src/defaults.ts
+++ b/packages/provider-azure/src/defaults.ts
@@ -14,4 +14,5 @@ export const AZURE_DEFAULT_FLAGS: FlagDefaults = {
   'demote-interleaved-system-to-user': false,
   'demote-developer-to-system': false,
   'strip-billing-attribution': true,
+  'strip-prompt-cache-key': false,
 };

--- a/packages/provider-claude-code/src/defaults.ts
+++ b/packages/provider-claude-code/src/defaults.ts
@@ -26,4 +26,5 @@ export const CLAUDE_CODE_DEFAULT_FLAGS: FlagDefaults = {
   'demote-interleaved-system-to-user': false,
   'demote-developer-to-system': false,
   'strip-billing-attribution': false,
+  'strip-prompt-cache-key': false,
 };

--- a/packages/provider-codex/src/defaults.ts
+++ b/packages/provider-codex/src/defaults.ts
@@ -13,4 +13,5 @@ export const CODEX_DEFAULT_FLAGS: FlagDefaults = {
   'demote-interleaved-system-to-user': false,
   'demote-developer-to-system': false,
   'strip-billing-attribution': true,
+  'strip-prompt-cache-key': false,
 };

--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -23,6 +23,7 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
   'demote-interleaved-system-to-user': false,
   'demote-developer-to-system': false,
   'strip-billing-attribution': true,
+  'strip-prompt-cache-key': false,
 };
 
 // True when the model id names a Claude release whose Anthropic Messages

--- a/packages/provider-custom/src/defaults.ts
+++ b/packages/provider-custom/src/defaults.ts
@@ -21,4 +21,5 @@ export const CUSTOM_DEFAULT_FLAGS: FlagDefaults = {
   // only to the Anthropic subscription endpoint; strip it here so it
   // does not pollute the OpenAI-compatible upstream's prompt-cache key.
   'strip-billing-attribution': true,
+  'strip-prompt-cache-key': false,
 };

--- a/packages/provider-ollama/src/defaults.ts
+++ b/packages/provider-ollama/src/defaults.ts
@@ -13,4 +13,5 @@ export const OLLAMA_DEFAULT_FLAGS: FlagDefaults = {
   'demote-interleaved-system-to-user': false,
   'demote-developer-to-system': false,
   'strip-billing-attribution': true,
+  'strip-prompt-cache-key': false,
 };

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -91,6 +91,11 @@ export const OPTIONAL_FLAGS = [
     label: 'Strip Claude Code billing attribution from system prompt',
     description: "Remove `x-anthropic-billing-header:` lines from the request's system prompt before forwarding upstream. The block is irrelevant to non-Anthropic upstreams and only pollutes their prompt-cache key. On `claude-code`, the same block is the input Anthropic uses to bill the request against the user's plan and must be preserved.",
   },
+  {
+    id: 'strip-prompt-cache-key',
+    label: 'Strip prompt_cache_key from request',
+    description: 'Drop the top-level `prompt_cache_key` field from Chat Completions and Responses requests before forwarding upstream. Pick this when the upstream rejects `prompt_cache_key` as an unknown argument (e.g. Azure DeepSeek). OpenAI-native and truly OpenAI-compatible upstreams accept the field for prefix-cache attribution, so this stays off by default.',
+  },
 ] as const satisfies readonly Flag[];
 
 export type FlagId = (typeof OPTIONAL_FLAGS)[number]['id'];


### PR DESCRIPTION
## Summary

Add a `strip-prompt-cache-key` per-upstream flag and a matching gateway interceptor on both Chat Completions and Responses that drops the top-level `prompt_cache_key` field before the request reaches the terminal fetch. Manual opt-in only — off by default on every provider.

## Motivation

Codex clients populate `prompt_cache_key` on every Responses request (Codex threadId, with an internal fallback) so OpenAI can attribute prefix-cache hits. Some OpenAI-shaped upstreams reject unknown top-level arguments outright — Azure DeepSeek returns `unrecognized_request_argument` for `prompt_cache_key` on the very first turn. Today the gateway has no knob to drop the field, so any Codex-driven session against such an upstream 400s before doing any work.

## Design

- **Flag-gated, not automatic.** Real OpenAI-compatible upstreams accept `prompt_cache_key` and rely on it for legitimate prefix-cache reuse. Auto-stripping on a 400 would introduce hidden per-upstream state and misclassify transient errors (rate limits, misroutes, timeouts) as capability signals. Operators enable the flag per upstream — or per model — via the existing `flag_overrides` UI.
- **Both Chat Completions and Responses; not Messages.** Messages has no top-level `prompt_cache_key`; Anthropic cache attribution is per-block `cache_control`. So no Messages interceptor is wired.
- **Interceptor position: after `demote-*`, before `vendor-*` normalizers.** Vendor normalizers translate the OpenAI-canonical payload into vendor wire dialects; running the strip first means vendor translation sees the already-stripped canonical form. When the flag is off, the interceptor early-returns and every downstream pass behaves identically to before.
- **Provider defaults: `false` everywhere.** All six `provider-*/defaults.ts` seed the flag as `false`. The flag catalog description points at Azure DeepSeek as the canonical example so operators know when to reach for it.

## Test plan

- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — clean.
- [x] `pnpm run test` — 328 files / 3836 tests pass (baseline was 326 / 3830; delta is 3 new tests per interceptor covering flag-on strip, absent-field no-op, flag-off no-op).
- [x] Manual smoke against production Azure DeepSeek: with the flag enabled on `deepseek-v4-pro` and `deepseek-v4-flash`, a `/responses` request carrying `prompt_cache_key: "test-thread-strip"` completes with HTTP 200 for both models. Without the flag, the same request 400s with `unrecognized_request_argument: prompt_cache_key`.