### PR TITLE
fix(responses): avoid rewriting durable items

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -396,21 +396,27 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
 
   private async commitItems(rows: readonly StoredResponsesItem[]): Promise<void> {
     const pending = rows.filter(row => !this.committedItemIds.has(row.id));
-    if (pending.length === 0) return;
-    await Promise.all(this.options.itemWrites.map(async write => {
-      const writable = write.durable ? pending.filter(row => this.isDurableWriteEligible(row)) : pending;
-      const payloadUpgrades = writable.filter(row => this.payloadUpgradeIds.has(row.id) && (!write.durable || this.durableItemIds.has(row.id)));
-      const inserts = writable.filter(row => !this.payloadUpgradeIds.has(row.id) || (write.durable && !this.durableItemIds.has(row.id)));
-      await Promise.all([
-        write.backing.insertItems(inserts, { durable: write.durable }),
-        write.backing.fillPayloads(payloadUpgrades, { durable: write.durable }),
-      ]);
-      if (write.durable) {
-        for (const row of writable) this.markDurable(row.apiKeyId, row.id);
-      }
-    }));
-    for (const row of pending) this.committedItemIds.add(row.id);
+    if (pending.length > 0) {
+      await Promise.all(this.options.itemWrites.map(async write => {
+        const writable = write.durable ? pending.filter(row => this.needsDurableWrite(row)) : pending;
+        const payloadUpgrades = writable.filter(row => this.payloadUpgradeIds.has(row.id) && (!write.durable || this.durableItemIds.has(row.id)));
+        const inserts = writable.filter(row => !this.payloadUpgradeIds.has(row.id) || (write.durable && !this.durableItemIds.has(row.id)));
+        await Promise.all([
+          write.backing.insertItems(inserts, { durable: write.durable }),
+          write.backing.fillPayloads(payloadUpgrades, { durable: write.durable }),
+        ]);
+        if (write.durable) {
+          for (const row of writable) this.markDurable(row.apiKeyId, row.id);
+        }
+      }));
+      for (const row of pending) this.committedItemIds.add(row.id);
+    }
     await this.refreshTouchedItems();
+  }
+
+  private needsDurableWrite(row: StoredResponsesItem): boolean {
+    return this.isDurableWriteEligible(row)
+      && (!this.durableItemIds.has(row.id) || this.payloadUpgradeIds.has(row.id));
   }
 
   private isDurableWriteEligible(row: StoredResponsesItem): boolean {

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -401,10 +401,10 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
         const writable = write.durable ? pending.filter(row => this.needsDurableWrite(row)) : pending;
         const payloadUpgrades = writable.filter(row => this.payloadUpgradeIds.has(row.id) && (!write.durable || this.durableItemIds.has(row.id)));
         const inserts = writable.filter(row => !this.payloadUpgradeIds.has(row.id) || (write.durable && !this.durableItemIds.has(row.id)));
-        await Promise.all([
-          write.backing.insertItems(inserts, { durable: write.durable }),
-          write.backing.fillPayloads(payloadUpgrades, { durable: write.durable }),
-        ]);
+        const operations: Promise<unknown>[] = [];
+        if (inserts.length > 0) operations.push(write.backing.insertItems(inserts, { durable: write.durable }));
+        if (payloadUpgrades.length > 0) operations.push(write.backing.fillPayloads(payloadUpgrades, { durable: write.durable }));
+        await Promise.all(operations);
         if (write.durable) {
           for (const row of writable) this.markDurable(row.apiKeyId, row.id);
         }

--- a/packages/gateway/src/data-plane/chat/responses/items/store_identity_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_identity_test.ts
@@ -1,0 +1,79 @@
+import { test } from 'vitest';
+
+import { createStoredResponsesItemId } from './format.ts';
+import { createResponsesHttpStore, type StatefulResponsesStore } from './store.ts';
+import { initRepo } from '../../../../repo/index.ts';
+import { InMemoryRepo } from '../../../../repo/memory.ts';
+import type { StoredResponsesItem } from '../../../../repo/types.ts';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+import { assert, assertEquals, assertExists } from '@floway-dev/test-utils';
+import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+
+const API_KEY_ID = 'key_responses_item_identity';
+
+const loadAndStage = async (store: StatefulResponsesStore, input: readonly ResponsesInputItem[]): Promise<void> => {
+  await store.loadInputItems({
+    sourceItems: input,
+    view: responsesItemsView,
+    inputItemsToStage: input,
+  });
+  await store.stageInputItems(input);
+};
+
+test('changed input payload with a stable client id persists as a distinct input row', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const first: ResponsesInputItem = { type: 'message', id: 'client_message_1', role: 'user', content: 'first' };
+  const second: ResponsesInputItem = { type: 'message', id: 'client_message_1', role: 'user', content: 'second' };
+
+  const firstStore = createResponsesHttpStore(API_KEY_ID, true);
+  await loadAndStage(firstStore, [first]);
+  await firstStore.commitSnapshot('resp_first', 'append');
+
+  const secondStore = createResponsesHttpStore(API_KEY_ID, true);
+  await loadAndStage(secondStore, [second]);
+  await secondStore.commitSnapshot('resp_second', 'append');
+
+  const firstSnapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_first');
+  const secondSnapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_second');
+  assertExists(firstSnapshot);
+  assertExists(secondSnapshot);
+  assertEquals(firstSnapshot.itemIds.length, 1);
+  assertEquals(secondSnapshot.itemIds.length, 1);
+  assert(firstSnapshot.itemIds[0] !== secondSnapshot.itemIds[0]);
+  const rows = await repo.responsesItems.lookupMany(API_KEY_ID, [firstSnapshot.itemIds[0]!, secondSnapshot.itemIds[0]!]);
+  assertEquals(rows.map(row => row.origin), ['input', 'input']);
+  assertEquals(rows.map(row => row.payload?.item), [first, second]);
+});
+
+test('metadata-only durable item accepts a full payload repair', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const item: StoredResponsesItem = {
+    id: createStoredResponsesItemId('message'),
+    apiKeyId: API_KEY_ID,
+    upstreamId: 'up_responses',
+    upstreamItemId: 'raw_message_1',
+    itemType: 'message',
+    origin: 'upstream',
+    payload: null,
+    contentHash: null,
+    encryptedContentHash: null,
+    createdAt: 1_000,
+    refreshedAt: 1_000,
+  };
+  await repo.responsesItems.insertMany([item]);
+  const input: ResponsesInputItem = { type: 'message', id: item.id, role: 'assistant', content: 'repaired' };
+  const store = createResponsesHttpStore(API_KEY_ID, true);
+
+  await loadAndStage(store, [input]);
+  await store.commitSnapshot('resp_repaired', 'append');
+
+  const [repaired] = await repo.responsesItems.lookupMany(API_KEY_ID, [item.id]);
+  assertExists(repaired);
+  assertEquals(repaired.origin, 'upstream');
+  assertEquals(repaired.payload?.item, input);
+  const snapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_repaired');
+  assertExists(snapshot);
+  assertEquals(snapshot.itemIds, [item.id]);
+});

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -140,7 +140,6 @@ test('snapshots with upstream-owned metadata-only rows remain replayable', async
 test('createNonResponsesSourceStore reads items for affinity but does not write snapshots', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);
-  const inputItem: ResponsesInputItem = { type: 'message', id: 'history_1', role: 'assistant', content: [] };
   const item = storedRow({
     id: createStoredResponsesItemId('message'),
     itemType: 'message',
@@ -218,6 +217,7 @@ test('createResponsesHttpStore with store=true writes snapshots', async () => {
 test('committing a snapshot refreshes durable history without rewriting it', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);
+  const inputItem: ResponsesInputItem = { type: 'message', id: 'history_1', role: 'assistant', content: [] };
   const item = storedRow({
     id: createStoredResponsesItemId('message'),
     itemType: 'message',

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 
 import { createStoredResponsesItemId } from './format.ts';
 import { createNonResponsesSourceStore, createResponsesHttpStore } from './store.ts';
@@ -140,6 +140,7 @@ test('snapshots with upstream-owned metadata-only rows remain replayable', async
 test('createNonResponsesSourceStore reads items for affinity but does not write snapshots', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);
+  const inputItem: ResponsesInputItem = { type: 'message', id: 'history_1', role: 'assistant', content: [] };
   const item = storedRow({
     id: createStoredResponsesItemId('message'),
     itemType: 'message',
@@ -212,4 +213,33 @@ test('createResponsesHttpStore with store=true writes snapshots', async () => {
   const snapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_with_store');
   assertExists(snapshot);
   assertEquals(snapshot.itemIds, [outputItem.id]);
+});
+
+test('committing a snapshot refreshes durable history without rewriting it', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const item = storedRow({
+    id: createStoredResponsesItemId('message'),
+    itemType: 'message',
+    upstreamId: 'up_history',
+    upstreamItemId: 'raw_history',
+    payload: { item: inputItem },
+  });
+  await repo.responsesItems.insertMany([item]);
+  const insertMany = vi.spyOn(repo.responsesItems, 'insertMany');
+  const refreshMany = vi.spyOn(repo.responsesItems, 'refreshMany');
+  const store = createResponsesHttpStore(API_KEY_ID, true);
+  const input = [inputItem];
+
+  await store.loadInputItems({ sourceItems: input, view: responsesItemsView });
+  await store.stageInputItems(input);
+  await store.commitSnapshot('resp_history', 'append');
+
+  assertEquals(insertMany.mock.calls, []);
+  assertEquals(refreshMany.mock.calls.length, 1);
+  assertEquals(refreshMany.mock.calls[0]![0], API_KEY_ID);
+  assertEquals(refreshMany.mock.calls[0]![1], [item.id]);
+  const snapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_history');
+  assertExists(snapshot);
+  assertEquals(snapshot.itemIds, [item.id]);
 });

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -217,9 +217,10 @@ test('createResponsesHttpStore with store=true writes snapshots', async () => {
 test('committing a snapshot refreshes durable history without rewriting it', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);
-  const inputItem: ResponsesInputItem = { type: 'message', id: 'history_1', role: 'assistant', content: [] };
+  const itemId = createStoredResponsesItemId('message');
+  const inputItem: ResponsesInputItem = { type: 'message', id: itemId, role: 'assistant', content: [] };
   const item = storedRow({
-    id: createStoredResponsesItemId('message'),
+    id: itemId,
     itemType: 'message',
     upstreamId: 'up_history',
     upstreamItemId: 'raw_history',


### PR DESCRIPTION
## Summary

- Exclude already-durable Responses history rows from durable insert and payload-fill paths.
- Keep new items and real payload upgrades eligible for durable persistence.
- Refresh touched durable history independently, including commits with no pending item writes.
- Avoid calling persistence backings with empty batches.

## Why

Long Responses turns replay their full durable history. At terminal snapshot commit, those rows were treated as pending because the committed-item set is request-local. The SQL repository then serialized every payload concurrently before D1 reached `ON CONFLICT DO NOTHING`, so a request could exceed the Worker isolate's 128 MiB limit after the upstream response had already completed.

The redundant insert never refreshed existing rows. Refresh already has a separate `refreshMany` path with its existing 24-hour debounce, so filtering durable writes does not change retention semantics.

## Memory evidence

The benchmark exercises the complete store load, stage, and terminal snapshot-commit path against the same captured 928-item request. Its durable backing reproduces `SqlResponsesItemRepo.insertMany` by serializing the received payloads concurrently. Each value is the median of three fresh Node processes with GC before the measured commit.

| Revision | Durable history rows serialized | Touched rows refreshed | Peak RSS delta | Peak heap delta | Peak ArrayBuffer delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `main` | 928 | 928 | 328.50 MiB | 62.47 MiB | 32.85 MiB |
| This branch | 0 | 928 | 0.08 MiB | 0.49 MiB | 0 MiB |

This removes 328.42 MiB (99.98%) of the measured terminal-commit RSS burst. The production failure peaked at 295,398,585 bytes (281.7 MiB) with `exceededMemory`, consistent with this serialization path being sufficient to cross the Worker limit.

## Persistence semantics

The identity tests cover the behavior on both `main` and this branch:

- An ordinary client item id with changed content produces a fresh `origin=input` storage row, so the new payload remains eligible for durable insertion.
- A durable metadata-only row still takes the one-time `null` to full-payload repair path.
- An existing Floway storage id with a full payload retains the established canonical stored-payload behavior.

## Risk

Low. The selection change applies only to durable write targets. Session-local WebSocket writes remain unchanged, durable lookup results are still tracked for snapshot eligibility, and metadata-only rows with a real payload upgrade still take the existing fill/insert paths. Regression coverage verifies that replayed durable history skips insertion while still refreshing retention and producing the snapshot.

The public persistence model is unchanged, so no documentation update is needed.

## Test plan

- [x] `pnpm vitest run --project @floway-dev/gateway` (146 files, 1,814 tests)
- [x] Run the same three item-identity semantics tests on `main` and this branch
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm eslint packages/gateway/src/data-plane/chat/responses/items/store.ts packages/gateway/src/data-plane/chat/responses/items/store_test.ts packages/gateway/src/data-plane/chat/responses/items/store_identity_test.ts`
- [x] Three-process before/after terminal-commit memory benchmark with the captured 928-item request
