### PR TITLE
fix(dump): count WebSocket response payload bytes

### DIFF
--- a/apps/web/src/components/dump/RequestList.vue
+++ b/apps/web/src/components/dump/RequestList.vue
@@ -166,11 +166,11 @@ const showEmpty = computed(() => !props.loading && props.records.length === 0 &&
                 <i class="i-lucide-timer size-3" />
                 {{ formatDuration(record.durationMs) }}
               </span>
-              <span class="inline-flex items-center gap-0.5" :title="`Request body ${record.requestBytes} bytes`">
+              <span class="inline-flex items-center gap-0.5" :title="`Request payload ${record.requestBytes} bytes`">
                 <i class="i-lucide-arrow-up size-3" />
                 {{ formatBytes(record.requestBytes) }}
               </span>
-              <span class="inline-flex items-center gap-0.5" :title="`Response body ${record.responseBytes} bytes`">
+              <span class="inline-flex items-center gap-0.5" :title="`Response payload ${record.responseBytes} bytes`">
                 <i class="i-lucide-arrow-down size-3" />
                 {{ formatBytes(record.responseBytes) }}
               </span>

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -537,12 +537,13 @@ const sendJson = (
   const payload = eventId === undefined || !value || typeof value !== 'object'
     ? value
     : { ...value, event_id: eventId };
-  const text = JSON.stringify(payload);
+  let text: string;
   try {
+    text = JSON.stringify(payload);
     socket.send(text);
-    dump?.recordResponsePayload(UTF8_ENCODER.encode(text).byteLength);
-    return true;
   } catch {
     return false;
   }
+  dump?.recordSentPayloadBytes(UTF8_ENCODER.encode(text).byteLength);
+  return true;
 };

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -4,6 +4,7 @@ import { createResponsesWsSession } from './items/store.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
+import type { DumpAccumulator } from '../../../dump/accumulator.ts';
 import { apiKeyFromContext, authenticateApiKey, type AuthedContext } from '../../../middleware/auth.ts';
 import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
@@ -28,6 +29,8 @@ interface ResponsesWebSocketSocket {
   readonly readyState: number;
   send(data: string): void;
 }
+
+const UTF8_ENCODER = new TextEncoder();
 
 export interface ResponsesWebSocketEvents {
   onOpen?(event: Event, socket: ResponsesWebSocketSocket): void;
@@ -250,7 +253,7 @@ const handleClientMessage = async (
           type: 'invalid_request_error',
           param: 'previous_response_id',
           code: 'previous_response_not_found',
-        }, eventId);
+        }, eventId, ctx.dump);
         ctx.dump?.failed(error);
         ctx.dump?.finalize(400, []);
         return;
@@ -269,7 +272,7 @@ const handleClientMessage = async (
       }, eventId);
       return;
     }
