### PR TITLE
fix(responses): fail requests when state persistence fails

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -146,15 +146,20 @@ const completedEvent = (id = 'resp_test'): ResponsesStreamEvent => ({
   response: makeResponsesResult(id),
 });
 
-test('POST /v1/responses streams a successful SSE body', async () => {
-  installRepo();
+const queueCompletedResponse = (id = 'resp_test') => {
   const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
     action: 'generate', ok: true,
-    events: makeProviderEvents([completedEvent()]),
+    events: makeProviderEvents([completedEvent(id)]),
     modelKey: 'test-model-key',
     headers: new Headers(),
   }));
   queueResolution([makeCandidate({ callResponses })]);
+  return callResponses;
+};
+
+test('POST /v1/responses streams a successful SSE body', async () => {
+  installRepo();
+  const callResponses = queueCompletedResponse();
 
   const response = await makeApp().request('/v1/responses', {
     method: 'POST',
@@ -175,13 +180,7 @@ test('POST /v1/responses streams a successful SSE body', async () => {
 
 test('POST /v1/responses returns a single JSON body when stream is omitted', async () => {
   installRepo();
-  const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
-    action: 'generate', ok: true,
-    events: makeProviderEvents([completedEvent('resp_nonstream')]),
-    modelKey: 'test-model-key',
-    headers: new Headers(),
-  }));
-  queueResolution([makeCandidate({ callResponses })]);
+  queueCompletedResponse('resp_nonstream');
 
   const response = await makeApp().request('/v1/responses', {
     method: 'POST',
@@ -194,6 +193,70 @@ test('POST /v1/responses returns a single JSON body when stream is omitted', asy
   const body = await response.json() as ResponsesResult;
   assert(isStoredResponseId(body.id), `expected Floway-minted resp_ id, got ${body.id}`);
   assertEquals(body.status, 'completed');
+});
+
+test('POST /v1/responses returns 502 when a non-streaming output item cannot be persisted', async () => {
+  const repo = installRepo();
+  const persistence = vi.spyOn(repo.responsesItems, 'insertMany').mockRejectedValue(new Error('simulated item persistence failure'));
+  try {
+    queueCompletedResponse();
+
+    const response = await makeApp().request('/v1/responses', {
+      method: 'POST',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ model: 'test-model', input: 'hello' }),
+    });
+
+    assertEquals(response.status, 502);
+    const body = await response.json() as { error: { message: string } };
+    assertEquals(body.error.message, 'simulated item persistence failure');
+  } finally {
+    persistence.mockRestore();
+  }
+});
+
+test('POST /v1/responses terminates an SSE stream with error when an output item cannot be persisted', async () => {
+  const repo = installRepo();
+  const persistence = vi.spyOn(repo.responsesItems, 'insertMany').mockRejectedValue(new Error('simulated item persistence failure'));
+  try {
+    queueCompletedResponse();
+
+    const response = await makeApp().request('/v1/responses', {
+      method: 'POST',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ model: 'test-model', input: 'hello', stream: true }),
+    });
+
+    // Streaming headers are already committed, so the protocol error frame is
+    // the failure signal; a successful terminal frame must never follow it.
+    assertEquals(response.status, 200);
+    const body = await response.text();
+    assert(body.includes('event: error'));
+    assert(body.includes('simulated item persistence failure'));
+    assert(!body.includes('event: response.completed'));
+  } finally {
+    persistence.mockRestore();
+  }
+});
+
+test('POST /v1/responses returns 502 when the response snapshot cannot be persisted', async () => {
+  const repo = installRepo();
+  const persistence = vi.spyOn(repo.responsesSnapshots, 'insert').mockRejectedValue(new Error('simulated snapshot persistence failure'));
+  try {
+    queueCompletedResponse();
+
+    const response = await makeApp().request('/v1/responses', {
+      method: 'POST',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ model: 'test-model', input: 'hello' }),
+    });
+
+    assertEquals(response.status, 502);
+    const body = await response.json() as { error: { message: string } };
+    assertEquals(body.error.message, 'simulated snapshot persistence failure');
+  } finally {
+    persistence.mockRestore();
+  }
 });
 
 test('POST /v1/responses/compact returns a non-streaming compaction envelope', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -12,8 +12,11 @@ import type { ChatTargetApi } from '@floway-dev/provider';
 //
 // Items are committed at their `done` frame and the snapshot is committed
 // at the terminal `response.completed` / `response.incomplete` frame.
-// `onItemFinalized` is awaited before the terminal frame is yielded, so a
-// client that has seen the frame can reference the row on its next turn.
+// Both writes are protocol state, not best-effort telemetry: their failures
+// propagate so the client never receives `done` / a successful terminal frame
+// for ids that cannot be referenced on its next turn. Streaming clients may
+// already have seen the item's `added` frame and deltas, but without `done`
+// they must treat that partial item as failed.
 //
 // Wrap is also the single source of truth for the response envelope id the
 // client sees. The caller mints a `resp_<crc>_<body>` once and passes it
@@ -87,11 +90,7 @@ export const wrapResponsesOutputForStorage = async function* (
       refreshedAt: now,
     };
     store.stageOutputItem(row);
-    try {
-      await store.commitOutputItems();
-    } catch (error) {
-      console.error('Failed to persist stored Responses items:', error);
-    }
+    await store.commitOutputItems();
   };
 
   // `seenItemTypes` records item type for every upstream id we have mapped
