### PR TITLE
perf(responses): share store-owned staged payloads

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -429,7 +429,11 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
   ): void {
     const metadata = cloneStoredResponsesItemMetadata('hasPayload' in row ? row : storedResponsesItemMetadata(row));
     this.loadedItemsById.set(metadata.id, metadata);
-    if (!('hasPayload' in row) && row.payload !== null) this.stagedPayloadsById.set(row.id, structuredClone(row.payload));
+    // Full rows are already owned by this store: input/repair rows clone the
+    // caller item when constructed, and stageOutputItem clones its row before
+    // reaching here. Share that internal payload between the staging indexes;
+    // candidate rewrite clones the hydrated item before downstream mutation.
+    if (!('hasPayload' in row) && row.payload !== null) this.stagedPayloadsById.set(row.id, row.payload);
     if (metadata.hasPayload && options.source !== undefined) this.payloadSourcesById.set(metadata.id, options.source);
     if (options.durable === true) this.durableItemIds.add(metadata.id);
     if (metadata.contentHash !== null) pushByHash(this.loadedItemsByContentHash, metadata.contentHash, metadata);

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -84,6 +84,50 @@ test('stages agent and context-compaction items with stable prefixes and preserv
   assertEquals(payloads.map(record => record.payload.item), input);
 });
 
+test('staged input payload ownership is isolated from later caller mutation', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const input: ResponsesInputItem[] = [{
+    type: 'message',
+    role: 'user',
+    content: [{ type: 'input_text', text: 'before' }],
+  }];
+  const store = createResponsesHttpStore(API_KEY_ID, true);
+
+  await store.stageInputItems(input);
+  (input[0] as { content: Array<{ text: string }> }).content[0]!.text = 'after';
+  await store.commitSnapshot('resp_input_owner', 'append');
+
+  const snapshot = await repo.responsesSnapshots.lookup(API_KEY_ID, 'resp_input_owner');
+  assertExists(snapshot);
+  const [payload] = await repo.responsesItems.lookupPayloads(API_KEY_ID, snapshot.itemIds);
+  assertExists(payload);
+  assertEquals((payload.payload.item as { content: Array<{ text: string }> }).content[0]!.text, 'before');
+});
+
+test('staged output payload ownership is isolated from later caller mutation', async () => {
+  const repo = new InMemoryRepo();
+  initRepo(repo);
+  const output = storedRow({
+    id: createStoredResponsesItemId('message'),
+    itemType: 'message',
+    origin: 'upstream',
+    payload: {
+      item: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'before' }] },
+    },
+  });
+  const store = createResponsesHttpStore(API_KEY_ID, true);
+
+  store.beginAttempt(new Map());
+  store.stageOutputItem(output);
+  ((output.payload!.item as { content: Array<{ text: string }> }).content[0]!).text = 'after';
+  await store.commitOutputItems();
+
+  const [payload] = await repo.responsesItems.lookupPayloads(API_KEY_ID, [output.id]);
+  assertExists(payload);
+  assertEquals((payload.payload.item as { content: Array<{ text: string }> }).content[0]!.text, 'before');
+});
+
 test('content-hash preload skips items already addressed by a stored id', async () => {
   const repo = new InMemoryRepo();
   initRepo(repo);


### PR DESCRIPTION
## Summary

- Keep the deep ownership clone where input and output payloads first enter the Responses store.
- Reuse that already store-owned payload in the staged lookup index instead of cloning it again.
- Continue cloning hydrated values at candidate rewrite boundaries so callers, retries, and stored rows remain isolated.

## Performance

Measured with a 7,474,243-byte production-derived cold-history request containing 2,538 input items and 2,496 newly staged payload rows.

| Runtime | Main | PR | Difference |
| --- | ---: | ---: | ---: |
| workerd live heap | 74.416 MiB | 66.359 MiB | **-8.057 MiB (-10.83%)** |
| Node live heap | 131.625 MiB | 124.410 MiB | **-7.215 MiB (-5.48%)** |

Node CPU profiles show `structuredClone` self-time falling from 20.127 ms to 10.566 ms (-47.5%). Total active samples vary with the live TLS path, so no aggregate latency claim is made.

Profiling used the supported Workers DevTools heap/CPU protocol:

- https://developers.cloudflare.com/workers/observability/dev-tools/
- https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/
- https://developers.cloudflare.com/workers/observability/dev-tools/cpu-usage/

Raw profiles remain local because they contain production request data.

## Safety

Input and repair rows clone caller items when constructed, and output rows clone before indexing. Candidate rewrite clones both public and private values before mutation. Regression tests mutate caller input/output objects after staging and verify committed payloads remain unchanged.

## Test Plan

- [x] `pnpm run test` — 345 files / 4,217 tests passed
- [x] `pnpm run lint`
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
