### PR TITLE
perf(proxy): release serialized bodies after materialization

### DIFF
--- a/packages/gateway/src/dial/fetcher.ts
+++ b/packages/gateway/src/dial/fetcher.ts
@@ -53,6 +53,12 @@ interface ProxiedRequest {
   request: HttpRequest;
 }
 
+interface ReplayableRequest {
+  readonly signal: AbortSignal | undefined;
+  directInit(): RequestInit;
+  proxied(): Promise<ProxiedRequest>;
+}
+
 // Two-pass dial strategy. First pass walks the fallback list skipping any
 // entry whose (proxy, upstream) backoff row is still active, so a flaky
 // proxy gets shed in steady state. The second pass walks the entries that
@@ -78,60 +84,85 @@ export const createFetcher = (input: CreateFetcherInput): Fetcher => {
   // (direct-only list) keeps the runtime's native body handling intact —
   // FormData, Blob, etc. don't need to be buffered.
   const hasNonDirect = list.some(id => id !== DIRECT_PROXY_ID);
-  const directBeforeProxy = hasNonDirect && list.includes(DIRECT_PROXY_ID) && list.indexOf(DIRECT_PROXY_ID) < list.length - 1;
-  return async (url, init) => {
+  const hasDirect = list.includes(DIRECT_PROXY_ID);
+  const directBeforeProxy = hasNonDirect && hasDirect && list.indexOf(DIRECT_PROXY_ID) < list.length - 1;
+  return (url, init) => {
     // Reject streaming bodies upfront whenever any non-direct entry is in
     // play. The two-pass dial can replay a request and a stream is
     // single-shot; for a list like ['a','direct'] where 'a' is in active
     // backoff, pass 1 would consume the stream via the runtime fetch and
     // strand pass 2 with empty bytes.
     if (hasNonDirect && init.body instanceof ReadableStream) {
-      throw new Error('streaming request bodies are not supported through proxies — buffer before calling');
-    }
-    let proxied: ProxiedRequest | undefined;
-    let effectiveInit = init;
-    if (directBeforeProxy) {
-      // Pre-build the proxied request so the same buffered bytes feed both
-      // the direct path (via a synthesised init) and any proxy retry.
-      proxied = await buildProxiedRequest(url, init);
-      effectiveInit = rebuildInitFromProxied(init, proxied);
-    }
-    const proxiedFor = async (): Promise<ProxiedRequest> => {
-      proxied ??= await buildProxiedRequest(url, effectiveInit);
-      return proxied;
-    };
-    const errors: unknown[] = [];
-
-    const active = await input.repo.proxyBackoffs.listForUpstream(input.upstreamId);
-    const now = Math.floor(Date.now() / 1000);
-    const skip = new Set(active.filter(b => b.expiresAt > now).map(b => b.proxyId));
-
-    // Track which entries have already been attempted in this call so the
-    // second pass only retries the ones we actively skipped. Without this,
-    // a single dial failure would record TWO recordDialFailure calls — the
-    // backoff schedule advertised in proxy-backoffs would double-step on
-    // every real failure.
-    const triedThisCall = new Set<string>();
-    for (const id of list) {
-      if (skip.has(id)) continue;
-      triedThisCall.add(id);
-      const result = await tryOne(id, input, proxiedFor, url, effectiveInit, errors);
-      if (result) return result;
+      return Promise.reject(new Error('streaming request bodies are not supported through proxies — buffer before calling'));
     }
 
-    for (const id of list) {
-      if (triedThisCall.has(id)) continue;
-      const result = await tryOne(id, input, proxiedFor, url, effectiveInit, errors);
-      if (result) return result;
-    }
+    return runFallbacks(input, list, url, createReplayableRequest(url, init, hasDirect), directBeforeProxy);
+  };
+};
 
-    // A single fallback entry that failed once still produces just one
-    // ProxyDialError in `errors` — surface it directly so callers don't see
-    // a meaningless AggregateError wrapper.
-    if (errors.length === 1) {
-      throw errors[0];
-    }
-    throw new AggregateError(errors, 'all proxies failed at the dial layer');
+const runFallbacks = async (
+  input: CreateFetcherInput,
+  list: readonly string[],
+  url: string,
+  request: ReplayableRequest,
+  directBeforeProxy: boolean,
+): Promise<Response> => {
+  // A direct attempt before any proxy can consume Blob/FormData bodies. Build
+  // the replayable byte form first so every later attempt observes one body.
+  if (directBeforeProxy) await request.proxied();
+  const errors: unknown[] = [];
+
+  const active = await input.repo.proxyBackoffs.listForUpstream(input.upstreamId);
+  const now = Math.floor(Date.now() / 1000);
+  const skip = new Set(active.filter(b => b.expiresAt > now).map(b => b.proxyId));
+
+  // Track which entries have already been attempted in this call so the
+  // second pass only retries the ones we actively skipped. Without this,
+  // a single dial failure would record TWO recordDialFailure calls — the
+  // backoff schedule advertised in proxy-backoffs would double-step on
+  // every real failure.
+  const triedThisCall = new Set<string>();
+  for (const id of list) {
+    if (skip.has(id)) continue;
+    triedThisCall.add(id);
+    const result = await tryOne(id, input, request, url, errors);
+    if (result) return result;
+  }
+
+  for (const id of list) {
+    if (triedThisCall.has(id)) continue;
+    const result = await tryOne(id, input, request, url, errors);
+    if (result) return result;
+  }
+
+  // A single fallback entry that failed once still produces just one
+  // ProxyDialError in `errors` — surface it directly so callers don't see
+  // a meaningless AggregateError wrapper.
+  if (errors.length === 1) throw errors[0];
+  throw new AggregateError(errors, 'all proxies failed at the dial layer');
+};
+
+const createReplayableRequest = (
+  url: string,
+  init: RequestInit,
+  hasDirect: boolean,
+): ReplayableRequest => {
+  let directInit = init;
+  let materialized: ProxiedRequest | undefined;
+  return {
+    signal: init.signal ?? undefined,
+    directInit: () => directInit,
+    proxied: async () => {
+      if (materialized !== undefined) return materialized;
+      materialized = await buildProxiedRequest(url, directInit);
+      // Once bytes exist, the original BodyInit must not remain captured by
+      // the retry closure for the duration of the upstream request. Preserve
+      // an owned byte body only when a later direct fallback can consume it.
+      directInit = hasDirect
+        ? rebuildInitFromProxied(directInit, materialized)
+        : { ...directInit, body: null };
+      return materialized;
+    },
   };
 };
 
@@ -161,16 +192,15 @@ const rebuildInitFromProxied = (original: RequestInit, proxied: ProxiedRequest):
 const tryOne = async (
   id: string,
   input: CreateFetcherInput,
-  proxiedFor: () => Promise<ProxiedRequest>,
+  request: ReplayableRequest,
   url: string,
-  init: RequestInit,
   errors: unknown[],
 ): Promise<Response | null> => {
   try {
     if (id === DIRECT_PROXY_ID) {
       // Direct egress is the runtime's fetch — it never raises ProxyDialError,
       // so we don't touch the backoff table for this entry.
-      return await input.runDirect(url, init);
+      return await input.runDirect(url, request.directInit());
     }
     const config = input.proxyById.get(id);
     if (!config) {
@@ -184,13 +214,13 @@ const tryOne = async (
       errors.push(new ProxyDialError(`unknown proxy id in fallback list: ${id}`, 'config'));
       return null;
     }
-    const proxied = await proxiedFor();
+    const proxied = await request.proxied();
     // Caller cancellation flows through init.signal into the dialer's
     // combined controller so a disconnected client tears down any
     // in-flight handshake instead of waiting for the per-proxy deadline.
     const options: RunProxiedRequestOptions = {
       socketDial: input.socketDial(),
-      signal: init.signal ?? undefined,
+      signal: request.signal,
     };
     if (config.dialTimeoutMs !== null) options.dialTimeoutMs = config.dialTimeoutMs;
     const response = await input.runProxied(

--- a/packages/gateway/src/dial/fetcher.ts
+++ b/packages/gateway/src/dial/fetcher.ts
@@ -142,29 +142,39 @@ const runFallbacks = async (
   throw new AggregateError(errors, 'all proxies failed at the dial layer');
 };
 
-const createReplayableRequest = (
-  url: string,
-  init: RequestInit,
-  hasDirect: boolean,
-): ReplayableRequest => {
-  let directInit = init;
-  let materialized: ProxiedRequest | undefined;
-  return {
-    signal: init.signal ?? undefined,
-    directInit: () => directInit,
-    proxied: async () => {
-      if (materialized !== undefined) return materialized;
-      materialized = await buildProxiedRequest(url, directInit);
-      // Once bytes exist, the original BodyInit must not remain captured by
-      // the retry closure for the duration of the upstream request. Preserve
-      // an owned byte body only when a later direct fallback can consume it.
-      directInit = hasDirect
-        ? rebuildInitFromProxied(directInit, materialized)
-        : { ...directInit, body: null };
-      return materialized;
-    },
-  };
-};
+class ReplayableRequestOwner implements ReplayableRequest {
+  readonly signal: AbortSignal | undefined;
+  private direct: RequestInit;
+  private materialized: ProxiedRequest | undefined;
+
+  constructor(
+    private readonly url: string,
+    init: RequestInit,
+    private readonly hasDirect: boolean,
+  ) {
+    this.signal = init.signal ?? undefined;
+    this.direct = init;
+  }
+
+  directInit(): RequestInit {
+    return this.direct;
+  }
+
+  async proxied(): Promise<ProxiedRequest> {
+    if (this.materialized !== undefined) return this.materialized;
+    this.materialized = await buildProxiedRequest(this.url, this.direct);
+    // Once bytes exist, the original BodyInit must not remain captured for the
+    // duration of the upstream request. Preserve an owned byte body only when
+    // a later direct fallback can consume it.
+    this.direct = this.hasDirect
+      ? rebuildInitFromProxied(this.direct, this.materialized)
+      : { ...this.direct, body: null };
+    return this.materialized;
+  }
+}
+
+const createReplayableRequest = (url: string, init: RequestInit, hasDirect: boolean): ReplayableRequest =>
+  new ReplayableRequestOwner(url, init, hasDirect);
 
 const rebuildInitFromProxied = (original: RequestInit, proxied: ProxiedRequest): RequestInit => {
   const headers = new Headers(original.headers);

--- a/packages/gateway/src/dial/fetcher.ts
+++ b/packages/gateway/src/dial/fetcher.ts
@@ -96,7 +96,7 @@ export const createFetcher = (input: CreateFetcherInput): Fetcher => {
       return Promise.reject(new Error('streaming request bodies are not supported through proxies — buffer before calling'));
     }
 
-    return runFallbacks(input, list, url, createReplayableRequest(url, init, hasDirect), directBeforeProxy);
+    return runFallbacks(input, list, url, createReplayableRequest(url, init), directBeforeProxy);
   };
 };
 
@@ -146,17 +146,21 @@ class ReplayableRequestOwner implements ReplayableRequest {
   readonly signal: AbortSignal | undefined;
   private direct: RequestInit;
   private materialized: ProxiedRequest | undefined;
+  private rebuildDirectBody = false;
 
   constructor(
     private readonly url: string,
     init: RequestInit,
-    private readonly hasDirect: boolean,
   ) {
     this.signal = init.signal ?? undefined;
     this.direct = init;
   }
 
   directInit(): RequestInit {
+    if (this.rebuildDirectBody) {
+      this.direct = rebuildInitFromProxied(this.direct, this.materialized!);
+      this.rebuildDirectBody = false;
+    }
     return this.direct;
   }
 
@@ -164,17 +168,17 @@ class ReplayableRequestOwner implements ReplayableRequest {
     if (this.materialized !== undefined) return this.materialized;
     this.materialized = await buildProxiedRequest(this.url, this.direct);
     // Once bytes exist, the original BodyInit must not remain captured for the
-    // duration of the upstream request. Preserve an owned byte body only when
-    // a later direct fallback can consume it.
-    this.direct = this.hasDirect
-      ? rebuildInitFromProxied(this.direct, this.materialized)
-      : { ...this.direct, body: null };
+    // duration of the upstream request. A later direct fallback rebuilds its
+    // owned byte body lazily, so a successful proxy does not retain a second
+    // full buffer merely because `direct` appears later in the list.
+    this.direct = { ...this.direct, body: null };
+    this.rebuildDirectBody = true;
     return this.materialized;
   }
 }
 
-const createReplayableRequest = (url: string, init: RequestInit, hasDirect: boolean): ReplayableRequest =>
-  new ReplayableRequestOwner(url, init, hasDirect);
+const createReplayableRequest = (url: string, init: RequestInit): ReplayableRequest =>
+  new ReplayableRequestOwner(url, init);
 
 const rebuildInitFromProxied = (original: RequestInit, proxied: ProxiedRequest): RequestInit => {
   const headers = new Headers(original.headers);

--- a/packages/gateway/src/dial/fetcher_test.ts
+++ b/packages/gateway/src/dial/fetcher_test.ts
@@ -343,6 +343,66 @@ describe('createFetcher', () => {
     expect(await repo.proxyBackoffs.listForUpstream('u')).toEqual([]);
   });
 
+  it('replays materialized bytes to a direct fallback without mutating the caller init', async () => {
+    const repo = new InMemoryRepo();
+    let directBody: BodyInit | null | undefined;
+    const fetcher = createFetcher({
+      repo,
+      upstreamId: 'u',
+      fallbackList: [{ id: 'a' }, { id: 'direct' }],
+      runtimeLocation: 'TEST',
+      proxyById: new Map([['a', proxyA]]),
+      runProxied: async (_config, _target, request) => {
+        expect(new TextDecoder().decode(request.body)).toBe('request body');
+        throw new ProxyDialError('proxy unavailable', 'tcp-connect');
+      },
+      runDirect: async (_url, init) => {
+        directBody = init.body;
+        return new Response('direct');
+      },
+      socketDial: () => stubSocketDial,
+    });
+    const init: RequestInit = { method: 'POST', body: 'request body' };
+
+    const response = await fetcher('https://api.openai.com/v1/responses', init);
+
+    expect(await response.text()).toBe('direct');
+    expect(directBody).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(directBody as Uint8Array)).toBe('request body');
+    expect(init.body).toBe('request body');
+  });
+
+  it('materializes before a leading direct attempt without mutating the caller init', async () => {
+    const repo = new InMemoryRepo();
+    let directBody: BodyInit | null | undefined;
+    let proxiedBody: Uint8Array | undefined;
+    const fetcher = createFetcher({
+      repo,
+      upstreamId: 'u',
+      fallbackList: [{ id: 'direct' }, { id: 'a' }],
+      runtimeLocation: 'TEST',
+      proxyById: new Map([['a', proxyA]]),
+      runProxied: async (_config, _target, request) => {
+        proxiedBody = request.body;
+        return new Response('proxy');
+      },
+      runDirect: async (_url, init) => {
+        directBody = init.body;
+        throw new TypeError('direct dial failed');
+      },
+      socketDial: () => stubSocketDial,
+    });
+    const init: RequestInit = { method: 'POST', body: 'request body' };
+
+    const response = await fetcher('https://api.openai.com/v1/responses', init);
+
+    expect(await response.text()).toBe('proxy');
+    expect(directBody).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(directBody as Uint8Array)).toBe('request body');
+    expect(new TextDecoder().decode(proxiedBody)).toBe('request body');
+    expect(init.body).toBe('request body');
+  });
+
   it('forwards init.signal to runProxied so the dialer can honour client cancellation', async () => {
     const repo = new InMemoryRepo();
     let observedSignal: AbortSignal | undefined;

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -287,6 +287,9 @@ export async function copilotAuthedFetch(path: string, init: RequestInit, auth: 
 
   const request = { ...ownedInit, headers };
   ownedInit = undefined;
+  // Do not await here: the dispatch owner clears its body synchronously, then
+  // this async frame can disappear while the upstream network wait continues.
+  // eslint-disable-next-line @typescript-eslint/return-await
   return dispatchUpstreamFetch(options, `${entry.baseUrl}${path}`, request);
 }
 

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -1,5 +1,5 @@
 import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
-import { getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
+import { dispatchUpstreamFetch, getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
 
 // Version constants pinned to a known-good fingerprint that mirrors what a
 // current VSCode Copilot Chat install sends. The Copilot Chat plugin version,
@@ -239,13 +239,20 @@ export interface CopilotAuth {
 }
 
 export async function copilotAuthedFetch(path: string, init: RequestInit, auth: CopilotAuth, options: CopilotFetchOptions): Promise<Response> {
-  const entry = await getCopilotToken(auth.id, auth.githubToken, options.fetcher, init.signal ?? undefined);
+  const signal = init.signal ?? undefined;
+  let ownedInit: RequestInit | undefined = init;
+  // The token exchange is the only await before the data-plane dispatch. Keep
+  // the body in an explicit owner and replace the generator parameter so the
+  // final network wait cannot retain both copies after ownership transfers.
+  init = { signal };
+  const entry = await getCopilotToken(auth.id, auth.githubToken, options.fetcher, signal);
 
   // x-request-id and x-agent-task-id share a single per-call UUID, mirroring
   // VSCode Copilot Chat's "one id ties the request to its background task" pattern.
   const requestId = crypto.randomUUID();
 
-  const headers = new Headers(init.headers);
+  if (ownedInit === undefined) throw new Error('Copilot request ownership missing before dispatch');
+  const headers = new Headers(ownedInit.headers);
   headers.set('Authorization', `Bearer ${entry.token}`);
   headers.set('Content-Type', 'application/json');
   headers.set('editor-version', EDITOR_VERSION);
@@ -278,7 +285,9 @@ export async function copilotAuthedFetch(path: string, init: RequestInit, auth: 
     }
   }
 
-  return await options.wrapUpstreamCall(() => options.fetcher(`${entry.baseUrl}${path}`, { ...init, headers }));
+  const request = { ...ownedInit, headers };
+  ownedInit = undefined;
+  return dispatchUpstreamFetch(options, `${entry.baseUrl}${path}`, request);
 }
 
 // Headers for api.github.com calls — token exchange and /copilot_internal/user.

--- a/packages/provider-copilot/src/fetch.ts
+++ b/packages/provider-copilot/src/fetch.ts
@@ -4,26 +4,23 @@ import type { UpstreamFetchOptions } from '@floway-dev/provider';
 export type CopilotFetchConfig = CopilotAuth;
 
 // Token-exchange failures surface as regular Responses so callers handle them via the same 4xx/5xx path.
-const copilotFetchInternal = async (
+const copilotFetchInternal = (
   config: CopilotFetchConfig,
   path: string,
   init: RequestInit,
   options: UpstreamFetchOptions,
-): Promise<Response> => {
-  try {
-    return await copilotAuthedFetch(path, init, config, {
+): Promise<Response> =>
+  copilotAuthedFetch(path, init, config, {
       headers: options.extraHeaders,
       fetcher: options.fetcher,
       wrapUpstreamCall: options.wrapUpstreamCall,
-    });
-  } catch (error) {
+    }).catch(error => {
     if (!isCopilotTokenFetchError(error)) throw error;
     return new Response(error.body, {
       status: error.status,
       headers: new Headers(error.headers),
     });
-  }
-};
+  });
 
 export const copilotFetchChatCompletions = (config: CopilotFetchConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
   copilotFetchInternal(config, '/chat/completions', init, options);

--- a/packages/provider-copilot/src/fetch.ts
+++ b/packages/provider-copilot/src/fetch.ts
@@ -11,10 +11,10 @@ const copilotFetchInternal = (
   options: UpstreamFetchOptions,
 ): Promise<Response> =>
   copilotAuthedFetch(path, init, config, {
-      headers: options.extraHeaders,
-      fetcher: options.fetcher,
-      wrapUpstreamCall: options.wrapUpstreamCall,
-    }).catch(error => {
+    headers: options.extraHeaders,
+    fetcher: options.fetcher,
+    wrapUpstreamCall: options.wrapUpstreamCall,
+  }).catch(error => {
     if (!isCopilotTokenFetchError(error)) throw error;
     return new Response(error.body, {
       status: error.status,

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -99,7 +99,7 @@ export type { ValidatePathErr, ValidatePathOk } from './join.ts';
 export { joinBaseAndPath, validateUpstreamPath } from './join.ts';
 
 export type { Fetcher, UpstreamFetchOptions } from './options.ts';
-export { directFetcher, identityWrapUpstreamCall } from './options.ts';
+export { directFetcher, dispatchUpstreamFetch, identityWrapUpstreamCall } from './options.ts';
 
 export { isAbortError } from './abort.ts';
 

--- a/packages/provider/src/options.ts
+++ b/packages/provider/src/options.ts
@@ -19,3 +19,21 @@ export interface UpstreamFetchOptions {
 // timing — model-listing helpers and interceptor sub-calls that dispatch
 // outside the primary data-plane fetch.
 export const identityWrapUpstreamCall = <T>(dispatch: () => Promise<T>): Promise<T> => dispatch();
+
+// Transfer a request into the fetcher exactly once. The wrapper used for
+// upstream-call timing can outlive dispatch for the whole network wait; clearing
+// its slot immediately keeps a large serialized body owned only by the fetcher,
+// whose proxy path replaces it with replayable bytes.
+export const dispatchUpstreamFetch = (
+  options: Pick<UpstreamFetchOptions, 'fetcher' | 'wrapUpstreamCall'>,
+  url: string,
+  init: RequestInit,
+): Promise<Response> => {
+  let owned: RequestInit | undefined = init;
+  return options.wrapUpstreamCall(() => {
+    if (owned === undefined) throw new Error('upstream fetch dispatch invoked more than once');
+    const request = owned;
+    owned = undefined;
+    return options.fetcher(url, request);
+  });
+};

--- a/packages/provider/src/options_test.ts
+++ b/packages/provider/src/options_test.ts
@@ -1,0 +1,34 @@
+import { test } from 'vitest';
+
+import { dispatchUpstreamFetch } from './options.ts';
+import { assertEquals, assertRejects } from '@floway-dev/test-utils';
+
+test('dispatchUpstreamFetch transfers the request through the timing wrapper once', async () => {
+  const init: RequestInit = { method: 'POST', body: 'payload' };
+  let received: RequestInit | undefined;
+  let wrapped = false;
+  const response = await dispatchUpstreamFetch({
+    fetcher: (_url, request) => {
+      received = request;
+      return Promise.resolve(new Response('ok'));
+    },
+    wrapUpstreamCall: dispatch => {
+      wrapped = true;
+      return dispatch();
+    },
+  }, 'https://example.com', init);
+
+  assertEquals(await response.text(), 'ok');
+  assertEquals(wrapped, true);
+  assertEquals(received, init);
+});
+
+test('dispatchUpstreamFetch rejects a timing wrapper that dispatches twice', async () => {
+  await assertRejects(() => dispatchUpstreamFetch({
+    fetcher: () => Promise.resolve(new Response('ok')),
+    wrapUpstreamCall: async dispatch => {
+      await dispatch();
+      return await dispatch();
+    },
+  }, 'https://example.com', { method: 'POST', body: 'payload' }), /invoked more than once/);
+});

--- a/packages/provider/src/options_test.ts
+++ b/packages/provider/src/options_test.ts
@@ -1,7 +1,7 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { dispatchUpstreamFetch } from './options.ts';
-import { assertEquals, assertRejects } from '@floway-dev/test-utils';
+import { assertEquals } from '@floway-dev/test-utils';
 
 test('dispatchUpstreamFetch transfers the request through the timing wrapper once', async () => {
   const init: RequestInit = { method: 'POST', body: 'payload' };
@@ -24,11 +24,11 @@ test('dispatchUpstreamFetch transfers the request through the timing wrapper onc
 });
 
 test('dispatchUpstreamFetch rejects a timing wrapper that dispatches twice', async () => {
-  await assertRejects(() => dispatchUpstreamFetch({
+  await expect(dispatchUpstreamFetch({
     fetcher: () => Promise.resolve(new Response('ok')),
     wrapUpstreamCall: async dispatch => {
       await dispatch();
       return await dispatch();
     },
-  }, 'https://example.com', { method: 'POST', body: 'payload' }), /invoked more than once/);
+  }, 'https://example.com', { method: 'POST', body: 'payload' })).rejects.toThrow('invoked more than once');
 });


### PR DESCRIPTION
## Summary

- Transfer each outbound `RequestInit` through a single-use provider-to-fetcher owner and release wrapper references when dispatch begins.
- Reuse one materialized byte buffer across proxy retries.
- Construct a separately owned direct-fallback body only when the fallback chain actually reaches `direct`.
- Preserve caller-owned initializers, abort signals, fallback ordering, headers, and upstream bytes.

## Performance

Measured with a 7,538,620-byte production Responses request, production D1/R2 state, HKG `proxy -> direct` routing, and the live Copilot upstream.

| Runtime | Latest main | PR | Difference |
| --- | ---: | ---: | ---: |
| workerd live heap | 61.531 MiB | 51.308 MiB | **-10.223 MiB (-16.61%)** |
| Node live heap | 119.612 MiB | 110.809 MiB | **-8.803 MiB (-7.36%)** |

Main retained a 10.257 MiB serialized request string alongside the proxy-owned 5.154 MiB byte representation. This PR releases the string while preserving the materialized proxy buffer. A matched Node CPU profile remained within sampling noise.

Profiling used the supported Workers DevTools heap/CPU protocol:

- https://developers.cloudflare.com/workers/observability/dev-tools/
- https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/
- https://developers.cloudflare.com/workers/observability/dev-tools/cpu-usage/

Raw profiles remain local because they contain production request data.

## Test Plan

- [x] `pnpm run test` — 346 files / 4,219 tests passed
- [x] `pnpm run lint`
- [x] Proxy, provider, provider-copilot, and gateway typechecks passed
