### PR TITLE
feat(auth): make ADMIN_KEY optional on dev instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,11 +217,12 @@ package, use pnpm filters (e.g.
 
 `dev:node` boots the Node deployment target. Configure via
 `FLOWAY_DB_PATH` (sqlite file path), `FLOWAY_FILES_DIR` (filesystem store
-root), `ADMIN_KEY` (admin secret), `PORT`, and optionally
-`RUNTIME_LOCATION` (instance tag used as the perf-telemetry
-`runtimeLocation` dimension and the dial-time colo-whitelist key —
-uppercased on read, defaults to `LOCAL` when unset). Default ports/paths in
-`apps/platform-node/entry.ts`. The Node entry runs `applyMigrations` against
+root), `ADMIN_KEY` (admin secret; optional on dev, mandatory when
+`NODE_ENV=production`), `PORT`, and optionally `RUNTIME_LOCATION`
+(instance tag used as the perf-telemetry `runtimeLocation` dimension and
+the dial-time colo-whitelist key — uppercased on read, defaults to
+`LOCAL` when unset). Default ports/paths in `apps/platform-node/entry.ts`.
+The Node entry runs `applyMigrations` against
 `packages/gateway/migrations/*.sql` at boot, then serves the same Hono app
 through `@hono/node-server`. Static-asset serving is Workers-only; the Node
 target serves no SPA.
@@ -229,11 +230,22 @@ target serves no SPA.
 Wrangler commands go through the local dependency with `pnpm wrangler` or
 package scripts. When deploying, do not pass `--dry-run`.
 
+`ADMIN_KEY` is optional on dev instances so a fresh checkout is usable
+without any secret setup: with the env var unset (which is the default
+once `.dev.vars` is deleted), the login page grants seed-admin access to
+a blank username + any password. Real deployments must set it — the Node
+entry refuses to boot under `NODE_ENV=production` with an empty
+`ADMIN_KEY`, and the Cloudflare-side request handler refuses passwordless
+logins whenever the request carries a `CF-Ray` header (workerd's local
+inbound used by `wrangler dev` never writes CF-Ray; only Cloudflare's
+edge does).
+
 For manual data-plane validation, log into the dashboard with the
-`ADMIN_KEY` backdoor or with your own user, then create or pick an API
-key under your account and use it as `x-api-key`. `ADMIN_KEY` is not a
-data-plane credential; its only purpose is to let an operator who lost
-the admin password log in via `POST /auth/login`.
+`ADMIN_KEY` backdoor (or, on a dev instance, the passwordless shortcut)
+or with your own user, then create or pick an API key under your account
+and use it as `x-api-key`. `ADMIN_KEY` is not a data-plane credential;
+its only purpose is to let an operator who lost the admin password log
+in via `POST /auth/login`.
 
 When investigating Copilot upstream quirks, compare at least one other
 Copilot gateway implementation before inventing a policy. For generic

--- a/README.md
+++ b/README.md
@@ -50,14 +50,20 @@ cp wrangler.example.jsonc wrangler.jsonc
 pnpm wrangler login
 pnpm wrangler d1 create <DB_NAME>
 
-# Apply schema and set the admin secret.
+# Apply schema. Prod also needs an admin secret; wrangler dev doesn't.
 pnpm run db:migrate
-pnpm wrangler secret put ADMIN_KEY
+pnpm wrangler secret put ADMIN_KEY   # production only
 
 # Run locally or deploy. In dev, open the Vite SPA at http://localhost:5174.
 pnpm run dev
 pnpm run deploy
 ```
+
+`ADMIN_KEY` is required on production deploys — a live Worker that
+receives requests from Cloudflare's edge (detected via the `CF-Ray`
+header) refuses passwordless logins. A local `wrangler dev` instance
+without `.dev.vars` has no `ADMIN_KEY`, and the login page then accepts a
+blank username with any (or empty) password as the seed admin.
 
 ### Node.js (self-hosted)
 
@@ -72,6 +78,12 @@ FLOWAY_FILES_DIR=./data/files \
 PORT=8788 \
 pnpm run dev:node
 ```
+
+`ADMIN_KEY` may be omitted on a dev machine — the login page then accepts
+a blank username with any (or empty) password as the seed admin. Setting
+`NODE_ENV=production` makes `ADMIN_KEY` mandatory: the entry point
+refuses to boot without it, and the running server also rejects
+passwordless logins.
 
 Optionally set `RUNTIME_LOCATION=<tag>` to label this instance in the
 performance telemetry's `runtimeLocation` dimension and as the dial-time
