### PR TITLE
fix(translate): map context-exceeded errors to prompt-too-long

### DIFF
--- a/packages/gateway/src/data-plane/chat/shared/translate-traverse.ts
+++ b/packages/gateway/src/data-plane/chat/shared/translate-traverse.ts
@@ -1,18 +1,34 @@
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ExecuteResult } from '@floway-dev/provider';
+import type { TranslatedApiError } from '@floway-dev/translate';
 
 // Threads a translate trip around an inner attempt. The trip itself is async
 // (the real `@floway-dev/translate` pair functions resolve a `Promise`), so
 // `translate` returns the trip object behind a promise. The pair functions
 // take `(src, ctx)`; this helper's `translate` parameter stays unary so each
 // caller closes over its own `ctx` (`p => translateXViaY(p, ctx)`).
+//
+// On an upstream api-error the trip's optional `apiError` hook is invoked so
+// the pair can rewrite the body into the source protocol's envelope — the
+// canonical case is `messages-via-*` translating an upstream context-window
+// error into the Anthropic `prompt is too long:` shape Claude Code recognizes
+// for auto-compaction. Pairs that don't set `apiError` (or return `undefined`)
+// pass the upstream body through verbatim.
 export const traverseTranslation = async <SP, TP, SE, TE>(
   payload: SP,
-  translate: (p: SP) => Promise<{ target: TP; events: (e: AsyncIterable<ProtocolFrame<TE>>) => AsyncIterable<ProtocolFrame<SE>> }>,
+  translate: (p: SP) => Promise<{
+    target: TP;
+    events: (e: AsyncIterable<ProtocolFrame<TE>>) => AsyncIterable<ProtocolFrame<SE>>;
+    apiError?: (upstream: TranslatedApiError) => TranslatedApiError | undefined;
+  }>,
   innerAttempt: (translated: TP) => Promise<ExecuteResult<ProtocolFrame<TE>>>,
 ): Promise<ExecuteResult<ProtocolFrame<SE>>> => {
   const trip = await translate(payload);
   const inner = await innerAttempt(trip.target);
-  if (inner.type !== 'events') return inner;
-  return { ...inner, events: trip.events(inner.events) };
+  if (inner.type === 'events') return { ...inner, events: trip.events(inner.events) };
+  if (inner.type === 'api-error' && inner.source === 'upstream' && trip.apiError !== undefined) {
+    const rewritten = trip.apiError({ status: inner.status, headers: inner.headers, body: inner.body });
+    if (rewritten !== undefined) return { ...inner, status: rewritten.status, headers: rewritten.headers, body: rewritten.body };
+  }
+  return inner;
 };

--- a/packages/gateway/src/data-plane/chat/shared/translate-traverse_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/translate-traverse_test.ts
@@ -86,4 +86,75 @@ describe('traverseTranslation', () => {
 
     expect(result).toBe(inner);
   });
+
+  test('upstream api-error with trip.apiError rewrite — outer returns the rewritten envelope', async () => {
+    const inner: ExecuteResult<ProtocolFrame<TgtEvent>> = {
+      type: 'api-error',
+      source: 'upstream',
+      status: 400,
+      headers: new Headers({ 'x-upstream-request-id': 'abc' }),
+      body: new TextEncoder().encode('raw upstream'),
+    };
+    const translateWithRewrite = async (payload: string): Promise<{
+      target: string;
+      events: (e: AsyncIterable<ProtocolFrame<TgtEvent>>) => AsyncIterable<ProtocolFrame<SrcEvent>>;
+      apiError: (upstream: { status: number; headers: Headers; body: Uint8Array }) => { status: number; headers: Headers; body: Uint8Array };
+    }> => ({
+      ...(await translate(payload)),
+      apiError: () => ({ status: 400, headers: new Headers({ 'content-type': 'application/json' }), body: new TextEncoder().encode('rewritten') }),
+    });
+
+    const result = await traverseTranslation('payload', translateWithRewrite, async () => inner);
+    expect(result.type).toBe('api-error');
+    if (result.type !== 'api-error') throw new Error('unreachable');
+    expect(new TextDecoder().decode(result.body)).toBe('rewritten');
+    expect(result.headers.get('content-type')).toBe('application/json');
+    expect(result.headers.get('x-upstream-request-id')).toBeNull();
+    // Fields not touched by the rewriter (source, performance, upstream) survive.
+    expect(result.source).toBe('upstream');
+  });
+
+  test('upstream api-error with trip.apiError returning undefined — outer passes the envelope through', async () => {
+    const inner: ExecuteResult<ProtocolFrame<TgtEvent>> = {
+      type: 'api-error',
+      source: 'upstream',
+      status: 502,
+      headers: new Headers(),
+      body: new TextEncoder().encode('bad gateway'),
+    };
+    const translateWithRewrite = async (payload: string): Promise<{
+      target: string;
+      events: (e: AsyncIterable<ProtocolFrame<TgtEvent>>) => AsyncIterable<ProtocolFrame<SrcEvent>>;
+      apiError: () => undefined;
+    }> => ({ ...(await translate(payload)), apiError: () => undefined });
+
+    const result = await traverseTranslation('payload', translateWithRewrite, async () => inner);
+    expect(result).toBe(inner);
+  });
+
+  test('gateway-sourced api-error — trip.apiError is NOT invoked', async () => {
+    const inner: ExecuteResult<ProtocolFrame<TgtEvent>> = {
+      type: 'api-error',
+      source: 'gateway',
+      status: 400,
+      headers: new Headers(),
+      body: new TextEncoder().encode('synthesized'),
+    };
+    let called = false;
+    const translateWithRewrite = async (payload: string): Promise<{
+      target: string;
+      events: (e: AsyncIterable<ProtocolFrame<TgtEvent>>) => AsyncIterable<ProtocolFrame<SrcEvent>>;
+      apiError: () => { status: number; headers: Headers; body: Uint8Array };
+    }> => ({
+      ...(await translate(payload)),
+      apiError: () => {
+        called = true;
+        return { status: 999, headers: new Headers(), body: new Uint8Array() };
+      },
+    });
+
+    const result = await traverseTranslation('payload', translateWithRewrite, async () => inner);
+    expect(called).toBe(false);
+    expect(result).toBe(inner);
+  });
 });

