### PR TITLE
fix(messages): align count_tokens request transforms

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -122,12 +122,19 @@ are billed as reasoning/output exactly once.
   it, decodes shim-owned replay history back into upstream `search_result`
   blocks, and rewrites shim-owned search results/citations back to native
   Messages shape. The shim is enabled by default for Copilot Messages targets
-  too, because Copilot search is executed by the gateway.
+  too, because Copilot search is executed by the gateway. `count_tokens`
+  performs the same request preparation without the generation-only response
+  stream rewrite.
 - strips reserved `x-anthropic-billing-header` prompt-attribution lines and
   `cch=<hash>` cache markers that some clients inline into the `system`
   prompt; these are opaque to every upstream and poison prompt-cache prefix
   hashes
 - strips stray `[DONE]` sentinels from Anthropic-shaped streams
+
+Messages generation and `count_tokens` apply billing-attribution stripping,
+forced-tool reasoning compatibility, inline-system role compatibility, and
+web-search request preparation in the same order. Token counts therefore
+measure the exact request shape sent by generation.
 
 ### Messages — Copilot provider boundary chain
 

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -133,8 +133,9 @@ are billed as reasoning/output exactly once.
 
 Messages generation and `count_tokens` apply billing-attribution stripping,
 forced-tool reasoning compatibility, inline-system role compatibility, and
-web-search request preparation in the same order. Token counts therefore
-measure the exact request shape sent by generation.
+web-search request preparation in the same order. Token counts therefore see
+the same gateway-level compatibility shape as generation; each provider still
+owns any operation-specific wire-boundary transforms.
 
 ### Messages — Copilot provider boundary chain
 

--- a/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt_test.ts
@@ -6,10 +6,11 @@ import { InMemoryRepo } from '../../../repo/memory.ts';
 import { mockChatGatewayCtx } from '../../../test-helpers/gateway-ctx.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
