### PR TITLE
fix(web): clear stale Save/Test error when operator resumes editing

### DIFF
--- a/apps/web/src/components/proxy-edit/ProxyEditDialog.vue
+++ b/apps/web/src/components/proxy-edit/ProxyEditDialog.vue
@@ -135,6 +135,14 @@ const saveError = ref<string | null>(null);
 const testing = ref(false);
 const testError = ref<string | null>(null);
 
+// Any operator edit invalidates the last Save/Test diagnostic — clear
+// the banner so it reflects the current form state instead of freezing
+// at the moment the operator hit Save or Test.
+watch([name, url, config, dialTimeoutInput], () => {
+  saveError.value = null;
+  testError.value = null;
+});
+
 const deleting = ref(false);
 const deleteError = ref<{ message: string; referencingUpstreamIds: string[] } | null>(null);
 


### PR DESCRIPTION
## Summary

The proxy Create/Edit dialog's `saveError` / `testError` banners were set on failure and only cleared at the start of the next Save/Test attempt, so an operator who fixed a bad URL, switched Protocol, or edited any form field kept seeing the previous diagnostic — a message describing a form state that no longer existed.

Add a Vue watcher on the four operator-edit signals (`name`, `url`, `config`, `dialTimeoutInput`) that resets both errors on any change, so the banner always tracks current form state.

## Test plan

- [x] Blank Name + Save → `Name is required` banner appears; typing into Name clears it.
- [x] Blank URL + Save → banner appears; editing URL clears it.
- [x] Save with syntactically invalid URL → `Invalid proxy URI: …` banner appears; switching Protocol clears it.
- [x] Blank URL + Test → `URL is required` banner appears; editing Dial timeout clears it.
- [x] All four watched signals individually confirmed to clear both `saveError` and `testError`.