### PR TITLE
fix(responses): bound payload codec concurrency

### DIFF
--- a/packages/gateway/src/repo/responses-items_test.ts
+++ b/packages/gateway/src/repo/responses-items_test.ts
@@ -1,10 +1,10 @@
 import initSqlJs from 'sql.js';
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 
 import { InMemoryRepo } from './memory.ts';
 import { SqlRepo } from './sql.ts';
 import type { ResponsesItemsRepo, StoredResponsesItem } from './types.ts';
-import { initFileProvider, MemoryFileProvider, type SqlDatabase } from '@floway-dev/platform';
+import { initFileProvider, MemoryFileProvider, sha256Hex, type FileProvider, type SqlDatabase } from '@floway-dev/platform';
 import { assert, assertEquals, assertRejects } from '@floway-dev/test-utils';
 
 // `refreshMany` debounces writes within a 24h window, so refresh-related
@@ -36,6 +36,85 @@ const storedItem = (overrides: Partial<StoredResponsesItem> & Pick<StoredRespons
   refreshedAt: overrides.createdAt,
   ...overrides,
 });
+
+const createDeferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => { resolve = accept; });
+  return { promise, resolve };
+};
+
+class GatedReadFileProvider implements FileProvider {
+  private readonly bodies = new Map<string, Uint8Array>();
+  private readonly firstGet = createDeferred<void>();
+  private readonly release = createDeferred<void>();
+  private released = false;
+  getCalls = 0;
+
+  put(key: string, body: Uint8Array): Promise<void> {
+    this.bodies.set(key, body.slice());
+    return Promise.resolve();
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    this.getCalls++;
+    this.firstGet.resolve();
+    if (!this.released) await this.release.promise;
+    return this.bodies.get(key)?.slice() ?? null;
+  }
+
+  deletePrefix(prefix: string): Promise<void> {
+    for (const key of this.bodies.keys()) {
+      if (key.startsWith(prefix)) this.bodies.delete(key);
+    }
+    return Promise.resolve();
+  }
+
+  listKeys(prefix: string): Promise<string[]> {
+    return Promise.resolve([...this.bodies.keys()].filter(key => key.startsWith(prefix)));
+  }
+
+  waitForFirstGet(): Promise<void> {
+    return this.firstGet.promise;
+  }
+
+  releaseAll(): void {
+    this.released = true;
+    this.release.resolve();
+  }
+}
+
+const runWithCompressionBlocked = async <T>(run: () => Promise<T>): Promise<{ started: number; result: T }> => {
+  const NativeCompressionStream = globalThis.CompressionStream;
+  const release = createDeferred<void>();
+  let started = 0;
+
+  class GatedCompressionStream {
+    readonly readable: ReadableStream<Uint8Array>;
+    readonly writable: WritableStream<Uint8Array>;
+
+    constructor(format: CompressionFormat) {
+      started++;
+      const gate = new TransformStream<Uint8Array, Uint8Array>({
+        async transform(chunk, controller) {
+          await release.promise;
+          controller.enqueue(chunk);
+        },
+      });
+      this.writable = gate.writable;
+      this.readable = gate.readable.pipeThrough(new NativeCompressionStream(format));
+    }
+  }
+
+  vi.stubGlobal('CompressionStream', GatedCompressionStream);
+  try {
+    const pending = run();
+    const startedBeforeRelease = started;
+    release.resolve();
+    return { started: startedBeforeRelease, result: await pending };
+  } finally {
+    vi.unstubAllGlobals();
+  }
+};
 
 const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
   initFileProvider(new MemoryFileProvider());