--- a/packages/protocols/src/messages/context-window-error.ts
+++ b/packages/protocols/src/messages/context-window-error.ts
@@ -1,0 +1,32 @@
+// Anthropic Messages envelope emitted for any context-exceeded upstream. The
+// leading `prompt is too long` substring is the load-bearing part: Claude
+// Code's context-exceeded detector is a case-insensitive substring match on
+// `error.message`, running
+//
+//   error.message.toLowerCase().includes('prompt is too long')
+//   error.message.toLowerCase().includes('input length and `max_tokens` exceed context limit')
+//
+// on whatever Error the SDK raises — same predicate for streaming and
+// non-streaming; `error.type` and the HTTP status are NOT inspected. A hit
+// routes into the internal `prompt_too_long` category and triggers
+// auto-compaction (telemetry event `tengu_compact_ptl_retry`). Evidence:
+// grep the shipped `@anthropic-ai/claude-code` v2.1.207 binary (build
+// fingerprint `bc512d5`, built 2026-07-10) — the two predicates sit next
+// to the `Prompt is too long` string constant. The client's source is
+// Anthropic-private, so the shipped bundle is the only public artefact
+// that verifies this behaviour; the docs summary at
+// https://docs.claude.com/en/docs/claude-code/common-workflows#prompt-too-long
+// covers the user-facing symptom without spelling out the predicate.
+export const PROMPT_TOO_LONG_MESSAGE =
+  'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.';
+
+// Byte-shape mirrors the Anthropic-direct error envelope. Only the
+// `prompt is too long` substring inside `error.message` is load-bearing for
+// Claude Code's auto-compaction gate (see PROMPT_TOO_LONG_MESSAGE above);
+// the `invalid_request_error` type matches Anthropic-direct convention but
+// is not part of the detector.
+export const buildPromptTooLongBody = (): Uint8Array =>
+  new TextEncoder().encode(JSON.stringify({
+    type: 'error',
+    error: { type: 'invalid_request_error', message: PROMPT_TOO_LONG_MESSAGE },
+  }));

--- a/packages/protocols/src/messages/index.ts
+++ b/packages/protocols/src/messages/index.ts
@@ -369,3 +369,4 @@ export const parseAnthropicBetaHeader = (raw: string | null | undefined): readon
 export { MESSAGES_MISSING_TERMINAL_MESSAGE, collectMessagesProtocolEventsToResult } from './to-result.ts';
 export { reassembleMessagesEvents } from './reassemble.ts';
 export { messagesProtocolFrameToSSEFrame } from './to-sse.ts';
+export { PROMPT_TOO_LONG_MESSAGE, buildPromptTooLongBody } from './context-window-error.ts';

--- a/packages/provider-copilot/src/interceptors/messages/rewrite-context-window-error.ts
+++ b/packages/provider-copilot/src/interceptors/messages/rewrite-context-window-error.ts
@@ -1,4 +1,5 @@
 import type { CopilotMessagesBoundaryInterceptor } from './types.ts';
+import { buildPromptTooLongBody } from '@floway-dev/protocols/messages';
 
 const isContextWindowError = (text: string): boolean => text.includes('Request body is too large for model context window') || text.includes('context_length_exceeded');
 
@@ -7,12 +8,14 @@ const isContextWindowError = (text: string): boolean => text.includes('Request b
  * Anthropic-shape body carrying a Copilot-specific message string; Claude
  * Code's detector matches on the message substring alone (case-insensitive
  * `error.message.toLowerCase().includes('prompt is too long')`), so we
- * rewrite this body to lead with that phrase and trigger auto-compaction.
- * The detector, string constants, and matching envelope live in
- * `@floway-dev/translate/shared/messages/context-window-error.ts` — see the
- * comment on `PROMPT_TOO_LONG_MESSAGE` there for the client-bundle
- * evidence. This interceptor exists in addition because Copilot's Messages
- * endpoint never traverses the `messages-via-*` translation pairs.
+ * rewrite this body to the canonical prompt-too-long envelope and trigger
+ * auto-compaction. The envelope + client-bundle evidence live in
+ * `@floway-dev/protocols/messages` (`buildPromptTooLongBody` /
+ * `PROMPT_TOO_LONG_MESSAGE`). This interceptor exists in addition to the
+ * translate-layer rewriter because Copilot's Messages endpoint never
+ * traverses the `messages-via-*` translation pairs — the Copilot Messages
+ * substring set here (`Request body is too large...`) is disjoint from
+ * the Responses/Chat shapes those pairs match on.
  */
 export const rewriteContextWindowError: CopilotMessagesBoundaryInterceptor = async (_ctx, _request, run) => {
   const result = await run();
@@ -25,14 +28,6 @@ export const rewriteContextWindowError: CopilotMessagesBoundaryInterceptor = asy
     ...result,
     status: 400,
     headers: new Headers({ 'content-type': 'application/json' }),
-    body: new TextEncoder().encode(
-      JSON.stringify({
-        type: 'error',
-        error: {
-          type: 'invalid_request_error',
-          message: 'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.',
-        },
-      }),
-    ),
+    body: buildPromptTooLongBody(),
   };
 };

