### PR TITLE
perf(responses): hydrate stored payloads on demand

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -4,7 +4,7 @@ import { applyRulesToUpstreamChatCompletions } from '../../model-aliases/apply-r
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../../shared/telemetry/attempt-helpers.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
-import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
+import { rewriteStoredItemsInSourceForCandidate } from '../responses/items/rewrite.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { tryCatchChatServeFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
@@ -86,7 +86,7 @@ const rewriteOrRenderChatCompletionsFailure = async (
   candidate: ModelCandidate,
 ): Promise<{ payload: ChatCompletionsPayload; failure?: undefined } | { payload?: undefined; failure: ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>> & { type: 'api-error' } }> => {
   try {
-    const rewrittenMessages = await rewriteStoredResponsesItemsForCandidate(
+    const rewrittenMessages = await rewriteStoredItemsInSourceForCandidate(
       payload.messages as readonly ChatCompletionsMessage[],
       chatCompletionsViaResponsesItemsView,
       store,

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -4,7 +4,7 @@ import { applyRulesToUpstreamMessages } from '../../model-aliases/apply-rules.ts
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, chatTargetPicker } from '../../shared/telemetry/attempt-helpers.ts';
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
-import { rewriteStoredResponsesItemsForCandidate } from '../responses/items/rewrite.ts';
+import { rewriteStoredItemsInSourceForCandidate } from '../responses/items/rewrite.ts';
 import type { StatefulResponsesStore } from '../responses/items/store.ts';
 import { tryCatchChatServeFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
@@ -126,7 +126,7 @@ const rewriteOrRenderMessagesFailure = async (
   candidate: ModelCandidate,
 ): Promise<{ payload: MessagesPayload; failure?: undefined } | { payload?: undefined; failure: ExecuteResult<ProtocolFrame<MessagesStreamEvent>> & { type: 'api-error' } }> => {
   try {
-    const rewrittenMessages = await rewriteStoredResponsesItemsForCandidate(
+    const rewrittenMessages = await rewriteStoredItemsInSourceForCandidate(
       payload.messages as readonly MessagesMessage[],
       messagesViaResponsesItemsView,
       store,

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -88,7 +88,7 @@ export const responsesAttempt = {
     // wire shape against an empty privatePayload map.
     const rewritten = await rewriteOrRenderFailure(payload, store, candidate);
     if (!('payload' in rewritten)) return rewritten.failure;
-    store.beginAttempt(rewritten.references);
+    store.beginAttempt(rewritten.privatePayloads);
     // Copilot compaction and Azure-native compaction both emit assistant
     // messages whose content blocks have `type: 'input_text'`, then refuse
     // the same items echoed back as input on the next turn. Normalising

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -3,7 +3,7 @@ import type { ResponsesAttemptResult, ResponsesInvocation } from './interceptors
 import { createStoredResponseId } from './items/format.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
 import { drainAsync, syntheticEventsFromResult, wrapResponsesOutputForStorage } from './items/output.ts';
-import { rewriteResponsesItemsForCandidate, type RewrittenResponsesPayload } from './items/rewrite.ts';
+import { rewriteResponsesPayloadForCandidate, type RewrittenResponsesPayload } from './items/rewrite.ts';
 import type { StatefulResponsesStore } from './items/store.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
 import { applyRulesToUpstreamResponses } from '../../model-aliases/apply-rules.ts';
@@ -184,7 +184,7 @@ const rewriteOrRenderFailure = async (
   candidate: ModelCandidate,
 ): Promise<RewriteOutcome> => {
   try {
-    return await rewriteResponsesItemsForCandidate(payload, store, candidate);
+    return await rewriteResponsesPayloadForCandidate(payload, store, candidate);
   } catch (error) {
     const failure = tryCatchChatServeFailure(error);
     if (failure === null) throw error;

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
@@ -1,6 +1,6 @@
 import { hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StatefulResponsesStore } from './store.ts';
-import type { StoredResponsesItem } from '../../../../repo/types.ts';
+import type { StoredResponsesItemMetadata } from '../../../../repo/types.ts';
 import type { ChatServeFailure } from '../../shared/errors.ts';
 import type { RoutingDecision } from '../../shared/routing.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
@@ -13,18 +13,18 @@ interface ResolvedStoredResponsesItemRef {
   type: string;
   id?: string;
   encryptedContent?: string;
-  row?: StoredResponsesItem;
+  row?: StoredResponsesItemMetadata;
   affinity?: StoredResponsesAffinity;
 }
 
-const isUpstreamOwned = (row: StoredResponsesItem): row is StoredResponsesItem & { upstreamId: string } =>
+const isUpstreamOwned = (row: StoredResponsesItemMetadata): row is StoredResponsesItemMetadata & { upstreamId: string } =>
   row.upstreamId !== null;
 
 const classifyStoredResponsesAffinity = (
   itemType: string,
-  row: StoredResponsesItem,
+  row: StoredResponsesItemMetadata,
 ): StoredResponsesAffinity => {
-  if (itemType === 'item_reference' && row.payload === null) return 'forcing';
+  if (itemType === 'item_reference' && !row.hasPayload) return 'forcing';
   if (!isUpstreamOwned(row)) return 'non_affinity';
   // Direct Copilot probes show the opaque item id on each program variant is
   // account-bound: same-account replay succeeds after token refresh, while
@@ -70,7 +70,7 @@ const findUnexpandedItemReferenceForcingId = (
     ref.affinity === 'forcing'
     && ref.type === 'item_reference'
     && ref.row?.upstreamId === upstreamId
-    && ref.row.payload === null)?.id ?? null;
+    && !ref.row.hasPayload)?.id ?? null;
 
 const collectStoredResponsesItemRefs = async <TSourceItems>(
   sourceItems: TSourceItems,
@@ -164,7 +164,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems, TCandidate ext
 
     store.touchItem(row.id);
     ref.row = row;
-    if (ref.type === 'item_reference' && row.payload === null && row.upstreamItemId === null) {
+    if (ref.type === 'item_reference' && !row.hasPayload && row.upstreamItemId === null) {
       failures.push({ kind: 'item-not-found', itemId: row.id });
       continue;
     }

--- a/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
@@ -5,7 +5,7 @@ import { drainAsync, syntheticEventsFromResult, wrapResponsesOutputForStorage } 
 import { createResponsesHttpStore, LayeredStatefulResponsesStore, RepoStatefulResponsesBacking, type StatefulResponsesBacking, type StatefulResponsesStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
-import type { ResponsesItemsRepo, StoredResponsesItem } from '../../../../repo/types.ts';
+import type { ResponsesItemsRepo, StoredResponsesItem, StoredResponsesItemMetadata, StoredResponsesItemPayloadRecord } from '../../../../repo/types.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesOutputItem, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { assert, assertEquals, assertRejects } from '@floway-dev/test-utils';
@@ -123,9 +123,10 @@ class ControlledResponsesItemsRepo implements ResponsesItemsRepo {
   resolveInsert: (() => void) | undefined;
   rejectInsert: ((error: unknown) => void) | undefined;
 
-  lookupMany(): Promise<StoredResponsesItem[]> { return Promise.resolve([]); }
-  lookupManyByEncryptedContentHash(): Promise<StoredResponsesItem[]> { return Promise.resolve([]); }
-  lookupManyByContentHash(): Promise<StoredResponsesItem[]> { return Promise.resolve([]); }
+  lookupMany(): Promise<StoredResponsesItemMetadata[]> { return Promise.resolve([]); }
+  lookupManyByEncryptedContentHash(): Promise<StoredResponsesItemMetadata[]> { return Promise.resolve([]); }
+  lookupManyByContentHash(): Promise<StoredResponsesItemMetadata[]> { return Promise.resolve([]); }
+  lookupPayloads(): Promise<StoredResponsesItemPayloadRecord[]> { return Promise.resolve([]); }
 
   insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
     this.calls.push(items.map(item => structuredClone(item)));
@@ -163,9 +164,10 @@ test('rewrites output item ids consistently across added, child, done, and termi
   assertEquals(eventAt(collected, 'response.completed').response.output[0].id, storedId);
 
   const [row] = await repo.responsesItems.lookupMany(apiKeyId, [storedId]);
+  const [payload] = await repo.responsesItems.lookupPayloads(apiKeyId, [storedId]);
   assertEquals(row.upstreamId, 'up_native');
   assertEquals(row.upstreamItemId, original.id);
-  assertEquals(row.payload, { item: original });
+  assertEquals(payload.payload, { item: original });
 });
 
 test('rewrites and persists programmatic tool output items without changing their payload', async () => {
@@ -205,8 +207,8 @@ test('rewrites and persists programmatic tool output items without changing thei
   assertEquals(storedProgram, { ...program, id: storedProgram.id });
   assertEquals(storedProgramOutput, { ...programOutput, id: storedProgramOutput.id });
 
-  const rows = await repo.responsesItems.lookupMany(apiKeyId, completed.response.output.map(item => item.id!));
-  assertEquals(rows.map(row => row.payload?.item), [additionalTools, program, programOutput]);
+  const payloads = await repo.responsesItems.lookupPayloads(apiKeyId, completed.response.output.map(item => item.id!));
+  assertEquals(payloads.map(record => record.payload.item), [additionalTools, program, programOutput]);
 });
 
 test('persists each row before yielding the item-done frame', async () => {
@@ -285,7 +287,7 @@ test('store false creates metadata rows with null payload', async () => {
   const collected = await collectEvents(events);
   const storedId = eventAt(collected, 'response.output_item.done').item.id!;
   const [row] = await repo.responsesItems.lookupMany(apiKeyId, [storedId]);
-  assertEquals(row.payload, null);
+  assertEquals(row.hasPayload, false);
   assertEquals(row.upstreamItemId, original.id);
 });
 
@@ -301,8 +303,8 @@ test('terminal output items missing done frames are stored and rewritten', async
   const collected = await collectEvents(events);
   const storedId = eventAt(collected, 'response.completed').response.output[0].id!;
   assert(isStoredResponsesItemId(storedId));
-  const [row] = await repo.responsesItems.lookupMany(apiKeyId, [storedId]);
-  assertEquals(row.payload, { item: original });
+  const [payload] = await repo.responsesItems.lookupPayloads(apiKeyId, [storedId]);
+  assertEquals(payload.payload, { item: original });
 });
 
 test('two distinct upstream items receive distinct stored ids', async () => {
@@ -389,8 +391,8 @@ test('private payload registered on the request is attached to the persisted row
 
   const collected = await collectEvents(events);
   const storedId = eventAt(collected, 'response.output_item.done').item.id!;
-  const [row] = await repo.responsesItems.lookupMany(apiKeyId, [storedId]);
-  assertEquals(row.payload?.private, privateBlob);
+  const [payload] = await repo.responsesItems.lookupPayloads(apiKeyId, [storedId]);
+  assertEquals(payload.payload.private, privateBlob);
 });
 
 // --- snapshot-mode derivation tests ---
@@ -548,6 +550,7 @@ test('snapshot commit failure rejects before yielding the terminal frame', async
   const repoBacking = new RepoStatefulResponsesBacking(() => repo);
   const faultyBacking: StatefulResponsesBacking = {
     lookupItems: args => repoBacking.lookupItems(args),
+    lookupPayloads: (aid, ids) => repoBacking.lookupPayloads(aid, ids),
     insertItems: items => repoBacking.insertItems(items),
     fillPayloads: items => repoBacking.fillPayloads(items),
     refreshItems: (aid, ids, at) => repoBacking.refreshItems(aid, ids, at),
@@ -607,7 +610,9 @@ test('end-of-stream items in terminal frame are stored and rewritten', async () 
   const storedId = eventAt(collected, 'response.completed').response.output[0].id!;
   assert(isStoredResponsesItemId(storedId));
   const [row] = await repo.responsesItems.lookupMany(apiKeyId, [storedId]);
-  assertEquals(row.payload, { item: original });
+  const [payload] = await repo.responsesItems.lookupPayloads(apiKeyId, [storedId]);
+  assertEquals(row.hasPayload, true);
+  assertEquals(payload.payload, { item: original });
 });
 
 // --- syntheticEventsFromResult / drainAsync ---

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -1,64 +1,97 @@
-import { createTemporaryResponsesItemId, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
+import { createTemporaryResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StatefulResponsesStore } from './store.ts';
-import type { StoredResponsesItem } from '../../../../repo/types.ts';
+import type { StoredResponsesItemMetadata, StoredResponsesItemPayload } from '../../../../repo/types.ts';
 import { throwChatServeFailure } from '../../shared/errors.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ModelCandidate } from '@floway-dev/provider';
 import type { CanonicalResponsesPayload, ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
-const isUpstreamOwned = (row: StoredResponsesItem): row is StoredResponsesItem & { upstreamId: string } =>
+const isUpstreamOwned = (row: StoredResponsesItemMetadata): row is StoredResponsesItemMetadata & { upstreamId: string } =>
   row.upstreamId !== null;
-
-const storedItemReplacementBase = (
-  item: ResponsesInputItem,
-  row: StoredResponsesItem,
-): ResponsesInputItem => {
-  if (row.payload === null) return item;
-  return structuredClone(row.payload.item) as ResponsesInputItem;
-};
 
 const itemWithId = (item: ResponsesInputItem, id: string): ResponsesInputItem => ({
   ...item,
   id,
 } as ResponsesInputItem);
 
-const rewriteItemForCandidate = (
+const canonicalStoredEcho = (item: ResponsesInputItem, row: StoredResponsesItemMetadata): ResponsesInputItem => {
+  const canonical = structuredClone(item) as ResponsesInputItem & Record<string, unknown>;
+  if (row.upstreamItemId !== null) canonical.id = row.upstreamItemId;
+  if (canonical.type === 'reasoning' && canonical.content == null) canonical.content = [];
+  if ((canonical.type === 'function_call' || canonical.type === 'message') && canonical.status === undefined) {
+    canonical.status = 'completed';
+  }
+  if (canonical.type === 'message' && Array.isArray(canonical.content)) {
+    canonical.content = canonical.content.map(block => {
+      if (block.type !== 'output_text') return block;
+      return {
+        ...block,
+        ...(!Object.hasOwn(block, 'annotations') ? { annotations: [] } : {}),
+        ...(!Object.hasOwn(block, 'logprobs') ? { logprobs: [] } : {}),
+      };
+    });
+  }
+  return canonical;
+};
+
+interface ResolvedItem {
+  readonly item: ResponsesInputItem;
+  readonly row?: StoredResponsesItemMetadata;
+  canonical?: ResponsesInputItem;
+}
+
+const resolveStoredRow = (
   item: ResponsesInputItem,
-  row: StoredResponsesItem,
+  store: StatefulResponsesStore,
+  hashByEncryptedContent: ReadonlyMap<string, string>,
+): StoredResponsesItemMetadata | undefined => {
+  const id = responsesItemId(item);
+  const encryptedContent = responsesItemEncryptedContent(item);
+  return (id !== null ? store.getItemById(id) : undefined)
+    ?? (encryptedContent !== null ? store.getItemsByEncryptedContentHash(hashByEncryptedContent.get(encryptedContent)!).find(
+      row => item.type === 'item_reference' || row.itemType === item.type,
+    ) ?? store.getItemsByEncryptedContentHash(hashByEncryptedContent.get(encryptedContent)!)[0] : undefined);
+};
+
+const shouldHydrate = async (
+  resolved: ResolvedItem,
+  candidate: ModelCandidate,
+): Promise<boolean> => {
+  const { item, row } = resolved;
+  if (row === undefined || !row.hasPayload) return false;
+  if (row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return false;
+  if (item.type === 'item_reference') {
+    return !(row.upstreamId === candidate.provider.upstream
+      && row.upstreamItemId !== null
+      && candidate.provider.supportsResponsesItemReference);
+  }
+  if (row.origin === 'synthetic') return true;
+  const canonical = canonicalStoredEcho(item, row);
+  if (row.contentHash !== null && await hashResponsesItemContent(canonical) === row.contentHash) {
+    resolved.canonical = canonical;
+    return false;
+  }
+  return true;
+};
+
+const rewriteItemForCandidate = (
+  resolved: ResolvedItem,
+  payload: StoredResponsesItemPayload | undefined,
   candidate: ModelCandidate,
 ): ResponsesInputItem | null => {
-  // An `item_reference` whose stored row has no inline payload can only
-  // travel as a reference on the wire; a provider that doesn't support
-  // `item_reference` input has no way to expand it.
-  if (item.type === 'item_reference' && row.payload === null && !candidate.provider.supportsResponsesItemReference) {
+  const { item, row } = resolved;
+  if (row === undefined) return item;
+  if (item.type === 'item_reference' && payload === undefined && !candidate.provider.supportsResponsesItemReference) {
     throwChatServeFailure({ kind: 'item-not-found', itemId: row.id });
   }
-
-  if (!isUpstreamOwned(row)) {
-    // Synthetic rows have no owning upstream and stay portable to any
-    // provider. Inline-expand from the stored payload and preserve
-    // `payload.item.id` verbatim so the wire id matches what the per-attempt
-    // `privatePayload` seed reads — source interceptors look the payload up
-    // by whatever id the rewriter puts on the wire, no rewriter-side stash.
-    return storedItemReplacementBase(item, row);
-  }
-
-  // Owned reasoning is bound to the upstream that produced it; drop it when
-  // routing elsewhere.
+  const replacement = resolved.canonical ?? (payload?.item as ResponsesInputItem | undefined) ?? item;
+  if (!isUpstreamOwned(row)) return replacement;
   if (row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return null;
-
-  if (row.upstreamId === candidate.provider.upstream && row.upstreamItemId) {
-    // Same upstream: substitute the original upstream-issued id. A
-    // reference-capable provider keeps the wire item as `item_reference`;
-    // others inline-expand against the stored payload.
+  if (row.upstreamId === candidate.provider.upstream && row.upstreamItemId !== null) {
     return item.type === 'item_reference' && candidate.provider.supportsResponsesItemReference
       ? itemWithId(item, row.upstreamItemId)
-      : itemWithId(storedItemReplacementBase(item, row), row.upstreamItemId);
+      : itemWithId(replacement, row.upstreamItemId);
   }
-
-  // Cross-upstream owned: mint a tmp id so the foreign upstream's id
-  // namespace can't bleed into the new upstream's view.
-  const replacement = storedItemReplacementBase(item, row);
   if (responsesItemId(replacement) !== null) return itemWithId(replacement, createTemporaryResponsesItemId(row.itemType));
   return replacement;
 };
@@ -66,79 +99,58 @@ const rewriteItemForCandidate = (
 const collectEncryptedContents = async (items: Iterable<ResponsesInputItem>): Promise<Map<string, string>> => {
   const encryptedContents = new Set<string>();
   for (const item of items) {
-    const enc = responsesItemEncryptedContent(item);
-    if (enc !== null) encryptedContents.add(enc);
+    const encryptedContent = responsesItemEncryptedContent(item);
+    if (encryptedContent !== null) encryptedContents.add(encryptedContent);
   }
-  return new Map(
-    await Promise.all([...encryptedContents].map(async enc => [enc, await hashResponsesItemEncryptedContent(enc)] as const)),
-  );
+  return new Map(await Promise.all([...encryptedContents].map(async value => [value, await hashResponsesItemEncryptedContent(value)] as const)));
 };
 
-export interface RewrittenResponsesReference {
-  readonly row?: StoredResponsesItem;
-}
+const rewriteItems = async (
+  items: readonly ResponsesInputItem[],
+  store: StatefulResponsesStore,
+  candidate: ModelCandidate,
+): Promise<{ readonly items: Array<ResponsesInputItem | null>; readonly privatePayloads: ReadonlyMap<string, unknown> }> => {
+  const hashByEncryptedContent = await collectEncryptedContents(items);
+  const resolved = items.map(item => ({ item, row: resolveStoredRow(item, store, hashByEncryptedContent) }));
+  const rowsToHydrate: StoredResponsesItemMetadata[] = [];
+  for (const item of resolved) {
+    if (await shouldHydrate(item, candidate) && item.row !== undefined) rowsToHydrate.push(item.row);
+  }
+  const payloads = await store.loadItemPayloads(rowsToHydrate);
+  const privatePayloads = new Map<string, unknown>();
+  const rewritten = resolved.map(item => {
+    const payload = item.row === undefined ? undefined : payloads.get(item.row.id);
+    const result = rewriteItemForCandidate(item, payload, candidate);
+    const wireId = result === null ? null : responsesItemId(result);
+    if (wireId !== null && payload?.private !== undefined) privatePayloads.set(wireId, payload.private);
+    return result;
+  });
+  return { items: rewritten, privatePayloads };
+};
 
 export interface RewrittenResponsesPayload {
   readonly payload: CanonicalResponsesPayload;
-  readonly references: ReadonlyArray<RewrittenResponsesReference>;
+  readonly privatePayloads: ReadonlyMap<string, unknown>;
 }
-
-const rewriteOneItemAgainstStore = (
-  item: ResponsesInputItem,
-  store: StatefulResponsesStore,
-  candidate: ModelCandidate,
-  hashByEncryptedContent: ReadonlyMap<string, string>,
-  references: RewrittenResponsesReference[],
-): ResponsesInputItem | null => {
-  const id = responsesItemId(item);
-  const encryptedContent = responsesItemEncryptedContent(item);
-  const row = (id !== null ? store.getItemById(id) : undefined)
-    ?? (encryptedContent !== null ? store.getItemsByEncryptedContentHash(hashByEncryptedContent.get(encryptedContent)!).find(
-      r => item.type === 'item_reference' || r.itemType === item.type,
-    ) ?? store.getItemsByEncryptedContentHash(hashByEncryptedContent.get(encryptedContent)!)[0] : undefined);
-
-  if (row === undefined) return item;
-  references.push({ row });
-  return rewriteItemForCandidate(item, row, candidate);
-};
 
 export const rewriteResponsesItemsForCandidate = async (
   payload: CanonicalResponsesPayload,
   store: StatefulResponsesStore,
   candidate: ModelCandidate,
 ): Promise<RewrittenResponsesPayload> => {
-  // Pre-compute encrypted_content hashes so each item lookup is a single
-  // synchronous map access rather than a fresh hash per item.
-  const hashByEncryptedContent = await collectEncryptedContents(payload.input);
-
-  const rewritten: ResponsesInputItem[] = [];
-  const references: RewrittenResponsesReference[] = [];
-  for (const item of payload.input) {
-    const result = rewriteOneItemAgainstStore(item, store, candidate, hashByEncryptedContent, references);
-    if (result !== null) rewritten.push(result);
-  }
-
-  return { payload: { ...payload, input: rewritten }, references };
+  const rewritten = await rewriteItems(payload.input, store, candidate);
+  return { payload: { ...payload, input: rewritten.items.filter(item => item !== null) }, privatePayloads: rewritten.privatePayloads };
 };
 
-// Source-items rewriter for non-Responses attempts (Messages, Chat
-// Completions, Gemini); per-row rewrite policy lives in rewriteItemForCandidate.
 export const rewriteStoredResponsesItemsForCandidate = async <TSourceItems>(
   sourceItems: TSourceItems,
   view: ResponsesItemsView<TSourceItems>,
   store: StatefulResponsesStore,
   candidate: ModelCandidate,
 ): Promise<TSourceItems> => {
-  // Pre-compute encrypted_content hashes so the per-item walk is a single
-  // synchronous lookup instead of re-hashing on every visit.
   const visited: ResponsesInputItem[] = [];
   await view.visitAsResponsesItems(sourceItems, item => { visited.push(item); });
-  const hashByEncryptedContent = await collectEncryptedContents(visited);
-
-  // Per-attempt private-payload seeding lives on the Responses-shaped variant
-  // because only `responsesAttempt` runs the seed; non-Responses sources
-  // discard references after the rewrite.
-  const references: RewrittenResponsesReference[] = [];
-  return (await view.mapAsResponsesItems(sourceItems, item =>
-    rewriteOneItemAgainstStore(item, store, candidate, hashByEncryptedContent, references))) as TSourceItems;
+  const rewritten = await rewriteItems(visited, store, candidate);
+  let index = 0;
+  return (await view.mapAsResponsesItems(sourceItems, () => rewritten.items[index++])) as TSourceItems;
 };

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -59,7 +59,7 @@ const shouldHydrate = async (
 ): Promise<boolean> => {
   const { item, row } = resolved;
   if (row === undefined || !row.hasPayload) return false;
-  if (row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return false;
+  if (isUpstreamOwned(row) && row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return false;
   if (item.type === 'item_reference') {
     return !(row.upstreamId === candidate.provider.upstream
       && row.upstreamItemId !== null

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -58,7 +58,7 @@ const shouldHydrate = async (
   candidate: ModelCandidate,
 ): Promise<boolean> => {
   const { item, row } = resolved;
-  if (row === undefined || !row.hasPayload) return false;
+  if (!row?.hasPayload) return false;
   if (isUpstreamOwned(row) && row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return false;
   if (item.type === 'item_reference') {
     return !(row.upstreamId === candidate.provider.upstream

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -14,6 +14,13 @@ const itemWithId = (item: ResponsesInputItem, id: string): ResponsesInputItem =>
   id,
 } as ResponsesInputItem);
 
+// Codex stores output items in an input-shaped history model: message/function
+// status and output-text annotations/logprobs are absent, while reasoning keeps
+// an optional content carrier. Restore the server defaults only for the durable
+// content-hash comparison; the normalized object is used only when that hash
+// proves it is exactly the persisted canonical payload.
+// https://github.com/openai/codex/blob/c888e8e75a9f0e90ce7d5517f8b9540832cbbf76/codex-rs/protocol/src/models.rs#L843-L858
+// https://github.com/openai/codex/blob/c888e8e75a9f0e90ce7d5517f8b9540832cbbf76/codex-rs/protocol/src/models.rs#L933-L1012
 const canonicalStoredEcho = (item: ResponsesInputItem, row: StoredResponsesItemMetadata): ResponsesInputItem => {
   const canonical = structuredClone(item) as ResponsesInputItem & Record<string, unknown>;
   if (row.upstreamItemId !== null) canonical.id = row.upstreamItemId;

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -113,7 +113,7 @@ const collectEncryptedContents = async (items: Iterable<ResponsesInputItem>): Pr
   return new Map(await Promise.all([...encryptedContents].map(async value => [value, await hashResponsesItemEncryptedContent(value)] as const)));
 };
 
-const rewriteItems = async (
+const rewriteResponsesItemListForCandidate = async (
   items: readonly ResponsesInputItem[],
   store: StatefulResponsesStore,
   candidate: ModelCandidate,
@@ -141,16 +141,16 @@ export interface RewrittenResponsesPayload {
   readonly privatePayloads: ReadonlyMap<string, unknown>;
 }
 
-export const rewriteResponsesItemsForCandidate = async (
+export const rewriteResponsesPayloadForCandidate = async (
   payload: CanonicalResponsesPayload,
   store: StatefulResponsesStore,
   candidate: ModelCandidate,
 ): Promise<RewrittenResponsesPayload> => {
-  const rewritten = await rewriteItems(payload.input, store, candidate);
+  const rewritten = await rewriteResponsesItemListForCandidate(payload.input, store, candidate);
   return { payload: { ...payload, input: rewritten.items.filter(item => item !== null) }, privatePayloads: rewritten.privatePayloads };
 };
 
-export const rewriteStoredResponsesItemsForCandidate = async <TSourceItems>(
+export const rewriteStoredItemsInSourceForCandidate = async <TSourceItems>(
   sourceItems: TSourceItems,
   view: ResponsesItemsView<TSourceItems>,
   store: StatefulResponsesStore,
@@ -158,7 +158,7 @@ export const rewriteStoredResponsesItemsForCandidate = async <TSourceItems>(
 ): Promise<TSourceItems> => {
   const visited: ResponsesInputItem[] = [];
   await view.visitAsResponsesItems(sourceItems, item => { visited.push(item); });
-  const rewritten = await rewriteItems(visited, store, candidate);
+  const rewritten = await rewriteResponsesItemListForCandidate(visited, store, candidate);
   let index = 0;
   return (await view.mapAsResponsesItems(sourceItems, () => rewritten.items[index++])) as TSourceItems;
 };

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -84,7 +84,8 @@ const rewriteItemForCandidate = (
   if (item.type === 'item_reference' && payload === undefined && !candidate.provider.supportsResponsesItemReference) {
     throwChatServeFailure({ kind: 'item-not-found', itemId: row.id });
   }
-  const replacement = resolved.canonical ?? (payload?.item as ResponsesInputItem | undefined) ?? item;
+  const replacement = resolved.canonical
+    ?? (payload === undefined ? item : structuredClone(payload.item) as ResponsesInputItem);
   if (!isUpstreamOwned(row)) return replacement;
   if (row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return null;
   if (row.upstreamId === candidate.provider.upstream && row.upstreamItemId !== null) {
@@ -122,7 +123,7 @@ const rewriteItems = async (
     const payload = item.row === undefined ? undefined : payloads.get(item.row.id);
     const result = rewriteItemForCandidate(item, payload, candidate);
     const wireId = result === null ? null : responsesItemId(result);
-    if (wireId !== null && payload?.private !== undefined) privatePayloads.set(wireId, payload.private);
+    if (wireId !== null && payload?.private !== undefined) privatePayloads.set(wireId, structuredClone(payload.private));
     return result;
   });
   return { items: rewritten, privatePayloads };

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -2,7 +2,7 @@ import { test, vi } from 'vitest';
 
 import { classifyResponsesItemAffinity } from './affinity.ts';
 import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, isStoredResponsesItemId } from './format.ts';
-import { rewriteResponsesItemsForCandidate } from './rewrite.ts';
+import { rewriteResponsesPayloadForCandidate } from './rewrite.ts';
 import { createNonResponsesSourceStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
@@ -80,7 +80,7 @@ const rewrite = async (
   await store.loadInputItems({ sourceItems: input, view: responsesItemsView });
   // Simulate the affinity classification that populates the store cache.
   await classifyResponsesItemAffinity({ sourceItems: input, view: responsesItemsView, store, candidates: [cand] });
-  const result = await rewriteResponsesItemsForCandidate(makePayload(input), store, cand);
+  const result = await rewriteResponsesPayloadForCandidate(makePayload(input), store, cand);
   return result.payload.input as ResponsesInputItem[];
 };
 

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -1,7 +1,7 @@
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 
 import { classifyResponsesItemAffinity } from './affinity.ts';
-import { createStoredResponsesItemId, hashResponsesItemEncryptedContent, isStoredResponsesItemId } from './format.ts';
+import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, isStoredResponsesItemId } from './format.ts';
 import { rewriteResponsesItemsForCandidate } from './rewrite.ts';
 import { createNonResponsesSourceStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
@@ -153,6 +153,37 @@ test('matching upstream rewrites to upstream_item_id', async () => {
   const rewritten = await rewrite(input, candidate('up_a'));
 
   assertEquals(rewritten, [{ type: 'message', id: 'raw_msg_a', role: 'assistant', content: 'stale' }]);
+});
+
+test('canonical projected echo rewrites from metadata without loading its payload', async () => {
+  const id = storedMessageId('metadata-fast-path');
+  const canonical = {
+    type: 'message',
+    id: 'raw_msg_a',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ type: 'output_text', text: 'hello', annotations: [], logprobs: [] }],
+  } as unknown as ResponsesInputItem;
+  const repo = await insertRows([storedRow({
+    id,
+    itemType: 'message',
+    upstreamId: 'up_a',
+    upstreamItemId: 'raw_msg_a',
+    contentHash: await hashResponsesItemContent(canonical),
+    payload: canonical,
+  })]);
+  const loadPayloads = vi.spyOn(repo.responsesItems, 'lookupPayloads');
+  const input: ResponsesInputItem[] = [{
+    type: 'message',
+    id,
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'hello' }],
+  }];
+
+  const rewritten = await rewrite(input, candidate('up_a'));
+
+  assertEquals(loadPayloads.mock.calls, []);
+  assertEquals(rewritten, [canonical]);
 });
 
 // Case 6: cross-upstream owned → mint tmp id

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -552,7 +552,7 @@ export class MemoryStatefulResponsesBacking implements StatefulResponsesBacking 
     const records: StoredResponsesItemPayloadRecord[] = [];
     for (const id of new Set(ids)) {
       const row = this.items.get(scopedKey(apiKeyId, id))?.row;
-      if (row?.payload !== null && row !== undefined) records.push({ id, payload: structuredClone(row.payload) });
+      if (row !== undefined && row.payload !== null) records.push({ id, payload: structuredClone(row.payload) });
     }
     return Promise.resolve(records);
   }

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -2,11 +2,13 @@ import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesIte
 import { getRepo } from '../../../../repo/index.ts';
 import {
   cloneStoredResponsesItem,
+  cloneStoredResponsesItemMetadata,
   cloneStoredResponsesSnapshot,
   compareResponsesItemsByFreshness as compareItemsByFreshness,
   responsesItemStoreKey as scopedKey,
+  storedResponsesItemMetadata,
 } from '../../../../repo/responses-clone.ts';
-import type { Repo, StoredResponsesItem, StoredResponsesSnapshot } from '../../../../repo/types.ts';
+import type { Repo, StoredResponsesItem, StoredResponsesItemMetadata, StoredResponsesItemPayload, StoredResponsesItemPayloadRecord, StoredResponsesSnapshot } from '../../../../repo/types.ts';
 import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
@@ -18,12 +20,13 @@ export interface StatefulResponsesItemLookup {
 }
 
 export interface StatefulResponsesItemLookupResult {
-  readonly row: StoredResponsesItem;
+  readonly metadata: StoredResponsesItemMetadata;
   readonly durable: boolean;
 }
 
 export interface StatefulResponsesBacking {
   lookupItems(query: StatefulResponsesItemLookup): Promise<StatefulResponsesItemLookupResult[]>;
+  lookupPayloads(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemPayloadRecord[]>;
   insertItems(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<void>;
   fillPayloads(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<void>;
   markDurable?(apiKeyId: string | null, id: string): void;
@@ -81,11 +84,12 @@ export interface StatefulResponsesStore {
     readonly view: Pick<ResponsesItemsView<TSourceItems>, 'visitAsResponsesItems'>;
     readonly inputItemsToStage?: readonly ResponsesInputItem[];
   }): Promise<void>;
-  getItemById(id: string): StoredResponsesItem | undefined;
-  getItemsByEncryptedContentHash(hash: string): StoredResponsesItem[];
+  getItemById(id: string): StoredResponsesItemMetadata | undefined;
+  getItemsByEncryptedContentHash(hash: string): StoredResponsesItemMetadata[];
+  loadItemPayloads(items: readonly StoredResponsesItemMetadata[]): Promise<ReadonlyMap<string, StoredResponsesItemPayload>>;
   touchItem(id: string): void;
   stageInputItems(items: readonly ResponsesInputItem[]): Promise<void>;
-  beginAttempt(references: Iterable<{ readonly row?: StoredResponsesItem }>): void;
+  beginAttempt(privatePayloads: ReadonlyMap<string, unknown>): void;
   addSyntheticItem(id: string, privatePayload?: unknown): void;
   isSyntheticItem(id: string): boolean;
   getPrivatePayload(id: string): unknown;
@@ -96,9 +100,11 @@ export interface StatefulResponsesStore {
 }
 
 export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
-  private readonly loadedItemsById = new Map<string, StoredResponsesItem>();
-  private readonly loadedItemsByContentHash = new Map<string, StoredResponsesItem[]>();
-  private readonly loadedItemsByEncryptedContentHash = new Map<string, StoredResponsesItem[]>();
+  private readonly loadedItemsById = new Map<string, StoredResponsesItemMetadata>();
+  private readonly loadedItemsByContentHash = new Map<string, StoredResponsesItemMetadata[]>();
+  private readonly loadedItemsByEncryptedContentHash = new Map<string, StoredResponsesItemMetadata[]>();
+  private readonly payloadSourcesById = new Map<string, StatefulResponsesBacking>();
+  private readonly stagedPayloadsById = new Map<string, StoredResponsesItemPayload>();
   private readonly privatePayload = new Map<string, unknown>();
   private readonly syntheticItemIds = new Set<string>();
   private readonly snapshotsById = new Map<string, StoredResponsesSnapshot>();
@@ -137,7 +143,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
       await this.loadItems({ ids: snapshot.itemIds, contentHashes: [], encryptedContentHashes: [] });
       if (!snapshot.itemIds.every(itemId => {
         const row = this.loadedItemsById.get(itemId);
-        return row !== undefined && isReplayableSnapshotRow(row);
+        return row !== undefined && isReplayableSnapshotMetadata(row);
       })) continue;
       this.rememberSnapshot(snapshot);
       this.previousSnapshotItemIds = [...snapshot.itemIds];
@@ -175,14 +181,42 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     });
   }
 
-  getItemById(id: string): StoredResponsesItem | undefined {
+  getItemById(id: string): StoredResponsesItemMetadata | undefined {
     const row = this.loadedItemsById.get(id) ?? this.stagedInputItems.get(id) ?? this.stagedOutputItems.get(id);
     if (row) this.touchItem(row.id);
-    return row ? cloneStoredResponsesItem(row) : undefined;
+    return row ? cloneStoredResponsesItemMetadata('hasPayload' in row ? row : storedResponsesItemMetadata(row)) : undefined;
   }
 
-  getItemsByEncryptedContentHash(hash: string): StoredResponsesItem[] {
-    return (this.loadedItemsByEncryptedContentHash.get(hash) ?? []).map(cloneStoredResponsesItem);
+  getItemsByEncryptedContentHash(hash: string): StoredResponsesItemMetadata[] {
+    return (this.loadedItemsByEncryptedContentHash.get(hash) ?? []).map(cloneStoredResponsesItemMetadata);
+  }
+
+  async loadItemPayloads(items: readonly StoredResponsesItemMetadata[]): Promise<ReadonlyMap<string, StoredResponsesItemPayload>> {
+    const payloads = new Map<string, StoredResponsesItemPayload>();
+    const groups = new Map<StatefulResponsesBacking, StoredResponsesItemMetadata[]>();
+    for (const item of items) {
+      if (!item.hasPayload || payloads.has(item.id)) continue;
+      const staged = this.stagedPayloadsById.get(item.id);
+      if (staged !== undefined) {
+        payloads.set(item.id, staged);
+        continue;
+      }
+      const source = this.payloadSourcesById.get(item.id);
+      if (source === undefined) throw new Error(`Stored Responses payload source missing for id=${item.id}`);
+      const rows = groups.get(source) ?? [];
+      rows.push(item);
+      groups.set(source, rows);
+    }
+    for (const [source, metadata] of groups) {
+      const records = await source.lookupPayloads(this.options.apiKeyId, metadata.map(item => item.id));
+      const byId = new Map(records.map(record => [record.id, record.payload]));
+      for (const item of metadata) {
+        const payload = byId.get(item.id);
+        if (payload === undefined) throw new Error(`Stored Responses payload disappeared during hydration for id=${item.id}`);
+        payloads.set(item.id, payload);
+      }
+    }
+    return payloads;
   }
 
   touchItem(id: string): void {
@@ -194,16 +228,12 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     for (const item of items) await this.stageInputItem(item);
   }
 
-  beginAttempt(references: Iterable<{ readonly row?: StoredResponsesItem }>): void {
+  beginAttempt(privatePayloads: ReadonlyMap<string, unknown>): void {
     this.stagedOutputItems.clear();
     this.stagedOutputItemIds.length = 0;
     this.privatePayload.clear();
     this.syntheticItemIds.clear();
-    for (const ref of references) {
-      if (ref.row?.payload?.private === undefined) continue;
-      const wireId = responsesItemId(ref.row.payload.item as { id?: unknown });
-      if (wireId !== null) this.privatePayload.set(wireId, ref.row.payload.private);
-    }
+    for (const [wireId, payload] of privatePayloads) this.privatePayload.set(wireId, payload);
   }
 
   addSyntheticItem(id: string, privatePayload?: unknown): void {
@@ -238,8 +268,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
       : [...this.previousSnapshotItemIds, ...this.stagedInputItemIds, ...this.stagedOutputItemIds];
     if (itemIds.length === 0) return;
 
-    const replayableRows = this.replayableRowsForSnapshot(itemIds);
-    await this.commitItems(replayableRows);
+    this.assertReplayableSnapshotItems(itemIds);
     const now = Date.now();
     const snapshot: StoredResponsesSnapshot = {
       id: responseId,
@@ -268,7 +297,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
         contentHashes,
         encryptedContentHashes,
       });
-      for (const result of results) this.rememberItem(result.row, { durable: result.durable });
+      for (const result of results) this.rememberItem(result.metadata, { durable: result.durable, source: backing });
       ids = ids.filter(id => !this.loadedItemsById.has(id));
     }
   }
@@ -294,7 +323,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     if (storedId !== null && isStoredResponsesItemId(storedId)) {
       const row = this.getItemById(storedId);
       if (row !== undefined) {
-        if (row.payload !== null) {
+        if (row.hasPayload) {
           this.stagedInputItemIds.push(row.id);
           return;
         }
@@ -309,7 +338,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
         .find(candidate => candidate.itemType === item.type);
       if (row !== undefined) {
         this.touchItem(row.id);
-        if (row.payload !== null) {
+        if (row.hasPayload) {
           this.stagedInputItemIds.push(row.id);
           return;
         }
@@ -345,10 +374,11 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     this.rememberItem(row, { durable: this.durableItemIds.has(row.id) });
   }
 
-  private async stagePayloadUpgrade(row: StoredResponsesItem, item: ResponsesInputItem, encryptedContent: string | null): Promise<void> {
+  private async stagePayloadUpgrade(row: StoredResponsesItemMetadata, item: ResponsesInputItem, encryptedContent: string | null): Promise<void> {
     const now = Date.now();
+    const { hasPayload: _hasPayload, ...metadata } = row;
     const upgraded: StoredResponsesItem = {
-      ...row,
+      ...metadata,
       payload: { item: structuredClone(item) },
       contentHash: await hashResponsesItemContent(item),
       encryptedContentHash: encryptedContent === null ? row.encryptedContentHash : await hashResponsesItemEncryptedContent(encryptedContent),
@@ -361,37 +391,41 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     this.rememberItem(upgraded);
   }
 
-  private reusableItemByContentHash(hash: string): StoredResponsesItem | undefined {
+  private reusableItemByContentHash(hash: string): StoredResponsesItemMetadata | undefined {
     const staged = [...this.stagedInputItems.values(), ...this.stagedOutputItems.values()].find(row => row.contentHash === hash);
-    if (staged) return staged;
-    return this.loadedItemsByContentHash.get(hash)?.find(row => row.payload !== null);
+    if (staged) return storedResponsesItemMetadata(staged);
+    return this.loadedItemsByContentHash.get(hash)?.find(row => row.hasPayload);
   }
 
-  private rememberItem(row: StoredResponsesItem, options: { readonly durable?: boolean } = {}): void {
-    const cloned = cloneStoredResponsesItem(row);
-    this.loadedItemsById.set(cloned.id, cloned);
-    if (options.durable === true) this.durableItemIds.add(cloned.id);
-    if (cloned.contentHash !== null) pushByHash(this.loadedItemsByContentHash, cloned.contentHash, cloned);
-    if (cloned.encryptedContentHash !== null) pushByHash(this.loadedItemsByEncryptedContentHash, cloned.encryptedContentHash, cloned);
+  private rememberItem(
+    row: StoredResponsesItem | StoredResponsesItemMetadata,
+    options: { readonly durable?: boolean; readonly source?: StatefulResponsesBacking } = {},
+  ): void {
+    const metadata = cloneStoredResponsesItemMetadata('hasPayload' in row ? row : storedResponsesItemMetadata(row));
+    this.loadedItemsById.set(metadata.id, metadata);
+    if (!('hasPayload' in row) && row.payload !== null) this.stagedPayloadsById.set(row.id, structuredClone(row.payload));
+    if (metadata.hasPayload && options.source !== undefined) this.payloadSourcesById.set(metadata.id, options.source);
+    if (options.durable === true) this.durableItemIds.add(metadata.id);
+    if (metadata.contentHash !== null) pushByHash(this.loadedItemsByContentHash, metadata.contentHash, metadata);
+    if (metadata.encryptedContentHash !== null) pushByHash(this.loadedItemsByEncryptedContentHash, metadata.encryptedContentHash, metadata);
   }
 
   private rememberSnapshot(snapshot: StoredResponsesSnapshot): void {
     this.snapshotsById.set(snapshot.id, cloneStoredResponsesSnapshot(snapshot));
   }
 
-  private replayableRowsForSnapshot(itemIds: readonly string[]): StoredResponsesItem[] {
-    const rows: StoredResponsesItem[] = [];
+  private assertReplayableSnapshotItems(itemIds: readonly string[]): void {
     const seen = new Set<string>();
     for (const id of itemIds) {
       if (seen.has(id)) continue;
       seen.add(id);
-      const row = this.loadedItemsById.get(id) ?? this.stagedInputItems.get(id) ?? this.stagedOutputItems.get(id);
-      if (row === undefined || !isReplayableSnapshotRow(row)) {
+      const row = this.loadedItemsById.get(id)
+        ?? (this.stagedInputItems.has(id) ? storedResponsesItemMetadata(this.stagedInputItems.get(id)!) : undefined)
+        ?? (this.stagedOutputItems.has(id) ? storedResponsesItemMetadata(this.stagedOutputItems.get(id)!) : undefined);
+      if (row === undefined || !isReplayableSnapshotMetadata(row)) {
         throw new Error(`Cannot persist Responses snapshot with non-replayable item id=${id}`);
       }
-      rows.push(row);
     }
-    return rows;
   }
 
   private async commitItems(rows: readonly StoredResponsesItem[]): Promise<void> {
@@ -458,11 +492,15 @@ export class RepoStatefulResponsesBacking implements StatefulResponsesBacking {
       this.repo.responsesItems.lookupManyByContentHash(query.apiKeyId, query.contentHashes),
       this.repo.responsesItems.lookupManyByEncryptedContentHash(query.apiKeyId, query.encryptedContentHashes),
     ]);
-    const rowsByKey = new Map<string, StoredResponsesItem>();
+    const rowsByKey = new Map<string, StoredResponsesItemMetadata>();
     for (const row of [...byId, ...byContentHash, ...byEncryptedContentHash]) {
-      rowsByKey.set(scopedKey(row.apiKeyId, row.id), cloneStoredResponsesItem(row));
+      rowsByKey.set(scopedKey(row.apiKeyId, row.id), cloneStoredResponsesItemMetadata(row));
     }
-    return [...rowsByKey.values()].map(row => ({ row, durable: true }));
+    return [...rowsByKey.values()].map(metadata => ({ metadata, durable: true }));
+  }
+
+  async lookupPayloads(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemPayloadRecord[]> {
+    return await this.repo.responsesItems.lookupPayloads(apiKeyId, ids);
   }
 
   async insertItems(items: readonly StoredResponsesItem[]): Promise<void> {
@@ -506,8 +544,17 @@ export class MemoryStatefulResponsesBacking implements StatefulResponsesBacking 
           || (row.contentHash !== null && contentHashes.has(row.contentHash))
           || (row.encryptedContentHash !== null && encryptedContentHashes.has(row.encryptedContentHash))
         ))
-      .map(({ row, durable }) => ({ row: cloneStoredResponsesItem(row), durable }))
-      .toSorted((a, b) => compareItemsByFreshness(a.row, b.row)));
+      .map(({ row, durable }) => ({ metadata: storedResponsesItemMetadata(row), durable }))
+      .toSorted((a, b) => compareItemsByFreshness(a.metadata, b.metadata)));
+  }
+
+  lookupPayloads(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemPayloadRecord[]> {
+    const records: StoredResponsesItemPayloadRecord[] = [];
+    for (const id of new Set(ids)) {
+      const row = this.items.get(scopedKey(apiKeyId, id))?.row;
+      if (row?.payload !== null && row !== undefined) records.push({ id, payload: structuredClone(row.payload) });
+    }
+    return Promise.resolve(records);
   }
 
   insertItems(items: readonly StoredResponsesItem[], options: { readonly durable: boolean }): Promise<void> {
@@ -640,14 +687,14 @@ export const createResponsesWsSession = (): {
   };
 };
 
-const pushByHash = (target: Map<string, StoredResponsesItem[]>, hash: string, row: StoredResponsesItem): void => {
+const pushByHash = (target: Map<string, StoredResponsesItemMetadata[]>, hash: string, row: StoredResponsesItemMetadata): void => {
   const rows = target.get(hash) ?? [];
   if (!rows.some(existing => existing.id === row.id && existing.apiKeyId === row.apiKeyId)) {
-    rows.push(cloneStoredResponsesItem(row));
+    rows.push(row);
     rows.sort(compareItemsByFreshness);
   }
   target.set(hash, rows);
 };
 
-const isReplayableSnapshotRow = (row: StoredResponsesItem): boolean =>
-  row.payload !== null || (row.upstreamId !== null && row.upstreamItemId !== null);
+const isReplayableSnapshotMetadata = (row: StoredResponsesItemMetadata): boolean =>
+  row.hasPayload || (row.upstreamId !== null && row.upstreamItemId !== null);

--- a/packages/gateway/src/data-plane/chat/responses/items/store_identity_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_identity_test.ts
@@ -42,8 +42,9 @@ test('changed input payload with a stable client id persists as a distinct input
   assertEquals(secondSnapshot.itemIds.length, 1);
   assert(firstSnapshot.itemIds[0] !== secondSnapshot.itemIds[0]);
   const rows = await repo.responsesItems.lookupMany(API_KEY_ID, [firstSnapshot.itemIds[0]!, secondSnapshot.itemIds[0]!]);
+  const payloads = await repo.responsesItems.lookupPayloads(API_KEY_ID, [firstSnapshot.itemIds[0]!, secondSnapshot.itemIds[0]!]);
   assertEquals(rows.map(row => row.origin), ['input', 'input']);
-  assertEquals(rows.map(row => row.payload?.item), [first, second]);
+  assertEquals(payloads.map(record => record.payload.item), [first, second]);
 });
 
 test('metadata-only durable item accepts a full payload repair', async () => {
@@ -70,9 +71,10 @@ test('metadata-only durable item accepts a full payload repair', async () => {
   await store.commitSnapshot('resp_repaired', 'append');
 
   const [repaired] = await repo.responsesItems.lookupMany(API_KEY_ID, [item.id]);
+  const [payload] = await repo.responsesItems.lookupPayloads(API_KEY_ID, [item.id]);
   assertExists(repaired);
   assertEquals(repaired.origin, 'upstream');
-  assertEquals(repaired.payload?.item, input);
+  assertEquals(payload.payload.item, input);
   const snapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_repaired');
   assertExists(snapshot);
   assertEquals(snapshot.itemIds, [item.id]);

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -59,8 +59,8 @@ test('stages programmatic tool items with their documented id prefixes and prese
   assert(snapshot.itemIds[0].startsWith('at_'));
   assert(snapshot.itemIds[1].startsWith('prog_'));
   assert(snapshot.itemIds[2].startsWith('prog_out_'));
-  const rows = await repo.responsesItems.lookupMany(API_KEY_ID, snapshot.itemIds);
-  assertEquals(rows.map(row => row.payload?.item), input);
+  const payloads = await repo.responsesItems.lookupPayloads(API_KEY_ID, snapshot.itemIds);
+  assertEquals(payloads.map(record => record.payload.item), input);
 });
 
 test('stages agent and context-compaction items with stable prefixes and preserves every field', async () => {
@@ -80,8 +80,8 @@ test('stages agent and context-compaction items with stable prefixes and preserv
   const snapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_agents');
   assertExists(snapshot);
   assertEquals(snapshot.itemIds.map(id => id.slice(0, id.indexOf('_'))), ['amsg', 'mac', 'maco', 'cmp']);
-  const rows = await repo.responsesItems.lookupMany(API_KEY_ID, snapshot.itemIds);
-  assertEquals(rows.map(row => row.payload?.item), input);
+  const payloads = await repo.responsesItems.lookupPayloads(API_KEY_ID, snapshot.itemIds);
+  assertEquals(payloads.map(record => record.payload.item), input);
 });
 
 test('snapshots with non-replayable metadata-only rows load as missing', async () => {
@@ -164,7 +164,7 @@ test('createNonResponsesSourceStore reads items for affinity but does not write 
     origin: 'upstream',
     payload: { item: { type: 'message', id: 'out_1', role: 'assistant', content: [] } },
   };
-  store.beginAttempt([]);
+  store.beginAttempt(new Map());
   store.stageOutputItem(outputItem);
   await store.commitOutputItems();
   await store.commitSnapshot('resp_new', 'append');
@@ -183,7 +183,7 @@ test('createResponsesHttpStore with store=false does not write snapshots', async
     itemType: 'message',
     origin: 'upstream',
   });
-  store.beginAttempt([]);
+  store.beginAttempt(new Map());
   store.stageOutputItem(outputItem);
   await store.commitOutputItems();
   await store.commitSnapshot('resp_no_store', 'append');
@@ -204,7 +204,7 @@ test('createResponsesHttpStore with store=true writes snapshots', async () => {
     upstreamItemId: 'raw_snap',
     payload: { item: { type: 'message', id: 'snap_1', role: 'assistant', content: [] } },
   });
-  store.beginAttempt([]);
+  store.beginAttempt(new Map());
   store.stageOutputItem(outputItem);
   await store.commitOutputItems();
   await store.commitSnapshot('resp_with_store', 'append');

--- a/packages/gateway/src/repo/memory.ts
+++ b/packages/gateway/src/repo/memory.ts
@@ -613,7 +613,7 @@ class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
     const records: StoredResponsesItemPayloadRecord[] = [];
     for (const metadata of this.lookupManySync(apiKeyId, ids)) {
       const row = this.store.get(responsesItemStoreKey(apiKeyId, metadata.id));
-      if (row?.payload !== null) records.push({ id: row.id, payload: structuredClone(row.payload) });
+      if (row !== undefined && row.payload !== null) records.push({ id: row.id, payload: structuredClone(row.payload) });
     }
     return Promise.resolve(records);
   }

--- a/packages/gateway/src/repo/memory.ts
+++ b/packages/gateway/src/repo/memory.ts
@@ -6,6 +6,7 @@ import {
   cloneStoredResponsesSnapshot,
   compareResponsesItemsByFreshness,
   responsesItemStoreKey,
+  storedResponsesItemMetadata,
 } from './responses-clone.ts';
 import { RESPONSES_REFRESH_DEBOUNCE_MS } from './responses-payload.ts';
 import type {
@@ -34,6 +35,8 @@ import type {
   Session,
   SessionsRepo,
   StoredResponsesItem,
+  StoredResponsesItemMetadata,
+  StoredResponsesItemPayloadRecord,
   StoredResponsesSnapshot,
   UpstreamRepo,
   UsageRecord,
@@ -578,40 +581,53 @@ const cloneUpstreamRecord = (upstream: UpstreamRecord): UpstreamRecord => ({
 class MemoryResponsesItemsRepo implements ResponsesItemsRepo {
   private store = new Map<string, StoredResponsesItem>();
 
-  lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItem[]> {
-    const rows: StoredResponsesItem[] = [];
+  lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemMetadata[]> {
+    return Promise.resolve(this.lookupManySync(apiKeyId, ids));
+  }
+
+  lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItemMetadata[]> {
+    const wanted = new Set(hashes);
+    if (wanted.size === 0) return Promise.resolve([]);
+    const rows: StoredResponsesItemMetadata[] = [];
+    for (const row of this.store.values()) {
+      if (row.apiKeyId === apiKeyId && row.encryptedContentHash !== null && wanted.has(row.encryptedContentHash)) {
+        rows.push(storedResponsesItemMetadata(row));
+      }
+    }
+    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
+  }
+
+  lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItemMetadata[]> {
+    const wanted = new Set(hashes);
+    if (wanted.size === 0) return Promise.resolve([]);
+    const rows: StoredResponsesItemMetadata[] = [];
+    for (const row of this.store.values()) {
+      if (row.apiKeyId === apiKeyId && row.contentHash !== null && wanted.has(row.contentHash)) {
+        rows.push(storedResponsesItemMetadata(row));
+      }
+    }
+    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
+  }
+
+  lookupPayloads(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemPayloadRecord[]> {
+    const records: StoredResponsesItemPayloadRecord[] = [];
+    for (const metadata of this.lookupManySync(apiKeyId, ids)) {
+      const row = this.store.get(responsesItemStoreKey(apiKeyId, metadata.id));
+      if (row?.payload !== null) records.push({ id: row.id, payload: structuredClone(row.payload) });
+    }
+    return Promise.resolve(records);
+  }
+
+  private lookupManySync(apiKeyId: string | null, ids: readonly string[]): StoredResponsesItemMetadata[] {
+    const rows: StoredResponsesItemMetadata[] = [];
     const seen = new Set<string>();
     for (const id of ids) {
       if (seen.has(id)) continue;
       seen.add(id);
       const row = this.store.get(responsesItemStoreKey(apiKeyId, id));
-      if (row?.apiKeyId === apiKeyId) rows.push(cloneStoredResponsesItem(row));
+      if (row?.apiKeyId === apiKeyId) rows.push(storedResponsesItemMetadata(row));
     }
-    return Promise.resolve(rows);
-  }
-
-  lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]> {
-    const wanted = new Set(hashes);
-    if (wanted.size === 0) return Promise.resolve([]);
-    const rows: StoredResponsesItem[] = [];
-    for (const row of this.store.values()) {
-      if (row.apiKeyId === apiKeyId && row.encryptedContentHash !== null && wanted.has(row.encryptedContentHash)) {
-        rows.push(cloneStoredResponsesItem(row));
-      }
-    }
-    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
-  }
-
-  lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]> {
-    const wanted = new Set(hashes);
-    if (wanted.size === 0) return Promise.resolve([]);
-    const rows: StoredResponsesItem[] = [];
-    for (const row of this.store.values()) {
-      if (row.apiKeyId === apiKeyId && row.contentHash !== null && wanted.has(row.contentHash)) {
-        rows.push(cloneStoredResponsesItem(row));
-      }
-    }
-    return Promise.resolve(rows.toSorted(compareResponsesItemsByFreshness));
+    return rows;
   }
 
   insertMany(items: readonly StoredResponsesItem[]): Promise<void> {

--- a/packages/gateway/src/repo/responses-clone.ts
+++ b/packages/gateway/src/repo/responses-clone.ts
@@ -1,9 +1,16 @@
-import type { StoredResponsesItem, StoredResponsesSnapshot } from './types.ts';
+import type { StoredResponsesItem, StoredResponsesItemMetadata, StoredResponsesSnapshot } from './types.ts';
 
 export const cloneStoredResponsesItem = (item: StoredResponsesItem): StoredResponsesItem => ({
   ...item,
   payload: item.payload === null ? null : structuredClone(item.payload),
 });
+
+export const storedResponsesItemMetadata = (item: StoredResponsesItem): StoredResponsesItemMetadata => {
+  const { payload, ...metadata } = item;
+  return { ...metadata, hasPayload: payload !== null };
+};
+
+export const cloneStoredResponsesItemMetadata = (item: StoredResponsesItemMetadata): StoredResponsesItemMetadata => ({ ...item });
 
 export const cloneStoredResponsesSnapshot = (snapshot: StoredResponsesSnapshot): StoredResponsesSnapshot => ({
   ...snapshot,
@@ -13,5 +20,8 @@ export const cloneStoredResponsesSnapshot = (snapshot: StoredResponsesSnapshot):
 export const responsesItemStoreKey = (apiKeyId: string | null, id: string): string =>
   `${apiKeyId ?? ''}\0${id}`;
 
-export const compareResponsesItemsByFreshness = (a: StoredResponsesItem, b: StoredResponsesItem): number =>
+export const compareResponsesItemsByFreshness = (
+  a: Pick<StoredResponsesItemMetadata, 'id' | 'createdAt' | 'refreshedAt'>,
+  b: Pick<StoredResponsesItemMetadata, 'id' | 'createdAt' | 'refreshedAt'>,
+): number =>
   b.refreshedAt - a.refreshedAt || b.createdAt - a.createdAt || a.id.localeCompare(b.id);

--- a/packages/gateway/src/repo/responses-items_test.ts
+++ b/packages/gateway/src/repo/responses-items_test.ts
@@ -2,6 +2,7 @@ import initSqlJs from 'sql.js';
 import { test, vi } from 'vitest';
 
 import { InMemoryRepo } from './memory.ts';
+import { storedResponsesItemMetadata } from './responses-clone.ts';
 import { SqlRepo } from './sql.ts';
 import type { ResponsesItemsRepo, StoredResponsesItem } from './types.ts';
 import { initFileProvider, MemoryFileProvider, sha256Hex, type FileProvider, type SqlDatabase } from '@floway-dev/platform';
@@ -149,11 +150,11 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
 
   await repo.insertMany([first, second, adminScoped]);
 
-  assertEquals(await repo.lookupMany('key_a', [second.id, adminScoped.id, first.id, 'missing']), [second, first]);
-  assertEquals(await repo.lookupMany(null, [first.id, adminScoped.id]), [adminScoped]);
+  assertEquals(await repo.lookupMany('key_a', [second.id, adminScoped.id, first.id, 'missing']), [second, first].map(storedResponsesItemMetadata));
+  assertEquals(await repo.lookupMany(null, [first.id, adminScoped.id]), [storedResponsesItemMetadata(adminScoped)]);
   assertEquals(await repo.lookupMany('key_b', [first.id, second.id, adminScoped.id]), []);
   assertEquals(await repo.lookupMany('key_a', []), []);
-  assertEquals(await repo.lookupManyByContentHash('key_a', ['content_hash_a']), [first]);
+  assertEquals(await repo.lookupManyByContentHash('key_a', ['content_hash_a']), [storedResponsesItemMetadata(first)]);
   assertEquals(await repo.lookupManyByContentHash('key_b', ['content_hash_a']), []);
 
   assertEquals(await repo.refreshMany('key_a', [first.id, first.id, second.id, adminScoped.id, 'missing'], 4_000 * DAY_MS), 2);
@@ -162,7 +163,7 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
     [
       { ...first, refreshedAt: 4_000 * DAY_MS },
       { ...second, refreshedAt: 4_000 * DAY_MS },
-    ],
+    ].map(storedResponsesItemMetadata),
   );
   // Smaller-than-stored refreshedAt: rejected for two overlapping reasons —
   // the never-go-backwards guard, and (since 3_500*DAY < 4_000*DAY - debounce)
@@ -179,14 +180,14 @@ const exerciseResponsesItemsRepo = async (repo: ResponsesItemsRepo) => {
     [
       { ...first, payload: null, refreshedAt: 4_000 * DAY_MS },
       { ...second, payload: null, refreshedAt: 4_000 * DAY_MS },
-    ],
+    ].map(storedResponsesItemMetadata),
   );
-  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [refreshedAdminScoped]);
+  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [storedResponsesItemMetadata(refreshedAdminScoped)]);
 
   assertEquals(await repo.deleteOlderThan(3_000 * DAY_MS), 0);
   assertEquals(await repo.deleteOlderThan(4_500 * DAY_MS), 2);
   assertEquals(await repo.lookupMany('key_a', [first.id, second.id]), []);
-  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [refreshedAdminScoped]);
+  assertEquals(await repo.lookupMany(null, [adminScoped.id]), [storedResponsesItemMetadata(refreshedAdminScoped)]);
 
   await repo.deleteAll();
   assertEquals(await repo.lookupMany(null, [adminScoped.id]), []);
@@ -282,9 +283,9 @@ test('memory responses items repo scopes ids by api key and treats duplicate sco
   // Same scope: the duplicate insert is a no-op; row reflects the first
   // write. Stored ids use random bodies, so colliding writes only happen
   // within one stream's mapper retries, which the wrap dedupes upstream.
-  assertEquals(await repo.lookupMany('key_a', [item.id]), [item]);
+  assertEquals(await repo.lookupMany('key_a', [item.id]), [storedResponsesItemMetadata(item)]);
   // Different scope: a parallel row is created.
-  assertEquals(await repo.lookupMany('key_b', [item.id]), [{ ...item, apiKeyId: 'key_b' }]);
+  assertEquals(await repo.lookupMany('key_b', [item.id]), [storedResponsesItemMetadata({ ...item, apiKeyId: 'key_b' })]);
 });
 
 const exerciseResponsesItemsRepoPayloadFill = async (repo: ResponsesItemsRepo) => {
@@ -309,9 +310,9 @@ const exerciseResponsesItemsRepoPayloadFill = async (repo: ResponsesItemsRepo) =
   await repo.insertMany([metadata]);
 
   assertEquals(await repo.fillPayloads([filled]), 1);
-  assertEquals(await repo.lookupMany('key_a', [metadata.id]), [filled]);
+  assertEquals(await repo.lookupMany('key_a', [metadata.id]), [storedResponsesItemMetadata(filled)]);
   assertEquals(await repo.fillPayloads([{ ...filled, payload: { item: { changed: true } }, createdAt: 3_000, refreshedAt: 3_000 }]), 0);
-  assertEquals(await repo.lookupMany('key_a', [metadata.id]), [filled]);
+  assertEquals(await repo.lookupMany('key_a', [metadata.id]), [storedResponsesItemMetadata(filled)]);
 };
 
 test('memory responses items repo fills metadata-only payloads once', async () => {
@@ -338,7 +339,10 @@ test('SQL responses items repo rejects malformed stored payload_json', async () 
     refreshed_at: 1_000,
   });
 
-  await assertRejects(() => new SqlRepo(db).responsesItems.lookupMany('key_a', ['msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA']), Error, 'Malformed responses_items.payload_json JSON');
+  const repo = new SqlRepo(db).responsesItems;
+  const [metadata] = await repo.lookupMany('key_a', ['msg_z1mVjw_0xVvS8c_KjD1sBkZk5qbdA']);
+  assertEquals(metadata.hasPayload, true);
+  await assertRejects(() => repo.lookupPayloads('key_a', [metadata.id]), Error, 'Malformed responses_items.payload_json JSON');
 });
 
 test('SQL responses items repo scopes ids by api key and treats duplicate scoped writes as no-ops', async () => {
@@ -350,8 +354,8 @@ test('SQL responses items repo scopes ids by api key and treats duplicate scoped
     { ...item, payload: { item: { changed: true } }, createdAt: 2_000 },
   ]);
 
-  assertEquals(await repo.lookupMany('key_a', [item.id]), [item]);
-  assertEquals(await repo.lookupMany('key_b', [item.id]), [{ ...item, apiKeyId: 'key_b' }]);
+  assertEquals(await repo.lookupMany('key_a', [item.id]), [storedResponsesItemMetadata(item)]);
+  assertEquals(await repo.lookupMany('key_b', [item.id]), [storedResponsesItemMetadata({ ...item, apiKeyId: 'key_b' })]);
 });
 
 test('SQL responses items repo fills metadata-only payloads once', async () => {
@@ -397,15 +401,18 @@ test('SQL responses items repo hydrates one payload at a time across query chunk
     });
     ids.push(id);
   }
-  const lookup = new SqlRepo(db).responsesItems.lookupMany('key_a', ids);
-
+  const repo = new SqlRepo(db).responsesItems;
+  const metadata = await repo.lookupMany('key_a', ids);
+  assertEquals(files.getCalls, 0);
+  const lookup = repo.lookupPayloads('key_a', ids);
   await files.waitForFirstGet();
   const startedBeforeRelease = files.getCalls;
   files.releaseAll();
-  const rows = await lookup;
+  const payloads = await lookup;
 
   assertEquals(startedBeforeRelease, 1);
-  assertEquals(rows.map(row => row.id), ids);
+  assertEquals(metadata.map(row => row.id), ids);
+  assertEquals(payloads.map(row => row.id), ids);
 });
 
 test('SQL responses items repo serializes one payload at a time within write batches', async () => {
@@ -462,7 +469,8 @@ test('SQL responses items repo spills large payloads through the runtime file pr
   assertEquals(typeof descriptor.key, 'string');
   assertEquals((descriptor.key as string).startsWith('responses-items/v1/expires/2026/06/27/12/'), true);
   assert((await files.get(descriptor.key as string)) !== null);
-  assertEquals(await repo.lookupMany('key_a', [item.id]), [item]);
+  assertEquals(await repo.lookupMany('key_a', [item.id]), [storedResponsesItemMetadata(item)]);
+  assertEquals((await repo.lookupPayloads('key_a', [item.id]))[0].payload, payload);
 });
 
 test('SQL responses items deleteAll removes spilled payload files alongside the rows', async () => {
@@ -775,24 +783,29 @@ class FakeResponsesItemsSqlDatabase implements SqlDatabase {
     return 1;
   }
 
-  lookup(query: string, binds: unknown[]): FakeResponsesItemRow[] {
+  lookup(query: string, binds: unknown[]): unknown[] {
     const [apiKeyId, ...keys] = binds as [string | null, ...string[]];
     const wanted = new Set(keys);
+    let matches: FakeResponsesItemRow[];
     if (query.includes('encrypted_content_hash IN')) {
-      return this.rows
+      matches = this.rows
         .filter(row => row.api_key_id === apiKeyId && row.encrypted_content_hash !== null && wanted.has(row.encrypted_content_hash))
         .map(row => ({ ...row }))
         .toSorted(compareFakeResponsesItemsByFreshness);
-    }
-    if (query.includes('content_hash IN')) {
-      return this.rows
+    } else if (query.includes('content_hash IN')) {
+      matches = this.rows
         .filter(row => row.api_key_id === apiKeyId && row.content_hash !== null && wanted.has(row.content_hash))
         .map(row => ({ ...row }))
         .toSorted(compareFakeResponsesItemsByFreshness);
+    } else {
+      matches = this.rows.filter(row => wanted.has(row.id) && row.api_key_id === apiKeyId);
+      const order = new Map(keys.map((id, index) => [id, index]));
+      matches = matches.map(row => ({ ...row })).toSorted((a, b) => order.get(a.id)! - order.get(b.id)!);
     }
-    const matches = this.rows.filter(row => wanted.has(row.id) && row.api_key_id === apiKeyId);
-    const order = new Map(keys.map((id, index) => [id, index]));
-    return matches.map(row => ({ ...row })).toSorted((a, b) => order.get(a.id)! - order.get(b.id)!);
+    if (query.startsWith('SELECT id, payload_json')) {
+      return matches.map(row => ({ id: row.id, payload_json: row.payload_json }));
+    }
+    return matches.map(({ payload_json: payloadJson, ...row }) => ({ ...row, has_payload: payloadJson === null ? 0 : 1 }));
   }
 
   clearPayloadOlderThan(createdBefore: number): number {

--- a/packages/gateway/src/repo/responses-items_test.ts
+++ b/packages/gateway/src/repo/responses-items_test.ts
@@ -261,11 +261,13 @@ test('memory responses items repo clones item JSON at the repo boundary', async 
   await repo.insertMany([item]);
   (item.payload!.item as { nested: { values: string[] } }).nested.values.push('mutated-after-write');
 
-  const [read] = await repo.lookupMany('key_a', [item.id]);
+  const [metadata] = await repo.lookupMany('key_a', [item.id]);
+  const [read] = await repo.lookupPayloads('key_a', [item.id]);
+  assertEquals(metadata.hasPayload, true);
   assertEquals(read.payload, { item: { nested: { values: ['original'] } } });
-  (read.payload!.item as { nested: { values: string[] } }).nested.values.push('mutated-after-read');
+  (read.payload.item as { nested: { values: string[] } }).nested.values.push('mutated-after-read');
 
-  assertEquals((await repo.lookupMany('key_a', [item.id]))[0].payload, { item: { nested: { values: ['original'] } } });
+  assertEquals((await repo.lookupPayloads('key_a', [item.id]))[0].payload, { item: { nested: { values: ['original'] } } });
 });
 
 test('memory responses items repo scopes ids by api key and treats duplicate scoped writes as no-ops', async () => {

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -908,20 +908,21 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
     const unique = [...new Set(ids)];
     const chunks: string[][] = [];
     for (let index = 0; index < unique.length; index += 90) chunks.push(unique.slice(index, index + 90));
-    const records: StoredResponsesItemPayloadRecord[] = [];
-    for (const chunk of chunks) {
+    const perChunk = await Promise.all(chunks.map(async chunk => {
       const placeholders = chunk.map(() => '?').join(', ');
       const { results } = await this.db
         .prepare(`SELECT id, payload_json FROM responses_items WHERE ${RESPONSES_ITEM_ID_SCOPE_SQL} AND id IN (${placeholders})`)
         .bind(apiKeyId, ...chunk)
         .all<{ id: string; payload_json: string | null }>();
-      const rowsById = new Map(results.map(row => [row.id, row]));
-      for (const id of chunk) {
-        const row = rowsById.get(id);
-        if (row?.payload_json === null || row === undefined) continue;
-        const payload = await parseStoredResponsesPayload(id, row.payload_json);
-        if (payload !== null) records.push({ id, payload });
-      }
+      return results;
+    }));
+    const rowsById = new Map(perChunk.flat().map(row => [row.id, row]));
+    const records: StoredResponsesItemPayloadRecord[] = [];
+    for (const id of unique) {
+      const row = rowsById.get(id);
+      if (row === undefined || row.payload_json === null) continue;
+      const payload = await parseStoredResponsesPayload(id, row.payload_json);
+      if (payload !== null) records.push({ id, payload });
     }
     return records;
   }

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -919,9 +919,9 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
     const rowsById = new Map(perChunk.flat().map(row => [row.id, row]));
     const records: StoredResponsesItemPayloadRecord[] = [];
     for (const id of unique) {
-      const row = rowsById.get(id);
-      if (row === undefined || row.payload_json === null) continue;
-      const payload = await parseStoredResponsesPayload(id, row.payload_json);
+      const payloadJson = rowsById.get(id)?.payload_json;
+      if (payloadJson === undefined || payloadJson === null) continue;
+      const payload = await parseStoredResponsesPayload(id, payloadJson);
       if (payload !== null) records.push({ id, payload });
     }
     return records;

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -28,6 +28,8 @@ import type {
   Session,
   SessionsRepo,
   StoredResponsesItem,
+  StoredResponsesItemMetadata,
+  StoredResponsesItemPayloadRecord,
   StoredResponsesSnapshot,
   UpstreamRepo,
   UsageRecord,
@@ -854,23 +856,24 @@ class SqlModelsCacheRepo implements ModelsCacheRepo {
   }
 }
 
-const RESPONSES_ITEM_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, content_hash, encrypted_content_hash, created_at, refreshed_at';
+const RESPONSES_ITEM_WRITE_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json, content_hash, encrypted_content_hash, created_at, refreshed_at';
+const RESPONSES_ITEM_METADATA_COLUMNS = 'id, api_key_id, upstream_id, upstream_item_id, item_type, origin, payload_json IS NOT NULL AS has_payload, content_hash, encrypted_content_hash, created_at, refreshed_at';
 const RESPONSES_ITEM_ID_SCOPE_SQL = "COALESCE(api_key_id, '') = COALESCE(?, '')";
 
 class SqlResponsesItemsRepo implements ResponsesItemsRepo {
   constructor(private db: SqlDatabase) {}
 
-  async lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItem[]> {
+  async lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemMetadata[]> {
     const rows = await this.lookupByColumn(apiKeyId, 'id', ids);
     const order = new Map([...new Set(ids)].map((id, index) => [id, index]));
     return rows.toSorted((a, b) => order.get(a.id)! - order.get(b.id)!);
   }
 
-  async lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]> {
+  async lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItemMetadata[]> {
     return await this.lookupByColumn(apiKeyId, 'encrypted_content_hash', hashes);
   }
 
-  async lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]> {
+  async lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItemMetadata[]> {
     return await this.lookupByColumn(apiKeyId, 'content_hash', hashes);
   }
 
@@ -880,7 +883,7 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
   // reasoning/compaction item each turn — so chunk the IN-list well under
   // the tightest backend (the `api_key_id` bind shares the budget) and union
   // the results.
-  private async lookupByColumn(apiKeyId: string | null, column: 'id' | 'content_hash' | 'encrypted_content_hash', values: readonly string[]): Promise<StoredResponsesItem[]> {
+  private async lookupByColumn(apiKeyId: string | null, column: 'id' | 'content_hash' | 'encrypted_content_hash', values: readonly string[]): Promise<StoredResponsesItemMetadata[]> {
     const unique = [...new Set(values)];
     if (unique.length === 0) return [];
 
@@ -893,16 +896,34 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
       const orderSql = column === 'id' ? '' : ' ORDER BY refreshed_at DESC, created_at DESC, id ASC';
       const scopeSql = column === 'id' ? RESPONSES_ITEM_ID_SCOPE_SQL : 'api_key_id IS ?';
       const { results } = await this.db
-        .prepare(`SELECT ${RESPONSES_ITEM_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
+        .prepare(`SELECT ${RESPONSES_ITEM_METADATA_COLUMNS} FROM responses_items WHERE ${scopeSql} AND ${column} IN (${placeholders})${orderSql}`)
         .bind(apiKeyId, ...chunk)
-        .all<ResponsesItemRow>();
+        .all<ResponsesItemMetadataRow>();
       return results;
     }));
-    // Payload codecs hold compressed bytes, expanded JSON, and the parsed clone
-    // at once. Keep D1 chunk reads parallel, then bound that transient working
-    // set to one item per lookup under Workers' 128 MB isolate limit.
-    // https://developers.cloudflare.com/workers/platform/limits/#memory
-    return await mapSequentially(perChunk.flat(), toStoredResponsesItem);
+    return perChunk.flat().map(toStoredResponsesItemMetadata);
+  }
+
+  async lookupPayloads(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemPayloadRecord[]> {
+    const unique = [...new Set(ids)];
+    const chunks: string[][] = [];
+    for (let index = 0; index < unique.length; index += 90) chunks.push(unique.slice(index, index + 90));
+    const records: StoredResponsesItemPayloadRecord[] = [];
+    for (const chunk of chunks) {
+      const placeholders = chunk.map(() => '?').join(', ');
+      const { results } = await this.db
+        .prepare(`SELECT id, payload_json FROM responses_items WHERE ${RESPONSES_ITEM_ID_SCOPE_SQL} AND id IN (${placeholders})`)
+        .bind(apiKeyId, ...chunk)
+        .all<{ id: string; payload_json: string | null }>();
+      const rowsById = new Map(results.map(row => [row.id, row]));
+      for (const id of chunk) {
+        const row = rowsById.get(id);
+        if (row?.payload_json === null || row === undefined) continue;
+        const payload = await parseStoredResponsesPayload(id, row.payload_json);
+        if (payload !== null) records.push({ id, payload });
+      }
+    }
+    return records;
   }
 
   async insertMany(items: readonly StoredResponsesItem[]): Promise<void> {
@@ -910,7 +931,7 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
       const payload = await serializeStoredResponsesPayload(item.id, item.apiKeyId, item.createdAt, item.payload);
       return this.db
         .prepare(
-          `INSERT INTO responses_items (${RESPONSES_ITEM_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO responses_items (${RESPONSES_ITEM_WRITE_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT (id, COALESCE(api_key_id, '')) DO NOTHING`,
         )
         .bind(item.id, item.apiKeyId, item.upstreamId, item.upstreamItemId, item.itemType, item.origin, payload, item.contentHash, item.encryptedContentHash, item.createdAt, item.refreshedAt);
@@ -966,28 +987,28 @@ class SqlResponsesItemsRepo implements ResponsesItemsRepo {
   }
 }
 
-interface ResponsesItemRow {
+interface ResponsesItemMetadataRow {
   id: string;
   api_key_id: string | null;
   upstream_id: string | null;
   upstream_item_id: string | null;
   item_type: string;
   origin: StoredResponsesItem['origin'];
-  payload_json: string | null;
+  has_payload: number;
   content_hash: string | null;
   encrypted_content_hash: string | null;
   created_at: number;
   refreshed_at: number;
 }
 
-const toStoredResponsesItem = async (row: ResponsesItemRow): Promise<StoredResponsesItem> => ({
+const toStoredResponsesItemMetadata = (row: ResponsesItemMetadataRow): StoredResponsesItemMetadata => ({
   id: row.id,
   apiKeyId: row.api_key_id,
   upstreamId: row.upstream_id,
   upstreamItemId: row.upstream_item_id,
   itemType: row.item_type,
   origin: row.origin,
-  payload: await parseStoredResponsesPayload(row.id, row.payload_json),
+  hasPayload: row.has_payload !== 0,
   contentHash: row.content_hash,
   encryptedContentHash: row.encrypted_content_hash,
   createdAt: row.created_at,

--- a/packages/gateway/src/repo/types.ts
+++ b/packages/gateway/src/repo/types.ts
@@ -350,14 +350,14 @@ export interface ModelAliasesRepo {
   deleteAll(): Promise<void>;
 }
 
-export interface StoredResponsesItem {
+export interface StoredResponsesItemMetadata {
   id: string;
   apiKeyId: string | null;
   upstreamId: string | null;
   upstreamItemId: string | null;
   itemType: string;
   origin: 'input' | 'upstream' | 'synthetic';
-  payload: StoredResponsesItemPayload | null;
+  hasPayload: boolean;
   contentHash: string | null;
   // sha256 of the item's `encrypted_content`, when it carries one (reasoning /
   // compaction). Lets a later turn that echoes the blob without a gateway id
@@ -365,6 +365,10 @@ export interface StoredResponsesItem {
   encryptedContentHash: string | null;
   createdAt: number;
   refreshedAt: number;
+}
+
+export interface StoredResponsesItem extends Omit<StoredResponsesItemMetadata, 'hasPayload'> {
+  payload: StoredResponsesItemPayload | null;
 }
 
 export interface StoredResponsesItemPayload {
@@ -376,10 +380,16 @@ export interface StoredResponsesItemPayload {
   private?: unknown;
 }
 
+export interface StoredResponsesItemPayloadRecord {
+  id: string;
+  payload: StoredResponsesItemPayload;
+}
+
 export interface ResponsesItemsRepo {
-  lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItem[]>;
-  lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
-  lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItem[]>;
+  lookupMany(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemMetadata[]>;
+  lookupManyByContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItemMetadata[]>;
+  lookupManyByEncryptedContentHash(apiKeyId: string | null, hashes: readonly string[]): Promise<StoredResponsesItemMetadata[]>;
+  lookupPayloads(apiKeyId: string | null, ids: readonly string[]): Promise<StoredResponsesItemPayloadRecord[]>;
   insertMany(items: readonly StoredResponsesItem[]): Promise<void>;
   fillPayloads(items: readonly StoredResponsesItem[]): Promise<number>;
   refreshMany(apiKeyId: string | null, ids: readonly string[], refreshedAt: number): Promise<number>;


### PR DESCRIPTION
## Summary

- Query stored Responses items as payload-free metadata, deriving only `hasPayload` from D1.
- Load selected payloads through a separate scoped bulk API only when rewrite needs canonical content or private state.
- Keep one shared metadata object per item across id/content/encrypted-hash indexes instead of cloning payload-bearing rows.
- Reconstruct Codex's input-shaped echoes and verify their durable content hash, avoiding hydration when the request already carries canonical content.
- Preserve affinity, refresh, payload repair, SQL batching, and `item_reference` capability semantics.

## Why

The captured 928-item request previously caused three eager lookups to decode 1,252 payload rows before upstream dispatch: 631 by id, 292 by content hash, and 329 by encrypted-content hash. Those results represented 923 unique rows, so every reasoning row was decoded twice, and payload-bearing rows were cloned again into each store index and getter.

The request already carries full item content. Metadata-only reconstruction matches the durable content hash for all 631 stored-id echoes after restoring their upstream id and the completed/empty defaults omitted by Codex's input-shaped history. The 292 id-less matches are already content-hash exact. As a result, this workload requires zero payload hydration before upstream dispatch.

## Memory and latency evidence

The benchmark exercises the real `SqlRepo.lookupMany` over 928 stored rows derived from the captured request. Values are medians from three fresh Node processes with GC immediately before the measured lookup.

| Revision | Payloads returned | R2 gets | Peak RSS delta | Peak heap delta | Peak ArrayBuffer delta | Lookup time |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `main` | 928 | 1 | 13.83 MiB | 30.28 MiB | 13.67 MiB | 143.60 ms |
| This branch | 0 | 0 | 0.02 MiB | 1.15 MiB | 0 MiB | 1.46 ms |

Read-only production-D1 correlation for the same request confirms the end-to-end lookup shape: 1,252 eager codec invocations become 923 unique metadata rows and zero payload decodes on the canonical fast path.

## Semantics and accepted tradeoffs

Metadata is sufficient for affinity, freshness ordering, durable eligibility, snapshot validation, and retention refresh. Explicit `item_reference` expansion, synthetic/private state, and a full caller item whose normalized hash differs from durable content still load the stored payload in bulk and preserve the existing canonical-body behavior.

Malformed descriptors and missing/corrupt files now fail when that payload is actually used instead of during unrelated metadata lookup. This fail-on-use shift is intrinsic to lazy loading; codec and integrity errors otherwise propagate unchanged. A corrupted row may be touched before its deferred payload failure, so failure-path refresh ordering can differ while happy-path retention semantics remain unchanged.

WebSocket session snapshots no longer copy pre-existing durable history payloads into the local backing. They retain item ids and resolve that history through the repository on later turns; new state created inside the socket remains local as before. This avoids defeating metadata-first memory savings. The accepted edge case is that durable payload cleanup between two turns can now make that old history unavailable where the previous local copy would have survived for the socket lifetime.

No schema migration is required. The metadata query derives `hasPayload` from the existing `payload_json` column.

## Test plan

- [x] `pnpm vitest run --project @floway-dev/gateway` (146 files, 1,819 tests)
- [x] Responses state/rewrite/output targeted suite (127 tests)
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] ESLint across all changed gateway files
- [x] Deploy the merged-main PR branch to production as version `3abab867-9166-4c21-9c91-166ed46bd01d` and verify public HTTP 200
