### PR TITLE
perf(copilot): release image compression scratch state

### DIFF
--- a/packages/provider-copilot/src/interceptors/chat-completions/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/chat-completions/compress-images.ts
@@ -1,8 +1,8 @@
 import { targetSizeForResponsesChat } from '../image-size.ts';
-import type { CopilotChatCompletionsBoundaryInterceptor } from './types.ts';
+import type { ChatCompletionsBoundaryCtx, CopilotChatCompletionsBoundaryInterceptor } from './types.ts';
 import { isBase64ImageDataUrl, memoizedDataUrlCompressor } from '@floway-dev/provider';
 
-const compressInlineImages = async (ctx: Parameters<CopilotChatCompletionsBoundaryInterceptor>[0]): Promise<void> => {
+const compressInlineImages = async (ctx: ChatCompletionsBoundaryCtx): Promise<void> => {
   const targets: { url: string }[] = [];
   for (const message of ctx.payload.messages) {
     if (!Array.isArray(message.content)) continue;

--- a/packages/provider-copilot/src/interceptors/chat-completions/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/chat-completions/compress-images.ts
@@ -2,10 +2,7 @@ import { targetSizeForResponsesChat } from '../image-size.ts';
 import type { CopilotChatCompletionsBoundaryInterceptor } from './types.ts';
 import { isBase64ImageDataUrl, memoizedDataUrlCompressor } from '@floway-dev/provider';
 
-// Recompresses every inline base64 image (`data:image/*;base64,...` in an
-// `image_url` part) in the outgoing Chat Completions payload to WebP before
-// the Copilot upstream call. Remote https image references are left untouched.
-export const withInlineImagesCompressed: CopilotChatCompletionsBoundaryInterceptor = async (ctx, _request, run) => {
+const compressInlineImages = async (ctx: Parameters<CopilotChatCompletionsBoundaryInterceptor>[0]): Promise<void> => {
   const targets: { url: string }[] = [];
   for (const message of ctx.payload.messages) {
     if (!Array.isArray(message.content)) continue;
@@ -14,14 +11,23 @@ export const withInlineImagesCompressed: CopilotChatCompletionsBoundaryIntercept
     }
   }
 
-  if (targets.length > 0) {
-    const compress = memoizedDataUrlCompressor(targetSizeForResponsesChat(ctx.model.id));
-    await Promise.all(
-      targets.map(async target => {
-        target.url = await compress(target.url);
-      }),
-    );
-  }
+  if (targets.length === 0) return;
 
+  const compress = memoizedDataUrlCompressor(targetSizeForResponsesChat(ctx.model.id));
+  await Promise.all(
+    targets.map(async target => {
+      target.url = await compress(target.url);
+    }),
+  );
+};
+
+// Recompresses every inline base64 image (`data:image/*;base64,...` in an
+// `image_url` part) in the outgoing Chat Completions payload to WebP before
+// the Copilot upstream call. Remote https image references are left untouched.
+export const withInlineImagesCompressed: CopilotChatCompletionsBoundaryInterceptor = async (ctx, _request, run) => {
+  // Finish this nested activation before starting the upstream call. Its
+  // request-local memoizer keys are the full source data URLs, which can be
+  // several megabytes each and must not stay live for the response stream.
+  await compressInlineImages(ctx);
   return await run();
 };

--- a/packages/provider-copilot/src/interceptors/messages/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/messages/compress-images.ts
@@ -48,6 +48,21 @@ const collectImageBlocks = (messages: MessagesMessage[]): MessagesImageBlock[] =
   return blocks;
 };
 
+const compressInlineImages = async (ctx: MessagesBoundaryCtx | MessagesCountTokensBoundaryCtx): Promise<void> => {
+  const blocks = collectImageBlocks(ctx.payload.messages);
+  if (blocks.length === 0) return;
+
+  const caps = claudeImageCaps(ctx.model.id);
+  const targetSize: ImageSizeCalculator = source => fitWithin(source, caps);
+  const compress = memoizedBase64Compressor(targetSize);
+  await Promise.all(
+    blocks.map(async block => {
+      block.source.data = await compress(block.source.data);
+      block.source.media_type = 'image/webp';
+    }),
+  );
+};
+
 // Recompresses every inline base64 image in the outgoing Messages payload to
 // WebP before the Copilot upstream call. Generic in the run-result type so the
 // same definition serves both the streaming Messages boundary chain and the
@@ -58,18 +73,9 @@ export const withInlineImagesCompressed = async <TResult>(
   _request: object,
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
-  const blocks = collectImageBlocks(ctx.payload.messages);
-  if (blocks.length > 0) {
-    const caps = claudeImageCaps(ctx.model.id);
-    const targetSize: ImageSizeCalculator = source => fitWithin(source, caps);
-    const compress = memoizedBase64Compressor(targetSize);
-    await Promise.all(
-      blocks.map(async block => {
-        block.source.data = await compress(block.source.data);
-        block.source.media_type = 'image/webp';
-      }),
-    );
-  }
-
+  // Finish this nested activation before starting the upstream call. Its
+  // request-local memoizer keys are the full source base64 strings, which can
+  // be several megabytes each and must not stay live for the response stream.
+  await compressInlineImages(ctx);
   return await run();
 };

--- a/packages/provider-copilot/src/interceptors/responses/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images.ts
@@ -3,6 +3,28 @@ import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ResponsesInputImage } from '@floway-dev/protocols/responses';
 import { isBase64ImageDataUrl, memoizedDataUrlCompressor } from '@floway-dev/provider';
 
+const compressInlineImages = async (ctx: ResponsesBoundaryCtx): Promise<void> => {
+  const targets: Array<{ part: ResponsesInputImage; imageUrl: string }> = [];
+  for (const item of ctx.payload.input) {
+    const parts = item.type === 'message' ? item.content : item.type === 'function_call_output' ? item.output : undefined;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      if (part.type === 'input_image' && typeof part.image_url === 'string' && isBase64ImageDataUrl(part.image_url)) {
+        targets.push({ part, imageUrl: part.image_url });
+      }
+    }
+  }
+
+  if (targets.length === 0) return;
+
+  const compress = memoizedDataUrlCompressor(targetSizeForResponsesChat(ctx.model.id));
+  await Promise.all(
+    targets.map(async target => {
+      target.part.image_url = await compress(target.imageUrl);
+    }),
+  );
+};
+
 // Recompresses every inline base64 image in the outgoing Responses payload to
 // WebP before the Copilot upstream call. Images appear both as `input_image`
 // parts inside message content and inside `function_call_output` outputs
