### PR TITLE
fix(gateway): allow unset ADMIN_KEY in development

### DIFF
--- a/packages/gateway/src/control-plane/auth/routes.ts
+++ b/packages/gateway/src/control-plane/auth/routes.ts
@@ -6,14 +6,14 @@ import { isProductionRequest } from '../../shared/is-production-request.ts';
 import { dummyPasswordHash, timingSafeEqual, verifyPassword } from '../../shared/passwords.ts';
 import type { authLoginBody } from '../schemas.ts';
 import { userToEffectiveWire } from '../users/wire.ts';
-import { getEnv } from '@floway-dev/platform';
+import { getEnvOptional } from '@floway-dev/platform';
 
 const resolveLoginUser = async (c: CtxWithJson<typeof authLoginBody>): Promise<User | null> => {
   const { username, password } = c.req.valid('json');
   const repo = getRepo();
 
   if (username === '') {
-    const adminKey = getEnv('ADMIN_KEY');
+    const adminKey = getEnvOptional('ADMIN_KEY', '');
     if (adminKey) {
       const utf8 = new TextEncoder();
       if (!timingSafeEqual(utf8.encode(password), utf8.encode(adminKey))) return null;

--- a/packages/gateway/src/control-plane/auth/routes_test.ts
+++ b/packages/gateway/src/control-plane/auth/routes_test.ts
@@ -113,6 +113,39 @@ test('/auth/login on Cloudflare edge (CF-Ray present) refuses passwordless login
   assertEquals(response.status, 401);
 });
 
+// A brand-new checkout has ADMIN_KEY entirely unset — not `''` but truly
+// undefined — because platform-node's EnvGetter is `name => process.env[name]`
+// and an unexported variable reads as undefined. The route must treat that
+// state identically to an explicitly empty string, or fresh Node dev
+// installs 500 on every login. Cloudflare has the same shape when the
+// operator has no `.dev.vars`.
+
+test('/auth/login on Node dev with ADMIN_KEY entirely unset (EnvGetter returns undefined) grants passwordless admin login', async () => {
+  await setupAppTest({ adminKey: null });
+  const response = await requestApp('/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: '', password: '' }),
+  });
+  assertEquals(response.status, 200);
+  const body = (await response.json()) as { user: { id: number; isAdmin: boolean } };
+  assertEquals(body.user.id, 1);
+  assertEquals(body.user.isAdmin, true);
+});
+
+test('/auth/login on Cloudflare wrangler dev with ADMIN_KEY entirely unset (no .dev.vars, no CF-Ray) grants passwordless admin login', async () => {
+  await setupAppTest({ adminKey: null });
+  initRuntimeKind('cloudflare');
+  const response = await requestApp('/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: '', password: '' }),
+  });
+  assertEquals(response.status, 200);
+  const body = (await response.json()) as { user: { id: number } };
+  assertEquals(body.user.id, 1);
+});
+
 test('/auth/login with username + matching password issues a session', async () => {
   const { repo } = await setupAppTest();
   await repo.users.save({

--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import type { Context, Next } from 'hono';
 import { getRepo } from '../repo/index.ts';
 import type { ApiKey, User } from '../repo/types.ts';
 import { timingSafeEqual } from '../shared/passwords.ts';
-import { getEnv } from '@floway-dev/platform';
+import { getEnvOptional } from '@floway-dev/platform';
 
 const PUBLIC_PATHS = new Set(['/api/health', '/favicon.ico']);
 const AUTH_VALIDATE_PATHS = new Set(['/auth/login']);
@@ -56,7 +56,7 @@ export const authMiddleware = async (c: AuthedContext, next: Next) => {
   const rawKey = extractApiKey(c);
   if (!rawKey) return c.json({ error: 'Unauthorized' }, 401);
 
-  const adminKey = getEnv('ADMIN_KEY');
+  const adminKey = getEnvOptional('ADMIN_KEY', '');
   if (adminKey) {
     const utf8 = new TextEncoder();
     if (timingSafeEqual(utf8.encode(rawKey), utf8.encode(adminKey))) {

--- a/packages/gateway/src/test-helpers.ts
+++ b/packages/gateway/src/test-helpers.ts
@@ -11,7 +11,12 @@ import type { UpstreamRecord } from '@floway-dev/provider';
 import { clearInProcessCopilotTokenCache } from '@floway-dev/provider-copilot';
 
 interface SetupOptions {
-  adminKey?: string;
+  // `null` models an unset ADMIN_KEY — the platform EnvGetter contract says
+  // missing vars surface as `undefined`, which is what a fresh Node dev
+  // checkout hits (`process.env.ADMIN_KEY` is unset). The `?? ''` default and
+  // the raw `string` type below cannot express that state, so tests targeting
+  // the "no ADMIN_KEY at all" path need this explicit third value.
+  adminKey?: string | null;
   apiKey?: ApiKey;
   githubAccount?: CopilotAccountFixture;
   copilotUpstream?: UpstreamRecord;
@@ -105,8 +110,12 @@ export async function setupAppTest(options: SetupOptions = {}): Promise<AppTestC
   // can deterministically await them — see test-helpers/background-tracker.ts.
   initBackgroundSchedulerResolver(_c => trackBackground);
 
-  const adminKey = options.adminKey ?? 'admin-test-key';
-  initEnv(name => (name === 'ADMIN_KEY' ? adminKey : ''));
+  const adminKeyProvided = 'adminKey' in options;
+  const adminKey = adminKeyProvided ? options.adminKey : 'admin-test-key';
+  initEnv(name => {
+    if (name !== 'ADMIN_KEY') return '';
+    return adminKey === null ? undefined : adminKey;
+  });
 
   clearInProcessCopilotTokenCache();
   clearInFlightForTesting();
@@ -158,7 +167,7 @@ export async function setupAppTest(options: SetupOptions = {}): Promise<AppTestC
   // `x-floway-session: adminSession`.
   const adminSession = (await repo.sessions.create(1)).id;
 
-  return { repo, adminKey, adminSession, apiKey, githubAccount, copilotUpstream };
+  return { repo, adminKey: adminKey ?? '', adminSession, apiKey, githubAccount, copilotUpstream };
 }
 
 export function sseResponse(chunks: SSEChunk[], status = 200): Response {

--- a/packages/gateway/src/test-helpers.ts
+++ b/packages/gateway/src/test-helpers.ts
@@ -110,8 +110,7 @@ export async function setupAppTest(options: SetupOptions = {}): Promise<AppTestC
   // can deterministically await them — see test-helpers/background-tracker.ts.
   initBackgroundSchedulerResolver(_c => trackBackground);
 
-  const adminKeyProvided = 'adminKey' in options;
-  const adminKey = adminKeyProvided ? options.adminKey : 'admin-test-key';
+  const adminKey = 'adminKey' in options ? options.adminKey : 'admin-test-key';
   initEnv(name => {
     if (name !== 'ADMIN_KEY') return '';
     return adminKey === null ? undefined : adminKey;


### PR DESCRIPTION
## Summary

`AGENTS.md` documents that a fresh checkout with no `ADMIN_KEY` set is a supported dev configuration — the login page grants seed-admin access through the empty-username shortcut. On Cloudflare `wrangler dev` this works whenever the operator has a `.dev.vars` file (even one with `ADMIN_KEY=`), because wrangler materializes it as an empty string. On Node `pnpm run dev:node`, however, every login request 500s.

Root cause: `packages/gateway/src/control-plane/auth/routes.ts` and `packages/gateway/src/middleware/auth.ts` both read `ADMIN_KEY` via `getEnv()`, which throws when the underlying `EnvGetter` returns `undefined`. The Node platform's `EnvGetter` is `name => process.env[name]`, which is exactly `undefined` for an unexported variable — so a brand-new Node dev checkout throws on every login instead of taking the documented passwordless path.

The existing test suite did not catch this because `packages/gateway/src/test-helpers.ts` and `vitest.setup.ts` install an `EnvGetter` that returns `''` for every unset variable, hiding the throw path entirely.

## Changes

- `routes.ts` / `middleware/auth.ts`: read `ADMIN_KEY` via `getEnvOptional('ADMIN_KEY', '')` so "unset" and "explicit empty string" collapse to the same dev-login branch. The production defence (`NODE_ENV=production` refuses to boot without `ADMIN_KEY`; the Cloudflare edge refuses passwordless login whenever `CF-Ray` is present) is unchanged.
- `test-helpers.ts`: extend `SetupOptions.adminKey` to `string | null` where `null` makes the mock `EnvGetter` return `undefined` — the state a fresh Node dev checkout is actually in. Existing callers are unaffected.
- `routes_test.ts`: two new regression tests covering Node dev + CF wrangler dev with `ADMIN_KEY` entirely unset (not just empty).
- Small follow-up: inline a one-shot local const in `setupAppTest`.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm --filter @floway-dev/gateway run test` (145 files, 1794 tests)
- [x] `pnpm run lint`
- [x] Manual: `unset ADMIN_KEY && pnpm run dev:node`, then `curl -X POST http://localhost:8788/auth/login -H 'content-type: application/json' -d '{"username":"","password":"whatever"}'` returns 200 with `user.id=1`.
- [x] Manual: `NODE_ENV=production pnpm run dev:node` still exits immediately with the FATAL message.