### PR TITLE
fix(dashboard): redirect upstream create/guard bounces to /dashboard/settings

### DIFF
--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -395,7 +395,7 @@ const save = async ({ openEdit = false }: { openEdit?: boolean } = {}) => {
       // per-provider "Save and load models" CTA sets openEdit so the newly-
       // saved row's edit page renders next, letting its mount-time list-models
       // populate the catalog for a review pass before the operator leaves.
-      await router.replace(openEdit ? `/dashboard/upstreams/${data.id}` : '/dashboard/upstreams');
+      await router.replace(openEdit ? `/dashboard/upstreams/${data.id}` : '/dashboard/settings');
     } else {
       // PATCH only user-owned fields. For OAuth providers the backend
       // rejects a `config` patch, so we skip config for them — their

--- a/apps/web/src/pages/dashboard/upstreams/new/[provider].vue
+++ b/apps/web/src/pages/dashboard/upstreams/new/[provider].vue
@@ -59,7 +59,7 @@ const data = useNewUpstreamData();
 const store = useUpstreamsStore();
 
 if (data.data.value.initialRecord === null) {
-  void router.replace('/dashboard/upstreams');
+  void router.replace('/dashboard/settings');
 }
 
 const onSaved = async () => {


### PR DESCRIPTION
## Summary

- Creating a new upstream and clicking **Save changes** navigates to `/dashboard/upstreams`, which has no file-based route and 404s. The `POST /api/upstreams` succeeded — the row is already in the list — but the operator sees a 404 for a few confusing seconds until they backtrack to the dashboard.
- The upstream list lives on the Settings page (`UpstreamsSettingsCard` in `pages/dashboard/settings.vue`). Every other "bounce back to the list" in this area already targets `/dashboard/settings` (`pages/dashboard/upstreams/[id].vue:49` record-not-found guard, `pages/dashboard/index.vue:11` admin landing). Two sites still pointed at the missing path:
  - `UpstreamEditPage.vue:398` — post-create Save (`openEdit === false` branch).
  - `pages/dashboard/upstreams/new/[provider].vue:62` — unknown-kind guard (typo / stale bookmark).
- Both now redirect to `/dashboard/settings`. The `openEdit === true` branch keeps its existing `/dashboard/upstreams/${id}` target (that route exists).

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] In `pnpm run dev`, open Settings → Add upstream → pick any provider → fill Name → **Save changes**. URL lands on `/dashboard/settings` and the new row is in the list.
- [x] Provider-specific "Save and load models" CTA (custom/ollama) still opens the new row's edit page at `/dashboard/upstreams/${id}`.
- [x] Manually visit `/dashboard/upstreams/new/no-such-kind` — redirects to `/dashboard/settings` instead of 404.