### PR TITLE
perf(responses): reuse request item hashes

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/affinity.ts
@@ -1,4 +1,4 @@
-import { hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
+import { isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItemMetadata } from '../../../../repo/types.ts';
 import type { ChatServeFailure } from '../../shared/errors.ts';
@@ -125,7 +125,7 @@ export const classifyResponsesItemAffinity = async <TSourceItems, TCandidate ext
   const queryableIds = new Set(references.flatMap(ref => ref.id !== undefined && isStoredResponsesItemId(ref.id) ? [ref.id] : []));
   const hashByContent = new Map(await Promise.all(
     [...new Set(references.flatMap(ref => ref.encryptedContent !== undefined ? [ref.encryptedContent] : []))]
-      .map(async content => [content, await hashResponsesItemEncryptedContent(content)] as const),
+      .map(async content => [content, await store.hashEncryptedContent(content)] as const),
   ));
 
   const failures: ChatServeFailure[] = [];

--- a/packages/gateway/src/data-plane/chat/responses/items/hash-cache.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/hash-cache.ts
@@ -1,0 +1,38 @@
+import { hashResponsesItemContent, hashResponsesItemEncryptedContent } from './format.ts';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+
+export interface ResponsesItemHashFunctions {
+  readonly content: (item: ResponsesInputItem) => Promise<string>;
+  readonly encryptedContent: (encryptedContent: string) => Promise<string>;
+}
+
+const defaultHashFunctions: ResponsesItemHashFunctions = {
+  content: hashResponsesItemContent,
+  encryptedContent: hashResponsesItemEncryptedContent,
+};
+
+export class ResponsesItemHashCache {
+  // Serve prep hashes and stages the same source-item objects before attempts
+  // can clone or mutate them. Keep identity caching on that turn-local store
+  // boundary; values created inside an attempt intentionally miss this cache.
+  private readonly contentByItem = new WeakMap<ResponsesInputItem, Promise<string>>();
+  private readonly encryptedByValue = new Map<string, Promise<string>>();
+
+  constructor(private readonly functions: ResponsesItemHashFunctions = defaultHashFunctions) {}
+
+  content(item: ResponsesInputItem): Promise<string> {
+    const cached = this.contentByItem.get(item);
+    if (cached !== undefined) return cached;
+    const hash = this.functions.content(item);
+    this.contentByItem.set(item, hash);
+    return hash;
+  }
+
+  encryptedContent(value: string): Promise<string> {
+    const cached = this.encryptedByValue.get(value);
+    if (cached !== undefined) return cached;
+    const hash = this.functions.encryptedContent(value);
+    this.encryptedByValue.set(value, hash);
+    return hash;
+  }
+}

--- a/packages/gateway/src/data-plane/chat/responses/items/hash-cache.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/hash-cache.ts
@@ -15,7 +15,7 @@ export class ResponsesItemHashCache {
   // Serve prep hashes and stages the same source-item objects before attempts
   // can clone or mutate them. Keep identity caching on that turn-local store
   // boundary; values created inside an attempt intentionally miss this cache.
-  private readonly contentByItem = new WeakMap<ResponsesInputItem, Promise<string>>();
+  private contentByItem = new WeakMap<ResponsesInputItem, Promise<string>>();
   private readonly encryptedByValue = new Map<string, Promise<string>>();
 
   constructor(private readonly functions: ResponsesItemHashFunctions = defaultHashFunctions) {}
@@ -34,5 +34,10 @@ export class ResponsesItemHashCache {
     const hash = this.functions.encryptedContent(value);
     this.encryptedByValue.set(value, hash);
     return hash;
+  }
+
+  clear(): void {
+    this.contentByItem = new WeakMap();
+    this.encryptedByValue.clear();
   }
 }

--- a/packages/gateway/src/data-plane/chat/responses/items/hash-cache_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/hash-cache_test.ts
@@ -33,3 +33,19 @@ test('encrypted content hashes are cached by string value', async () => {
   assertEquals(await first, 'encrypted-1');
   assertEquals(calls, 1);
 });
+
+test('clear starts a new hash lifetime', async () => {
+  let contentCalls = 0;
+  let encryptedCalls = 0;
+  const cache = new ResponsesItemHashCache({
+    content: async () => `content-${++contentCalls}`,
+    encryptedContent: async () => `encrypted-${++encryptedCalls}`,
+  });
+  const item: ResponsesInputItem = { type: 'message', role: 'user', content: 'hello' };
+
+  assertEquals(await cache.content(item), 'content-1');
+  assertEquals(await cache.encryptedContent('opaque'), 'encrypted-1');
+  cache.clear();
+  assertEquals(await cache.content(item), 'content-2');
+  assertEquals(await cache.encryptedContent('opaque'), 'encrypted-2');
+});

--- a/packages/gateway/src/data-plane/chat/responses/items/hash-cache_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/hash-cache_test.ts
@@ -1,0 +1,35 @@
+import { test } from 'vitest';
+
+import { ResponsesItemHashCache } from './hash-cache.ts';
+import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+import { assert, assertEquals } from '@floway-dev/test-utils';
+
+test('content hashes are cached by item identity', async () => {
+  let calls = 0;
+  const cache = new ResponsesItemHashCache({
+    content: async () => `content-${++calls}`,
+    encryptedContent: async () => 'unused',
+  });
+  const item: ResponsesInputItem = { type: 'message', role: 'user', content: 'hello' };
+
+  const first = cache.content(item);
+  const second = cache.content(item);
+  assert(first === second);
+  assertEquals(await first, 'content-1');
+  assertEquals(await cache.content(structuredClone(item)), 'content-2');
+  assertEquals(calls, 2);
+});
+
+test('encrypted content hashes are cached by string value', async () => {
+  let calls = 0;
+  const cache = new ResponsesItemHashCache({
+    content: async () => 'unused',
+    encryptedContent: async () => `encrypted-${++calls}`,
+  });
+
+  const first = cache.encryptedContent('opaque-content');
+  const second = cache.encryptedContent(`opaque-${'content'}`);
+  assert(first === second);
+  assertEquals(await first, 'encrypted-1');
+  assertEquals(calls, 1);
+});

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -1,4 +1,4 @@
-import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
+import { createStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
@@ -84,8 +84,8 @@ export const wrapResponsesOutputForStorage = async function* (
       itemType: originalItem.type,
       origin: upstreamOwned ? 'upstream' : 'synthetic',
       payload: store.shouldStorePayload ? persistedPayload : null,
-      contentHash: await hashResponsesItemContent(originalItem),
-      encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
+      contentHash: await store.hashItemContent(originalItem),
+      encryptedContentHash: encryptedContent === null ? null : await store.hashEncryptedContent(encryptedContent),
       createdAt: now,
       refreshedAt: now,
     };

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -137,6 +137,10 @@ const rewriteResponsesItemListForCandidate = async (
     if (wireId !== null && payload?.private !== undefined) privatePayloads.set(wireId, structuredClone(payload.private));
     return result;
   });
+  // The outbound objects no longer need hashes from their source inputs. Drop
+  // those values before the upstream wait; output persistence starts a fresh
+  // cache through the same turn-local store.
+  store.clearItemHashes();
   return { items: rewritten, privatePayloads };
 };
 

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -1,4 +1,4 @@
-import { createTemporaryResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, responsesItemEncryptedContent, responsesItemId } from './format.ts';
+import { createTemporaryResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItemMetadata, StoredResponsesItemPayload } from '../../../../repo/types.ts';
 import { throwChatServeFailure } from '../../shared/errors.ts';
