### PR TITLE
fix(husky): detect linked worktree via git-dir, not `.worktrees/` path

### DIFF
--- a/.husky/main-commit-warning
+++ b/.husky/main-commit-warning
@@ -1,20 +1,19 @@
 #!/bin/sh
 # Warn the agent before a commit / merge-commit / cherry-pick / FF lands
-# from a checkout that is NOT a linked worktree under <repo_root>/.worktrees/.
-# Always exits 0; the warning goes to stderr and never blocks the calling
-# git command. Sourced by `.husky/post-commit` and `.husky/post-merge`.
+# from the main worktree (NOT from any linked worktree). Always exits 0;
+# the warning goes to stderr and never blocks the calling git command.
+# Sourced by `.husky/post-commit` and `.husky/post-merge`.
 
-toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+# A linked worktree's per-worktree git dir sits under the main repo's
+# .git/worktrees/<name>/, so --git-dir and --git-common-dir differ. In the
+# main worktree they point at the same .git directory.
+git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null) || exit 0
 common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
 case "$common_dir" in
   /*) ;;
   *) common_dir=$(cd "$common_dir" 2>/dev/null && pwd) || exit 0 ;;
 esac
-main_root=$(dirname "$common_dir")
-
-case "$toplevel" in
-  "$main_root"/.worktrees/*) exit 0 ;;
-esac
+[ "$git_dir" = "$common_dir" ] || exit 0
 
 cat >&2 <<'WARNING'
 WARNING! NOT in a worktree. Please double check: is the user really *explicitly* asking you to commit here?

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,9 +1,9 @@
 #!/bin/sh
-# Keep the main worktree pinned to `main`. Linked worktrees under
-# <repo_root>/.worktrees/ are free to be on any branch, tag, or revision —
-# the agent rules forbid in-flight work on main itself, so any checkout that
-# moves the main worktree off `main` is reverted immediately and reported as
-# an error.
+# Keep the main worktree pinned to `main`. Linked worktrees — wherever they
+# live on disk — are free to be on any branch, tag, or revision; the agent
+# rules forbid in-flight work on main itself, so any checkout that moves
+# the main worktree off `main` is reverted immediately and reported as an
+# error.
 
 prev_head="$1"
 new_head="$2"
@@ -16,18 +16,16 @@ branch_flag="$3"
 # Nothing actually moved (e.g. `git checkout` of the current branch).
 [ "$prev_head" = "$new_head" ] && exit 0
 
-toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+# A linked worktree's per-worktree git dir sits under the main repo's
+# .git/worktrees/<name>/, so --git-dir and --git-common-dir differ. In the
+# main worktree they point at the same .git directory.
+git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null) || exit 0
 common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
 case "$common_dir" in
   /*) ;;
   *) common_dir=$(cd "$common_dir" 2>/dev/null && pwd) || exit 0 ;;
 esac
-main_root=$(dirname "$common_dir")
-
-# A linked worktree — anything goes.
-case "$toplevel" in
-  "$main_root"/.worktrees/*) exit 0 ;;
-esac
+[ "$git_dir" = "$common_dir" ] || exit 0
 
 # In the main worktree. `main` is the only acceptable HEAD. Husky runs us
 # under `sh -e`, so detached-HEAD failures from `git symbolic-ref` must be


### PR DESCRIPTION
## Summary

- `.husky/post-checkout` and `.husky/main-commit-warning` whitelisted linked worktrees by the hardcoded path `<repo_root>/.worktrees/*`. Any tool that places worktrees elsewhere — Claude Code's `EnterWorktree` uses `.claude/worktrees/<name>` — fell outside the whitelist and got misclassified as the main worktree.
- Failure mode 1: `git worktree add .claude/worktrees/<name> -b <branch>` runs an internal checkout inside the new worktree; `post-checkout` treated that as the main worktree switching off `main`, errored, and tried `git checkout main` to restore — which failed because `main` was already checked out at the actual main worktree. The `git worktree add` command exited 1 even though the worktree metadata and directory had been created.
- Failure mode 2: every commit inside such a worktree produced a spurious "NOT in a worktree" warning from `main-commit-warning`.
- Fix: swap the path-prefix check for a git-semantic one. A linked worktree's `--absolute-git-dir` points at `<main>/.git/worktrees/<name>/` while `--git-common-dir` points at `<main>/.git/`; in the main worktree they coincide. Location-agnostic — any linked worktree, wherever it lives on disk, is now correctly recognized.
- The `.worktrees/<name>` recommendation in `post-checkout`'s error message stays: hooks no longer enforce that path, but it remains the project's convention.

## Test plan

- [x] `git worktree add .claude/worktrees/verify-a -b verify-a` → exits 0, no hook error.
- [x] `git worktree add .worktrees/verify-b -b verify-b` (legacy convention path) → still exits 0.
- [x] `git worktree add /tmp/floway-verify-c -b verify-c` (arbitrary path) → exits 0.
- [x] `git commit --allow-empty` from the main worktree → still emits the "NOT in a worktree" warning, exit 0.
- [x] Running the fixed `main-commit-warning` from inside a linked worktree's cwd → exits 0 with no warning.
- [x] End-to-end: Claude Code's `EnterWorktree` tool now enters a fresh `.claude/worktrees/<name>` cleanly, without the "already checked out" error that motivated this fix.

Note: each existing linked worktree carries its own copy of `.husky/*` from its branch checkout, and `core.hooksPath = .husky/_` resolves relative to cwd. Existing worktrees on older branches will keep emitting the spurious commit warning until they pull this fix; the primary bug (main worktree unable to spawn a new worktree via Claude Code) is fully resolved.