### PR TITLE
perf(responses): structurally share canonical echoes

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite.ts
@@ -18,25 +18,31 @@ const itemWithId = (item: ResponsesInputItem, id: string): ResponsesInputItem =>
 // status and output-text annotations/logprobs are absent, while reasoning keeps
 // an optional content carrier. Restore the server defaults only for the durable
 // content-hash comparison; the normalized object is used only when that hash
-// proves it is exactly the persisted canonical payload.
+// proves it is exactly the persisted canonical payload. Each candidate already
+// owns a deep-cloned source payload, so canonicalization copies only the item
+// and content blocks whose defaults actually change.
 // https://github.com/openai/codex/blob/c888e8e75a9f0e90ce7d5517f8b9540832cbbf76/codex-rs/protocol/src/models.rs#L843-L858
 // https://github.com/openai/codex/blob/c888e8e75a9f0e90ce7d5517f8b9540832cbbf76/codex-rs/protocol/src/models.rs#L933-L1012
 const canonicalStoredEcho = (item: ResponsesInputItem, row: StoredResponsesItemMetadata): ResponsesInputItem => {
-  const canonical = structuredClone(item) as ResponsesInputItem & Record<string, unknown>;
+  const canonical = { ...item } as ResponsesInputItem & Record<string, unknown>;
   if (row.upstreamItemId !== null) canonical.id = row.upstreamItemId;
   if (canonical.type === 'reasoning' && canonical.content == null) canonical.content = [];
   if ((canonical.type === 'function_call' || canonical.type === 'message') && canonical.status === undefined) {
     canonical.status = 'completed';
   }
   if (canonical.type === 'message' && Array.isArray(canonical.content)) {
-    canonical.content = canonical.content.map(block => {
+    let changed = false;
+    const content = canonical.content.map(block => {
       if (block.type !== 'output_text') return block;
+      if (Object.hasOwn(block, 'annotations') && Object.hasOwn(block, 'logprobs')) return block;
+      changed = true;
       return {
         ...block,
         ...(!Object.hasOwn(block, 'annotations') ? { annotations: [] } : {}),
         ...(!Object.hasOwn(block, 'logprobs') ? { logprobs: [] } : {}),
       };
     });
+    if (changed) canonical.content = content;
   }
   return canonical;
 };

--- a/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/rewrite_test.ts
@@ -185,6 +185,45 @@ test('canonical projected echo rewrites from metadata without loading its payloa
   assertEquals(rewritten, [canonical]);
 });
 
+test('canonical projected echo shares unchanged attempt-owned content blocks', async () => {
+  const id = storedMessageId('metadata-structural-sharing');
+  const inputImage = { type: 'input_image', image_url: 'data:image/png;base64,AA==' } as const;
+  const outputText = { type: 'output_text', text: 'hello' } as const;
+  const canonical = {
+    type: 'message',
+    id: 'raw_msg_a',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ ...outputText, annotations: [], logprobs: [] }, inputImage],
+  } as unknown as ResponsesInputItem;
+  await insertRows([storedRow({
+    id,
+    itemType: 'message',
+    upstreamId: 'up_a',
+    upstreamItemId: 'raw_msg_a',
+    contentHash: await hashResponsesItemContent(canonical),
+    payload: canonical,
+  })]);
+  const input = [{
+    type: 'message',
+    id,
+    role: 'assistant',
+    content: [outputText, inputImage],
+  }] as unknown as ResponsesInputItem[];
+
+  const [rewritten] = await rewrite(input, candidate('up_a'));
+  assert(rewritten.type === 'message' && Array.isArray(rewritten.content));
+
+  assert(rewritten.content[0] !== outputText, 'the block receiving defaults must be copied');
+  assert(rewritten.content[1] === inputImage, 'unchanged attempt-owned blocks should be shared');
+  assertEquals(input[0], {
+    type: 'message',
+    id,
+    role: 'assistant',
+    content: [outputText, inputImage],
+  });
+});
+
 // Case 6: cross-upstream owned → mint tmp id
 test('non-matching portable owned item gets a temporary id without leaking raw upstream ids', async () => {
   const id = storedMessageId('portable');


### PR DESCRIPTION
## Summary

- Build canonical echoes from a fresh top-level item.
- Reuse nested values that normalization leaves unchanged.
- Copy content blocks only when output-text annotations or logprobs require defaults.
- Preserve source immutability, canonical hashes, item ids, and candidate-specific rewrites.

## Performance

Measured with the 7,538,620-byte production Responses request against production state and the live Copilot upstream.

| Runtime | Main | PR | Difference |
| --- | ---: | ---: | ---: |
| workerd live heap | 61.630 MiB | 59.076 MiB | **-2.554 MiB (-4.14%)** |
| Node live heap | 118.952 MiB | 117.042 MiB | **-1.910 MiB (-1.61%)** |

Node active CPU samples differed by 0.7%, within live-path noise. GC self-time decreased from 87.5 ms to 73.7 ms; no latency improvement is claimed.

Profiling used the supported Workers DevTools heap protocol:

- https://developers.cloudflare.com/workers/observability/dev-tools/
- https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/

Raw profiles remain local because they contain production request data.

## Safety

Regression coverage verifies structural sharing for unchanged children, copy-on-write normalization for changed blocks, and source stability after rewriting.

## Test Plan

- [x] `pnpm run test` — 345 files / 4,216 tests passed
- [x] `pnpm run lint`
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