@@ -103,7 +115,8 @@ use.
 ### After the first boot
 
 Open the deployed URL (or `http://localhost:8788` for Node), log in with
-`ADMIN_KEY`, and:
+`ADMIN_KEY` (or leave the password blank on a dev instance with no
+`ADMIN_KEY` set), and:
 
 1. **Settings -> Upstreams -> Add Upstream**. Upstreams are *Custom*
    (OpenAI/Anthropic-shaped, static credential), *Azure* (one endpoint, API key,

--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -49,6 +49,18 @@ initResponsesWebSocketUpgradeResolver((c, events) =>
 const { db } = bootstrapNodePlatform();
 const port = Number(getEnvOptional('PORT', '8788'));
 
+// Passwordless admin login is granted when ADMIN_KEY is unset so a fresh
+// local instance is immediately usable, but that shortcut has no place in
+// a real deployment. Refuse to boot the production target with an empty
+// ADMIN_KEY so a misconfiguration surfaces at start instead of at first
+// login. The per-request check in packages/gateway/src/shared/
+// is-production-request.ts gates the same combination on Cloudflare and
+// backstops Node here.
+if (process.env.NODE_ENV === 'production' && !process.env.ADMIN_KEY) {
+  console.error('FATAL: NODE_ENV=production requires ADMIN_KEY. Passwordless admin login is only allowed on dev instances.');
+  process.exit(1);
+}
+
 const SCHEDULED_INTERVAL_MS = 60 * 60 * 1000;
 
 await applyMigrations(db);

--- a/apps/platform-node/entry.ts
+++ b/apps/platform-node/entry.ts
@@ -49,13 +49,11 @@ initResponsesWebSocketUpgradeResolver((c, events) =>
 const { db } = bootstrapNodePlatform();
 const port = Number(getEnvOptional('PORT', '8788'));
 
-// Passwordless admin login is granted when ADMIN_KEY is unset so a fresh
-// local instance is immediately usable, but that shortcut has no place in
-// a real deployment. Refuse to boot the production target with an empty
-// ADMIN_KEY so a misconfiguration surfaces at start instead of at first
-// login. The per-request check in packages/gateway/src/shared/
-// is-production-request.ts gates the same combination on Cloudflare and
-// backstops Node here.
+// Passwordless admin login is a dev-only shortcut (empty ADMIN_KEY on a
+// local instance grants seed-admin access). Refuse to boot the Node
+// target under NODE_ENV=production without ADMIN_KEY so misconfiguration
+// surfaces at start, not at first login. The Cloudflare side gates the
+// same combination per-request via isProductionRequest.
 if (process.env.NODE_ENV === 'production' && !process.env.ADMIN_KEY) {
   console.error('FATAL: NODE_ENV=production requires ADMIN_KEY. Passwordless admin login is only allowed on dev instances.');
   process.exit(1);

--- a/packages/gateway/src/control-plane/auth/routes.ts
+++ b/packages/gateway/src/control-plane/auth/routes.ts
@@ -18,14 +18,10 @@ const resolveLoginUser = async (c: CtxWithJson<typeof authLoginBody>): Promise<U
       const utf8 = new TextEncoder();
       if (!timingSafeEqual(utf8.encode(password), utf8.encode(adminKey))) return null;
     } else if (isProductionRequest(c)) {
-      // Zero-config passwordless admin login is a dev-only shortcut so
-      // brand-new local instances (no .dev.vars, no ADMIN_KEY set) still
-      // let the operator into the dashboard. A production deployment
-      // that shipped without ADMIN_KEY would otherwise be world-open;
-      // refuse instead. The Node target additionally hard-fails at boot
-      // under NODE_ENV=production with no ADMIN_KEY (apps/platform-node/
-      // entry.ts) so this branch is the Cloudflare-side gate plus Node
-      // defence-in-depth.
+      // Empty ADMIN_KEY grants zero-config passwordless admin login on
+      // dev instances (no .dev.vars needed) but would leave a production
+      // deployment world-open. Refuse when the request signals prod —
+      // per-runtime detection lives in isProductionRequest.
       return null;
     }
     const user = await repo.users.getById(1);

--- a/packages/gateway/src/control-plane/auth/routes.ts
+++ b/packages/gateway/src/control-plane/auth/routes.ts
@@ -2,18 +2,32 @@ import { type AuthedContext, sessionIdFromContext, userFromContext } from '../..
 import { type CtxWithJson } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { User } from '../../repo/types.ts';
+import { isProductionRequest } from '../../shared/is-production-request.ts';
 import { dummyPasswordHash, timingSafeEqual, verifyPassword } from '../../shared/passwords.ts';
 import type { authLoginBody } from '../schemas.ts';
 import { userToEffectiveWire } from '../users/wire.ts';
 import { getEnv } from '@floway-dev/platform';
 
-const resolveLoginUser = async (username: string, password: string): Promise<User | null> => {
+const resolveLoginUser = async (c: CtxWithJson<typeof authLoginBody>): Promise<User | null> => {
+  const { username, password } = c.req.valid('json');
   const repo = getRepo();
 
   if (username === '') {
     const adminKey = getEnv('ADMIN_KEY');
-    const utf8 = new TextEncoder();
-    if (!adminKey || !timingSafeEqual(utf8.encode(password), utf8.encode(adminKey))) return null;
+    if (adminKey) {
+      const utf8 = new TextEncoder();
+      if (!timingSafeEqual(utf8.encode(password), utf8.encode(adminKey))) return null;
+    } else if (isProductionRequest(c)) {
+      // Zero-config passwordless admin login is a dev-only shortcut so
+      // brand-new local instances (no .dev.vars, no ADMIN_KEY set) still
+      // let the operator into the dashboard. A production deployment
+      // that shipped without ADMIN_KEY would otherwise be world-open;
+      // refuse instead. The Node target additionally hard-fails at boot
+      // under NODE_ENV=production with no ADMIN_KEY (apps/platform-node/
+      // entry.ts) so this branch is the Cloudflare-side gate plus Node
+      // defence-in-depth.
+      return null;
+    }
     const user = await repo.users.getById(1);
     if (!user) throw new Error('ADMIN_KEY login: seed admin (user 1) is missing');
     return user;
@@ -31,8 +45,7 @@ const resolveLoginUser = async (username: string, password: string): Promise<Use
 };
 
 export const authLogin = async (c: CtxWithJson<typeof authLoginBody>) => {
-  const { username, password } = c.req.valid('json');
-  const user = await resolveLoginUser(username, password);
+  const user = await resolveLoginUser(c);
   if (!user) return c.json({ error: 'Invalid username or password' }, 401);
   const session = await getRepo().sessions.create(user.id);
   return c.json({ token: session.id, user: userToEffectiveWire(user) });

--- a/packages/gateway/src/control-plane/auth/routes_test.ts
+++ b/packages/gateway/src/control-plane/auth/routes_test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 
 // Copilot OAuth poll handler warms the SWR models cache after rotating the PAT.
 // The warm calls Copilot's /models which the existing fetch mock here doesn't
@@ -12,7 +12,15 @@ vi.mock('../../data-plane/providers/models-cache.ts', () => ({
 
 import { hashPassword } from '../../shared/passwords.ts';
 import { buildCopilotUpstreamRecord, requestApp, setupAppTest } from '../../test-helpers.ts';
+import { initRuntimeKind } from '@floway-dev/platform';
 import { assertEquals, assertStringIncludes, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
+
+// vitest.setup pins the runtime kind to 'node'; the CF-side tests below
+// re-init and this restores the default so they don't leak.
+afterEach(() => {
+  initRuntimeKind('node');
+  vi.unstubAllEnvs();
+});
 
 const githubUser = {
   id: 777,
@@ -43,6 +51,64 @@ test('/auth/login with blank username + wrong ADMIN_KEY rejects', async () => {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ username: '', password: 'wrong-admin' }),
+  });
+  assertEquals(response.status, 401);
+});
+
+// Zero-config passwordless admin login: with no ADMIN_KEY set, a brand-new
+// local instance still lets the operator in. The four cases below cover the
+// dev/prod matrix on both runtimes — dev accepts, prod refuses. Node prod
+// additionally hard-fails at boot (see apps/platform-node/entry.ts), but
+// this per-request guard is the Cloudflare-side gate and Node
+// defence-in-depth.
+
+test('/auth/login on Node dev (empty ADMIN_KEY, NODE_ENV != production) grants passwordless admin login', async () => {
+  await setupAppTest({ adminKey: '' });
+  const response = await requestApp('/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: '', password: '' }),
+  });
+  assertEquals(response.status, 200);
+  const body = (await response.json()) as { user: { id: number; isAdmin: boolean } };
+  assertEquals(body.user.id, 1);
+  assertEquals(body.user.isAdmin, true);
+});
+
+test('/auth/login on Node with NODE_ENV=production refuses passwordless login when ADMIN_KEY is empty', async () => {
+  await setupAppTest({ adminKey: '' });
+  vi.stubEnv('NODE_ENV', 'production');
+  const response = await requestApp('/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: '', password: '' }),
+  });
+  assertEquals(response.status, 401);
+});
+
+test('/auth/login on Cloudflare wrangler dev (empty ADMIN_KEY, no CF-Ray) grants passwordless admin login', async () => {
+  await setupAppTest({ adminKey: '' });
+  initRuntimeKind('cloudflare');
+  const response = await requestApp('/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: '', password: '' }),
+  });
+  assertEquals(response.status, 200);
+  const body = (await response.json()) as { user: { id: number } };
+  assertEquals(body.user.id, 1);
+});
+
+test('/auth/login on Cloudflare edge (CF-Ray present) refuses passwordless login when ADMIN_KEY is empty', async () => {
+  await setupAppTest({ adminKey: '' });
+  initRuntimeKind('cloudflare');
+  const response = await requestApp('/auth/login', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'cf-ray': '9a1b2c3d4e5f6789-SJC',
+    },
+    body: JSON.stringify({ username: '', password: '' }),
   });
   assertEquals(response.status, 401);
 });

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -188,11 +188,12 @@ const ollamaConfigSchema = z.object({
 // JSON-parse + zod + pre-hash work is still worth bounding.
 const passwordSchema = z.string().min(1).max(1024);
 
-// Username is allowed empty so the ADMIN_KEY-only login path passes
-// validation; the login handler dispatches on the empty value.
+// Both fields are allowed empty so the blank-username login path (ADMIN_KEY
+// match, or the dev-only passwordless shortcut when ADMIN_KEY is unset)
+// passes validation; the login handler dispatches on the empty values.
 export const authLoginBody = z.object({
   username: z.string().regex(/^[a-zA-Z0-9_.\-]{0,64}$/, 'username must be 0-64 chars of [A-Za-z0-9_.-] (empty for ADMIN_KEY login)'),
-  password: passwordSchema,
+  password: z.string().max(1024),
 });
 
 // --- users ---

--- a/packages/gateway/src/repo/types.ts
+++ b/packages/gateway/src/repo/types.ts
@@ -20,8 +20,9 @@ export interface ApiKey {
 export interface User {
   id: number;
   username: string;
-  // null = the row is not a credential — sign-in is only possible through
-  // the ADMIN_KEY backdoor.
+  // null = the row is not a credential — sign-in is only possible via
+  // the blank-username /auth/login path (ADMIN_KEY match, or the
+  // dev-only passwordless shortcut when ADMIN_KEY is unset).
   passwordHash: string | null;
   isAdmin: boolean;
   // null = unrestricted at the user level; an array intersects with the

--- a/packages/gateway/src/shared/is-production-request.ts
+++ b/packages/gateway/src/shared/is-production-request.ts
@@ -2,22 +2,18 @@ import type { Context } from 'hono';
 
 import { getRuntimeKind } from '@floway-dev/platform';
 
-// True when this request is being served by a real deployment, false when
-// it's `wrangler dev` locally or a Node process without NODE_ENV=production.
-// The signal is split per runtime because neither side has a portable
-// answer:
+// True when this request is being served by a real deployment, false
+// under `wrangler dev` locally or a Node process without
+// NODE_ENV=production. The signal is split per runtime because neither
+// side has a portable answer:
 //
-// - Node: `process.env.NODE_ENV === 'production'` is the operator's
-//   explicit declaration. The Node startup gate (apps/platform-node/
-//   entry.ts) refuses to boot under NODE_ENV=production with an empty
-//   ADMIN_KEY; this per-request check is defence-in-depth if the process
-//   ever reaches the request layer with that combination.
+// - Node: `process.env.NODE_ENV === 'production'` — the operator's
+//   explicit declaration.
 //
-// - Cloudflare: the edge always attaches a `CF-Ray` header on inbound
-//   Worker requests. workerd's local inbound (which `wrangler dev` runs
-//   on) never writes it, and miniflare does not synthesize it either, so
-//   the header's presence is a zero-config signal that traffic came from
-//   the real edge.
+// - Cloudflare: presence of the `CF-Ray` request header. The edge always
+//   attaches CF-Ray on inbound Worker requests; workerd's local inbound
+//   (used by `wrangler dev`) never writes it, and miniflare does not
+//   synthesize it either.
 //   https://github.com/cloudflare/workerd/blob/7fa4a4bceedd2f83215a6fe584d478afbbefb0c0/src/workerd/io/io-thread-context.c%2B%2B#L28
 export const isProductionRequest = (c: Context): boolean => {
   if (getRuntimeKind() === 'node') return process.env.NODE_ENV === 'production';

--- a/packages/gateway/src/shared/is-production-request.ts
+++ b/packages/gateway/src/shared/is-production-request.ts
@@ -1,0 +1,25 @@
+import type { Context } from 'hono';
+
+import { getRuntimeKind } from '@floway-dev/platform';
+
+// True when this request is being served by a real deployment, false when
+// it's `wrangler dev` locally or a Node process without NODE_ENV=production.
+// The signal is split per runtime because neither side has a portable
+// answer:
+//
+// - Node: `process.env.NODE_ENV === 'production'` is the operator's
+//   explicit declaration. The Node startup gate (apps/platform-node/
+//   entry.ts) refuses to boot under NODE_ENV=production with an empty
+//   ADMIN_KEY; this per-request check is defence-in-depth if the process
+//   ever reaches the request layer with that combination.
+//
+// - Cloudflare: the edge always attaches a `CF-Ray` header on inbound
+//   Worker requests. workerd's local inbound (which `wrangler dev` runs
+//   on) never writes it, and miniflare does not synthesize it either, so
+//   the header's presence is a zero-config signal that traffic came from
+//   the real edge.
+//   https://github.com/cloudflare/workerd/blob/7fa4a4bceedd2f83215a6fe584d478afbbefb0c0/src/workerd/io/io-thread-context.c%2B%2B#L28
+export const isProductionRequest = (c: Context): boolean => {
+  if (getRuntimeKind() === 'node') return process.env.NODE_ENV === 'production';
+  return c.req.header('cf-ray') !== undefined;
+};


### PR DESCRIPTION
A fresh local instance with no `ADMIN_KEY` set (the zero-config dev default once `.dev.vars` is deleted) grants seed-admin access to a blank username with any password. No secret has to be provisioned before the dashboard becomes usable.

Real deployments must still set `ADMIN_KEY`. Two independent, runtime-native gates enforce this:

- **Node**: `apps/platform-node/entry.ts` refuses to boot when `NODE_ENV=production` and `ADMIN_KEY` is unset. Misconfiguration surfaces at start, not at first login.
- **Cloudflare**: the login handler refuses passwordless logins whenever the request carries a `CF-Ray` header. Cloudflare's edge always attaches `CF-Ray` on inbound Worker requests; workerd's local inbound (used by `wrangler dev`) never writes it and miniflare does not synthesize it either, giving a zero-config runtime signal that traffic came from the real edge. Source: [`workerd/src/workerd/io/io-thread-context.c++#L28`](https://github.com/cloudflare/workerd/blob/7fa4a4bceedd2f83215a6fe584d478afbbefb0c0/src/workerd/io/io-thread-context.c%2B%2B#L28).

The runtime detection lives in `packages/gateway/src/shared/is-production-request.ts` and is called from `resolveLoginUser`; both platform targets flow through the same code path. The `authLoginBody` schema drops its `min(1)` password constraint (only on `/auth/login` — the password-taking user-management endpoints keep it) so the passwordless flow validates without a workaround.

## Test plan

- [x] `pnpm run test` — 3868 passing, including 4 new cases in `packages/gateway/src/control-plane/auth/routes_test.ts` covering the Node dev / Node prod / CF wrangler-dev / CF edge matrix.
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Node prod startup gate: `NODE_ENV=production pnpm run dev:node` without `ADMIN_KEY` exits with `FATAL: NODE_ENV=production requires ADMIN_KEY.` and status 1.
- [ ] Manual browser round-trip: `pnpm run dev`, remove `.dev.vars`, submit `/login` with blank credentials — should return a valid session. (Behavior is asserted end-to-end via `requestApp` in the automated tests.)
- [ ] Manual CF deploy: publish a Worker without the `ADMIN_KEY` secret and confirm `/auth/login` returns 401 for blank credentials. (Requires a Cloudflare account; the CF-Ray branch is exercised by the automated tests.)