### PR TITLE
fix(gateway): isolate candidate attempt inputs

### DIFF
--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -238,16 +238,17 @@ alias-origin candidates through the same iteration but never observe
 non-empty rules (passthrough alias kinds — `embedding`, `image` — carry
 `{}` by schema; the apply-rules call is a no-op).
 
-The `payload.model` normalization is unconditional across every chat
-serve site (`chat-completions`, `messages`, `responses`): each attempt
-sees `payload.model === candidate.model.id`, whether the inbound id was
-an alias name, a prefix-addressable variant like `cop/gpt-5.4`, a dated
-suffix like `claude-opus-4-7-20250929`, or a bare public id. The wire
-body drops `payload.model` at the last step; the provider layer stamps
-the emitting upstream's own id from `providerModelOf(candidate)`.
-Gemini omits the normalization because its inbound model rides on the
-URL path, not the body — dispatch keys off `candidate.model.id`
-directly.
+Every chat attempt owns a `structuredClone` of the source payload and a
+fresh `Headers` object, so rewrites and provider-boundary mutations cannot
+leak into a fallback candidate or the caller-owned request. Chat Completions,
+Messages, and Responses stamp `candidate.model.id` only onto that private
+clone, whether the inbound id was an alias name, a prefix-addressable variant
+like `cop/gpt-5.4`, a dated suffix like `claude-opus-4-7-20250929`, or a bare
+public id. The wire body drops `payload.model` at the last step; the provider
+layer stamps the emitting upstream's own id from `providerModelOf(candidate)`.
+Gemini clones for the same attempt isolation but needs no body-model stamp:
+its inbound model rides on the URL path and dispatch keys off
+`candidate.model.id` directly.
 
 By construction alias names never re-enter the alias layer: the target
 id is a real model id, so the shadow pattern (an alias whose first

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -29,7 +29,9 @@ export interface ChatCompletionsAttemptArgs {
 
 export const chatCompletionsAttempt = {
   generate: async (args: ChatCompletionsAttemptArgs): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
-    const { payload, ctx, candidate, headers } = args;
+    const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
+    const payload = structuredClone(sourcePayload);
+    const headers = new Headers(sourceHeaders);
     const targetApi = chatCompletionsTarget.pick(candidate.model.endpoints);
     const rewritten = await rewriteOrRenderChatCompletionsFailure(payload, ctx.store, candidate);
     if (rewritten.failure) return rewritten.failure;

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -30,7 +30,7 @@ export interface ChatCompletionsAttemptArgs {
 export const chatCompletionsAttempt = {
   generate: async (args: ChatCompletionsAttemptArgs): Promise<ExecuteResult<ProtocolFrame<ChatCompletionsStreamEvent>>> => {
     const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
-    const payload = structuredClone(sourcePayload);
+    const payload = { ...structuredClone(sourcePayload), model: candidate.model.id };
     const headers = new Headers(sourceHeaders);
     const targetApi = chatCompletionsTarget.pick(candidate.model.endpoints);
     const rewritten = await rewriteOrRenderChatCompletionsFailure(payload, ctx.store, candidate);

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve.ts
@@ -41,19 +41,15 @@ export const chatCompletionsServe = {
     // from one candidate falls through to the next so the gateway absorbs
     // transient 5xx/429/network failures. When the list is exhausted, the
     // most recent failure is forwarded verbatim so the client still sees
-    // real upstream telemetry rather than a synthetic envelope. Normalize
-    // `payload.model` to the candidate's real id — inbound may be an alias
-    // name, a prefix-addressable variant, or a dated-suffix id, but every
-    // attempt sees the canonical resolved public id.
+    // real upstream telemetry rather than a synthetic envelope. Each attempt
+    // stamps its private payload clone with the candidate's canonical model id
+    // so aliases and prefixed ids resolve without mutating the caller payload.
     return await iterateCandidates(
       decision.candidates,
       'chatCompletionsServe.generate',
       ctx,
       'chat',
-      candidate => {
-        payload.model = candidate.model.id;
-        return chatCompletionsAttempt.generate({ payload, ctx, candidate, headers });
-      },
+      candidate => chatCompletionsAttempt.generate({ payload, ctx, candidate, headers }),
     );
   },
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -101,6 +101,13 @@ const makeCandidate = (overrides: {
   };
 };
 
+const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
+  Object.assign(candidate.model, { id });
+  const providerModel = candidate.model.providerModels[candidate.provider.upstream];
+  if (providerModel === undefined) throw new Error('expected candidate provider model');
+  Object.assign(providerModel, { id });
+};
+
 const collectEvents = async <TEvent>(events: AsyncIterable<ProtocolFrame<TEvent>>): Promise<TEvent[]> => {
   const out: TEvent[] = [];
   for await (const frame of events) {
@@ -317,7 +324,7 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
   // The attempt stamps its private clone with `candidate.model.id` and reads
   // the overlay directly off `candidate.rules` at wire-call time.
   const candidate = makeCandidate({ upstream: 'up_a', callChatCompletions });
-  Object.assign(candidate.model, { id: 'gpt-5.4' });
+  setCandidateModelId(candidate, 'gpt-5.4');
   queueResolution([candidate], { aliasRules: { reasoning: { effort: 'low' }, verbosity: 'low' } });
 
   const payload = makePayload({ model: 'gpt-fast' });
@@ -354,7 +361,7 @@ test('direct dispatch uses the resolved public id without mutating the addressed
     return { ok: true, events: makeProtocolFrames(makeChatCompletionsEvents()), modelKey: 'gpt-5.4', headers: new Headers() };
   });
   const candidate = makeCandidate({ upstream: 'up_a', callChatCompletions });
-  Object.assign(candidate.model, { id: 'gpt-5.4' });
+  setCandidateModelId(candidate, 'gpt-5.4');
   queueResolution([candidate]);
 
   const payload = makePayload({ model: 'cop/gpt-5.4' });

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -103,7 +103,7 @@ const makeCandidate = (overrides: {
 
 const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
   Object.assign(candidate.model, { id });
-  const providerModel = candidate.model.providerModels[candidate.provider.upstream];
+  const providerModel = candidate.model.providerModels?.[candidate.provider.upstream];
   if (providerModel === undefined) throw new Error('expected candidate provider model');
   Object.assign(providerModel, { id });
 };

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -306,14 +306,16 @@ test('generate renders model-missing when no candidates are available', async ()
 test('alias resolution swaps the inbound model id for the target and overlays rules onto the IR', async () => {
   installRepo();
   const capturedBodies: ChatCompletionsPayload[] = [];
-  const callChatCompletions = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => {
+  const observedModelIds: string[] = [];
+  const callChatCompletions = vi.fn(async (model: unknown, body: unknown): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => {
+    observedModelIds.push((model as { id: string }).id);
     capturedBodies.push(body as ChatCompletionsPayload);
     return { ok: true, events: makeProtocolFrames(makeChatCompletionsEvents()), modelKey: 'gpt-5.4', headers: new Headers() };
   });
   // Alias flow shape: the resolver returns candidates carrying the target's
   // upstream catalog id AND the alias's rule overlay on `candidate.rules`.
-  // Serve normalizes `payload.model` to `candidate.model.id`; the attempt
-  // reads the overlay directly off `candidate.rules` at wire-call time.
+  // The attempt stamps its private clone with `candidate.model.id` and reads
+  // the overlay directly off `candidate.rules` at wire-call time.
   const candidate = makeCandidate({ upstream: 'up_a', callChatCompletions });
   Object.assign(candidate.model, { id: 'gpt-5.4' });
   queueResolution([candidate], { aliasRules: { reasoning: { effort: 'low' }, verbosity: 'low' } });
@@ -332,11 +334,8 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
   // The resolver saw the inbound alias id verbatim — target-id walking
   // happens inside the resolver, not in serve.
   assertEquals(lastResolveCall.model, 'gpt-fast');
-  // Serve normalized payload.model to the candidate's real id before the
-  // attempt. Every attempt sees the canonical resolved public id — for an
-  // alias inbound the change is visible (gpt-fast → gpt-5.4); for a direct
-  // inbound the rewrite is a no-op.
-  assertEquals(payload.model, 'gpt-5.4');
+  assertEquals(observedModelIds, ['gpt-5.4']);
+  assertEquals(payload.model, 'gpt-fast');
   // Alias rules land on the IR through candidate.rules → the attempt's
   // applyRulesToUpstreamChatCompletions call.
   const observed = capturedBodies[0]!;
@@ -344,15 +343,16 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
   assertEquals(observed.verbosity, 'low');
 });
 
-test('direct dispatch normalizes payload.model to the resolved public id', async () => {
+test('direct dispatch uses the resolved public id without mutating the addressed model', async () => {
   // A prefix-addressable id ('cop/gpt-5.4') resolves to the catalog's
-  // 'gpt-5.4' — the resolver strips the prefix internally. Serve then
-  // pins payload.model to the candidate's real id so every attempt sees
-  // the canonical form regardless of how the client addressed the model.
+  // 'gpt-5.4' — the resolver strips the prefix internally. The attempt pins
+  // only its private clone to that canonical id.
   installRepo();
-  const callChatCompletions = vi.fn(async (): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => ({
-    ok: true, events: makeProtocolFrames(makeChatCompletionsEvents()), modelKey: 'gpt-5.4', headers: new Headers(),
-  }));
+  const observedModelIds: string[] = [];
+  const callChatCompletions = vi.fn(async (model: unknown): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => {
+    observedModelIds.push((model as { id: string }).id);
+    return { ok: true, events: makeProtocolFrames(makeChatCompletionsEvents()), modelKey: 'gpt-5.4', headers: new Headers() };
+  });
   const candidate = makeCandidate({ upstream: 'up_a', callChatCompletions });
   Object.assign(candidate.model, { id: 'gpt-5.4' });
   queueResolution([candidate]);
@@ -367,9 +367,11 @@ test('direct dispatch normalizes payload.model to the resolved public id', async
   if (result.type !== 'events') throw new Error('unreachable');
   await collectEvents(result.events);
 
-  // Resolver saw the prefixed inbound; serve normalized to the catalog id.
+  // Resolver and caller payload retain the prefixed address while dispatch
+  // uses the catalog id.
   assertEquals(lastResolveCall.model, 'cop/gpt-5.4');
-  assertEquals(payload.model, 'gpt-5.4');
+  assertEquals(observedModelIds, ['gpt-5.4']);
+  assertEquals(payload.model, 'cop/gpt-5.4');
 });
 
 test('alias whose targets have no kind-matching binding surfaces as the regular model-missing 404', async () => {

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -84,6 +84,7 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 
 const makeCandidate = (overrides: {
   upstream?: string;
+  modelId?: string;
   endpoints?: ModelEndpoints;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
 } = {}): ModelCandidate => {
@@ -96,16 +97,12 @@ const makeCandidate = (overrides: {
       upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
-    model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
+    model: stubInternalModel({
+      id: overrides.modelId ?? 'test-model',
+      ...(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
+    }, upstream),
     fetcher: directFetcher,
   };
-};
-
-const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
-  Object.assign(candidate.model, { id });
-  const providerModel = candidate.model.providerModels?.[candidate.provider.upstream];
-  if (providerModel === undefined) throw new Error('expected candidate provider model');
-  Object.assign(providerModel, { id });
 };
 
 const collectEvents = async <TEvent>(events: AsyncIterable<ProtocolFrame<TEvent>>): Promise<TEvent[]> => {
@@ -323,8 +320,7 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
   // upstream catalog id AND the alias's rule overlay on `candidate.rules`.
   // The attempt stamps its private clone with `candidate.model.id` and reads
   // the overlay directly off `candidate.rules` at wire-call time.
-  const candidate = makeCandidate({ upstream: 'up_a', callChatCompletions });
-  setCandidateModelId(candidate, 'gpt-5.4');
+  const candidate = makeCandidate({ upstream: 'up_a', modelId: 'gpt-5.4', callChatCompletions });
   queueResolution([candidate], { aliasRules: { reasoning: { effort: 'low' }, verbosity: 'low' } });
 
   const payload = makePayload({ model: 'gpt-fast' });
@@ -360,8 +356,7 @@ test('direct dispatch uses the resolved public id without mutating the addressed
     observedModelIds.push((model as { id: string }).id);
     return { ok: true, events: makeProtocolFrames(makeChatCompletionsEvents()), modelKey: 'gpt-5.4', headers: new Headers() };
   });
-  const candidate = makeCandidate({ upstream: 'up_a', callChatCompletions });
-  setCandidateModelId(candidate, 'gpt-5.4');
+  const candidate = makeCandidate({ upstream: 'up_a', modelId: 'gpt-5.4', callChatCompletions });
   queueResolution([candidate]);
 
   const payload = makePayload({ model: 'cop/gpt-5.4' });

--- a/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts
@@ -156,22 +156,36 @@ test('generate filters out candidates that do not expose any chat-completions-ta
 
 test('generate falls through to the next candidate when the first yields an upstream error', async () => {
   installRepo();
+  const originalImageUrl = 'data:image/png;base64,AQID';
+  const payload = makePayload({
+    messages: [{
+      role: 'user',
+      content: [{ type: 'image_url', image_url: { url: originalImageUrl, detail: 'auto' } }],
+    }],
+  });
   const firstError = new Response(JSON.stringify({ error: { message: 'nope' } }), {
     status: 502, headers: new Headers({ 'content-type': 'application/json' }),
   });
-  const firstCall = vi.fn(async (): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => ({
-    ok: false, response: firstError, modelKey: 'first-key',
-  }));
-  const secondCall = vi.fn(async (): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => ({
-    ok: true, events: makeProtocolFrames(makeChatCompletionsEvents()), modelKey: 'second-key', headers: new Headers(),
-  }));
+  const firstCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => {
+    const message = (body as Omit<ChatCompletionsPayload, 'model'>).messages[0];
+    if (!Array.isArray(message.content) || message.content[0]?.type !== 'image_url') throw new Error('expected image content');
+    message.content[0].image_url.url = 'data:image/webp;base64,COMPRESSED';
+    return { ok: false, response: firstError, modelKey: 'first-key' };
+  });
+  let fallbackImageUrl: string | undefined;
+  const secondCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => {
+    const message = (body as Omit<ChatCompletionsPayload, 'model'>).messages[0];
+    if (!Array.isArray(message.content) || message.content[0]?.type !== 'image_url') throw new Error('expected image content');
+    fallbackImageUrl = message.content[0].image_url.url;
+    return { ok: true, events: makeProtocolFrames(makeChatCompletionsEvents()), modelKey: 'second-key', headers: new Headers() };
+  });
   queueResolution([
     makeCandidate({ upstream: 'up_a', callChatCompletions: firstCall }),
     makeCandidate({ upstream: 'up_b', callChatCompletions: secondCall }),
   ]);
 
   const result = await chatCompletionsServe.generate({
-    payload: makePayload(),
+    payload,
     ctx: makeGatewayCtx(),
     headers: new Headers(),
   });
@@ -182,6 +196,10 @@ test('generate falls through to the next candidate when the first yields an upst
   assertEquals(result.type, 'events');
   assertEquals(firstCall.mock.calls.length, 1);
   assertEquals(secondCall.mock.calls.length, 1);
+  assertEquals(fallbackImageUrl, originalImageUrl);
+  const sourceMessage = payload.messages[0];
+  if (!Array.isArray(sourceMessage.content) || sourceMessage.content[0]?.type !== 'image_url') throw new Error('expected source image content');
+  assertEquals(sourceMessage.content[0].image_url.url, originalImageUrl);
 });
 
 // A mid-attempt throw (interceptor bug / translation error / provider-layer

--- a/packages/gateway/src/data-plane/chat/gemini/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/attempt.ts
@@ -36,7 +36,9 @@ export interface GeminiAttemptCountTokensArgs {
 
 export const geminiAttempt = {
   generate: async (args: GeminiAttemptGenerateArgs): Promise<ExecuteResult<ProtocolFrame<GeminiStreamEvent>>> => {
-    const { payload, ctx, candidate, headers } = args;
+    const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
+    const payload = structuredClone(sourcePayload);
+    const headers = new Headers(sourceHeaders);
     const targetApi = geminiGenerateTarget.pick(candidate.model.endpoints);
     const invocation: GeminiInvocation = { payload, candidate, targetApi, headers };
     return await runInterceptors(invocation, ctx, geminiInterceptors, async () => {
@@ -80,7 +82,9 @@ export const geminiAttempt = {
   },
 
   countTokens: async (args: GeminiAttemptCountTokensArgs): Promise<PlainResult> => {
-    const { payload, ctx, candidate, headers } = args;
+    const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
+    const payload = structuredClone(sourcePayload);
+    const headers = new Headers(sourceHeaders);
     const targetApi = geminiCountTokensTarget.pick(candidate.model.endpoints);
     const invocation: GeminiInvocation = { payload, candidate, targetApi, headers };
     return await runInterceptors(invocation, ctx, geminiCountTokensInterceptors, async () => {
@@ -90,13 +94,13 @@ export const geminiAttempt = {
       // shipped Gemini interceptors that mutate the payload pre-dispatch
       // cannot run via the countTokens interceptor list — the post-`run()`
       // ones inspect event streams the result type cannot carry — so the
-      // payload-mutators are applied inline here on a structuredClone of
-      // the source so the caller's payload stays intact.
+      // payload-mutators are applied inline here before translation; the
+      // attempt-owned payload clone keeps the caller's source intact.
       const transCtx = {
         model: candidate.model.id,
         fallbackMaxOutputTokens: candidate.model.limits.max_output_tokens,
       };
-      const cleaned = structuredClone(invocation.payload);
+      const cleaned = invocation.payload;
       stripUnsupportedPartFieldsFromPayload(cleaned);
       stripUnsupportedToolsFromPayload(cleaned);
       delete cleaned.safetySettings;

--- a/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/serve_test.ts
@@ -218,6 +218,12 @@ test('generate translates through Responses when only that endpoint is exposed',
 
 test('generate falls through to the next candidate when the first yields an upstream error', async () => {
   installRepo();
+  const payload = makePayload({
+    contents: [{
+      role: 'user',
+      parts: [{ text: 'hello', thought: true, thoughtSignature: 'opaque-signature' }],
+    }],
+  });
   const firstError = new Response(JSON.stringify({ error: { message: 'nope' } }), {
     status: 502, headers: new Headers({ 'content-type': 'application/json' }),
   });
@@ -233,7 +239,7 @@ test('generate falls through to the next candidate when the first yields an upst
   ]);
 
   const result = await geminiServe.generate({
-    payload: makePayload(),
+    payload,
     ctx: makeGatewayCtx(),
     model: 'test-model',
     headers: new Headers(),
@@ -245,6 +251,11 @@ test('generate falls through to the next candidate when the first yields an upst
   expectType(result, 'events');
   assertEquals(firstCall.mock.calls.length, 1);
   assertEquals(secondCall.mock.calls.length, 1);
+  assertEquals(payload.contents?.[0]?.parts, [{
+    text: 'hello',
+    thought: true,
+    thoughtSignature: 'opaque-signature',
+  }]);
 });
 
 // A mid-attempt throw (interceptor bug / translation error / provider-layer

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -36,7 +36,7 @@ export interface MessagesAttemptArgs {
 export const messagesAttempt = {
   generate: async (args: MessagesAttemptArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => {
     const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
-    const payload = structuredClone(sourcePayload);
+    const payload = { ...structuredClone(sourcePayload), model: candidate.model.id };
     const headers = new Headers(sourceHeaders);
     const { store } = ctx;
     const targetApi = messagesGenerateTarget.pick(candidate.model.endpoints);
@@ -84,7 +84,7 @@ export const messagesAttempt = {
 
   countTokens: async (args: MessagesAttemptArgs): Promise<PlainResult> => {
     const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
-    const payload = structuredClone(sourcePayload);
+    const payload = { ...structuredClone(sourcePayload), model: candidate.model.id };
     const headers = new Headers(sourceHeaders);
     const { store } = ctx;
     // `pick` here is contractually total — serve filtered with

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -35,7 +35,9 @@ export interface MessagesAttemptArgs {
 
 export const messagesAttempt = {
   generate: async (args: MessagesAttemptArgs): Promise<ExecuteResult<ProtocolFrame<MessagesStreamEvent>>> => {
-    const { payload, ctx, candidate, headers } = args;
+    const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
+    const payload = structuredClone(sourcePayload);
+    const headers = new Headers(sourceHeaders);
     const { store } = ctx;
     const targetApi = messagesGenerateTarget.pick(candidate.model.endpoints);
     const rewritten = await rewriteOrRenderMessagesFailure(payload, store, candidate);
@@ -81,7 +83,9 @@ export const messagesAttempt = {
   },
 
   countTokens: async (args: MessagesAttemptArgs): Promise<PlainResult> => {
-    const { payload, ctx, candidate, headers } = args;
+    const { payload: sourcePayload, ctx, candidate, headers: sourceHeaders } = args;
+    const payload = structuredClone(sourcePayload);
+    const headers = new Headers(sourceHeaders);
     const { store } = ctx;
     // `pick` here is contractually total — serve filtered with
     // `messagesCountTokensTarget.canServe`, so a non-messages candidate is

--- a/packages/gateway/src/data-plane/chat/messages/serve.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve.ts
@@ -46,18 +46,14 @@ export const messagesServe = {
     // stream opened) is the final answer; an api-error or internal-error
     // from one candidate falls through to the next so the gateway absorbs
     // transient 5xx/429/network failures. When the list is exhausted, the
-    // most recent failure is forwarded verbatim. Normalize `payload.model`
-    // to the candidate's real id so every attempt sees the canonical
-    // resolved public id.
+    // most recent failure is forwarded verbatim. Each attempt stamps its
+    // private payload clone with the candidate's canonical model id.
     return await iterateCandidates(
       decision.candidates,
       'messagesServe.generate',
       ctx,
       'chat',
-      candidate => {
-        payload.model = candidate.model.id;
-        return messagesAttempt.generate({ payload, ctx, candidate, headers });
-      },
+      candidate => messagesAttempt.generate({ payload, ctx, candidate, headers }),
     );
   },
 
@@ -85,12 +81,7 @@ export const messagesServe = {
       'messagesServe.countTokens',
       ctx,
       'chat',
-      candidate => {
-        // Same normalization as generate above — every attempt sees
-        // payload.model === candidate.model.id regardless of inbound form.
-        payload.model = candidate.model.id;
-        return messagesAttempt.countTokens({ payload, ctx, candidate, headers });
-      },
+      candidate => messagesAttempt.countTokens({ payload, ctx, candidate, headers }),
     );
   },
 };

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -158,7 +158,7 @@ const makeCandidate = (overrides: {
 
 const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
   Object.assign(candidate.model, { id });
-  const providerModel = candidate.model.providerModels[candidate.provider.upstream];
+  const providerModel = candidate.model.providerModels?.[candidate.provider.upstream];
   if (providerModel === undefined) throw new Error('expected candidate provider model');
   Object.assign(providerModel, { id });
 };

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -124,6 +124,7 @@ const makeProtocolFrames = async function* <TEvent>(events: readonly TEvent[]): 
 
 const makeCandidate = (overrides: {
   upstream?: string;
+  modelId?: string;
   endpoints?: ModelEndpoints;
   kind?: ModelCandidate['provider']['kind'];
   enabledFlags?: ReadonlySet<FlagId>;
@@ -132,6 +133,7 @@ const makeCandidate = (overrides: {
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
 } = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
+  const modelId = overrides.modelId ?? 'test-model';
   const kind = overrides.kind ?? 'custom';
   const provider = stubProvider({
     callMessages: overrides.callMessages,
@@ -144,9 +146,11 @@ const makeCandidate = (overrides: {
       disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
     model: stubInternalModel({
+      id: modelId,
       ...(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
       providerModels: {
         [upstream]: stubProviderModel({
+          id: modelId,
           ...(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
           ...(overrides.enabledFlags ? { enabledFlags: overrides.enabledFlags } : {}),
         }),
@@ -154,13 +158,6 @@ const makeCandidate = (overrides: {
     }, upstream),
     fetcher: directFetcher,
   };
-};
-
-const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
-  Object.assign(candidate.model, { id });
-  const providerModel = candidate.model.providerModels?.[candidate.provider.upstream];
-  if (providerModel === undefined) throw new Error('expected candidate provider model');
-  Object.assign(providerModel, { id });
 };
 
 const collectEvents = async <TEvent>(events: AsyncIterable<ProtocolFrame<TEvent>>): Promise<TEvent[]> => {
@@ -351,8 +348,7 @@ test('countTokens proxies the upstream measurement response as a plain result', 
       modelKey: 'test-model-key',
     };
   });
-  const candidate = makeCandidate({ upstream: 'up_a', callMessagesCountTokens });
-  setCandidateModelId(candidate, 'claude-target');
+  const candidate = makeCandidate({ upstream: 'up_a', modelId: 'claude-target', callMessagesCountTokens });
   queueResolution([candidate]);
   const payload = makePayload({ model: 'claude-alias' });
 
@@ -641,8 +637,7 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
   // upstream catalog id AND the alias's rule overlay on `candidate.rules`.
   // The attempt stamps its private clone with `candidate.model.id` and reads
   // the overlay directly off `candidate.rules` at wire-call time.
-  const candidate = makeCandidate({ upstream: 'up_cf', callMessages });
-  setCandidateModelId(candidate, 'claude-opus-4-7');
+  const candidate = makeCandidate({ upstream: 'up_cf', modelId: 'claude-opus-4-7', callMessages });
   queueResolution([candidate], { aliasRules: { reasoning: { effort: 'high', budget_tokens: 2048 }, serviceTier: 'fast' } });
 
   const payload = makePayload({ model: 'claude-fast' });

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -156,6 +156,13 @@ const makeCandidate = (overrides: {
   };
 };
 
+const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
+  Object.assign(candidate.model, { id });
+  const providerModel = candidate.model.providerModels[candidate.provider.upstream];
+  if (providerModel === undefined) throw new Error('expected candidate provider model');
+  Object.assign(providerModel, { id });
+};
+
 const collectEvents = async <TEvent>(events: AsyncIterable<ProtocolFrame<TEvent>>): Promise<TEvent[]> => {
   const out: TEvent[] = [];
   for await (const frame of events) {
@@ -345,7 +352,7 @@ test('countTokens proxies the upstream measurement response as a plain result', 
     };
   });
   const candidate = makeCandidate({ upstream: 'up_a', callMessagesCountTokens });
-  Object.assign(candidate.model, { id: 'claude-target' });
+  setCandidateModelId(candidate, 'claude-target');
   queueResolution([candidate]);
   const payload = makePayload({ model: 'claude-alias' });
 
@@ -635,7 +642,7 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
   // The attempt stamps its private clone with `candidate.model.id` and reads
   // the overlay directly off `candidate.rules` at wire-call time.
   const candidate = makeCandidate({ upstream: 'up_cf', callMessages });
-  Object.assign(candidate.model, { id: 'claude-opus-4-7' });
+  setCandidateModelId(candidate, 'claude-opus-4-7');
   queueResolution([candidate], { aliasRules: { reasoning: { effort: 'high', budget_tokens: 2048 }, serviceTier: 'fast' } });
 
   const payload = makePayload({ model: 'claude-fast' });

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -333,17 +333,24 @@ test('generate filters out candidates whose endpoints do not satisfy the message
 
 test('countTokens proxies the upstream measurement response as a plain result', async () => {
   installRepo();
-  const callMessagesCountTokens = vi.fn(async (): Promise<ProviderCallResult> => ({
-    response: new Response(JSON.stringify({ input_tokens: 42 }), {
-      status: 200,
-      headers: new Headers({ 'content-type': 'application/json' }),
-    }),
-    modelKey: 'test-model-key',
-  }));
-  queueResolution([makeCandidate({ upstream: 'up_a', callMessagesCountTokens })]);
+  const observedModelIds: string[] = [];
+  const callMessagesCountTokens = vi.fn(async (model: unknown): Promise<ProviderCallResult> => {
+    observedModelIds.push((model as { id: string }).id);
+    return {
+      response: new Response(JSON.stringify({ input_tokens: 42 }), {
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+      }),
+      modelKey: 'test-model-key',
+    };
+  });
+  const candidate = makeCandidate({ upstream: 'up_a', callMessagesCountTokens });
+  Object.assign(candidate.model, { id: 'claude-target' });
+  queueResolution([candidate]);
+  const payload = makePayload({ model: 'claude-alias' });
 
   const result = await messagesServe.countTokens({
-    payload: makePayload(),
+    payload,
     ctx: makeGatewayCtx(),
     headers: new Headers(),
   });
@@ -353,6 +360,8 @@ test('countTokens proxies the upstream measurement response as a plain result', 
   const body = JSON.parse(new TextDecoder().decode(plain.body));
   assertEquals(body.input_tokens, 42);
   assertEquals(callMessagesCountTokens.mock.calls.length, 1);
+  assertEquals(observedModelIds, ['claude-target']);
+  assertEquals(payload.model, 'claude-alias');
 });
 
 test('countTokens renders model-missing as a 404 when no candidates are available', async () => {
@@ -615,14 +624,16 @@ test('countTokens failover preserves billing blocks for a strip-off candidate', 
 test('alias resolution swaps the inbound model id for the target and overlays rules onto the Messages IR', async () => {
   installRepo();
   const capturedBodies: MessagesPayload[] = [];
-  const callMessages = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<MessagesStreamEvent>> => {
+  const observedModelIds: string[] = [];
+  const callMessages = vi.fn(async (model: unknown, body: unknown): Promise<ProviderStreamResult<MessagesStreamEvent>> => {
+    observedModelIds.push((model as { id: string }).id);
     capturedBodies.push({ ...(body as Omit<MessagesPayload, 'model'>), model: 'claude-opus-4-7' });
     return { ok: true, events: makeProtocolFrames(makeMessagesResultEvents()), modelKey: 'claude-opus-4-7' };
   });
   // Alias flow shape: the resolver returns candidates carrying the target's
   // upstream catalog id AND the alias's rule overlay on `candidate.rules`.
-  // Serve normalizes `payload.model` to `candidate.model.id`; the attempt
-  // reads the overlay directly off `candidate.rules` at wire-call time.
+  // The attempt stamps its private clone with `candidate.model.id` and reads
+  // the overlay directly off `candidate.rules` at wire-call time.
   const candidate = makeCandidate({ upstream: 'up_cf', callMessages });
   Object.assign(candidate.model, { id: 'claude-opus-4-7' });
   queueResolution([candidate], { aliasRules: { reasoning: { effort: 'high', budget_tokens: 2048 }, serviceTier: 'fast' } });
@@ -636,10 +647,11 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
 
   await collectEvents(assertResultType(result, 'events').events);
 
-  // The resolver saw the inbound alias id verbatim; serve rewrote
-  // payload.model to the target id before the attempt.
+  // The resolver and caller payload retain the inbound alias while dispatch
+  // uses the resolved target id.
   assertEquals(lastResolveCall.model, 'claude-fast');
-  assertEquals(payload.model, 'claude-opus-4-7');
+  assertEquals(observedModelIds, ['claude-opus-4-7']);
+  assertEquals(payload.model, 'claude-fast');
   const observed = capturedBodies[0]!;
   assertEquals(observed.output_config?.effort, 'high');
   assertEquals(observed.thinking?.budget_tokens, 2048);

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -505,6 +505,113 @@ test('copilot candidate strips x-anthropic-billing-header system block via the d
   assertEquals(observed.system[0].text, 'You are a helpful assistant.');
 });
 
+test('generate failover preserves billing blocks for a strip-off candidate', async () => {
+  installRepo();
+  const billingBlock = 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;';
+  const system = [
+    { type: 'text' as const, text: billingBlock },
+    { type: 'text' as const, text: "You are Claude Code, Anthropic's official CLI for Claude." },
+  ];
+  const expectedSystem = structuredClone(system);
+  const messages = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'original user text' }] }];
+  const expectedMessages = structuredClone(messages);
+  const firstCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<MessagesStreamEvent>> => {
+    const message = (body as Omit<MessagesPayload, 'model'>).messages[0];
+    if (!Array.isArray(message.content) || message.content[0]?.type !== 'text') throw new Error('expected text content');
+    message.content[0].text = 'mutated by first provider';
+    return {
+      ok: false,
+      response: new Response('unavailable', { status: 503 }),
+      modelKey: 'first-key',
+    };
+  });
+  const observedBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const secondCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<MessagesStreamEvent>> => {
+    observedBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return {
+      ok: true,
+      events: makeProtocolFrames(makeMessagesResultEvents('msg_claude_code')),
+      modelKey: 'claude-code-key',
+    };
+  });
+  queueResolution([
+    makeCandidate({
+      upstream: 'up_copilot',
+      kind: 'copilot',
+      enabledFlags: new Set(['strip-billing-attribution']),
+      callMessages: firstCall,
+    }),
+    makeCandidate({
+      upstream: 'up_claude_code',
+      kind: 'claude-code',
+      enabledFlags: new Set(),
+      callMessages: secondCall,
+    }),
+  ]);
+
+  const payload = makePayload({ system, messages });
+  const result = await messagesServe.generate({ payload, ctx: makeGatewayCtx(), headers: new Headers() });
+  await collectEvents(assertResultType(result, 'events').events);
+
+  assertEquals(firstCall.mock.calls.length, 1);
+  assertEquals(secondCall.mock.calls.length, 1);
+  assertEquals(observedBodies[0]?.system, expectedSystem);
+  assertEquals(observedBodies[0]?.messages, expectedMessages);
+  assertEquals(payload.system, expectedSystem);
+  assertEquals(payload.messages, expectedMessages);
+});
+
+test('countTokens failover preserves billing blocks for a strip-off candidate', async () => {
+  installRepo();
+  const system = [
+    { type: 'text' as const, text: 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;' },
+    { type: 'text' as const, text: 'Count this prompt.' },
+  ];
+  const expectedSystem = structuredClone(system);
+  const messages = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'original user text' }] }];
+  const expectedMessages = structuredClone(messages);
+  const firstCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderCallResult> => {
+    const message = (body as Omit<MessagesPayload, 'model'>).messages[0];
+    if (!Array.isArray(message.content) || message.content[0]?.type !== 'text') throw new Error('expected text content');
+    message.content[0].text = 'mutated by first provider';
+    return {
+      response: new Response('unavailable', { status: 503 }),
+      modelKey: 'first-key',
+    };
+  });
+  const observedBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const secondCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderCallResult> => {
+    observedBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return {
+      response: Response.json({ input_tokens: 12 }),
+      modelKey: 'second-key',
+    };
+  });
+  queueResolution([
+    makeCandidate({
+      upstream: 'up_strip_on',
+      enabledFlags: new Set(['strip-billing-attribution']),
+      callMessagesCountTokens: firstCall,
+    }),
+    makeCandidate({
+      upstream: 'up_strip_off',
+      enabledFlags: new Set(),
+      callMessagesCountTokens: secondCall,
+    }),
+  ]);
+
+  const payload = makePayload({ system, messages });
+  const result = await messagesServe.countTokens({ payload, ctx: makeGatewayCtx(), headers: new Headers() });
+
+  assertEquals(assertResultType(result, 'plain').status, 200);
+  assertEquals(firstCall.mock.calls.length, 1);
+  assertEquals(secondCall.mock.calls.length, 1);
+  assertEquals(observedBodies[0]?.system, expectedSystem);
+  assertEquals(observedBodies[0]?.messages, expectedMessages);
+  assertEquals(payload.system, expectedSystem);
+  assertEquals(payload.messages, expectedMessages);
+});
+
 test('alias resolution swaps the inbound model id for the target and overlays rules onto the Messages IR', async () => {
   installRepo();
   const capturedBodies: MessagesPayload[] = [];

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -75,7 +75,9 @@ export interface ResponsesAttemptInvokeArgs {
 // no-op at the store-write layer.
 export const responsesAttempt = {
   invoke: async (args: ResponsesAttemptInvokeArgs): Promise<ResponsesAttemptResult> => {
-    const { payload, action, ctx, candidate, headers } = args;
+    const { payload: sourcePayload, action, ctx, candidate, headers: sourceHeaders } = args;
+    const payload = structuredClone(sourcePayload);
+    const headers = new Headers(sourceHeaders);
     const { store } = ctx;
     const targetApi = responsesTarget.pick(candidate.model.endpoints);
     // Rewrite + privatePayload seed + assistant-content normalization all run

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -76,7 +76,7 @@ export interface ResponsesAttemptInvokeArgs {
 export const responsesAttempt = {
   invoke: async (args: ResponsesAttemptInvokeArgs): Promise<ResponsesAttemptResult> => {
     const { payload: sourcePayload, action, ctx, candidate, headers: sourceHeaders } = args;
-    const payload = structuredClone(sourcePayload);
+    const payload = { ...structuredClone(sourcePayload), model: candidate.model.id };
     const headers = new Headers(sourceHeaders);
     const { store } = ctx;
     const targetApi = responsesTarget.pick(candidate.model.endpoints);

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -397,11 +397,10 @@ test('POST /v1/responses renders a routing-unavailable 400 when a forcing item n
   assertEquals(body.error.code, 'responses_item_routing_unavailable');
 });
 
-// Alias flow: the resolver returns a candidate whose upstream catalog id
-// is the target model id, plus the alias's rule overlay. Serve rewrites
-// `payload.model` to `candidate.model.id` before dispatching, and the
-// attempt's leaf wire call reads `candidate.rules` to overlay the rules
-// onto the target IR.
+// Alias flow: the resolver returns a candidate whose upstream catalog id is
+// the target model id, plus the alias's rule overlay. The attempt stamps its
+// private clone with `candidate.model.id`, and the leaf wire call reads
+// `candidate.rules` to overlay the rules onto the target IR.
 const queueCodexAutoReviewCandidate = (
   callResponses: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>,
 ): void => {

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -29,17 +29,14 @@ export const responsesServe = {
     // final answer; per-candidate failures fall through so a transient
     // 5xx/429/network does not become the request's verdict when another
     // candidate can serve. The last failure surfaces verbatim on exhaustion.
-    // Normalize `prepared.model` to the candidate's real id so every
-    // attempt sees the canonical resolved public id.
+    // Each attempt stamps its private prepared-payload clone with the
+    // candidate's canonical model id.
     return await iterateCandidates(
       plan.candidates,
       'responsesServe.generate',
       ctx,
       'chat',
-      candidate => {
-        plan.prepared.model = candidate.model.id;
-        return responsesAttempt.generate({ payload: plan.prepared, ctx, candidate, headers });
-      },
+      candidate => responsesAttempt.generate({ payload: plan.prepared, ctx, candidate, headers }),
     );
   },
 
@@ -60,10 +57,7 @@ export const responsesServe = {
       'responsesServe.compact',
       ctx,
       'chat',
-      candidate => {
-        plan.prepared.model = candidate.model.id;
-        return responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate, headers });
-      },
+      candidate => responsesAttempt.invoke({ payload: plan.prepared, action: 'compact', ctx, candidate, headers }),
     );
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -181,15 +181,19 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
     object: 'response.compaction',
     output: [compactionItem] as unknown as ResponsesResult['output'],
   };
-  const callResponses = vi.fn(async (_model: unknown, _body: unknown, action: ResponsesAction): Promise<ProviderResponsesResult> => {
+  const observedModelIds: string[] = [];
+  const callResponses = vi.fn(async (model: unknown, _body: unknown, action: ResponsesAction): Promise<ProviderResponsesResult> => {
     if (action !== 'compact') throw new Error(`expected compact, got ${action}`);
+    observedModelIds.push((model as { id: string }).id);
     return { action: 'compact', ok: true, result: compactionResult, modelKey: 'test-model-key' };
   });
   const candidate = makeCandidate({ upstream: 'up_a', callResponses });
+  Object.assign(candidate.model, { id: 'gpt-target' });
   queueResolution([candidate]);
+  const payload = compactPayload({ model: 'gpt-alias' });
 
   const result = await responsesServe.compact({
-    payload: compactPayload(),
+    payload,
     ctx: makeGatewayCtx(),
     headers: new Headers(),
   });
@@ -199,6 +203,8 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
   assertEquals(result.result.object, 'response.compaction');
   assertEquals(callResponses.mock.calls.length, 1);
   assertEquals(callResponses.mock.calls[0][2], 'compact');
+  assertEquals(observedModelIds, ['gpt-target']);
+  assertEquals(payload.model, 'gpt-alias');
 });
 
 test('generate falls through to the next candidate when the first yields an upstream error', async () => {
@@ -739,7 +745,9 @@ test('generate treats compaction_trigger-bearing input as compaction: snapshot r
 test('alias resolution swaps the inbound model id for the target and overlays rules onto the Responses IR', async () => {
   installRepo();
   const capturedBodies: ResponsesPayload[] = [];
-  const callResponses = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderResponsesResult> => {
+  const observedModelIds: string[] = [];
+  const callResponses = vi.fn(async (model: unknown, body: unknown): Promise<ProviderResponsesResult> => {
+    observedModelIds.push((model as { id: string }).id);
     capturedBodies.push(body as ResponsesPayload);
     return { action: 'generate', ok: true, events: makeProtocolFrames([{ type: 'response.completed', sequence_number: 0, response: makeResponsesResult() }]), modelKey: 'gpt-5.4', headers: new Headers() };
   });
@@ -760,12 +768,11 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
   if (result.type !== 'events') throw new Error('unreachable');
   await collectEvents(result.events);
 
-  // Resolver saw the inbound alias id; serve rewrote the prepared payload's
-  // model to the target id before dispatching. (The attempt strips `model`
-  // from the body — the provider re-stamps it from `candidate.model.id` —
-  // so we only verify payload rewriting via `payload.model` here.)
+  // Resolver and caller payload retain the inbound alias; the provider model
+  // argument carries the resolved target id while the body omits `model`.
   assertEquals(lastResolveCall.model, 'gpt-fast');
-  assertEquals(payload.model, 'gpt-5.4');
+  assertEquals(observedModelIds, ['gpt-5.4']);
+  assertEquals(payload.model, 'gpt-fast');
   const observed = capturedBodies[0]!;
   assertEquals(observed.reasoning?.effort, 'high');
   assertEquals(observed.reasoning?.summary, 'detailed');

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -109,6 +109,7 @@ const makeProtocolFrames = async function* <E>(events: readonly E[]): AsyncGener
 
 const makeCandidate = (overrides: {
   upstream?: string;
+  modelId?: string;
   endpoints?: ModelEndpoints;
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callMessages?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<MessagesStreamEvent>>;
@@ -131,16 +132,12 @@ const makeCandidate = (overrides: {
     },
     // Default keeps stubInternalModel's three-endpoint map intact; tests that
     // need a rejected candidate pass an explicit `endpoints` override.
-    model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
+    model: stubInternalModel({
+      id: overrides.modelId ?? 'test-model',
+      ...(overrides.endpoints ? { endpoints: overrides.endpoints } : {}),
+    }, upstream),
     fetcher: directFetcher,
   };
-};
-
-const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
-  Object.assign(candidate.model, { id });
-  const providerModel = candidate.model.providerModels?.[candidate.provider.upstream];
-  if (providerModel === undefined) throw new Error('expected candidate provider model');
-  Object.assign(providerModel, { id });
 };
 
 const collectEvents = async (events: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesStreamEvent[]> => {
@@ -194,8 +191,7 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
     observedModelIds.push((model as { id: string }).id);
     return { action: 'compact', ok: true, result: compactionResult, modelKey: 'test-model-key' };
   });
-  const candidate = makeCandidate({ upstream: 'up_a', callResponses });
-  setCandidateModelId(candidate, 'gpt-target');
+  const candidate = makeCandidate({ upstream: 'up_a', modelId: 'gpt-target', callResponses });
   queueResolution([candidate]);
   const payload = compactPayload({ model: 'gpt-alias' });
 
@@ -758,8 +754,7 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
     capturedBodies.push(body as ResponsesPayload);
     return { action: 'generate', ok: true, events: makeProtocolFrames([{ type: 'response.completed', sequence_number: 0, response: makeResponsesResult() }]), modelKey: 'gpt-5.4', headers: new Headers() };
   });
-  const candidate = makeCandidate({ upstream: 'up_a', callResponses });
-  setCandidateModelId(candidate, 'gpt-5.4');
+  const candidate = makeCandidate({ upstream: 'up_a', modelId: 'gpt-5.4', callResponses });
   queueResolution([candidate], {
     aliasRules: { reasoning: { effort: 'high', summary: 'detailed' }, verbosity: 'medium', serviceTier: 'priority' },
   });

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -203,26 +203,41 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
 
 test('generate falls through to the next candidate when the first yields an upstream error', async () => {
   installRepo();
+  const originalImageUrl = 'data:image/png;base64,AQID';
+  const payload = makePayload({
+    input: [{
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_image', image_url: originalImageUrl, detail: 'auto' }],
+    }],
+  });
   const firstError = new Response(JSON.stringify({ error: { message: 'nope' } }), {
     status: 502, headers: new Headers({ 'content-type': 'application/json' }),
   });
-  const firstCall = vi.fn(async (): Promise<ProviderResponsesResult> => ({
-    action: 'generate', ok: false, response: firstError, modelKey: 'first-key',
-  }));
+  const firstCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderResponsesResult> => {
+    const item = (body as Omit<CanonicalResponsesPayload, 'model'>).input[0];
+    if (item.type !== 'message' || !Array.isArray(item.content) || item.content[0]?.type !== 'input_image') throw new Error('expected image content');
+    item.content[0].image_url = 'data:image/webp;base64,COMPRESSED';
+    return { action: 'generate', ok: false, response: firstError, modelKey: 'first-key' };
+  });
   const completed: ResponsesStreamEvent = {
     type: 'response.completed',
     sequence_number: 0,
     response: makeResponsesResult('resp_second'),
   };
-  const secondCall = vi.fn(async (): Promise<ProviderResponsesResult> => ({
-    action: 'generate', ok: true, events: makeProtocolFrames([completed]), modelKey: 'second-key', headers: new Headers(),
-  }));
+  let fallbackImageUrl: string | null | undefined;
+  const secondCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderResponsesResult> => {
+    const item = (body as Omit<CanonicalResponsesPayload, 'model'>).input[0];
+    if (item.type !== 'message' || !Array.isArray(item.content) || item.content[0]?.type !== 'input_image') throw new Error('expected image content');
+    fallbackImageUrl = item.content[0].image_url;
+    return { action: 'generate', ok: true, events: makeProtocolFrames([completed]), modelKey: 'second-key', headers: new Headers() };
+  });
   const first = makeCandidate({ upstream: 'up_a', callResponses: firstCall });
   const second = makeCandidate({ upstream: 'up_b', callResponses: secondCall });
   queueResolution([first, second]);
 
   const result = await responsesServe.generate({
-    payload: makePayload(),
+    payload,
     ctx: makeGatewayCtx(),
     headers: new Headers(),
   });
@@ -233,6 +248,10 @@ test('generate falls through to the next candidate when the first yields an upst
   assertEquals(result.type, 'events');
   assertEquals(firstCall.mock.calls.length, 1);
   assertEquals(secondCall.mock.calls.length, 1);
+  assertEquals(fallbackImageUrl, originalImageUrl);
+  const sourceItem = payload.input[0];
+  if (sourceItem.type !== 'message' || !Array.isArray(sourceItem.content) || sourceItem.content[0]?.type !== 'input_image') throw new Error('expected source image content');
+  assertEquals(sourceItem.content[0].image_url, originalImageUrl);
 });
 
 // A mid-attempt throw (interceptor bug / translation error / provider-layer

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -138,7 +138,7 @@ const makeCandidate = (overrides: {
 
 const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
   Object.assign(candidate.model, { id });
-  const providerModel = candidate.model.providerModels[candidate.provider.upstream];
+  const providerModel = candidate.model.providerModels?.[candidate.provider.upstream];
   if (providerModel === undefined) throw new Error('expected candidate provider model');
   Object.assign(providerModel, { id });
 };

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -136,6 +136,13 @@ const makeCandidate = (overrides: {
   };
 };
 
+const setCandidateModelId = (candidate: ModelCandidate, id: string): void => {
+  Object.assign(candidate.model, { id });
+  const providerModel = candidate.model.providerModels[candidate.provider.upstream];
+  if (providerModel === undefined) throw new Error('expected candidate provider model');
+  Object.assign(providerModel, { id });
+};
+
 const collectEvents = async (events: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesStreamEvent[]> => {
   const out: ResponsesStreamEvent[] = [];
   for await (const frame of events) {
@@ -188,7 +195,7 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
     return { action: 'compact', ok: true, result: compactionResult, modelKey: 'test-model-key' };
   });
   const candidate = makeCandidate({ upstream: 'up_a', callResponses });
-  Object.assign(candidate.model, { id: 'gpt-target' });
+  setCandidateModelId(candidate, 'gpt-target');
   queueResolution([candidate]);
   const payload = compactPayload({ model: 'gpt-alias' });
 
@@ -752,7 +759,7 @@ test('alias resolution swaps the inbound model id for the target and overlays ru
     return { action: 'generate', ok: true, events: makeProtocolFrames([{ type: 'response.completed', sequence_number: 0, response: makeResponsesResult() }]), modelKey: 'gpt-5.4', headers: new Headers() };
   });
   const candidate = makeCandidate({ upstream: 'up_a', callResponses });
-  Object.assign(candidate.model, { id: 'gpt-5.4' });
+  setCandidateModelId(candidate, 'gpt-5.4');
   queueResolution([candidate], {
     aliasRules: { reasoning: { effort: 'high', summary: 'detailed' }, verbosity: 'medium', serviceTier: 'priority' },
   });


### PR DESCRIPTION
## Summary

- Give every Chat Completions, Messages, Responses, and Gemini candidate attempt a private payload and `Headers` object before rewrites, interceptors, translation, or provider dispatch.
- Stamp resolved model ids only on private attempt payloads, preserving the caller-addressed model while preventing a failed candidate from mutating later fallbacks.
- Document the attempt-isolation invariant and cover generation, token-counting, compaction, failover, alias, and prefix-addressing paths.

## Test Plan

- [x] `pnpm exec vitest run packages/gateway/src/data-plane/chat/chat-completions/serve_test.ts packages/gateway/src/data-plane/chat/gemini/serve_test.ts packages/gateway/src/data-plane/chat/messages/serve_test.ts packages/gateway/src/data-plane/chat/responses/serve_test.ts` (58 tests)
- [x] `pnpm run test` (339 files, 4157 tests)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`