### PR TITLE
refactor(responses): enforce canonical provider payloads

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -15,11 +15,9 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { traverseTranslation } from '../shared/translate-traverse.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
-import { type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, eventResult, readUpstreamApiError, providerModelOf, type ChatTargetApi, type ExecuteResult, type ProviderResponsesResult, type ResponsesAction } from '@floway-dev/provider';
 import { translateResponsesViaChatCompletions, translateResponsesViaMessages } from '@floway-dev/translate';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // `/v1/responses` generate prefers the native Responses target, then the
 // translated Messages path, then the translated Chat Completions path. The

--- a/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt_test.ts
@@ -11,10 +11,9 @@ import { mockChatGatewayCtx } from '../../../test-helpers/gateway-ctx.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, directFetcher, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions, type FlagId } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubInternalModel, stubProviderModel } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const API_KEY_ID = 'key_attempt_test';
 
@@ -50,7 +49,7 @@ const makeProviderEvents = async function* (events: readonly ResponsesStreamEven
 };
 
 const makeCandidate = (
-  callResponses: (model: ProviderModel, body: Omit<ResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions) => Promise<ProviderResponsesResult>,
+  callResponses: (model: ProviderModel, body: Omit<CanonicalResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions) => Promise<ProviderResponsesResult>,
   enabledFlags: ReadonlySet<FlagId> = new Set<FlagId>(),
 ): ModelCandidate => {
   const provider = stubProvider({ callResponses });
@@ -297,7 +296,7 @@ test('compact reshapes the trigger turn into a result and derives snapshotMode=r
     output: [compactionItem] as unknown as ResponsesResult['output'],
   };
 
-  const callResponses = vi.fn(async (_model: ProviderModel, _body: Omit<ResponsesPayload, 'model'>, action: ResponsesAction): Promise<ProviderResponsesResult> => {
+  const callResponses = vi.fn(async (_model: ProviderModel, _body: Omit<CanonicalResponsesPayload, 'model'>, action: ResponsesAction): Promise<ProviderResponsesResult> => {
     if (action !== 'compact') throw new Error(`compact candidate received action='${action}'`);
     return { action: 'compact', ok: true, result: compactionResult, modelKey: 'test-model-key' };
   });

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -10,10 +10,10 @@ import { settle } from '../../shared/telemetry/settle.ts';
 import { createChatGatewayCtxFromHono, createGatewayCtxFromHono, finalizeGatewayResponse, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
 import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
-import type { ResponsesRequestPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesRequestPayload } from '@floway-dev/protocols/responses';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
 import { TranslatorInputError } from '@floway-dev/translate';
-import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import { canonicalizeResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // OpenAI's verbatim previous_response_not_found envelope. Codex compares this
 // body byte-for-byte against upstream — see the cross-references on

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -7,7 +7,7 @@ import { initRepo } from '../../../repo/index.ts';
 import { InMemoryRepo } from '../../../repo/memory.ts';
 import type { ApiKey, StoredResponsesItem, User } from '../../../repo/types.ts';
 import { type AliasRules, doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubInternalModel } from '@floway-dev/test-utils';
 
@@ -179,9 +179,9 @@ test('POST /v1/responses streams a successful SSE body', async () => {
 
 test('POST /v1/responses canonicalizes implicit messages before provider dispatch', async () => {
   installRepo();
-  let observedBody: Omit<ResponsesPayload, 'model'> | undefined;
+  let observedBody: Omit<CanonicalResponsesPayload, 'model'> | undefined;
   const callResponses = vi.fn(async (_model, body): Promise<ProviderResponsesResult> => {
-    observedBody = body as Omit<ResponsesPayload, 'model'>;
+    observedBody = body as Omit<CanonicalResponsesPayload, 'model'>;
     return {
       action: 'generate',
       ok: true,
@@ -413,9 +413,9 @@ const queueCodexAutoReviewCandidate = (
 test('POST /v1/responses routes a codex-auto-review request through the seeded alias: rewrites the model to gpt-5.4 and stamps reasoning.effort=low', async () => {
   installRepo();
   lastSeenModel.value = null;
-  const observedBodies: ResponsesPayload[] = [];
+  const observedBodies: Omit<CanonicalResponsesPayload, 'model'>[] = [];
   queueCodexAutoReviewCandidate(async (_model, body): Promise<ProviderResponsesResult> => {
-    observedBodies.push(body as ResponsesPayload);
+    observedBodies.push(body as Omit<CanonicalResponsesPayload, 'model'>);
     return {
       action: 'generate', ok: true,
       events: makeProviderEvents([completedEvent()]),
@@ -445,7 +445,7 @@ test('POST /v1/responses routes a codex-auto-review request through the seeded a
 test('POST /v1/responses/compact routes a codex-auto-review request through the seeded alias: rewrites the model to gpt-5.4 and stamps reasoning.effort=low (the alias rule overlays the compact body too)', async () => {
   installRepo();
   lastSeenModel.value = null;
-  const observedBodies: ResponsesPayload[] = [];
+  const observedBodies: Omit<CanonicalResponsesPayload, 'model'>[] = [];
   const compactionItem = { type: 'compaction' as const, id: 'cmp_1', encrypted_content: 'ENC' };
   const compactionResult: ResponsesResult = {
     ...makeResponsesResult(),
@@ -454,7 +454,7 @@ test('POST /v1/responses/compact routes a codex-auto-review request through the 
   };
   queueCodexAutoReviewCandidate(async (_model, body, action): Promise<ProviderResponsesResult> => {
     if (action !== 'compact') throw new Error(`expected compact, got ${action}`);
-    observedBodies.push(body as ResponsesPayload);
+    observedBodies.push(body as Omit<CanonicalResponsesPayload, 'model'>);
     return { action: 'compact', ok: true, result: compactionResult, modelKey: 'test-model-key' };
   });
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items_test.ts
@@ -4,10 +4,9 @@ import { withResponsesOutputItemsCanonicalized } from './canonicalize-output-ite
 import type { ResponsesInvocation } from './types.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, eventResult } from '@floway-dev/provider';
 import { stubModelCandidate, testTelemetryModelIdentity, assertEquals } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -56,9 +56,8 @@ import { isJsonObject } from '../../../../shared/json-helpers.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { syntheticEventsFromResult } from '../items/output.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { providerModelOf, type ExecuteResult } from '@floway-dev/provider';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // The two vendored constants below (SUMMARIZATION_PROMPT and SUMMARY_PREFIX)
 // are the compactor system prompt and the handoff prefix openai/codex ships

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -5,10 +5,9 @@ import type { ResponsesInvocation } from './types.ts';
 import { encodeBase64UrlJson } from '../../../../shared/base64url-json.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -6,7 +6,7 @@ import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-developer-to-system_test.ts
@@ -4,9 +4,9 @@ import { withDemoteDeveloperToSystem } from './demote-developer-to-system.ts';
 import type { ResponsesInvocation } from './types.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -6,7 +6,7 @@ import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/demote-interleaved-system-to-user_test.ts
@@ -4,9 +4,9 @@ import { withInterleavedSystemDemotedToUser } from './demote-interleaved-system-
 import type { ResponsesInvocation } from './types.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/disable-reasoning-on-forced-tool-choice_test.ts
@@ -4,9 +4,9 @@ import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-
 import type { ResponsesInvocation } from './types.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -5,10 +5,9 @@ import type { ResponsesInvocation } from './types.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { eventResult, type ExecuteResult } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const makePayload = (): CanonicalResponsesPayload => ({
   model: 'gpt-test',

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -7,6 +7,7 @@ import type { StatefulResponsesStore } from '../items/store.ts';
 import type { InterceptorRun } from '@floway-dev/interceptor';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
+  CanonicalResponsesPayload,
   ResponsesHostedTool,
   ResponsesInputItem,
   ResponsesOutputItem,
@@ -16,7 +17,6 @@ import type {
   ResponsesToolChoice,
 } from '@floway-dev/protocols/responses';
 import type { EventResultMetadata, ExecuteResult } from '@floway-dev/provider';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 export interface MergeUsage {
   input_tokens?: number;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -31,6 +31,7 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { eventFrame } from '@floway-dev/protocols/common';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
+  CanonicalResponsesPayload,
   ResponsesOutputItem,
   ResponsesInputItem,
   ResponsesInputWebSearchCall,
@@ -44,7 +45,6 @@ import type {
 } from '@floway-dev/protocols/responses';
 import { type EventResult, type ExecuteResult, type FlagId } from '@floway-dev/provider';
 import { assert, assertEquals, assertFalse, stubModelCandidate } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const withResponsesWebSearchShim = withResponsesServerToolShim([webSearchServerTool]);
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -21,9 +21,8 @@ import { initRepo } from '../../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../../repo/memory.ts';
 import { mockChatGatewayCtx } from '../../../../../test-helpers/gateway-ctx.ts';
 import type { ResponsesInvocation } from '../types.ts';
-import type { ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputItem, ResponsesPayload, ResponsesTool } from '@floway-dev/protocols/responses';
 import { assert, assertEquals, assertFalse, assertStringIncludes, stubModelCandidate } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const PNG_B64 = 'aGVsbG8='; // "hello" — any decodable base64 works for source tests.
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/strip-prompt-cache-key_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/strip-prompt-cache-key_test.ts
@@ -4,9 +4,9 @@ import { withPromptCacheKeyStripped } from './strip-prompt-cache-key.ts';
 import type { ResponsesInvocation } from './types.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
@@ -3,12 +3,9 @@ import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import type { Interceptor } from '@floway-dev/interceptor';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { EventResultMetadata, ExecuteResult, ResponsesInvocation as WireResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import type { EventResultMetadata, ExecuteResult, ResponsesInvocation, TelemetryModelIdentity } from '@floway-dev/provider';
 
-export interface ResponsesInvocation extends Omit<WireResponsesInvocation, 'payload'> {
-  payload: CanonicalResponsesPayload;
-}
+export type { ResponsesInvocation };
 
 // The chain runner produces an event stream for both actions — the attempt
 // post-processes it into a single `response.compaction` envelope when the

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
@@ -20,7 +20,7 @@
 
 import type { ResponsesInterceptor } from './types.ts';
 import { providerModelOf } from '@floway-dev/provider';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 
 interface DeepseekDisableField {
   thinking?: { type: 'disabled' };

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize.ts
@@ -19,8 +19,8 @@
 // - https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
 
 import type { ResponsesInterceptor } from './types.ts';
-import { providerModelOf } from '@floway-dev/provider';
 import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
+import { providerModelOf } from '@floway-dev/provider';
 
 interface DeepseekDisableField {
   thinking?: { type: 'disabled' };

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-deepseek-normalize_test.ts
@@ -4,9 +4,9 @@ import type { ResponsesInvocation } from './types.ts';
 import { withVendorDeepseekResponsesNormalize } from './vendor-deepseek-normalize.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
@@ -14,8 +14,8 @@
 // - https://www.alibabacloud.com/help/en/model-studio/deep-thinking
 
 import type { ResponsesInterceptor } from './types.ts';
-import { providerModelOf } from '@floway-dev/provider';
 import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
+import { providerModelOf } from '@floway-dev/provider';
 
 export const withVendorQwenResponsesNormalize: ResponsesInterceptor = async (ctx, _request, run) => {
   if (!providerModelOf(ctx.candidate).enabledFlags.has('vendor-qwen')) return await run();

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize.ts
@@ -15,7 +15,7 @@
 
 import type { ResponsesInterceptor } from './types.ts';
 import { providerModelOf } from '@floway-dev/provider';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 
 export const withVendorQwenResponsesNormalize: ResponsesInterceptor = async (ctx, _request, run) => {
   if (!providerModelOf(ctx.candidate).enabledFlags.has('vendor-qwen')) return await run();

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/vendor-qwen-normalize_test.ts
@@ -4,9 +4,9 @@ import type { ResponsesInvocation } from './types.ts';
 import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 import { mockChatGatewayCtx } from '../../../../test-helpers/gateway-ctx.ts';
 import { doneFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import { eventResult, type FlagId } from '@floway-dev/provider';
 import { assertEquals, stubModelCandidate, testTelemetryModelIdentity } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 const stubCtx = mockChatGatewayCtx();
 

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -2,9 +2,9 @@ import { createTemporaryResponsesItemId, responsesItemEncryptedContent, response
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItemMetadata, StoredResponsesItemPayload } from '../../../../repo/types.ts';
 import { throwChatServeFailure } from '../../shared/errors.ts';
-import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ModelCandidate } from '@floway-dev/provider';
-import type { CanonicalResponsesPayload, ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
+import type { ResponsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 const isUpstreamOwned = (row: StoredResponsesItemMetadata): row is StoredResponsesItemMetadata & { upstreamId: string } =>
   row.upstreamId !== null;

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -7,11 +7,11 @@ import { createNonResponsesSourceStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
 import { InMemoryRepo } from '../../../../repo/memory.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
-import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputItem } from '@floway-dev/protocols/responses';
 import type { ModelCandidate } from '@floway-dev/provider';
 import { directFetcher } from '@floway-dev/provider';
 import { stubProvider, stubInternalModel, stubProviderModel, assert, assertEquals, assertFalse } from '@floway-dev/test-utils';
-import { responsesItemsView, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 const API_KEY_ID = 'key_rewrite_test';
 

--- a/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve-prep.ts
@@ -6,9 +6,9 @@ import { enumerateModelCandidates } from '../../providers/registry.ts';
 import { noViableCandidateFailure } from '../shared/errors.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ModelCandidate, ExecuteResult } from '@floway-dev/provider';
-import { responsesItemsView, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import { responsesItemsView } from '@floway-dev/translate/via-responses/responses-items';
 
 // Thrown when a request names a `previous_response_id` that the store cannot
 // resolve. The HTTP/WS entry layer catches this and renders the OpenAI-shaped

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -4,9 +4,8 @@ import { prepareResponsesServePlan } from './serve-prep.ts';
 import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 export interface ResponsesServeGenerateArgs {
   readonly payload: CanonicalResponsesPayload;

--- a/packages/gateway/src/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve_test.ts
@@ -10,10 +10,9 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { type AliasRules, doneFrame, eventFrame, type ModelEndpoints, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ModelCandidate, directFetcher, type ProviderResponsesResult, type ProviderStreamResult, type ResponsesAction, type UpstreamCallOptions } from '@floway-dev/provider';
 import { assert, assertEquals, stubProvider, stubInternalModel } from '@floway-dev/test-utils';
-import type { CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 // Mock the resolver seam so each test hands the serve exactly the provider
 // candidates it wants, optionally with an alias-rules overlay attached.

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -16,11 +16,11 @@ import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS, type StreamCompletion } from '../sha
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { RESPONSES_MISSING_TERMINAL_MESSAGE } from '@floway-dev/protocols/responses';
-import { isResponsesTerminalEvent, type ResponsesRequestPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ResponsesRequestPayload, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { toInternalDebugError } from '@floway-dev/provider';
 import { TranslatorInputError } from '@floway-dev/translate';
-import { canonicalizeResponsesPayload, type CanonicalResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
+import { canonicalizeResponsesPayload } from '@floway-dev/translate/via-responses/responses-items';
 
 interface WorkerWebSocket extends WebSocket {
   accept(): void;

--- a/packages/gateway/src/data-plane/providers/azure/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/azure/provider_test.ts
@@ -87,7 +87,7 @@ test('createAzureProvider sends upstream model ids in OpenAI-shaped request bodi
     },
     async () => {
       const chat = await instance.instance.callChatCompletions(providerModel, { messages: [{ role: 'user', content: 'hello' }] }, undefined, noopUpstreamCallOptions());
-      const responses = await instance.instance.callResponses(providerModel, { input: 'hello' }, 'generate', undefined, noopUpstreamCallOptions());
+      const responses = await instance.instance.callResponses(providerModel, { input: [{ type: 'message', role: 'user', content: 'hello' }] }, 'generate', undefined, noopUpstreamCallOptions());
       const embeddings = await instance.instance.callEmbeddings(providerModel, { input: 'hello' }, undefined, noopUpstreamCallOptions());
 
       assertEquals(chat.modelKey, 'gpt-prod');
@@ -151,7 +151,7 @@ test('createAzureProvider supports Azure AI cross-provider models with explicit 
     },
     async () => {
       const chat = await instance.instance.callChatCompletions(chatProviderModel, { messages: [{ role: 'user', content: 'hello' }] }, undefined, chatOpts);
-      const responses = await instance.instance.callResponses(responsesProviderModel, { input: 'hello' }, 'generate', undefined, responsesOpts);
+      const responses = await instance.instance.callResponses(responsesProviderModel, { input: [{ type: 'message', role: 'user', content: 'hello' }] }, 'generate', undefined, responsesOpts);
       assertEquals(chat.modelKey, 'deepseek-v4-pro');
       assertEquals(responses.modelKey, 'gpt-5.4-pro');
     },
@@ -171,7 +171,7 @@ test('createAzureProvider supports Azure AI cross-provider models with explicit 
       url: 'https://example.openai.azure.com/openai/v1/responses',
       apiKey: 'az-key',
       body: {
-        input: 'hello',
+        input: [{ type: 'message', role: 'user', content: 'hello' }],
         stream: true,
         model: 'gpt-5.4-pro',
       },

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -76,6 +76,10 @@ export type ResponsesCompactRequestPayload = Omit<ResponsesCompactPayload, 'inpu
   input: string | ResponsesRequestInputItem[];
 };
 
+export type CanonicalResponsesCompactPayload = Omit<ResponsesCompactPayload, 'input'> & {
+  input: ResponsesInputItem[];
+};
+
 // Project a (possibly-wider) ResponsesPayload-shaped object into the strict
 // compact wire shape. Every native-compact provider terminal calls this
 // before dispatching to its upstream's `/responses/compact` endpoint, so a
@@ -85,7 +89,7 @@ export type ResponsesCompactRequestPayload = Omit<ResponsesCompactPayload, 'inpu
 // the resolved upstream id; store is gateway-only). `prompt_cache_retention`
 // only exists on the compact payload type today, so there is no
 // generate-side value to forward.
-export const toCompactPayloadShape = (payload: Omit<ResponsesPayload, 'model'>): Omit<ResponsesCompactPayload, 'model' | 'store'> => ({
+export const toCompactPayloadShape = (payload: Omit<CanonicalResponsesPayload, 'model'>): Omit<CanonicalResponsesCompactPayload, 'model' | 'store'> => ({
   input: payload.input,
   ...(payload.instructions !== undefined && { instructions: payload.instructions }),
   ...(payload.previous_response_id !== undefined && { previous_response_id: payload.previous_response_id }),
@@ -158,6 +162,10 @@ export type ResponsesRequestInputItem =
 
 export type ResponsesRequestPayload = Omit<ResponsesPayload, 'input'> & {
   input: string | ResponsesRequestInputItem[];
+};
+
+export type CanonicalResponsesPayload = Omit<ResponsesPayload, 'input'> & {
+  input: ResponsesInputItem[];
 };
 
 export type ResponsesInputContent = ResponsesInputText | ResponsesInputImage | ResponsesInputFile;

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -13,7 +13,7 @@ import {
   putCodexQuota,
 } from './quota.ts';
 import type { CodexAccountCredential } from './state.ts';
-import type { ResponsesCompactPayload, ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesCompactPayload, CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
 import { type ProviderModel, type ProviderStreamResult, streamingProviderCall, uuidV7, type UpstreamCallOptions } from '@floway-dev/provider';
 
@@ -45,11 +45,11 @@ interface CodexBackendCallBase {
 }
 
 export interface CallCodexResponsesOptions extends CodexBackendCallBase {
-  body: Omit<ResponsesPayload, 'model'>;
+  body: Omit<CanonicalResponsesPayload, 'model'>;
 }
 
 export interface CallCodexResponsesCompactOptions extends CodexBackendCallBase {
-  body: Omit<ResponsesCompactPayload, 'model' | 'store'>;
+  body: Omit<CanonicalResponsesCompactPayload, 'model' | 'store'>;
 }
 
 export const callCodexResponses = async (opts: CallCodexResponsesOptions): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -13,7 +13,7 @@ import {
   putCodexQuota,
 } from './quota.ts';
 import type { CodexAccountCredential } from './state.ts';
-import type { CanonicalResponsesCompactPayload, CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesCompactPayload, CanonicalResponsesPayload, ResponsesInputItem, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
 import { type ProviderModel, type ProviderStreamResult, streamingProviderCall, uuidV7, type UpstreamCallOptions } from '@floway-dev/provider';
 
@@ -51,6 +51,8 @@ export interface CallCodexResponsesOptions extends CodexBackendCallBase {
 export interface CallCodexResponsesCompactOptions extends CodexBackendCallBase {
   body: Omit<CanonicalResponsesCompactPayload, 'model' | 'store'>;
 }
+
+type CodexResponsesBody = CallCodexResponsesOptions['body'] | CallCodexResponsesCompactOptions['body'];
 
 export const callCodexResponses = async (opts: CallCodexResponsesOptions): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
   const ready = await prepareCodexCall(opts);
@@ -165,7 +167,7 @@ const IDENTITY_MIRRORED_CLIENT_METADATA_KEYS = new Set<string>([
 
 const buildCodexRequestIdentity = async (
   opts: CodexBackendCallBase,
-  body: unknown,
+  body: CodexResponsesBody,
   clientMetadata: Record<string, unknown>,
   clientTurnMetadata: Record<string, unknown> | null,
 ): Promise<CodexRequestIdentity> => {
@@ -207,8 +209,7 @@ const buildCodexRequestIdentity = async (
 // code path with the input already expanded from the snapshot in
 // attempt.ts, so they hash the same prefix as the original turn and get
 // the same session id — no server-side session map required.
-const deriveSessionIdFromInput = async (body: unknown): Promise<string | null> => {
-  if (!isPlainObject(body)) return null;
+const deriveSessionIdFromInput = async (body: CodexResponsesBody): Promise<string | null> => {
   const seed = seedUpToFirstUserMessage(body.input);
   if (seed === null) return null;
   const instructions = typeof body.instructions === 'string' ? body.instructions : '';
@@ -217,10 +218,8 @@ const deriveSessionIdFromInput = async (body: unknown): Promise<string | null> =
   return await sha256Uuid(`${instructions}${JSON.stringify(seed)}`);
 };
 
-const seedUpToFirstUserMessage = (input: unknown): readonly unknown[] | null => {
-  if (typeof input === 'string') return [input];
-  if (!Array.isArray(input)) return null;
-  const collected: unknown[] = [];
+const seedUpToFirstUserMessage = (input: readonly ResponsesInputItem[]): readonly ResponsesInputItem[] | null => {
+  const collected: ResponsesInputItem[] = [];
   for (const item of input) {
     collected.push(item);
     if (isUserMessageItem(item)) return collected;
@@ -228,14 +227,8 @@ const seedUpToFirstUserMessage = (input: unknown): readonly unknown[] | null => 
   return null;
 };
 
-const isUserMessageItem = (item: unknown): boolean => {
-  if (typeof item !== 'object' || item === null) return false;
-  const obj = item as { type?: unknown; role?: unknown };
-  // Implicit `type: "message"` is valid per the OpenAI Responses schema;
-  // explicit non-message items (tool results, reasoning, etc.) skip.
-  if (obj.type !== undefined && obj.type !== 'message') return false;
-  return obj.role === 'user';
-};
+const isUserMessageItem = (item: ResponsesInputItem): boolean =>
+  item.type === 'message' && item.role === 'user';
 
 const buildCodexTurnMetadata = (
   identity: CodexRequestIdentity,
@@ -397,7 +390,7 @@ const performStreamingResponsesCall = async (
   const clientTurnMetadata = parseClientTurnMetadataJson(trimHeader(opts.headers, 'x-codex-turn-metadata'));
   const clientMetadata = clientCodexClientMetadata(opts.body);
   const identity = await buildCodexRequestIdentity(opts, opts.body, clientMetadata, clientTurnMetadata);
-  const metadata = opts.turnMetadata ?? (Array.isArray(opts.body.input) && opts.body.input.some(item => item.type === 'compaction_trigger') ? CODEX_RESPONSES_COMPACTION_V2_TURN_METADATA : { requestKind: 'turn' });
+  const metadata = opts.turnMetadata ?? (opts.body.input.some(item => item.type === 'compaction_trigger') ? CODEX_RESPONSES_COMPACTION_V2_TURN_METADATA : { requestKind: 'turn' });
   const turnMetadataJson = buildCodexTurnMetadataJson(identity, metadata, clientTurnMetadata);
   const upstreamFetch = dispatchCodexHttpCall(
     opts,

--- a/packages/provider-codex/src/interceptors/responses/inject-default-instructions_test.ts
+++ b/packages/provider-codex/src/interceptors/responses/inject-default-instructions_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { injectDefaultInstructions } from './inject-default-instructions.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ProviderStreamResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel } from '@floway-dev/test-utils';
 
@@ -11,7 +11,7 @@ const stubRequest = {};
 const okEvents = (): Promise<ProviderStreamResult<ResponsesStreamEvent>> =>
   Promise.resolve({ ok: true, events: (async function* () {})(), modelKey: 'test', headers: new Headers() });
 
-const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
+const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx => ({
   payload,
   headers: new Headers(),
   model: stubProviderModel({ endpoints: { responses: {} } }),
@@ -19,7 +19,7 @@ const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
 });
 
 test('injects the default when instructions is absent', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hello' });
+  const ctx = invocation({ model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }] });
 
   await injectDefaultInstructions(ctx, stubRequest, okEvents);
 
@@ -27,7 +27,7 @@ test('injects the default when instructions is absent', async () => {
 });
 
 test('injects the default when instructions is an empty string', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hello', instructions: '' });
+  const ctx = invocation({ model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }], instructions: '' });
 
   await injectDefaultInstructions(ctx, stubRequest, okEvents);
 
@@ -35,7 +35,7 @@ test('injects the default when instructions is an empty string', async () => {
 });
 
 test('preserves a caller-supplied instructions string', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hello', instructions: 'You are a pirate.' });
+  const ctx = invocation({ model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }], instructions: 'You are a pirate.' });
 
   await injectDefaultInstructions(ctx, stubRequest, okEvents);
 

--- a/packages/provider-codex/src/interceptors/responses/strip-unsupported-fields_test.ts
+++ b/packages/provider-codex/src/interceptors/responses/strip-unsupported-fields_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { stripUnsupportedFields } from './strip-unsupported-fields.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ProviderStreamResult } from '@floway-dev/provider';
 import { assertEquals, assertFalse, stubProviderModel } from '@floway-dev/test-utils';
 
@@ -11,7 +11,7 @@ const stubRequest = {};
 const okEvents = (): Promise<ProviderStreamResult<ResponsesStreamEvent>> =>
   Promise.resolve({ ok: true, events: (async function* () {})(), modelKey: 'test', headers: new Headers() });
 
-const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
+const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx => ({
   payload,
   headers: new Headers(),
   model: stubProviderModel({ endpoints: { responses: {} } }),
@@ -24,13 +24,13 @@ test('drops every field Codex rejects with Unsupported parameter', async () => {
   // drift if the constant inside the interceptor is edited without updating
   // its rationale. Several entries (frequency_penalty, presence_penalty,
   // user, prompt_cache_retention, stream_options) are not on the canonical
-  // `ResponsesPayload` shape — they reach Codex only when an upstream
+  // `CanonicalResponsesPayload` shape — they reach Codex only when an upstream
   // translator or a permissive caller smuggles them in, which is exactly
   // the case the interceptor exists to handle, so we widen the literal
   // through `unknown` for the test.
   const ctx = invocation({
     model: 'gpt-test',
-    input: 'hello',
+    input: [{ type: 'message', role: 'user', content: 'hello' }],
     max_output_tokens: 1024,
     temperature: 0.7,
     top_p: 0.9,
@@ -41,7 +41,7 @@ test('drops every field Codex rejects with Unsupported parameter', async () => {
     prompt_cache_retention: '24h',
     safety_identifier: 'caller-supplied',
     stream_options: { include_usage: true },
-  } as unknown as ResponsesPayload);
+  } as unknown as CanonicalResponsesPayload);
 
   await stripUnsupportedFields(ctx, stubRequest, okEvents);
 
@@ -60,7 +60,7 @@ test('drops every field Codex rejects with Unsupported parameter', async () => {
 test('leaves supported fields intact', async () => {
   const ctx = invocation({
     model: 'gpt-test',
-    input: 'hello',
+    input: [{ type: 'message', role: 'user', content: 'hello' }],
     instructions: 'be terse',
     stream: true,
     store: false,
@@ -70,7 +70,7 @@ test('leaves supported fields intact', async () => {
   await stripUnsupportedFields(ctx, stubRequest, okEvents);
 
   assertEquals(ctx.payload.model, 'gpt-test');
-  assertEquals(ctx.payload.input, 'hello');
+  assertEquals(ctx.payload.input, [{ type: 'message', role: 'user', content: 'hello' }]);
   assertEquals(ctx.payload.instructions, 'be terse');
   assertEquals(ctx.payload.stream, true);
   assertEquals(ctx.payload.store, false);
@@ -78,10 +78,10 @@ test('leaves supported fields intact', async () => {
 });
 
 test('payload without any unsupported fields is preserved as-is', async () => {
-  const payload: ResponsesPayload = { model: 'gpt-test', input: 'hello' };
+  const payload: CanonicalResponsesPayload = { model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }] };
   const ctx = invocation(payload);
 
   await stripUnsupportedFields(ctx, stubRequest, okEvents);
 
-  assertEquals(ctx.payload, { model: 'gpt-test', input: 'hello' });
+  assertEquals(ctx.payload, { model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }] });
 });

--- a/packages/provider-codex/src/interceptors/responses/types.ts
+++ b/packages/provider-codex/src/interceptors/responses/types.ts
@@ -1,4 +1,4 @@
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import type { ProviderModel, ResponsesAction } from '@floway-dev/provider';
 
 // Boundary ctx for Codex Responses interceptors. The same ctx feeds both the
@@ -6,7 +6,7 @@ import type { ProviderModel, ResponsesAction } from '@floway-dev/provider';
 // (action='compact') chains; the terminal switches on `action` to pick the
 // wire shape (see provider.ts callResponses).
 export interface ResponsesBoundaryCtx {
-  payload: ResponsesPayload;
+  payload: CanonicalResponsesPayload;
   headers: Headers;
   readonly model: ProviderModel;
   // Mirrors the gateway-side ResponsesInvocation.action. Interceptors MAY

--- a/packages/provider-copilot/src/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/abort-on-tool-argument-whitespace_test.ts
@@ -4,14 +4,14 @@ import { withToolArgumentWhitespaceAborted } from './abort-on-tool-argument-whit
 import type { ResponsesBoundaryCtx } from './types.ts';
 import { MAX_CONSECUTIVE_WHITESPACE } from '../shared/whitespace-overflow.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ProviderResponsesResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel } from '@floway-dev/test-utils';
 
 const invocation = (): ResponsesBoundaryCtx => ({
   payload: {
     model: 'test-model',
-    input: [] as unknown as ResponsesPayload['input'],
+    input: [],
     instructions: null,
     temperature: 1,
     top_p: null,

--- a/packages/provider-copilot/src/interceptors/responses/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images.ts
@@ -16,14 +16,12 @@ export const withInlineImagesCompressed = async <TResult>(
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
   const targets: Array<{ part: ResponsesInputImage; imageUrl: string }> = [];
-  if (Array.isArray(ctx.payload.input)) {
-    for (const item of ctx.payload.input) {
-      const parts = item.type === 'message' ? item.content : item.type === 'function_call_output' ? item.output : undefined;
-      if (!Array.isArray(parts)) continue;
-      for (const part of parts) {
-        if (part.type === 'input_image' && typeof part.image_url === 'string' && isBase64ImageDataUrl(part.image_url)) {
-          targets.push({ part, imageUrl: part.image_url });
-        }
+  for (const item of ctx.payload.input) {
+    const parts = item.type === 'message' ? item.content : item.type === 'function_call_output' ? item.output : undefined;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      if (part.type === 'input_image' && typeof part.image_url === 'string' && isBase64ImageDataUrl(part.image_url)) {
+        targets.push({ part, imageUrl: part.image_url });
       }
     }
   }

--- a/packages/provider-copilot/src/interceptors/responses/compress-images_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images_test.ts
@@ -4,7 +4,7 @@ import { withInlineImagesCompressed } from './compress-images.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
 import { type ImageProcessor, initImageProcessor } from '@floway-dev/platform';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
@@ -18,14 +18,14 @@ const fixedProcessor: ImageProcessor = {
   compressToWebp: () => Promise.resolve(new Uint8Array([1, 2, 3])),
 };
 
-const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
+const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx => ({
   payload,
   headers: new Headers(),
   model: stubProviderModel({ endpoints: { responses: {} } }),
   action: 'generate',
 });
 
-const firstImageUrl = (payload: ResponsesPayload): string => {
+const firstImageUrl = (payload: CanonicalResponsesPayload): string => {
   const input = payload.input as Array<{ type: string; content?: Array<{ type: string; image_url?: string }> }>;
   const message = input.find(item => item.type === 'message');
   const image = message?.content?.find(part => part.type === 'input_image');

--- a/packages/provider-copilot/src/interceptors/responses/force-store-false_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/force-store-false_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { withStoreForcedFalse } from './force-store-false.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
@@ -13,7 +13,7 @@ const stubRequest = {};
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> =>
   Promise.resolve(eventResult((async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {})(), testTelemetryModelIdentity));
 
-const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
+const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx => ({
   payload,
   headers: new Headers(),
   model: stubProviderModel({ endpoints: { responses: {} } }),
@@ -21,7 +21,7 @@ const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
 });
 
 test('forces store:false when the caller requested store:true', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hello', store: true });
+  const ctx = invocation({ model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }], store: true });
 
   await withStoreForcedFalse(ctx, stubRequest, okEvents);
 
@@ -29,7 +29,7 @@ test('forces store:false when the caller requested store:true', async () => {
 });
 
 test('sets store:false when the caller omitted store', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hello' });
+  const ctx = invocation({ model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }] });
 
   await withStoreForcedFalse(ctx, stubRequest, okEvents);
 
@@ -37,7 +37,7 @@ test('sets store:false when the caller omitted store', async () => {
 });
 
 test('leaves an explicit store:false untouched', async () => {
-  const ctx = invocation({ model: 'gpt-test', input: 'hello', store: false });
+  const ctx = invocation({ model: 'gpt-test', input: [{ type: 'message', role: 'user', content: 'hello' }], store: false });
 
   await withStoreForcedFalse(ctx, stubRequest, okEvents);
 

--- a/packages/provider-copilot/src/interceptors/responses/set-initiator-header.ts
+++ b/packages/provider-copilot/src/interceptors/responses/set-initiator-header.ts
@@ -12,7 +12,7 @@ import type { ResponsesInputItem } from '@floway-dev/protocols/responses';
  *   plus any future hosted-tool output shape). Classify all of them as agent.
  * - An assistant message replayed back into `input` is also agent-driven.
  *
- * Everything else (user / system / developer messages, plain string input)
+ * Everything else (a user / system / developer message, or no input item)
  * means the user just spoke, so initiator = user.
  *
  * The header name is lowercase `x-initiator`; HTTP header names are

--- a/packages/provider-copilot/src/interceptors/responses/set-initiator-header.ts
+++ b/packages/provider-copilot/src/interceptors/responses/set-initiator-header.ts
@@ -36,8 +36,7 @@ export const withInitiatorHeaderSet = async <TResult>(
   _request: object,
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
-  const input = ctx.payload.input;
-  const initiator: 'user' | 'agent' = Array.isArray(input) && isAgentInitiated(input.at(-1)) ? 'agent' : 'user';
+  const initiator: 'user' | 'agent' = isAgentInitiated(ctx.payload.input.at(-1)) ? 'agent' : 'user';
   ctx.headers.set('x-initiator', initiator);
 
   return await run();

--- a/packages/provider-copilot/src/interceptors/responses/set-initiator-header_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/set-initiator-header_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { withInitiatorHeaderSet } from './set-initiator-header.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputItem, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
@@ -13,7 +13,7 @@ const stubRequest = {};
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> =>
   Promise.resolve(eventResult((async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {})(), testTelemetryModelIdentity));
 
-const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
+const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx => ({
   payload,
   headers: new Headers(),
   model: stubProviderModel({ endpoints: { responses: {} } }),
@@ -30,17 +30,6 @@ test('Responses initiator is user when the last input item is a plain user messa
         content: [{ type: 'input_text', text: 'hello' }],
       },
     ],
-  });
-
-  await withInitiatorHeaderSet(ctx, stubRequest, okEvents);
-
-  assertEquals(ctx.headers.get('x-initiator'), 'user');
-});
-
-test('Responses initiator is user when input is a plain string', async () => {
-  const ctx = invocation({
-    model: 'gpt-test',
-    input: 'plain string input',
   });
 
   await withInitiatorHeaderSet(ctx, stubRequest, okEvents);

--- a/packages/provider-copilot/src/interceptors/responses/set-vision-header.ts
+++ b/packages/provider-copilot/src/interceptors/responses/set-vision-header.ts
@@ -32,10 +32,7 @@ export const withVisionHeaderSet = async <TResult>(
   _request: object,
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
-  const input = ctx.payload.input;
-  if (!Array.isArray(input)) return await run();
-
-  if (containsVisionContent(input)) ctx.headers.set('copilot-vision-request', 'true');
+  if (containsVisionContent(ctx.payload.input)) ctx.headers.set('copilot-vision-request', 'true');
 
   return await run();
 };

--- a/packages/provider-copilot/src/interceptors/responses/set-vision-header_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/set-vision-header_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { withVisionHeaderSet } from './set-vision-header.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesInputItem, ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputItem, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
@@ -13,7 +13,7 @@ const stubRequest = {};
 const okEvents = (): Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> =>
   Promise.resolve(eventResult((async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {})(), testTelemetryModelIdentity));
 
-const invocation = (payload: ResponsesPayload): ResponsesBoundaryCtx => ({
+const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx => ({
   payload,
   headers: new Headers(),
   model: stubProviderModel({ endpoints: { responses: {} } }),
@@ -77,17 +77,6 @@ test('Responses vision header absent when content is pure text', async () => {
         content: [{ type: 'input_text', text: 'plain text only' }],
       },
     ],
-  });
-
-  await withVisionHeaderSet(ctx, stubRequest, okEvents);
-
-  assertEquals(ctx.headers.has('copilot-vision-request'), false);
-});
-
-test('Responses vision header absent when input is a plain string', async () => {
-  const ctx = invocation({
-    model: 'gpt-test',
-    input: 'plain string input',
   });
 
   await withVisionHeaderSet(ctx, stubRequest, okEvents);

--- a/packages/provider-copilot/src/interceptors/responses/strip-image-generation.ts
+++ b/packages/provider-copilot/src/interceptors/responses/strip-image-generation.ts
@@ -1,5 +1,5 @@
 import type { ResponsesBoundaryCtx } from './types.ts';
-import type { ResponsesPayload, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 /**
  * Copilot's `/responses` endpoint rejects public `image_generation` tool
@@ -20,7 +20,7 @@ const isImageGenerationTool = (tool: ResponsesTool): boolean => tool.type === 'i
 const isImageGenerationToolChoice = (choice: ResponsesToolChoice | null | undefined): boolean =>
   typeof choice === 'object' && choice !== null && choice.type === 'image_generation';
 
-export const stripImageGenerationFromPayload = (payload: ResponsesPayload): void => {
+export const stripImageGenerationFromPayload = (payload: CanonicalResponsesPayload): void => {
   let removedTool = false;
 
   if (Array.isArray(payload.tools)) {

--- a/packages/provider-copilot/src/interceptors/responses/strip-image-generation_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/strip-image-generation_test.ts
@@ -1,13 +1,13 @@
 import { test } from 'vitest';
 
 import { stripImageGenerationFromPayload } from './strip-image-generation.ts';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import { assertEquals, assertFalse } from '@floway-dev/test-utils';
 
 test('stripImageGenerationFromPayload removes image_generation tools', () => {
   const payload = {
     model: 'gpt-test',
-    input: 'draw this',
+    input: [{ type: 'message', role: 'user', content: 'draw this' }],
     tools: [
       { type: 'image_generation' },
       {
@@ -18,7 +18,7 @@ test('stripImageGenerationFromPayload removes image_generation tools', () => {
       },
     ],
     tool_choice: 'auto',
-  } as ResponsesPayload;
+  } as CanonicalResponsesPayload;
 
   stripImageGenerationFromPayload(payload);
 
@@ -30,10 +30,10 @@ test('stripImageGenerationFromPayload removes image_generation tools', () => {
 test('stripImageGenerationFromPayload removes forced image_generation tool_choice', () => {
   const payload = {
     model: 'gpt-test',
-    input: 'draw this',
+    input: [{ type: 'message', role: 'user', content: 'draw this' }],
     tools: [{ type: 'image_generation' }],
     tool_choice: { type: 'image_generation' },
-  } as ResponsesPayload;
+  } as CanonicalResponsesPayload;
 
   stripImageGenerationFromPayload(payload);
 
@@ -44,10 +44,10 @@ test('stripImageGenerationFromPayload removes forced image_generation tool_choic
 test('stripImageGenerationFromPayload removes required tool_choice when no tools remain', () => {
   const payload = {
     model: 'gpt-test',
-    input: 'draw this',
+    input: [{ type: 'message', role: 'user', content: 'draw this' }],
     tools: [{ type: 'image_generation' }],
     tool_choice: 'required',
-  } as ResponsesPayload;
+  } as CanonicalResponsesPayload;
 
   stripImageGenerationFromPayload(payload);
 
@@ -61,7 +61,7 @@ test('stripImageGenerationFromPayload preserves Copilot-accepted hosted and defe
   // must still see those entries even after image_generation is dropped.
   const payload = {
     model: 'gpt-test',
-    input: 'search the web',
+    input: [{ type: 'message', role: 'user', content: 'search the web' }],
     tools: [
       {
         type: 'function',
@@ -75,7 +75,7 @@ test('stripImageGenerationFromPayload preserves Copilot-accepted hosted and defe
       { type: 'image_generation', output_format: 'png' },
     ],
     tool_choice: 'auto',
-  } as ResponsesPayload;
+  } as CanonicalResponsesPayload;
 
   stripImageGenerationFromPayload(payload);
 
@@ -87,10 +87,10 @@ test('stripImageGenerationFromPayload preserves forced non-image hosted and defe
   for (const type of ['web_search', 'tool_search', 'namespace'] as const) {
     const payload = {
       model: 'gpt-test',
-      input: 'search',
+      input: [{ type: 'message', role: 'user', content: 'search' }],
       tools: [{ type }],
       tool_choice: { type },
-    } as ResponsesPayload;
+    } as CanonicalResponsesPayload;
 
     stripImageGenerationFromPayload(payload);
 
@@ -102,7 +102,7 @@ test('stripImageGenerationFromPayload preserves forced non-image hosted and defe
 test('stripImageGenerationFromPayload preserves custom Freeform tools for downstream wrapping', () => {
   const payload = {
     model: 'gpt-test',
-    input: 'do x',
+    input: [{ type: 'message', role: 'user', content: 'do x' }],
     tools: [
       {
         type: 'function',
@@ -113,7 +113,7 @@ test('stripImageGenerationFromPayload preserves custom Freeform tools for downst
       { type: 'custom', name: 'freeform_other', description: 'x' },
     ],
     tool_choice: { type: 'custom', name: 'freeform_other' },
-  } as ResponsesPayload;
+  } as CanonicalResponsesPayload;
 
   stripImageGenerationFromPayload(payload);
 

--- a/packages/provider-copilot/src/interceptors/responses/synchronize-output-item-ids_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/synchronize-output-item-ids_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { withOutputItemIdsSynchronized } from './synchronize-output-item-ids.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ProviderResponsesResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel } from '@floway-dev/test-utils';
 
@@ -12,7 +12,7 @@ const stubRequest = {};
 const invocation = (): ResponsesBoundaryCtx => ({
   payload: {
     model: 'test-model',
-    input: [] as unknown as ResponsesPayload['input'],
+    input: [],
     instructions: null,
     temperature: 1,
     top_p: null,

--- a/packages/provider-copilot/src/interceptors/responses/types.ts
+++ b/packages/provider-copilot/src/interceptors/responses/types.ts
@@ -1,5 +1,5 @@
 import type { Interceptor } from '@floway-dev/interceptor';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 import type { ProviderModel, ProviderResponsesResult, ResponsesAction } from '@floway-dev/provider';
 
 // Boundary ctx for Copilot Responses interceptors. See messages/types.ts for
@@ -9,7 +9,7 @@ import type { ProviderModel, ProviderResponsesResult, ResponsesAction } from '@f
 // `action` mirrors the gateway-side ResponsesInvocation.action — interceptors
 // MAY mutate it during the chain to re-route dispatch in the terminal.
 export interface ResponsesBoundaryCtx {
-  payload: ResponsesPayload;
+  payload: CanonicalResponsesPayload;
   headers: Headers;
   readonly model: ProviderModel;
   action: ResponsesAction;

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -20,7 +20,7 @@ import { runInterceptors } from '@floway-dev/interceptor';
 import { parseChatCompletionsStream, type ChatCompletionsPayload, type ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { type ModelEndpointKey, type ModelEndpoints, type ProtocolFrame, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseAnthropicBetaHeader, parseMessagesStream, type MessagesPayload, type MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import { parseResponsesStream, type ResponsesInputItem, type ResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
+import { parseResponsesStream, type CanonicalResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
 import { COMPACTION_TRIGGER, compactionResponse, eventResult, getProviderRepo, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, resolveEffectiveFlags, type ExecuteResult, type FlagOverrides, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CopilotProviderData {
@@ -111,7 +111,7 @@ const chatReasoningEffort = (body: Omit<ChatCompletionsPayload, 'model'>): strin
 
 const messagesReasoningEffort = (body: Omit<MessagesPayload, 'model'>): string | undefined => body.output_config?.effort;
 
-const responsesReasoningEffort = (body: Omit<ResponsesPayload, 'model'>): string | undefined => (body.reasoning?.effort && body.reasoning.effort !== 'none' ? body.reasoning.effort : undefined);
+const responsesReasoningEffort = (body: Omit<CanonicalResponsesPayload, 'model'>): string | undefined => (body.reasoning?.effort && body.reasoning.effort !== 'none' ? body.reasoning.effort : undefined);
 
 const rejectUnsupported = (capability: string) => (): Promise<never> =>
   Promise.reject(new Error(`Copilot provider does not implement ${capability}`));
@@ -362,9 +362,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
               : { action: 'generate', ok: false, response: stream.response, modelKey: stream.modelKey };
           }
           case 'compact': {
-            const input: ResponsesInputItem[] = typeof wireBody.input === 'string'
-              ? [{ type: 'message', role: 'user', content: wireBody.input }]
-              : wireBody.input.map(item => item.type === undefined ? { ...item, type: 'message' } : item);
+            const input = wireBody.input;
             const triggered = { ...wireBody, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
             const response = await copilotFetchResponses(
               upstreamConfig,

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -362,7 +362,9 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
               : { action: 'generate', ok: false, response: stream.response, modelKey: stream.modelKey };
           }
           case 'compact': {
-            const input: ResponsesInputItem[] = typeof wireBody.input === 'string' ? [{ type: 'message', role: 'user', content: wireBody.input }] : wireBody.input;
+            const input: ResponsesInputItem[] = typeof wireBody.input === 'string'
+              ? [{ type: 'message', role: 'user', content: wireBody.input }]
+              : wireBody.input.map(item => item.type === undefined ? { ...item, type: 'message' } : item);
             const triggered = { ...wireBody, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
             const response = await copilotFetchResponses(
               upstreamConfig,

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -376,7 +376,6 @@ test('Copilot provider runs the Responses boundary chain on the compact path', a
       const result = await provider.callResponses(providerModel, {
         input: [
           {
-            type: 'message',
             role: 'user',
             content: [
               { type: 'input_text', text: 'compact me' },
@@ -397,6 +396,7 @@ test('Copilot provider runs the Responses boundary chain on the compact path', a
   if (!responsesBody) throw new Error('expected /responses to be hit');
   assertEquals('service_tier' in responsesBody, false);
   const wireInput = responsesBody?.input as Array<{ type: string }>;
+  assertEquals(wireInput[0]?.type, 'message');
   assertEquals(wireInput.at(-1)?.type, 'compaction_trigger');
   assertEquals(visionHeader, 'true');
   assertEquals(initiatorHeader, 'user');

--- a/packages/provider-copilot/src/provider_test.ts
+++ b/packages/provider-copilot/src/provider_test.ts
@@ -376,6 +376,7 @@ test('Copilot provider runs the Responses boundary chain on the compact path', a
       const result = await provider.callResponses(providerModel, {
         input: [
           {
+            type: 'message',
             role: 'user',
             content: [
               { type: 'input_text', text: 'compact me' },

--- a/packages/provider/src/invocation.ts
+++ b/packages/provider/src/invocation.ts
@@ -5,7 +5,7 @@ import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completi
 import type { AliasRules } from '@floway-dev/protocols/common';
 import type { GeminiPayload } from '@floway-dev/protocols/gemini';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload } from '@floway-dev/protocols/responses';
 
 export type ChatTargetApi = 'messages' | 'responses' | 'chat-completions';
 
@@ -75,7 +75,7 @@ export interface MessagesInvocation {
 }
 
 export interface ResponsesInvocation {
-  payload: ResponsesPayload;
+  payload: CanonicalResponsesPayload;
   // Mutable action tag — interceptors can flip 'compact' to 'generate' so the
   // inner provider call runs a normal summarization turn (see the
   // responses-compact-shim) and the gateway derives snapshot mode from the

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -8,7 +8,7 @@ import type { CompletionsPayload } from '@floway-dev/protocols/completions';
 import type { EmbeddingsPayload } from '@floway-dev/protocols/embeddings';
 import type { ImagesGenerationsPayload } from '@floway-dev/protocols/images';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 // Action tag threaded through the Responses pipeline. `generate` is a normal
 // streaming /responses turn; `compact` is the summarize-and-replace-history
@@ -124,7 +124,7 @@ export interface ProviderInstance {
   // before the wire header is filtered down to the Copilot allow-list)
   // re-parse it from `opts.headers.get('anthropic-beta')` themselves.
   callChatCompletions(model: ProviderModel, body: Omit<ChatCompletionsPayload, 'model'>, signal: AbortSignal | undefined, opts: UpstreamCallOptions): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>>;
-  callResponses(model: ProviderModel, body: Omit<ResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions): Promise<ProviderResponsesResult>;
+  callResponses(model: ProviderModel, body: Omit<CanonicalResponsesPayload, 'model'>, action: ResponsesAction, signal: AbortSignal | undefined, opts: UpstreamCallOptions): Promise<ProviderResponsesResult>;
   callMessages(model: ProviderModel, body: Omit<MessagesPayload, 'model'>, signal: AbortSignal | undefined, opts: UpstreamCallOptions): Promise<ProviderStreamResult<MessagesStreamEvent>>;
   // count_tokens is non-streaming JSON; the gateway relays the upstream
   // Response verbatim.

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -1,9 +1,8 @@
 import { chatCompletionsContentToResponsesInputContent, chatCompletionsContentToText } from '../shared/chat-completions-and-responses/content.ts';
 import { scalarToResponsesReasoningItem, translateChatCompletionsReasoningItems } from '../shared/chat-completions-and-responses/reasoning.ts';
-import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
-import type { ResponsesInputItem, ResponsesInputReasoning, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputItem, ResponsesInputReasoning, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool[] | null =>
   tools?.length

--- a/packages/translate/src/chat-completions-via-responses/translate.ts
+++ b/packages/translate/src/chat-completions-via-responses/translate.ts
@@ -1,9 +1,8 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
-import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 export const translateChatCompletionsViaResponses: TranslateTrip<
   ChatCompletionsPayload, ChatCompletionsStreamEvent, CanonicalResponsesPayload, ResponsesStreamEvent

--- a/packages/translate/src/gemini-via-responses/request.ts
+++ b/packages/translate/src/gemini-via-responses/request.ts
@@ -13,10 +13,9 @@ import {
   type GeminiToolCallIds,
   geminiVisibleText,
 } from '../shared/gemini-via/gemini.ts';
-import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import type { GeminiContent, GeminiPayload, GeminiGenerationConfig, GeminiPart } from '@floway-dev/protocols/gemini';
-import type { ResponsesInputContent, ResponsesInputItem, ResponsesTool } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputContent, ResponsesInputItem, ResponsesTool } from '@floway-dev/protocols/responses';
 
 const flushPendingContent = (input: ResponsesInputItem[], pending: ResponsesInputContent[], role: 'user' | 'assistant'): void => {
   if (pending.length === 0) return;

--- a/packages/translate/src/gemini-via-responses/translate.ts
+++ b/packages/translate/src/gemini-via-responses/translate.ts
@@ -1,9 +1,8 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
-import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { GeminiPayload, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 export const translateGeminiViaResponses: TranslateTrip<
   GeminiPayload, GeminiStreamEvent, CanonicalResponsesPayload, ResponsesStreamEvent

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -2,7 +2,6 @@ import { openAiJsonSchemaCoreFromMessagesFormat } from '../shared/messages/struc
 import { messagesReasoningBlockToResponsesReasoning } from '../shared/messages-and-responses/reasoning.ts';
 import { resolveMessagesReasoningEffort } from '../shared/messages-via/reasoning-effort.ts';
 import { normalizeMessagesToolInputSchema } from '../shared/messages-via/tool-schema.ts';
-import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import {
   type MessagesAssistantMessage,
@@ -18,7 +17,7 @@ import {
   type MessagesUserMessage,
   type MessagesWebSearchToolResultBlock,
 } from '@floway-dev/protocols/messages';
-import type { ResponsesInputContent, ResponsesInputItem, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputContent, ResponsesInputItem, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 const flushPendingContent = (pending: ResponsesInputContent[], input: ResponsesInputItem[], role: 'user' | 'assistant'): void => {
   if (pending.length === 0) return;

--- a/packages/translate/src/messages-via-responses/translate.ts
+++ b/packages/translate/src/messages-via-responses/translate.ts
@@ -1,10 +1,9 @@
 import { translateToSourceEvents } from './events.ts';
 import { buildTargetRequest } from './request.ts';
 import { rewriteContextExceededToPromptTooLong } from '../shared/messages/context-window-error.ts';
-import { type CanonicalResponsesPayload } from '../shared/via-responses/responses-items.ts';
 import type { TranslateTrip } from '../types.ts';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 export const translateMessagesViaResponses: TranslateTrip<
   MessagesPayload, MessagesStreamEvent, CanonicalResponsesPayload, ResponsesStreamEvent

--- a/packages/translate/src/shared/via-responses/responses-items.ts
+++ b/packages/translate/src/shared/via-responses/responses-items.ts
@@ -4,21 +4,13 @@ import { responsesReasoningToMessagesBlock, unpackReasoningSignature } from '../
 import type { ChatCompletionsReasoningItem, ChatCompletionsMessage } from '@floway-dev/protocols/chat-completions';
 import type { GeminiContent } from '@floway-dev/protocols/gemini';
 import type { MessagesAssistantContentBlock, MessagesMessage } from '@floway-dev/protocols/messages';
-import type { ResponsesEasyInputMessage, ResponsesInputItem, ResponsesRequestPayload } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesEasyInputMessage, ResponsesInputItem, ResponsesRequestPayload } from '@floway-dev/protocols/responses';
 
 // Wire `ResponsesRequestPayload.input` accepts a bare string and EasyInputMessage
 // objects whose `type: "message"` discriminator is omitted. The gateway's
 // canonical internal shape is an explicitly discriminated item array: every
 // consumer past HTTP / WS entry normalization or cross-protocol translation
 // sees `type: "message"` on every message.
-// The name is owned here because `*-via-responses` translators produce this
-// shape directly — their `buildTargetRequest` always constructs an array —
-// so the boundary between "wire" and "canonical" naturally sits at the
-// translator's return type.
-export type CanonicalResponsesPayload = Omit<ResponsesRequestPayload, 'input'> & {
-  input: ResponsesInputItem[];
-};
-
 // Lifts a wire `ResponsesRequestPayload` to canonical form. Called at every wire
 // boundary that produces a payload destined for internal use and by direct
 // Responses-source translators; cross-protocol translators already construct


### PR DESCRIPTION
## Summary

Responses wire payloads allow scalar and implicit-message input, while every internal consumer after ingress operates on an explicitly discriminated item array. This change makes that boundary part of the shared protocol contract instead of a translate-local convention.

`CanonicalResponsesPayload` and `CanonicalResponsesCompactPayload` now live in `@floway-dev/protocols`. Gateway invocations, provider interfaces, provider boundary interceptors, and Responses-target translators consume those canonical types directly. Raw request shapes remain confined to HTTP, WebSocket, and direct Responses-source translation entry points.

Copilot compact dispatch now appends its compaction trigger to already-canonical input, and Codex request identity derives its seed from the same typed item array. Provider interceptors no longer carry scalar-input or omitted-discriminator branches that cannot occur past the canonical boundary.

## Test Plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` (339 files, 4153 tests)