-    sendError(socket, 500, serverErrorEnvelope(error), eventId);
+    sendError(socket, 500, serverErrorEnvelope(error), eventId, ctx?.dump);
     if (ctx !== undefined) {
       // Mid-attempt throws (interceptor bug, translation error, provider-layer JS
       // exception that bypassed tryCatchChatServeFailure) never reach the
@@ -323,16 +326,16 @@ const respondResponsesWebSocket = async (input: {
   if (result.type === 'api-error') {
     recordFailedRequest(ctx, result.performance);
     ctx.dump?.error(result.source, result.upstream);
+    sendError(socket, result.status, normalizeErrorBody(parseMaybeJson(result.body, result.headers), result.status), eventId, ctx.dump);
     ctx.dump?.finalize(result.status, []);
-    sendError(socket, result.status, normalizeErrorBody(parseMaybeJson(result.body, result.headers), result.status), eventId);
     return;
   }
 
   if (result.type === 'internal-error') {
     recordFailedRequest(ctx, result.performance);
     ctx.dump?.failed(result.error.message);
+    sendError(socket, result.status, internalErrorEnvelope(result.error), eventId, ctx.dump);
     ctx.dump?.finalize(result.status, []);
-    sendError(socket, result.status, internalErrorEnvelope(result.error), eventId);
     return;
   }
 
@@ -360,7 +363,7 @@ const respondResponsesWebSocket = async (input: {
         const next = await nextFrameOrKeepAlive(pendingNext);
 
         if (next.type === 'keep-alive') {
-          if (!sendJson(socket, { type: 'ping' }, eventId)) {
+          if (!sendJson(socket, { type: 'ping' }, eventId, ctx.dump)) {
             stopForDownstream();
             return;
           }
@@ -392,7 +395,7 @@ const respondResponsesWebSocket = async (input: {
         if (terminalEvent !== undefined) continue;
 
         if (isResponsesTerminalEvent(event)) {
-          if (!sendJson(socket, event, eventId)) {
+          if (!sendJson(socket, event, eventId, ctx.dump)) {
             completion = 'cancel';
             continue;
           }
@@ -401,7 +404,7 @@ const respondResponsesWebSocket = async (input: {
           continue;
         }
 
-        if (!sendJson(socket, event, eventId)) {
+        if (!sendJson(socket, event, eventId, ctx.dump)) {
           stopForDownstream();
           return;
         }
@@ -418,7 +421,7 @@ const respondResponsesWebSocket = async (input: {
       throw new Error(RESPONSES_MISSING_TERMINAL_MESSAGE);
     }
     const done = responseDoneSummary(terminalEvent);
-    if (done !== null && !sendJson(socket, { type: 'response.done', response: done }, eventId)) {
+    if (done !== null && !sendJson(socket, { type: 'response.done', response: done }, eventId, ctx.dump)) {
       completion = 'cancel';
       return;
     }
@@ -429,7 +432,7 @@ const respondResponsesWebSocket = async (input: {
       return;
     }
     state.failed = true;
-    sendError(socket, 500, serverErrorEnvelope(error), eventId);
+    sendError(socket, 500, serverErrorEnvelope(error), eventId, ctx.dump);
   } finally {
     const metadata = await eventResultMetadata(result);
     const failed = state.failedAfter(completion);
@@ -514,17 +517,30 @@ const normalizeErrorBody = (body: unknown, statusCode: number): Record<string, u
   };
 };
 
-const sendError = (socket: ResponsesWebSocketSocket, statusCode: number, error: Record<string, unknown>, eventId?: string): void => {
-  sendJson(socket, { type: 'error', status_code: statusCode, error }, eventId);
+const sendError = (
+  socket: ResponsesWebSocketSocket,
+  statusCode: number,
+  error: Record<string, unknown>,
+  eventId?: string,
+  dump?: DumpAccumulator | null,
+): void => {
+  sendJson(socket, { type: 'error', status_code: statusCode, error }, eventId, dump);
 };
 
-const sendJson = (socket: ResponsesWebSocketSocket, value: unknown, eventId?: string): boolean => {
+const sendJson = (
+  socket: ResponsesWebSocketSocket,
+  value: unknown,
+  eventId?: string,
+  dump?: DumpAccumulator | null,
+): boolean => {
   if (socket.readyState !== 1) return false;
   const payload = eventId === undefined || !value || typeof value !== 'object'
     ? value
     : { ...value, event_id: eventId };
+  const text = JSON.stringify(payload);
   try {
-    socket.send(JSON.stringify(payload));
+    socket.send(text);
+    dump?.recordResponsePayload(UTF8_ENCODER.encode(text).byteLength);
     return true;
   } catch {
     return false;

--- a/packages/gateway/src/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket_test.ts
@@ -100,6 +100,18 @@ const waitForMessages = async (
   });
 };
 
+const recordRawMessages = (socket: TestWorkerWebSocket) => {
+  const messages: string[] = [];
+  const onMessage = (event: Event): void => {
+    messages.push((event as MessageEvent<string>).data);
+  };
+  socket.addEventListener('message', onMessage);
+  return {
+    messages,
+    stop: () => socket.removeEventListener('message', onMessage),
+  };
+};
+
 const waitForMicrotasks = async (): Promise<void> => {
   for (let i = 0; i < 10; i++) await Promise.resolve();
 };
@@ -300,6 +312,34 @@ test('Responses WebSocket stops capturing on the next turn when dump retention i
 
       assertEquals(dumps.stored.length, 1);
       client.close();
+    }),
+  );
+});
+
+test('Responses WebSocket dump responseBytes equals the UTF-8 payload bytes sent downstream', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  await repo.apiKeys.save({ ...apiKey, dumpRetentionSeconds: 3600 });
+  const dumps = installDumpStubs(initDumpStore, initDumpBroker);
+
+  await withSuccessfulResponsesUpstream(
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const recorded = recordRawMessages(client);
+      try {
+        await completeResponsesTurn(client, '响应-byte-count');
+        await vi.waitFor(() => assertEquals(dumps.stored.length, 1));
+
+        const expectedBytes = recorded.messages.reduce(
+          (total, message) => total + new TextEncoder().encode(message).byteLength,
+          0,
+        );
+        const utf16CodeUnits = recorded.messages.reduce((total, message) => total + message.length, 0);
+        assert(expectedBytes > utf16CodeUnits, 'non-ASCII event_id must be counted as UTF-8 bytes');
+        assertEquals(dumps.stored[0]?.record.meta.responseBytes, expectedBytes);
+      } finally {
+        recorded.stop();
+        client.close();
+      }
     }),
   );
 });
@@ -604,6 +644,50 @@ test('Responses WebSocket forwards HTTP failures with status_code, error.code, a
           message: 'Model missing-model is not available on any configured upstream.',
         },
       }]);
+    }),
+  );
+});
+
+test('Responses WebSocket dump responseBytes counts an error envelope sent downstream', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  await repo.apiKeys.save({ ...apiKey, dumpRetentionSeconds: 3600 });
+  const dumps = installDumpStubs(initDumpStore, initDumpBroker);
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') return jsonResponse(copilotModels([]));
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const recorded = recordRawMessages(client);
+      try {
+        const received = waitForMessages(client, messages => messages.length === 1);
+        client.send(JSON.stringify({
+          type: 'response.create',
+          event_id: '错误-byte-count',
+          response: {
+            model: 'missing-model',
+            input: 'hello',
+          },
+        }));
+
+        assertEquals((await received)[0]?.status_code, 404);
+        await vi.waitFor(() => assertEquals(dumps.stored.length, 1));
+        const expectedBytes = recorded.messages.reduce(
+          (total, message) => total + new TextEncoder().encode(message).byteLength,
+          0,
+        );
+        assertEquals(dumps.stored[0]?.record.meta.responseBytes, expectedBytes);
+      } finally {
+        recorded.stop();
+        client.close();
+      }
     }),
   );
 });

