### PR TITLE
feat(copilot): refresh pinned editor fingerprint

### DIFF
--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -1,17 +1,24 @@
 import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
 import { getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
 
-// Version constants pinned to a known-good set. GitHub Copilot rejects too-new
-// editor-plugin-version values (caozhiyuan/copilot-api@80e17dfd downgraded
-// 0.48.0 → 0.47.1 after upstream broke on the newer one); dynamically tracking
-// the latest VSCode release in a server-side gateway buys no realism and adds
-// a startup HTTP dependency, so we pin both.
-const COPILOT_VERSION = '0.47.1';
-const VSCODE_VERSION = '1.119.1';
+// Version constants pinned to a known-good fingerprint that mirrors what a
+// current VSCode Copilot Chat install sends. The Copilot Chat plugin version,
+// the VSCode host version, and the Copilot data-plane api version are one
+// coordinated set — they ship together in a real editor build and Copilot
+// validates the combination, so they move together on every bump. We track a
+// maintained reference implementation rather than fetching these at startup: a
+// server-side gateway gains no realism from chasing the latest editor release,
+// and a boot-time HTTP dependency is a needless failure mode. Sourced from
+// caozhiyuan/copilot-api@b16e019 (COPILOT_VERSION, USER_AGENT, api version):
+//   https://github.com/caozhiyuan/copilot-api/blob/b16e01909e747b5ad49ce38137a6c1453e0052a6/src/lib/api-config.ts#L148-L156
+// and its VSCode host version fallback:
+//   https://github.com/caozhiyuan/copilot-api/blob/b16e01909e747b5ad49ce38137a6c1453e0052a6/src/services/get-vscode-version.ts#L1
+const COPILOT_VERSION = '0.52.0';
+const VSCODE_VERSION = '1.124.2';
 const EDITOR_VERSION = `vscode/${VSCODE_VERSION}`;
 const EDITOR_PLUGIN_VERSION = `copilot-chat/${COPILOT_VERSION}`;
 const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`;
-const COPILOT_API_VERSION = '2026-01-09';
+const COPILOT_API_VERSION = '2026-06-01';
 const GITHUB_API_VERSION = '2025-04-01';
 
 // User-agent VSCode Copilot Chat sends on its Claude Code SDK proxy path.


### PR DESCRIPTION
## What

Update the coordinated Copilot Chat editor fingerprint to the current known-good set:

| constant | before | after |
|---|---:|---:|
| Copilot Chat | `0.47.1` | `0.52.0` |
| VS Code | `1.119.1` | `1.124.2` |
| Copilot data-plane API | `2026-01-09` | `2026-06-01` |

The three values move together because a real editor build ships them as one fingerprint. The stale downgrade narrative is replaced with current source links and the rationale for keeping the values pinned rather than adding a startup network dependency.

`GITHUB_API_VERSION` and `CLAUDE_AGENT_USER_AGENT` are intentionally unchanged.

Sources:

- https://github.com/caozhiyuan/copilot-api/blob/b16e01909e747b5ad49ce38137a6c1453e0052a6/src/lib/api-config.ts#L148-L156
- https://github.com/caozhiyuan/copilot-api/blob/b16e01909e747b5ad49ce38137a6c1453e0052a6/src/services/get-vscode-version.ts#L1

## Test plan

- [x] `pnpm --filter @floway-dev/provider-copilot exec vitest run` — 257 tests pass
- [x] `pnpm --filter @floway-dev/provider-copilot run typecheck`
- [x] ESLint on `packages/provider-copilot/src/auth.ts`
- [x] Direct Enterprise Copilot probes accepted the fingerprint on `/models`, `/chat/completions`, and `/responses`
