### PR TITLE
fix(gateway): complete upstream response projections

### DIFF
--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -70,12 +70,13 @@ interface ModelsCacheStatus {
   lastError: { message: string; at: number } | null;
 }
 
-type UpstreamResponse = SerializedUpstreamRecord & {
-  modelsCache?: ModelsCacheStatus;
-  codex_quota?: CodexQuotaSnapshotMap | null;
+type CodexQuotaProjection = { codex_quota?: CodexQuotaSnapshotMap | null };
+
+type UpstreamListResponse = SerializedUpstreamRecord & CodexQuotaProjection & {
+  modelsCache: ModelsCacheStatus;
 };
 
-const codexQuotaForResponse = async (record: UpstreamRecord): Promise<Pick<UpstreamResponse, 'codex_quota'>> => {
+const codexQuotaForResponse = async (record: UpstreamRecord): Promise<CodexQuotaProjection> => {
   if (record.kind !== 'codex') return {};
   assertCodexUpstreamRecord(record);
   return {
@@ -86,7 +87,7 @@ const codexQuotaForResponse = async (record: UpstreamRecord): Promise<Pick<Upstr
 // The response projections depend on repository state, while serialize.ts is a
 // pure persisted-record transform. Build the wire value only after both parts
 // are ready so callers cannot observe or extend a partially serialized record.
-const serializeForResponse = async (record: UpstreamRecord): Promise<UpstreamResponse> => {
+const serializeForResponse = async (record: UpstreamRecord): Promise<UpstreamListResponse> => {
   const [cacheRow, codexQuota] = await Promise.all([
     getRepo().modelsCache.get(record.id),
     codexQuotaForResponse(record),

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -65,27 +65,40 @@ import { clearInProcessCopilotTokenCache, emptyCopilotUpstreamState, exchangeCop
 import { assertCustomUpstreamRecord, fetchCustomModels } from '@floway-dev/provider-custom';
 import { assertOllamaUpstreamRecord, createOllamaProvider } from '@floway-dev/provider-ollama';
 
-const codexQuotaForResponse = (record: UpstreamRecord): Promise<CodexQuotaSnapshotMap | null> | null => {
-  if (record.kind !== 'codex') return null;
-  assertCodexUpstreamRecord(record);
-  return getCodexQuota(record.id, record.config.accounts[0].chatgptAccountId);
+interface ModelsCacheStatus {
+  fetchedAt: number | null;
+  lastError: { message: string; at: number } | null;
+}
+
+type UpstreamResponse = SerializedUpstreamRecord & {
+  modelsCache?: ModelsCacheStatus;
+  codex_quota?: CodexQuotaSnapshotMap | null;
 };
 
-// Serialize for the HTTP response, attaching the live codex_quota snapshot map
-// when the row is a Codex upstream and the SWR models-cache freshness for
-// every row. Keeps serialize.ts free of provider I/O and a global repo handle,
-// while ensuring every response shape carries the panels the dashboard
-// expects.
-const serializeForResponse = async (record: UpstreamRecord): Promise<SerializedUpstreamRecord> => {
-  const codexQuotaPromise = codexQuotaForResponse(record);
-  const cacheRow = await getRepo().modelsCache.get(record.id);
-  const serialized = upstreamRecordToJson(record);
-  serialized.modelsCache = {
-    fetchedAt: cacheRow?.fetchedAt ?? null,
-    lastError: cacheRow?.lastError ?? null,
+const codexQuotaForResponse = async (record: UpstreamRecord): Promise<Pick<UpstreamResponse, 'codex_quota'>> => {
+  if (record.kind !== 'codex') return {};
+  assertCodexUpstreamRecord(record);
+  return {
+    codex_quota: await getCodexQuota(record.id, record.config.accounts[0].chatgptAccountId),
   };
-  if (codexQuotaPromise) serialized.codex_quota = await codexQuotaPromise;
-  return serialized;
+};
+
+// The response projections depend on repository state, while serialize.ts is a
+// pure persisted-record transform. Build the wire value only after both parts
+// are ready so callers cannot observe or extend a partially serialized record.
+const serializeForResponse = async (record: UpstreamRecord): Promise<UpstreamResponse> => {
+  const [cacheRow, codexQuota] = await Promise.all([
+    getRepo().modelsCache.get(record.id),
+    codexQuotaForResponse(record),
+  ]);
+  return {
+    ...upstreamRecordToJson(record),
+    modelsCache: {
+      fetchedAt: cacheRow?.fetchedAt ?? null,
+      lastError: cacheRow?.lastError ?? null,
+    },
+    ...codexQuota,
+  };
 };
 
 type ValidationResult<T> = { ok: true; value: T } | { ok: false; error: string };
@@ -241,10 +254,10 @@ export const getUpstream = async (c: AuthedContext<'/:id'>) => {
   const id = c.req.param('id');
   const record = await getRepo().upstreams.getById(id);
   if (!record) return c.json({ error: 'upstream not found' }, 404);
-  const serialized = upstreamRecordToFullJson(record);
-  const codexQuotaPromise = codexQuotaForResponse(record);
-  if (codexQuotaPromise) serialized.codex_quota = await codexQuotaPromise;
-  return c.json(serialized);
+  return c.json({
+    ...upstreamRecordToFullJson(record),
+    ...await codexQuotaForResponse(record),
+  });
 };
 
 export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) => {

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -65,17 +65,19 @@ import { clearInProcessCopilotTokenCache, emptyCopilotUpstreamState, exchangeCop
 import { assertCustomUpstreamRecord, fetchCustomModels } from '@floway-dev/provider-custom';
 import { assertOllamaUpstreamRecord, createOllamaProvider } from '@floway-dev/provider-ollama';
 
+const codexQuotaForResponse = (record: UpstreamRecord): Promise<CodexQuotaSnapshotMap | null> | null => {
+  if (record.kind !== 'codex') return null;
+  assertCodexUpstreamRecord(record);
+  return getCodexQuota(record.id, record.config.accounts[0].chatgptAccountId);
+};
+
 // Serialize for the HTTP response, attaching the live codex_quota snapshot map
 // when the row is a Codex upstream and the SWR models-cache freshness for
 // every row. Keeps serialize.ts free of provider I/O and a global repo handle,
 // while ensuring every response shape carries the panels the dashboard
 // expects.
 const serializeForResponse = async (record: UpstreamRecord): Promise<SerializedUpstreamRecord> => {
-  let codexQuotaPromise: Promise<CodexQuotaSnapshotMap | null> | null = null;
-  if (record.kind === 'codex') {
-    assertCodexUpstreamRecord(record);
-    codexQuotaPromise = getCodexQuota(record.id, record.config.accounts[0].chatgptAccountId);
-  }
+  const codexQuotaPromise = codexQuotaForResponse(record);
   const cacheRow = await getRepo().modelsCache.get(record.id);
   const serialized = upstreamRecordToJson(record);
   serialized.modelsCache = {
@@ -232,13 +234,17 @@ export const getUpstreamBlueprint = (c: Context): Response => {
 // Single-record read for the edit page. Returns the FULL record — no
 // secret redaction — because every editor-scoped action posts the record
 // back to a helper endpoint that needs the same credentials the data plane
-// uses (refresh tokens, api keys, etc.). The list endpoint continues to
-// serve the redacted projection for surfaces that don't need secrets.
+// uses (refresh tokens, api keys, etc.). Codex quota remains a response-only
+// projection so the edit card receives the same fresh snapshot map as the
+// redacted list endpoint.
 export const getUpstream = async (c: AuthedContext<'/:id'>) => {
   const id = c.req.param('id');
   const record = await getRepo().upstreams.getById(id);
   if (!record) return c.json({ error: 'upstream not found' }, 404);
-  return c.json(upstreamRecordToFullJson(record));
+  const serialized = upstreamRecordToFullJson(record);
+  const codexQuotaPromise = codexQuotaForResponse(record);
+  if (codexQuotaPromise) serialized.codex_quota = await codexQuotaPromise;
+  return c.json(serialized);
 };
 
 export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) => {

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -65,15 +65,15 @@ import { clearInProcessCopilotTokenCache, emptyCopilotUpstreamState, exchangeCop
 import { assertCustomUpstreamRecord, fetchCustomModels } from '@floway-dev/provider-custom';
 import { assertOllamaUpstreamRecord, createOllamaProvider } from '@floway-dev/provider-ollama';
 
-interface ModelsCacheStatus {
-  fetchedAt: number | null;
-  lastError: { message: string; at: number } | null;
-}
-
 type CodexQuotaProjection = { codex_quota?: CodexQuotaSnapshotMap | null };
 
-type UpstreamListResponse = SerializedUpstreamRecord & CodexQuotaProjection & {
-  modelsCache: ModelsCacheStatus;
+type UpstreamResponse = SerializedUpstreamRecord & CodexQuotaProjection;
+
+type UpstreamWithCacheResponse = UpstreamResponse & {
+  modelsCache: {
+    fetchedAt: number | null;
+    lastError: { message: string; at: number } | null;
+  };
 };
 
 const codexQuotaForResponse = async (record: UpstreamRecord): Promise<CodexQuotaProjection> => {
@@ -84,10 +84,9 @@ const codexQuotaForResponse = async (record: UpstreamRecord): Promise<CodexQuota
   };
 };
 
-// The response projections depend on repository state, while serialize.ts is a
-// pure persisted-record transform. Build the wire value only after both parts
-// are ready so callers cannot observe or extend a partially serialized record.
-const serializeForResponse = async (record: UpstreamRecord): Promise<UpstreamListResponse> => {
+// These projections need repository/provider I/O, which serialize.ts excludes
+// so it stays a pure persisted-record transform.
+const serializeForResponse = async (record: UpstreamRecord): Promise<UpstreamWithCacheResponse> => {
   const [cacheRow, codexQuota] = await Promise.all([
     getRepo().modelsCache.get(record.id),
     codexQuotaForResponse(record),
@@ -248,17 +247,17 @@ export const getUpstreamBlueprint = (c: Context): Response => {
 // Single-record read for the edit page. Returns the FULL record — no
 // secret redaction — because every editor-scoped action posts the record
 // back to a helper endpoint that needs the same credentials the data plane
-// uses (refresh tokens, api keys, etc.). Codex quota remains a response-only
-// projection so the edit card receives the same fresh snapshot map as the
-// redacted list endpoint.
+// uses (refresh tokens, api keys, etc.). Codex quota is a response-only
+// projection, so it is attached here as well.
 export const getUpstream = async (c: AuthedContext<'/:id'>) => {
   const id = c.req.param('id');
   const record = await getRepo().upstreams.getById(id);
   if (!record) return c.json({ error: 'upstream not found' }, 404);
-  return c.json({
+  const response: UpstreamResponse = {
     ...upstreamRecordToFullJson(record),
     ...await codexQuotaForResponse(record),
-  });
+  };
+  return c.json(response);
 };
 
 export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) => {

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -2150,16 +2150,30 @@ test('GET /api/upstreams/blueprint serves a pure-blank record with provider flag
   assertEquals(ccPreview.flag_defaults['strip-billing-attribution'], false);
 });
 
-test('GET /api/upstreams/:id returns the full unredacted record so the edit page can post it back to action endpoints', async () => {
+test('GET /api/upstreams/:id returns the full record with fresh Codex quota for the edit page', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();
 
   const created = await createCodexUpstreamViaExchange(adminSession);
+  const stored = await getRecord(repo, created.id);
+  const quota = {
+    observed_at: new Date().toISOString(),
+    active_limit: 'premium',
+    primary_used_percent: 7,
+    primary_window_minutes: 300,
+  };
+  const state = structuredClone(stored.state) as JsonObject;
+  state.accounts[0].quotaSnapshot = {
+    premium: { fetchedAt: Date.now(), data: quota },
+  };
+  const saved = await repo.upstreams.saveState(created.id, state, { expectedState: stored.state });
+  assertEquals(saved.updated, true);
 
   const resp = await requestApp(`/api/upstreams/${created.id}`, { headers: { 'x-floway-session': adminSession } });
   assertEquals(resp.status, 200);
   const body = (await resp.json()) as JsonObject;
   assertEquals(body.id, created.id);
+  assertEquals(body.codex_quota, { premium: quota });
   // Unredacted: the refresh_token secret is present verbatim, not projected
   // as the list-view's `refresh_token_set` boolean.
   assertEquals(body.state.accounts[0].refresh_token, 'rt_test');

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -2180,6 +2180,30 @@ test('GET /api/upstreams/:id returns the full record with fresh Codex quota for 
   assertEquals('refresh_token_set' in body.state.accounts[0], false);
 });
 
+test('GET /api/upstreams/:id returns null Codex quota when no fresh snapshot exists', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+
+  const created = await createCodexUpstreamViaExchange(adminSession);
+  const resp = await requestApp(`/api/upstreams/${created.id}`, { headers: { 'x-floway-session': adminSession } });
+  assertEquals(resp.status, 200);
+  const body = (await resp.json()) as JsonObject;
+  assertEquals('codex_quota' in body, true);
+  assertEquals(body.codex_quota, null);
+});
+
+test('GET /api/upstreams/:id omits Codex quota from non-Codex responses', async () => {
+  const { adminSession } = await setupAppTest();
+  const createdResp = await requestApp('/api/upstreams', authed(adminSession, createBody()));
+  assertEquals(createdResp.status, 201);
+  const created = (await createdResp.json()) as JsonObject;
+
+  const resp = await requestApp(`/api/upstreams/${created.id}`, { headers: { 'x-floway-session': adminSession } });
+  assertEquals(resp.status, 200);
+  const body = (await resp.json()) as JsonObject;
+  assertEquals('codex_quota' in body, false);
+});
+
 test('GET /api/upstreams/:id returns 404 for an unknown id', async () => {
   const { adminSession } = await setupAppTest();
   const resp = await requestApp('/api/upstreams/up_never', { headers: { 'x-floway-session': adminSession } });

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -10,9 +10,7 @@ export interface SerializedUpstreamRecord {
   created_at: string;
   updated_at: string;
   flag_overrides: FlagOverrides;
-  // Sent per record (rather than a separate per-kind lookup) so the
-  // dashboard's "Inherit → on/off" pill renders each row without a
-  // second round trip.
+  // Pure per-kind derivation of the record's effective flag baseline.
   flag_defaults: FlagDefaults;
   disabled_public_model_ids: string[];
   proxy_fallback_list: ProxyFallbackEntry[];

--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -1,11 +1,5 @@
 import { flagDefaultsForKind } from '../../data-plane/providers/registry.ts';
 import type { FlagDefaults, FlagOverrides, ModelPrefixConfig, ProxyFallbackEntry, UpstreamProviderKind, UpstreamRecord } from '@floway-dev/provider';
-import type { CodexQuotaSnapshotMap } from '@floway-dev/provider-codex';
-
-export interface ModelsCacheStatus {
-  fetchedAt: number | null;
-  lastError: { message: string; at: number } | null;
-}
 
 export interface SerializedUpstreamRecord {
   id: string;
@@ -25,12 +19,6 @@ export interface SerializedUpstreamRecord {
   model_prefix: ModelPrefixConfig | null;
   config: unknown;
   state: unknown;
-  // SWR models-cache freshness joined from the models_cache table by the
-  // route handler. Both inner values are null on a row that has never been
-  // warmed.
-  modelsCache?: ModelsCacheStatus;
-  // Present only for kind === 'codex'.
-  codex_quota?: CodexQuotaSnapshotMap | null;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/gateway/src/control-plane/upstreams/serialize_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize_test.ts
@@ -1,10 +1,15 @@
-import { expect, test } from 'vitest';
+import { expect, expectTypeOf, test } from 'vitest';
 
-import { upstreamRecordToFullJson, upstreamRecordToJson } from './serialize.ts';
+import { upstreamRecordToFullJson, upstreamRecordToJson, type SerializedUpstreamRecord } from './serialize.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 
 const timestamp = '2026-04-29T00:00:00.000Z';
+
+test('SerializedUpstreamRecord excludes route-layer response projections', () => {
+  expectTypeOf<'modelsCache' extends keyof SerializedUpstreamRecord ? true : false>().toEqualTypeOf<false>();
+  expectTypeOf<'codex_quota' extends keyof SerializedUpstreamRecord ? true : false>().toEqualTypeOf<false>();
+});
 
 const custom: UpstreamRecord = {
   id: 'up_custom_test',


### PR DESCRIPTION
## Summary

Fix the Codex upstream editor showing:

> No quota snapshots yet. Make Codex calls to populate.

even when fresh quota snapshots already exist.

The upstream list endpoint included the response-only `codex_quota` projection, but `GET /api/upstreams/:id` returned only the full persisted record. Since commit [`cfc3ad5`](https://github.com/Menci/Floway/commit/cfc3ad54a0b3035c53d4f2e410b6bbc500f243e9) moved the upstream editor onto the single-record `GET /api/upstreams/:id` response, `CodexAccountCard` received no `codex_quota` map and rendered the empty state.

## Changes

- Extract the existing Codex quota projection into a shared response helper.
- Attach the `codex_quota` map to `GET /api/upstreams/:id`.
- Add regression coverage for a fresh `premium` quota snapshot while retaining the existing unredacted-state assertions.