### PR TITLE
feat(cache): version persisted model catalogs

### DIFF
--- a/.agents/skills/fetching-models-pricing/SKILL.md
+++ b/.agents/skills/fetching-models-pricing/SKILL.md
@@ -45,8 +45,8 @@ notional API-equivalent value so the usage dashboard remains comparable.
    `packages/gateway/src/data-plane/providers/models-cache.ts`. Static pricing
    is serialized inside cached `ProviderModel` rows; a revision mismatch makes
    every older row cold before TTL evaluation.
-7. Add boundary tests for exact ids, aliases, dated releases, and threshold
-   edges encoded by the table.
+7. Add boundary tests for exact ids, aliases, dated releases, and RegExp
+   coverage boundaries encoded by the table.
 8. Run the affected provider tests, typecheck, lint, and the full test suite.
 9. If an existing rate changed, use `backfill-model-pricing` for the intended
    historical usage slice. Cache revisioning changes future catalog snapshots;

--- a/.agents/skills/fetching-models-pricing/SKILL.md
+++ b/.agents/skills/fetching-models-pricing/SKILL.md
@@ -1,138 +1,97 @@
 ---
 name: fetching-models-pricing
-description: Use when refreshing a per-model pricing table for a Floway
-  provider whose upstream doesn't publish per-token rates and needs
-  notional billing (Copilot, Codex, Ollama). Manual procedure — no script.
+description: Refresh per-model pricing tables for Floway providers whose upstream does not bill per token or publish usable token rates, especially Copilot, Codex, Claude Code, and Ollama. Manual research procedure; no script.
 ---
 
 # Fetching Models Pricing
 
-Floway's subscription / free providers (Copilot, Codex, Ollama) each own a
-hardcoded per-model pricing table. The upstream doesn't bill per token — it's
-a flat subscription or self-hosted at zero cost — but the dashboard tracks
-"value consumed" as if the operator were paying the model on its own API.
-This skill is how those tables stay in sync with reality.
+Maintain the notional per-token rate tables in:
 
-## The three tables
-
-| Provider | File | Catalog source | Source of truth |
+| Provider | Table | Live catalog | Preferred rate source |
 |---|---|---|---|
-| Copilot | `packages/provider-copilot/src/pricing.ts` | Copilot `/models` per account | <https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing> |
-| Codex   | `packages/provider-codex/src/pricing.ts`   | `/codex/models` via ChatGPT OAuth | <https://openai.com/api/pricing/> |
-| Ollama  | `packages/provider-ollama/src/pricing.ts`  | `/api/tags` + `/api/show` on the configured base URL | varies per model family — vendor first-party where the vendor operates an API, commodity host otherwise |
+| Copilot | `packages/provider-copilot/src/pricing.ts` | Copilot `/models` | model vendor's first-party API |
+| Codex | `packages/provider-codex/src/pricing.ts` | authenticated `/codex/models` | OpenAI API pricing |
+| Claude Code | `packages/provider-claude-code/src/pricing.ts` | authenticated Anthropic `/v1/models` | Anthropic API pricing |
+| Ollama | `packages/provider-ollama/src/pricing.ts` | `/api/tags` + `/api/show` | vendor API or a credible commodity host |
 
-All three tables share the same shape: `readonly [key, ModelPricing][]` with
-first-hit-wins, where `key` is either a literal model id string or a RegExp.
+These providers are subscription-backed or self-hosted. Floway records
+notional API-equivalent value so the usage dashboard remains comparable.
 
-## Flow
+## Procedure
 
-1. **Pull the live catalog** for the provider you're refreshing.
-   - Copilot: load a real Copilot upstream and inspect what
-     `getProvidedModels` returns (`packages/provider-copilot/src/provider.ts`),
-     or read the dashboard's cached row.
-   - Codex: an authenticated OAuth session against `/codex/models` —
-     normally only reachable through an imported Codex upstream.
-   - Ollama: `curl -s <baseUrl>/api/tags | jq -r '.models[].name' | sort`
-     (for ollama.com, base URL is `https://ollama.com`).
+1. Fetch the provider's live catalog and diff its ids against the table's
+   string and RegExp keys. Record new, retired, and renamed models.
+2. Find a defensible rate source for every new id:
+   - Prefer the model vendor's first-party API.
+   - For open weights with no vendor API, use the cheapest credible commodity
+     host that publishes the required dimensions.
+   - For retired versions, use a permalink or dated archive from when that
+     version was current.
+3. Cross-check at least two sources. models.dev is useful as an independent
+   comparison:
 