--- a/packages/provider-copilot/src/interceptors/messages/rewrite-context-window-error.ts
+++ b/packages/provider-copilot/src/interceptors/messages/rewrite-context-window-error.ts
@@ -3,13 +3,16 @@ import type { CopilotMessagesBoundaryInterceptor } from './types.ts';
 const isContextWindowError = (text: string): boolean => text.includes('Request body is too large for model context window') || text.includes('context_length_exceeded');
 
 /**
- * Copilot can report context-window failures using non-Messages strings, but
- * Messages clients expect a Messages-shaped `invalid_request_error`; Claude
- * Code uses that shape to trigger compaction instead of surfacing a raw
- * upstream error.
- *
- * References:
- * - https://docs.claude.com/en/docs/claude-code/common-workflows#prompt-too-long
+ * Copilot's `/v1/messages` endpoint reports context-window failures with an
+ * Anthropic-shape body carrying a Copilot-specific message string; Claude
+ * Code's detector matches on the message substring alone (case-insensitive
+ * `error.message.toLowerCase().includes('prompt is too long')`), so we
+ * rewrite this body to lead with that phrase and trigger auto-compaction.
+ * The detector, string constants, and matching envelope live in
+ * `@floway-dev/translate/shared/messages/context-window-error.ts` — see the
+ * comment on `PROMPT_TOO_LONG_MESSAGE` there for the client-bundle
+ * evidence. This interceptor exists in addition because Copilot's Messages
+ * endpoint never traverses the `messages-via-*` translation pairs.
  */
 export const rewriteContextWindowError: CopilotMessagesBoundaryInterceptor = async (_ctx, _request, run) => {
   const result = await run();

--- a/packages/translate/src/index.ts
+++ b/packages/translate/src/index.ts
@@ -8,5 +8,5 @@ export { translateGeminiViaMessages } from './gemini-via-messages/translate.ts';
 export { translateGeminiViaResponses } from './gemini-via-responses/translate.ts';
 export { translateGeminiViaChatCompletions } from './gemini-via-chat-completions/translate.ts';
 
-export type { TranslationContext } from './types.ts';
+export type { TranslatedApiError, TranslationContext } from './types.ts';
 export { TranslatorInputError } from './translator-input-error.ts';

--- a/packages/translate/src/messages-via-chat-completions/translate.ts
+++ b/packages/translate/src/messages-via-chat-completions/translate.ts
@@ -1,5 +1,6 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
+import { rewriteContextExceededToPromptTooLong } from '../shared/messages/context-window-error.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -9,4 +10,5 @@ export const translateMessagesViaChatCompletions: TranslateTrip<
 > = async src => ({
   target: buildTargetRequest(src),
   events: translateToSourceEvents,
+  apiError: rewriteContextExceededToPromptTooLong,
 });

--- a/packages/translate/src/messages-via-responses/events.ts
+++ b/packages/translate/src/messages-via-responses/events.ts
@@ -1,3 +1,4 @@
+import { isContextExceededError, PROMPT_TOO_LONG_MESSAGE } from '../shared/messages/context-window-error.ts';
 import { parseToolArgumentsObject } from '../shared/messages/tool-arguments.ts';
 import { packReasoningSignature, responsesReasoningToMessagesBlock } from '../shared/messages-and-responses/reasoning.ts';
 import { createResponsesOutputOrderState, recordResponsesOutputOrderEvent, type ResponsesOutputOrderState, shouldDeferForEarlierResponsesOutput } from '../shared/via-responses/responses-stream-order.ts';
@@ -427,25 +428,37 @@ const handleCompleted = (response: ResponsesResult, state: ResponsesToMessagesSt
   return events;
 };
 
-const handleStreamError = (state: ResponsesToMessagesStreamState, message: string): MessagesStreamEvent[] => {
+interface StreamErrorPayload {
+  type: 'api_error' | 'invalid_request_error';
+  message: string;
+}
+
+const handleStreamError = (state: ResponsesToMessagesStreamState, error: StreamErrorPayload): MessagesStreamEvent[] => {
   const events: MessagesStreamEvent[] = [];
   closeAllBlocks(state, events);
   state.messageCompleted = true;
-  events.push({
-    type: 'error',
-    error: {
-      type: 'api_error',
-      message,
-    },
-  });
+  events.push({ type: 'error', error });
   return events;
 };
 
+// A Responses upstream can report a context-exceeded failure inside the SSE
+// stream (Codex emits `response.failed` with `error.code =
+// context_length_exceeded`; some Copilot fronts surface a stream `error`
+// event with the same code). We rewrite those into the same Anthropic
+// `invalid_request_error` + `prompt is too long:` envelope the unary path
+// uses, so a Messages client (Claude Code in particular) recognizes the
+// condition and triggers auto-compaction whether the failure arrived
+// pre-stream or mid-stream.
+const streamErrorForFailure = (error: { code?: string; message?: string } | undefined, fallbackMessage: string): StreamErrorPayload =>
+  isContextExceededError(error)
+    ? { type: 'invalid_request_error', message: PROMPT_TOO_LONG_MESSAGE }
+    : { type: 'api_error', message: error?.message ?? fallbackMessage };
+
 const handleFailed = (response: ResponsesResult, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] =>
-  handleStreamError(state, response.error?.message ?? 'Response failed due to unknown error.');
+  handleStreamError(state, streamErrorForFailure(response.error ?? undefined, 'Response failed due to unknown error.'));
 
 const handleError = (event: ResponsesEvent<'error'>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] =>
-  handleStreamError(state, typeof event.message === 'string' ? event.message : 'An unexpected error occurred during streaming.');
+  handleStreamError(state, streamErrorForFailure({ code: event.code, message: event.message }, 'An unexpected error occurred during streaming.'));
 
 export const createResponsesToMessagesStreamState = (): ResponsesToMessagesStreamState => ({
   messageCompleted: false,

--- a/packages/translate/src/messages-via-responses/events.ts
+++ b/packages/translate/src/messages-via-responses/events.ts
@@ -428,19 +428,6 @@ const handleCompleted = (response: ResponsesResult, state: ResponsesToMessagesSt
   return events;
 };
 
-interface StreamErrorPayload {
-  type: 'api_error' | 'invalid_request_error';
-  message: string;
-}
-
-const handleStreamError = (state: ResponsesToMessagesStreamState, error: StreamErrorPayload): MessagesStreamEvent[] => {
-  const events: MessagesStreamEvent[] = [];
-  closeAllBlocks(state, events);
-  state.messageCompleted = true;
-  events.push({ type: 'error', error });
-  return events;
-};
-
 // A Responses upstream can report a context-exceeded failure inside the SSE
 // stream (Codex emits `response.failed` with `error.code =
 // context_length_exceeded`; some Copilot fronts surface a stream `error`
@@ -449,16 +436,28 @@ const handleStreamError = (state: ResponsesToMessagesStreamState, error: StreamE
 // uses, so a Messages client (Claude Code in particular) recognizes the
 // condition and triggers auto-compaction whether the failure arrived
 // pre-stream or mid-stream.
-const streamErrorForFailure = (error: { code?: string; message?: string } | undefined, fallbackMessage: string): StreamErrorPayload =>
-  isContextExceededError(error)
-    ? { type: 'invalid_request_error', message: PROMPT_TOO_LONG_MESSAGE }
-    : { type: 'api_error', message: error?.message ?? fallbackMessage };
+const handleStreamError = (
+  state: ResponsesToMessagesStreamState,
+  error: { code?: string; message?: string } | undefined,
+  fallbackMessage: string,
+): MessagesStreamEvent[] => {
+  const events: MessagesStreamEvent[] = [];
+  closeAllBlocks(state, events);
+  state.messageCompleted = true;
+  events.push({
+    type: 'error',
+    error: isContextExceededError(error)
+      ? { type: 'invalid_request_error', message: PROMPT_TOO_LONG_MESSAGE }
+      : { type: 'api_error', message: error?.message ?? fallbackMessage },
+  });
+  return events;
+};
 
 const handleFailed = (response: ResponsesResult, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] =>
-  handleStreamError(state, streamErrorForFailure(response.error ?? undefined, 'Response failed due to unknown error.'));
+  handleStreamError(state, response.error ?? undefined, 'Response failed due to unknown error.');
 
 const handleError = (event: ResponsesEvent<'error'>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] =>
-  handleStreamError(state, streamErrorForFailure({ code: event.code, message: event.message }, 'An unexpected error occurred during streaming.'));
+  handleStreamError(state, { code: event.code, message: event.message }, 'An unexpected error occurred during streaming.');
 
 export const createResponsesToMessagesStreamState = (): ResponsesToMessagesStreamState => ({
   messageCompleted: false,

--- a/packages/translate/src/messages-via-responses/events_test.ts
+++ b/packages/translate/src/messages-via-responses/events_test.ts
@@ -672,3 +672,108 @@ test('translateResponsesToMessagesResult omits usage.speed when service_tier is 
 
   assertEquals(result.usage.speed, undefined);
 });
+
+const responseFailedEvent = (error: { code: string; message: string }): Parameters<typeof translateResponsesStreamEventToMessagesEvents>[0] => ({
+  type: 'response.failed',
+  response: {
+    id: 'resp_ctx',
+    object: 'response',
+    model: 'gpt-test',
+    output: [],
+    output_text: '',
+    status: 'failed',
+    error,
+    incomplete_details: null,
+    usage: undefined,
+  },
+});
+
+test('Codex-shaped response.failed with context_length_exceeded → invalid_request_error with prompt-too-long prefix', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = translateResponsesStreamEventToMessagesEvents(
+    responseFailedEvent({ code: 'context_length_exceeded', message: 'Your input exceeds the context window of this model. Please adjust your input and try again.' }),
+    state,
+  );
+
+  assertEquals(events, [{
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.',
+    },
+  }]);
+});
+
+test('Copilot-shaped response.failed with model_max_prompt_tokens_exceeded → invalid_request_error with prompt-too-long prefix', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = translateResponsesStreamEventToMessagesEvents(
+    responseFailedEvent({ code: 'model_max_prompt_tokens_exceeded', message: 'prompt token count of 1000000 exceeds the limit of 128000' }),
+    state,
+  );
+
+  assertEquals(events, [{
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.',
+    },
+  }]);
+});
+
+test('response.failed with an unrelated code passes through as api_error carrying the upstream message', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = translateResponsesStreamEventToMessagesEvents(
+    responseFailedEvent({ code: 'server_error', message: 'upstream failed' }),
+    state,
+  );
+
+  assertEquals(events, [{
+    type: 'error',
+    error: { type: 'api_error', message: 'upstream failed' },
+  }]);
+});
+
+test('stream `error` event with context_length_exceeded code → invalid_request_error with prompt-too-long prefix', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = translateResponsesStreamEventToMessagesEvents(
+    { type: 'error', code: 'context_length_exceeded', message: 'Your input exceeds the context window of this model.' },
+    state,
+  );
+
+  assertEquals(events, [{
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.',
+    },
+  }]);
+});
+
+test('stream `error` event without a matching code but with a matching message substring → invalid_request_error', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = translateResponsesStreamEventToMessagesEvents(
+    { type: 'error', message: "This model's maximum context length is 4097 tokens. However, your messages resulted in 4498 tokens." },
+    state,
+  );
+
+  assertEquals(events, [{
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.',
+    },
+  }]);
+});
+
+test('stream `error` event with a mundane message → api_error carrying that message', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = translateResponsesStreamEventToMessagesEvents(
+    { type: 'error', message: 'transient upstream hiccup' },
+    state,
+  );
+
+  assertEquals(events, [{
+    type: 'error',
+    error: { type: 'api_error', message: 'transient upstream hiccup' },
+  }]);
+});

