### PR TITLE
feat(gateway): serve [1m] variants to Claude Code CLI picker

### DIFF
--- a/packages/gateway/src/data-plane/models/serve.ts
+++ b/packages/gateway/src/data-plane/models/serve.ts
@@ -70,10 +70,13 @@ export const models = async (c: Context) => {
     const fetcherForUpstream = await createPerRequestFetcher(getCurrentColo(c.req.raw));
     const response = await loadModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c), getRepo().modelAliases);
     // The Claude Code CLI's model discovery request identifies itself with
-    // a `claude-cli/<version>` User-Agent prefix; every other caller
-    // (OpenAI SDKs, Anthropic SDKs, dashboards) receives the standard
-    // PublicModel superset.
-    if (c.req.header('user-agent')?.startsWith('claude-cli/')) {
+    // a `claude-code/<version>` User-Agent (built from the CLI's `n_()`
+    // helper — verified in the v2.1.206 binary). The CLI's other request
+    // paths use the Anthropic SDK's `claude-cli/*` UA, so match on the
+    // discovery UA specifically. Every other caller (OpenAI SDKs,
+    // Anthropic SDKs, dashboards) receives the standard PublicModel
+    // superset.
+    if (c.req.header('user-agent')?.startsWith('claude-code/')) {
       return Response.json(toClaudeCodeShape(response));
     }
     return Response.json(response);

--- a/packages/gateway/src/data-plane/models/serve.ts
+++ b/packages/gateway/src/data-plane/models/serve.ts
@@ -1,5 +1,6 @@
 // OpenAI and Anthropic /models field names do not overlap, so one payload
-// satisfies both client shapes.
+// satisfies both client shapes. The one exception is the Claude Code CLI
+// discovery caller — see toClaudeCodeShape below.
 
 import type { Context } from 'hono';
 
@@ -10,12 +11,97 @@ import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import { getRepo } from '../../repo/index.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getCurrentColo } from '../../runtime/runtime-info.ts';
+import type { PublicModel, PublicModelsResponse } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
+
+// Claude Code CLI's `/model` picker discovers gateway-served models by GET
+// /v1/models?limit=1000, reads only `id` (+ optional `display_name`), and
+// adds each entry as-is. Two picker mechanics dictate the shape below.
+//
+// (1) The CLI's `[1m]` suffix convention — append `[1m]` to a model id and
+// the CLI switches that pick to the 1M-context window — only reaches the
+// picker when the discovered id itself carries the suffix; the CLI does
+// not synthesize the variant on discovered ids in gateway mode. So we
+// rewrite the id of every 1M-capable model on the wire. Provider-side
+// routing is unaffected: the CLI strips `[1m]` before every inference
+// request and pairs it with `anthropic-beta: context-1m-2025-08-07`,
+// which providers already honor (Copilot's `context1m` variant selector;
+// Claude Code passes it through to the upstream).
+//
+// (2) The response follows Anthropic's official /v1/models shape —
+// `{data, first_id, has_more, last_id}` with `ModelInfo` rows — instead
+// of Floway's OpenAI-Anthropic superset. Other Anthropic-format callers
+// parse the same official shape, so mirroring it here also lets any
+// future Anthropic-native picker reuse the payload. `capabilities` is
+// nullable per the SDK type; Floway does not track every dimension the
+// SDK declares (batch, citations, code_execution, pdf_input,
+// structured_outputs), so returning null is honest — contrast with
+// fabricating {supported: false} rows for features we do not observe.
+// CLI-side the whole object is `.strip()`ed away regardless.
+//
+// https://code.claude.com/docs/en/llm-gateway-protocol#model-discovery
+// https://docs.claude.com/en/api/models-list
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/models.ts
+const CLAUDE_CODE_UA_PREFIX = 'claude-cli/';
+
+// Anthropic /v1/models envelope + row shape. Kept local: the transform is
+// serve-time only; nothing downstream persists these rows.
+interface ClaudeCodeModelInfo {
+  id: string;
+  type: 'model';
+  display_name: string;
+  created_at: string;
+  max_input_tokens: number | null;
+  max_tokens: number | null;
+  capabilities: null;
+}
+
+interface ClaudeCodeModelsResponse {
+  data: ClaudeCodeModelInfo[];
+  first_id: string | null;
+  has_more: false;
+  last_id: string | null;
+}
+
+// Anthropic requires `created_at` on every row; Floway does not always
+// track a creation timestamp (Copilot catalog, custom upstreams). Epoch
+// is the least-lossy sentinel — never confuseable with a real release
+// date and stable across catalog fetches.
+const CREATED_AT_UNKNOWN = '1970-01-01T00:00:00Z';
+
+const toClaudeCodeModelInfo = (model: PublicModel): ClaudeCodeModelInfo => {
+  const max = model.limits.max_context_window_tokens;
+  const id = max !== undefined && max >= 1_000_000 ? `${model.id}[1m]` : model.id;
+  return {
+    id,
+    type: 'model',
+    display_name: model.display_name,
+    created_at: model.created_at ?? CREATED_AT_UNKNOWN,
+    max_input_tokens: max ?? null,
+    max_tokens: model.limits.max_output_tokens ?? null,
+    capabilities: null,
+  };
+};
+
+const toClaudeCodeShape = (response: PublicModelsResponse): ClaudeCodeModelsResponse => {
+  const data = response.data.map(toClaudeCodeModelInfo);
+  return {
+    data,
+    first_id: data[0]?.id ?? null,
+    has_more: false,
+    last_id: data[data.length - 1]?.id ?? null,
+  };
+};
 
 export const models = async (c: Context) => {
   try {
     const fetcherForUpstream = await createPerRequestFetcher(getCurrentColo(c.req.raw));
-    return Response.json(await loadModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c), getRepo().modelAliases));
+    const response = await loadModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c), getRepo().modelAliases);
+    const userAgent = c.req.header('user-agent');
+    if (userAgent?.startsWith(CLAUDE_CODE_UA_PREFIX)) {
+      return Response.json(toClaudeCodeShape(response));
+    }
+    return Response.json(response);
   } catch (e) {
     // Upstream HTTP/parse failures squash to a generic message so we do not
     // leak upstream identity. Other registry-thrown errors (e.g. the "no

--- a/packages/gateway/src/data-plane/models/serve.ts
+++ b/packages/gateway/src/data-plane/models/serve.ts
@@ -14,9 +14,9 @@ import { getCurrentColo } from '../../runtime/runtime-info.ts';
 import type { PublicModelsResponse } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 
-// Claude Code CLI's `/model` picker discovers gateway-served models by GET
-// /v1/models?limit=1000, reads only `id` (+ optional `display_name`), and
-// adds each entry as-is. Two picker mechanics dictate the shape below.
+// Anthropic's official /v1/models shape — `{data, first_id, has_more,
+// last_id}` with `ModelInfo` rows — served to Claude Code CLI's `/model`
+// picker. Two picker mechanics dictate the fields below.
 //
 // (1) The CLI's `[1m]` suffix convention — append `[1m]` to a model id and
 // the CLI switches that pick to the 1M-context window — only reaches the
@@ -28,26 +28,22 @@ import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 // which providers already honor (Copilot's `context1m` variant selector;
 // Claude Code passes it through to the upstream).
 //
-// (2) The response follows Anthropic's official /v1/models shape —
-// `{data, first_id, has_more, last_id}` with `ModelInfo` rows — instead
-// of the OpenAI-Anthropic superset. Other Anthropic-format callers
-// parse the same official shape, so mirroring it here also lets any
-// future Anthropic-native picker reuse the payload. `capabilities` is
-// nullable per the SDK type; we do not track every dimension the SDK
-// declares (batch, citations, code_execution, pdf_input,
+// (2) Mirroring the official shape (instead of the OpenAI-Anthropic
+// superset the handler serves everyone else) also lets any future
+// Anthropic-native picker consume the payload verbatim. `capabilities`
+// is nullable per the SDK type; we do not track every dimension the
+// SDK declares (batch, citations, code_execution, pdf_input,
 // structured_outputs), so returning null is honest — contrast with
 // fabricating {supported: false} rows for features we do not observe.
-// CLI-side the whole object is `.strip()`ed away regardless.
+// CLI-side the whole object is `.strip()`ed away regardless. Similarly,
+// `created_at` falls back to the epoch when the upstream never declared
+// one — the least-lossy sentinel, never confuseable with a real release
+// date and stable across catalog fetches.
 //
 // https://code.claude.com/docs/en/llm-gateway-protocol#model-discovery
 // https://docs.claude.com/en/api/models-list
 // https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/models.ts
-const toClaudeCodeShape = (response: PublicModelsResponse, userAgent: string | undefined) => {
-  if (!userAgent?.startsWith('claude-cli/')) return response;
-  // Anthropic requires `created_at` on every row, but not every catalog
-  // (Copilot, custom upstreams) declares one. Epoch is the least-lossy
-  // sentinel — never confuseable with a real release date and stable
-  // across catalog fetches.
+const toClaudeCodeShape = (response: PublicModelsResponse) => {
   const CREATED_AT_UNKNOWN = '1970-01-01T00:00:00Z';
   const data = response.data.map(model => {
     const max = model.limits.max_context_window_tokens;
@@ -73,7 +69,14 @@ export const models = async (c: Context) => {
   try {
     const fetcherForUpstream = await createPerRequestFetcher(getCurrentColo(c.req.raw));
     const response = await loadModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c), getRepo().modelAliases);
-    return Response.json(toClaudeCodeShape(response, c.req.header('user-agent')));
+    // The Claude Code CLI's model discovery request identifies itself with
+    // a `claude-cli/<version>` User-Agent prefix; every other caller
+    // (OpenAI SDKs, Anthropic SDKs, dashboards) receives the standard
+    // PublicModel superset.
+    if (c.req.header('user-agent')?.startsWith('claude-cli/')) {
+      return Response.json(toClaudeCodeShape(response));
+    }
+    return Response.json(response);
   } catch (e) {
     // Upstream HTTP/parse failures squash to a generic message so we do not
     // leak upstream identity. Other registry-thrown errors (e.g. the "no

--- a/packages/gateway/src/data-plane/models/serve.ts
+++ b/packages/gateway/src/data-plane/models/serve.ts
@@ -11,7 +11,7 @@ import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import { getRepo } from '../../repo/index.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getCurrentColo } from '../../runtime/runtime-info.ts';
-import type { PublicModel, PublicModelsResponse } from '@floway-dev/protocols/common';
+import type { PublicModelsResponse } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 
 // Claude Code CLI's `/model` picker discovers gateway-served models by GET
@@ -30,11 +30,11 @@ import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 //
 // (2) The response follows Anthropic's official /v1/models shape —
 // `{data, first_id, has_more, last_id}` with `ModelInfo` rows — instead
-// of Floway's OpenAI-Anthropic superset. Other Anthropic-format callers
+// of the OpenAI-Anthropic superset. Other Anthropic-format callers
 // parse the same official shape, so mirroring it here also lets any
 // future Anthropic-native picker reuse the payload. `capabilities` is
-// nullable per the SDK type; Floway does not track every dimension the
-// SDK declares (batch, citations, code_execution, pdf_input,
+// nullable per the SDK type; we do not track every dimension the SDK
+// declares (batch, citations, code_execution, pdf_input,
 // structured_outputs), so returning null is honest — contrast with
 // fabricating {supported: false} rows for features we do not observe.
 // CLI-side the whole object is `.strip()`ed away regardless.
@@ -42,53 +42,29 @@ import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 // https://code.claude.com/docs/en/llm-gateway-protocol#model-discovery
 // https://docs.claude.com/en/api/models-list
 // https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/models.ts
-const CLAUDE_CODE_UA_PREFIX = 'claude-cli/';
-
-// Anthropic /v1/models envelope + row shape. Kept local: the transform is
-// serve-time only; nothing downstream persists these rows.
-interface ClaudeCodeModelInfo {
-  id: string;
-  type: 'model';
-  display_name: string;
-  created_at: string;
-  max_input_tokens: number | null;
-  max_tokens: number | null;
-  capabilities: null;
-}
-
-interface ClaudeCodeModelsResponse {
-  data: ClaudeCodeModelInfo[];
-  first_id: string | null;
-  has_more: false;
-  last_id: string | null;
-}
-
-// Anthropic requires `created_at` on every row; Floway does not always
-// track a creation timestamp (Copilot catalog, custom upstreams). Epoch
-// is the least-lossy sentinel — never confuseable with a real release
-// date and stable across catalog fetches.
-const CREATED_AT_UNKNOWN = '1970-01-01T00:00:00Z';
-
-const toClaudeCodeModelInfo = (model: PublicModel): ClaudeCodeModelInfo => {
-  const max = model.limits.max_context_window_tokens;
-  const id = max !== undefined && max >= 1_000_000 ? `${model.id}[1m]` : model.id;
-  return {
-    id,
-    type: 'model',
-    display_name: model.display_name,
-    created_at: model.created_at ?? CREATED_AT_UNKNOWN,
-    max_input_tokens: max ?? null,
-    max_tokens: model.limits.max_output_tokens ?? null,
-    capabilities: null,
-  };
-};
-
-const toClaudeCodeShape = (response: PublicModelsResponse): ClaudeCodeModelsResponse => {
-  const data = response.data.map(toClaudeCodeModelInfo);
+const toClaudeCodeShape = (response: PublicModelsResponse, userAgent: string | undefined) => {
+  if (!userAgent?.startsWith('claude-cli/')) return response;
+  // Anthropic requires `created_at` on every row, but not every catalog
+  // (Copilot, custom upstreams) declares one. Epoch is the least-lossy
+  // sentinel — never confuseable with a real release date and stable
+  // across catalog fetches.
+  const CREATED_AT_UNKNOWN = '1970-01-01T00:00:00Z';
+  const data = response.data.map(model => {
+    const max = model.limits.max_context_window_tokens;
+    return {
+      id: max !== undefined && max >= 1_000_000 ? `${model.id}[1m]` : model.id,
+      type: 'model' as const,
+      display_name: model.display_name,
+      created_at: model.created_at ?? CREATED_AT_UNKNOWN,
+      max_input_tokens: max ?? null,
+      max_tokens: model.limits.max_output_tokens ?? null,
+      capabilities: null,
+    };
+  });
   return {
     data,
     first_id: data[0]?.id ?? null,
-    has_more: false,
+    has_more: false as const,
     last_id: data[data.length - 1]?.id ?? null,
   };
 };
@@ -97,11 +73,7 @@ export const models = async (c: Context) => {
   try {
     const fetcherForUpstream = await createPerRequestFetcher(getCurrentColo(c.req.raw));
     const response = await loadModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c), getRepo().modelAliases);
-    const userAgent = c.req.header('user-agent');
-    if (userAgent?.startsWith(CLAUDE_CODE_UA_PREFIX)) {
-      return Response.json(toClaudeCodeShape(response));
-    }
-    return Response.json(response);
+    return Response.json(toClaudeCodeShape(response, c.req.header('user-agent')));
   } catch (e) {
     // Upstream HTTP/parse failures squash to a generic message so we do not
     // leak upstream identity. Other registry-thrown errors (e.g. the "no

--- a/packages/gateway/src/data-plane/models/serve_test.ts
+++ b/packages/gateway/src/data-plane/models/serve_test.ts
@@ -799,3 +799,188 @@ test('/v1/models folds a real-id collision onto the alias even when the alias po
     },
   );
 });
+
+// Claude Code CLI's `/model` picker discovers gateway-served models by GET
+// /v1/models?limit=1000. Its `[1m]` suffix — which flips a pick to the
+// 1M-context window — only reaches the picker when the discovered id
+// carries the suffix, and the CLI does not synthesize the variant on
+// discovered ids in gateway mode. So the handler rewrites 1M-capable ids
+// on the wire only for callers that identify as the Claude Code CLI, and
+// translates the payload into the official Anthropic /v1/models shape
+// (`{data, first_id, has_more, last_id}` with `ModelInfo` rows).
+// Non-Claude-Code callers still see Floway's PublicModel superset.
+test('/v1/models serves Anthropic-shape rows with a [1m] suffix on 1M-capable ids to Claude Code CLI callers', async () => {
+  const { apiKey } = await setupAppTest();
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({
+          token: 'copilot-access-token',
+          expires_at: 4102444800,
+          refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
+        });
+      }
+      if (url.pathname === '/models' && url.hostname === 'api.individual.githubcopilot.com') {
+        return jsonResponse(
+          copilotModels([
+            {
+              id: 'claude-opus-4.7',
+              display_name: 'Claude Opus 4.7',
+              supported_endpoints: ['/v1/messages'],
+              maxContextWindowTokens: 1_000_000,
+              maxOutputTokens: 128_000,
+            },
+            {
+              id: 'claude-haiku-4.5',
+              display_name: 'Claude Haiku 4.5',
+              supported_endpoints: ['/v1/messages'],
+              maxContextWindowTokens: 200_000,
+              maxOutputTokens: 64_000,
+            },
+          ]),
+        );
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const claudeCodeResp = await requestApp('/v1/models', {
+        headers: { 'x-api-key': apiKey.key, 'user-agent': 'claude-cli/2.1.206 (external, cli)' },
+      });
+      assertEquals(claudeCodeResp.status, 200);
+      const claudeCodeBody = (await claudeCodeResp.json()) as {
+        object?: unknown;
+        first_id: string | null;
+        has_more: boolean;
+        last_id: string | null;
+        data: Array<{
+          id: string;
+          type: string;
+          display_name: string;
+          created_at: string;
+          max_input_tokens: number | null;
+          max_tokens: number | null;
+          capabilities: unknown;
+          // Floway superset leftovers that must not reach the wire in this branch.
+          object?: unknown;
+          kind?: unknown;
+          endpoints?: unknown;
+          limits?: unknown;
+          cost?: unknown;
+          chat?: unknown;
+        }>;
+      };
+      // Anthropic envelope: no `object` field, has_more literal false,
+      // container edges reflect the rewritten id order (Copilot merges in
+      // input order, so `claude-opus-4.7` lands first).
+      assertEquals(claudeCodeBody.object, undefined);
+      assertEquals(claudeCodeBody.has_more, false);
+      assertEquals(claudeCodeBody.first_id, 'claude-opus-4-7[1m]');
+      assertEquals(claudeCodeBody.last_id, 'claude-haiku-4-5');
+
+      // 1M model gains the suffix; display_name and token limits mirror
+      // upstream, so the picker keeps rendering the original label and
+      // downstream Anthropic-shape consumers still see accurate windows.
+      const opus = claudeCodeBody.data.find(m => m.display_name === 'Claude Opus 4.7')!;
+      assertEquals(opus.id, 'claude-opus-4-7[1m]');
+      assertEquals(opus.type, 'model');
+      assertEquals(opus.max_input_tokens, 1_000_000);
+      assertEquals(opus.max_tokens, 128_000);
+      // `capabilities` is intentionally null: Floway does not track every
+      // dimension the SDK declares; nulling out is honest, and the CLI
+      // strips the field anyway.
+      assertEquals(opus.capabilities, null);
+      // Unknown upstream release date collapses to the epoch sentinel.
+      assertEquals(opus.created_at, '1970-01-01T00:00:00Z');
+      // Floway superset fields are dropped from this branch.
+      assertEquals(opus.object, undefined);
+      assertEquals(opus.kind, undefined);
+      assertEquals(opus.endpoints, undefined);
+      assertEquals(opus.limits, undefined);
+      assertEquals(opus.cost, undefined);
+      assertEquals(opus.chat, undefined);
+
+      // 200K model stays bare and carries the same Anthropic-shape fields.
+      const haiku = claudeCodeBody.data.find(m => m.display_name === 'Claude Haiku 4.5')!;
+      assertEquals(haiku.id, 'claude-haiku-4-5');
+      assertEquals(haiku.max_input_tokens, 200_000);
+      assertEquals(haiku.max_tokens, 64_000);
+
+      // Non-Claude-Code caller: Floway's PublicModel superset is unchanged.
+      const openAiResp = await requestApp('/v1/models', {
+        headers: { 'x-api-key': apiKey.key, 'user-agent': 'openai-python/1.42.0' },
+      });
+      assertEquals(openAiResp.status, 200);
+      const openAiBody = (await openAiResp.json()) as {
+        object: string;
+        first_id: string | null;
+        last_id: string | null;
+        data: Array<{ id: string; kind?: string; limits?: Record<string, number>; type?: string; display_name?: string }>;
+      };
+      assertEquals(openAiBody.object, 'list');
+      assertEquals(openAiBody.data.map(m => m.id).sort(), ['claude-haiku-4-5', 'claude-opus-4-7']);
+      assertEquals(openAiBody.first_id, 'claude-opus-4-7');
+      assertEquals(openAiBody.last_id, 'claude-haiku-4-5');
+      const openAiOpus = openAiBody.data.find(m => m.id === 'claude-opus-4-7')!;
+      // Superset fields (kind, limits) still present on the default branch.
+      assertEquals(openAiOpus.kind, 'chat');
+      assertEquals(openAiOpus.limits?.max_context_window_tokens, 1_000_000);
+    },
+  );
+});
+
+// The Anthropic-shape branch also applies when nothing in the catalog
+// hits the 1M threshold: the caller must still get the official envelope
+// with bare ids, not the Floway superset.
+test('/v1/models serves Anthropic-shape rows without a [1m] suffix when no model advertises 1M context', async () => {
+  const { apiKey } = await setupAppTest();
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({
+          token: 'copilot-access-token',
+          expires_at: 4102444800,
+          refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
+        });
+      }
+      if (url.pathname === '/models' && url.hostname === 'api.individual.githubcopilot.com') {
+        return jsonResponse(
+          copilotModels([
+            {
+              id: 'claude-haiku-4.5',
+              display_name: 'Claude Haiku 4.5',
+              supported_endpoints: ['/v1/messages'],
+              maxContextWindowTokens: 200_000,
+            },
+          ]),
+        );
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const response = await requestApp('/v1/models', {
+        headers: { 'x-api-key': apiKey.key, 'user-agent': 'claude-cli/2.1.206' },
+      });
+      assertEquals(response.status, 200);
+      const body = (await response.json()) as {
+        object?: unknown;
+        has_more: boolean;
+        data: Array<{ id: string; type: string; capabilities: unknown; max_input_tokens: number | null }>;
+      };
+      assertEquals(body.object, undefined);
+      assertEquals(body.has_more, false);
+      assertEquals(body.data.length, 1);
+      assertEquals(body.data[0].id, 'claude-haiku-4-5');
+      assertEquals(body.data[0].type, 'model');
+      assertEquals(body.data[0].max_input_tokens, 200_000);
+      assertEquals(body.data[0].capabilities, null);
+    },
+  );
+});