@@ -63,6 +63,7 @@ const resolveStoredRow = (
 const shouldHydrate = async (
   resolved: ResolvedItem,
   candidate: ModelCandidate,
+  store: StatefulResponsesStore,
 ): Promise<boolean> => {
   const { item, row } = resolved;
   if (!row?.hasPayload) return false;
@@ -70,7 +71,7 @@ const shouldHydrate = async (
   if (item.type === 'item_reference') return true;
   if (row.origin === 'synthetic') return true;
   const canonical = canonicalStoredEcho(item, row);
-  if (row.contentHash !== null && await hashResponsesItemContent(canonical) === row.contentHash) {
+  if (row.contentHash !== null && await store.hashItemContent(canonical) === row.contentHash) {
     resolved.canonical = canonical;
     return false;
   }
@@ -104,13 +105,16 @@ const rewriteItemForCandidate = (
   return replacement;
 };
 
-const collectEncryptedContents = async (items: Iterable<ResponsesInputItem>): Promise<Map<string, string>> => {
+const collectEncryptedContents = async (
+  items: Iterable<ResponsesInputItem>,
+  store: StatefulResponsesStore,
+): Promise<Map<string, string>> => {
   const encryptedContents = new Set<string>();
   for (const item of items) {
     const encryptedContent = responsesItemEncryptedContent(item);
     if (encryptedContent !== null) encryptedContents.add(encryptedContent);
   }
-  return new Map(await Promise.all([...encryptedContents].map(async value => [value, await hashResponsesItemEncryptedContent(value)] as const)));
+  return new Map(await Promise.all([...encryptedContents].map(async value => [value, await store.hashEncryptedContent(value)] as const)));
 };
 
 const rewriteResponsesItemListForCandidate = async (
@@ -118,11 +122,11 @@ const rewriteResponsesItemListForCandidate = async (
   store: StatefulResponsesStore,
   candidate: ModelCandidate,
 ): Promise<{ readonly items: Array<ResponsesInputItem | null>; readonly privatePayloads: ReadonlyMap<string, unknown> }> => {
-  const hashByEncryptedContent = await collectEncryptedContents(items);
+  const hashByEncryptedContent = await collectEncryptedContents(items, store);
   const resolved = items.map(item => ({ item, row: resolveStoredRow(item, store, hashByEncryptedContent) }));
   const rowsToHydrate: StoredResponsesItemMetadata[] = [];
   for (const item of resolved) {
-    if (await shouldHydrate(item, candidate) && item.row !== undefined) rowsToHydrate.push(item.row);
+    if (await shouldHydrate(item, candidate, store) && item.row !== undefined) rowsToHydrate.push(item.row);
   }
   const payloads = await store.loadItemPayloads(rowsToHydrate);
   const privatePayloads = new Map<string, unknown>();

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -190,6 +190,9 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     const contentHashes = new Set<string>();
     for (const item of options.inputItemsToStage ?? []) {
       const id = responsesItemId(item);
+      // A gateway-owned id is authoritative: affinity rejects it when the row
+      // is absent, while staging reuses or repairs that exact row. A content
+      // lookup cannot change either outcome.
       if (id !== null && isStoredResponsesItemId(id)) continue;
       contentHashes.add(await this.hashItemContent(item));
     }

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -247,6 +247,10 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
   }
 
   beginAttempt(privatePayloads: ReadonlyMap<string, unknown>): void {
+    // Candidate rewrite has consumed every source-input hash. Release its
+    // encrypted string keys before the upstream wait and start a fresh cache
+    // for output items produced by this attempt.
+    this.hashes.clear();
     this.stagedOutputItems.clear();
     this.stagedOutputItemIds.length = 0;
     this.privatePayload.clear();

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -1,4 +1,5 @@
-import { createStoredResponsesItemId, hashResponsesItemContent, hashResponsesItemEncryptedContent, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
+import { createStoredResponsesItemId, isStoredResponsesItemId, responsesItemEncryptedContent, responsesItemId } from './format.ts';
+import { ResponsesItemHashCache } from './hash-cache.ts';
 import { getRepo } from '../../../../repo/index.ts';
 import {
   cloneStoredResponsesItem,
@@ -86,6 +87,8 @@ export interface StatefulResponsesStore {
   }): Promise<void>;
   getItemById(id: string): StoredResponsesItemMetadata | undefined;
   getItemsByEncryptedContentHash(hash: string): StoredResponsesItemMetadata[];
+  hashItemContent(item: ResponsesInputItem): Promise<string>;
+  hashEncryptedContent(encryptedContent: string): Promise<string>;
   loadItemPayloads(items: readonly StoredResponsesItemMetadata[]): Promise<ReadonlyMap<string, StoredResponsesItemPayload>>;
   touchItem(id: string): void;
   stageInputItems(items: readonly ResponsesInputItem[]): Promise<void>;
@@ -120,7 +123,10 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
   private readonly refreshedItemIds = new Set<string>();
   private readonly durableItemIds = new Set<string>();
 
-  constructor(private readonly options: LayeredStatefulResponsesStoreOptions) {}
+  constructor(
+    private readonly options: LayeredStatefulResponsesStoreOptions,
+    private readonly hashes = new ResponsesItemHashCache(),
+  ) {}
 
   get apiKeyId(): string | null {
     return this.options.apiKeyId;
@@ -128,6 +134,14 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
 
   get shouldStorePayload(): boolean {
     return this.options.shouldStorePayload !== false;
+  }
+
+  hashItemContent(item: ResponsesInputItem): Promise<string> {
+    return this.hashes.content(item);
+  }
+
+  hashEncryptedContent(encryptedContent: string): Promise<string> {
+    return this.hashes.encryptedContent(encryptedContent);
   }
 
   async loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null> {
@@ -169,10 +183,14 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     });
 
     const contentHashes = new Set<string>();
-    for (const item of options.inputItemsToStage ?? []) contentHashes.add(await hashResponsesItemContent(item));
+    for (const item of options.inputItemsToStage ?? []) {
+      const id = responsesItemId(item);
+      if (id !== null && isStoredResponsesItemId(id)) continue;
+      contentHashes.add(await this.hashItemContent(item));
+    }
 
     const encryptedContentHashes = new Set<string>();
-    for (const encryptedContent of encryptedContents) encryptedContentHashes.add(await hashResponsesItemEncryptedContent(encryptedContent));
+    for (const encryptedContent of encryptedContents) encryptedContentHashes.add(await this.hashEncryptedContent(encryptedContent));
 
     await this.loadItems({
       ids: [...ids],
@@ -334,7 +352,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
 
     const encryptedContent = responsesItemEncryptedContent(item);
     if (encryptedContent !== null) {
-      const row = this.getItemsByEncryptedContentHash(await hashResponsesItemEncryptedContent(encryptedContent))
+      const row = this.getItemsByEncryptedContentHash(await this.hashEncryptedContent(encryptedContent))
         .find(candidate => candidate.itemType === item.type);
       if (row !== undefined) {
         this.touchItem(row.id);
@@ -347,7 +365,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
       }
     }
 
-    const contentHash = await hashResponsesItemContent(item);
+    const contentHash = await this.hashItemContent(item);
     const existing = this.reusableItemByContentHash(contentHash);
     if (existing) {
       this.touchItem(existing.id);
@@ -365,7 +383,7 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
       origin: 'input',
       payload: { item: structuredClone(item) },
       contentHash,
-      encryptedContentHash: encryptedContent === null ? null : await hashResponsesItemEncryptedContent(encryptedContent),
+      encryptedContentHash: encryptedContent === null ? null : await this.hashEncryptedContent(encryptedContent),
       createdAt: now,
       refreshedAt: now,
     };
@@ -380,8 +398,8 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     const upgraded: StoredResponsesItem = {
       ...metadata,
       payload: { item: structuredClone(item) },
-      contentHash: await hashResponsesItemContent(item),
-      encryptedContentHash: encryptedContent === null ? row.encryptedContentHash : await hashResponsesItemEncryptedContent(encryptedContent),
+      contentHash: await this.hashItemContent(item),
+      encryptedContentHash: encryptedContent === null ? row.encryptedContentHash : await this.hashEncryptedContent(encryptedContent),
       createdAt: now,
       refreshedAt: now,
     };

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -89,6 +89,7 @@ export interface StatefulResponsesStore {
   getItemsByEncryptedContentHash(hash: string): StoredResponsesItemMetadata[];
   hashItemContent(item: ResponsesInputItem): Promise<string>;
   hashEncryptedContent(encryptedContent: string): Promise<string>;
+  clearItemHashes(): void;
   loadItemPayloads(items: readonly StoredResponsesItemMetadata[]): Promise<ReadonlyMap<string, StoredResponsesItemPayload>>;
   touchItem(id: string): void;
   stageInputItems(items: readonly ResponsesInputItem[]): Promise<void>;
@@ -142,6 +143,10 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
 
   hashEncryptedContent(encryptedContent: string): Promise<string> {
     return this.hashes.encryptedContent(encryptedContent);
+  }
+
+  clearItemHashes(): void {
+    this.hashes.clear();
   }
 
   async loadSnapshot(id: string): Promise<StoredResponsesSnapshot | null> {
@@ -247,10 +252,6 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
   }
 
   beginAttempt(privatePayloads: ReadonlyMap<string, unknown>): void {
-    // Candidate rewrite has consumed every source-input hash. Release its
-    // encrypted string keys before the upstream wait and start a fresh cache
-    // for output items produced by this attempt.
-    this.hashes.clear();
     this.stagedOutputItems.clear();
     this.stagedOutputItemIds.length = 0;
     this.privatePayload.clear();

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -84,6 +84,23 @@ test('stages agent and context-compaction items with stable prefixes and preserv
   assertEquals(payloads.map(record => record.payload.item), input);
 });
 
+test('content-hash preload skips items already addressed by a stored id', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const lookupByContentHash = vi.spyOn(repo.responsesItems, 'lookupManyByContentHash');
+  const storedId = createStoredResponsesItemId('message');
+  const input: ResponsesInputItem[] = [
+    { type: 'message', id: storedId, role: 'assistant', content: 'stored' },
+    { type: 'message', id: 'client-message', role: 'user', content: 'new' },
+  ];
+  const store = createResponsesHttpStore(API_KEY_ID, true);
+
+  await store.loadInputItems({ sourceItems: input, view: responsesItemsView, inputItemsToStage: input });
+
+  assertEquals(lookupByContentHash.mock.calls.length, 1);
+  assertEquals(lookupByContentHash.mock.calls[0][1].length, 1);
+});
+
 test('snapshots with non-replayable metadata-only rows load as missing', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);


### PR DESCRIPTION
## Summary

- Memoize Responses content hashes by source-item identity and encrypted-content hashes by string value for one candidate rewrite.
- Skip content-hash preload for gateway-owned item ids, whose exact row is authoritative for lookup, repair, and missing-item errors.
- Clear the cache at the shared rewrite boundary so native Responses and translated protocols release input keys before upstream I/O; output persistence starts a fresh cache.

## Semantics

The cache never crosses a candidate rewrite. Serve prep and input staging operate on the same source objects, while attempt-local clones intentionally miss the identity cache. Touched-item refresh still completes before dispatch, stable client ids with changed payloads still create distinct rows, and metadata-only rows still accept payload repair.

## Controlled profiling

All variants used Node 25.6.1, Wrangler 4.81.0, workerd 1.20260405.1, the same 4,701,147-byte / 928-item request, its exact 923-row production-data closure, one file-backed payload, and the Copilot provider path against a deterministic local upstream. Quantitative c1 runs used five fresh processes or isolates per variant; CPU profiles and heap snapshots were separate diagnostic passes.

| Metric | pre-series `b0ff173f` | current `5d7164f0` | this PR `8563b5bf` |
|---|---:|---:|---:|
| Node c1 peak RSS delta | 470.8 MiB | 105.7 MiB | 103.6 MiB |
| Node c1 request median | 1507.6 ms | 1183.8 ms | 1159.3 ms |
| Node hold heap-snapshot self size | 101.77 MiB | 87.16 MiB | 87.83 MiB |
| workerd c1 request median | 1590.4 ms | 1220.3 ms | 1194.8 ms |
| workerd hold heap-snapshot self size | 40.06 MiB | 26.53 MiB | 26.62 MiB |
| workerd c4 tracked-memory delta | 159.2 MiB¹ | 115.2 MiB | 91.5 MiB |

¹ The baseline c4 process was run once because it was already beyond the Worker limit; current and PR c4 values are three-run medians.

Digest instrumentation on the exact request changed from 2,845 calls / 13.88 MB of input to 1,259 calls / 7.04 MB: 55.7% fewer calls and 49.3% fewer hashed bytes. This optimization is CPU/latency-focused; single-request live memory is effectively neutral. Its c4 improvement comes from reducing overlapping transient work.

Cloudflare's supported local workflow was used: [DevTools CPU Profiler](https://github.com/cloudflare/cloudflare-docs/blob/1fcfa05cd63592b0859efe41d7d27f8f7888e068/src/content/docs/workers/observability/dev-tools/cpu-usage.mdx#L15-L35) and [Memory heap snapshots](https://github.com/cloudflare/cloudflare-docs/blob/1fcfa05cd63592b0859efe41d7d27f8f7888e068/src/content/docs/workers/observability/dev-tools/memory-usage.mdx#L15-L35). `Runtime.getHeapUsage` curves were supporting signals only: synchronous work can starve the inspector and GC timing makes sampled peaks bimodal, so the table uses snapshots for the c1 live-set comparison.

## Production anchor

This is not substituted for the controlled three-way because traffic differs by deployment. Cloudflare `workersInvocationsAdaptive` shows the pre-series version recorded 377 `exceededMemory` invocations out of 12,678 during its final 5.3 hours. The previously deployed metadata-lazy version recorded 2 out of 15,927 during the queried four-hour window, a roughly 99.6% failure-rate reduction; those two NRT invocations reached approximately 147 MB and 197 MB isolate memory. The primary fixture contains no `item_reference`, so #194 does not change this workload relative to the deployed #193 version.

## Deployment

Deployed from this branch as Worker version `1db75c37-c28b-4a87-b603-50627b4d1efb`. No D1 migrations were pending, and the public health endpoint returned HTTP 200 after deployment.

## Test Plan

- [x] Run focused Responses store, affinity, rewrite, output, serve, and translated-attempt tests (10 files, 103 tests).
- [x] Run the full workspace test suite (336 files, 4,087 tests).
- [x] Run workspace typechecking.
- [x] Run workspace linting.
- [x] Verify the production health endpoint returns HTTP 200.