@@ -15,25 +37,9 @@ export const withInlineImagesCompressed = async <TResult>(
   _request: object,
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
-  const targets: Array<{ part: ResponsesInputImage; imageUrl: string }> = [];
-  for (const item of ctx.payload.input) {
-    const parts = item.type === 'message' ? item.content : item.type === 'function_call_output' ? item.output : undefined;
-    if (!Array.isArray(parts)) continue;
-    for (const part of parts) {
-      if (part.type === 'input_image' && typeof part.image_url === 'string' && isBase64ImageDataUrl(part.image_url)) {
-        targets.push({ part, imageUrl: part.image_url });
-      }
-    }
-  }
-
-  if (targets.length > 0) {
-    const compress = memoizedDataUrlCompressor(targetSizeForResponsesChat(ctx.model.id));
-    await Promise.all(
-      targets.map(async target => {
-        target.part.image_url = await compress(target.imageUrl);
-      }),
-    );
-  }
-
+  // Finish this nested activation before starting the upstream call. Its
+  // request-local memoizer keys are the full source data URLs, which can be
+  // several megabytes each and must not stay live for the response stream.
+  await compressInlineImages(ctx);
   return await run();
 };


### PR DESCRIPTION
## Summary

- Finish image collection, compression, and request-local memoization before entering the long-lived upstream call.
- Release full source data URLs/base64 keys, memoized promises, and compression scratch buffers while the response stream is pending.
- Apply the same lifetime boundary to Responses, Chat Completions, Messages, and Messages `count_tokens`.
- Preserve generated WebP payloads, duplicate-image deduplication, and remote image handling.

## Performance

Measured with a 7,538,620-byte production request containing four inline PNG data URLs totaling 2,862,280 characters. workerd used the Cloudflare Images binding; Node used `sharp`.

| Runtime | Main | PR | Difference |
| --- | ---: | ---: | ---: |
| workerd live heap | 61.531 MiB | 53.642 MiB | **-7.889 MiB (-12.82%)** |
| Node live heap | 119.612 MiB | 117.658 MiB | **-1.954 MiB (-1.63%)** |

The directly attributable lower bound is one released copy of each source PNG: retained source-image strings fall from 5.459 MiB to 2.730 MiB. workerd additionally releases more of the memoized promise and compression-buffer graph.

Profiling used the supported Workers DevTools heap protocol:

- https://developers.cloudflare.com/workers/observability/dev-tools/
- https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/

Raw profiles remain local because they contain production request data.

## Test Plan

- [x] `pnpm run test` — 345 files / 4,215 tests passed
- [x] `pnpm run lint`
- [x] `pnpm --filter @floway-dev/provider-copilot run typecheck`