--- a/packages/translate/src/messages-via-responses/translate.ts
+++ b/packages/translate/src/messages-via-responses/translate.ts
@@ -1,5 +1,6 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
+import { rewriteContextExceededToPromptTooLong } from '../shared/messages/context-window-error.ts';
 import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -10,4 +11,5 @@ export const translateMessagesViaResponses: TranslateTrip<
 > = async src => ({
   target: buildTargetRequest(src),
   events: translateToSourceEvents,
+  apiError: rewriteContextExceededToPromptTooLong,
 });

--- a/packages/translate/src/shared/messages/context-window-error.ts
+++ b/packages/translate/src/shared/messages/context-window-error.ts
@@ -1,10 +1,24 @@
 import type { TranslatedApiError } from '../../types.ts';
 
-// Anthropic Messages canonical envelope for a prompt-too-long error. Claude
-// Code recognizes the `prompt is too long:` prefix and uses it to trigger
-// auto-compaction; without it the client surfaces a raw upstream error and
-// gives up. Ref:
+// Anthropic Messages envelope emitted for any context-exceeded upstream. The
+// leading `prompt is too long` substring is the load-bearing part: Claude
+// Code's context-exceeded detector is a case-insensitive substring match on
+// `error.message`, running
+//
+//   error.message.toLowerCase().includes('prompt is too long')
+//   error.message.toLowerCase().includes('input length and `max_tokens` exceed context limit')
+//
+// on whatever Error the SDK raises — same predicate for streaming and
+// non-streaming; `error.type` and the HTTP status are NOT inspected. A hit
+// routes into the internal `prompt_too_long` category and triggers
+// auto-compaction (telemetry event `tengu_compact_ptl_retry`). Evidence:
+// grep the shipped `@anthropic-ai/claude-code` v2.1.207 binary (build
+// fingerprint `bc512d5`, built 2026-07-10) — the two predicates sit next
+// to the `Prompt is too long` string constant. The client's source is
+// Anthropic-private, so the shipped bundle is the only public artefact
+// that verifies this behaviour; the docs summary at
 // https://docs.claude.com/en/docs/claude-code/common-workflows#prompt-too-long