+import type { MessagesClientTool, MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, directFetcher, type ProviderCallResult, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
-import { assertEquals, assertExists, stubProvider, stubInternalModel } from '@floway-dev/test-utils';
+import type { FlagId } from '@floway-dev/provider/flags';
+import { assertEquals, assertExists, stubProvider, stubInternalModel, stubProviderModel } from '@floway-dev/test-utils';
 
 const API_KEY_ID = 'key_messages_attempt_test';
 
@@ -55,8 +56,10 @@ const makeCandidate = (overrides: {
   callResponses?: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>;
   callChatCompletions?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
   callMessagesCountTokens?: (model: unknown, body: unknown, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderCallResult>;
+  enabledFlags?: ReadonlySet<FlagId>;
 } = {}): ModelCandidate => {
   const upstream = overrides.upstream ?? 'up_test';
+  const endpoints = overrides.endpoints ?? { chatCompletions: {}, responses: {}, messages: {} };
   const provider = stubProvider({
     callMessages: overrides.callMessages,
     callResponses: overrides.callResponses,
@@ -68,7 +71,15 @@ const makeCandidate = (overrides: {
       upstream, kind: 'custom', name: upstream,
       disabledPublicModelIds: [], modelPrefix: null, instance: provider,
     },
-    model: stubInternalModel(overrides.endpoints ? { endpoints: overrides.endpoints } : {}, upstream),
+    model: stubInternalModel({
+      endpoints,
+      providerModels: {
+        [upstream]: stubProviderModel({
+          endpoints,
+          enabledFlags: overrides.enabledFlags ?? new Set(),
+        }),
+      },
+    }, upstream),
     fetcher: directFetcher,
   };
 };
@@ -154,6 +165,80 @@ test('countTokens proxies the upstream response as a plain result', async () => 
   const body = JSON.parse(new TextDecoder().decode(result.body));
   assertEquals(body.input_tokens, 7);
   assertEquals(callMessagesCountTokens.mock.calls.length, 1);
+});
+
+test('countTokens applies generation request transforms before provider dispatch', async () => {
+  installRepo();
+  const observedBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const callMessagesCountTokens = vi.fn(async (_model, body): Promise<ProviderCallResult> => {
+    observedBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return { response: Response.json({ input_tokens: 9 }), modelKey: 'k' };
+  });
+
+  const result = await messagesAttempt.countTokens({
+    payload: makePayload({
+      system: 'x-anthropic-billing-header: token\ncch=deadbeef1234;\nbase rules',
+      messages: [
+        { role: 'system', content: 'inline rules' },
+        { role: 'user', content: 'hello' },
+      ],
+      thinking: { type: 'enabled', budget_tokens: 1024 },
+      output_config: { effort: 'high' },
+      tool_choice: { type: 'tool', name: 'lookup' },
+    }),
+    ctx: makeGatewayCtx(),
+    candidate: makeCandidate({
+      callMessagesCountTokens,
+      enabledFlags: new Set<FlagId>([
+        'strip-billing-attribution',
+        'disable-reasoning-on-forced-tool-choice',
+        'demote-interleaved-system-to-user',
+      ]),
+    }),
+    headers: new Headers(),
+  });
+
+  assertEquals(result.type, 'plain');
+  assertEquals(observedBodies, [{
+    max_tokens: 32,
+    system: 'base rules',
+    messages: [
+      { role: 'user', content: 'inline rules' },
+      { role: 'user', content: 'hello' },
+    ],
+    thinking: { type: 'disabled' },
+    tool_choice: { type: 'tool', name: 'lookup' },
+  }]);
+});
+
+test('countTokens prepares the generation web-search request shape', async () => {
+  installRepo();
+  const observedBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const callMessagesCountTokens = vi.fn(async (_model, body): Promise<ProviderCallResult> => {
+    observedBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return { response: Response.json({ input_tokens: 11 }), modelKey: 'k' };
+  });
+
+  const result = await messagesAttempt.countTokens({
+    payload: makePayload({ tools: [{ type: 'web_search_20260209', max_uses: 3 }] }),
+    ctx: makeGatewayCtx(),
+    candidate: makeCandidate({
+      callMessagesCountTokens,
+      enabledFlags: new Set<FlagId>(['messages-web-search-shim']),
+    }),
+    headers: new Headers(),
+  });
+
+  assertEquals(result.type, 'plain');
+  const tool = observedBodies[0]?.tools?.[0] as MessagesClientTool | undefined;
+  if (tool === undefined) throw new Error('expected rewritten web-search tool');
+  assertEquals(tool.name, 'web_search');
+  assertEquals('type' in tool, false);
+  assertEquals(tool.input_schema, {
+    type: 'object',
+    properties: { query: { type: 'string', description: 'Search query' } },
+    required: ['query'],
+  });
 });
 
 test('countTokens refuses a non-messages candidate', async () => {

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/demote-interleaved-system-to-user.ts
@@ -1,4 +1,4 @@
-import type { MessagesInterceptor } from './types.ts';
+import type { MessagesPayloadInterceptor } from './types.ts';
 import { providerModelOf } from '@floway-dev/provider';
 
 // Workaround for upstreams (e.g. DeepSeek-R1) that reject `role: 'system'`
@@ -6,7 +6,7 @@ import { providerModelOf } from '@floway-dev/provider';
 // conceptually-first system slot on the top-level `payload.system` field;
 // any inline message with `role: 'system'` is therefore by definition
 // interleaved, and gets demoted to `role: 'user'` with content preserved.
-export const demoteInterleavedSystemToUser: MessagesInterceptor = (ctx, _gatewayCtx, run) => {
+export const demoteInterleavedSystemToUser: MessagesPayloadInterceptor = (ctx, _gatewayCtx, run) => {
   if (!providerModelOf(ctx.candidate).enabledFlags.has('demote-interleaved-system-to-user')) return run();
 
   const { messages } = ctx.payload;

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/disable-reasoning-on-forced-tool-choice.ts
@@ -1,5 +1,5 @@
 
-import type { MessagesInterceptor } from './types.ts';
+import type { MessagesPayloadInterceptor } from './types.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import { providerModelOf } from '@floway-dev/provider';
 
@@ -24,7 +24,7 @@ const disableMessagesReasoning = (payload: MessagesPayload): MessagesPayload => 
   return next;
 };
 
-export const withReasoningDisabledOnForcedToolChoice: MessagesInterceptor = async (ctx, _gatewayCtx, run) => {
+export const withReasoningDisabledOnForcedToolChoice: MessagesPayloadInterceptor = async (ctx, _gatewayCtx, run) => {
   if (!providerModelOf(ctx.candidate).enabledFlags.has('disable-reasoning-on-forced-tool-choice')) return await run();
   if (!hasForcedToolChoice(ctx.payload)) return await run();
   ctx.payload = disableMessagesReasoning(ctx.payload);

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
@@ -28,7 +28,8 @@ import { withMessagesWebSearchRequestPrepared, withMessagesWebSearchShim } from 
 //
 // The remaining three entries mutate only the request payload and are shared
 // with count_tokens in the same order. Token counting therefore observes the
-// exact billing-attribution, reasoning, and role shape sent by generation.
+// same gateway-level billing-attribution, reasoning, and role shape as
+// generation.
 const messagesPayloadInterceptors: readonly MessagesPayloadInterceptor[] = [
   stripBillingAttribution,
   withReasoningDisabledOnForcedToolChoice,

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
@@ -1,18 +1,19 @@
 import { demoteInterleavedSystemToUser } from './demote-interleaved-system-to-user.ts';
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
 import { stripBillingAttribution } from './strip-billing-attribution.ts';
-import type { MessagesCountTokensInterceptor, MessagesInterceptor } from './types.ts';
-import { withMessagesWebSearchShim } from './web-search-shim.ts';
+import type { MessagesCountTokensInterceptor, MessagesInterceptor, MessagesPayloadInterceptor } from './types.ts';
+import { withMessagesWebSearchRequestPrepared, withMessagesWebSearchShim } from './web-search-shim.ts';
 
-// Unified Messages interceptor list. All entries are attached to every
-// candidate; each interceptor's body decides whether to act (flag-gated entries
-// early-return on `providerModelOf(ctx.candidate).enabledFlags.has(flagId)`).
+// Unified Messages generation chain. All entries are attached to every
+// candidate; each interceptor decides whether to act from the candidate's
+// model flags and selected target.
 //
-// Order follows source-then-target semantics collapsed into a single chain:
-//   - withMessagesWebSearchShim: registered first so its replay rewrite and
-//     intercept loop wrap the rest of the chain. Unconditional for translated
-//     targets (Responses / Chat Completions cannot carry Anthropic server
-//     tools); gated by `messages-web-search-shim` for native Messages targets.
+//   - withMessagesWebSearchShim: registered first so its request preparation,
+//     replay rewrite, and intercept loop wrap the rest of the generation chain.
+//     Unconditional for translated targets (Responses / Chat Completions cannot
+//     carry Anthropic server tools); gated by `messages-web-search-shim` for
+//     native Messages targets. count_tokens runs the same request preparation
+//     without the stream-response wrapper.
 //   - stripBillingAttribution: gated by `strip-billing-attribution` (default
 //     on for copilot/azure/custom, off for claude-code). On candidates
 //     where it runs, it scrubs Claude Code's `x-anthropic-billing-header` /
@@ -21,20 +22,25 @@ import { withMessagesWebSearchShim } from './web-search-shim.ts';
 //     because Anthropic uses it for plan-tier billing.
 //   - withReasoningDisabledOnForcedToolChoice: gated by
 //     `disable-reasoning-on-forced-tool-choice`.
-//   - demoteInterleavedSystemToUser: gated by
-//     `demote-interleaved-system-to-user`. Anthropic's top-level
-//     `payload.system` is conceptually the first-position system slot, so
-//     every inline `role: 'system'` message in `payload.messages` is by
-//     definition interleaved and gets rewritten to `role: 'user'`.
-export const messagesInterceptors: readonly MessagesInterceptor[] = [
-  withMessagesWebSearchShim,
+//   - demoteInterleavedSystemToUser: Anthropic's top-level `payload.system` is
+//     the only first-position system slot, so the interleaved-system flag
+//     rewrites every inline system message to user.
+//
+// The remaining three entries mutate only the request payload and are shared
+// with count_tokens in the same order. Token counting therefore observes the
+// exact billing-attribution, reasoning, and role shape sent by generation.
+const messagesPayloadInterceptors: readonly MessagesPayloadInterceptor[] = [
   stripBillingAttribution,
   withReasoningDisabledOnForcedToolChoice,
   demoteInterleavedSystemToUser,
 ];
 
-// The shipped Messages interceptors all inspect post-`run()` event streams,
-// which the non-streaming count_tokens path cannot supply — so the list
-// stays empty today. Kept as a separate readonly array so the count-tokens
-// attempt has a clear extension point.
-export const messagesCountTokensInterceptors: readonly MessagesCountTokensInterceptor[] = [];
+export const messagesInterceptors: readonly MessagesInterceptor[] = [
+  withMessagesWebSearchShim,
+  ...messagesPayloadInterceptors,
+];
+
+export const messagesCountTokensInterceptors: readonly MessagesCountTokensInterceptor[] = [
+  withMessagesWebSearchRequestPrepared,
+  ...messagesPayloadInterceptors,
+];

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/strip-billing-attribution.ts
@@ -1,4 +1,4 @@
-import type { MessagesInterceptor } from './types.ts';
+import type { MessagesPayloadInterceptor } from './types.ts';
 import { providerModelOf } from '@floway-dev/provider';
 
 // Claude Code clients seed every Messages request with an
@@ -21,20 +21,21 @@ const CCH_HASH_RE = /cch=[0-9a-f]{5,};?/gi;
 
 const stripText = (text: string): string => text.replace(BILLING_HEADER_LINE_RE, '').replace(CCH_HASH_RE, '').trim();
 
-export const stripBillingAttribution: MessagesInterceptor = (ctx, _gatewayCtx, run) => {
+export const stripBillingAttribution: MessagesPayloadInterceptor = (ctx, _gatewayCtx, run) => {
   if (!providerModelOf(ctx.candidate).enabledFlags.has('strip-billing-attribution')) return run();
 
   const { payload } = ctx;
 
   if (typeof payload.system === 'string') {
-    payload.system = stripText(payload.system);
-    if (!payload.system) delete payload.system;
+    const system = stripText(payload.system);
+    const { system: _system, ...rest } = payload;
+    ctx.payload = system.length > 0 ? { ...rest, system } : rest;
   } else if (Array.isArray(payload.system)) {
-    for (const block of payload.system) {
-      block.text = stripText(block.text);
-    }
-    payload.system = payload.system.filter(block => block.text.length > 0);
-    if (payload.system.length === 0) delete payload.system;
+    const system = payload.system
+      .map(block => ({ ...block, text: stripText(block.text) }))
+      .filter(block => block.text.length > 0);
+    const { system: _system, ...rest } = payload;
+    ctx.payload = system.length > 0 ? { ...rest, system } : rest;
   }
 
   return run();

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/types.ts
@@ -1,5 +1,5 @@
 import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
-import type { Interceptor } from '@floway-dev/interceptor';
+import type { Interceptor, InterceptorRun } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import type { ExecuteResult, MessagesInvocation } from '@floway-dev/provider';
@@ -12,15 +12,21 @@ export type MessagesInterceptor = Interceptor<
   ExecuteResult<ProtocolFrame<MessagesStreamEvent>>
 >;
 
-// count_tokens is a one-shot, non-streaming HTTP exchange — the terminal
-// returns the raw upstream `Response` directly, with no protocol-frame
-// translation in between. The interceptor chain still runs against a
-// `MessagesInvocation` so payload-shaped reads (vision detection, last-message
-// initiator classification, anthropic-beta filtering) match the chat path
-// exactly. Interceptors registered here MUST be pure header/payload mutators;
-// post-`run()` result inspection is not portable to this result type.
+// count_tokens is a one-shot, non-streaming HTTP exchange whose terminal
+// returns the raw upstream `Response`. Shared entries must therefore be pure
+// header/payload mutators; post-run stream inspection is not portable to this
+// result type.
 export type MessagesCountTokensInterceptor = Interceptor<
   MessagesInvocation,
   GatewayCtx,
   Response
 >;
+
+// Payload-only transforms can run in both the streaming generation chain and
+// the one-shot count_tokens chain. Keeping the result generic prevents those
+// shared interceptors from accidentally inspecting either result shape.
+export type MessagesPayloadInterceptor = <TResult>(
+  ctx: MessagesInvocation,
+  gatewayCtx: GatewayCtx,
+  run: InterceptorRun<TResult>,
+) => Promise<TResult>;

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
@@ -1,5 +1,5 @@
 
-import type { MessagesInterceptor } from './types.ts';
+import type { MessagesCountTokensInterceptor, MessagesInterceptor, MessagesInvocation } from './types.ts';
 import { decodeBase64UrlJson, encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import { isJsonObject } from '../../../../shared/json-helpers.ts';
 import { resolveConfiguredWebSearchProvider } from '../../../tools/web-search/provider.ts';
@@ -838,21 +838,24 @@ export const rewriteMessagesWebSearchEventsToNative = async function* (
   }
 };
 
+const messagesWebSearchInvalidRequestBody = (message: string) => ({
+  type: 'error',
+  error: {
+    type: 'invalid_request_error',
+    message,
+  },
+});
+
 const buildSyntheticInvalidRequestUpstreamError = (message: string) => ({
   type: 'api-error' as const,
   source: 'gateway' as const,
   status: 400,
   headers: new Headers({ 'content-type': 'application/json' }),
-  body: new TextEncoder().encode(
-    JSON.stringify({
-      type: 'error',
-      error: {
-        type: 'invalid_request_error',
-        message,
-      },
-    }),
-  ),
+  body: new TextEncoder().encode(JSON.stringify(messagesWebSearchInvalidRequestBody(message))),
 });
+
+const buildInvalidRequestResponse = (message: string): Response =>
+  Response.json(messagesWebSearchInvalidRequestBody(message), { status: 400 });
 
 const resolveActiveMessagesWebSearchProvider = async (apiKeyId: string): Promise<{ type: 'ok'; provider: ActiveMessagesWebSearchProvider } | ReturnType<typeof internalErrorResult>> => {
   const searchConfig = await loadSearchConfig();
@@ -881,6 +884,26 @@ const resolveActiveMessagesWebSearchProvider = async (apiKeyId: string): Promise
   );
 };
 
+type PreparedMessagesWebSearchShimState = Exclude<MessagesWebSearchShimState, { mode: 'inactive' }>;
+
+type PrepareMessagesWebSearchInvocationResult =
+  | { type: 'inactive' }
+  | { type: 'invalid-request'; message: string }
+  | { type: 'prepared'; state: PreparedMessagesWebSearchShimState };
+
+const prepareMessagesWebSearchInvocation = (ctx: MessagesInvocation): PrepareMessagesWebSearchInvocationResult => {
+  if (ctx.targetApi === 'messages' && !providerModelOf(ctx.candidate).enabledFlags.has('messages-web-search-shim')) {
+    return { type: 'inactive' };
+  }
+
+  const prepared = prepareMessagesWebSearchShimRequest(ctx.payload);
+  if (prepared.type === 'invalid-request') return prepared;
+  if (prepared.state.mode === 'inactive') return { type: 'inactive' };
+
+  ctx.payload = prepared.payload;
+  return { type: 'prepared', state: prepared.state };
+};
+
 /**
  * Anthropic exposes native `web_search_*` server tools, but non-Messages
  * targets cannot run Anthropic server tools. This shim rewrites the native tool
@@ -895,22 +918,12 @@ const resolveActiveMessagesWebSearchProvider = async (apiKeyId: string): Promise
  * may or may not be able to serve web_search natively).
  */
 export const withMessagesWebSearchShim: MessagesInterceptor = async (ctx, gatewayCtx, run) => {
-  if (ctx.targetApi === 'messages' && !providerModelOf(ctx.candidate).enabledFlags.has('messages-web-search-shim')) return await run();
-
-  const prepared = prepareMessagesWebSearchShimRequest(ctx.payload);
-
-  if (prepared.type === 'invalid-request') {
-    return buildSyntheticInvalidRequestUpstreamError(prepared.message);
-  }
-
-  if (prepared.state.mode === 'inactive') {
-    return await run();
-  }
+  const prepared = prepareMessagesWebSearchInvocation(ctx);
+  if (prepared.type === 'inactive') return await run();
+  if (prepared.type === 'invalid-request') return buildSyntheticInvalidRequestUpstreamError(prepared.message);
 
   const provider = prepared.state.mode === 'active' ? await resolveActiveMessagesWebSearchProvider(gatewayCtx.apiKeyId) : { type: 'ok' as const, provider: undefined };
   if (provider.type !== 'ok') return provider;
-
-  ctx.payload = prepared.payload;
 
   const result = await run();
   if (result.type !== 'events') return result;
@@ -919,4 +932,12 @@ export const withMessagesWebSearchShim: MessagesInterceptor = async (ctx, gatewa
     ...result,
     events: rewriteMessagesWebSearchEventsToNative(result.events, prepared.state, provider.provider),
   };
+};
+
+// count_tokens has no stream to rewrite, but it must measure the same client-
+// tool and replay-history request shape that generation sends upstream.
+export const withMessagesWebSearchRequestPrepared: MessagesCountTokensInterceptor = async (ctx, _gatewayCtx, run) => {
+  const prepared = prepareMessagesWebSearchInvocation(ctx);
+  if (prepared.type === 'invalid-request') return buildInvalidRequestResponse(prepared.message);
+  return await run();
 };

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim_test.ts
@@ -9,6 +9,7 @@ import {
   type MessagesWebSearchShimState,
   prepareMessagesWebSearchShimRequest,
   rewriteMessagesWebSearchEventsToNative,
+  withMessagesWebSearchRequestPrepared,
   withMessagesWebSearchShim,
 } from './web-search-shim.ts';
 import { initRepo } from '../../../../repo/index.ts';
@@ -569,6 +570,62 @@ const initDisabledSearchRepo = async (): Promise<void> => {
   initRepo(repo);
   await repo.searchConfig.save(DEFAULT_SEARCH_CONFIG);
 };
+
+const initEnabledSearchRepo = async (): Promise<void> => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  await repo.searchConfig.save({
+    ...DEFAULT_SEARCH_CONFIG,
+    provider: 'tavily',
+    tavily: { apiKey: 'test-key' },
+  });
+};
+
+test('generation and count_tokens prepare identical web-search request payloads', async () => {
+  await initEnabledSearchRepo();
+  const source = makeNativeReplayPayload();
+  const generationInvocation = invocation(structuredClone(source));
+  const countInvocation = invocation(structuredClone(source));
+
+  await withMessagesWebSearchShim(generationInvocation, mockChatGatewayCtx(), () => Promise.resolve({
+    type: 'events',
+    events: toAsyncIterable<ProtocolFrame<MessagesStreamEvent>>([]),
+    modelIdentity: testTelemetryModelIdentity,
+  }));
+  const countResponse = await withMessagesWebSearchRequestPrepared(
+    countInvocation,
+    mockChatGatewayCtx(),
+    () => Promise.resolve(new Response(null, { status: 204 })),
+  );
+
+  assertEquals(countResponse.status, 204);
+  assertEquals(countInvocation.payload, generationInvocation.payload);
+  const rewrittenTool = generationInvocation.payload.tools?.[0] as MessagesClientTool;
+  assertEquals(rewrittenTool.name, 'web_search');
+  assertEquals('type' in rewrittenTool, false);
+});
+
+test('count_tokens returns a native error response for invalid web-search tools', async () => {
+  const response = await withMessagesWebSearchRequestPrepared(
+    invocation({
+      model: 'claude-test',
+      max_tokens: 64,
+      messages: [{ role: 'user', content: 'search' }],
+      tools: [{ type: 'web_search_20260209' }, { type: 'web_search_20260209' }],
+    }),
+    mockChatGatewayCtx(),
+    () => Promise.reject(new Error('run should not be called')),
+  );
+
+  assertEquals(response.status, 400);
+  assertEquals(await response.json(), {
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'Only one native web search tool definition is supported per request.',
+    },
+  });
+});
 
 const runReplayOnlyShim = async (messageId: string): Promise<ProtocolFrame<MessagesStreamEvent>[]> => {
   await initDisabledSearchRepo();

--- a/packages/gateway/src/data-plane/chat/messages/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/serve_test.ts
@@ -505,6 +505,76 @@ test('copilot candidate strips x-anthropic-billing-header system block via the d
   assertEquals(observed.system[0].text, 'You are a helpful assistant.');
 });
 
+test('generate failover preserves billing blocks for a strip-off candidate', async () => {
+  installRepo();
+  const system = [
+    { type: 'text' as const, text: 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;' },
+    { type: 'text' as const, text: 'Keep this prompt.' },
+  ];
+  const expectedSystem = structuredClone(system);
+  const firstBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const secondBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const firstCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<MessagesStreamEvent>> => {
+    firstBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return { ok: false, response: new Response('unavailable', { status: 503 }), modelKey: 'first-key' };
+  });
+  const secondCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderStreamResult<MessagesStreamEvent>> => {
+    secondBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return { ok: true, events: makeProtocolFrames(makeMessagesResultEvents('msg_second')), modelKey: 'second-key' };
+  });
+  queueResolution([
+    makeCandidate({
+      upstream: 'up_strip_on',
+      enabledFlags: new Set(['strip-billing-attribution']),
+      callMessages: firstCall,
+    }),
+    makeCandidate({ upstream: 'up_strip_off', enabledFlags: new Set(), callMessages: secondCall }),
+  ]);
+
+  const payload = makePayload({ system });
+  const result = await messagesServe.generate({ payload, ctx: makeGatewayCtx(), headers: new Headers() });
+  await collectEvents(assertResultType(result, 'events').events);
+
+  assertEquals(firstBodies[0]?.system, [{ type: 'text', text: 'Keep this prompt.' }]);
+  assertEquals(secondBodies[0]?.system, expectedSystem);
+  assertEquals(payload.system, expectedSystem);
+});
+
+test('countTokens failover preserves billing blocks for a strip-off candidate', async () => {
+  installRepo();
+  const system = [
+    { type: 'text' as const, text: 'x-anthropic-billing-header: per-turn-token\ncch=deadbeef1234;' },
+    { type: 'text' as const, text: 'Count this prompt.' },
+  ];
+  const expectedSystem = structuredClone(system);
+  const firstBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const secondBodies: Array<Omit<MessagesPayload, 'model'>> = [];
+  const firstCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderCallResult> => {
+    firstBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return { response: new Response('unavailable', { status: 503 }), modelKey: 'first-key' };
+  });
+  const secondCall = vi.fn(async (_model: unknown, body: unknown): Promise<ProviderCallResult> => {
+    secondBodies.push(body as Omit<MessagesPayload, 'model'>);
+    return { response: Response.json({ input_tokens: 12 }), modelKey: 'second-key' };
+  });
+  queueResolution([
+    makeCandidate({
+      upstream: 'up_strip_on',
+      enabledFlags: new Set(['strip-billing-attribution']),
+      callMessagesCountTokens: firstCall,
+    }),
+    makeCandidate({ upstream: 'up_strip_off', enabledFlags: new Set(), callMessagesCountTokens: secondCall }),
+  ]);
+
+  const payload = makePayload({ system });
+  const result = await messagesServe.countTokens({ payload, ctx: makeGatewayCtx(), headers: new Headers() });
+
+  assertEquals(assertResultType(result, 'plain').status, 200);
+  assertEquals(firstBodies[0]?.system, [{ type: 'text', text: 'Count this prompt.' }]);
+  assertEquals(secondBodies[0]?.system, expectedSystem);
+  assertEquals(payload.system, expectedSystem);
+});
+
 test('alias resolution swaps the inbound model id for the target and overlays rules onto the Messages IR', async () => {
   installRepo();
   const capturedBodies: MessagesPayload[] = [];

--- a/packages/provider-codex/src/interceptors/responses/inject-default-instructions_test.ts
+++ b/packages/provider-codex/src/interceptors/responses/inject-default-instructions_test.ts
@@ -35,7 +35,7 @@ test('injects the default when instructions is an empty string', async () => {
 });
 
 test('injects the default when instructions is null', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hello', instructions: null });
+  const ctx = invocation({ model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }], instructions: null });
 
   await injectDefaultInstructions(ctx, stubRequest, okEvents);
 
@@ -60,7 +60,7 @@ test.each([
   async ({ value }) => {
     const ctx = invocation({
       model: 'gpt-test',
-      input: 'hello',
+      input: [{ type: 'message', role: 'user', content: 'hello' }],
       instructions: value as unknown as string,
     });
 


### PR DESCRIPTION
## Summary

- run billing-attribution stripping, forced-tool reasoning compatibility, inline-system demotion, and web-search request preparation in the same order for Messages generation and `count_tokens`
- keep web-search response synthesis generation-only while returning the same native validation envelope from token-count preparation
- rebuild billing-attribution system blocks copy-on-write so a failed strip-on candidate cannot alter the request seen by a later strip-off candidate

## Integration

- preserve the current candidate-isolation failover tests while asserting that the first strip-on provider receives the cleaned system prompt
- align two Codex boundary test fixtures with the canonical provider input-array contract now on `main`

## Test Plan

- [x] Focused Messages and Codex boundary tests (7 files, 85 tests)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm exec vitest run --silent=passed-only --reporter=dot` (345 files, 4219 tests)
