### PR TITLE
ci(build): make image publishing portable across forks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      PUSH_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +30,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        if: ${{ secrets.DOCKERHUB_TOKEN != '' }}
+        if: env.PUSH_DOCKERHUB == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -41,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate Tag List
         run: |
-          echo "TAGS<<EOF" >> $GITHUB_ENV
+          echo "TAGS<<EOF" >> "$GITHUB_ENV"
 
           # OCI image names must be lowercase; GitHub owner casing varies by user
           OWNER_LC="${OWNER,,}"
@@ -54,16 +56,15 @@ jobs:
           fi
 
           for REGISTRY in "${REGISTRIES[@]}"; do
-              echo "${REGISTRY}${IMAGE_NAME}:latest" >> $GITHUB_ENV
-              echo "${REGISTRY}${IMAGE_NAME}:${DATE}.${RUN_ID}" >> $GITHUB_ENV
+              echo "${REGISTRY}${IMAGE_NAME}:latest" >> "$GITHUB_ENV"
+              echo "${REGISTRY}${IMAGE_NAME}:${DATE}.${RUN_ID}" >> "$GITHUB_ENV"
           done
 
-          echo "EOF" >> $GITHUB_ENV
+          echo "EOF" >> "$GITHUB_ENV"
         env:
           TARGET: ${{ matrix.target.name }}
           RUN_ID: ${{ github.run_id }}
           OWNER: ${{ github.repository_owner }}
-          PUSH_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' }}
       - name: Build and Push
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,8 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      # Docker Hub only receives images from the upstream repo; forks publish to GHCR only
       - name: Login to DockerHub
-        if: github.repository_owner == 'Menci'
+        if: ${{ secrets.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -49,9 +48,8 @@ jobs:
           IMAGE_NAME="$OWNER_LC/floway-$TARGET"
           DATE="$(date +'%Y%m%d')"
 
-          # Docker Hub for upstream only, GHCR for everyone.
           REGISTRIES=("ghcr.io/")
-          if [ "$OWNER" = "Menci" ]; then
+          if [ "$PUSH_DOCKERHUB" = "true" ]; then
               REGISTRIES=("" "ghcr.io/")
           fi
 
@@ -65,6 +63,7 @@ jobs:
           TARGET: ${{ matrix.target.name }}
           RUN_ID: ${{ github.run_id }}
           OWNER: ${{ github.repository_owner }}
+          PUSH_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' }}
       - name: Build and Push
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,9 +7,6 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
-env:
-  IMAGE_PREFIX: menci/floway
-
 jobs:
   build:
     permissions:
@@ -30,7 +27,9 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+      # Docker Hub only receives images from the upstream repo; forks publish to GHCR only
       - name: Login to DockerHub
+        if: github.repository_owner == 'Menci'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -45,17 +44,27 @@ jobs:
         run: |
           echo "TAGS<<EOF" >> $GITHUB_ENV
 
-          IMAGE_NAME="$IMAGE_PREFIX-$TARGET"
+          # OCI image names must be lowercase; GitHub owner casing varies by user
+          OWNER_LC="${OWNER,,}"
+          IMAGE_NAME="$OWNER_LC/floway-$TARGET"
           DATE="$(date +'%Y%m%d')"
-          for REGISTRY in {"","ghcr.io/"}; do
-              echo $REGISTRY$IMAGE_NAME:latest >> $GITHUB_ENV
-              echo $REGISTRY$IMAGE_NAME:$DATE.$RUN_ID >> $GITHUB_ENV
+
+          # Docker Hub for upstream only, GHCR for everyone.
+          REGISTRIES=("ghcr.io/")
+          if [ "$OWNER" = "Menci" ]; then
+              REGISTRIES=("" "ghcr.io/")
+          fi
+
+          for REGISTRY in "${REGISTRIES[@]}"; do
+              echo "${REGISTRY}${IMAGE_NAME}:latest" >> $GITHUB_ENV
+              echo "${REGISTRY}${IMAGE_NAME}:${DATE}.${RUN_ID}" >> $GITHUB_ENV
           done
 
           echo "EOF" >> $GITHUB_ENV
         env:
           TARGET: ${{ matrix.target.name }}
           RUN_ID: ${{ github.run_id }}
+          OWNER: ${{ github.repository_owner }}
       - name: Build and Push
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
## Summary

- Derive the image prefix from `github.repository_owner` at run time
  (lowercased, since OCI image names must be lowercase and GitHub owner
  casing varies) instead of the hardcoded top-level `IMAGE_PREFIX:
  menci/floway` env.
- Gate the DockerHub login step and the DockerHub tag entries in the
  tag-list loop on `secrets.DOCKERHUB_TOKEN != ''`. Any fork that
  configures `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` in its own repo
  secrets publishes to Docker Hub under `<owner-lowercased>/floway-*`;
  forks without those secrets skip the Docker Hub login and publish to
  GHCR only. No owner name is hard-coded.
- Upstream behavior is unchanged — Menci's secrets remain set, so the
  workflow still yields identical `menci/floway-{server,web}` tags on
  both Docker Hub and `ghcr.io`.

## Test plan

- [ ] From a fork **without** DockerHub secrets, `gh workflow run "Build
  and Push" --repo <owner>/Floway --ref <branch>`; confirm the run
  succeeds, the "Login to DockerHub" step is skipped, and images land
  only on `ghcr.io/<owner-lowercased>/floway-{server,web}:*`.
- [ ] From a fork **with** DockerHub secrets, run the same dispatch;
  confirm login runs and images land on both
  `<owner-lc>/floway-{server,web}` (Docker Hub) and
  `ghcr.io/<owner-lc>/floway-{server,web}` with matching digests.
- [ ] After merge, the next push-to-main / scheduled run on Menci/Floway
  publishes `menci/floway-{server,web}:latest` and `:<date>.<run_id>` to
  both Docker Hub and GHCR with the same digest.