### PR TITLE
perf(gateway): release parsed request body ownership

### DIFF
--- a/packages/gateway/src/data-plane/chat/chat-completions/http.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http.ts
@@ -6,7 +6,7 @@ import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import { createChatGatewayCtxFromHono, createGatewayCtxFromHono, finalizeGatewayResponse, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
-import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
+import { readRequestBody, takeRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { ChatCompletionsPayload } from '@floway-dev/protocols/chat-completions';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
@@ -25,7 +25,7 @@ import { TranslatorInputError } from '@floway-dev/translate';
 const respondWithInternalError = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
   const verbatim = providerModelsUnavailableResponse(error);
   if (verbatim !== null) return verbatim;
-  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   const result = internalErrorResult(502, toInternalDebugError(error), effectiveCtx.attempt.telemetry);
   const { response } = await respondChatCompletions(c, result, false, false, effectiveCtx);
   return finalizeGatewayResponse(effectiveCtx, response);
@@ -36,7 +36,7 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
 // falls through to the internal-error 502 path.
 const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
   if (!(error instanceof TranslatorInputError)) return await respondWithInternalError(c, error, requestBody, ctx);
-  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   const { response } = await respondChatCompletions(c, translatorInputErrorResult(error, effectiveCtx.attempt.telemetry), false, false, effectiveCtx);
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
@@ -54,7 +54,7 @@ export const chatCompletionsHttp = {
       // slots — the value lives in this http-entry closure for the duration of
       // the request.
       const includeUsageChunk = payload.stream_options?.include_usage === true;
-      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
       const result = await chatCompletionsServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondChatCompletions(c, result, wantsStream, includeUsageChunk, ctx);
       return finalizeGatewayResponse(ctx, response);

--- a/packages/gateway/src/data-plane/chat/gemini/http.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http.ts
@@ -6,7 +6,7 @@ import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import { createChatGatewayCtxFromHono, finalizeGatewayResponse, type ChatGatewayCtx } from '../shared/gateway-ctx.ts';
-import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
+import { readRequestBody, takeRequestBody, type RequestBody } from '../shared/request-body.ts';
 import type { GeminiContent, GeminiPayload } from '@floway-dev/protocols/gemini';
 import { internalErrorResult, ProviderModelsUnavailableError, toInternalDebugError } from '@floway-dev/provider';
 import { TranslatorInputError } from '@floway-dev/translate';
@@ -103,7 +103,7 @@ const runGeminiGenerate = async (c: AuthedContext, model: string, wantsStream: b
   const payload = parseGeminiBodyBytes(requestBody, body => body as GeminiPayload);
   if (payload instanceof Response) return payload;
 
-  const ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
+  const ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody: takeRequestBody(requestBody), model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
   try {
     const result = await geminiServe.generate({ payload, ctx, model, headers: inboundHeadersForUpstream(c) });
     const { response } = await respondGemini(c, result, wantsStream, ctx);
@@ -118,7 +118,7 @@ const runGeminiCountTokens = async (c: AuthedContext, model: string): Promise<Re
   const payload = parseGeminiBodyBytes(requestBody, parseGeminiCountTokensPayload);
   if (payload instanceof Response) return payload;
 
-  const ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody, model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
+  const ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
   try {
     const result = await geminiServe.countTokens({ payload, ctx, model, headers: inboundHeadersForUpstream(c) });
     const { response } = await respondGemini(c, result, false, ctx);

--- a/packages/gateway/src/data-plane/chat/messages/http.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http.ts
@@ -6,7 +6,7 @@ import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { createNonResponsesSourceStore } from '../responses/items/store.ts';
 import { createChatGatewayCtxFromHono, createGatewayCtxFromHono, finalizeGatewayResponse, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
-import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
+import { readRequestBody, takeRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
@@ -45,7 +45,7 @@ const rejectBodyBetaResponse = (payload: MessagesPayload): Response | null => {
 const respondWithInternalError = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
   const verbatim = providerModelsUnavailableResponse(error);
   if (verbatim !== null) return verbatim;
-  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   const result = internalErrorResult(502, toInternalDebugError(error), effectiveCtx.attempt.telemetry);
   const { response } = await respondMessages(c, result, false, effectiveCtx);
   return finalizeGatewayResponse(effectiveCtx, response);
@@ -56,7 +56,7 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
 // internal-error 502 path.
 const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
   if (!(error instanceof TranslatorInputError)) return await respondWithInternalError(c, error, requestBody, ctx);
-  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   const { response } = await respondMessages(c, translatorInputErrorResult(error, effectiveCtx.attempt.telemetry), false, effectiveCtx);
   return (effectiveCtx.dump?.finalize(response) ?? response);
 };
@@ -74,7 +74,7 @@ export const messagesHttp = {
       if (rejected) return rejected;
 
       const wantsStream = payload.stream === true;
-      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
       const result = await messagesServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondMessages(c, result, wantsStream, ctx);
       return finalizeGatewayResponse(ctx, response);
@@ -91,7 +91,7 @@ export const messagesHttp = {
       const rejected = rejectBodyBetaResponse(payload);
       if (rejected) return rejected;
 
-      ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody, model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, createNonResponsesSourceStore);
       const result = await messagesServe.countTokens({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondMessages(c, result, false, ctx);
       return finalizeGatewayResponse(ctx, response);

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -8,7 +8,7 @@ import { backgroundSchedulerFromContext } from '../../../runtime/background.ts';
 import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { settle } from '../../shared/telemetry/settle.ts';
 import { createChatGatewayCtxFromHono, createGatewayCtxFromHono, finalizeGatewayResponse, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
-import { readRequestBody, type RequestBody } from '../shared/request-body.ts';
+import { readRequestBody, takeRequestBody, type RequestBody } from '../shared/request-body.ts';
 import { providerModelsUnavailableResponse } from '../shared/upstream-models-error.ts';
 import type { ResponsesPayload } from '@floway-dev/protocols/responses';
 import { internalErrorResult, toInternalDebugError } from '@floway-dev/provider';
@@ -44,7 +44,7 @@ const previousResponseNotFoundResponse = (id: string): Response =>
 const respondWithInternalError = async (c: AuthedContext, error: unknown, requestBody: RequestBody, ctx?: GatewayCtx): Promise<Response> => {
   const verbatim = providerModelsUnavailableResponse(error);
   if (verbatim !== null) return verbatim;
-  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
+  const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   const result = internalErrorResult(502, toInternalDebugError(error), effectiveCtx.attempt.telemetry);
   const { response } = await respondResponses(c, result, false, effectiveCtx);
   return finalizeGatewayResponse(effectiveCtx, response);
@@ -60,7 +60,7 @@ const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: Req
     return ctx ? finalizeGatewayResponse(ctx, response) : response;
   }
   if (error instanceof TranslatorInputError) {
-    const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
+    const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
     const { response } = await respondResponses(c, translatorInputErrorResult(error, effectiveCtx.attempt.telemetry), false, effectiveCtx);
     return finalizeGatewayResponse(effectiveCtx, response);
   }
@@ -77,7 +77,7 @@ export const responsesHttp = {
     try {
       const payload = parsePayload(requestBody);
       const wantsStream = payload.stream === true;
-      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody, model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, apiKeyId => createResponsesHttpStore(apiKeyId, payload.store ?? undefined));
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, apiKeyId => createResponsesHttpStore(apiKeyId, payload.store ?? undefined));
       const result = await responsesServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       const { response } = await respondResponses(c, result, wantsStream, ctx);
       return finalizeGatewayResponse(ctx, response);
@@ -91,7 +91,7 @@ export const responsesHttp = {
     let ctx: ChatGatewayCtx | undefined;
     try {
       const payload = parsePayload(requestBody);
-      ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody, model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, apiKeyId => createResponsesHttpStore(apiKeyId, payload.store ?? undefined));
+      ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, apiKeyId => createResponsesHttpStore(apiKeyId, payload.store ?? undefined));
       const result = await responsesServe.compact({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       if (result.type === 'result') {
         // Compact drains the upstream stream into a single envelope with

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -11,6 +11,7 @@ import { inboundHeadersForUpstream } from '../../shared/inbound-headers.ts';
 import { recordFailedRequest } from '../../shared/telemetry/performance.ts';
 import { settle } from '../../shared/telemetry/settle.ts';
 import { createChatGatewayCtxFromHono, type ChatGatewayCtx, type GatewayCtx } from '../shared/gateway-ctx.ts';
+import { takeRequestBody } from '../shared/request-body.ts';
 import { SourceStreamState, eventResultMetadata } from '../shared/respond.ts';
 import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS, type StreamCompletion } from '../shared/stream/sse.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
@@ -195,7 +196,7 @@ const handleClientMessage = async (
     // request body when `ctx` is constructed below. Payloads that fail to
     // parse never reach ctx construction, so no dump record is emitted for
     // them — there is no api-key-scoped turn to attribute them to.
-    const requestBytes = wsDataToBytes(data);
+    const requestBody = { bytes: wsDataToBytes(data), streamError: null };
     if (!(await authenticateApiKey(c, authenticatedRawKey))) {
       sendError(socket, 401, {
         type: 'authentication_error',
@@ -206,7 +207,7 @@ const handleClientMessage = async (
     }
     let parsed: unknown;
     try {
-      parsed = JSON.parse(new TextDecoder().decode(requestBytes)) as unknown;
+      parsed = JSON.parse(new TextDecoder().decode(requestBody.bytes)) as unknown;
     } catch (cause) {
       throw new WebSocketClientMessageError(`WebSocket message must be valid JSON: ${cause instanceof Error ? cause.message : String(cause)}`);
     }
@@ -233,7 +234,7 @@ const handleClientMessage = async (
       // The WS upgrade has no HTTP body; the dump's request body is the
       // per-turn JSON frame bytes so an operator reading the dashboard
       // sees the exact `response.create` payload the client sent.
-      requestBody: { bytes: requestBytes, streamError: null },
+      requestBody: takeRequestBody(requestBody),
       method: 'WS',
       model: payload.model,
       backgroundScheduler,

--- a/packages/gateway/src/data-plane/chat/shared/gateway-ctx.ts
+++ b/packages/gateway/src/data-plane/chat/shared/gateway-ctx.ts
@@ -1,4 +1,4 @@
-import { takeRequestBody, type RequestBody } from './request-body.ts';
+import type { RequestBody } from './request-body.ts';
 import { type DumpAccumulator, openDumpAccumulator } from '../../../dump/accumulator.ts';
 import { apiKeyFromContext, type AuthedContext, effectiveUpstreamIdsFromContext } from '../../../middleware/auth.ts';
 import { getRuntimeLocation } from '../../../runtime/runtime-info.ts';
@@ -94,7 +94,7 @@ export const createGatewayCtxFromHono = (c: AuthedContext, opts: CreateGatewayCt
   const controller = opts.downstreamAbortController ?? (opts.wantsStream ? new AbortController() : undefined);
   const apiKey = apiKeyFromContext(c);
   const upstreamIds = effectiveUpstreamIdsFromContext(c);
-  const dump = openDumpAccumulator(c, opts.method ?? c.req.method, apiKey, takeRequestBody(opts.requestBody), opts.backgroundScheduler);
+  const dump = openDumpAccumulator(c, opts.method ?? c.req.method, apiKey, opts.requestBody, opts.backgroundScheduler);
   if (opts.model !== undefined) dump?.requestedModel(opts.model);
   return {
     apiKeyId: apiKey.id,

--- a/packages/gateway/src/data-plane/chat/shared/gateway-ctx.ts
+++ b/packages/gateway/src/data-plane/chat/shared/gateway-ctx.ts
@@ -1,4 +1,4 @@
-import type { RequestBody } from './request-body.ts';
+import { takeRequestBody, type RequestBody } from './request-body.ts';
 import { type DumpAccumulator, openDumpAccumulator } from '../../../dump/accumulator.ts';
 import { apiKeyFromContext, type AuthedContext, effectiveUpstreamIdsFromContext } from '../../../middleware/auth.ts';
 import { getRuntimeLocation } from '../../../runtime/runtime-info.ts';
@@ -94,7 +94,7 @@ export const createGatewayCtxFromHono = (c: AuthedContext, opts: CreateGatewayCt
   const controller = opts.downstreamAbortController ?? (opts.wantsStream ? new AbortController() : undefined);
   const apiKey = apiKeyFromContext(c);
   const upstreamIds = effectiveUpstreamIdsFromContext(c);
-  const dump = openDumpAccumulator(c, opts.method ?? c.req.method, apiKey, opts.requestBody, opts.backgroundScheduler);
+  const dump = openDumpAccumulator(c, opts.method ?? c.req.method, apiKey, takeRequestBody(opts.requestBody), opts.backgroundScheduler);
   if (opts.model !== undefined) dump?.requestedModel(opts.model);
   return {
     apiKeyId: apiKey.id,

--- a/packages/gateway/src/data-plane/chat/shared/request-body.ts
+++ b/packages/gateway/src/data-plane/chat/shared/request-body.ts
@@ -5,9 +5,19 @@ import type { Context } from 'hono';
 // bytes without a second read). `streamError` surfaces a client mid-upload
 // abort as a non-null message; the dump records it as `meta.error`.
 export interface RequestBody {
-  readonly bytes: Uint8Array;
+  bytes: Uint8Array;
   readonly streamError: string | null;
 }
+
+// Transfers the byte buffer into the request context after payload parsing.
+// Async HTTP handlers keep their local RequestBody across the upstream wait;
+// clearing that slot prevents it from retaining the full wire body after the
+// dump pipeline (when enabled) has started preparing its own representation.
+export const takeRequestBody = (source: RequestBody): RequestBody => {
+  const owned = { bytes: source.bytes, streamError: source.streamError };
+  source.bytes = new Uint8Array();
+  return owned;
+};
 
 // Reads the inbound body in full into a Uint8Array; the handler parses its
 // payload off the same buffer so the wire body is consumed exactly once. A

--- a/packages/gateway/src/data-plane/chat/shared/request-body_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/request-body_test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+
+import { takeRequestBody } from './request-body.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+test('takeRequestBody transfers bytes and clears the source owner', () => {
+  const bytes = new Uint8Array([1, 2, 3]);
+  const source = { bytes, streamError: 'partial upload' };
+
+  const owned = takeRequestBody(source);
+
+  expect(owned.bytes).toBe(bytes);
+  assertEquals(owned.streamError, 'partial upload');
+  assertEquals(source.bytes.byteLength, 0);
+});

--- a/packages/gateway/src/data-plane/completions/serve.ts
+++ b/packages/gateway/src/data-plane/completions/serve.ts
@@ -12,7 +12,7 @@ import { tokenUsageFromCompletionsUsage } from './usage.ts';
 import type { TokenUsage } from '../../repo/types.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { createGatewayCtxFromHono, finalizeGatewayResponse } from '../chat/shared/gateway-ctx.ts';
-import { readRequestBody } from '../chat/shared/request-body.ts';
+import { readRequestBody, takeRequestBody } from '../chat/shared/request-body.ts';
 import { passthroughApiError, passthroughServe } from '../shared/passthrough-serve.ts';
 import { isOpenAIUsageOnlyEventShape, type ProtocolFrame } from '@floway-dev/protocols/common';
 
@@ -62,7 +62,7 @@ export const completions = async (c: Context): Promise<Response> => {
   const request = prepareCompletionsRequest(requestBody.bytes);
   const ctx = createGatewayCtxFromHono(c, {
     wantsStream: request.type === 'ok' ? request.wantsStream : false,
-    requestBody,
+    requestBody: takeRequestBody(requestBody),
     backgroundScheduler: backgroundSchedulerFromContext(c),
   });
   if (request.type === 'invalid') {

--- a/packages/gateway/src/data-plane/embeddings/serve.ts
+++ b/packages/gateway/src/data-plane/embeddings/serve.ts
@@ -5,7 +5,7 @@ import type { Context } from 'hono';
 
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { createGatewayCtxFromHono, finalizeGatewayResponse } from '../chat/shared/gateway-ctx.ts';
-import { readRequestBody } from '../chat/shared/request-body.ts';
+import { readRequestBody, takeRequestBody } from '../chat/shared/request-body.ts';
 import { passthroughApiError, passthroughServe } from '../shared/passthrough-serve.ts';
 import { tokenUsageFromEmbeddingsBody } from '../shared/telemetry/usage.ts';
 
@@ -46,8 +46,8 @@ const prepareEmbeddingsRequest = (bytes: Uint8Array): { type: 'ok'; body: Record
 
 export const embeddings = async (c: Context): Promise<Response> => {
   const requestBody = await readRequestBody(c);
-  const ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
   const request = prepareEmbeddingsRequest(requestBody.bytes);
+  const ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   if (request.type === 'invalid') {
     ctx.dump?.error('gateway');
     return finalizeGatewayResponse(ctx, passthroughApiError(c, request.message, 400));

--- a/packages/gateway/src/data-plane/images/serve.ts
+++ b/packages/gateway/src/data-plane/images/serve.ts
@@ -12,7 +12,7 @@ import type { Context } from 'hono';
 
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { createGatewayCtxFromHono, finalizeGatewayResponse } from '../chat/shared/gateway-ctx.ts';
-import { readRequestBody } from '../chat/shared/request-body.ts';
+import { readRequestBody, takeRequestBody } from '../chat/shared/request-body.ts';
 import { passthroughApiError, passthroughServe } from '../shared/passthrough-serve.ts';
 import { tokenUsageFromImagesBody } from '../shared/telemetry/usage.ts';
 
@@ -45,8 +45,8 @@ const prepareImagesGenerationsRequest = (bytes: Uint8Array): PreparedRequest => 
 
 export const imagesGenerations = async (c: Context): Promise<Response> => {
   const requestBody = await readRequestBody(c);
-  const ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
   const request = prepareImagesGenerationsRequest(requestBody.bytes);
+  const ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   if (request.type === 'invalid') {
     ctx.dump?.error('gateway');
     return finalizeGatewayResponse(ctx, passthroughApiError(c, request.message, 400));
@@ -75,7 +75,6 @@ export const imagesEdits = async (c: Context): Promise<Response> => {
   // c.req.raw.body internally; re-parsing from the captured bytes via a fresh
   // Response keeps the dump capture honest without a second read on the wire.
   const requestBody = await readRequestBody(c);
-  const ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody, backgroundScheduler: backgroundSchedulerFromContext(c) });
   let form: FormData;
   try {
     form = await new Response(requestBody.bytes as BodyInit, { headers: { 'content-type': c.req.header('content-type') ?? '' } }).formData();
@@ -83,9 +82,12 @@ export const imagesEdits = async (c: Context): Promise<Response> => {
     // Match the embeddings serve stance: do not surface the underlying
     // parser's error text. The wording is enough for a client to know
     // they sent the wrong content type or a malformed body.
-    ctx.dump?.error('gateway');
-    return finalizeGatewayResponse(ctx, passthroughApiError(c, 'Image edits request body must be a valid multipart/form-data payload.', 400));
+    const errorCtx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
+    errorCtx.dump?.error('gateway');
+    return finalizeGatewayResponse(errorCtx, passthroughApiError(c, 'Image edits request body must be a valid multipart/form-data payload.', 400));
   }
+
+  const ctx = createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
 
   const modelRaw = form.get('model');
   if (typeof modelRaw !== 'string' || modelRaw.length === 0) {


### PR DESCRIPTION
## Summary

- Transfer request-body bytes after each endpoint finishes parsing.
- Clear the async handler's local byte slot before the upstream wait.
- Pass the same buffer into dump capture when retention is enabled.
- Preserve malformed-body handling, multipart parsing, WebSocket turns, and exact captured bytes.

## Performance

Measured with a 7,538,620-byte production Responses request, production D1/R2 state, HKG `proxy -> direct` routing, and the live Copilot upstream.

| Runtime | Latest main | PR | Difference |
| --- | ---: | ---: | ---: |
| workerd live heap | 61.531 MiB | 54.287 MiB | **-7.244 MiB (-11.77%)** |
| Node live heap | 119.612 MiB | 113.933 MiB | **-5.679 MiB (-4.75%)** |

Main retained the 7.189 MiB inbound `ArrayBuffer` through the HTTP handler generator for the upstream wait. The explicit ownership transfer makes that buffer unreachable without adding parsing, hashing, compression, or wire work.

Profiling used the supported Workers DevTools heap protocol:

- https://developers.cloudflare.com/workers/observability/dev-tools/
- https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/

Raw profiles remain local because they contain production request data.

## Test Plan

- [x] `pnpm run test` — all 346 files passed
- [x] `pnpm run lint`
- [x] Gateway and affected package typechecks passed