-   Diff against the existing table's string keys + regex coverage. Note
-   new models, retired models, and entries whose family no longer
-   appears upstream.
+   ```bash
+   curl -s https://models.dev/api.json | jq '.<provider>.models["<id>"].cost'
+   ```
 
-2. **Identify the source of truth for each new entry.** The right anchor
-   depends on whether the model's vendor operates its own API:
+   OpenRouter prices below first-party rates are usually mirror-host prices,
+   not the canonical vendor rate.
+4. Edit the provider table. Use USD per million tokens and preserve the table's
+   first-hit-wins ordering. Exact ids are preferable; use a RegExp only when
+   every matched release genuinely shares one rate.
+5. Return `null` when no defensible price exists. Never extrapolate from an
+   adjacent version or silently substitute a similarly named model.
+6. Increment `MODEL_CATALOG_REVISION` in
+   `packages/gateway/src/data-plane/providers/models-cache.ts`. Static pricing
+   is serialized inside cached `ProviderModel` rows; a revision mismatch makes
+   every older row cold before TTL evaluation.
+7. Add boundary tests for exact ids, aliases, dated releases, and threshold
+   edges encoded by the table.
+8. Run the affected provider tests, typecheck, lint, and the full test suite.
+9. If an existing rate changed, use `backfill-model-pricing` for the intended
+   historical usage slice. Cache revisioning changes future catalog snapshots;
+   it does not rewrite recorded unit prices.
 
