### PR TITLE
fix(codex): preserve invalid instructions for upstream validation

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -217,8 +217,11 @@ inline and rebuilds the envelope client-side).
 
 - hoists `role: "system"` items out of `input` into top-level `instructions`
   (the upstream rejects system messages inside `input`)
-- injects a default `instructions` string when none is supplied (the upstream
-  rejects empty / missing `instructions`)
+- injects a neutral default only when `instructions` is absent, `null`, or an
+  empty string. Other malformed external values pass through so the upstream
+  owns validation. Current ChatGPT-subscription catalog models reject empty or
+  missing instructions (implementation record:
+  https://github.com/im4codes/imcodes/blob/5f769d933dfd679e3a4d670183b0384a1baf62cd/src/agent/providers/codex-sdk.ts#L560-L579)
 - strips fields the upstream rejects with `Unsupported parameter`:
   `max_output_tokens`, `temperature`, `top_p`, `frequency_penalty`,
   `presence_penalty`, `user`, `metadata`, `prompt_cache_retention`,

--- a/packages/provider-codex/src/interceptors/responses/inject-default-instructions.ts
+++ b/packages/provider-codex/src/interceptors/responses/inject-default-instructions.ts
@@ -1,20 +1,16 @@
 import type { ResponsesBoundaryCtx } from './types.ts';
 
-// Codex backend rejects /responses requests that lack a non-empty
-// `instructions` field with a 4xx ("Instructions are required"). Native
-// /v1/responses callers may legitimately omit it, and the
-// Messages/ChatCompletions/Gemini translators only synthesize it from a
-// caller-supplied system message — so when no system message exists we still
-// need a fallback string. We inject a neutral default at the Codex target
-// boundary so every request shape (native + every translated source
-// protocol) satisfies the upstream contract.
+// ChatGPT-subscription catalog models reject missing or empty `instructions`.
+// Native and translated callers may omit the field, so the provider supplies a
+// neutral value at its boundary. Other values remain upstream-owned validation.
+// https://github.com/im4codes/imcodes/blob/5f769d933dfd679e3a4d670183b0384a1baf62cd/src/agent/providers/codex-sdk.ts#L560-L579
 export const injectDefaultInstructions = async <TResult>(
   ctx: ResponsesBoundaryCtx,
   _request: object,
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
   const instructions = ctx.payload.instructions;
-  if (typeof instructions !== 'string' || instructions.length === 0) {
+  if (instructions === undefined || instructions === null || instructions === '') {
     ctx.payload = { ...ctx.payload, instructions: "You're a helpful assistant." };
   }
   return await run();

--- a/packages/provider-codex/src/interceptors/responses/inject-default-instructions_test.ts
+++ b/packages/provider-codex/src/interceptors/responses/inject-default-instructions_test.ts
@@ -34,6 +34,14 @@ test('injects the default when instructions is an empty string', async () => {
   assertEquals(ctx.payload.instructions, "You're a helpful assistant.");
 });
 
+test('injects the default when instructions is null', async () => {
+  const ctx = invocation({ model: 'gpt-test', input: 'hello', instructions: null });
+
+  await injectDefaultInstructions(ctx, stubRequest, okEvents);
+
+  assertEquals(ctx.payload.instructions, "You're a helpful assistant.");
+});
+
 test('preserves a caller-supplied instructions string', async () => {
   const ctx = invocation({ model: 'gpt-test', input: 'hello', instructions: 'You are a pirate.' });
 
@@ -41,6 +49,26 @@ test('preserves a caller-supplied instructions string', async () => {
 
   assertEquals(ctx.payload.instructions, 'You are a pirate.');
 });
+
+test.each([
+  { name: 'number', value: 42 },
+  { name: 'boolean', value: false },
+  { name: 'object', value: { text: 'invalid' } },
+  { name: 'array', value: ['invalid'] },
+])(
+  'preserves malformed $name instructions for upstream validation',
+  async ({ value }) => {
+    const ctx = invocation({
+      model: 'gpt-test',
+      input: 'hello',
+      instructions: value as unknown as string,
+    });
+
+    await injectDefaultInstructions(ctx, stubRequest, okEvents);
+
+    assertEquals(ctx.payload.instructions, value);
+  },
+);
 
 test('injects the default and preserves in-array role:"system" items when no top-level instructions are supplied', async () => {
   // Behavior validated after removing hoist-system-input-to-instructions:


### PR DESCRIPTION
## Summary

- inject the neutral Codex instructions default only when the field is absent, `null`, or empty
- preserve malformed external non-string values so the ChatGPT subscription backend remains the authoritative validator
- document the boundary contract and cover valid defaults plus malformed number, boolean, object, and array values

## Test Plan

- [x] `pnpm exec vitest run packages/provider-codex/src/interceptors/responses/inject-default-instructions_test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm exec vitest run --silent=passed-only --reporter=default` (339 files, 4160 tests)
