### PR TITLE
perf(copilot): reuse compressed images across retries

### DIFF
--- a/packages/provider-copilot/src/interceptors/responses/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images.ts
@@ -3,6 +3,9 @@ import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ResponsesInputImage } from '@floway-dev/protocols/responses';
 import { isBase64ImageDataUrl, memoizedDataUrlCompressor } from '@floway-dev/provider';
 
+const compressedImageUrl = Symbol('compressedImageUrl');
+type CompressibleImagePart = ResponsesInputImage & { [compressedImageUrl]?: string };
+
 // Recompresses every inline base64 image in the outgoing Responses payload to
 // WebP before the Copilot upstream call. Images appear both as `input_image`
 // parts inside message content and inside `function_call_output` outputs
@@ -15,12 +18,17 @@ export const withInlineImagesCompressed = async <TResult>(
   _request: object,
   run: () => Promise<TResult>,
 ): Promise<TResult> => {
-  const targets: Array<{ part: ResponsesInputImage; imageUrl: string }> = [];
+  const targets: Array<{ part: CompressibleImagePart; imageUrl: string }> = [];
   for (const item of ctx.payload.input) {
     const parts = item.type === 'message' ? item.content : item.type === 'function_call_output' ? item.output : undefined;
     if (!Array.isArray(parts)) continue;
     for (const part of parts) {
-      if (part.type === 'input_image' && typeof part.image_url === 'string' && isBase64ImageDataUrl(part.image_url)) {
+      if (
+        part.type === 'input_image'
+        && typeof part.image_url === 'string'
+        && part[compressedImageUrl] !== part.image_url
+        && isBase64ImageDataUrl(part.image_url)
+      ) {
         targets.push({ part, imageUrl: part.image_url });
       }
     }
@@ -31,6 +39,11 @@ export const withInlineImagesCompressed = async <TResult>(
     await Promise.all(
       targets.map(async target => {
         target.part.image_url = await compress(target.imageUrl);
+        Object.defineProperty(target.part, compressedImageUrl, {
+          configurable: true,
+          value: target.part.image_url,
+          writable: true,
+        });
       }),
     );
   }

--- a/packages/provider-copilot/src/interceptors/responses/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images.ts
@@ -9,7 +9,7 @@ import { isBase64ImageDataUrl, memoizedDataUrlCompressor } from '@floway-dev/pro
 // for our output. The non-enumerable property stays off the wire and does not
 // cross an object-spread/JSON ownership boundary.
 const compressedImageUrl = Symbol('compressedImageUrl');
-type CompressibleImagePart = ResponsesInputImage & { [compressedImageUrl]?: string };
+type CompressibleImagePart = ResponsesInputImage & { image_url: string; [compressedImageUrl]?: string };
 
 // Recompresses every inline base64 image in the outgoing Responses payload to
 // WebP before the Copilot upstream call. Images appear both as `input_image`

--- a/packages/provider-copilot/src/interceptors/responses/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images.ts
@@ -28,14 +28,10 @@ export const withInlineImagesCompressed = async <TResult>(
     const parts = item.type === 'message' ? item.content : item.type === 'function_call_output' ? item.output : undefined;
     if (!Array.isArray(parts)) continue;
     for (const part of parts) {
-      if (
-        part.type === 'input_image'
-        && typeof part.image_url === 'string'
-        && part[compressedImageUrl] !== part.image_url
-        && isBase64ImageDataUrl(part.image_url)
-      ) {
-        targets.push({ part, imageUrl: part.image_url });
-      }
+      if (part.type !== 'input_image' || typeof part.image_url !== 'string') continue;
+      const imagePart = part as CompressibleImagePart;
+      if (imagePart[compressedImageUrl] === imagePart.image_url || !isBase64ImageDataUrl(imagePart.image_url)) continue;
+      targets.push({ part: imagePart, imageUrl: imagePart.image_url });
     }
   }
 

--- a/packages/provider-copilot/src/interceptors/responses/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images.ts
@@ -3,6 +3,11 @@ import type { ResponsesBoundaryCtx } from './types.ts';
 import type { ResponsesInputImage } from '@floway-dev/protocols/responses';
 import { isBase64ImageDataUrl, memoizedDataUrlCompressor } from '@floway-dev/provider';
 
+// A cyber-policy retry re-enters this boundary with the same nested image
+// part. Remember the exact generated URL on that request-owned object so the
+// retry neither re-encodes a lossy WebP nor mistakes an unrelated client WebP
+// for our output. The non-enumerable property stays off the wire and does not
+// cross an object-spread/JSON ownership boundary.
 const compressedImageUrl = Symbol('compressedImageUrl');
 type CompressibleImagePart = ResponsesInputImage & { [compressedImageUrl]?: string };
 

--- a/packages/provider-copilot/src/interceptors/responses/compress-images_test.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images_test.ts
@@ -134,3 +134,35 @@ test('compresses each unique inline image only once when the same data URL appea
   // Two unique data URLs across four targets → exactly two compress calls.
   assertEquals(calls, 2);
 });
+
+test('reuses its compressed image when the same attempt payload is retried', async () => {
+  let calls = 0;
+  initImageProcessor({
+    compressToWebp: () => {
+      calls += 1;
+      return Promise.resolve(new Uint8Array([1, 2, 3]));
+    },
+  });
+
+  const ctx = invocation({
+    model: 'gpt-test',
+    input: [{
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_image', image_url: 'data:image/png;base64,AAAA', detail: 'auto' }],
+    }],
+  });
+
+  await withInlineImagesCompressed(ctx, stubRequest, okEvents);
+  await withInlineImagesCompressed(ctx, stubRequest, okEvents);
+
+  assertEquals(calls, 1);
+  assertEquals(firstImageUrl(ctx.payload), 'data:image/webp;base64,AQID');
+
+  const item = ctx.payload.input[0];
+  if (item.type !== 'message' || !Array.isArray(item.content) || item.content[0]?.type !== 'input_image') throw new Error('expected image content');
+  item.content[0].image_url = 'data:image/png;base64,BBBB';
+  await withInlineImagesCompressed(ctx, stubRequest, okEvents);
+
+  assertEquals(calls, 2);
+});


### PR DESCRIPTION
## Summary

- Record the exact generated WebP on each request-owned Responses image part.
- Reuse that image when a cyber-policy retry re-enters the boundary with the same part and URL.
- Continue compressing client-supplied WebP and any URL changed after the first pass.
- Keep the marker non-enumerable so it is absent from JSON, object spread, and new candidate ownership boundaries.

## Performance

Measured by running the real Copilot image boundary twice over a 7,538,620-byte production request containing four production PNGs.

| Runtime | Main retry pass | PR retry pass | Difference |
| --- | ---: | ---: | ---: |
| Node / `sharp` | 40.94 ms | 0.212 ms | **-99.48%** |
| workerd / Cloudflare Images | 46 ms | <1 ms | second encode eliminated |

The first pass is unchanged. Main's second lossy encode also produced different WebP bytes; this PR sends the exact first-pass images again. Normal one-pass heap profiles show no attributable memory cost.

Profiling used the supported Workers DevTools heap/CPU protocol:

- https://developers.cloudflare.com/workers/observability/dev-tools/
- https://developers.cloudflare.com/workers/observability/dev-tools/cpu-usage/
- https://developers.cloudflare.com/workers/observability/dev-tools/memory-usage/

Raw profiles remain local because they contain production request data.

## Safety

The marker value is the generated URL itself, so a changed URL invalidates the match. Regression coverage invokes the boundary twice, verifies one processor call, then changes the URL and verifies compression runs again.

## Test Plan

- [x] `pnpm run test` — 345 files / 4,216 tests passed
- [x] `pnpm run lint`
- [x] `pnpm --filter @floway-dev/provider-copilot run typecheck`
- [x] Combined #217/#219 conflict resolution passed the full 348-file integration suite before finalization
