### PR TITLE
fix(perf): interpolate percentiles within buckets

### DIFF
--- a/packages/gateway/src/control-plane/performance/aggregate_test.ts
+++ b/packages/gateway/src/control-plane/performance/aggregate_test.ts
@@ -30,8 +30,8 @@ const record = (overrides: Partial<PerformanceTelemetryRecord> = {}): Performanc
   ttftMsSum: 100,
   tpotUsSum: 500,
   // Bucket edges here are illustrative test fixtures, not the production edge set.
-  // ttft bucket [50, 100] → geometric midpoint sqrt(5000) ≈ 70.71
-  // tpot bucket [200, 500] → geometric midpoint sqrt(100000) ≈ 316.23
+  // A singleton is the first of one uniformly distributed sample, so its
+  // expected order statistic lies at the interval midpoint.
   buckets: [
     { metric: 'ttft_ms', lower: 50, upper: 100, count: 1 },
     { metric: 'tpot_us', lower: 200, upper: 500, count: 1 },
@@ -39,9 +39,8 @@ const record = (overrides: Partial<PerformanceTelemetryRecord> = {}): Performanc
   ...overrides,
 });
 
-// Geometric midpoints of the fixture buckets — expected percentile values.
-const TTFT_MID = Math.sqrt(50 * 100);
-const TPOT_MID = Math.sqrt(200 * 500);
+const TTFT_MID = (50 + 100) / 2;
+const TPOT_MID = (200 + 500) / 2;
 
 test('aggregatePerformanceForDisplay produces correct averages and percentiles for a single record', () => {
   const rows = aggregateSingle(
@@ -118,7 +117,7 @@ test('aggregatePerformanceForDisplay merges two hours under bucket: all', () => 
   assertEquals(rows[0].requests, 2);
   assertEquals(rows[0].ttftSamples, 2);
   assertEquals(rows[0].tpotSamples, 2);
-  assertEquals(rows[0].ttftMsP50, TTFT_MID);
+  assertEquals(rows[0].ttftMsP50, 50 + 50 / 3);
 });
 
 test('aggregatePerformanceForDisplay splits rows by upstream when groupBy is upstream', () => {
@@ -138,8 +137,8 @@ test('aggregatePerformanceForDisplay splits rows by upstream when groupBy is ups
 test('aggregatePerformanceForDisplay returns lower edge for overflow-bucket percentile', () => {
   // A ttftMs value above the highest edge falls into the overflow bucket
   // { lower: <top-finite-edge>, upper: null }. percentileFromBuckets returns
-  // bucket.lower when upper is null (geometric midpoint is undefined without an
-  // upper edge).
+  // bucket.lower when upper is null because a finite uniform distribution
+  // cannot be inferred without an upper edge.
   const rows = aggregateSingle(
     [
       record({

--- a/packages/gateway/src/control-plane/performance/aggregate_test.ts
+++ b/packages/gateway/src/control-plane/performance/aggregate_test.ts
@@ -30,8 +30,6 @@ const record = (overrides: Partial<PerformanceTelemetryRecord> = {}): Performanc
   ttftMsSum: 100,
   tpotUsSum: 500,
   // Bucket edges here are illustrative test fixtures, not the production edge set.
-  // A singleton is the first of one uniformly distributed sample, so its
-  // expected order statistic lies at the interval midpoint.
   buckets: [
     { metric: 'ttft_ms', lower: 50, upper: 100, count: 1 },
     { metric: 'tpot_us', lower: 200, upper: 500, count: 1 },
@@ -39,6 +37,8 @@ const record = (overrides: Partial<PerformanceTelemetryRecord> = {}): Performanc
   ...overrides,
 });
 
+// A singleton bucket places its sole sample's expected order statistic at
+// the interval midpoint, so every percentile has the same estimate.
 const TTFT_MID = (50 + 100) / 2;
 const TPOT_MID = (200 + 500) / 2;
 
@@ -117,6 +117,7 @@ test('aggregatePerformanceForDisplay merges two hours under bucket: all', () => 
   assertEquals(rows[0].requests, 2);
   assertEquals(rows[0].ttftSamples, 2);
   assertEquals(rows[0].tpotSamples, 2);
+  // The merged bucket has count 2, so p50 is its first order statistic.
   assertEquals(rows[0].ttftMsP50, 50 + 50 / 3);
 });
 

--- a/packages/gateway/src/control-plane/performance/routes_test.ts
+++ b/packages/gateway/src/control-plane/performance/routes_test.ts
@@ -17,9 +17,8 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
   };
 
   // 90 fast samples (ttftMs=100 → bucket [0, 100]) + 10 slow samples (ttftMs=300 → bucket [200, 300]).
-  // Rank(p50, 100) = 50 lands in the first bucket → arithmetic midpoint 100/2 = 50 (geometric midpoint
-  // is undefined when lower=0). Rank(p95, 100) = 95 lands in [200, 300] → geometric midpoint sqrt(60000).
-  // Every tpotUs=500 falls in [0, 500] → arithmetic midpoint 250.
+  // Percentiles select a global nearest rank, then estimate that bucket's local
+  // order statistic under a uniform distribution over its stored bounds.
   for (let i = 0; i < 90; i++) {
     await repo.performance.recordSample({ ...sample, ttftMs: 100 });
   }
@@ -31,7 +30,6 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
 
   assertEquals(response.status, 200);
   const body = await response.json();
-  const slowMid = Math.sqrt(200 * 300);
   assertEquals(body.axes.model, [
     {
       bucket: 'all',
@@ -41,12 +39,12 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
       ttftSamples: 100,
       tpotSamples: 100,
       neutral: 0,
-      ttftMsP50: 50,
-      ttftMsP95: slowMid,
-      ttftMsP99: slowMid,
-      tpotUsP50: 250,
-      tpotUsP95: 250,
-      tpotUsP99: 250,
+      ttftMsP50: 100 * 50 / 91,
+      ttftMsP95: 200 + 100 * 5 / 11,
+      ttftMsP99: 200 + 100 * 9 / 11,
+      tpotUsP50: 500 * 50 / 101,
+      tpotUsP95: 500 * 95 / 101,
+      tpotUsP99: 500 * 99 / 101,
     },
   ]);
 });

--- a/packages/gateway/src/control-plane/performance/routes_test.ts
+++ b/packages/gateway/src/control-plane/performance/routes_test.ts
@@ -17,8 +17,8 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
   };
 
   // 90 fast samples (ttftMs=100 → bucket [0, 100]) + 10 slow samples (ttftMs=300 → bucket [200, 300]).
-  // Percentiles select a global nearest rank, then estimate that bucket's local
-  // order statistic under a uniform distribution over its stored bounds.
+  // TTFT p50 is local rank 50 of 90; p95 and p99 are local ranks 5 and 9 of
+  // 10. Every TPOT sample shares [0, 500], so its local rank is the global rank.
   for (let i = 0; i < 90; i++) {
     await repo.performance.recordSample({ ...sample, ttftMs: 100 });
   }

--- a/packages/gateway/src/shared/performance-histogram.ts
+++ b/packages/gateway/src/shared/performance-histogram.ts
@@ -44,16 +44,14 @@ const bucketForValue = (edges: readonly number[], value: number): Omit<Histogram
 export const bucketForTtftMs = (ttftMs: number) => bucketForValue(TTFT_UPPER_EDGES_MS, ttftMs);
 export const bucketForTpotUs = (tpotUs: number) => bucketForValue(TPOT_UPPER_EDGES_US, tpotUs);
 
-// Nearest-rank percentile that returns the bucket's GEOMETRIC MIDPOINT
-// rather than the upper edge, so a bucket [a, b] contributes sqrt(a*b) —
-// the log-scale center. Rationale: our edges form a near-geometric series,
-// so geometric mean is the unbiased estimate of "typical value in this
-// bucket" per DDSketch (Masson et al., VLDB 2019,
-// https://www.vldb.org/pvldb/vol12/p2195-masson.pdf). Returning the upper
-// edge (pessimistic bound) instead concentrates all reported values at the
-// slowest end of the bucket, which for TPOT-inverted tok/s underreports
-// speed by the full bucket factor. The overflow bucket has no upper, so
-// it falls back to lower (still pessimistic for the overflow tail).
+// Nearest-rank selects one global order statistic. Within a finite bucket,
+// only its interval and sample count survive aggregation, so we estimate the
+// selected sample as the corresponding uniform order statistic: the x-th of
+// n samples from Uniform(lower, upper) has expectation
+// lower + (upper - lower) * x / (n + 1). This preserves the selected sample's
+// position instead of collapsing every percentile in the bucket to one value.
+// The overflow bucket has no finite distribution to interpolate, so it returns
+// its lower bound.
 export const percentileFromBuckets = (buckets: readonly HistogramBucket[], percentile: number): number | null => {
   const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
   if (total <= 0) return null;
@@ -70,13 +68,12 @@ export const percentileFromBuckets = (buckets: readonly HistogramBucket[], perce
 
   let seen = 0;
   for (const bucket of ordered) {
-    seen += bucket.count;
-    if (seen >= rank) {
+    if (seen + bucket.count >= rank) {
       if (bucket.upper === null) return bucket.lower;
-      // Geometric midpoint; falls back to arithmetic when lower is 0 (the
-      // first bucket, since a 0-lower log midpoint is undefined).
-      return bucket.lower === 0 ? bucket.upper / 2 : Math.sqrt(bucket.lower * bucket.upper);
+      const rankWithinBucket = rank - seen;
+      return bucket.lower + (bucket.upper - bucket.lower) * rankWithinBucket / (bucket.count + 1);
     }
+    seen += bucket.count;
   }
   throw new Error('percentileFromBuckets: unreachable — total>0 and rank<=total should have terminated the loop');
 };

--- a/packages/gateway/src/shared/performance-histogram_test.ts
+++ b/packages/gateway/src/shared/performance-histogram_test.ts
@@ -96,6 +96,14 @@ describe('percentileFromBuckets', () => {
     expect(percentileFromBuckets(buckets, 0.5)).toBe(50);
   });
 
+  it('interpolates within a multi-sample bucket whose lower bound is zero', () => {
+    const buckets: HistogramBucket[] = [
+      { lower: 0, upper: 100, count: 10 },
+    ];
+
+    expect(percentileFromBuckets(buckets, 0.5)).toBeCloseTo(500 / 11, 10);
+  });
+
   it('uses the rank local to the selected bucket', () => {
     const buckets: HistogramBucket[] = [
       { lower: 0, upper: 50, count: 1 },

--- a/packages/gateway/src/shared/performance-histogram_test.ts
+++ b/packages/gateway/src/shared/performance-histogram_test.ts
@@ -78,38 +78,44 @@ describe('bucketForTpotUs', () => {
 });
 
 describe('percentileFromBuckets', () => {
-  it('returns the bucket geometric midpoint sqrt(lower*upper), not the upper edge', () => {
+  it('estimates the selected order statistic within a finite bucket', () => {
     const buckets: HistogramBucket[] = [
       { lower: 100, upper: 200, count: 10 },
     ];
-    // sqrt(100 * 200) ≈ 141.42, not 200
-    expect(percentileFromBuckets(buckets, 0.5)).toBeCloseTo(Math.sqrt(20_000), 5);
+
+    expect(percentileFromBuckets(buckets, 0.01)).toBeCloseTo(100 + 100 / 11, 10);
+    expect(percentileFromBuckets(buckets, 0.5)).toBeCloseTo(100 + 500 / 11, 10);
+    expect(percentileFromBuckets(buckets, 1)).toBeCloseTo(100 + 1_000 / 11, 10);
   });
 
-  it('first bucket (lower=0) falls back to arithmetic midpoint to avoid sqrt(0)', () => {
+  it('estimates a singleton sample at the bucket midpoint', () => {
     const buckets: HistogramBucket[] = [
-      { lower: 0, upper: 100, count: 10 },
+      { lower: 0, upper: 100, count: 1 },
     ];
+
     expect(percentileFromBuckets(buckets, 0.5)).toBe(50);
   });
 
-  it('p50 lands in the highest-count bucket', () => {
+  it('uses the rank local to the selected bucket', () => {
     const buckets: HistogramBucket[] = [
       { lower: 0, upper: 50, count: 1 },
       { lower: 50, upper: 100, count: 2 },
       { lower: 100, upper: 200, count: 7 },
     ];
-    // p50 rank = ceil(10 * 0.5) = 5; falls in the third bucket. Geometric mid sqrt(100*200) ≈ 141.42.
-    expect(percentileFromBuckets(buckets, 0.5)).toBeCloseTo(Math.sqrt(20_000), 5);
+
+    // Global p50 rank 5 is the second of seven samples in the third bucket.
+    expect(percentileFromBuckets(buckets, 0.5)).toBe(125);
   });
 
-  it('p99 lands in the top bucket', () => {
+  it('places a high local rank near the top of its bucket', () => {
     const buckets: HistogramBucket[] = [
       { lower: 0, upper: 50, count: 1 },
       { lower: 50, upper: 100, count: 2 },
       { lower: 100, upper: 200, count: 7 },
     ];
-    expect(percentileFromBuckets(buckets, 0.99)).toBeCloseTo(Math.sqrt(20_000), 5);
+
+    // Global p99 rank 10 is the seventh of seven samples in the third bucket.
+    expect(percentileFromBuckets(buckets, 0.99)).toBe(187.5);
   });
 
   it('empty histogram returns null', () => {
@@ -132,8 +138,8 @@ describe('percentileFromBuckets', () => {
       upper: (i + 1) * 50,
       count: 50,
     }));
-    // rank(0.29, 200) = ceil(58 - ε) = 58; cumulative counts 50/100/150/200 → hits second bucket [50, 100].
-    // Geometric mid sqrt(50 * 100) ≈ 70.71.
-    expect(percentileFromBuckets(flat, 0.29)).toBeCloseTo(Math.sqrt(5_000), 5);
+    // rank(0.29, 200) = ceil(58 - ε) = 58; cumulative counts 50/100/150/200,
+    // so this is the eighth of 50 uniformly distributed samples in [50, 100].
+    expect(percentileFromBuckets(flat, 0.29)).toBeCloseTo(50 + 400 / 51, 10);
   });
 });


### PR DESCRIPTION
## Summary

Performance histogram percentiles now preserve nearest-rank selection across all samples and estimate the selected sample's position within its finite bucket. For local rank `x` in a bucket containing `count` samples, the estimate is `lower + (upper - lower) * x / (count + 1)`, matching the expected x-th order statistic under a uniform distribution over the stored bounds.

This prevents P50, P95, and P99 from collapsing to one geometric midpoint when they land in the same bucket. Open-ended overflow buckets continue to return their lower bound because no finite distribution can be inferred without an upper bound.

No migration is required. Migration 0050 already persists `lower` and `upper` for every finite bucket, and the repository and export/import paths preserve both values. `upper = NULL` remains the intentional overflow representation.

## Test Plan

- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Boot the Node deployment against an isolated migrated SQLite database, seed a 100-sample `[100, 200]` histogram, and confirm the live `/api/performance/overview` response reports distinct P50, P95, and P99 estimates
- [x] Seed an open-ended histogram in the isolated database and confirm the live response reports its lower bound for P50, P95, and P99

## Risk

This intentionally changes percentile estimates returned from existing finite-bucket rows without rewriting stored data. Overflow estimates retain their previous conservative lower-bound behavior.
