### PR TITLE
perf(responses): share immutable attempt leaves

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -7,6 +7,7 @@ import { rewriteResponsesPayloadForCandidate, type RewrittenResponsesPayload } f
 import type { StatefulResponsesStore } from './items/store.ts';
 import { tokenUsageFromResponsesResult } from './usage.ts';
 import { applyRulesToUpstreamResponses } from '../../model-aliases/apply-rules.ts';
+import { cloneProtocolPayload } from '../../shared/clone-protocol-payload.ts';
 import { providerStreamResultToExecuteResult, buildUpstreamCallOptions, telemetryModelIdentity, chatTargetPicker, upstreamPerformanceContext } from '../../shared/telemetry/attempt-helpers.ts';
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
@@ -74,7 +75,7 @@ export interface ResponsesAttemptInvokeArgs {
 export const responsesAttempt = {
   invoke: async (args: ResponsesAttemptInvokeArgs): Promise<ResponsesAttemptResult> => {
     const { payload: sourcePayload, action, ctx, candidate, headers: sourceHeaders } = args;
-    const payload = { ...structuredClone(sourcePayload), model: candidate.model.id };
+    const payload = { ...cloneProtocolPayload(sourcePayload), model: candidate.model.id };
     const headers = new Headers(sourceHeaders);
     const { store } = ctx;
     const targetApi = responsesTarget.pick(candidate.model.endpoints);

--- a/packages/gateway/src/data-plane/shared/clone-protocol-payload.ts
+++ b/packages/gateway/src/data-plane/shared/clone-protocol-payload.ts
@@ -1,0 +1,14 @@
+// Wire payloads are JSON-shaped trees. Mutable containers need an
+// attempt-owned copy, while immutable primitive leaves can be reused without
+// giving one candidate write access to another candidate's request. This is
+// intentionally narrower than structuredClone: callers must not pass host
+// objects or mutable binary leaves.
+export const cloneProtocolPayload = <T>(value: T): T => {
+  if (Array.isArray(value)) return value.map(cloneProtocolPayload) as T;
+  if (value === null || typeof value !== 'object') return value;
+
+  const source = value as Record<string, unknown>;
+  const cloned: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) cloned[key] = cloneProtocolPayload(source[key]);
+  return cloned as T;
+};

--- a/packages/gateway/src/data-plane/shared/clone-protocol-payload_test.ts
+++ b/packages/gateway/src/data-plane/shared/clone-protocol-payload_test.ts
@@ -1,0 +1,29 @@
+import { test } from 'vitest';
+
+import { cloneProtocolPayload } from './clone-protocol-payload.ts';
+import { assert, assertEquals } from '@floway-dev/test-utils';
+
+test('cloneProtocolPayload isolates every mutable protocol container', () => {
+  const source = {
+    input: [{ content: [{ type: 'input_text', text: 'hello' }] }],
+    metadata: { labels: ['one', 'two'] },
+    optional: undefined,
+  };
+
+  const cloned = cloneProtocolPayload(source);
+
+  assert(cloned !== source);
+  assert(cloned.input !== source.input);
+  assert(cloned.input[0] !== source.input[0]);
+  assert(cloned.input[0].content !== source.input[0].content);
+  assert(cloned.input[0].content[0] !== source.input[0].content[0]);
+  assert(cloned.metadata !== source.metadata);
+  assert(cloned.metadata.labels !== source.metadata.labels);
+
+  cloned.input[0].content[0].text = 'changed';
+  cloned.metadata.labels.push('three');
+
+  assertEquals(source.input[0].content[0].text, 'hello');
+  assertEquals(source.metadata.labels, ['one', 'two']);
+  assertEquals(Object.hasOwn(cloned, 'optional'), true);
+});


### PR DESCRIPTION
## Summary

- keep a private array/object tree for every Responses candidate attempt
- reuse immutable primitive leaves instead of asking `structuredClone` to duplicate large strings
- preserve candidate-fallback isolation while reducing the retained cost of the mandatory attempt ownership boundary

## Real production workload

- source request SHA-256: `73ef5256bc2c10fcdaed84642cdaf478c5a6810b68dae43dc5cea79937362a36`
- 7,538,620 bytes / 2,538 input items / 713 encrypted reasoning items / four inline PNG images
- fresh production D1/R2 snapshot with four production upstreams, dump disabled, HKG `proxy -> direct`, and a live Copilot call
- both main and branch runs started from fresh golden state with an empty image cache
- snapshot trigger: three seconds after the complete request body is uploaded, while the live upstream attempt is active
- Node 25.6.1; Wrangler 4.81.0; workerd 1.20260405.1

Cloudflare DevTools / Node Inspector heap snapshots:

| runtime | current main `c51bc0e87` | branch `9f198b519` | branch vs main |
| --- | ---: | ---: | ---: |
| workerd live heap self-size | 61.531 MiB | 55.062 MiB | **-6.469 MiB (-10.51%)** |
| Node live heap self-size | 119.612 MiB | 112.470 MiB | **-7.142 MiB (-5.97%)** |
| retained source PNG strings (both runtimes) | 5.459 MiB / 8 strings | 2.730 MiB / 4 strings | **-2.730 MiB (-50.0%)** |

The PNG count is a directly attributable fingerprint of primitive-leaf reuse. The remaining saving comes from other large immutable request strings, including tool definitions and encrypted content; mutable arrays and objects are still distinct.

The Node CPU profile samples `cloneProtocolPayload` at 1.505 ms self-time for the 7.54 MB request. Main's aggregate `structuredClone` self-time is 4.434 ms across its clone sites. Live TLS and upstream work make total active samples noisy, so this PR claims no aggregate latency improvement; it does show no CPU tradeoff for the memory saving.

Official profiling references:

- https://developers.cloudflare.com/workers/observability/dev-tools/
- https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/
- https://developers.cloudflare.com/workers/observability/dev-tools/cpu-usage/

Raw profiles remain local because they contain production data. Profile SHA-256s:

- workerd main/branch heap: `fc0aef69…` / `8b8a7646…`
- Node main/branch heap: `cd5d62b6…` / `5cb62d7d…`
- Node main/branch CPU: `73bf7062…` / `7712d4d2…`

## Semantics and risk

Every enumerable object and array in the wire payload is recursively copied. Only `string`, `number`, `boolean`, `null`, and `undefined` leaves are reused, and none can carry a mutation from one attempt into another. The helper is deliberately scoped to JSON-shaped protocol payloads and documents that host objects and mutable binary leaves are outside its contract.

The existing two-candidate regression still proves that a first provider mutating a nested image part cannot alter the fallback candidate or caller payload. The new focused test verifies distinct identities for every nested mutable container and source stability after mutation.

This PR is independent of the image-compression scratch-lifetime PR. Their image-string fingerprints overlap, so their total savings must be re-profiled after both land rather than added arithmetically.

## Verification

- `pnpm run test` — 346 files / 4,216 tests passed
- `pnpm run lint`
- `pnpm --filter @floway-dev/gateway run typecheck`
- `pnpm run typecheck` reaches an existing main-branch failure in `provider-codex/src/interceptors/responses/inject-default-instructions_test.ts` (two string-input fixtures no longer match canonical array input); the same command fails identically on `main`
