### PR TITLE
feat(codex): restore first-frame tunneled errors to HTTP

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -196,6 +196,19 @@ inline and rebuilds the envelope client-side).
   `(instructions + first user-message text)` so the upstream prompt cache
   hits across turns of the same conversation (~88% input-token cache hit
   measured against gpt-5.4)
+- promotes a tunneled HTTP error back to a real failure. The Codex backend
+  answers `200 text/event-stream` and, when the call fails after the stream
+  is open, emits a first-frame `{ type: "error", status, headers, error }`
+  event instead of `response.failed`. The provider peeks exactly the first
+  parsed frame: an empty stream becomes `502`; a first-frame tunneled error
+  becomes an `ok:false` HTTP response (status from `status`/`status_code`
+  when a valid `400..599`, else `502`; body preserving the upstream error;
+  headers merged from the upstream response and the event, minus hop-by-hop
+  and body-framing), which flows into the normal candidate fallback. A
+  normal first frame is replayed unchanged. Only the first frame is
+  eligible — a later `error` is mid-stream failure owned by the client. The
+  one-frame lookahead delays downstream TTFB to the first event; the TTFT
+  output-token metric is unchanged.
 
 ### Chat Completions — gateway interceptors
 

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -726,6 +726,23 @@ type ResponsesStreamEventVariant =
     stack?: string;
     cause?: unknown;
     target_api?: string;