--- a/packages/gateway/src/dump/accumulator.ts
+++ b/packages/gateway/src/dump/accumulator.ts
@@ -97,6 +97,7 @@ const resolveUpstreamRef = async (id: string | null): Promise<DumpUpstreamRef | 
 
 export class DumpAccumulator {
   private readonly events: DumpStreamEvent[] = [];
+  private responsePayloadBytes = 0;
   private model: string | null = null;
   private upstreamId: string | null = null;
   private inputTokens: number | null = null;
@@ -133,6 +134,10 @@ export class DumpAccumulator {
     this.events.push({ frame, ts: Date.now() - this.startedAt });
   }
 
+  recordResponsePayload(byteLength: number): void {
+    this.responsePayloadBytes += byteLength;
+  }
+
   success(identity: TelemetryModelIdentity, usage: TokenUsage | null): void {
     this.model = identity.model;
     this.upstreamId = identity.upstream;
@@ -147,8 +152,8 @@ export class DumpAccumulator {
   //
   //   • `(status, headers)` — no HTTP Response object to tee. The WebSocket
   //     Responses path uses this: its "response" is the stream of frames
-  //     already captured via `frame()` and the terminal status is supplied
-  //     by the caller.
+  //     already captured via `frame()`, while the send seam records their
+  //     actual UTF-8 payload bytes via `recordResponsePayload()`.
   //   • `(response)` — tees the response body so the client gets bytes
   //     flowing while a background reader accumulates the other half. The
   //     returned Response streams the client-side bytes; status, statusText,
@@ -244,7 +249,7 @@ export class DumpAccumulator {
       inputTokens: this.inputTokens,
       outputTokens: this.outputTokens,
       requestBytes: this.requestSnapshot.body.byteLength,
-      responseBytes: response.bytes.byteLength,
+      responseBytes: response.bytes.byteLength + this.responsePayloadBytes,
       durationMs: completedAt - this.startedAt,
       // Precedence: an explicit error stamp from the respond path wins;
       // otherwise a request-body read failure (operator-side payload didn't

--- a/packages/gateway/src/dump/accumulator.ts
+++ b/packages/gateway/src/dump/accumulator.ts
@@ -38,6 +38,7 @@ interface ResponseSnapshot {
   readonly headers: ReadonlyArray<readonly [string, string]>;
   readonly isStream: boolean;
   readonly bytes: Uint8Array;
+  readonly payloadBytes: number;
   readonly streamError: string | null;
 }
 
@@ -97,7 +98,7 @@ const resolveUpstreamRef = async (id: string | null): Promise<DumpUpstreamRef | 
 
 export class DumpAccumulator {
   private readonly events: DumpStreamEvent[] = [];
-  private responsePayloadBytes = 0;
+  private sentPayloadBytes = 0;
   private model: string | null = null;
   private upstreamId: string | null = null;
   private inputTokens: number | null = null;
@@ -134,8 +135,8 @@ export class DumpAccumulator {
     this.events.push({ frame, ts: Date.now() - this.startedAt });
   }
 
-  recordResponsePayload(byteLength: number): void {
-    this.responsePayloadBytes += byteLength;
+  recordSentPayloadBytes(byteLength: number): void {
+    this.sentPayloadBytes += byteLength;
   }
 
   success(identity: TelemetryModelIdentity, usage: TokenUsage | null): void {
@@ -153,7 +154,7 @@ export class DumpAccumulator {
   //   • `(status, headers)` — no HTTP Response object to tee. The WebSocket
   //     Responses path uses this: its "response" is the stream of frames
   //     already captured via `frame()`, while the send seam records their
-  //     actual UTF-8 payload bytes via `recordResponsePayload()`.
+  //     actual UTF-8 payload bytes via `recordSentPayloadBytes()`.
   //   • `(response)` — tees the response body so the client gets bytes
   //     flowing while a background reader accumulates the other half. The
   //     returned Response streams the client-side bytes; status, statusText,
@@ -173,6 +174,7 @@ export class DumpAccumulator {
         headers: headers.map(([k, v]) => [k, v]),
         isStream: this.events.length > 0,
         bytes: new Uint8Array(),
+        payloadBytes: this.sentPayloadBytes,
         streamError: null,
       }));
       return;
@@ -207,7 +209,14 @@ export class DumpAccumulator {
       const bytes = new Uint8Array(total);
       let offset = 0;
       for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
-      await this.write({ status: responseStatus, headers: responseHeaders, isStream, bytes, streamError });
+      await this.write({
+        status: responseStatus,
+        headers: responseHeaders,
+        isStream,
+        bytes,
+        payloadBytes: bytes.byteLength,
+        streamError,
+      });
     })());
 
     return new Response(forClient, {
@@ -249,7 +258,7 @@ export class DumpAccumulator {
       inputTokens: this.inputTokens,
       outputTokens: this.outputTokens,
       requestBytes: this.requestSnapshot.body.byteLength,
-      responseBytes: response.bytes.byteLength + this.responsePayloadBytes,
+      responseBytes: response.payloadBytes,
       durationMs: completedAt - this.startedAt,
       // Precedence: an explicit error stamp from the respond path wins;
       // otherwise a request-body read failure (operator-side payload didn't

--- a/packages/gateway/src/dump/types.ts
+++ b/packages/gateway/src/dump/types.ts
@@ -44,7 +44,9 @@ export interface DumpMetadata {
   model: string | null;
   inputTokens: number | null;
   outputTokens: number | null;
-  // Raw (pre-gzip) byte counts of the captured bodies.
+  // Captured application-payload bytes. HTTP counts body bytes; WebSocket
+  // counts UTF-8 message payloads. Transport framing/compression and the
+  // dump store's gzip encoding are excluded.
   requestBytes: number;
   responseBytes: number;
   durationMs: number;


### PR DESCRIPTION
## Summary

Responses WebSocket dumps stored canonical protocol events but left `responseBytes` at zero because the transport has no HTTP response body. The dashboard therefore showed `↓ 0 B` even when a complete response stream was delivered.

This change records the UTF-8 byte length of every JSON text payload successfully handed to the downstream socket, including protocol events, keepalive pings, `response.done`, and error envelopes. The status-only WebSocket finalizer snapshots that sent total, while the HTTP finalizer continues to use the drained body length; each path supplies one authoritative payload-byte count.

The metric remains application-level: WebSocket framing, compression, TLS, and dump-storage gzip are excluded. Dashboard tooltips now say request/response payload rather than body so the label is truthful for both HTTP and WebSocket records.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway exec vitest run src/data-plane/chat/responses/websocket_test.ts` (16 tests)
- [x] `pnpm run test` (334 files, 4075 tests)
- [x] `pnpm run lint`
- [x] `pnpm run typecheck` (19 workspace projects)
