### PR TITLE
fix(translate): preserve empty Gemini effort

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -278,9 +278,11 @@ Request mapping shared by the Gemini source translation pairs:
   thinking controls. Budget `0` disables thinking via Messages
   `thinking.disabled`, Responses `reasoning.effort: "none"`, or Chat
   `reasoning_effort: "none"`; positive budgets choose low/medium/high effort
-  where the target only supports effort levels. Explicit `thinkingLevel`
-  strings, including empty and future values, pass verbatim to the target's
-  open-string effort slot for upstream validation.
+  where the target only supports effort levels. When both controls are present,
+  the numeric budget takes precedence on Chat and Responses; Messages preserves
+  its native budget and the level in separate fields. Without a budget,
+  explicit `thinkingLevel` strings, including empty and future values, pass
+  verbatim to the target's open-string effort slot for upstream validation.
 - `maxOutputTokens`, `temperature`, `topP`, `topK`, `stopSequences`,
   `presencePenalty`, `frequencyPenalty`, `seed`, `responseMimeType`, and
   `responseSchema` are passed through when the selected target has a natural

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -278,7 +278,9 @@ Request mapping shared by the Gemini source translation pairs:
   thinking controls. Budget `0` disables thinking via Messages
   `thinking.disabled`, Responses `reasoning.effort: "none"`, or Chat
   `reasoning_effort: "none"`; positive budgets choose low/medium/high effort
-  where the target only supports effort levels.
+  where the target only supports effort levels. Explicit `thinkingLevel`
+  strings, including empty and future values, pass verbatim to the target's
+  open-string effort slot for upstream validation.
 - `maxOutputTokens`, `temperature`, `topP`, `topK`, `stopSequences`,
   `presencePenalty`, `frequencyPenalty`, `seed`, `responseMimeType`, and
   `responseSchema` are passed through when the selected target has a natural

--- a/packages/translate/src/gemini-via-chat-completions/request.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request.ts
@@ -188,7 +188,7 @@ const applyGenerationConfig = (request: ChatCompletionsPayload, generationConfig
   }
 
   const reasoningEffort = geminiReasoningEffort(generationConfig.thinkingConfig);