+    // Tunneled-HTTP-error extension. The ChatGPT backend's Responses transport
+    // restores an HTTP error that surfaced *after* the response stream already
+    // opened as a single first-frame `error` event carrying the original HTTP
+    // status, response headers, and error body — instead of the standard
+    // `response.failed` envelope. `status` is the canonical key with
+    // `status_code` accepted as an alias; `headers` values arrive as strings or
+    // numbers on the wire. These fields are absent on the standard streaming
+    // `error` event; only the Codex provider boundary reads them, to promote
+    // the frame back to a real HTTP failure.
+    // openai/codex WrappedWebsocketErrorEvent (canonical shape + `status_code`
+    // alias): https://github.com/openai/codex/blob/385c0a9351e2199929e01f7864ec78a8f7d5e580/codex-rs/codex-api/src/endpoint/responses_websocket.rs#L585-L596
+    // caozhiyuan/copilot-api first-frame restoration (commit 141f86fa):
+    // https://github.com/caozhiyuan/copilot-api/blob/0353da479b1612c82629086dccdbca56621e5958/src/services/copilot/create-responses.ts#L411-L423
+    status?: number;
+    status_code?: number;
+    headers?: Record<string, string | number>;
+    error?: unknown;
   }
   | { type: 'ping' };
 

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -15,6 +15,7 @@ import {
 import type { CodexAccountCredential } from './state.ts';
 import type { ResponsesCompactPayload, ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
+import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ProviderModel, type ProviderStreamResult, streamingProviderCall, uuidV7, type UpstreamCallOptions } from '@floway-dev/provider';
 
 export type ProviderCompactionResult =
@@ -411,14 +412,167 @@ const performStreamingResponsesCall = async (
 
   const result = await streamingProviderCall(upstreamFetch, parseResponsesStream, opts.model.id, opts.signal);
 
-  if (!result.ok && result.response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts);
-    if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
-    return await performStreamingResponsesCall(opts, fresh.accessToken, true);
+  if (!result.ok) {
+    if (result.response.status === 401 && !alreadyRetried) {
+      const fresh = await refreshAccessTokenForRetry(opts);
+      if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
+      return await performStreamingResponsesCall(opts, fresh.accessToken, true);
+    }
+    return result;
   }
 
-  return result;
+  return await promoteTunneledResponsesError(result);
 };
+
+type ResponsesErrorEvent = Extract<ResponsesStreamEvent, { type: 'error' }>;
+
+// Headers that must never survive onto the promoted HTTP response: hop-by-hop
+// (RFC 7230 §6.1) and the body-framing set the streaming layer re-derives. The
+// promoted body is a fresh JSON payload, so the upstream's framing headers
+// would mis-describe it. We deliberately keep everything else — vendor traces,
+// rate-limit counters — so operators see what the tunneled error carried.
+const TUNNELED_ERROR_STRIPPED_HEADERS: ReadonlySet<string> = new Set([
+  'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+  'te', 'trailer', 'transfer-encoding', 'upgrade',
+  'content-length', 'content-encoding', 'content-type',
+]);
+
+// The Codex backend answers 200 + text/event-stream and then, when the real
+// upstream call fails after the stream is already open, tunnels the HTTP error
+// as a first-frame `{ type: 'error', status, headers, error }` event instead of
+// the standard `response.failed` envelope. We restore it to a real ok:false
+// HTTP response here so the gateway's existing candidate fallback treats it
+// like any other upstream failure. Only the FIRST parsed frame is eligible —
+// once a normal frame has been replayed the stream is committed and a later
+// `error` is mid-stream failure that belongs to the client.
+//
+// Standard OpenAI `codex` recognizes this frame only on its WebSocket
+// transport; its plain-SSE handler drops a generic `type: 'error'` into a
+// catch-all and keys failure off `response.failed` / `response.incomplete`.
+// We add the promotion at the SSE boundary so the tunneled error is not lost.
+// caozhiyuan/copilot-api restores the identical first frame (commits 141f86fa
+// / 0034feb9):
+// https://github.com/caozhiyuan/copilot-api/blob/0353da479b1612c82629086dccdbca56621e5958/src/routes/provider/responses/handler.ts#L191-L211
+// openai/codex plain-SSE handler has no generic-error arm:
+// https://github.com/openai/codex/blob/385c0a9351e2199929e01f7864ec78a8f7d5e580/codex-rs/codex-api/src/sse/responses.rs#L466-L468
+//
+// Peeking one frame delays the downstream TTFB to the arrival of the first
+// event; the TTFT output-token metric is unchanged because it stamps on the
+// first output-bearing frame, which is at or after this point either way.
+const promoteTunneledResponsesError = async (
+  result: Extract<ProviderStreamResult<ResponsesStreamEvent>, { ok: true }>,
+): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
+  const iterator = result.events[Symbol.asyncIterator]();
+  let first: IteratorResult<ProtocolFrame<ResponsesStreamEvent>>;
+  try {
+    first = await iterator.next();
+  } catch (err) {
+    await iterator.return?.();
+    throw err;
+  }
+
+  if (first.done) {
+    await iterator.return?.();
+    return { ok: false, modelKey: result.modelKey, response: emptyResponsesStreamResponse() };
+  }
+
+  const frame = first.value;
+  if (frame.type === 'event' && isTunneledHttpError(frame.event)) {
+    await iterator.return?.();
+    return { ok: false, modelKey: result.modelKey, response: tunneledErrorResponse(frame.event, result.headers) };
+  }
+
+  return {
+    ok: true,
+    modelKey: result.modelKey,
+    events: replayFirstFrame(frame, iterator),
+    ...(result.headers ? { headers: result.headers } : {}),
+  };
+};
+
+// A tunneled HTTP error is distinguished from a normal in-stream `error` event
+// (which carries only `message` / `code`) by the presence of the HTTP-response
+// metadata the backend restores: the status (`status`, canonical, or its
+// `status_code` alias), the response headers, or the nested error body.
+const isTunneledHttpError = (event: ResponsesStreamEvent): event is ResponsesErrorEvent =>
+  event.type === 'error'
+  && (typeof event.status === 'number' || typeof event.status_code === 'number' || isPlainObject(event.headers) || event.error !== undefined);
+
+const tunneledErrorResponse = (event: ResponsesErrorEvent, upstreamHeaders: Headers | undefined): Response =>
+  new Response(tunneledErrorBody(event), {
+    status: tunneledErrorStatus(event),
+    headers: tunneledErrorHeaders(upstreamHeaders, event.headers),
+  });
+
+// The restored status is only trusted when it is a real HTTP error code;
+// anything else (missing, non-integer, out of the 4xx/5xx band) collapses to
+// 502 — the gateway is reporting a failed upstream leg, not a success. The
+// canonical `status` key wins over the `status_code` alias when both appear.
+const tunneledErrorStatus = (event: ResponsesErrorEvent): number => {
+  const raw = typeof event.status === 'number' ? event.status : event.status_code;
+  return typeof raw === 'number' && Number.isInteger(raw) && raw >= 400 && raw <= 599 ? raw : 502;
+};
+
+// Preserve the upstream error body verbatim when it ships a nested `error`
+// object; otherwise rebuild one from the event's own `message` / `code` so the
+// client still receives a well-formed `{ error: { … } }` envelope.
+const tunneledErrorBody = (event: ResponsesErrorEvent): string => {
+  if (isPlainObject(event.error)) return JSON.stringify({ error: event.error });
+  const error: Record<string, unknown> = {};
+  if (typeof event.message === 'string') error.message = event.message;
+  if (typeof event.code === 'string') error.code = event.code;
+  return JSON.stringify({ error });
+};
+
+const tunneledErrorHeaders = (upstreamHeaders: Headers | undefined, eventHeaders: Record<string, string | number> | undefined): Headers => {
+  const headers = new Headers();
+  if (upstreamHeaders) {
+    for (const [name, value] of upstreamHeaders) {
+      if (!TUNNELED_ERROR_STRIPPED_HEADERS.has(name.toLowerCase())) headers.set(name, value);
+    }
+  }
+  // The tunneled headers describe the real failed HTTP response, so they win
+  // over the outer SSE envelope's headers on any collision. Values arrive as
+  // strings or numbers on the wire; stringify before setting.
+  if (isPlainObject(eventHeaders)) {
+    for (const [name, value] of Object.entries(eventHeaders)) {
+      if ((typeof value === 'string' || typeof value === 'number') && !TUNNELED_ERROR_STRIPPED_HEADERS.has(name.toLowerCase())) {
+        headers.set(name, String(value));
+      }
+    }
+  }
+  headers.set('content-type', 'application/json');
+  return headers;
+};
+
+// Re-emits the already-consumed first frame, then delegates to the parser's
+// own iterator. Forwarding `return` keeps client cancellation / abort wired
+// through to the parser generator, so the underlying SSE body is still
+// released when the consumer breaks early.
+const replayFirstFrame = (
+  first: ProtocolFrame<ResponsesStreamEvent>,
+  rest: AsyncIterator<ProtocolFrame<ResponsesStreamEvent>>,
+): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> => ({
+  [Symbol.asyncIterator]() {
+    let replayed = false;
+    return {
+      next: async () => {
+        if (replayed) return await rest.next();
+        replayed = true;
+        return { done: false, value: first };
+      },
+      return: async () => {
+        await rest.return?.();
+        return { done: true, value: undefined };
+      },
+    };
+  },
+});
+
+const emptyResponsesStreamResponse = (): Response => new Response(
+  JSON.stringify({ error: { type: 'codex_upstream_error', message: 'Codex upstream closed the stream without emitting any event' } }),
+  { status: 502, headers: { 'content-type': 'application/json' } },
+);
 
 const performUnaryCompactCall = async (
   opts: CallCodexResponsesCompactOptions,

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -13,9 +13,9 @@ import {
   putCodexQuota,
 } from './quota.ts';
 import type { CodexAccountCredential } from './state.ts';
+import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesCompactPayload, ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
-import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { type ProviderModel, type ProviderStreamResult, streamingProviderCall, uuidV7, type UpstreamCallOptions } from '@floway-dev/provider';
 
 export type ProviderCompactionResult =

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from './constants.ts';
 import { callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from './fetch.ts';
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotMapEntry, CodexUpstreamState } from './state.ts';
-import type { ResponsesResult } from '@floway-dev/protocols/responses';
+import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
 
@@ -859,4 +860,222 @@ describe('callCodexResponsesCompact', () => {
     expect(effects.persistRefreshTokenRotation).not.toHaveBeenCalled();
   });
 
+});
+
+const sseStreamResponse = (
+  frames: readonly string[],
+  init: { status?: number; headers?: Record<string, string>; onCancel?: (reason?: unknown) => void } = {},
+): Response => new Response(
+  new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(new TextEncoder().encode(frame));
+      controller.close();
+    },
+    cancel(reason) { init.onCancel?.(reason); },
+  }),
+  { status: init.status ?? 200, headers: new Headers({ 'content-type': 'text/event-stream', ...(init.headers ?? {}) }) },
+);
+
+const dataFrame = (event: unknown): string => `data: ${JSON.stringify(event)}\n\n`;
+
+const collectFrameTypes = async (events: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<string[]> => {
+  const types: string[] = [];
+  for await (const frame of events) types.push(frame.type === 'event' ? frame.event.type : 'done');
+  return types;
+};
+
+const runResponses = () => callCodexResponses({
+  upstreamId, account: activeAccount,
+  model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
+});
+
+describe('callCodexResponses — first-frame tunneled-error promotion', () => {
+  beforeEach(() => seedFreshAccessToken());
+
+  test('promotes a first-frame tunneled error with a valid status_code to ok:false', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'error', status_code: 429, error: { type: 'usage_limit_reached', message: 'cap reached', plan_type: 'pro' } }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(429);
+      expect(result.response.headers.get('content-type')).toBe('application/json');
+      const body = await result.response.json() as { error: Record<string, unknown> };
+      expect(body.error).toEqual({ type: 'usage_limit_reached', message: 'cap reached', plan_type: 'pro' });
+    }
+  });
+
+  test('accepts the canonical `status` key as an alias for status_code', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'error', status: 400, error: { type: 'invalid_request_error', message: 'bad' } }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(400);
+  });
+
+  test('a tunneled error without a status collapses to 502 while preserving the body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'error', error: { message: 'no status here' } }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(502);
+      const body = await result.response.json() as { error: { message: string } };
+      expect(body.error.message).toBe('no status here');
+    }
+  });
+
+  test('an out-of-band status_code (2xx) collapses to 502', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'error', status_code: 200, headers: {}, error: { message: 'nonsense' } }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(502);
+  });
+
+  test('falls back to the event message/code when there is no nested error object', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'error', status_code: 503, message: 'upstream down', code: 'unavailable' }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(503);
+      const body = await result.response.json() as { error: { message: string; code: string } };
+      expect(body.error).toEqual({ message: 'upstream down', code: 'unavailable' });
+    }
+  });
+
+  test('merges upstream and event headers, stripping hop-by-hop/body-framing and stringifying numbers', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({
+        type: 'error',
+        status_code: 429,
+        headers: {
+          'x-codex-primary-window-minutes': 15,
+          'retry-after': '30',
+          'content-length': '999',
+          'transfer-encoding': 'chunked',
+        },
+        error: { message: 'rate limited' },
+      }),
+    ], { headers: { 'x-request-id': 'req-123', 'content-encoding': 'gzip' } }));
+    const result = await runResponses();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.headers.get('x-request-id')).toBe('req-123');
+      expect(result.response.headers.get('x-codex-primary-window-minutes')).toBe('15');
+      expect(result.response.headers.get('retry-after')).toBe('30');
+      expect(result.response.headers.get('content-length')).toBeNull();
+      expect(result.response.headers.get('transfer-encoding')).toBeNull();
+      expect(result.response.headers.get('content-encoding')).toBeNull();
+      expect(result.response.headers.get('content-type')).toBe('application/json');
+    }
+  });
+
+  test('an empty stream (no frames) becomes an ok:false 502 JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([]));
+    const result = await runResponses();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(502);
+      const body = await result.response.json() as { error: { type: string } };
+      expect(body.error.type).toBe('codex_upstream_error');
+    }
+  });
+
+  test('replays a normal first frame exactly once and streams the rest', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'response.created', response: { id: 'resp_1' } }),
+      dataFrame({ type: 'response.output_text.delta', item_id: 'i', output_index: 0, content_index: 0, delta: 'hi' }),
+      'data: [DONE]\n\n',
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const types = await collectFrameTypes(result.events);
+      expect(types).toEqual(['response.created', 'response.output_text.delta', 'done']);
+    }
+  });
+
+  test('does not promote a first-frame response.failed envelope', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'response.failed', response: { id: 'r', status: 'failed', output: [], error: { code: 'rate_limit_exceeded', message: 'slow down' } } }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const types = await collectFrameTypes(result.events);
+      expect(types).toContain('response.failed');
+    }
+  });
+
+  test('does not promote a first-frame response.incomplete envelope', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'response.incomplete', response: { id: 'r', status: 'incomplete', output: [], incomplete_details: { reason: 'max_output_tokens' } } }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const types = await collectFrameTypes(result.events);
+      expect(types).toContain('response.incomplete');
+    }
+  });
+
+  test('does not promote a first-frame plain error without HTTP metadata', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'error', message: 'mid-stream glitch', code: 'server_error' }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const types = await collectFrameTypes(result.events);
+      expect(types).toEqual(['error']);
+    }
+  });
+
+  test('does not promote a tunneled error that arrives after a prior frame', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'response.created', response: { id: 'resp_1' } }),
+      dataFrame({ type: 'error', status_code: 500, error: { message: 'late failure' } }),
+    ]));
+    const result = await runResponses();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const types = await collectFrameTypes(result.events);
+      expect(types).toEqual(['response.created', 'error']);
+    }
+  });
+
+  test('propagates client cancellation to the underlying upstream stream', async () => {
+    const onCancel = vi.fn();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseStreamResponse([
+      dataFrame({ type: 'response.created', response: { id: 'resp_1' } }),
+      dataFrame({ type: 'response.output_text.delta', item_id: 'i', output_index: 0, content_index: 0, delta: 'hi' }),
+      dataFrame({ type: 'response.output_text.delta', item_id: 'i', output_index: 0, content_index: 0, delta: 'there' }),
+    ], { onCancel }));
+    const result = await runResponses();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const iterator = result.events[Symbol.asyncIterator]();
+      const first = await iterator.next();
+      expect(first.done).toBe(false);
+      await iterator.return?.();
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test('surfaces an error thrown while reading the first frame', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      pull() { throw new Error('upstream socket blew up'); },
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(stream, {
+      status: 200, headers: new Headers({ 'content-type': 'text/event-stream' }),
+    }));
+    await expect(runResponses()).rejects.toThrow('upstream socket blew up');
+  });
 });

