### PR TITLE
fix(web): keep Settings usable when the model catalog fails to load

### DIFF
--- a/apps/web/src/composables/useModels.ts
+++ b/apps/web/src/composables/useModels.ts
@@ -20,23 +20,36 @@ const makeStore = (params: { includeAliases: boolean; includeUnlisted?: boolean 
   const models = ref<ControlPlaneModel[] | null>(null);
   const loading = ref(false);
   const error = ref<string | null>(null);
+  let inflight: Promise<void> | null = null;
 
   return () => {
     const api = useApi();
 
-    const load = async () => {
-      loading.value = true;
-      error.value = null;
-      const query: { aliases?: 'false'; include_unlisted?: 'true' } = {};
-      if (!params.includeAliases) query.aliases = 'false';
-      if (params.includeUnlisted) query.include_unlisted = 'true';
-      const { data, error: err } = await callApi<ModelsResponse>(() => api.api.models.$get({ query }));
-      loading.value = false;
-      if (err) {
-        error.value = err.message;
-        return;
+    const load = async (): Promise<void> => {
+      if (inflight !== null) return await inflight;
+      const current = (async () => {
+        loading.value = true;
+        error.value = null;
+        try {
+          const query: { aliases?: 'false'; include_unlisted?: 'true' } = {};
+          if (!params.includeAliases) query.aliases = 'false';
+          if (params.includeUnlisted) query.include_unlisted = 'true';
+          const { data, error: err } = await callApi<ModelsResponse>(() => api.api.models.$get({ query }));
+          if (err) {
+            error.value = err.message;
+            return;
+          }
+          models.value = data.data;
+        } finally {
+          loading.value = false;
+        }
+      })();
+      inflight = current;
+      try {
+        await current;
+      } finally {
+        if (inflight === current) inflight = null;
       }
-      models.value = data?.data ?? [];
     };
 
     return { models, loading, error, load };

--- a/apps/web/src/composables/useModels_test.ts
+++ b/apps/web/src/composables/useModels_test.ts
@@ -1,0 +1,32 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { useRawModelsStore } from './useModels.ts';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('concurrent model loads share one in-flight API request', async () => {
+  let resolveFetch: ((response: Response) => void) | undefined;
+  const response = new Promise<Response>(resolve => { resolveFetch = resolve; });
+  const fetchMock = vi.fn(() => response);
+  vi.stubGlobal('fetch', fetchMock);
+
+  const store = useRawModelsStore();
+  const first = store.load();
+  const second = store.load();
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(store.loading.value).toBe(true);
+  resolveFetch?.(Response.json({ object: 'list', data: [] }));
+  await Promise.all([first, second]);
+
+  expect(store.loading.value).toBe(false);
+  expect(store.error.value).toBeNull();
+  expect(store.models.value).toEqual([]);
+});

--- a/apps/web/src/pages/dashboard/settings.vue
+++ b/apps/web/src/pages/dashboard/settings.vue
@@ -32,7 +32,6 @@ export const useSettingsPageData = defineBasicLoader(async () => {
   const [searchRes] = await Promise.all([
     callApi<SearchConfig>(() => api.api['search-config'].$get()),
     useUpstreamsStore().load(),
-    useRawModelsStore().load(),
     useProxiesStore().load(),
     useModelAliases().load(),
     useRuntimeInfo().load(),
@@ -51,6 +50,10 @@ definePage({ meta: { requiresAdmin: true } });
 const router = useRouter();
 const { upstreams, loading: storeLoading, load } = useUpstreamsStore();
 const modelsStore = useRawModelsStore();
+// The model catalog enriches counts and alias target labels, but it is not a
+// prerequisite for editing upstreams or proxies. Start it after navigation
+// so an unreachable upstream cannot hold the entire Settings route open.
+void modelsStore.load();
 const proxiesStore = useProxiesStore();
 const aliasesStore = useModelAliases();
 const { load: loadProxies } = proxiesStore;
@@ -87,6 +90,12 @@ const openAliasDialog = (record: ModelAlias | null): void => {
 
 <template>
   <div>
+    <p
+      v-if="modelsStore.error.value"
+      class="mb-4 rounded-md border border-accent-rose/40 bg-accent-rose/10 px-3 py-2 text-sm text-accent-rose"
+    >
+      Model catalog unavailable: {{ modelsStore.error.value }}
+    </p>
     <div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
       <div class="flex flex-col gap-5">
         <UpstreamsSettingsCard

--- a/apps/web/src/pages/dashboard/settings.vue
+++ b/apps/web/src/pages/dashboard/settings.vue
@@ -36,6 +36,7 @@ export const useSettingsPageData = defineBasicLoader(async () => {
     useModelAliases().load(),
     useRuntimeInfo().load(),
   ]);
+  await useRawModelsStore().load();
   return {
     searchConfig: searchRes.data ?? defaultSearchConfig,
     searchConfigError: searchRes.error?.message ?? null,
@@ -50,10 +51,6 @@ definePage({ meta: { requiresAdmin: true } });
 const router = useRouter();
 const { upstreams, loading: storeLoading, load } = useUpstreamsStore();
 const modelsStore = useRawModelsStore();
-// The model catalog enriches counts and alias target labels, but it is not a
-// prerequisite for editing upstreams or proxies. Start it after navigation
-// so an unreachable upstream cannot hold the entire Settings route open.
-void modelsStore.load();
 const proxiesStore = useProxiesStore();
 const aliasesStore = useModelAliases();
 const { load: loadProxies } = proxiesStore;

--- a/packages/gateway/src/control-plane/models/routes_test.ts
+++ b/packages/gateway/src/control-plane/models/routes_test.ts
@@ -30,6 +30,23 @@ const azureUpstream = (): UpstreamRecord => ({
   state: null,
 });
 
+test('/api/models returns an empty catalog when the gateway has no upstreams', async () => {
+  const { adminSession, repo } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+
+  const response = await requestApp('/api/models?aliases=false&include_unlisted=true', {
+    headers: { 'x-floway-session': adminSession },
+  });
+  assertEquals(response.status, 200);
+  assertEquals(await response.json(), {
+    object: 'list',
+    has_more: false,
+    first_id: null,
+    last_id: null,
+    data: [],
+  });
+});
+
 test('/api/models exposes each upstream as { kind, id } so multi-provider models are unambiguous', async () => {
   const { apiKey, repo } = await setupAppTest();
   await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_custom_models', sortOrder: 100 }));


### PR DESCRIPTION
## Summary

- load the Settings page's required data concurrently, then fetch the raw model catalog
- keep the route in its navigation-loading state until the catalog request settles, so Settings renders once with complete content instead of filling model-derived fields after mount
- surface catalog failures inline while keeping Settings usable after the failed request completes
- deduplicate concurrent model-store loads so repeated callers share one HTTP request
- cover the empty-gateway contract: `/api/models?aliases=false&include_unlisted=true` returns an empty 200 response when there are truly no upstreams

## Original reproduction

1. Run the Node gateway on `http://localhost:8788` and the Vite dashboard on `http://localhost:5174`.
2. Import a ChatGPT/Codex subscription credential without configuring a working network path or proxy.
3. Navigate to **Settings**.
4. The route waits for live model discovery; repeated attempts previously created overlapping `/api/models` requests.

During diagnosis, the local database contained an enabled `codex` upstream with an empty proxy fallback list and no model-cache row. No credential material is included in this PR. A database with genuinely zero upstream rows already follows a different, valid path and returns an empty catalog.

## Root cause

The Settings loader originally fetched all page data and the live model catalog in the same `Promise.all`, allowing catalog discovery to race data needed to construct the upstream and alias views. Moving catalog loading into component setup avoided that race but introduced a third visual state: Settings rendered first and model-derived counts and labels filled in later.

The module-scoped models store also shared state without sharing an in-flight Promise. Concurrent callers could therefore start duplicate catalog requests.

## Fix

The Settings data loader now completes its required page-data `Promise.all` first, then awaits `useRawModelsStore().load()`. This preserves the required ordering while keeping navigation in its loading state until all visible Settings content is ready. A catalog failure is retained in the store and rendered as an inline error once the page opens.

Each models-store variant owns one in-flight Promise. Concurrent `load()` calls join that Promise, and the entry is cleared after success or failure so a later explicit reload can retry.

## Expected behavior

- Required Settings data loads concurrently; the model catalog request starts afterward.
- Settings does not render a partially populated intermediate state.
- Concurrent model-store loads do not create duplicate catalog requests.
- A catalog 502 appears as an inline error after the request settles.
- Upstream, proxy, alias, search, import, and export controls remain available after a catalog failure.
- A gateway with no upstream rows receives an empty 200 catalog.

## Verification

- `pnpm --filter @floway-dev/web run test` — 17 files, 152 tests passed
- `pnpm --filter @floway-dev/web run typecheck` — passed
- `git diff --check` — passed