@@ -285,6 +364,76 @@ test('SQL responses items repo chunks lookups exceeding the 100-parameter limit 
 
   const byHash = await repo.lookupManyByEncryptedContentHash('key_a', items.map(item => item.encryptedContentHash!));
   assertEquals(new Set(byHash.map(row => row.id)).size, 200);
+});
+
+test('SQL responses items repo hydrates one payload at a time across query chunks', async () => {
+  const db = new FakeResponsesItemsSqlDatabase();
+  const files = new GatedReadFileProvider();
+  initFileProvider(files);
+  const ids: string[] = [];
+  const encoder = new TextEncoder();
+  for (let index = 0; index < 91; index++) {
+    const id = `msg_codec_${index.toString().padStart(3, '0')}`;
+    const key = `codec/${id}.json`;
+    const body = encoder.encode(JSON.stringify({ item: { type: 'message', id, role: 'assistant', content: `payload ${index}` } }));
+    await files.put(key, body);
+    db.rows.push({
+      id,
+      api_key_id: 'key_a',
+      upstream_id: 'up_a',
+      upstream_item_id: `raw_${index}`,
+      item_type: 'message',
+      origin: 'upstream',
+      payload_json: JSON.stringify({ version: 1, storage: 'file', key, sha256: await sha256Hex(body), byteLength: body.byteLength }),
+      content_hash: null,
+      encrypted_content_hash: null,
+      created_at: index,
+      refreshed_at: index,
+    });
+    ids.push(id);
+  }
+  const lookup = new SqlRepo(db).responsesItems.lookupMany('key_a', ids);
+
+  await files.waitForFirstGet();
+  const startedBeforeRelease = files.getCalls;
+  files.releaseAll();
+  const rows = await lookup;
+
+  assertEquals(startedBeforeRelease, 1);
+  assertEquals(rows.map(row => row.id), ids);
+});
+
+test('SQL responses items repo serializes one payload at a time within write batches', async () => {
+  initFileProvider(new MemoryFileProvider());
+  const db = new FakeResponsesItemsSqlDatabase();
+  const repo = new SqlRepo(db).responsesItems;
+  const inserts = Array.from({ length: 3 }, (_, index) => storedItem({
+    id: `msg_insert_${index}`,
+    apiKeyId: 'key_a',
+    createdAt: 1_000 + index,
+  }));
+
+  const insert = await runWithCompressionBlocked(async () => await repo.insertMany(inserts));
+
+  assertEquals(insert.started, 1);
+  assertEquals((await repo.lookupMany('key_a', inserts.map(item => item.id))).map(row => row.id), inserts.map(item => item.id));
+
+  const metadata = Array.from({ length: 3 }, (_, index) => storedItem({
+    id: `msg_fill_${index}`,
+    apiKeyId: 'key_a',
+    payload: null,
+    createdAt: 2_000 + index,
+  }));
+  await repo.insertMany(metadata);
+  const fills = metadata.map((item, index) => ({
+    ...item,
+    payload: { item: { type: 'message', id: item.id, role: 'assistant', content: `filled ${index}` } },
+  }));
+
+  const fill = await runWithCompressionBlocked(async () => await repo.fillPayloads(fills));
+
+  assertEquals(fill.started, 1);
+  assertEquals(fill.result, 3);
 });
 
 test('SQL responses items repo spills large payloads through the runtime file provider without storing backend identity', async () => {

--- a/packages/gateway/src/repo/responses-items_test.ts
+++ b/packages/gateway/src/repo/responses-items_test.ts
@@ -90,18 +90,21 @@ const runWithCompressionBlocked = async <T>(run: () => Promise<T>): Promise<{ st
 
   class GatedCompressionStream {
     readonly readable: ReadableStream<Uint8Array>;
-    readonly writable: WritableStream<Uint8Array>;
+    readonly writable: WritableStream<BufferSource>;
 
     constructor(format: CompressionFormat) {
       started++;
-      const gate = new TransformStream<Uint8Array, Uint8Array>({
-        async transform(chunk, controller) {
+      const native = new NativeCompressionStream(format);
+      const writer = native.writable.getWriter();
+      this.readable = native.readable;
+      this.writable = new WritableStream<BufferSource>({
+        async write(chunk) {
           await release.promise;
-          controller.enqueue(chunk);
+          await writer.write(chunk);
         },
+        async close() { await writer.close(); },
+        async abort(reason) { await writer.abort(reason); },
       });
-      this.writable = gate.writable;
-      this.readable = gate.readable.pipeThrough(new NativeCompressionStream(format));
     }
   }
 

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -53,6 +53,12 @@ const runStatements = async (db: SqlDatabase, statements: SqlPreparedStatement[]
   return results;
 };
 
+const mapSequentially = async <T, U>(values: readonly T[], mapper: (value: T) => Promise<U>): Promise<U[]> => {
+  const mapped: U[] = [];
+  for (const value of values) mapped.push(await mapper(value));
+  return mapped;
+};
+
 interface ApiKeyRow {
   id: string;
   user_id: number;
@@ -890,13 +896,17 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
         .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
         .all<ResponsesItemRow>();
-      return await Promise.all(results.map(toStoredResponsesItem));
+      return results;
     }));
-    return perChunk.flat();
+    // Payload codecs hold compressed bytes, expanded JSON, and the parsed clone
+    // at once. Keep D1 chunk reads parallel, then bound that transient working
+    // set to one item per lookup under Workers' 128 MB isolate limit.
+    // https://developers.cloudflare.com/workers/platform/limits/#memory
+    return await mapSequentially(perChunk.flat(), toStoredResponsesItem);
   }
 
   async insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
-    const statements = await Promise.all(items.map(async item => {
+    const statements = await mapSequentially(items, async item => {
       const payload = await serializeStoredResponsesPayload(item.id, item.apiKeyId, item.createdAt, item.payload);
       return this.db
         .prepare(
@@ -904,22 +914,21 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
            ON CONFLICT (id, COALESCE(api_key_id, '')) DO NOTHING`,
         )
         .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, item.origin, payload, item.contentHash, item.encryptedContentHash, item.createdAt, item.refreshedAt);
-    }));
+    });
     await runStatements(this.db, statements);
   }
 
   async fillPayloads(items: readonly StoredResponsesItem[]): Promise<number> {
-    const statements = await Promise.all(items.flatMap(item => {
-      if (item.payload === null) return [];
-      return [serializeStoredResponsesPayload(item.id, item.apiKeyId, item.createdAt, item.payload).then(payload =>
-        this.db
-          .prepare(
-            `UPDATE responses_items
-             SET payload_json = ?, content_hash = ?, encrypted_content_hash = ?, created_at = ?, refreshed_at = ?
-             WHERE ${RESPONSES_ITEM_ID_SCOPE_SQL} AND id = ? AND payload_json IS NULL`,
-          )
-          .bind(payload, item.contentHash, item.encryptedContentHash, item.createdAt, item.refreshedAt, item.apiKeyId, item.id))];
-    }));
+    const statements = await mapSequentially(items.filter(item => item.payload !== null), async item => {
+      const payload = await serializeStoredResponsesPayload(item.id, item.apiKeyId, item.createdAt, item.payload);
+      return this.db
+        .prepare(
+          `UPDATE responses_items
+           SET payload_json = ?, content_hash = ?, encrypted_content_hash = ?, created_at = ?, refreshed_at = ?
+           WHERE ${RESPONSES_ITEM_ID_SCOPE_SQL} AND id = ? AND payload_json IS NULL`,
+        )
+        .bind(payload, item.contentHash, item.encryptedContentHash, item.createdAt, item.refreshedAt, item.apiKeyId, item.id);
+    });
     const results = await runStatements(this.db, statements);
     return results.reduce((sum, result) => sum + (result.meta.changes ?? 0), 0);
   }


### PR DESCRIPTION
## Summary

- Hydrate Responses payload rows one at a time after parallel D1 chunk reads complete.
- Serialize insert and payload-repair batches one item at a time before executing the existing SQL batch.
- Preserve row order, D1 query concurrency, SQL batch boundaries, and the original codec errors.
- Add deterministic gates that fail when more than one codec starts within a lookup or write batch.

## Why

Responses payload codecs temporarily retain several representations of the same item: JSON bytes, gzip bytes, base64 text, parsed JSON, and a structured clone. The SQL repository previously started one codec promise per row, so a long history multiplied that transient working set by hundreds inside a Worker with a 128 MiB isolate limit.

This change keeps database I/O parallel but makes codec work within each repository operation sequential. The three lookup families can still run concurrently at the store layer, so request-level codec concurrency is fixed rather than proportional to history length.

## Memory evidence

Both benchmarks exercise the real `SqlRepo` against the same captured 928-item request. Values are medians from three fresh Node processes with GC immediately before the measured operation.

### Hydrate 928 stored rows

| Revision | Peak RSS delta | Peak heap delta | Peak ArrayBuffer delta |
| --- | ---: | ---: | ---: |
| `main` | 30.41 MiB | 46.59 MiB | 36.96 MiB |
| This branch | 20.63 MiB | 27.59 MiB | 12.09 MiB |
| Reduction | 32.2% | 40.8% | 67.3% |

### Serialize 928 new rows

| Revision | Peak RSS delta | Peak heap delta | Peak ArrayBuffer delta |
| --- | ---: | ---: | ---: |
| `main` | 332.84 MiB | 62.61 MiB | 28.04 MiB |
| This branch | 84.11 MiB | 34.11 MiB | 9.60 MiB |
| Reduction | 74.7% | 45.5% | 65.8% |

The write benchmark executes the same 928 statements through one D1 batch on both revisions; only payload codec scheduling changes.

## Performance tradeoff

This deliberately exchanges codec parallelism for a lower peak working set. Long-history hydration happens before the upstream request, so sequential Web Compression work can increase time to first token. Batches of genuinely new input rows or payload repairs can likewise take longer before the terminal response event is emitted. Normal output persistence is usually one item at a time already and should see little change.

The captured workload contains 927 inline payloads and one file-backed payload. Its relevant tradeoff is therefore sequential local stream decompression, not hundreds of serialized R2 round trips. A warm repeated Node benchmark, which is a risk signal rather than Workers latency evidence, measured the 928-row read phase at roughly 0.28 seconds on `main` and 1.03 seconds on this branch, and the all-new write phase at roughly 0.81 seconds and 1.37 seconds respectively. Web Streams timings were noisy across fresh processes, so production telemetry remains authoritative.

Metadata-first lazy hydration is the follow-up that removes most of this work rather than merely scheduling it differently.

## Scope and risk

This PR bounds transient codec fan-out. It does not remove duplicate lookups or avoid retaining hydrated history.

D1 chunk queries remain parallel, and insert/fill statements retain their existing order and batch execution. The public persistence model is unchanged, so no documentation update is needed.

## Test plan

- [x] `pnpm vitest run --project @floway-dev/gateway` (146 files, 1,818 tests)
- [x] `pnpm vitest run packages/gateway/src/repo/responses-items_test.ts packages/gateway/src/repo/responses-payload_test.ts` (27 tests)
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm eslint packages/gateway/src/repo/sql.ts packages/gateway/src/repo/responses-items_test.ts`
- [x] Deploy the merged-main PR branch to production as version `f18bdaae-93c7-4acc-acb1-9b0a3fed0870` and verify public HTTP 200