--- a/packages/provider-codex/src/fetch_test.ts
+++ b/packages/provider-codex/src/fetch_test.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from './constants.ts';
 import { callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from './fetch.ts';
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotMapEntry, CodexUpstreamState } from './state.ts';
-import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
+import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
 
@@ -120,7 +120,7 @@ describe('callCodexResponses — gates', () => {
         },
       },
     });
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     const result = await callCodexResponses({
       upstreamId, account: activeAccount,
       model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
@@ -150,7 +150,7 @@ describe('callCodexResponses — token freshness', () => {
 
   test('reuses fresh state-cached access token without refreshing', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
@@ -174,7 +174,7 @@ describe('callCodexResponses — token freshness', () => {
 describe('callCodexResponses — upstream classification', () => {
   test('happy path: 200 → ok:true, quota persisted', async () => {
     seedFreshAccessToken();
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     const result = await callCodexResponses({
       upstreamId, account: activeAccount,
       model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
@@ -188,7 +188,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('upstream body has store:false and stream:true forced even if caller passes otherwise', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model, body: { input: [], stream: false as unknown as true, store: true } as unknown as Parameters<typeof callCodexResponses>[0]['body'],
@@ -202,7 +202,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('builds Codex responses headers and metadata from a clean set', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model,
@@ -382,7 +382,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('preserves a hyphenated Codex session id for prompt cache', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model,
@@ -399,7 +399,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('canonicalizes downstream session_id to the Codex session-id header', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model,
@@ -416,7 +416,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('prefers downstream session-id over session_id when both are provided', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model,
@@ -433,7 +433,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('generates a Codex session id when the downstream request has none', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount,
       model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
@@ -447,7 +447,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('derives the same session id across turns of a stateless conversation', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     const turn = {
       upstreamId, account: activeAccount, model,
       body: {
@@ -471,7 +471,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('derives distinct session ids when only the instructions differ', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     const call = (instructions: string) => callCodexResponses({
       upstreamId, account: activeAccount, model,
       body: {
@@ -493,7 +493,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('derives distinct session ids when only the first user message differs', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     const call = (content: string) => callCodexResponses({
       upstreamId, account: activeAccount, model,
       body: {
@@ -515,7 +515,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('uses account.openaiDeviceId as the installation id', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     const deviceId = '22222222-3333-4444-9555-666666666666';
     await callCodexResponses({
       upstreamId, account: { ...activeAccount, openaiDeviceId: deviceId },
@@ -531,7 +531,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('prefers a caller-supplied installation id from client_metadata over the account device id', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: { ...activeAccount, openaiDeviceId: 'account-device-id' },
       model,
@@ -553,7 +553,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('passes through caller thread-id and x-client-request-id when distinct from session-id', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount, model,
       body: { input: [], stream: true },
@@ -577,7 +577,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('merges caller-supplied x-codex-turn-metadata extras over the synthesized blob', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount, model,
       body: { input: [], stream: true },
@@ -611,7 +611,7 @@ describe('callCodexResponses — upstream classification', () => {
 
   test('preserves caller client_metadata extras while keeping identity-mirror keys gateway-owned', async () => {
     seedFreshAccessToken();
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     await callCodexResponses({
       upstreamId, account: activeAccount, model,
       body: {
@@ -703,7 +703,7 @@ describe('callCodexResponses — background-write registration', () => {
   // on the floor and the next request re-mints / re-races the upstream.
   test('2xx persists quota snapshot via opts.call.waitUntil', async () => {
     seedFreshAccessToken();
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => sseResponse());
     const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
     await callCodexResponses({
       upstreamId, account: activeAccount,


### PR DESCRIPTION
## What

Restore Codex Responses errors that arrive as the first SSE frame with tunneled HTTP metadata back to a normal HTTP error before the downstream stream is committed.

At the provider-codex `/responses` boundary:

- peek exactly one parsed frame
- empty stream → HTTP 502 provider failure
- first generic `{ type: "error", status/status_code, headers, error }` frame → provider failure using the valid 4xx/5xx status, otherwise 502
- merge safe upstream/event headers and preserve the error body
- replay every normal first frame exactly once
- leave `response.failed`, `response.incomplete`, later errors, Copilot, Chat, and Messages unchanged

Returning `ok:false` feeds Floway's existing candidate fallback. Iterator cancellation and abort propagation are preserved.

This one-frame lookahead delays downstream response headers until the first upstream event. It does not change TTFT's output-token definition; error/lifecycle frames are not output tokens.

Evidence:

- https://github.com/caozhiyuan/copilot-api/commit/141f86fa0376f7fd87216a80e621ecc4a2e7325b
- https://github.com/caozhiyuan/copilot-api/commit/0034feb928404fffd28de937561b199f830e89fd
- current openai/codex distinguishes standard `response.failed` lifecycle events from generic tunneled errors

## Test plan

- [x] `pnpm run test` — 333 files / 4007 tests pass
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] 14 cases cover status aliases/fallback, body and header preservation, empty stream, replay, standard lifecycle exclusions, later errors, cancellation, and iterator failure
