### PR TITLE
fix(translate): reject unhydrated item references

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -176,7 +176,15 @@ Header shaping (UA, `X-Stainless-*`, `anthropic-beta`) and the dated
 upstream model id are set in the provider's fetch path, not as interceptor
 steps.
 
-### Responses — gateway interceptors
+### Responses — gateway flow and interceptors
+
+- resolves `previous_response_id` and every `item_reference` through the
+  gateway's Responses store before candidate dispatch. Affinity is classified
+  from each referenced item's stored type, then the candidate rewrite replaces
+  every reference with its durable payload. Same-upstream items recover their
+  upstream wire id; portable items receive a temporary id when needed. A
+  missing durable payload returns `item_not_found`, and no provider receives an
+  `item_reference` carrier.
 
 - removes unsupported `image_generation` Responses tool entries and forced
   tool choices that targeted them before target request construction. Other
@@ -203,9 +211,7 @@ The same boundary runs for both `/v1/responses` (streaming) and
   the chain runs, so durable storage is unaffected
 - compresses inline base64 image data URLs to WebP
 - injects `x-vision-request` and `x-initiator` headers
-- on `/v1/responses` only: retries expired connection-bound input IDs once
-  with deterministic rewrites, and synchronizes mismatched stream output
-  item IDs
+- on `/v1/responses` only: synchronizes mismatched stream output item IDs
 
 ### Responses — Codex provider boundary chain
 

--- a/packages/translate/src/responses-via-chat-completions/request.ts
+++ b/packages/translate/src/responses-via-chat-completions/request.ts
@@ -200,9 +200,9 @@ export const translateResponsesToChatCompletions = (source: ResponsesRequestPayl
       continue;
     }
 
-    // item_reference items are connection-bound pointers with no inline
-    // content to translate; skip them.
-    if (item.type === 'item_reference') continue;
+    if (item.type === 'item_reference') {
+      throw new TranslatorInputError("Invalid input item type 'item_reference'.");
+    }
 
     // The shim must translate echoed web_search_call input items
     // into function_call + function_call_output pairs before this

--- a/packages/translate/src/responses-via-chat-completions/request_test.ts
+++ b/packages/translate/src/responses-via-chat-completions/request_test.ts
@@ -1408,6 +1408,7 @@ test.each([
   { name: 'multi_agent_call', input: [{ type: 'multi_agent_call', action: 'spawn_agent', arguments: '{}', call_id: 'call_1' }] },
   { name: 'multi_agent_call_output', input: [{ type: 'multi_agent_call_output', action: 'spawn_agent', call_id: 'call_1', output: [] as ResponsesInputMultiAgentCallOutputItem['output'] }] },
   { name: 'context_compaction', input: [{ type: 'context_compaction', encrypted_content: 'opaque' }] },
+  { name: 'item_reference', input: [{ type: 'item_reference', id: 'msg_1' }] },
 ] as const)('translateResponsesToChatCompletions rejects Responses-only $name input', ({ name, input }) => {
   assertThrows(
     () => translateResponsesToChatCompletions({ model: 'gpt-test', input: [...input] }),

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -255,9 +255,7 @@ const translateResponsesInput = async (input: ResponsesInputItem[], loadRemoteIm
       break;
     }
     case 'item_reference':
-      // Connection-bound pointer with no inline content to translate; drop it.
-      // Mirrors the responses-via-chat-completions translator behaviour.
-      break;
+      throw new TranslatorInputError("Invalid input item type 'item_reference'.");
     case 'web_search_call':
       // The shim must translate echoed web_search_call input items
       // into function_call + function_call_output pairs before this

--- a/packages/translate/src/responses-via-messages/request_test.ts
+++ b/packages/translate/src/responses-via-messages/request_test.ts
@@ -44,6 +44,7 @@ test.each([
   { name: 'multi_agent_call', input: [{ type: 'multi_agent_call', action: 'spawn_agent', arguments: '{}', call_id: 'call_1' }] },
   { name: 'multi_agent_call_output', input: [{ type: 'multi_agent_call_output', action: 'spawn_agent', call_id: 'call_1', output: [] as ResponsesInputMultiAgentCallOutputItem['output'] }] },
   { name: 'context_compaction', input: [{ type: 'context_compaction', encrypted_content: 'opaque' }] },
+  { name: 'item_reference', input: [{ type: 'item_reference', id: 'msg_1' }] },
 ] as const)('translateResponsesToMessages rejects Responses-only $name input', async ({ name, input }) => {
   await assertRejects(
     () => translateResponsesToMessages({ ...minimalPayload, input: [...input] }),


### PR DESCRIPTION
## Summary

- Reject unhydrated Responses `item_reference` input in the Chat Completions and Messages translators instead of silently dropping referenced context.
- Document gateway-owned `previous_response_id` and `item_reference` hydration, and remove the obsolete Copilot connection-bound retry description.

## Rationale

The gateway resolves every Responses reference before candidate dispatch. Reaching a non-Responses translator with an `item_reference` therefore indicates a broken hydration invariant or an invalid direct translator call; surfacing `TranslatorInputError` preserves the missing-context failure instead of producing a truncated request.

## Test Plan

- [x] `pnpm exec vitest run packages/translate/src/responses-via-chat-completions/request_test.ts packages/translate/src/responses-via-messages/request_test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`
