### PR TITLE
feat(pricing): add gpt-5.6-{sol,terra,luna} to Copilot + Codex tables

### DIFF
--- a/packages/provider-codex/src/constants.ts
+++ b/packages/provider-codex/src/constants.ts
@@ -47,10 +47,11 @@ export const CODEX_MODELS_PATH = '/codex/models';
 // codex_cli_rs version we impersonate on the data plane. Bumped against the
 // latest stable release at https://github.com/openai/codex/releases — newer entries in
 // /codex/models gate themselves behind a `minimal_client_version` (e.g.
-// gpt-5.5 needs 0.124.0+), so a stale value here silently truncates the model
-// list. The same value flows into both the `?client_version=` query param and
-// the User-Agent so the upstream sees a self-consistent client.
-export const CODEX_CLI_VERSION = '0.142.0';
+// the gpt-5.6 Sol / Terra / Luna family needs 0.144.0+), so a stale value
+// here silently truncates the model list. The same value flows into both
+// the `?client_version=` query param and the User-Agent so the upstream sees
+// a self-consistent client.
+export const CODEX_CLI_VERSION = '0.144.0';
 
 // Shared official Codex data-plane identity for /codex/models and
 // /codex/responses. The User-Agent intentionally includes Codex's normal

--- a/packages/provider-codex/src/pricing.ts
+++ b/packages/provider-codex/src/pricing.ts
@@ -25,10 +25,11 @@
 // actually-served tier in `usage.service_tier` and the gateway captures it
 // onto `TokenUsage.tier` so cost compute picks the right row.
 //
-// Coverage: every slug surfaced by /codex/models for ChatGPT Plus today
-// (gpt-5.5, gpt-5.4, gpt-5.4-mini, codex-auto-review). New slugs the upstream
-// rolls out at higher plans (Pro / Team / Enterprise) should be added here so
-// the dashboard reports their cost too.
+// Coverage: every slug the upstream catalog surfaces across current plans —
+// the GPT-5.6 Sol / Terra / Luna family that shipped in July 2026, the
+// preceding GPT-5.5 / 5.4 / 5.4-mini slugs, and the internal codex-auto-review
+// entry. New slugs the upstream rolls out at higher plans (Pro / Team /
+// Enterprise) should be added here so the dashboard reports their cost too.
 
 import type { ModelPricing } from '@floway-dev/protocols/common';
 
