### PR TITLE
refactor(responses): expand item references before upstream

### DIFF
--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -276,9 +276,9 @@ interface ModelCandidate {
 }
 ```
 
-- `provider` is the resolved upstream provider instance — every wire call,
-  capability flag, and pricing lookup reads off `provider.*` directly
-  (upstream id, upstream name, provider kind, `supportsResponsesItemReference`).
+- `provider` is the resolved upstream provider instance — every wire call and
+  pricing lookup reads off `provider.*` directly (upstream id, upstream name,
+  and provider kind).
 - `model` is the merged public row for this id, projected to a single
   contributing upstream: `providerModels` carries exactly one entry keyed
   on `provider.upstream`. That entry is the `ProviderModel` the upstream
@@ -358,11 +358,12 @@ Candidates are ordered before they reach dispatch:
 
 For Responses-shape inbound, the affinity walk
 (`classifyResponsesItemAffinity`) adjusts the ordering by stored-item
-affinity before dispatch sees it. The walk reads
-`provider.supportsResponsesItemReference` to decide whether a candidate
-can absorb an unexpanded `item_reference` carrier and rejects a request
-that names a forcing upstream the candidate list does not include. The
-affinity walk never invents new candidates; it only narrows or re-orders
+affinity before dispatch sees it. It resolves stored ids from metadata,
+rejects an `item_reference` whose durable payload is unavailable, and uses
+the referenced row's actual item type to determine upstream affinity. The
+candidate rewrite then bulk-loads the payloads it needs and replaces every
+`item_reference` with the stored item before the upstream request is built.
+The affinity walk never invents new candidates; it only narrows or re-orders
 the list the resolver produced.
 
 Serve dispatches the first candidate of the ordered list exactly once.

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt_test.ts
@@ -73,7 +73,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
@@ -108,7 +108,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -94,7 +94,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt_test.ts
@@ -89,7 +89,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -117,7 +117,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel({ endpoints }, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -139,7 +139,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel({ endpoints }, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
@@ -66,7 +66,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -113,7 +113,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind: 'custom', name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -141,7 +141,7 @@ const makeCandidate = (overrides: {
   return {
     provider: {
       upstream, kind, name: upstream,
-      disabledPublicModelIds: [], modelPrefix: null, instance: provider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel({
       ...(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -63,7 +63,6 @@ const makeCandidate = (
       disabledPublicModelIds: [],
       modelPrefix: null,
       instance: provider,
-      supportsResponsesItemReference: true,
     },
     model: stubInternalModel({
       providerModels: { [upstream]: stubProviderModel({ enabledFlags }) },
@@ -213,14 +212,10 @@ test('generate returns failure when rewrite throws item-not-found', async () => 
     throw new Error('callResponses should not be called when rewrite fails');
   });
   const candidate = makeCandidate(callResponses);
-  // Force `supportsResponsesItemReference: false` so a stored row with no
-  // inline payload triggers the rewrite-side throw.
-  candidate.provider.supportsResponsesItemReference = false;
 
   const missingId = createStoredResponsesItemId('message');
-  // Pre-seed the store cache: a row with no inline payload, referenced as
-  // `item_reference`. The store will resolve the id, and rewrite will throw
-  // because the candidate cannot accept `item_reference`.
+  // Pre-seed the store cache with a row whose payload is unavailable so the
+  // rewrite cannot expand the reference.
   const store = createResponsesHttpStore(API_KEY_ID, true);
   // Insert into the underlying repo so `loadInputItems` populates the cache.
   // The store uses `getRepo()` lazily, so the repo installed via `installRepo`
@@ -373,7 +368,7 @@ test('generate inherits invocation headers across translation to Messages', asyn
   const candidate: ModelCandidate = {
     provider: {
       upstream: 'up_test', kind: 'custom', name: 'up_test',
-      disabledPublicModelIds: [], modelPrefix: null, instance: messagesProvider, supportsResponsesItemReference: true,
+      disabledPublicModelIds: [], modelPrefix: null, instance: messagesProvider,
     },
     model: upstreamModel,
     fetcher: directFetcher,

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -133,7 +133,6 @@ const makeCandidate = (overrides: {
       disabledPublicModelIds: [],
       modelPrefix: null,
       instance: provider,
-      supportsResponsesItemReference: true,
     },
     model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
     fetcher: directFetcher,
@@ -326,7 +325,7 @@ test('POST /v1/responses renders a routing-unavailable 400 when a forcing item n
     origin: 'upstream',
     contentHash: null,
     encryptedContentHash: null,
-    payload: null,
+    payload: { item: { type: 'compaction', id } },
     createdAt: 1_000,
     refreshedAt: 1_000,
   };

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -44,7 +44,6 @@ const defaultCandidates = vi.hoisted(() => () => [{
     disabledPublicModelIds: [],
     modelPrefix: null,
     color: null,
-    supportsResponsesItemReference: false,
     instance: {
       getPricingForModelKey: () => null,
       callImagesGenerations: async (_model: unknown, body: Record<string, unknown>) => {

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
@@ -20,11 +20,7 @@ interface ResolvedStoredResponsesItemRef {
 const isUpstreamOwned = (row: StoredResponsesItemMetadata): row is StoredResponsesItemMetadata & { upstreamId: string } =>
   row.upstreamId !== null;
 
-const classifyStoredResponsesAffinity = (
-  itemType: string,
-  row: StoredResponsesItemMetadata,
-): StoredResponsesAffinity => {
-  if (itemType === 'item_reference' && !row.hasPayload) return 'forcing';
+const classifyStoredResponsesAffinity = (row: StoredResponsesItemMetadata): StoredResponsesAffinity => {
   if (!isUpstreamOwned(row)) return 'non_affinity';
   // Direct Copilot probes show the opaque item id on each program variant is
   // account-bound: same-account replay succeeds after token refresh, while
@@ -61,16 +57,6 @@ const collectPreferredUpstreams = (
   }
   return preferred;
 };
-
-const findUnexpandedItemReferenceForcingId = (
-  references: readonly ResolvedStoredResponsesItemRef[],
-  upstreamId: string,
-): string | null =>
-  references.find(ref =>
-    ref.affinity === 'forcing'
-    && ref.type === 'item_reference'
-    && ref.row?.upstreamId === upstreamId
-    && !ref.row.hasPayload)?.id ?? null;
 
 const collectStoredResponsesItemRefs = async <TSourceItems>(
   sourceItems: TSourceItems,
@@ -164,7 +150,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems, TCandidate ext
 
     store.touchItem(row.id);
     ref.row = row;
-    if (ref.type === 'item_reference' && !row.hasPayload && row.upstreamItemId === null) {
+    if (ref.type === 'item_reference' && !row.hasPayload) {
       failures.push({ kind: 'item-not-found', itemId: row.id });
       continue;
     }
@@ -175,7 +161,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems, TCandidate ext
       });
       continue;
     }
-    ref.affinity = classifyStoredResponsesAffinity(ref.type, row);
+    ref.affinity = classifyStoredResponsesAffinity(row);
     if (ref.affinity === 'forcing' && !isUpstreamOwned(row)) {
       failures.push({ kind: 'item-not-found', itemId: row.id });
     }
@@ -206,14 +192,6 @@ export const classifyResponsesItemAffinity = async <TSourceItems, TCandidate ext
           message: `Stored Responses items in this request require upstream '${upstreamId}', which is not available for the selected model.`,
         },
       };
-    }
-    const unexpandedReferenceId = findUnexpandedItemReferenceForcingId(references, upstreamId);
-    if (unexpandedReferenceId !== null) {
-      const itemReferenceCapable = matching.filter(cand => cand.provider.supportsResponsesItemReference);
-      if (itemReferenceCapable.length === 0) {
-        return { kind: 'failure', failure: { kind: 'item-not-found', itemId: unexpandedReferenceId } };
-      }
-      return { kind: 'success', candidates: itemReferenceCapable };
     }
     return { kind: 'success', candidates: matching };
   }

--- a/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity_test.ts
@@ -14,7 +14,7 @@ import { responsesItemsView } from '@floway-dev/translate/via-responses/response
 
 const API_KEY_ID = 'key_affinity_test';
 
-const candidate = (upstream: string, supportsResponsesItemReference = true): ModelCandidate => {
+const candidate = (upstream: string): ModelCandidate => {
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([stubProviderModel()]),
   });
@@ -26,7 +26,6 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Mod
       disabledPublicModelIds: [],
       modelPrefix: null,
       instance: modelProvider,
-      supportsResponsesItemReference,
     },
     model: stubInternalModel({}, upstream),
     fetcher: directFetcher,
@@ -232,13 +231,13 @@ test('row item type must match source item type', async () => {
   if (result.kind === 'failure') assertEquals(result.failure.kind, 'routing-unavailable');
 });
 
-test('metadata-only item_reference rejects when the origin upstream does not support item_reference', async () => {
-  const id = storedMessageId('metadata-only-reference-unsupported');
+test('metadata-only item_reference rejects even with an upstream item id', async () => {
+  const id = storedMessageId('metadata-only-reference-with-upstream-item-id');
   await insertRows([
     storedRow({ id, itemType: 'message', upstreamId: 'up_a', upstreamItemId: 'raw_msg_a', payload: null }),
   ]);
 
-  const result = await classifyItems([{ type: 'item_reference', id }], [candidate('up_a', false)]);
+  const result = await classifyItems([{ type: 'item_reference', id }], [candidate('up_a')]);
 
   assertEquals(result.kind, 'failure');
   if (result.kind === 'failure') {

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -67,11 +67,7 @@ const shouldHydrate = async (
   const { item, row } = resolved;
   if (!row?.hasPayload) return false;
   if (isUpstreamOwned(row) && row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return false;
-  if (item.type === 'item_reference') {
-    return !(row.upstreamId === candidate.provider.upstream
-      && row.upstreamItemId !== null
-      && candidate.provider.supportsResponsesItemReference);
-  }
+  if (item.type === 'item_reference') return true;
   if (row.origin === 'synthetic') return true;
   const canonical = canonicalStoredEcho(item, row);
   if (row.contentHash !== null && await hashResponsesItemContent(canonical) === row.contentHash) {
@@ -87,18 +83,22 @@ const rewriteItemForCandidate = (
   candidate: ModelCandidate,
 ): ResponsesInputItem | null => {
   const { item, row } = resolved;
-  if (row === undefined) return item;
-  if (item.type === 'item_reference' && payload === undefined && !candidate.provider.supportsResponsesItemReference) {
+  if (row === undefined) {
+    if (item.type === 'item_reference') throwChatServeFailure({ kind: 'item-not-found', itemId: item.id });
+    return item;
+  }
+  if (item.type === 'item_reference' && !row.hasPayload) {
+    throwChatServeFailure({ kind: 'item-not-found', itemId: row.id });
+  }
+  if (isUpstreamOwned(row) && row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return null;
+  if (item.type === 'item_reference' && payload === undefined) {
     throwChatServeFailure({ kind: 'item-not-found', itemId: row.id });
   }
   const replacement = resolved.canonical
     ?? (payload === undefined ? item : structuredClone(payload.item) as ResponsesInputItem);
   if (!isUpstreamOwned(row)) return replacement;
-  if (row.itemType === 'reasoning' && row.upstreamId !== candidate.provider.upstream) return null;
   if (row.upstreamId === candidate.provider.upstream && row.upstreamItemId !== null) {
-    return item.type === 'item_reference' && candidate.provider.supportsResponsesItemReference
-      ? itemWithId(item, row.upstreamItemId)
-      : itemWithId(replacement, row.upstreamItemId);
+    return itemWithId(replacement, row.upstreamItemId);
   }
   if (responsesItemId(replacement) !== null) return itemWithId(replacement, createTemporaryResponsesItemId(row.itemType));
   return replacement;

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -15,7 +15,7 @@ import { responsesItemsView, type CanonicalResponsesPayload } from '@floway-dev/
 
 const API_KEY_ID = 'key_rewrite_test';
 
-const candidate = (upstream: string, supportsResponsesItemReference = true): ModelCandidate => {
+const candidate = (upstream: string): ModelCandidate => {
   const modelProvider = stubProvider({
     getProvidedModels: () => Promise.resolve([stubProviderModel()]),
   });
@@ -27,7 +27,6 @@ const candidate = (upstream: string, supportsResponsesItemReference = true): Mod
       disabledPublicModelIds: [],
       modelPrefix: null,
       instance: modelProvider,
-      supportsResponsesItemReference,
     },
     model: stubInternalModel({}, upstream),
     fetcher: directFetcher,
@@ -92,8 +91,8 @@ test('item with no stored row is kept as-is', async () => {
   assertEquals(rewritten, [item]);
 });
 
-// Case 2: item_reference + row.payload === null + provider doesn't support item_reference → throw item-not-found
-test('item_reference with null payload throws item-not-found when provider does not support item_reference', async () => {
+// Case 2: item_reference + row.payload === null → throw item-not-found
+test('item_reference with null payload throws item-not-found', async () => {
   const id = storedMessageId('no-payload-ref');
   await insertRows([
     storedRow({ id, itemType: 'message', upstreamId: 'up_a', upstreamItemId: 'raw_msg_a', payload: null }),
@@ -101,7 +100,7 @@ test('item_reference with null payload throws item-not-found when provider does 
 
   let threw = false;
   try {
-    await rewrite([{ type: 'item_reference', id }], candidate('up_a', false));
+    await rewrite([{ type: 'item_reference', id }], candidate('up_a'));
   } catch {
     threw = true;
   }
@@ -233,7 +232,7 @@ test('stored payload replaces stale caller content before provider id rewrite', 
   }]);
 });
 
-test('matching upstream keeps item_reference shape and rewrites to upstream item id', async () => {
+test('matching upstream expands item_reference and rewrites to upstream item id', async () => {
   const id = storedMessageId('origin-reference');
   await insertRows([
     storedRow({
@@ -253,11 +252,16 @@ test('matching upstream keeps item_reference shape and rewrites to upstream item
   const input: ResponsesInputItem[] = [{ type: 'item_reference', id }];
   const rewritten = await rewrite(input, candidate('up_a'));
 
-  assertEquals(rewritten, [{ type: 'item_reference', id: 'raw_msg_a' }]);
+  assertEquals(rewritten, [{
+    type: 'message',
+    id: 'raw_msg_a',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'stored content' }],
+  }]);
 });
 
-test('matching upstream without item_reference support expands the stored item body', async () => {
-  const id = storedMessageId('origin-reference-expanded');
+test('non-matching upstream expands item_reference and mints a temporary id', async () => {
+  const id = storedMessageId('cross-upstream-reference');
   await insertRows([
     storedRow({
       id,
@@ -274,14 +278,15 @@ test('matching upstream without item_reference support expands the stored item b
   ]);
 
   const input: ResponsesInputItem[] = [{ type: 'item_reference', id }];
-  const rewritten = await rewrite(input, candidate('up_a', false));
+  const rewritten = await rewrite(input, candidate('up_b'));
 
-  assertEquals(rewritten, [{
-    type: 'message',
-    id: 'raw_msg_a',
-    role: 'assistant',
-    content: [{ type: 'output_text', text: 'stored content' }],
-  }]);
+  assertEquals(rewritten.length, 1);
+  const [item] = rewritten;
+  assert(item.type === 'message');
+  assert(typeof item.id === 'string');
+  assert(item.id.startsWith('msg_tmp_'), item.id);
+  assertEquals(item.role, 'assistant');
+  assertEquals(item.content, [{ type: 'output_text', text: 'stored content' }]);
 });
 
 test('id-less reasoning matched by encrypted_content routes to owner and stamps upstream id', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -47,7 +47,7 @@ export const responsesServe = {
     const { payload, ctx, headers } = args;
     // Compact accepts `previous_response_id` (the official endpoint documents
     // it). When present serve-prep expands it the same way generate does so
-    // the upstream sees the same item_reference + current input shape.
+    // the candidate rewrite can restore the stored history before dispatch.
     //
     // For non-responses targets the responses-compact-shim picks up the
     // request inside the interceptor chain, flips action='compact' to

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -128,7 +128,6 @@ const makeCandidate = (overrides: {
       disabledPublicModelIds: [],
       modelPrefix: null,
       instance: provider,
-      supportsResponsesItemReference: true,
     },
     // Default keeps stubInternalModel's three-endpoint map intact; tests that
     // need a rejected candidate pass an explicit `endpoints` override.
@@ -325,7 +324,7 @@ test('generate renders routing-unavailable as a 400 when a forcing item names an
     origin: 'upstream',
     contentHash: null,
     encryptedContentHash: null,
-    payload: null,
+    payload: { item: { type: 'compaction', id } },
     createdAt: 1_000,
     refreshedAt: 1_000,
   };
@@ -358,7 +357,7 @@ test('compact renders routing-unavailable when no candidate exposes the response
     origin: 'upstream',
     contentHash: null,
     encryptedContentHash: null,
-    payload: null,
+    payload: { item: { type: 'compaction', id } },
     createdAt: 1_000,
     refreshedAt: 1_000,
   }]);
@@ -711,9 +710,10 @@ test('generate treats compaction_trigger-bearing input as compaction: snapshot r
   assertEquals(onlyItemId.startsWith('cmp_'), true);
 
   // The trigger still reaches the upstream — the gateway only intercepts at
-  // the storage seam, not on the wire. The expanded prefix puts item_reference
-  // first, the trigger last.
+  // the storage seam, not on the wire. The stored message is expanded first
+  // and the trigger remains last.
   if (!Array.isArray(receivedInput)) throw new Error('expected the wire input to be an array');
+  assertEquals(receivedInput[0], { type: 'message', id: priorMessageId, role: 'user', content: 'old turn' });
   assertEquals((receivedInput.at(-1) as { type?: unknown })?.type, 'compaction_trigger');
 });
 

--- a/packages/gateway/src/data-plane/chat/shared/routing.ts
+++ b/packages/gateway/src/data-plane/chat/shared/routing.ts
@@ -3,8 +3,7 @@ import type { ModelCandidate } from '@floway-dev/provider';
 
 // Generic over the candidate type so call sites can narrow back to their
 // concrete shape. The candidate filtering and ordering inside routing is
-// shape-agnostic — it touches `candidate.provider.upstream` and
-// `candidate.provider.supportsResponsesItemReference` only.
+// shape-agnostic and preserves the concrete candidate objects it receives.
 export type RoutingDecision<T extends ModelCandidate = ModelCandidate> =
   | { readonly kind: 'success'; readonly candidates: readonly T[] }
   | { readonly kind: 'failure'; readonly failure: ChatServeFailure };

--- a/packages/gateway/src/data-plane/providers/azure/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/azure/provider_test.ts
@@ -51,7 +51,6 @@ test('createAzureProvider projects configured models into upstream models', asyn
 
   assertEquals(instance.upstream, 'up_azure');
   assertEquals(instance.name, 'Azure Resource');
-  assertEquals(instance.supportsResponsesItemReference, true);
   assertEquals(models[0]?.enabledFlags.has('vendor-kimi'), true);
   assertEquals(
     models.map(model => ({ id: model.id, displayName: model.display_name, endpoints: model.endpoints, providerData: model.providerData })),

--- a/packages/gateway/src/data-plane/providers/custom/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/custom/provider_test.ts
@@ -34,8 +34,6 @@ test('Custom provider forces stream=true for streaming endpoints and leaves coun
   const provider = instance.instance;
   const bodies: Record<string, Record<string, unknown>> = {};
 
-  assertEquals(instance.supportsResponsesItemReference, true);
-
   await withMockedFetch(
     async request => {
       const url = new URL(request.url);

--- a/packages/gateway/src/data-plane/providers/models-cache_test.ts
+++ b/packages/gateway/src/data-plane/providers/models-cache_test.ts
@@ -17,7 +17,6 @@ const stubInstance = (
   name: upstreamId,
   disabledPublicModelIds: [],
   modelPrefix: null,
-  supportsResponsesItemReference: false,
   instance: stubProvider({ getProvidedModels: fetchFn }),
 });
 

--- a/packages/gateway/src/data-plane/shared/iterate-candidates_test.ts
+++ b/packages/gateway/src/data-plane/shared/iterate-candidates_test.ts
@@ -16,7 +16,6 @@ const stubCandidate = (id: string, upstream = 'up'): ModelCandidate =>
       disabledPublicModelIds: [],
       modelPrefix: null,
       instance: stubProvider(),
-      supportsResponsesItemReference: false,
     },
   });
 

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -111,6 +111,5 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
     disabledPublicModelIds: azure.disabledPublicModelIds,
     modelPrefix: azure.modelPrefix,
     instance,
-    supportsResponsesItemReference: true,
   };
 };

--- a/packages/provider-claude-code/src/provider.ts
+++ b/packages/provider-claude-code/src/provider.ts
@@ -105,7 +105,6 @@ export const createClaudeCodeProvider = (record: UpstreamRecord): Provider => {
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
     instance,
-    supportsResponsesItemReference: false,
   };
 };
 

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -142,10 +142,9 @@ describe('createClaudeCodeProvider — factory surface', () => {
     expect(instance.instance.getPricingForModelKey('unknown-id')).toBeNull();
   });
 
-  test('kind is "claude-code" and supportsResponsesItemReference is false', async () => {
+  test('kind is "claude-code"', async () => {
     const instance = createClaudeCodeProvider(currentRecord);
     expect(instance.kind).toBe('claude-code');
-    expect(instance.supportsResponsesItemReference).toBe(false);
     expect(instance.upstream).toBe(upstreamId);
   });
 });

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -152,7 +152,6 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
     instance,
-    supportsResponsesItemReference: false,
   };
 };
 

--- a/packages/provider-codex/src/provider_test.ts
+++ b/packages/provider-codex/src/provider_test.ts
@@ -75,7 +75,6 @@ describe('createCodexProvider', () => {
     expect(instance.kind).toBe('codex');
     expect(instance.upstream).toBe('up_codex');
     expect(instance.name).toBe('Codex Plus');
-    expect(instance.supportsResponsesItemReference).toBe(false);
   });
 
   test('getProvidedModels uses the cached access token when fresh and surfaces every catalog entry', async () => {

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -470,6 +470,5 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
     disabledPublicModelIds: copilot.disabledPublicModelIds,
     modelPrefix: copilot.modelPrefix,
     instance,
-    supportsResponsesItemReference: false,
   };
 };

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -126,7 +126,6 @@ test('Copilot provider exposes the highest-priority non-Claude endpoint', async 
   const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
 
-
   await withMockedFetch(
     request => {
       const url = new URL(request.url);

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -126,7 +126,6 @@ test('Copilot provider exposes the highest-priority non-Claude endpoint', async 
   const instance = createCopilotProvider(copilotUpstream);
   const provider = instance.instance;
 
-  assertEquals(instance.supportsResponsesItemReference, false);
 
   await withMockedFetch(
     request => {

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -218,6 +218,5 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
     instance,
-    supportsResponsesItemReference: true,
   };
 };

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -186,6 +186,5 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
     disabledPublicModelIds: record.disabledPublicModelIds,
     modelPrefix: record.modelPrefix,
     instance,
-    supportsResponsesItemReference: true,
   };
 };

--- a/packages/provider/src/invocation_test.ts
+++ b/packages/provider/src/invocation_test.ts
@@ -64,7 +64,6 @@ test('providerModelOf throws the alias-row diagnostic when the candidate names a
       disabledPublicModelIds: [],
       modelPrefix: null,
       instance: stubProvider(),
-      supportsResponsesItemReference: false,
     },
     model: {
       id: 'gpt-fast',

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -30,7 +30,6 @@ export interface Provider {
   // instance instead of re-fetching the row. `null` keeps the bare-id behavior.
   modelPrefix: ModelPrefixConfig | null;
   instance: ProviderInstance;
-  supportsResponsesItemReference: boolean;
 }
 
 export interface ProviderCallResult {

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -101,7 +101,6 @@ export const stubModelCandidate = (overrides: {
     disabledPublicModelIds: [],
     modelPrefix: null,
     instance: stubProvider(),
-    supportsResponsesItemReference: false,
   };
   const modelOverrides = overrides.model ?? {};
   const outerMeta = {


### PR DESCRIPTION
## Summary

- Resolve every Responses `item_reference` from its durable stored payload before candidate dispatch.
- Classify routing affinity from the referenced row's actual item type.
- Preserve same-upstream wire ids on expanded items and mint temporary ids for portable cross-upstream items.
- Remove the provider-level item-reference passthrough capability and its provider-specific routing branches.

## Behavior

Floway no longer sends `item_reference` carriers to upstreams. A reference whose durable payload is unavailable returns `item-not-found`, even when its metadata still contains a same-upstream raw item id.

## Performance tradeoff

Same-upstream references require a payload lookup and clone instead of passing through. The metadata-lazy path from #193 keeps affinity and ordinary canonical echoes metadata-only, while candidate rewrite bulk-loads only the payloads selected for expansion. This intentionally exchanges some per-reference work for provider-independent wire semantics.

## Test Plan

- [x] Run focused Responses affinity, rewrite, attempt, serve, and HTTP tests.
- [x] Run the full workspace test suite.
- [x] Run workspace typechecking.
- [x] Run workspace linting.