-  if (reasoningEffort) request.reasoning_effort = reasoningEffort;
+  if (reasoningEffort !== null) request.reasoning_effort = reasoningEffort;
 };
 
 const buildTools = (payload: GeminiPayload): ChatCompletionsTool[] | undefined => {

--- a/packages/translate/src/gemini-via-chat-completions/request_test.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request_test.ts
@@ -4,6 +4,14 @@ import { buildTargetRequest } from './request.ts';
 import { assertEquals, assertThrows } from '../test-assert.ts';
 import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 
+test('buildTargetRequest forwards an empty thinkingLevel verbatim', () => {
+  const request = buildTargetRequest({
+    generationConfig: { thinkingConfig: { thinkingLevel: '' } },
+  }, 'gpt-test');
+
+  assertEquals(request.reasoning_effort, '');
+});
+
 test('buildTargetRequest maps system instruction and multimodal user content', () => {
   const payload: GeminiPayload = {
     systemInstruction: {

--- a/packages/translate/src/gemini-via-chat-completions/request_test.ts
+++ b/packages/translate/src/gemini-via-chat-completions/request_test.ts
@@ -12,6 +12,14 @@ test('buildTargetRequest forwards an empty thinkingLevel verbatim', () => {
   assertEquals(request.reasoning_effort, '');
 });
 
+test('buildTargetRequest gives thinkingBudget precedence over an empty thinkingLevel', () => {
+  const request = buildTargetRequest({
+    generationConfig: { thinkingConfig: { thinkingBudget: 2048, thinkingLevel: '' } },
+  }, 'gpt-test');
+
+  assertEquals(request.reasoning_effort, 'low');
+});
+
 test('buildTargetRequest maps system instruction and multimodal user content', () => {
   const payload: GeminiPayload = {
     systemInstruction: {

--- a/packages/translate/src/gemini-via-messages/request_test.ts
+++ b/packages/translate/src/gemini-via-messages/request_test.ts
@@ -17,6 +17,15 @@ test('buildTargetRequest forwards an empty thinkingLevel verbatim', () => {
   assertEquals(request.output_config, { effort: '' });
 });
 
+test('buildTargetRequest preserves native thinkingBudget beside an empty thinkingLevel', () => {
+  const request = buildTargetRequest({
+    generationConfig: { thinkingConfig: { thinkingBudget: 2048, thinkingLevel: '' } },
+  }, 'claude-test', noOptions);
+
+  assertEquals(request.thinking, { type: 'enabled', budget_tokens: 2048 });
+  assertEquals(request.output_config, { effort: '' });
+});
+
 test('buildTargetRequest maps system, default max tokens, and multimodal user content', () => {
   const payload: GeminiPayload = {
     systemInstruction: {

--- a/packages/translate/src/gemini-via-messages/request_test.ts
+++ b/packages/translate/src/gemini-via-messages/request_test.ts
@@ -9,6 +9,14 @@ const noOptions = {};
 
 const withMaxOutputTokens = (maxOutputTokens: number) => ({ fallbackMaxOutputTokens: maxOutputTokens });
 
+test('buildTargetRequest forwards an empty thinkingLevel verbatim', () => {
+  const request = buildTargetRequest({
+    generationConfig: { thinkingConfig: { thinkingLevel: '' } },
+  }, 'claude-test', noOptions);
+
+  assertEquals(request.output_config, { effort: '' });
+});
+
 test('buildTargetRequest maps system, default max tokens, and multimodal user content', () => {
   const payload: GeminiPayload = {
     systemInstruction: {

--- a/packages/translate/src/gemini-via-responses/request.ts
+++ b/packages/translate/src/gemini-via-responses/request.ts
@@ -148,7 +148,7 @@ const applyGenerationConfig = (request: CanonicalResponsesPayload, generationCon
   }
 
   const effort = geminiReasoningEffort(generationConfig.thinkingConfig);
-  if (!effort) return;
+  if (effort === null) return;
 
   request.reasoning = {
     effort,

--- a/packages/translate/src/gemini-via-responses/request_test.ts
+++ b/packages/translate/src/gemini-via-responses/request_test.ts
@@ -4,6 +4,14 @@ import { buildTargetRequest } from './request.ts';
 import { assertEquals, assertFalse, assertThrows } from '../test-assert.ts';
 import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 
+test('buildTargetRequest forwards an empty thinkingLevel verbatim', () => {
+  const request = buildTargetRequest({
+    generationConfig: { thinkingConfig: { thinkingLevel: '' } },
+  }, 'gpt-test');
+
+  assertEquals(request.reasoning, { effort: '' });
+});
+
 test('buildTargetRequest maps instructions and multimodal user input without defaults', () => {
   const payload: GeminiPayload = {
     systemInstruction: {

--- a/packages/translate/src/gemini-via-responses/request_test.ts
+++ b/packages/translate/src/gemini-via-responses/request_test.ts
@@ -6,10 +6,18 @@ import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini'
 
 test('buildTargetRequest forwards an empty thinkingLevel verbatim', () => {
   const request = buildTargetRequest({
-    generationConfig: { thinkingConfig: { thinkingLevel: '' } },
+    generationConfig: { thinkingConfig: { thinkingLevel: '', includeThoughts: true } },
   }, 'gpt-test');
 
-  assertEquals(request.reasoning, { effort: '' });
+  assertEquals(request.reasoning, { effort: '', summary: 'detailed' });
+});
+
+test('buildTargetRequest gives thinkingBudget precedence over an empty thinkingLevel', () => {
+  const request = buildTargetRequest({
+    generationConfig: { thinkingConfig: { thinkingBudget: 2048, thinkingLevel: '', includeThoughts: true } },
+  }, 'gpt-test');
+
+  assertEquals(request.reasoning, { effort: 'low', summary: 'detailed' });
 });
 
 test('buildTargetRequest maps instructions and multimodal user input without defaults', () => {


### PR DESCRIPTION
## Summary

- Forward every explicit Gemini `thinkingLevel` string, including the empty string and future values, into Chat Completions and Responses open-string effort fields instead of dropping falsy values. Messages already preserves the same value and now has matching regression coverage.
- Keep existing precedence explicit: `thinkingBudget` wins on Chat Completions and Responses, while Messages preserves its native budget and effort in separate fields. Preserve Responses `includeThoughts` summary behavior for empty effort values.
- Document the cross-target open-string and precedence rules.

## Test Plan

- [x] `pnpm exec vitest run packages/translate/src/gemini-via-chat-completions/request_test.ts packages/translate/src/gemini-via-messages/request_test.ts packages/translate/src/gemini-via-responses/request_test.ts` (53 tests)
- [x] `pnpm run test` (339 files, 4161 tests)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`