+// covers the user-facing symptom without spelling out the predicate.
 export const PROMPT_TOO_LONG_MESSAGE =
   'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.';
 
@@ -66,10 +80,11 @@ export const isContextExceededErrorText = (text: string): boolean => {
   }
 };
 
-// Byte-shape matches the Anthropic-direct error envelope for a
-// prompt-too-long condition. `type: 'invalid_request_error'` and the
-// `prompt is too long:` prefix are both load-bearing for Claude Code
-// compaction detection.
+// Byte-shape mirrors the Anthropic-direct error envelope. Only the
+// `prompt is too long` substring inside `error.message` is load-bearing for
+// Claude Code's auto-compaction gate (see PROMPT_TOO_LONG_MESSAGE above);
+// the `invalid_request_error` type matches Anthropic-direct convention but
+// is not part of the detector.
 export const buildPromptTooLongBody = (): Uint8Array =>
   new TextEncoder().encode(JSON.stringify({
     type: 'error',

--- a/packages/translate/src/shared/messages/context-window-error.ts
+++ b/packages/translate/src/shared/messages/context-window-error.ts
@@ -1,26 +1,7 @@
 import type { TranslatedApiError } from '../../types.ts';
+import { buildPromptTooLongBody } from '@floway-dev/protocols/messages';
 
-// Anthropic Messages envelope emitted for any context-exceeded upstream. The
-// leading `prompt is too long` substring is the load-bearing part: Claude
-// Code's context-exceeded detector is a case-insensitive substring match on
-// `error.message`, running
-//
-//   error.message.toLowerCase().includes('prompt is too long')
-//   error.message.toLowerCase().includes('input length and `max_tokens` exceed context limit')
-//
-// on whatever Error the SDK raises — same predicate for streaming and
-// non-streaming; `error.type` and the HTTP status are NOT inspected. A hit
-// routes into the internal `prompt_too_long` category and triggers
-// auto-compaction (telemetry event `tengu_compact_ptl_retry`). Evidence:
-// grep the shipped `@anthropic-ai/claude-code` v2.1.207 binary (build
-// fingerprint `bc512d5`, built 2026-07-10) — the two predicates sit next
-// to the `Prompt is too long` string constant. The client's source is
-// Anthropic-private, so the shipped bundle is the only public artefact
-// that verifies this behaviour; the docs summary at
-// https://docs.claude.com/en/docs/claude-code/common-workflows#prompt-too-long
-// covers the user-facing symptom without spelling out the predicate.
-export const PROMPT_TOO_LONG_MESSAGE =
-  'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.';
+export { PROMPT_TOO_LONG_MESSAGE } from '@floway-dev/protocols/messages';
 
 // Structural + textual detector for context-exceeded error bodies coming from
 // any OpenAI-shaped upstream. Codes take precedence; message substrings are a
@@ -67,29 +48,18 @@ export const isContextExceededError = (error: MaybeErrorFields | undefined | nul
   return codeIsContextExceeded(error.code) || messageIsContextExceeded(error.message);
 };
 
-export const isContextExceededErrorObject = (parsed: unknown): boolean => {
+const isContextExceededErrorObject = (parsed: unknown): boolean => {
   if (parsed === null || typeof parsed !== 'object') return false;
   return isContextExceededError((parsed as MaybeErrorBody).error);
 };
 
-export const isContextExceededErrorText = (text: string): boolean => {
+const isContextExceededErrorText = (text: string): boolean => {
   try {
     return isContextExceededErrorObject(JSON.parse(text));
   } catch {
     return messageIsContextExceeded(text);
   }
 };
-
-// Byte-shape mirrors the Anthropic-direct error envelope. Only the
-// `prompt is too long` substring inside `error.message` is load-bearing for
-// Claude Code's auto-compaction gate (see PROMPT_TOO_LONG_MESSAGE above);
-// the `invalid_request_error` type matches Anthropic-direct convention but
-// is not part of the detector.
-export const buildPromptTooLongBody = (): Uint8Array =>
-  new TextEncoder().encode(JSON.stringify({
-    type: 'error',
-    error: { type: 'invalid_request_error', message: PROMPT_TOO_LONG_MESSAGE },
-  }));
 
 // Shared `TranslateTrip.apiError` implementation for the `messages-via-*`
 // pairs. Rewrites an upstream context-exceeded body into an Anthropic

--- a/packages/translate/src/shared/messages/context-window-error.ts
+++ b/packages/translate/src/shared/messages/context-window-error.ts
@@ -1,0 +1,89 @@
+import type { TranslatedApiError } from '../../types.ts';
+
+// Anthropic Messages canonical envelope for a prompt-too-long error. Claude
+// Code recognizes the `prompt is too long:` prefix and uses it to trigger
+// auto-compaction; without it the client surfaces a raw upstream error and
+// gives up. Ref:
+// https://docs.claude.com/en/docs/claude-code/common-workflows#prompt-too-long
+export const PROMPT_TOO_LONG_MESSAGE =
+  'prompt is too long: your prompt is too long. Please reduce the number of messages or use a model with a larger context window.';
+
+// Structural + textual detector for context-exceeded error bodies coming from
+// any OpenAI-shaped upstream. Codes take precedence; message substrings are a
+// fallback for shapes where the code was renamed or omitted.
+//
+// Coverage (all captured live or from vendor fixtures):
+//
+// - Copilot Responses / Chat Completions (HTTP 400):
+//     {"error":{"code":"model_max_prompt_tokens_exceeded","message":"prompt token count of N exceeds the limit of M"}}
+// - Codex Responses unary (HTTP 400):
+//     {"error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. ..."}}
+// - Codex Responses streaming SSE `response.failed` frame:
+//     data: {..., "response": {..., "error":{"code":"context_length_exceeded", "message":"..."}}}
+//     — https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/sse/responses.rs
+// - Canonical OpenAI Chat Completions:
+//     {"error":{"code":"context_length_exceeded","type":"invalid_request_error","message":"This model's maximum context length is ..."}}
+// - Copilot `/v1/messages` (Anthropic-shaped body carrying a Copilot-specific
+//   message string):
+//     {"type":"error","error":{"type":"invalid_request_error","message":"Request body is too large for model context window ..."}}
+//   The provider-copilot Messages interceptor handles this at the provider
+//   layer; the substring is listed here so a Messages-via-Responses trip that
+//   ever encounters the same phrasing behaves consistently.
+
+const codeIsContextExceeded = (code: unknown): boolean =>
+  code === 'context_length_exceeded' || code === 'model_max_prompt_tokens_exceeded';
+
+const messageIsContextExceeded = (message: unknown): boolean =>
+  typeof message === 'string'
+  && (message.includes('exceeds the context window of this model')
+    || message.includes('maximum context length is')
+    || message.includes('Request body is too large for model context window'));
+
+interface MaybeErrorFields {
+  code?: unknown;
+  message?: unknown;
+}
+
+interface MaybeErrorBody {
+  error?: MaybeErrorFields;
+}
+
+export const isContextExceededError = (error: MaybeErrorFields | undefined | null): boolean => {
+  if (error === undefined || error === null) return false;
+  return codeIsContextExceeded(error.code) || messageIsContextExceeded(error.message);
+};
+
+export const isContextExceededErrorObject = (parsed: unknown): boolean => {
+  if (parsed === null || typeof parsed !== 'object') return false;
+  return isContextExceededError((parsed as MaybeErrorBody).error);
+};
+
+export const isContextExceededErrorText = (text: string): boolean => {
+  try {
+    return isContextExceededErrorObject(JSON.parse(text));
+  } catch {
+    return messageIsContextExceeded(text);
+  }
+};
+
+// Byte-shape matches the Anthropic-direct error envelope for a
+// prompt-too-long condition. `type: 'invalid_request_error'` and the
+// `prompt is too long:` prefix are both load-bearing for Claude Code
+// compaction detection.
+export const buildPromptTooLongBody = (): Uint8Array =>
+  new TextEncoder().encode(JSON.stringify({
+    type: 'error',
+    error: { type: 'invalid_request_error', message: PROMPT_TOO_LONG_MESSAGE },
+  }));
+
+// Shared `TranslateTrip.apiError` implementation for the `messages-via-*`
+// pairs. Rewrites an upstream context-exceeded body into an Anthropic
+// prompt-too-long envelope; passes anything else through unchanged.
+export const rewriteContextExceededToPromptTooLong = (upstream: TranslatedApiError): TranslatedApiError | undefined => {
+  if (!isContextExceededErrorText(new TextDecoder().decode(upstream.body))) return undefined;
+  return {
+    status: 400,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    body: buildPromptTooLongBody(),
+  };
+};

--- a/packages/translate/src/shared/messages/context-window-error_test.ts
+++ b/packages/translate/src/shared/messages/context-window-error_test.ts
@@ -1,0 +1,95 @@
+import { test } from 'vitest';
+
+import {
+  buildPromptTooLongBody,
+  isContextExceededError,
+  isContextExceededErrorObject,
+  isContextExceededErrorText,
+  PROMPT_TOO_LONG_MESSAGE,
+  rewriteContextExceededToPromptTooLong,
+} from './context-window-error.ts';
+import { assert, assertEquals, assertFalse } from '../../test-assert.ts';
+
+test('isContextExceededError — recognizes canonical code strings', () => {
+  assert(isContextExceededError({ code: 'context_length_exceeded' }));
+  assert(isContextExceededError({ code: 'model_max_prompt_tokens_exceeded' }));
+  assertFalse(isContextExceededError({ code: 'rate_limit_exceeded' }));
+  assertFalse(isContextExceededError(undefined));
+  assertFalse(isContextExceededError(null));
+});
+
+test('isContextExceededError — recognizes fallback message substrings', () => {
+  assert(isContextExceededError({ message: 'Your input exceeds the context window of this model. Please adjust your input.' }));
+  assert(isContextExceededError({ message: "This model's maximum context length is 4097 tokens." }));
+  assert(isContextExceededError({ message: 'Request body is too large for model context window' }));
+  assertFalse(isContextExceededError({ message: 'a network hiccup' }));
+});
+
+test('isContextExceededErrorObject — walks the outer envelope', () => {
+  assert(isContextExceededErrorObject({ error: { code: 'context_length_exceeded', message: 'x' } }));
+  assert(isContextExceededErrorObject({ error: { code: 'model_max_prompt_tokens_exceeded', message: 'x' } }));
+  assertFalse(isContextExceededErrorObject({ error: { code: 'server_error', message: 'x' } }));
+  assertFalse(isContextExceededErrorObject({ nope: true }));
+});
+
+test('isContextExceededErrorText — parses JSON when it can, falls back to plain-text substring', () => {
+  assert(isContextExceededErrorText(JSON.stringify({ error: { code: 'context_length_exceeded' } })));
+  assert(isContextExceededErrorText('some non-json prefix: exceeds the context window of this model'));
+  assertFalse(isContextExceededErrorText('unrelated 502 body'));
+});
+
+test('buildPromptTooLongBody — Anthropic envelope with load-bearing prefix', () => {
+  const body = new TextDecoder().decode(buildPromptTooLongBody());
+  const parsed = JSON.parse(body) as { type: string; error: { type: string; message: string } };
+  assertEquals(parsed.type, 'error');
+  assertEquals(parsed.error.type, 'invalid_request_error');
+  assertEquals(parsed.error.message, PROMPT_TOO_LONG_MESSAGE);
+  assert(parsed.error.message.startsWith('prompt is too long:'));
+});
+
+test('rewriteContextExceededToPromptTooLong — rewrites Copilot Responses shape', () => {
+  const upstream = {
+    status: 400,
+    headers: new Headers({ 'x-copilot-request-id': 'abc' }),
+    body: new TextEncoder().encode(JSON.stringify({
+      error: { code: 'model_max_prompt_tokens_exceeded', message: 'prompt token count of 1000000 exceeds the limit of 128000' },
+    })),
+  };
+
+  const result = rewriteContextExceededToPromptTooLong(upstream);
+  assert(result !== undefined);
+  assertEquals(result!.status, 400);
+  assertEquals(result!.headers.get('content-type'), 'application/json');
+  const parsed = JSON.parse(new TextDecoder().decode(result!.body)) as { error: { message: string } };
+  assert(parsed.error.message.startsWith('prompt is too long:'));
+});
+
+test('rewriteContextExceededToPromptTooLong — rewrites Codex Responses shape', () => {
+  const upstream = {
+    status: 400,
+    headers: new Headers(),
+    body: new TextEncoder().encode(JSON.stringify({
+      error: { code: 'context_length_exceeded', message: 'Your input exceeds the context window of this model. Please adjust your input and try again.' },
+    })),
+  };
+  const result = rewriteContextExceededToPromptTooLong(upstream);
+  assert(result !== undefined);
+});
+
+test('rewriteContextExceededToPromptTooLong — passes unrelated bodies through unchanged', () => {
+  const upstream = {
+    status: 401,
+    headers: new Headers(),
+    body: new TextEncoder().encode(JSON.stringify({ error: { code: 'invalid_api_key', message: 'bad token' } })),
+  };
+  assertEquals(rewriteContextExceededToPromptTooLong(upstream), undefined);
+});
+
+test('rewriteContextExceededToPromptTooLong — passes non-json bodies through unchanged', () => {
+  const upstream = {
+    status: 502,
+    headers: new Headers(),
+    body: new TextEncoder().encode('Bad Gateway'),
+  };
+  assertEquals(rewriteContextExceededToPromptTooLong(upstream), undefined);
+});

--- a/packages/translate/src/shared/messages/context-window-error_test.ts
+++ b/packages/translate/src/shared/messages/context-window-error_test.ts
@@ -1,14 +1,12 @@
 import { test } from 'vitest';
 
 import {
-  buildPromptTooLongBody,
   isContextExceededError,
-  isContextExceededErrorObject,
-  isContextExceededErrorText,
   PROMPT_TOO_LONG_MESSAGE,
   rewriteContextExceededToPromptTooLong,
 } from './context-window-error.ts';
 import { assert, assertEquals, assertFalse } from '../../test-assert.ts';
+import { buildPromptTooLongBody } from '@floway-dev/protocols/messages';
 
 test('isContextExceededError — recognizes canonical code strings', () => {
   assert(isContextExceededError({ code: 'context_length_exceeded' }));
@@ -23,19 +21,6 @@ test('isContextExceededError — recognizes fallback message substrings', () => 
   assert(isContextExceededError({ message: "This model's maximum context length is 4097 tokens." }));
   assert(isContextExceededError({ message: 'Request body is too large for model context window' }));
   assertFalse(isContextExceededError({ message: 'a network hiccup' }));
-});
-
-test('isContextExceededErrorObject — walks the outer envelope', () => {
-  assert(isContextExceededErrorObject({ error: { code: 'context_length_exceeded', message: 'x' } }));
-  assert(isContextExceededErrorObject({ error: { code: 'model_max_prompt_tokens_exceeded', message: 'x' } }));
-  assertFalse(isContextExceededErrorObject({ error: { code: 'server_error', message: 'x' } }));
-  assertFalse(isContextExceededErrorObject({ nope: true }));
-});
-
-test('isContextExceededErrorText — parses JSON when it can, falls back to plain-text substring', () => {
-  assert(isContextExceededErrorText(JSON.stringify({ error: { code: 'context_length_exceeded' } })));
-  assert(isContextExceededErrorText('some non-json prefix: exceeds the context window of this model'));
-  assertFalse(isContextExceededErrorText('unrelated 502 body'));
 });
 
 test('buildPromptTooLongBody — Anthropic envelope with load-bearing prefix', () => {
@@ -76,6 +61,17 @@ test('rewriteContextExceededToPromptTooLong — rewrites Codex Responses shape',
   assert(result !== undefined);
 });
 
+test('rewriteContextExceededToPromptTooLong — recognizes bodies whose signal is in the message substring only', () => {
+  const upstream = {
+    status: 400,
+    headers: new Headers(),
+    body: new TextEncoder().encode(JSON.stringify({
+      error: { message: "This model's maximum context length is 4097 tokens. However, your messages resulted in 4498 tokens." },
+    })),
+  };
+  assert(rewriteContextExceededToPromptTooLong(upstream) !== undefined);
+});
+
 test('rewriteContextExceededToPromptTooLong — passes unrelated bodies through unchanged', () => {
   const upstream = {
     status: 401,
@@ -85,11 +81,18 @@ test('rewriteContextExceededToPromptTooLong — passes unrelated bodies through 
   assertEquals(rewriteContextExceededToPromptTooLong(upstream), undefined);
 });
 
-test('rewriteContextExceededToPromptTooLong — passes non-json bodies through unchanged', () => {
-  const upstream = {
+test('rewriteContextExceededToPromptTooLong — falls back to plain-text substring when the body is not JSON', () => {
+  const matching = {
+    status: 502,
+    headers: new Headers(),
+    body: new TextEncoder().encode('some upstream prose: exceeds the context window of this model'),
+  };
+  assert(rewriteContextExceededToPromptTooLong(matching) !== undefined);
+
+  const unrelated = {
     status: 502,
     headers: new Headers(),
     body: new TextEncoder().encode('Bad Gateway'),
   };
-  assertEquals(rewriteContextExceededToPromptTooLong(upstream), undefined);
+  assertEquals(rewriteContextExceededToPromptTooLong(unrelated), undefined);
 });

--- a/packages/translate/src/types.ts
+++ b/packages/translate/src/types.ts
@@ -19,7 +19,7 @@ export type TranslationContext<TCaps = unknown> = {
 
 /**
  * A wire-shaped upstream error body handed to `TranslateTrip.apiError`. The
- * pair returns a same-shaped tuple to rewrite the outbound envelope, or
+ * pair returns a same-shaped object to rewrite the outbound envelope, or
  * `undefined` to pass it through unchanged. The provider layer's
  * `ApiErrorResult` shape is intentionally not imported here — translate is a
  * leaf below provider, so we express the contract in bare HTTP-response

--- a/packages/translate/src/types.ts
+++ b/packages/translate/src/types.ts
@@ -18,6 +18,20 @@ export type TranslationContext<TCaps = unknown> = {
 } & TCaps;
 
 /**
+ * A wire-shaped upstream error body handed to `TranslateTrip.apiError`. The
+ * pair returns a same-shaped tuple to rewrite the outbound envelope, or
+ * `undefined` to pass it through unchanged. The provider layer's
+ * `ApiErrorResult` shape is intentionally not imported here — translate is a
+ * leaf below provider, so we express the contract in bare HTTP-response
+ * primitives and let the gateway compose it back into an `ApiErrorResult`.
+ */
+export interface TranslatedApiError {
+  readonly status: number;
+  readonly headers: Headers;
+  readonly body: Uint8Array;
+}
+
+/**
  * One pairwise translation trip. The function body owns the trip: it builds
  * the target payload and returns an events translator closure that maps
  * target-protocol events back into source-protocol events. Trip-scoped state
@@ -30,6 +44,12 @@ export type TranslationContext<TCaps = unknown> = {
  * `TCaps` is the pair-declared capability surface: each pair lists exactly
  * the fields it reads from `TranslationContext`. Pairs that do not need any
  * upstream capability data leave it as `unknown` (default).
+ *
+ * `apiError` is optional: when the target upstream returns a non-2xx HTTP
+ * body (rather than an SSE stream), the pair may rewrite it into the source
+ * protocol's envelope. Returning `undefined` — or omitting the field
+ * entirely — passes the upstream body through verbatim, which is what most
+ * pairs want.
  */
 export type TranslateTrip<SrcPayload, SrcEvent, TgtPayload extends { model: string }, TgtEvent, TCaps = unknown> = (
   src: SrcPayload,
@@ -37,4 +57,5 @@ export type TranslateTrip<SrcPayload, SrcEvent, TgtPayload extends { model: stri
 ) => Promise<{
   target: TgtPayload;
   events: (frames: AsyncIterable<ProtocolFrame<TgtEvent>>) => AsyncIterable<ProtocolFrame<SrcEvent>>;
+  apiError?: (upstream: TranslatedApiError) => TranslatedApiError | undefined;
 }>;


### PR DESCRIPTION
## Summary

Rewrite upstream context-exceeded errors into the Anthropic Messages envelope Claude Code recognizes for auto-compaction. Copilot native `/v1/messages` was already doing this at the provider layer, but the `messages-via-responses` and `messages-via-chat-completions` translation paths passed the upstream body through verbatim, so Codex Responses `context_length_exceeded` and Copilot Responses `model_max_prompt_tokens_exceeded` reached clients as-is and Claude Code never triggered compaction.

## Client detector

Reverse-engineered the shipped `@anthropic-ai/claude-code` v2.1.207 binary (build fingerprint `bc512d5`, built 2026-07-10). The context-exceeded gate is a case-insensitive substring match on the raised `Error.message`:

    error.message.toLowerCase().includes('prompt is too long')
    error.message.toLowerCase().includes('input length and `max_tokens` exceed context limit')

A hit routes into the internal `prompt_too_long` category and enters the auto-compact loop (telemetry event `tengu_compact_ptl_retry`). The detector does NOT inspect `error.type`, HTTP status, or the transport — streaming SSE errors and non-streaming bodies both land in the same classifier via the SDK-raised Error. The client's source is Anthropic-private, so the shipped bundle is the only public artefact that verifies this; the docs summary at https://docs.claude.com/en/docs/claude-code/common-workflows#prompt-too-long covers the user-facing symptom without spelling out the predicate.

## Approach

- Promote the canonical Anthropic prompt-too-long envelope (`PROMPT_TOO_LONG_MESSAGE` + `buildPromptTooLongBody`) to `@floway-dev/protocols/messages` so both `translate` and `provider-copilot` share the exact bytes.
- Extend `TranslateTrip` with an optional `apiError` hook wired through `traverseTranslation` on `source: 'upstream'` api-errors. Protocol-shape ownership stays inside the translate pair rather than leaking into the gateway dispatcher.
- Add a shared detector + rewriter (`packages/translate/src/shared/messages/context-window-error.ts`) covering Codex / Copilot / canonical OpenAI shapes via `error.code` discriminators (`context_length_exceeded`, `model_max_prompt_tokens_exceeded`) plus message-substring fallbacks. Both `messages-via-*` pairs use it as their `apiError` hook.
- Codex Responses also reports the same failure inside the SSE stream as a `response.failed` frame; `messages-via-responses/events.ts` `handleFailed` / `handleError` reuse the same detector to upgrade the stream `error` event's `error.type` to `invalid_request_error` and rewrite the message.
- `provider-copilot`'s Messages interceptor keeps its Copilot-specific substring set (`Request body is too large for model context window` and `context_length_exceeded`, the two strings Copilot's `/v1/messages` endpoint actually emits) and now generates the response body through the shared `buildPromptTooLongBody()` — no more duplicated literal.

## Upstream shape references

- Copilot Responses / Chat Completions (HTTP 400): `{"error":{"code":"model_max_prompt_tokens_exceeded","message":"prompt token count of N exceeds the limit of M"}}` — captured live.
- Codex Responses unary (HTTP 400): `{"error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. ..."}}` — from `openai/codex` `compact_remote.rs` fixture.
- Codex Responses SSE `response.failed`: [openai/codex codex-rs/codex-api/src/sse/responses.rs](https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/sse/responses.rs).
- Canonical OpenAI Chat Completions used as the message-substring fallback (`context_length_exceeded` code + `This model's maximum context length is ...` message).
- Copilot `/v1/messages` (Anthropic-shaped body carrying a Copilot-specific message string): `{"type":"error","error":{"type":"invalid_request_error","message":"Request body is too large for model context window ..."}}`. This endpoint never traverses the translate pairs, so `provider-copilot`'s interceptor handles it independently.

## Test plan

- [x] `pnpm run test` — 3855 pass, including new tests in `packages/translate/src/shared/messages/context-window-error_test.ts`, streaming-error cases in `packages/translate/src/messages-via-responses/events_test.ts`, and `apiError`-hook cases in `packages/gateway/src/data-plane/chat/shared/translate-traverse_test.ts`.
- [x] `pnpm run lint`.
- [x] `pnpm run typecheck`.
- [x] Live: verified in prod against a Codex/Responses candidate with an oversized prompt — Claude Code receives the `prompt is too long: ...` envelope and triggers auto-compaction, no longer surfaces the raw upstream `context_length_exceeded` body.