### PR TITLE
feat(responses): expose reasoning.context as an open string

### DIFF
--- a/packages/gateway/src/data-plane/model-aliases/apply-rules_test.ts
+++ b/packages/gateway/src/data-plane/model-aliases/apply-rules_test.ts
@@ -111,15 +111,18 @@ test('responses: budget_tokens / adaptive have no native slot — silently dropp
   assertEquals('adaptive_thinking' in body, false);
 });
 
-test('responses: alias rules overwrite existing reasoning + service_tier fields', () => {
-  const body = resPayload({ reasoning: { effort: 'low', summary: 'auto' }, service_tier: 'default', text: { verbosity: 'high' } });
+test('responses: alias rules overwrite owned fields while preserving reasoning.context', () => {
+  const body = resPayload({
+    reasoning: { effort: 'low', summary: 'auto', context: 'future_mode' },
+    service_tier: 'default',
+    text: { verbosity: 'high' },
+  });
   applyRulesToUpstreamResponses(body, {
     reasoning: { effort: 'xhigh', summary: 'detailed' },
     verbosity: 'low',
     serviceTier: 'priority',
   });
-  assertEquals(body.reasoning?.effort, 'xhigh');
-  assertEquals(body.reasoning?.summary, 'detailed');
+  assertEquals(body.reasoning, { effort: 'xhigh', summary: 'detailed', context: 'future_mode' });
   assertEquals(body.text?.verbosity, 'low');
   assertEquals(body.service_tier, 'priority');
 });

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -27,6 +27,15 @@ export interface ResponsesPayload {
   reasoning?: {
     effort?: string;
     summary?: 'detailed' | 'auto' | 'concise' | (string & {});
+    // Controls which reasoning items are rendered back to the model on later
+    // turns; echoed on the response as the effective mode. Canonical values are
+    // `auto` / `current_turn` / `all_turns`, but the slot stays open-string so
+    // future upstream modes forward verbatim rather than being narrowed at this
+    // boundary. Reference (openai-python shared Reasoning.context):
+    // https://github.com/openai/openai-python/blob/f16fbbd2bd25dc1ff150b5f78dbd15ff6bab6d91/src/openai/types/shared/reasoning.py#L19-L25
+    // Reference (openai-node Reasoning.context):
+    // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/shared.ts#L262-L269
+    context?: 'auto' | 'current_turn' | 'all_turns' | (string & {}) | null;
   };
   include?: string[];
   // `text.verbosity` is a native GPT-5-family Responses field that controls

--- a/packages/translate/src/chat-completions-via-responses/request_test.ts
+++ b/packages/translate/src/chat-completions-via-responses/request_test.ts
@@ -143,6 +143,18 @@ test('translateChatCompletionsToResponses preserves translated OpenAI request fi
   assertFalse('include' in result);
 });
 
+test('translateChatCompletionsToResponses never invents reasoning.context from reasoning_effort', () => {
+  const result = translateChatCompletionsToResponses({
+    model: 'gpt-test',
+    messages: [{ role: 'user', content: 'hello' }],
+    reasoning_effort: 'high',
+  });
+
+  assertEquals(result.reasoning, { effort: 'high' });
+  assertEquals(result.reasoning?.context, undefined);
+  assertFalse('context' in (result.reasoning ?? {}));
+});
+
 test('translateChatCompletionsToResponses omits store when Chat omits store', () => {
   const result = translateChatCompletionsToResponses({
     model: 'gpt-test',

--- a/packages/translate/src/gemini-via-responses/request_test.ts
+++ b/packages/translate/src/gemini-via-responses/request_test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 
 import { buildTargetRequest } from './request.ts';
-import { assertEquals, assertThrows } from '../test-assert.ts';
+import { assertEquals, assertFalse, assertThrows } from '../test-assert.ts';
 import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 
 test('buildTargetRequest maps instructions and multimodal user input without defaults', () => {
@@ -178,6 +178,18 @@ test('buildTargetRequest maps generation config, JSON schema, and reasoning cont
   });
 
   assertEquals(buildTargetRequest({ generationConfig: { responseMimeType: 'application/json' } }, 'gpt-test').text, { format: { type: 'json_object' } });
+});
+
+test('buildTargetRequest never invents reasoning.context from Gemini thinking controls', () => {
+  const result = buildTargetRequest({
+    generationConfig: {
+      thinkingConfig: { thinkingLevel: 'high', includeThoughts: true },
+    },
+  }, 'gpt-test');
+
+  assertEquals(result.reasoning, { effort: 'high', summary: 'detailed' });
+  assertEquals(result.reasoning?.context, undefined);
+  assertFalse('context' in (result.reasoning ?? {}));
 });
 
 test('buildTargetRequest filters tools to allowed function names for ANY mode', () => {

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -248,8 +248,10 @@ export const translateMessagesToResponses = (payload: MessagesPayload): Canonica
   const serviceTier = payload.speed === 'fast' ? 'fast' : payload.speed === undefined ? payload.service_tier : undefined;
 
   // Keep fallback semantics strict: do not synthesize `temperature: 1`,
-  // `store: false`, `parallel_tool_calls: true`, or `reasoning.summary` when the
-  // Messages source did not express those knobs.
+  // `store: false`, `parallel_tool_calls: true`, `reasoning.summary`, or
+  // `reasoning.context` when the Messages source did not express those knobs.
+  // The source thinking block carries no reasoning-context mode, so we never
+  // invent `all_turns` (or any other value) on the target reasoning object.
   return {
     model: payload.model,
     input: [...prependItems, ...translateMessagesInput(payload.messages)],

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -189,6 +189,22 @@ test('translateMessagesToResponses maps thinking.adaptive to reasoning.effort me
   assertEquals(result.reasoning, { effort: 'medium' });
 });
 
+test('translateMessagesToResponses never invents reasoning.context from a source thinking block', () => {
+  // The Messages thinking shape carries no reasoning-context mode, so the
+  // target reasoning object must expose effort only — never a synthesized
+  // `all_turns` (or any other) context value.
+  const result = translateMessagesToResponses({
+    model: 'gpt-test',
+    max_tokens: 4096,
+    thinking: { type: 'enabled', budget_tokens: 8192 },
+    messages: [{ role: 'user', content: 'hi' }],
+  });
+
+  assertEquals(result.reasoning, { effort: 'medium' });
+  assertEquals(result.reasoning?.context, undefined);
+  assertFalse('context' in (result.reasoning ?? {}));
+});
+
 test('translateMessagesToResponses preserves max_tokens at the translation boundary', () => {
   const result = translateMessagesToResponses({
     model: 'gpt-test',

--- a/packages/translate/src/shared/via-responses/responses-items_test.ts
+++ b/packages/translate/src/shared/via-responses/responses-items_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { chatCompletionsViaResponsesItemsView, geminiViaResponsesItemsView, messagesViaResponsesItemsView, responsesItemsView } from './responses-items.ts';
+import { chatCompletionsViaResponsesItemsView, canonicalizeResponsesPayload, geminiViaResponsesItemsView, messagesViaResponsesItemsView, responsesItemsView } from './responses-items.ts';
 import { assertEquals } from '../../test-assert.ts';
 import { packReasoningSignature } from '../messages-and-responses/reasoning.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
@@ -181,4 +181,22 @@ test('mapAsResponsesItems does not treat Gemini thought signatures as Responses 
   assertEquals(calls, 0);
   assertEquals(mapped, payload.contents);
   assertEquals(mapped === payload.contents, false);
+});
+
+test('canonicalizeResponsesPayload preserves reasoning.context verbatim, including future modes', () => {
+  const canonicalCurrent = canonicalizeResponsesPayload({
+    model: 'gpt-test',
+    input: [{ type: 'message', role: 'user', content: 'hi' }],
+    reasoning: { effort: 'high', context: 'current_turn' },
+  });
+  assertEquals(canonicalCurrent.reasoning, { effort: 'high', context: 'current_turn' });
+
+  // An unknown/future context string rides through the wire→canonical boundary
+  // untouched — the upstream owns the accept/reject decision.
+  const canonicalFuture = canonicalizeResponsesPayload({
+    model: 'gpt-test',
+    input: 'hi',
+    reasoning: { context: 'future_mode' },
+  });
+  assertEquals(canonicalFuture.reasoning, { context: 'future_mode' });
 });


### PR DESCRIPTION
## What

Add the official OpenAI Responses `reasoning.context` field to Floway's protocol type as an open string:

- documented values: `auto`, `current_turn`, `all_turns`
- unknown future values remain valid and pass through verbatim
- `null` matches the official SDK contract

Runtime payload preservation already worked through Floway's object-spread boundaries; this PR makes that contract explicit and locks it in with tests.

Cross-protocol behavior is intentionally asymmetric:

- native Responses payloads preserve `context`, including future values and alias effort/summary overlays
- Messages, Chat Completions, and Gemini do not have an equivalent source field, so their `*-via-responses` translators omit rather than invent it
- reverse target protocols have no destination slot and continue dropping it

This PR does not enable Responses Lite or force encrypted reasoning content.

Sources:

- https://github.com/openai/openai-python/blob/f16fbbd2bd25dc1ff150b5f78dbd15ff6bab6d91/src/openai/types/shared/reasoning.py#L19-L25
- https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/shared.ts#L262-L269

## Test plan

- [x] `pnpm --filter @floway-dev/protocols run typecheck`
- [x] `pnpm --filter @floway-dev/translate run typecheck`
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] ESLint on all changed TypeScript files
- [x] Protocols tests — 22 files / 110 tests
- [x] Translate tests — 26 files / 454 tests
- [x] Gateway tests — 145 files / 1792 tests
- [x] Native known/future context values preserve verbatim
- [x] Messages, Chat Completions, and Gemini translators never synthesize context
- [x] Alias effort/summary overlays preserve an existing context