--- a/packages/gateway/src/data-plane/models/serve_test.ts
+++ b/packages/gateway/src/data-plane/models/serve_test.ts
@@ -848,7 +848,7 @@ test('/v1/models serves Anthropic-shape rows with a [1m] suffix on 1M-capable id
     },
     async () => {
       const claudeCodeResp = await requestApp('/v1/models', {
-        headers: { 'x-api-key': apiKey.key, 'user-agent': 'claude-cli/2.1.206 (external, cli)' },
+        headers: { 'x-api-key': apiKey.key, 'user-agent': 'claude-code/2.1.206' },
       });
       assertEquals(claudeCodeResp.status, 200);
       const claudeCodeBody = (await claudeCodeResp.json()) as {
@@ -966,7 +966,7 @@ test('/v1/models serves Anthropic-shape rows without a [1m] suffix when no model
     },
     async () => {
       const response = await requestApp('/v1/models', {
-        headers: { 'x-api-key': apiKey.key, 'user-agent': 'claude-cli/2.1.206' },
+        headers: { 'x-api-key': apiKey.key, 'user-agent': 'claude-code/2.1.206' },
       });
       assertEquals(response.status, 200);
       const body = (await response.json()) as {


### PR DESCRIPTION
## Summary

`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` makes the Claude Code CLI (v2.1.129+) pull `GET /v1/models` at startup and add each row to its `/model` picker. In gateway mode the CLI does not synthesize `<id>[1m]` variants on discovered ids (its `eligible1mSuffixTarget` path gates on firstParty), and its picker parser filters out anything whose id does not start with `claude` or `anthropic`. So 1M-capable Anthropic models routed through this gateway never surfaced as their `[1m]` picker entry, and users on this gateway could not select the 1M-context window from `/model`.

For callers whose `User-Agent` starts with `claude-code/` (the UA the CLI's discovery `fetch` emits via its `n_()` helper — distinct from the `claude-cli/*` UA the Anthropic SDK sends on `/v1/messages`), the `/v1/models` handler now:

- suffixes ids whose `max_context_window_tokens >= 1_000_000` with `[1m]`, and
- translates the payload into Anthropic's official `/v1/models` shape (`{data, first_id, has_more, last_id}` with `ModelInfo` rows) so other Anthropic-native pickers can reuse it too.

Non-CLI callers (OpenAI SDKs, Anthropic SDKs, dashboards) continue to receive Floway's OpenAI-Anthropic PublicModel superset unchanged.

Request routing is untouched: the CLI strips `[1m]` before every inference request and pairs it with `anthropic-beta: context-1m-2025-08-07`, which the providers already honor — Copilot maps the beta to its `context1m` variant selector, and `provider-claude-code` passes the header through to Anthropic.

## Design notes

`capabilities` returns `null` on every row. The SDK type allows null, and we do not track every dimension it declares (`batch`, `citations`, `code_execution`, `pdf_input`, `structured_outputs`) — fabricating `{supported: false}` would be fake robustness, and the CLI `.strip()`s the whole object regardless.

`created_at` falls back to the epoch when the upstream never declared one (Copilot catalog, custom upstreams). The CLI ignores the field; other Anthropic-shape consumers see an unambiguous sentinel.

## References

- https://code.claude.com/docs/en/llm-gateway-protocol#model-discovery
- https://docs.claude.com/en/api/models-list
- https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/models.ts

## Test plan

- [x] `pnpm run test` — 3840/3840 pass, including two new HTTP-boundary tests for the CLI branch (1M+ models get `[1m]`; the Anthropic envelope shape is emitted with or without 1M-capable models)
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] Production probe: `curl -H "User-Agent: claude-code/2.1.207"` against the deployed gateway returns the Anthropic envelope with `[1m]`-suffixed ids for every 1M-capable model, and a `User-Agent: openai-python/*` probe against the same endpoint still returns the OpenAI-Anthropic superset unchanged
- [x] End-to-end: with a fresh CLI cache the CLI writes `[1m]`-suffixed ids into `~/.claude/cache/gateway-models.json`; running the CLI with `ANTHROPIC_MODEL=claude-sonnet-5[1m]` and `ANTHROPIC_MODEL=claude-opus-4-7[1m]` produces `/v1/messages` requests carrying `anthropic-beta: context-1m-2025-08-07` (verified via `wrangler tail`), while the bare `claude-sonnet-5` / `sonnet` variants do not; picking Sonnet 5 from the `/model` picker under the refreshed cache shows the 1M context window in `/context`