### PR TITLE
fix(telemetry): snapshot dispatched model cost

### DIFF
--- a/RESOLUTION.md
+++ b/RESOLUTION.md
@@ -276,15 +276,16 @@ interface ModelCandidate {
 }
 ```
 
-- `provider` is the resolved upstream provider instance — every wire call and
-  pricing lookup reads off `provider.*` directly (upstream id, upstream name,
-  and provider kind).
+- `provider` is the resolved upstream provider instance — every wire call reads
+  its upstream id, upstream name, provider kind, and implementation from this
+  binding.
 - `model` is the merged public row for this id, projected to a single
   contributing upstream: `providerModels` carries exactly one entry keyed
   on `provider.upstream`. That entry is the `ProviderModel` the upstream
   emitted verbatim — its `providerData` carries the per-provider wire id,
-  its `enabledFlags` carries the operator's per-model flag set. Dispatch
-  and interceptor gates read the entry through `providerModelOf(candidate)`.
+  its `enabledFlags` carries the operator's per-model flag set, and its `cost`
+  carries the exact schedule for this candidate. Dispatch, telemetry, and
+  interceptor gates read the entry through `providerModelOf(candidate)`.
 - `fetcher` is the per-request proxy-chain-bound `Fetcher` for the
   candidate's upstream, minted once at resolution time and carried with
   the candidate that dispatches.

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation-integration_test.ts
@@ -45,7 +45,6 @@ const defaultCandidates = vi.hoisted(() => () => [{
     modelPrefix: null,
     color: null,
     instance: {
-      getPricingForModelKey: () => null,
       callImagesGenerations: async (_model: unknown, body: Record<string, unknown>) => {
         stub.generationsCalls.push(body);
         const response = stub.nextGenerations.shift();

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -465,7 +465,7 @@ const recordImageUsage = (state: ShimState, provider: Provider, model: ProviderM
     model: model.id,
     upstream: provider.upstream,
     modelKey,
-    cost: provider.instance.getPricingForModelKey(modelKey) ?? null,
+    cost: model.cost ?? null,
   }, usage).catch((error: unknown) => {
     console.error('Failed to record image generation usage:', error);
   });

--- a/packages/gateway/src/data-plane/providers/azure/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/azure/provider_test.ts
@@ -348,31 +348,6 @@ test('createAzureProvider attaches cost field from model config', async () => {
   assertEquals(models[1].cost, undefined);
 });
 
-test('createAzureProvider getPricingForModelKey resolves by upstream model id', () => {
-  const instance = createAzureProvider(
-    azureRecord({
-      config: {
-        endpoint: 'https://example.openai.azure.com',
-        apiKey: 'az-key',
-        models: [
-          {
-            upstreamModelId: 'gpt-prod',
-            endpoints: { chatCompletions: {} },
-            cost: { input: 2.5, output: 15 },
-          },
-          {
-            upstreamModelId: 'gpt-small',
-            endpoints: { chatCompletions: {} },
-          },
-        ],
-      },
-    }),
-  );
-  assertEquals(instance.instance.getPricingForModelKey('gpt-prod'), { input: 2.5, output: 15 });
-  assertEquals(instance.instance.getPricingForModelKey('gpt-small'), null);
-  assertEquals(instance.instance.getPricingForModelKey('unknown'), null);
-});
-
 test('createAzureProvider exposes image models and routes generations with api-version=preview', async () => {
   const record: UpstreamRecord = {
     id: 'az-image',

--- a/packages/gateway/src/data-plane/providers/custom/provider_test.ts
+++ b/packages/gateway/src/data-plane/providers/custom/provider_test.ts
@@ -137,11 +137,6 @@ test('Custom provider projects display_name / created / limits / cost from a Flo
       assertEquals(model.cost?.output, 15);
       assertEquals(model.cost?.input_cache_read, 0.3);
 
-      const pricing = instance.instance.getPricingForModelKey('m-rich');
-      assertEquals(pricing?.input, 3);
-      assertEquals(pricing?.output, 15);
-
-      assertEquals(instance.instance.getPricingForModelKey('unknown'), null);
     },
   );
 });
@@ -282,9 +277,6 @@ test('Custom provider with modelsFetch disabled serves only manual models and ne
       assertEquals(models[0].limits.max_output_tokens, 4096);
       assertEquals(models[0].cost?.input, 1);
 
-      const pricing = provider.getPricingForModelKey('pinned-chat');
-      assertEquals(pricing?.input, 1);
-      assertEquals(pricing?.output, 2);
     },
   );
 });
@@ -332,15 +324,8 @@ test('Custom provider with a manual override sharing an upstream id wins over th
       const shared = models.find(m => m.id === 'shared');
       assertExists(shared);
       assertEquals(shared.display_name, 'Manual Shared');
-
-      // Pricing resolves from the manual config first, not the cached upstream cost.
-      const sharedPricing = provider.getPricingForModelKey('shared');
-      assertEquals(sharedPricing?.input, 1);
-      assertEquals(sharedPricing?.output, 2);
-
-      // Auto models without upstream cost data resolve to null pricing.
-      const autoOnly = provider.getPricingForModelKey('auto-only');
-      assertEquals(autoOnly, null);
+      assertEquals(shared.cost, { input: 1, output: 2 });
+      assertEquals(models.find(m => m.id === 'auto-only')?.cost, undefined);
     },
   );
 });

--- a/packages/gateway/src/data-plane/shared/telemetry/attempt-helpers.ts
+++ b/packages/gateway/src/data-plane/shared/telemetry/attempt-helpers.ts
@@ -2,7 +2,7 @@ import { isFirstOutputTokenFrame } from '../../chat/shared/first-output-token.ts
 import type { GatewayCtx } from '../../chat/shared/gateway-ctx.ts';
 import { stampUpstreamCallStart } from '../../chat/shared/gateway-ctx.ts';
 import type { ModelEndpoints, ProtocolFrame } from '@floway-dev/protocols/common';
-import { eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ModelCandidate, type PerformanceOperation, type PerformanceTelemetryContext, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
+import { eventResult, providerModelOf, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ModelCandidate, type PerformanceOperation, type PerformanceTelemetryContext, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions } from '@floway-dev/provider';
 
 export const upstreamPerformanceContext = (
   ctx: GatewayCtx,
@@ -63,7 +63,7 @@ export const telemetryModelIdentity = (candidate: ModelCandidate, modelKey: stri
   model: candidate.model.id,
   upstream: candidate.provider.upstream,
   modelKey,
-  cost: candidate.provider.instance.getPricingForModelKey(modelKey),
+  cost: providerModelOf(candidate).cost ?? null,
 });
 
 // See UpstreamCallOptions in `@floway-dev/provider` for the contract on each

--- a/packages/gateway/src/data-plane/shared/telemetry/attempt-helpers_test.ts
+++ b/packages/gateway/src/data-plane/shared/telemetry/attempt-helpers_test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { chatTargetPicker, providerStreamResultToExecuteResult } from './attempt-helpers.ts';
+import { chatTargetPicker, providerStreamResultToExecuteResult, telemetryModelIdentity } from './attempt-helpers.ts';
 import { mockGatewayCtx } from '../../../test-helpers/gateway-ctx.ts';
 import { setupAppTest } from '../../../test-helpers.ts';
 import { enumerateModelCandidates } from '../../providers/registry.ts';
@@ -136,6 +136,17 @@ const drainEvents = async <T>(result: Awaited<ReturnType<typeof providerStreamRe
 };
 
 describe('providerStreamResultToExecuteResult (first-output-token stamping)', () => {
+  test('captures cost from the exact dispatched provider model', () => {
+    const cost = { input: 3, output: 12 };
+    const candidate = stubModelCandidate({ model: { cost } });
+    expect(telemetryModelIdentity(candidate, 'raw-model')).toEqual({
+      model: 'test-model',
+      upstream: 'test-upstream',
+      modelKey: 'raw-model',
+      cost,
+    });
+  });
+
   test('stamps firstOutputTokenAt on the first generated-token frame (messages thinking_delta)', async () => {
     const ctx = mockGatewayCtx();
     const frames: ProtocolFrame<unknown>[] = [

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -60,9 +60,6 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
         };
       }));
     },
-    getPricingForModelKey(modelKey) {
-      return azure.config.models.find(model => model.upstreamModelId === modelKey)?.cost ?? null;
-    },
     callCompletions: (model, body, signal, opts) => callNonStreaming(azureFetchCompletions, model, body, signal, opts.headers, opts),
     callChatCompletions: (model, body, signal, opts) => callStreaming(azureFetchChatCompletions, model, body, signal, opts.headers, parseChatCompletionsStream, opts),
     callResponses: async (model, body, action, signal, opts) => {

--- a/packages/provider-claude-code/src/provider.ts
+++ b/packages/provider-claude-code/src/provider.ts
@@ -5,7 +5,6 @@ import { isClaudeCodeShapedRequest } from './detection.ts';
 import { detectHaikuProbe, callClaudeCodeMessages } from './fetch.ts';
 import { claudeCodeMessagesChain, type ClaudeCodeMessagesBoundaryCtx } from './interceptors/messages/index.ts';
 import { buildClaudeCodeCatalog, fetchClaudeCodeModelsList } from './models.ts';
-import { pricingForClaudeCodeModelKey } from './pricing.ts';
 import { assertClaudeCodeUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
@@ -39,8 +38,6 @@ export const createClaudeCodeProvider = (record: UpstreamRecord): Provider => {
       const apiModels = await fetchClaudeCodeModelsList(access.entry.token, fetcher);
       return buildClaudeCodeCatalog(apiModels, enabledFlags);
     },
-
-    getPricingForModelKey: pricingForClaudeCodeModelKey,
 
     callMessages: async (model, body, signal: AbortSignal | undefined, opts) => {
       const ctx: ClaudeCodeMessagesBoundaryCtx = {

--- a/packages/provider-claude-code/src/provider_test.ts
+++ b/packages/provider-claude-code/src/provider_test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { buildClaudeCodeCatalog, type ClaudeCodeApiModel } from './models.ts';
-import { pricingForClaudeCodeModelKey } from './pricing.ts';
 import { createClaudeCodeProvider } from './provider.ts';
 import type { ClaudeCodeAccessTokenEntry, ClaudeCodeAccountCredential, ClaudeCodeUpstreamState } from './state.ts';
 import { initProviderRepo, type FlagId, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
@@ -133,13 +132,6 @@ describe('createClaudeCodeProvider — factory surface', () => {
       expect(m.enabledFlags.has('strip-billing-attribution')).toBe(false);
       expect(m.enabledFlags.has('responses-compact-shim')).toBe(true);
     }
-  });
-
-  test('getPricingForModelKey wires through the pricing table (keyed by dated upstream id)', async () => {
-    const instance = createClaudeCodeProvider(currentRecord);
-    expect(instance.instance.getPricingForModelKey('claude-sonnet-4-5-20250929'))
-      .toEqual(pricingForClaudeCodeModelKey('claude-sonnet-4-5-20250929'));
-    expect(instance.instance.getPricingForModelKey('unknown-id')).toBeNull();
   });
 
   test('kind is "claude-code"', async () => {

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -6,7 +6,6 @@ import { callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } 
 import { CODEX_RESPONSES_BOUNDARY } from './interceptors/responses/index.ts';
 import type { ResponsesBoundaryCtx } from './interceptors/responses/types.ts';
 import { codexRawToProviderModel, fetchCodexCatalog } from './models.ts';
-import { pricingForCodexModelKey } from './pricing.ts';
 import { assertCodexUpstreamState, type CodexUpstreamState } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import { toCompactPayloadShape } from '@floway-dev/protocols/responses';
@@ -96,11 +95,6 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
       // toggles them per-upstream when needed.
       return raw.map(r => codexRawToProviderModel(r, enabledFlags));
     },
-
-    // Codex itself is a flat-fee subscription, but the dashboard reports
-    // notional cost per request as if the operator were paying OpenAI's
-    // public API rates.
-    getPricingForModelKey: pricingForCodexModelKey,
 
     callResponses: async (model, body, action, signal, opts) => {
       const ctx: ResponsesBoundaryCtx = {

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -13,7 +13,7 @@ import { emptyKnownModels, mergeKnownModels, projectKnownModels } from './known-
 import { mergeClaudeVariants } from './merge-claude-variants.ts';
 import { copilotPublicModelId } from './model-name.ts';
 import { CONTEXT_1M_BETA, copilotModelSupportsFastMode, type ModelSelectionHints, resolveCopilotRawModel } from './model-selection.ts';
-import { pricingForCopilotModelKey, pricingForCopilotPublicModelId } from './pricing.ts';
+import { pricingForCopilotPublicModelId } from './pricing.ts';
 import { readCopilotUpstreamState, type CopilotUpstreamState } from './state.ts';
 import type { CopilotRawModel } from './types.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
@@ -239,7 +239,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
     model: modelKey,
     upstream: copilot.id,
     modelKey,
-    cost: pricingForCopilotModelKey(modelKey),
+    cost: null,
   });
 
   // Materialize an upstream error body up-front so any interceptor that
@@ -312,7 +312,6 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
       }
       return finalizeCopilotModels(projectKnownModels(merged, now), copilot.flagOverrides);
     },
-    getPricingForModelKey: pricingForCopilotModelKey,
     // Copilot's catalog never declares endpoints.completions, so this
     // stub is unreachable; the rejection surfaces a routing bug.
     callCompletions: rejectUnsupported('callCompletions'),

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -4,7 +4,7 @@ import { fetchCustomModels, type CustomModelsResponse, type CustomRawModel } fro
 import { customFetchChatCompletions, customFetchCompletions, customFetchEmbeddings, customFetchImagesEdits, customFetchImagesGenerations, customFetchMessages, customFetchMessagesCountTokens, customFetchResponses, customFetchResponsesCompact } from './fetch.ts';
 import { inferEndpointsFromModelId } from './infer-endpoints.ts';
 import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completions';
-import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
+import { type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
 import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type FlagId, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
@@ -93,28 +93,6 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     if (model.chat) internal.chat = model.chat;
     return internal;
   });
-  const manualPricingByUpstreamId = new Map<string, ModelPricing>(
-    config.models.flatMap(m => (m.cost ? [[m.upstreamModelId, m.cost] as const] : [])),
-  );
-
-  // Last-known pricing keyed by raw model id from the auto-fetch path. Read
-  // synchronously by getPricingForModelKey after the manual map misses, so it
-  // must be populated by the time telemetry runs. Two writers keep it warm:
-  //   1. `getProvidedModels` re-stamps the whole table from a fresh /models
-  //      response (cold path / cache miss).
-  //   2. Every `call*` re-stamps the entry for the model it is dispatching
-  //      against, sourced from the `ProviderModel.cost` already carried on
-  //      the candidate's model. This second writer is what saves us in any isolate
-  //      where the SWR layer (`fetchUpstreamModelsCached`) returns the cached
-  //      `ProviderModel[]` row directly without ever calling
-  //      `getProvidedModels` — without it, telemetry would see `null` cost
-  //      for auto-fetched models on every isolate that started cold against
-  //      a SOFT-fresh cache row.
-  const pricingByRawId = new Map<string, ModelPricing>();
-  const rememberPricingForModel = (model: ProviderModel): void => {
-    if (model.cost) pricingByRawId.set(rawModelIdOf(model), model.cost);
-  };
-
   const call = (
     transport: (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,
     model: ProviderModel,
@@ -123,7 +101,6 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     headers: Headers,
     opts: UpstreamCallOptions,
   ): Promise<ProviderCallResult> => {
-    rememberPricingForModel(model);
     const rawModelId = rawModelIdOf(model);
     return transport(config, { method: 'POST', body: JSON.stringify({ ...body, model: rawModelId }), signal }, { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall })
       .then(response => ({
@@ -141,7 +118,6 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     parser: ProviderStreamParser<TEvent>,
     opts: UpstreamCallOptions,
   ) => {
-    rememberPricingForModel(model);
     const rawModelId = rawModelIdOf(model);
     return streamingProviderCall(
       transport(
@@ -159,16 +135,19 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     getProvidedModels: async fetcher => {
       if (!config.modelsFetch.enabled) return manualModels;
       const response = await fetchCustomModels(config, fetcher);
-      pricingByRawId.clear();
-      for (const raw of response.data) {
-        if (raw.id && raw.cost) pricingByRawId.set(raw.id, raw.cost);
-      }
+      const fetchedCost = new Map(
+        response.data.flatMap(model => model.cost ? [[model.id, model.cost] as const] : []),
+      );
+      const effectiveManualModels = manualModels.map(model => {
+        if (model.cost !== undefined) return model;
+        const cost = fetchedCost.get(rawModelIdOf(model));
+        return cost === undefined ? model : { ...model, cost };
+      });
       // Drop any auto-fetched model whose id is pinned by a manual
       // override so the manual copy is the only one emitted for that id.
       const filtered: CustomModelsResponse = { data: response.data.filter(raw => !overriddenIds.has(raw.id)) };
-      return [...manualModels, ...finalizeCustomModels(filtered, configuredEndpoints, upstreamFlags)];
+      return [...effectiveManualModels, ...finalizeCustomModels(filtered, configuredEndpoints, upstreamFlags)];
     },
-    getPricingForModelKey: modelKey => manualPricingByUpstreamId.get(modelKey) ?? pricingByRawId.get(modelKey) ?? null,
     callCompletions: (model, body, signal, opts) => call(customFetchCompletions, model, body, signal, opts.headers, opts),
     callChatCompletions: (model, body, signal, opts) => callStreaming(customFetchChatCompletions, model, body, signal, opts.headers, parseChatCompletionsStream, opts),
     callResponses: async (model, body, action, signal, opts) => {
@@ -180,7 +159,6 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
           : { action: 'generate', ok: false, response: stream.response, modelKey: stream.modelKey };
       }
       case 'compact': {
-        rememberPricingForModel(model);
         const rawModelId = rawModelIdOf(model);
         const response = await customFetchResponsesCompact(
           config,
@@ -201,7 +179,6 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     callEmbeddings: (model, body, signal, opts) => call(customFetchEmbeddings, model, body, signal, opts.headers, opts),
     callImagesGenerations: (model, body, signal, opts) => call(customFetchImagesGenerations, model, body, signal, opts.headers, opts),
     callImagesEdits: async (model, body, signal, opts) => {
-      rememberPricingForModel(model);
       // The runtime auto-encodes the FormData with a fresh boundary and sets
       // Content-Type itself.
       const rawModelId = rawModelIdOf(model);

--- a/packages/provider-custom/src/provider_test.ts
+++ b/packages/provider-custom/src/provider_test.ts
@@ -98,23 +98,22 @@ test('getProvidedModels rethrows when the upstream fetch fails — no fallback i
   );
 });
 
-test('getProvidedModels remembers pricing from the fetched response so getPricingForModelKey resolves auto models', async () => {
+test('getProvidedModels carries cost on auto models', async () => {
   const record = buildCustomUpstream();
   const instance = createCustomProvider(record);
 
   const upstreamCost: ModelPricing = { input: 3, output: 12 };
-  await withMockedFetch(
+  const models = await withMockedFetch(
     () => jsonResponse({
       object: 'list',
       data: [{ id: 'priced-model', cost: upstreamCost }],
     }),
     async () => {
-      await instance.instance.getProvidedModels(directFetcher);
+      return await instance.instance.getProvidedModels(directFetcher);
     },
   );
 
-  const pricing = instance.instance.getPricingForModelKey('priced-model');
-  assertEquals(pricing, upstreamCost);
+  assertEquals(models[0]?.cost, upstreamCost);
 });
 
 test('A manual model whose upstreamModelId matches an auto-fetched id overrides the auto entry', async () => {
@@ -144,8 +143,27 @@ test('A manual model whose upstreamModelId matches an auto-fetched id overrides 
       const models = await instance.instance.getProvidedModels(directFetcher);
       assertEquals(models.map(m => m.id), ['shared-id', 'auto-only']);
       assertEquals(models[0].display_name, 'Manual Override');
+      assertEquals(models[0].cost, manualCost);
     },
   );
+});
 
-  assertEquals(instance.instance.getPricingForModelKey('shared-id'), manualCost);
+test('a manual model without explicit cost inherits cost from its shadowed auto row', async () => {
+  const inheritedCost: ModelPricing = { input: 3, output: 12 };
+  const instance = createCustomProvider(buildCustomUpstream({
+    models: [{ upstreamModelId: 'shared-id', kind: 'chat', endpoints: { chatCompletions: {} } }],
+  }));
+
+  await withMockedFetch(
+    () => jsonResponse({
+      object: 'list',
+      data: [{ id: 'shared-id', cost: inheritedCost }],
+    }),
+    async () => {
+      const models = await instance.instance.getProvidedModels(directFetcher);
+      assertEquals(models.length, 1);
+      assertEquals(models[0]?.id, 'shared-id');
+      assertEquals(models[0]?.cost, inheritedCost);
+    },
+  );
 });

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -25,7 +25,7 @@ import { fetchOllamaCatalog, type OllamaCatalog } from './fetch-models.ts';
 import { ollamaFetchChatCompletions, ollamaFetchCompletions, ollamaFetchEmbeddings, ollamaFetchMessages, ollamaFetchMessagesCountTokens, ollamaFetchResponses, ollamaFetchResponsesCompact } from './fetch.ts';
 import { pricingForOllamaModelKey } from './pricing.ts';
 import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completions';
-import { type ModelEndpoints, type ModelPricing, kindForEndpoints } from '@floway-dev/protocols/common';
+import { type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
 import { publicModelId, resolveEffectiveFlags, streamingProviderCall, type FlagId, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
@@ -87,14 +87,11 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
       enabledFlags,
     };
     if (model.display_name !== undefined) internal.display_name = model.display_name;
-    if (model.cost) internal.cost = model.cost;
+    const cost = model.cost ?? pricingForOllamaModelKey(model.upstreamModelId);
+    if (cost) internal.cost = cost;
     if (model.chat) internal.chat = model.chat;
     return internal;
   });
-  const manualPricingByUpstreamId = new Map<string, ModelPricing>(
-    config.models.flatMap(m => (m.cost ? [[m.upstreamModelId, m.cost] as const] : [])),
-  );
-
   const call = (
     transport: (config: OllamaUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,
     model: ProviderModel,
@@ -143,7 +140,6 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
       );
       return [...manualModels, ...auto];
     },
-    getPricingForModelKey: modelKey => manualPricingByUpstreamId.get(modelKey) ?? pricingForOllamaModelKey(modelKey),
     callCompletions: (model, body, signal, opts) => call(ollamaFetchCompletions, model, body, signal, opts),
     callChatCompletions: (model, body, signal, opts) => callStreaming(ollamaFetchChatCompletions, model, body, signal, parseChatCompletionsStream, opts),
     callResponses: async (model, body, action, signal, opts) => {

--- a/packages/provider-ollama/src/provider_test.ts
+++ b/packages/provider-ollama/src/provider_test.ts
@@ -100,12 +100,13 @@ test('getProvidedModels merges manual overrides in front of auto-fetched models 
     assertEquals(models[0].id, 'gpt-oss:120b');
     assertEquals(models[0].display_name, 'Pinned 120B');
     assertEquals(Object.keys(models[0].endpoints), ['chatCompletions']);
+    assertEquals(models[0].cost, { input: 0.15, input_cache_read: 0.075, output: 0.6 });
     // No duplicate gpt-oss:120b further down.
     assertEquals(models.filter(m => m.id === 'gpt-oss:120b').length, 1);
   });
 });
 
-test('getPricingForModelKey resolves manual cost first, then falls back to the OLLAMA_MODEL_PRICING table', () => {
+test('getProvidedModels preserves explicit manual cost over built-in cost', async () => {
   const instance = createOllamaProvider(buildRecord({
     config: {
       baseUrl: 'https://ollama.com',
@@ -118,12 +119,10 @@ test('getPricingForModelKey resolves manual cost first, then falls back to the O
       }],
     },
   }));
-  // Manual cost wins for the pinned id.
-  assertEquals(instance.instance.getPricingForModelKey('gpt-oss:120b'), { input: 99, output: 99 });
-  // Unpinned model falls back to the table.
-  assertEquals(instance.instance.getPricingForModelKey('deepseek-v4-flash')?.input, 0.14);
-  // Unknown model returns null rather than fabricating a guess.
-  assertEquals(instance.instance.getPricingForModelKey('devstral-small-2:24b'), null);
+  await withMockedFetch(tagsAndShow, async () => {
+    const models = await instance.instance.getProvidedModels(directFetcher);
+    assertEquals(models[0].cost, { input: 99, output: 99 });
+  });
 });
 
 test('call* methods POST to /v1/<endpoint> with the upstream model id and Bearer header', async () => {

--- a/packages/provider/src/provider.ts
+++ b/packages/provider/src/provider.ts
@@ -3,7 +3,7 @@ import type { ModelPrefixConfig } from './model-prefix.ts';
 import type { ProviderModel, UpstreamProviderKind, UpstreamRecord } from './model.ts';
 import type { Fetcher } from './options.ts';
 import type { ChatCompletionsPayload, ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
-import type { ModelPricing, ProtocolFrame } from '@floway-dev/protocols/common';
+import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { CompletionsPayload } from '@floway-dev/protocols/completions';
 import type { EmbeddingsPayload } from '@floway-dev/protocols/embeddings';
 import type { ImagesGenerationsPayload } from '@floway-dev/protocols/images';
@@ -109,8 +109,6 @@ export interface ProviderInstance {
   // latency budget, so it takes the per-upstream fetcher directly instead of
   // the broader `UpstreamCallOptions` bag the data-plane `call*` methods use.
   getProvidedModels(fetcher: Fetcher): Promise<readonly ProviderModel[]>;
-  // Resolve pricing for a usage record's `model_key` (the raw upstream model id).
-  getPricingForModelKey(modelKey: string): ModelPricing | null;
   // /v1/completions text completions. Passthrough. Providers whose
   // upstream doesn't expose /v1/completions set `endpoints.completions`
   // to absent in getProvidedModels, so this method is unreachable for

--- a/packages/test-utils/src/stubs.ts
+++ b/packages/test-utils/src/stubs.ts
@@ -69,7 +69,6 @@ export const mockPerfTelemetryContext = (overrides: Partial<PerformanceTelemetry
 
 export const stubProvider = (overrides: Partial<ProviderInstance> = {}): ProviderInstance => ({
   getProvidedModels: overrides.getProvidedModels ?? (() => Promise.resolve([])),
-  getPricingForModelKey: overrides.getPricingForModelKey ?? (() => null),
   callCompletions: overrides.callCompletions ?? (() => Promise.reject(new Error('stubProvider.callCompletions was called'))),
   callChatCompletions: overrides.callChatCompletions ?? (() => Promise.reject(new Error('stubProvider.callChatCompletions was called'))),
   callResponses: overrides.callResponses ?? (() => Promise.reject(new Error('stubProvider.callResponses was called'))),
@@ -115,6 +114,7 @@ export const stubModelCandidate = (overrides: {
     kind: outerMeta.kind,
     endpoints: outerMeta.endpoints,
     enabledFlags: overrides.enabledFlags ?? new Set<FlagId>(),
+    ...(modelOverrides.cost !== undefined ? { cost: modelOverrides.cost } : {}),
     ...(overrides.providerData !== undefined ? { providerData: overrides.providerData } : {}),
   });
   return {


### PR DESCRIPTION
## Summary

Make the exact dispatched ProviderModel the sole source of cost metadata attached to usage telemetry.

- Remove the synchronous ProviderInstance.getPricingForModelKey contract and every provider-specific implementation.
- Read cost from the selected candidate’s single-upstream ProviderModel for chat, passthrough, and image-generation tool usage.
- Remove Custom provider mutable model-key cost caches.
- Preserve explicit Custom manual cost or inherit cost from the shadowed fetched catalog row before caching.
- Materialize explicit or built-in cost on Ollama manual models.
- Keep Copilot boundary-only placeholder telemetry deliberately unpriced because downstream dispatch rebuilds the real identity.

## Behavior

This PR keeps the existing cost/tiers schema and all persistence formats unchanged. Providers now materialize effective cost on catalog models before those models are cached or dispatched.

## Risk

Custom manual shadows without explicit cost now inherit the fetched row’s cost. Ollama manual models use built-in cost when no operator override is configured.

## Test Plan

- [x] `pnpm run test`
- [x] `pnpm --filter @floway-dev/provider-ollama run test`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`