### PR TITLE
fix(web): preserve proxy form after clearing URL

### DIFF
--- a/apps/web/src/components/proxy-edit/ProxyEditDialog.vue
+++ b/apps/web/src/components/proxy-edit/ProxyEditDialog.vue
@@ -74,10 +74,10 @@ watch(url, next => {
   if (lastSource === 'form') { lastSource = null; return; }
   const parsed = tryParse(next);
   if (parsed === null) {
-    lastSource = 'url';
-    config.value = null;
+    // URL cleared: leave config untouched so v-if keeps the form panel
+    // mounted and the reverse watch does not fire and re-fill URL from
+    // the stale config.
     urlError.value = null;
-    void nextTick(() => { if (lastSource === 'url') lastSource = null; });
     return;
   }
   if (parsed.ok) {


### PR DESCRIPTION
## Summary

- In the Create/Edit Proxy dialog, clearing the URL input made the Protocol selector (and all kind-specific subfields) disappear until a valid URL was typed again.
- Root cause: `watch(url)` set `config.value = null` on the empty branch, which failed `<ProxyConfigForm v-if="config">` and unmounted the whole form panel.
- Fix: on the empty branch, leave `config` untouched and just clear `urlError`. The form panel stays mounted with the last good config, matching the existing UX for the "URL syntactically invalid" branch. The reverse `watch(config)` will re-fill the URL the moment the operator touches any subfield, so two-way binding is preserved.

## Test plan

- [x] `pnpm run dev`, log into the dashboard, open Create Proxy
- [x] Type `vless://uuid@host:443?type=tcp&security=tls&sni=x.example.com`; Protocol switches to VLESS / TLS, subfields populated
- [x] Clear the URL input; Protocol selector remains visible with VLESS / TLS selected, subfields preserved, no error banner (screenshot captured)
- [x] Switch Protocol to another kind via the selector; URL auto-fills from the reverse watch
- [x] Save flow with empty URL still errors with the existing "URL is required" guard
- [x] `pnpm --filter @floway-dev/web run typecheck` clean
- [x] `pnpm --filter @floway-dev/web run lint` clean
- [x] `pnpm --filter @floway-dev/web run test` clean