-   - **Vendor first-party API exists** — use the vendor's published rate.
-     Examples: DeepSeek's API for `deepseek-v*`, Z.ai for `glm-*`,
-     Anthropic for `claude-*` on Copilot, OpenAI for `gpt-*` on Codex
-     and Copilot, Mistral for `mistral-large-*` / `devstral-*` /
-     `ministral-*` on Ollama.
-   - **Open weights with no vendor API** — use the cheapest credible
-     commodity host (DeepInfra, Groq, Together, OpenRouter). Examples:
-     `gpt-oss:*` (OpenAI released weights but doesn't host them),
-     `nemotron-*` (NVIDIA NIM Hub surfaces partner endpoints, no
-     first-party token SKU), `rnj-*` (Essential AI publishes weights, no
-     API).
-   - **Past version whose alias rotated** — DeepSeek's `deepseek-chat`
-     alias points at the current generation; older versions like v3.1 /
-     v3.2 are no longer reachable on the live page. Use Wayback
-     snapshots from the period the version was current.
+## Catalog revision policy
 
-   For Ollama's many model families, the per-family anchor:
+`MODEL_CATALOG_REVISION` versions the complete persisted `ProviderModel`
+contract, not only pricing tables. Increment it for any code change that alters
+code-derived catalog metadata or its serialized representation. Upstream-only
+catalog changes do not require a bump because normal TTL refreshes fetch them.
 
-   | Family | Anchor |
-   |---|---|
-   | `gpt-oss:*` | Groq (cheapest commodity host with cached-input pricing) |
-   | `qwen*` | Alibaba International first-party (`qwencloud.com/models/<id>`); fall back to DeepInfra Turbo only when Alibaba doesn't publish a SKU |
-   | `deepseek-v*` | DeepSeek first-party (`api-docs.deepseek.com/quick_start/pricing`); for past versions whose `deepseek-chat` alias has rotated, use Wayback snapshots |
-   | `glm-*` | Z.ai first-party (`docs.z.ai/guides/overview/pricing`) |
-   | `kimi-*` | Kimi first-party (`platform.kimi.ai/docs/pricing/chat`) |
-   | `minimax-*` | MiniMax international PAYGo (`platform.minimax.io/docs/guides/pricing-paygo`) |
-   | `mistral-large-*` / `devstral-*` / `ministral-*` | Mistral first-party (`mistral.ai/pricing`) |
-   | `nemotron-3-*` | DeepInfra (cheapest commodity host) |
-   | `gemini-*` | Google AI Studio (`ai.google.dev/gemini-api/docs/pricing`) |
-   | `gemma*` | Vertex AI sells per-token only for `gemma-4-26b-a4b-it`; every other Gemma tag is GPU-hour self-host. Leave NULL. |
-   | `rnj-*` | Together (Essential AI doesn't run its own API) |
+The revision is global by design. A mismatch blocks on a fresh fetch and never
+falls back to the incompatible stored row. Successful fetches overwrite the row
+with the current revision; failed fetches leave the old row present but
+ineligible.
 
-3. **Verify against multiple sources before writing.** Cross-check the
-   first-party rate against models.dev's catalog
-   (`curl -s https://models.dev/api.json | jq '.<provider>.models["<id>"].cost'`)
-   and against OpenRouter's `/api/v1/models`. OpenRouter rates that sit
-   *below* first-party are mirror prices — some other host running the
-   open weights more cheaply — not the canonical anchor. Use first-party.
+## Model identity
 
-4. **Edit the pricing.ts.** Add/update entries with `input`,
-   `input_cache_read` (when the upstream publishes one), `input_cache_write`
-   (Copilot exposes this on Anthropic models), `output`. Group exact
-   string keys; use a regex only when several versions genuinely share a
-   single rate.
+- Copilot usage stores raw variant suffixes such as `-high`, `-xhigh`, and
+  `-1m` in `model_key`; its pricing lookup normalizes them to the public id.
+- Claude Code resolves pricing from the dated raw upstream id before catalog
+  aliases are merged into public ids.
+- Codex and Ollama use the raw upstream slug directly.
 
-5. **Leave NULL when there's no defensible reference.** Examples:
-   - Versions whose name doesn't map to any upstream release.
-   - Free-tier-only Labs SKUs with no commercial rate.
-   - Open weights with no published per-token host (rare; investigate
-     before falling back).
-   `pricingForXxxModelKey` returning `null` is correct — it persists
-   `usage.unit_price` as NULL, which aggregates to zero cost. Better than
-   a guess.
+## Choosing a source
 
-6. **Backfill historical rows** with `backfill-model-pricing` when an
-   existing model's rate moved. New rows pick the new price automatically.
+- DeepSeek, Z.ai, Anthropic, OpenAI, Mistral, Google, Kimi, and MiniMax models:
+  use the vendor's first-party API price when available.
+- Open weights without a vendor-operated API: compare credible commodity hosts
+  such as DeepInfra, Groq, Together, and OpenRouter.
+- Historical aliases that now point at another release: use a dated official
+  page or Wayback snapshot from the relevant period.
+- Models whose visible name cannot be tied to a release: leave unpriced.
 
-## Modelkey shape per provider
+## Sources to reject
 
-- **Copilot**: `usage.model_key` carries variant suffixes (`-high`,
-  `-xhigh`, `-1m`, dated snapshots). The lookup helper
-  `pricingForCopilotModelKey` strips them via `copilotPublicModelId`
-  before matching the table; keep table keys at the public-id level
-  (`claude-opus-4-7`, not `claude-opus-4-7-xhigh`).
-- **Codex** and **Ollama**: the modelkey IS the raw upstream slug
-  verbatim. The table key matches directly.
+- LiteLLM's zero-valued `ollama/*` entries: those zeroes are intentional
+  placeholders, not market prices.
+- Ollama library labels such as Light, Medium, High, or Extra High: they are
+  subscription GPU-time weights, not token prices.
+- A cheaper OpenRouter mirror when the vendor itself sells the model: that is a
+  different host's price.
+- Ambiguous name similarity without release-note evidence.
 
-## Sources to avoid
-
-- **LiteLLM `model_prices_and_context_window.json`** for the `ollama/*`
-  namespace — those entries are hardcoded to `0.0` by design. Reading
-  from there silently zeros every row.
-- **OpenRouter rates that sit below the vendor's first-party** — these
-  are mirror prices (some other host running the open weights more
-  cheaply), not the canonical anchor.
-- **HTML scraping per-model tier labels** (e.g. `Light` / `Medium` /
-  `High` / `Extra High` on Ollama's library page) — those are
-  subscription GPU-time weights, not token prices, and conflating them
-  silently mis-bills.
-
-## Cautions
-
-- Don't fabricate a price by extrapolating from an adjacent version
-  (e.g. estimating `glm-4.7` from `glm-4.6`). Leave NULL.
-- Don't map by name string when the version reads ambiguous. Versions
-  like `qwen3.5` on Ollama and `qwen3-235b-a22b-instruct-2507` on
-  DashScope are not necessarily the same release; confirm with a
-  release-note pair before linking them.
-- Cross-provider spread is large; the choice of anchor changes
-  user-visible cost several-fold. Pick deliberately, and write the choice
-  into the comment so the next refresh doesn't have to re-derive it.
-- Pricing is USD per million tokens, single REAL per `BillingDimension`.
-  Falls back per `unitPriceForDimension` (cached → uncached, image →
-  text). Don't pre-bake the fallback into the table.
+Every vendor constant must retain a permalink or stable official URL explaining
+the selected rate. Record non-obvious source choices beside the table entry so
+the next refresh does not have to reconstruct the decision.

--- a/packages/gateway/migrations/0052_models_cache_revision.sql
+++ b/packages/gateway/migrations/0052_models_cache_revision.sql
@@ -1,0 +1,1 @@
+ALTER TABLE models_cache ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -260,6 +260,7 @@ test('PATCH /api/upstreams preserves omitted secrets and re-warms the models cac
   // it with the new upstream-supplied catalog rather than leaving the old
   // models in place.
   await repo.modelsCache.put(created.id, {
+    revision: 1,
     fetchedAt: 1,
     models: [{ id: 'stale-model', kind: 'chat', endpoints: {}, enabledFlags: new Set(), limits: {} }],
   });
@@ -408,10 +409,12 @@ test('GET /api/upstreams attaches models-cache freshness to every row', async ()
   await repo.upstreams.save({ ...baseRow, id: 'up_failed', name: 'Failed', sortOrder: 2 });
 
   await repo.modelsCache.put('up_warm', {
+    revision: 1,
     fetchedAt: 1_700_000_000_000,
     models: [{ id: 'm1', kind: 'chat', endpoints: {}, enabledFlags: new Set(), limits: {} }],
   });
   await repo.modelsCache.put('up_failed', {
+    revision: 1,
     fetchedAt: 1_700_000_000_000,
     models: [{ id: 'm1', kind: 'chat', endpoints: {}, enabledFlags: new Set(), limits: {} }],
   });

--- a/packages/gateway/src/data-plane/providers/models-cache.ts
+++ b/packages/gateway/src/data-plane/providers/models-cache.ts
@@ -12,6 +12,11 @@ import type { Fetcher, Provider, ProviderModel } from '@floway-dev/provider';
 const SOFT_MS = 10 * 60 * 1000;
 const HARD_MS = 24 * 60 * 60 * 1000;
 
+// Persisted ProviderModel rows contain code-derived metadata as well as the
+// upstream response. Increment this whenever that derived catalog contract or
+// its serialization changes so older rows become cold across deployments.
+export const MODEL_CATALOG_REVISION = 1;
+
 export interface ModelsCacheFetchOptions {
   scheduler: BackgroundScheduler;
   fetcher: Fetcher;
@@ -51,7 +56,7 @@ const runFetch = async (
 ): Promise<ProviderModel[]> => {
   try {
     const models = [...await instance.instance.getProvidedModels(fetcher)];
-    await getRepo().modelsCache.put(key, { fetchedAt: Date.now(), models });
+    await getRepo().modelsCache.put(key, { revision: MODEL_CATALOG_REVISION, fetchedAt: Date.now(), models });
     return models;
   } catch (err) {
     // `setLastError` is a no-op when no stored row exists; a brand-new
@@ -74,7 +79,8 @@ export const fetchUpstreamModelsCached = async (
     return await memoInFlight(key, () => runFetch(instance, fetcher, key));
   }
 
-  const cached = await getRepo().modelsCache.get(key);
+  const stored = await getRepo().modelsCache.get(key);
+  const cached = stored?.revision === MODEL_CATALOG_REVISION ? stored : null;
 
   if (cached && now - cached.fetchedAt < SOFT_MS) {
     return cached.models;

--- a/packages/gateway/src/data-plane/providers/models-cache_test.ts
+++ b/packages/gateway/src/data-plane/providers/models-cache_test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { clearInFlightForTesting, fetchUpstreamModelsCached } from './models-cache.ts';
+import { clearInFlightForTesting, fetchUpstreamModelsCached, MODEL_CATALOG_REVISION } from './models-cache.ts';
 import { initRepo } from '../../repo/index.ts';
 import { InMemoryRepo } from '../../repo/memory.ts';
 import { directFetcher, type Provider, type ProviderModel } from '@floway-dev/provider';
@@ -48,7 +48,7 @@ describe('fetchUpstreamModelsCached', () => {
 
   test('within SOFT: no fetch, returns stored', async () => {
     const repo = setupRepo();
-    await repo.modelsCache.put('up_a', { fetchedAt: Date.now() - 1000, models: [aModel('cached')] });
+    await repo.modelsCache.put('up_a', { revision: MODEL_CATALOG_REVISION, fetchedAt: Date.now() - 1000, models: [aModel('cached')] });
     const fetchFn = vi.fn(async () => [aModel('fresh')]);
 
     const result = await fetchUpstreamModelsCached(
@@ -62,7 +62,7 @@ describe('fetchUpstreamModelsCached', () => {
 
   test('past SOFT within HARD: returns stored + schedules revalidate', async () => {
     const repo = setupRepo();
-    await repo.modelsCache.put('up_a', { fetchedAt: Date.now() - 20 * 60_000, models: [aModel('stale')] });
+    await repo.modelsCache.put('up_a', { revision: MODEL_CATALOG_REVISION, fetchedAt: Date.now() - 20 * 60_000, models: [aModel('stale')] });
     const fetchFn = vi.fn(async () => [aModel('fresh')]);
     let scheduled: Promise<unknown> | null = null;
 
@@ -80,7 +80,7 @@ describe('fetchUpstreamModelsCached', () => {
 
   test('past HARD: blocks on fetch', async () => {
     const repo = setupRepo();
-    await repo.modelsCache.put('up_a', { fetchedAt: Date.now() - 25 * 60 * 60_000, models: [aModel('stale')] });
+    await repo.modelsCache.put('up_a', { revision: MODEL_CATALOG_REVISION, fetchedAt: Date.now() - 25 * 60 * 60_000, models: [aModel('stale')] });
     const fetchFn = vi.fn(async () => [aModel('fresh')]);
 
     const result = await fetchUpstreamModelsCached(
@@ -95,7 +95,7 @@ describe('fetchUpstreamModelsCached', () => {
 
   test('force=true: bypasses cache and blocks on fetch', async () => {
     const repo = setupRepo();
-    await repo.modelsCache.put('up_a', { fetchedAt: Date.now() - 1000, models: [aModel('stored')] });
+    await repo.modelsCache.put('up_a', { revision: MODEL_CATALOG_REVISION, fetchedAt: Date.now() - 1000, models: [aModel('stored')] });
     const fetchFn = vi.fn(async () => [aModel('fresh')]);
 
     const result = await fetchUpstreamModelsCached(
@@ -129,7 +129,7 @@ describe('fetchUpstreamModelsCached', () => {
 
   test('background revalidate failure preserves stored row and writes lastError', async () => {
     const repo = setupRepo();
-    await repo.modelsCache.put('up_a', { fetchedAt: Date.now() - 20 * 60_000, models: [aModel('stale')] });
+    await repo.modelsCache.put('up_a', { revision: MODEL_CATALOG_REVISION, fetchedAt: Date.now() - 20 * 60_000, models: [aModel('stale')] });
     const fetchFn = vi.fn(async () => { throw new Error('boom'); });
     let scheduled: Promise<unknown> | null = null;
 
@@ -160,7 +160,7 @@ describe('fetchUpstreamModelsCached', () => {
 
   test('force=true + fetch failure: throws (no fallback) and annotates lastError', async () => {
     const repo = setupRepo();
-    await repo.modelsCache.put('up_a', { fetchedAt: Date.now() - 1000, models: [aModel('stored')] });
+    await repo.modelsCache.put('up_a', { revision: MODEL_CATALOG_REVISION, fetchedAt: Date.now() - 1000, models: [aModel('stored')] });
     const fetchFn = vi.fn(async () => { throw new Error('boom'); });
 
     await expect(fetchUpstreamModelsCached(
@@ -171,5 +171,24 @@ describe('fetchUpstreamModelsCached', () => {
     const row = await repo.modelsCache.get('up_a');
     expect(row?.models.map(m => m.id)).toEqual(['stored']);
     expect(row?.lastError?.message).toContain('boom');
+  });
+
+  test('catalog revision mismatch bypasses a soft-fresh stored row', async () => {
+    const repo = setupRepo();
+    await repo.modelsCache.put('up_a', {
+      revision: MODEL_CATALOG_REVISION - 1,
+      fetchedAt: Date.now() - 1000,
+      models: [aModel('old-catalog')],
+    });
+    const fetchFn = vi.fn(async () => [aModel('current-catalog')]);
+
+    const result = await fetchUpstreamModelsCached(
+      stubInstance('up_a', fetchFn),
+      { scheduler: () => {}, fetcher: directFetcher },
+    );
+
+    expect(result.map(model => model.id)).toEqual(['current-catalog']);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect((await repo.modelsCache.get('up_a'))?.revision).toBe(MODEL_CATALOG_REVISION);
   });
 });

--- a/packages/gateway/src/repo/memory.ts
+++ b/packages/gateway/src/repo/memory.ts
@@ -496,8 +496,8 @@ class MemoryModelsCacheRepo implements ModelsCacheRepo {
     return Promise.resolve(row ? { ...row, models: [...row.models] } : null);
   }
 
-  put(upstreamId: string, row: { fetchedAt: number; models: ProviderModel[] }): Promise<void> {
-    this.rows.set(upstreamId, { fetchedAt: row.fetchedAt, models: [...row.models], lastError: null });
+  put(upstreamId: string, row: { revision: number; fetchedAt: number; models: ProviderModel[] }): Promise<void> {
+    this.rows.set(upstreamId, { revision: row.revision, fetchedAt: row.fetchedAt, models: [...row.models], lastError: null });
     return Promise.resolve();
   }
 

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -819,27 +819,29 @@ class SqlModelsCacheRepo implements ModelsCacheRepo {
 
   async get(upstreamId: string): Promise<CachedModelsRow | null> {
     const row = await this.db
-      .prepare('SELECT fetched_at, models_json, last_error_json FROM models_cache WHERE upstream_id = ?')
+      .prepare('SELECT revision, fetched_at, models_json, last_error_json FROM models_cache WHERE upstream_id = ?')
       .bind(upstreamId)
-      .first<{ fetched_at: number; models_json: string; last_error_json: string | null }>();
+      .first<{ revision: number; fetched_at: number; models_json: string; last_error_json: string | null }>();
     if (!row) return null;
     return {
+      revision: row.revision,
       fetchedAt: row.fetched_at,
       models: JSON.parse(row.models_json, modelsReviver) as ProviderModel[],
       lastError: row.last_error_json ? JSON.parse(row.last_error_json) as { message: string; at: number } : null,
     };
   }
 
-  async put(upstreamId: string, row: { fetchedAt: number; models: ProviderModel[] }): Promise<void> {
+  async put(upstreamId: string, row: { revision: number; fetchedAt: number; models: ProviderModel[] }): Promise<void> {
     await this.db
       .prepare(
-        `INSERT INTO models_cache (upstream_id, fetched_at, models_json, last_error_json) VALUES (?, ?, ?, NULL)
+        `INSERT INTO models_cache (upstream_id, revision, fetched_at, models_json, last_error_json) VALUES (?, ?, ?, ?, NULL)
          ON CONFLICT (upstream_id) DO UPDATE SET
+           revision = excluded.revision,
            fetched_at = excluded.fetched_at,
            models_json = excluded.models_json,
            last_error_json = NULL`,
       )
-      .bind(upstreamId, row.fetchedAt, JSON.stringify(row.models, modelsReplacer))
+      .bind(upstreamId, row.revision, row.fetchedAt, JSON.stringify(row.models, modelsReplacer))
       .run();
   }
 

--- a/packages/gateway/src/repo/sql_test.ts
+++ b/packages/gateway/src/repo/sql_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { SqlRepo } from './sql.ts';
 import { createSqliteTestDb } from './test-sqlite.ts';
 import type { UpstreamRecord } from '@floway-dev/provider';
-import { assertEquals } from '@floway-dev/test-utils';
+import { assertEquals, stubProviderModel } from '@floway-dev/test-utils';
 
 const goodAccount = { chatgptAccountId: 'aid', refresh_token: 'rt_v1', state: 'active' as const, state_updated_at: '2026-01-01T00:00:00Z' };
 const baseRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => ({
@@ -22,6 +22,20 @@ const baseRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => 
   modelPrefix: null,
   color: null,
   ...overrides,
+});
+
+test('SQL models cache round-trips the catalog revision', async () => {
+  const repo = new SqlRepo(await createSqliteTestDb());
+  await repo.upstreams.save(baseRecord());
+  await repo.modelsCache.put('up_test', {
+    revision: 7,
+    fetchedAt: 1_700_000_000_000,
+    models: [stubProviderModel({ id: 'cached-model' })],
+  });
+
+  const cached = await repo.modelsCache.get('up_test');
+  assertEquals(cached?.revision, 7);
+  assertEquals(cached?.models.map(model => model.id), ['cached-model']);
 });
 
 test('SQL upstream repo round-trips state_json on save/list/getById', async () => {

--- a/packages/gateway/src/repo/types.ts
+++ b/packages/gateway/src/repo/types.ts
@@ -224,6 +224,7 @@ export interface PerformanceRepo {
 }
 
 export interface CachedModelsRow {
+  revision: number;
   fetchedAt: number;
   models: ProviderModel[];
   lastError: { message: string; at: number } | null;
@@ -231,7 +232,7 @@ export interface CachedModelsRow {
 
 export interface ModelsCacheRepo {
   get(upstreamId: string): Promise<CachedModelsRow | null>;
-  put(upstreamId: string, row: { fetchedAt: number; models: ProviderModel[] }): Promise<void>;
+  put(upstreamId: string, row: { revision: number; fetchedAt: number; models: ProviderModel[] }): Promise<void>;
   setLastError(upstreamId: string, error: { message: string; at: number } | null): Promise<void>;
   delete(upstreamId: string): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Persist a global catalog revision with every cached ProviderModel snapshot so code-derived catalog changes cannot remain soft-fresh across deployments.

- Add a migration that assigns existing cache rows revision 0.
- Stamp successful catalog fetches with the current MODEL_CATALOG_REVISION in both SQL and memory repositories.
- Treat revision mismatches as cold before evaluating the soft or hard TTL, then overwrite the row after a successful blocking refresh.
- Document the global bump policy for embedded pricing and any other code-derived catalog metadata or serialization changes.

## Behavior

Rows written before this migration become ineligible once until their upstream catalog is fetched again. A failed refresh records the error on the old row but does not serve that incompatible snapshot.

## Test Plan

- [x] `pnpm run test`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`