@@ -43,6 +44,36 @@ const GPT_5_4_PRICING: ModelPricing = {
 };
 
 const CODEX_MODEL_PRICING: readonly (readonly [key: string | RegExp, pricing: ModelPricing])[] = [
+  // GPT-5.6 family (Sol / Terra / Luna) shipped July 2026 and requires
+  // codex-cli 0.144.0+ per the upstream models.json minimal_client_version.
+  // Standard rates match models.dev + OpenRouter; each variant's catalog
+  // entry advertises a `priority` service tier (no `flex` lane), and the
+  // priority per-token rate is a flat 2× standard across the family —
+  // distinct from GPT-5.5's 2.5× multiplier.
+  ['gpt-5.6-sol', {
+    input: 5,
+    input_cache_read: 0.5,
+    output: 30,
+    tiers: {
+      priority: { input: 10, input_cache_read: 1, output: 60 },
+    },
+  }],
+  ['gpt-5.6-terra', {
+    input: 2.5,
+    input_cache_read: 0.25,
+    output: 15,
+    tiers: {
+      priority: { input: 5, input_cache_read: 0.5, output: 30 },
+    },
+  }],
+  ['gpt-5.6-luna', {
+    input: 1,
+    input_cache_read: 0.1,
+    output: 6,
+    tiers: {
+      priority: { input: 2, input_cache_read: 0.2, output: 12 },
+    },
+  }],
   ['gpt-5.5', {
     input: 5,
     input_cache_read: 0.5,

--- a/packages/provider-copilot/src/interceptors/image-size.ts
+++ b/packages/provider-copilot/src/interceptors/image-size.ts
@@ -7,8 +7,9 @@ import { type ImageSizeCalculator, type SizeCaps, fitWithin } from '@floway-dev/
 // - gpt-4o / gpt-4.1: tile encoder — samples within a 2048px box with the short
 //   edge clamped to 768px.
 // - gpt-5-mini: patch encoder, but likewise clamps the short edge to 768px.
-// - gpt-5.4 / gpt-5.4-mini / gpt-5.5 (and any other model via the fallback):
-//   patch encoder capped at ~2500 32px patches (~2.56 MP) within a 2048px box.
+// - gpt-5.4 / gpt-5.4-mini / gpt-5.5 / gpt-5.6-{sol,terra,luna} (and any
+//   other model via the fallback): patch encoder capped at ~2500 32px
+//   patches (~2.56 MP) within a 2048px box.
 // - Gemini: no documented sampling cap; we clamp the long edge to 2048px to
 //   keep tile/token cost bounded.
 //

--- a/packages/provider-copilot/src/pricing.ts
+++ b/packages/provider-copilot/src/pricing.ts
@@ -100,6 +100,14 @@ const COPILOT_MODEL_PRICING: readonly PricingRule[] = [
       output: 5,
     },
   ],
+  // OpenAI's July 2026 GPT-5.6 launch splits the family into three
+  // named variants (Sol / Terra / Luna). Copilot's live catalog exposes
+  // all three with per-model billing blocks that agree exactly with
+  // models.dev and OpenRouter — Sol matches the GPT-5.5 rate, Terra
+  // matches GPT-5.4, and Luna sits between GPT-5.4-mini and GPT-4o-mini.
+  ['gpt-5.6-sol', { input: 5, input_cache_read: 0.5, output: 30 }],
+  ['gpt-5.6-terra', { input: 2.5, input_cache_read: 0.25, output: 15 }],
+  ['gpt-5.6-luna', { input: 1, input_cache_read: 0.1, output: 6 }],
   ['gpt-5.5', { input: 5, input_cache_read: 0.5, output: 30 }],
   ['gpt-5.4', { input: 2.5, input_cache_read: 0.25, output: 15 }],
   ['gpt-5.4-mini', { input: 0.75, input_cache_read: 0.075, output: 4.5 }],


### PR DESCRIPTION
## Summary

- Add `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` to both Copilot and Codex pricing tables — three-source cross-check (Copilot live billing block, models.dev, OpenRouter) agrees on `$5/$0.5/$30`, `$2.5/$0.25/$15`, `$1/$0.1/$6` (USD per 1M input / cache_read / output).
- Codex table adds a `priority` service-tier override at a uniform **2× standard** across the family (distinct from GPT-5.5's 2.5×). No `flex` tier — the upstream `codex-rs/models-manager/models.json` only advertises `priority`, and no public source publishes per-token flex rates for GPT-5.6.
- Bump `CODEX_CLI_VERSION` from `0.142.0` to `0.144.0` (latest stable, `rust-v0.144.0` published 2026-07-09). The GPT-5.6 slugs gate themselves behind `minimal_client_version: 0.144.0`, so the impersonated CLI version must reach that floor or `/codex/models` silently truncates them from the response.
- Touch up `provider-copilot/interceptors/image-size.ts` doc comment to list the new family alongside `gpt-5.4` / `gpt-5.5` (the fallback path already covered them functionally).

## Test plan

- [x] `pnpm --filter @floway-dev/provider-copilot --filter @floway-dev/provider-codex run typecheck`
- [x] `pnpm exec vitest run` in both packages (Copilot 41 files / 257 tests, Codex 13 files / 170 tests — all green)
- [x] `pnpm run lint` clean
- [ ] Post-deploy: point a Copilot upstream at any `gpt-5.6-*` slug via the dashboard, confirm `usage.model_key` matches the table key and the cost snapshot is non-null