### PR TITLE
ci(build): tag non-main refs with sanitized branch name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,9 +7,6 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
-env:
-  IMAGE_PREFIX: menci/floway
-
 jobs:
   build:
     permissions:
@@ -30,7 +27,9 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+      # Docker Hub only receives images from the upstream repo; forks publish to GHCR only
       - name: Login to DockerHub
+        if: github.repository_owner == 'Menci'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -45,17 +44,27 @@ jobs:
         run: |
           echo "TAGS<<EOF" >> $GITHUB_ENV
 
-          IMAGE_NAME="$IMAGE_PREFIX-$TARGET"
+          # OCI image names must be lowercase; GitHub owner casing varies by user
+          OWNER_LC="${OWNER,,}"
+          IMAGE_NAME="$OWNER_LC/floway-$TARGET"
           DATE="$(date +'%Y%m%d')"
-          for REGISTRY in {"","ghcr.io/"}; do
-              echo $REGISTRY$IMAGE_NAME:latest >> $GITHUB_ENV
-              echo $REGISTRY$IMAGE_NAME:$DATE.$RUN_ID >> $GITHUB_ENV
+
+          # Docker Hub for upstream only, GHCR for everyone.
+          REGISTRIES=("ghcr.io/")
+          if [ "$OWNER" = "Menci" ]; then
+              REGISTRIES=("" "ghcr.io/")
+          fi
+
+          for REGISTRY in "${REGISTRIES[@]}"; do
+              echo "${REGISTRY}${IMAGE_NAME}:latest" >> $GITHUB_ENV
+              echo "${REGISTRY}${IMAGE_NAME}:${DATE}.${RUN_ID}" >> $GITHUB_ENV
           done
 
           echo "EOF" >> $GITHUB_ENV
         env:
           TARGET: ${{ matrix.target.name }}
           RUN_ID: ${{ github.run_id }}
+          OWNER: ${{ github.repository_owner }}
       - name: Build and Push
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,6 +48,8 @@ jobs:
           OWNER_LC="${OWNER,,}"
           IMAGE_NAME="$OWNER_LC/floway-$TARGET"
           DATE="$(date +'%Y%m%d')"
+          # `/` is legal in a branch name, not in a docker tag.
+          REF_TAG="${REF_NAME//\//-}"
 
           # Docker Hub for upstream only, GHCR for everyone.
           REGISTRIES=("ghcr.io/")
@@ -58,6 +60,10 @@ jobs:
           for REGISTRY in "${REGISTRIES[@]}"; do
               echo "${REGISTRY}${IMAGE_NAME}:latest" >> $GITHUB_ENV
               echo "${REGISTRY}${IMAGE_NAME}:${DATE}.${RUN_ID}" >> $GITHUB_ENV
+              # Non-main refs also get a `:branch-name` tag so downstream stacks can pin to a per-branch image
+              if [ "$REF_NAME" != "main" ]; then
+                  echo "${REGISTRY}${IMAGE_NAME}:${REF_TAG}" >> $GITHUB_ENV
+              fi
           done
 
           echo "EOF" >> $GITHUB_ENV
@@ -65,6 +71,7 @@ jobs:
           TARGET: ${{ matrix.target.name }}
           RUN_ID: ${{ github.run_id }}
           OWNER: ${{ github.repository_owner }}
+          REF_NAME: ${{ github.ref_name }}
       - name: Build and Push
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
## Summary

- Non-`main` refs now also emit `<image>:<sanitized-branch>` alongside `:latest` and `:<date>.<run_id>`, so downstream stacks (e.g. a `docker-compose.*.yml` on a fork) can pin to a stable per-branch image without needing to track each run's ephemeral date/id.
- Slashes in branch names (`fix/foo`) become `-` because docker tags disallow `/`.
- `main` still produces only `:latest` and `:<date>.<run_id>` — no redundant `:main` tag.

Stacked on #163 — that PR adds the `OWNER` env-plumbing pattern this one reuses (adds `REF_NAME`) and drops the top-level `IMAGE_PREFIX` env; landing this on its own would conflict with the same block.

## Test plan

- [ ] Dispatch on a non-`main` ref and confirm the manifest for `:latest`, `:<date>.<run_id>`, and `:<branch>` are all the same digest.
- [ ] Dispatch on `main` and confirm no `:main` tag is produced.
- [ ] Dispatch on a branch containing `/` (e.g. `fix/foo`) and confirm the emitted tag is `:fix-foo` (not rejected by the registry).