@@ -164,11 +163,7 @@ export const wrapResponsesOutputForStorage = async function* (
       // generator another tick, so any post-yield work would be lost.
       // The downstream HTTP entry has nothing to observe pre-snapshot —
       // ordering matches a synchronous emit.
-      try {
-        await store.commitSnapshot(responseId, sawCompactionItem ? 'replace' : 'append');
-      } catch (error) {
-        console.error('Failed to persist stored Responses snapshot:', error);
-      }
+      await store.commitSnapshot(responseId, sawCompactionItem ? 'replace' : 'append');
       yield rewritten;
       return;
     }

--- a/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
@@ -8,7 +8,7 @@ import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { ResponsesItemsRepo, StoredResponsesItem } from '../../../../repo/types.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesOutputItem, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import { assert, assertEquals } from '@floway-dev/test-utils';
+import { assert, assertEquals, assertRejects } from '@floway-dev/test-utils';
 
 const apiKeyId = 'key_output_new';
 
@@ -236,47 +236,25 @@ test('persists each row before yielding the item-done frame', async () => {
   assertEquals(((await doneFrame).value as ProtocolFrame<ResponsesStreamEvent>).type, 'event');
 });
 
-test('insert failure does not sink the stream', async () => {
+test('insert failure rejects before yielding the item-done frame', async () => {
   const repo = new InMemoryRepo();
   const controlled = new ControlledResponsesItemsRepo();
   repo.responsesItems = controlled;
   initRepo(repo);
-  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-  try {
-    const original = messageItem('raw_msg_native', 'hello');
-    // The controlled repo holds insertMany pending until told to resolve.
-    // To keep this test focused on item-insert failure handling, configure
-    // the store without snapshotWrites so the terminal frame does not
-    // re-trigger the controlled insertMany via the snapshot commit path.
-    const repoBacking = new RepoStatefulResponsesBacking(() => repo);
-    const store = new LayeredStatefulResponsesStore({
-      apiKeyId,
-      reads: [repoBacking],
-      itemWrites: [{ backing: repoBacking, durable: true }],
-      snapshotWrites: [],
-      stageInputs: false,
-    });
-    const iterator = wrapWithStore(framesFrom([
-      { type: 'response.output_item.added', output_index: 0, item: { ...original, content: [] } },
-      { type: 'response.output_item.done', output_index: 0, item: original },
-      { type: 'response.completed', response: response([original]) },
-    ]), store)[Symbol.asyncIterator]();
+  const original = messageItem('raw_msg_native', 'hello');
+  const iterator = wrapWithStore(framesFrom([
+    { type: 'response.output_item.added', output_index: 0, item: { ...original, content: [] } },
+    { type: 'response.output_item.done', output_index: 0, item: original },
+    { type: 'response.completed', response: response([original]) },
+  ]), createResponsesHttpStore(apiKeyId, undefined))[Symbol.asyncIterator]();
 
-    assertEquals(((await iterator.next()).value as ProtocolFrame<ResponsesStreamEvent>).type, 'event');
+  assertEquals(((await iterator.next()).value as ProtocolFrame<ResponsesStreamEvent>).type, 'event');
 
-    const doneFrame = iterator.next();
-    assertEquals(await promiseStateAfterMicrotasks(doneFrame), 'pending');
-    await waitForInsertCall(controlled);
-    controlled.rejectInsert?.(new Error('insert failed'));
-    assertEquals(((await doneFrame).value as ProtocolFrame<ResponsesStreamEvent>).type, 'event');
-
-    const completed = (await iterator.next()).value as ProtocolFrame<ResponsesStreamEvent>;
-    assert(completed.type === 'event' && completed.event.type === 'response.completed');
-    assert((await iterator.next()).done);
-    assert(errorSpy.mock.calls.length > 0);
-  } finally {
-    errorSpy.mockRestore();
-  }
+  const doneFrame = iterator.next();
+  assertEquals(await promiseStateAfterMicrotasks(doneFrame), 'pending');
+  await waitForInsertCall(controlled);
+  controlled.rejectInsert?.(new Error('insert failed'));
+  await assertRejects(() => doneFrame, Error, 'insert failed');
 });
 
 test('does not insert rows for failed streams without observed items', async () => {
@@ -563,43 +541,36 @@ test('no snapshot is written when the store has no snapshotWrites configured', a
   assertEquals(snapshot, null);
 });
 
-test('snapshot commit error does not sink the stream', async () => {
+test('snapshot commit failure rejects before yielding the terminal frame', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);
   const original = messageItem('raw_msg_snap_err', 'hi');
-  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-  try {
-    const repoBacking = new RepoStatefulResponsesBacking(() => repo);
-    const faultyBacking: StatefulResponsesBacking = {
-      lookupItems: args => repoBacking.lookupItems(args),
-      insertItems: items => repoBacking.insertItems(items),
-      fillPayloads: items => repoBacking.fillPayloads(items),
-      refreshItems: (aid, ids, at) => repoBacking.refreshItems(aid, ids, at),
-      lookupSnapshot: async () => null,
-      insertSnapshot: async () => { throw new Error('snapshot write failed'); },
-      refreshSnapshot: async () => {},
-    };
+  const repoBacking = new RepoStatefulResponsesBacking(() => repo);
+  const faultyBacking: StatefulResponsesBacking = {
+    lookupItems: args => repoBacking.lookupItems(args),
+    insertItems: items => repoBacking.insertItems(items),
+    fillPayloads: items => repoBacking.fillPayloads(items),
+    refreshItems: (aid, ids, at) => repoBacking.refreshItems(aid, ids, at),
+    lookupSnapshot: async () => null,
+    insertSnapshot: async () => { throw new Error('snapshot write failed'); },
+    refreshSnapshot: async () => {},
+  };
 
-    const faultyStore = new LayeredStatefulResponsesStore({
-      apiKeyId,
-      reads: [repoBacking],
-      itemWrites: [{ backing: repoBacking, durable: true }],
-      snapshotWrites: [{ backing: faultyBacking, durable: false }],
-      stageInputs: true,
-    });
+  const faultyStore = new LayeredStatefulResponsesStore({
+    apiKeyId,
+    reads: [repoBacking],
+    itemWrites: [{ backing: repoBacking, durable: true }],
+    snapshotWrites: [{ backing: faultyBacking, durable: false }],
+    stageInputs: true,
+  });
 
-    const events = wrapWithStore(framesFrom([
-      { type: 'response.output_item.done', output_index: 0, item: original },
-      { type: 'response.completed', response: { ...response([original]), id: 'resp_snap_fail' } },
-    ]), faultyStore);
+  const events = wrapWithStore(framesFrom([
+    { type: 'response.output_item.done', output_index: 0, item: original },
+    { type: 'response.completed', response: { ...response([original]), id: 'resp_snap_fail' } },
+  ]), faultyStore);
 
-    const collected = await collectEvents(events);
-    // Stream should complete despite snapshot failure
-    assert(collected.at(-1)?.type === 'response.completed');
-    assert(errorSpy.mock.calls.some(call => String(call[0]).includes('snapshot')));
-  } finally {
-    errorSpy.mockRestore();
-  }
+  await assertRejects(() => collectEvents(events), Error, 'snapshot write failed');
+  assertEquals(await repo.responsesSnapshots.lookup(apiKeyId, TEST_RESPONSE_ID), null);
 });
 
 test('in-stream commit: row is visible immediately after done frame', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -370,11 +370,11 @@ const respondResponsesWebSocket = async (input: {
         if (failed) state.failed = true;
         state.rememberUsage('response' in event ? tokenUsageFromResponsesResult((event as { response: ResponsesResult }).response) : null);
 
-        // The upstream terminal event flushes immediately; we then drain the
-        // remainder of the generator (storage commit, any post-terminal frames)
-        // before emitting the WS-only `response.done` envelope, so the client
-        // sees `response.done` last and treats it as the stable signal that the
-        // stored response can be referenced by a follow-up message.
+        // The wrapped terminal event arrives only after its item and snapshot
+        // writes have committed. Flush it immediately, then drain the remainder
+        // of the generator before emitting the WS-only `response.done` envelope,
+        // so `response.done` remains the stable signal that a follow-up message
+        // can reference the stored response.
         if (terminalEvent !== undefined) continue;
 
         if (isResponsesTerminalEvent(event)) {

--- a/packages/gateway/src/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket_test.ts
@@ -208,6 +208,66 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
   );
 });
 
+test('Responses WebSocket reports a failed turn when an output item cannot be persisted', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  const persistence = vi.spyOn(repo.responsesItems, 'insertMany').mockRejectedValue(new Error('simulated item persistence failure'));
+  try {
+    await withMockedFetch(
+      async request => {
+        const url = new URL(request.url);
+        if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+        if (url.pathname === '/copilot_internal/v2/token') {
+          return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+        }
+        if (url.pathname === '/models') {
+          return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+        }
+        if (url.pathname === '/responses') {
+          return sseResponsesResponse({
+            id: 'resp_ws_persist_failure',
+            object: 'response',
+            model: 'gpt-direct-responses',
+            status: 'completed',
+            output: [{
+              type: 'message',
+              id: 'msg_upstream',
+              role: 'assistant',
+              status: 'completed',
+              content: [{ type: 'output_text', text: 'done' }],
+            }],
+            output_text: 'done',
+            usage: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
+          });
+        }
+        throw new Error(`Unhandled fetch ${request.url}`);
+      },
+      async () => await withWorkerWebSocketRuntime(async () => {
+        const client = await connectResponsesWebSocket(apiKey.key);
+        const received = waitForMessages(client, messages => messages.some(message => message.type === 'error'));
+
+        client.send(JSON.stringify({
+          type: 'response.create',
+          event_id: 'evt_persist_failure',
+          response: {
+            model: 'gpt-direct-responses',
+            input: 'hello',
+          },
+        }));
+
+        const messages = await received;
+        const error = messages.find(message => message.type === 'error') as { status_code?: unknown; error?: { message?: unknown } } | undefined;
+        assertExists(error);
+        assertEquals(error.status_code, 500);
+        assertEquals(error.error?.message, 'simulated item persistence failure');
+        assert(!messages.some(message => message.type === 'response.completed'));
+        assert(!messages.some(message => message.type === 'response.done'));
+      }),
+    );
+  } finally {
+    persistence.mockRestore();
+  }
+});
+
 test('Responses WebSocket keepalive during an in-flight request does not drop the pending upstream frame', async () => {
   const { apiKey } = await setupAppTest();
   const time = new FakeTime();


### PR DESCRIPTION
## Summary

- Treat stored Responses item and snapshot writes as required protocol state.
- Propagate persistence failures before `response.output_item.done` or successful terminal events.
- Cover non-streaming HTTP, SSE, and WebSocket failure semantics.

## Risk

A transient state-store failure now fails the current turn instead of returning IDs that cannot be replayed. SSE clients may already have received partial item frames; they receive an `error` event and no `response.completed`. WebSocket clients receive a 500 error and no `response.done`.

## Test Plan

- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`