### PR TITLE
feat(proxy): add direct TCP egress transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,9 +152,10 @@ Dependency direction is strict. The leaf-most packages are `protocols`,
 `interceptor`, and `http` (HTTP/1.1 over a duplex byte stream + userspace
 TLS + WebSocket upgrade, no runtime dependencies). `translate` depends on
 `protocols`. `proxy` depends on `http`; it parses subscription-style
-proxy URIs, dispatches to per-protocol byte-stream dialers, and exposes a
-`runProxiedRequest` orchestrator that composes dial → optional userspace
-TLS → fetch-on-stream. All dialers — including `vless-ws`, which layers
+proxy URIs, dispatches to per-protocol byte-stream dialers, and exposes
+request runners for both proxy-backed and direct TCP streams. Both compose
+dial → optional userspace TLS → fetch-on-stream. All dialers — including
+`vless-ws`, which layers
 `wsUpgradeAndFrame` over the runtime's TLS-wrapped duplex — stay
 runtime-agnostic by taking the raw TCP `socketDial` primitive through
 `DialOptions`, so they never import `@floway-dev/platform`. `provider`

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ passwordless logins.
 
 Optionally set `RUNTIME_LOCATION=<tag>` to label this instance in the
 performance telemetry's `runtimeLocation` dimension and as the dial-time
-key for the egress fallback list's per-instance colo whitelist. The value
+key for the egress route list's per-instance colo whitelist. The value
 is uppercased on read so `local`, `Local`, and `LOCAL` all match the
 dashboard's uppercased whitelist input; defaults to `LOCAL` when unset.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ passwordless logins.
 
 Optionally set `RUNTIME_LOCATION=<tag>` to label this instance in the
 performance telemetry's `runtimeLocation` dimension and as the dial-time
-key for the egress route list's per-instance colo whitelist. The value
+key for the proxy fallback list's per-instance colo whitelist. The value
 is uppercased on read so `local`, `Local`, and `LOCAL` all match the
 dashboard's uppercased whitelist input; defaults to `LOCAL` when unset.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ passwordless logins.
 
 Optionally set `RUNTIME_LOCATION=<tag>` to label this instance in the
 performance telemetry's `runtimeLocation` dimension and as the dial-time
-key for the proxy fallback list's per-instance colo whitelist. The value
+key for the egress fallback list's per-instance colo whitelist. The value
 is uppercased on read so `local`, `Local`, and `LOCAL` all match the
 dashboard's uppercased whitelist input; defaults to `LOCAL` when unset.
 

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -267,7 +267,7 @@ interface UpstreamRecordBase {
   // unroutable, but their per-model metadata stays editable. May include ids no
   // longer present in the live model list.
   disabled_public_model_ids: string[];
-  // Ordered egress fallback list. Each entry pins a proxy id or one of the
+  // Ordered egress routes. Each entry pins a proxy id or one of the
   // built-in direct transports (`direct_fetch`, `direct_connect`), plus an
   // optional `colos` whitelist that scopes it to location tags (Cloudflare
   // colos / the Node `RUNTIME_LOCATION` env var). Empty/missing whitelist

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -267,7 +267,7 @@ interface UpstreamRecordBase {
   // unroutable, but their per-model metadata stays editable. May include ids no
   // longer present in the live model list.
   disabled_public_model_ids: string[];
-  // Ordered egress routes. Each entry pins a proxy id or one of the
+  // Ordered proxy fallback list. Each entry pins a proxy id or one of the
   // built-in direct transports (`direct_fetch`, `direct_connect`), plus an
   // optional `colos` whitelist that scopes it to location tags (Cloudflare
   // colos / the Node `RUNTIME_LOCATION` env var). Empty/missing whitelist

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -267,11 +267,12 @@ interface UpstreamRecordBase {
   // unroutable, but their per-model metadata stays editable. May include ids no
   // longer present in the live model list.
   disabled_public_model_ids: string[];
-  // Ordered fallback dial-list. Each entry pins a proxy id (or the literal
-  // string `'direct'` for "no proxy") and an optional `colos` whitelist that
-  // scopes the entry to specific location tags (Cloudflare colos / the Node
-  // `RUNTIME_LOCATION` env var). Empty/missing whitelist means "active in
-  // all locations". Empty top-level list means "always direct".
+  // Ordered egress fallback list. Each entry pins a proxy id or one of the
+  // built-in direct transports (`direct_fetch`, `direct_connect`), plus an
+  // optional `colos` whitelist that scopes it to location tags (Cloudflare
+  // colos / the Node `RUNTIME_LOCATION` env var). Empty/missing whitelist
+  // means "active in all locations". Empty top-level list defaults to
+  // `direct_fetch`.
   proxy_fallback_list: ProxyFallbackEntry[];
   // Per-upstream model name prefix. When set, this upstream's models can be
   // addressed in two forms (`unprefixed` and `prefixed`) and listed in either

--- a/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
+++ b/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
@@ -12,8 +12,8 @@ import { formatCountdown } from '../../utils/format-countdown.ts';
 import { Sortable, TagCombobox, Tooltip } from '@floway-dev/ui';
 
 const BUILT_IN_TRANSPORTS = [
-  { id: 'direct_fetch', label: 'Direct · fetch()', title: 'Runtime-native fetch with automatic HTTP handling' },
-  { id: 'direct_connect', label: 'Direct · connect()', title: 'Raw TCP socket with userspace TLS and HTTP/1.1' },
+  { id: 'direct_fetch', label: 'DIRECT fetch()', title: 'Runtime-native fetch with automatic HTTP handling' },
+  { id: 'direct_connect', label: 'DIRECT connect()', title: 'Raw TCP socket with userspace TLS and HTTP/1.1' },
 ] as const;
 
 const isBuiltInTransport = (id: string): boolean => BUILT_IN_TRANSPORTS.some(transport => transport.id === id);
@@ -177,7 +177,7 @@ const toggleCurrentColoAt = (index: number) => {
     </p>
 
     <div v-if="list.length === 0" class="rounded-md border border-dashed border-white/[0.08] bg-surface-900/40 px-3 py-2.5 text-xs text-gray-500">
-      No fallback list configured — defaults to Direct · fetch().
+      No fallback list configured — defaults to DIRECT fetch().
     </div>
 
     <Sortable

--- a/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
+++ b/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
@@ -11,7 +11,12 @@ import { useProxiesStore } from '../../composables/useProxies.ts';
 import { formatCountdown } from '../../utils/format-countdown.ts';
 import { Sortable, TagCombobox, Tooltip } from '@floway-dev/ui';
 
-const DIRECT = 'direct';
+const BUILT_IN_TRANSPORTS = [
+  { id: 'direct_fetch', label: 'Direct · fetch()', title: 'Runtime-native fetch with automatic HTTP handling' },
+  { id: 'direct_connect', label: 'Direct · connect()', title: 'Raw TCP socket with userspace TLS and HTTP/1.1' },
+] as const;
+
+const isBuiltInTransport = (id: string): boolean => BUILT_IN_TRANSPORTS.some(transport => transport.id === id);
 
 // Common CF colos for the combobox suggestion list. Not exhaustive — the
 // editor still accepts free-form codes (Node RUNTIME_LOCATION tags can be
@@ -50,10 +55,14 @@ const proxiesNotInList = computed<ProxyRecord[]>(() => {
   return (proxies.value ?? []).filter(p => !used.has(p.id));
 });
 
-const directInList = computed(() => list.value.some(e => e.id === DIRECT));
+const builtInTransportsNotInList = computed(() => {
+  const used = new Set(list.value.map(entry => entry.id));
+  return BUILT_IN_TRANSPORTS.filter(transport => !used.has(transport.id));
+});
 
 const labelFor = (entry: ProxyFallbackEntry): string => {
-  if (entry.id === DIRECT) return 'direct';
+  const builtIn = BUILT_IN_TRANSPORTS.find(transport => transport.id === entry.id);
+  if (builtIn) return builtIn.label;
   return proxiesById.value.get(entry.id)!.name;
 };
 
@@ -63,7 +72,7 @@ const labelFor = (entry: ProxyFallbackEntry): string => {
 // remove them in one click instead of silently masquerading as a normal
 // entry whose label happens to be a UUID.
 const isOrphan = (entry: ProxyFallbackEntry): boolean =>
-  entry.id !== DIRECT && !proxiesById.value.has(entry.id);
+  !isBuiltInTransport(entry.id) && !proxiesById.value.has(entry.id);
 
 const now = useNow({ interval: 1000 });
 
@@ -78,7 +87,7 @@ const activeBackoffByEntry = computed<Map<string, ActiveBackoff>>(() => {
   const map = new Map<string, ActiveBackoff>();
   const nowSec = Math.floor(now.value.getTime() / 1000);
   for (const entry of list.value) {
-    if (entry.id === DIRECT) continue;
+    if (isBuiltInTransport(entry.id)) continue;
     const rows = backoffsByProxyId.value.get(entry.id);
     // `>=` keeps the entry's badge visible during its expiry second so the
     // countdown's `now` edge label is reachable; a strict `>` would hide it
@@ -161,14 +170,14 @@ const toggleCurrentColoAt = (index: number) => {
 <template>
   <section>
     <p class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
-      Proxy Fallback List <span class="text-accent-cyan">({{ list.length }})</span>
+      Egress Fallback List <span class="text-accent-cyan">({{ list.length }})</span>
       <span v-if="coloAware && currentColo" class="ml-2 font-mono text-gray-500">
         · this colo = <span class="text-accent-cyan">{{ currentColo }}</span>
       </span>
     </p>
 
     <div v-if="list.length === 0" class="rounded-md border border-dashed border-white/[0.08] bg-surface-900/40 px-3 py-2.5 text-xs text-gray-500">
-      No fallback list configured — defaults to direct.
+      No fallback list configured — defaults to Direct · fetch().
     </div>
 
     <Sortable
@@ -194,9 +203,9 @@ const toggleCurrentColoAt = (index: number) => {
             <span
               class="min-w-0 truncate"
               :class="[
-                entry.id === DIRECT ? 'font-mono text-gray-300' : (isOrphan(entry) ? 'font-mono text-accent-rose' : 'text-white'),
+                isBuiltInTransport(entry.id) ? 'font-mono text-gray-300' : (isOrphan(entry) ? 'font-mono text-accent-rose' : 'text-white'),
               ]"
-              :title="entry.id === DIRECT ? 'No proxy — connect directly' : entry.id"
+              :title="BUILT_IN_TRANSPORTS.find(transport => transport.id === entry.id)?.title ?? entry.id"
             >
               <template v-if="isOrphan(entry)">Unknown proxy · {{ entry.id }}</template>
               <template v-else>{{ labelFor(entry) }}</template>
@@ -334,7 +343,7 @@ const toggleCurrentColoAt = (index: number) => {
         <DropdownMenuTrigger
           class="inline-flex h-9 w-full items-center justify-between rounded-[10px] border border-white/[0.06] bg-surface-700 px-3 text-sm text-gray-300 transition-colors hover:border-white/[0.1] focus:border-accent-cyan/50 focus:outline-none focus:ring-1 focus:ring-accent-cyan/30"
         >
-          <span>+ Add proxy</span>
+          <span>+ Add fallback</span>
           <svg class="size-4 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25">
             <path d="m6 9 6 6 6-6" />
           </svg>
@@ -346,11 +355,13 @@ const toggleCurrentColoAt = (index: number) => {
             class="z-50 w-[var(--reka-dropdown-menu-trigger-width)] min-w-[8rem] overflow-hidden rounded-[10px] border border-white/[0.06] bg-surface-800 p-1 text-white shadow-xl"
           >
             <DropdownMenuItem
-              v-if="!directInList"
+              v-for="transport in builtInTransportsNotInList"
+              :key="transport.id"
               class="flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 font-mono text-sm text-gray-300 outline-none data-[highlighted]:bg-accent-cyan/10 data-[highlighted]:text-accent-cyan"
-              @select="append(DIRECT)"
+              :title="transport.title"
+              @select="append(transport.id)"
             >
-              direct
+              {{ transport.label }}
             </DropdownMenuItem>
             <DropdownMenuItem
               v-for="p in proxiesNotInList"

--- a/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
+++ b/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
@@ -170,14 +170,14 @@ const toggleCurrentColoAt = (index: number) => {
 <template>
   <section>
     <p class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
-      Egress Fallback List <span class="text-accent-cyan">({{ list.length }})</span>
+      Egress Routes <span class="text-accent-cyan">({{ list.length }})</span>
       <span v-if="coloAware && currentColo" class="ml-2 font-mono text-gray-500">
         · this colo = <span class="text-accent-cyan">{{ currentColo }}</span>
       </span>
     </p>
 
     <div v-if="list.length === 0" class="rounded-md border border-dashed border-white/[0.08] bg-surface-900/40 px-3 py-2.5 text-xs text-gray-500">
-      No fallback list configured — defaults to DIRECT fetch().
+      No egress routes configured — defaults to DIRECT fetch().
     </div>
 
     <Sortable
@@ -343,7 +343,7 @@ const toggleCurrentColoAt = (index: number) => {
         <DropdownMenuTrigger
           class="inline-flex h-9 w-full items-center justify-between rounded-[10px] border border-white/[0.06] bg-surface-700 px-3 text-sm text-gray-300 transition-colors hover:border-white/[0.1] focus:border-accent-cyan/50 focus:outline-none focus:ring-1 focus:ring-accent-cyan/30"
         >
-          <span>+ Add fallback</span>
+          <span>+ Add route</span>
           <svg class="size-4 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25">
             <path d="m6 9 6 6 6-6" />
           </svg>
@@ -375,7 +375,7 @@ const toggleCurrentColoAt = (index: number) => {
               v-if="proxiesNotInList.length === 0 && builtInTransportsNotInList.length === 0"
               class="px-2 py-1.5 text-xs text-gray-500"
             >
-              All fallbacks already added.
+              All routes already added.
             </p>
           </DropdownMenuContent>
         </DropdownMenuPortal>

--- a/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
+++ b/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
@@ -170,14 +170,14 @@ const toggleCurrentColoAt = (index: number) => {
 <template>
   <section>
     <p class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
-      Egress Routes <span class="text-accent-cyan">({{ list.length }})</span>
+      Proxy Fallback List <span class="text-accent-cyan">({{ list.length }})</span>
       <span v-if="coloAware && currentColo" class="ml-2 font-mono text-gray-500">
         · this colo = <span class="text-accent-cyan">{{ currentColo }}</span>
       </span>
     </p>
 
     <div v-if="list.length === 0" class="rounded-md border border-dashed border-white/[0.08] bg-surface-900/40 px-3 py-2.5 text-xs text-gray-500">
-      No egress routes configured — defaults to DIRECT fetch().
+      No fallback list configured — defaults to DIRECT fetch().
     </div>
 
     <Sortable
@@ -343,7 +343,7 @@ const toggleCurrentColoAt = (index: number) => {
         <DropdownMenuTrigger
           class="inline-flex h-9 w-full items-center justify-between rounded-[10px] border border-white/[0.06] bg-surface-700 px-3 text-sm text-gray-300 transition-colors hover:border-white/[0.1] focus:border-accent-cyan/50 focus:outline-none focus:ring-1 focus:ring-accent-cyan/30"
         >
-          <span>+ Add route</span>
+          <span>+ Add entry</span>
           <svg class="size-4 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25">
             <path d="m6 9 6 6 6-6" />
           </svg>
@@ -375,7 +375,7 @@ const toggleCurrentColoAt = (index: number) => {
               v-if="proxiesNotInList.length === 0 && builtInTransportsNotInList.length === 0"
               class="px-2 py-1.5 text-xs text-gray-500"
             >
-              All routes already added.
+              All entries already added.
             </p>
           </DropdownMenuContent>
         </DropdownMenuPortal>

--- a/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
+++ b/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
@@ -372,10 +372,10 @@ const toggleCurrentColoAt = (index: number) => {
               {{ p.name }}
             </DropdownMenuItem>
             <p
-              v-if="proxiesNotInList.length === 0 && directInList"
+              v-if="proxiesNotInList.length === 0 && builtInTransportsNotInList.length === 0"
               class="px-2 py-1.5 text-xs text-gray-500"
             >
-              All proxies already added.
+              All fallbacks already added.
             </p>
           </DropdownMenuContent>
         </DropdownMenuPortal>

--- a/packages/gateway/migrations/0055_direct_transport_fallbacks.sql
+++ b/packages/gateway/migrations/0055_direct_transport_fallbacks.sql
@@ -1,0 +1,18 @@
+-- The former direct sentinel meant runtime-native fetch. Name that transport
+-- explicitly so direct TCP can coexist in the same ordered fallback list.
+UPDATE upstreams
+SET proxy_fallback_list_json = (
+  SELECT json_group_array(json(
+    CASE
+      WHEN json_extract(entry.value, '$.id') = 'direct'
+        THEN json_set(entry.value, '$.id', 'direct_fetch')
+      ELSE entry.value
+    END
+  ))
+  FROM json_each(upstreams.proxy_fallback_list_json) AS entry
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM json_each(upstreams.proxy_fallback_list_json) AS entry
+  WHERE json_extract(entry.value, '$.id') = 'direct'
+);

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -19,7 +19,7 @@ import { getDumpStore, notifyDisabledBestEffort } from '../../dump/registry.ts';
 import { type CtxWithJson, type CtxWithQuery } from '../../middleware/zod-validator.ts';
 import { parseDisabledPublicModelIdsWire } from '../../repo/disabled-public-models.ts';
 import { getRepo } from '../../repo/index.ts';
-import { DIRECT_PROXY_ID, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
+import { DIRECT_FALLBACK_IDS, isDirectFallbackId, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
 import type { ApiKey, PerformanceBucketRow, PerformanceMetric, PerformanceTelemetryRecord, SearchUsageRecord, TokenUsage, UsageRecord, User } from '../../repo/types.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getRuntimeLocation } from '../../runtime/runtime-info.ts';
@@ -199,7 +199,7 @@ const parseProxyRecords = (value: unknown): { type: 'ok'; records: SerializedPro
       const item = value[i];
       if (!isRecord(item)) throw new Error('record must be an object');
       const id = nonEmptyString(item.id, 'id');
-      if (id === DIRECT_PROXY_ID) throw new Error(`id must not be the reserved '${DIRECT_PROXY_ID}' sentinel`);
+      if (isDirectFallbackId(id)) throw new Error(`id must not be a reserved direct-transport sentinel`);
       const name = nonEmptyString(item.name, 'name');
       const url = nonEmptyString(item.url, 'url');
       try {
@@ -233,9 +233,9 @@ const validateProxyIdentities = (records: readonly SerializedProxy[]): string | 
 // Every entry in every upstream's proxy_fallback_list must resolve to a proxy
 // id that will exist after the import completes — that is, an imported proxy,
 // an existing local proxy (merge mode only; replace mode wipes them first),
-// or the 'direct' sentinel. A dangling reference would silently disable that
-// fallback in the dial layer, which is exactly the silent-truncation
-// behavior the import contract is supposed to prevent.
+// or one of the built-in direct transports. A dangling reference would
+// silently disable that fallback in the dial layer, which is exactly the
+// silent-truncation behavior the import contract is supposed to prevent.
 const validateProxyFallbackReferences = (
   upstreams: readonly UpstreamRecord[],
   proxies: readonly SerializedProxy[],
@@ -243,7 +243,7 @@ const validateProxyFallbackReferences = (
 ): string | null => {
   const knownIds = new Set<string>(proxies.map(p => p.id));
   for (const id of existingProxyIds) knownIds.add(id);
-  knownIds.add(DIRECT_PROXY_ID);
+  for (const id of DIRECT_FALLBACK_IDS) knownIds.add(id);
   for (const upstream of upstreams) {
     for (const ref of upstream.proxyFallbackList) {
       if (!knownIds.has(ref.id)) {

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -199,7 +199,7 @@ const parseProxyRecords = (value: unknown): { type: 'ok'; records: SerializedPro
       const item = value[i];
       if (!isRecord(item)) throw new Error('record must be an object');
       const id = nonEmptyString(item.id, 'id');
-      if (isDirectFallbackId(id)) throw new Error(`id must not be a reserved direct-transport sentinel`);
+      if (isDirectFallbackId(id)) throw new Error('id must not be a reserved direct-transport sentinel');
       const name = nonEmptyString(item.name, 'name');
       const url = nonEmptyString(item.url, 'url');
       try {

--- a/packages/gateway/src/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes_test.ts
@@ -919,7 +919,7 @@ test('export includes proxies with full credential URIs and round-trips through 
   const { app, repo } = setup();
   await repo.proxies.save({ id: 'p_socks', name: 'SOCKS', url: SOCKS_PROXY_URL, dialTimeoutSeconds: 45 });
   await repo.proxies.save({ id: 'p_http', name: 'HTTP', url: HTTP_PROXY_URL, dialTimeoutSeconds: null });
-  const upstreamWithFallback: UpstreamRecord = { ...CUSTOM_UPSTREAM, proxyFallbackList: [{ id: 'p_socks' }, { id: 'p_http' }, { id: 'direct' }] };
+  const upstreamWithFallback: UpstreamRecord = { ...CUSTOM_UPSTREAM, proxyFallbackList: [{ id: 'p_socks' }, { id: 'direct_connect' }, { id: 'p_http' }, { id: 'direct_fetch' }] };
   await repo.upstreams.save(upstreamWithFallback);
 
   const exported = await doExport(app);
@@ -944,7 +944,18 @@ test('export includes proxies with full credential URIs and round-trips through 
   ]);
 
   const restoredUpstream = await fresh.upstreams.getById(upstreamWithFallback.id);
-  assertEquals(restoredUpstream?.proxyFallbackList, [{ id: 'p_socks' }, { id: 'p_http' }, { id: 'direct' }]);
+  assertEquals(restoredUpstream?.proxyFallbackList, [{ id: 'p_socks' }, { id: 'direct_connect' }, { id: 'p_http' }, { id: 'direct_fetch' }]);
+});
+
+test('import rejects proxy rows that collide with built-in direct transports', async () => {
+  const { app } = setup();
+
+  const result = await doImport(app, 'replace', latestImportData({
+    proxies: [{ id: 'direct_connect', name: 'Collision', url: HTTP_PROXY_URL, dial_timeout_seconds: null }],
+  }));
+
+  assertEquals(result.status, 400);
+  assertEquals(String(result.body.error).includes('reserved direct-transport sentinel'), true);
 });
 
 test('import in replace mode rejects an upstream fallback reference that does not resolve to an imported proxy', async () => {
@@ -952,7 +963,7 @@ test('import in replace mode rejects an upstream fallback reference that does no
   await repo.upstreams.save(CUSTOM_UPSTREAM);
 
   const result = await doImport(app, 'replace', latestImportData({
-    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), proxy_fallback_list: [{ id: 'p_missing' }, { id: 'direct' }] }],
+    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), proxy_fallback_list: [{ id: 'p_missing' }, { id: 'direct_fetch' }] }],
     proxies: [],
   }));
 
@@ -970,14 +981,14 @@ test('import in merge mode accepts an upstream fallback reference that resolves 
   // local proxies table, so this is a legitimate reference that must not be
   // rejected as dangling.
   const result = await doImport(app, 'merge', latestImportData({
-    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), proxy_fallback_list: [{ id: 'p_local' }, { id: 'direct' }] }],
+    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), proxy_fallback_list: [{ id: 'p_local' }, { id: 'direct_fetch' }] }],
     proxies: [],
   }));
 
   assertEquals(result.status, 200);
   assertEquals(result.body.imported.upstreams, 1);
   const restored = await repo.upstreams.getById(CUSTOM_UPSTREAM.id);
-  assertEquals(restored?.proxyFallbackList, [{ id: 'p_local' }, { id: 'direct' }]);
+  assertEquals(restored?.proxyFallbackList, [{ id: 'p_local' }, { id: 'direct_fetch' }]);
 });
 
 test('import in merge mode rejects an upstream fallback reference that resolves to neither an imported nor an existing proxy', async () => {

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -265,8 +265,8 @@ export const updateKeyBody = z.object({
 // --- upstreams ---
 
 // Per-upstream proxy fallback list. Each entry is an object with a required
-// `id` (a proxy id known to the proxies repo, or the literal `'direct'`
-// sentinel meaning "dial without a proxy") and an optional `colos` whitelist
+// `id` (a proxy id known to the proxies repo, or a built-in direct transport)
+// and an optional `colos` whitelist
 // of location tags (Cloudflare colos / the Node `RUNTIME_LOCATION` env
 // var). `colos` is intentionally not cross-checked against a known-colo list
 // — Node `RUNTIME_LOCATION` is free-form and CF adds new colos we haven't

--- a/packages/gateway/src/control-plane/upstreams/proxy-resolution.ts
+++ b/packages/gateway/src/control-plane/upstreams/proxy-resolution.ts
@@ -1,10 +1,10 @@
 import { createFetcher, type ProxyEntry } from '../../dial/fetcher.ts';
 import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import { getRepo } from '../../repo/index.ts';
-import { DIRECT_PROXY_ID, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
+import { DIRECT_CONNECT_ID, isDirectFallbackId, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
 import { getSocketDial } from '@floway-dev/platform';
 import { directFetcher, type Fetcher, type ProxyFallbackEntry } from '@floway-dev/provider';
-import { parseProxyUri, type ProxyUriError, runProxiedRequest } from '@floway-dev/proxy';
+import { parseProxyUri, type ProxyUriError, runDirectConnectRequest, runProxiedRequest } from '@floway-dev/proxy';
 
 // Fetcher resolution for control-plane operations that fire from the
 // dashboard edit form, where the in-progress proxy_fallback_list must take
@@ -31,8 +31,8 @@ const buildOverrideFetcher = async (
   runtimeLocation: string,
 ): Promise<Fetcher> => {
   const list = normalizeProxyFallbackList(rawList);
-  const referenced = new Set(list.filter(entry => entry.id !== DIRECT_PROXY_ID).map(entry => entry.id));
-  if (referenced.size === 0) {
+  const referenced = new Set(list.filter(entry => !isDirectFallbackId(entry.id)).map(entry => entry.id));
+  if (referenced.size === 0 && !list.some(entry => entry.id === DIRECT_CONNECT_ID)) {
     return directFetcher;
   }
 
@@ -52,7 +52,7 @@ const buildOverrideFetcher = async (
     }
   }
 
-  const unknown = list.find(entry => entry.id !== DIRECT_PROXY_ID && !proxyById.has(entry.id) && !parseErrors.has(entry.id));
+  const unknown = list.find(entry => !isDirectFallbackId(entry.id) && !proxyById.has(entry.id) && !parseErrors.has(entry.id));
   if (unknown !== undefined) {
     throw new Error(`unknown proxy id in fallback list: ${unknown.id}`);
   }
@@ -69,7 +69,8 @@ const buildOverrideFetcher = async (
     runtimeLocation,
     proxyById,
     runProxied: runProxiedRequest,
-    runDirect: directFetcher,
+    runDirectFetch: directFetcher,
+    runDirectConnect: runDirectConnectRequest,
     socketDial: getSocketDial,
   });
 };

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -9,7 +9,7 @@ import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import { type AuthedContext, userFromContext } from '../../middleware/auth.ts';
 import { type CtxWithJson } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
-import { DIRECT_PROXY_ID, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
+import { isDirectFallbackId, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getRuntimeLocation } from '../../runtime/runtime-info.ts';
 import { shortId } from '../../shared/short-id.ts';
@@ -188,12 +188,11 @@ const warmModelsCache = async (record: UpstreamRecord, c: Context): Promise<void
   }
 };
 
-// 'direct' is always a valid entry id; any other id must reference an
-// existing proxy row. List order matters at dial time (see createFetcher),
-// and persistence layers dedupe via normalizeProxyFallbackList before
-// storing.
+// Built-in direct transports are always valid entry ids; every other id must
+// reference an existing proxy row. List order matters at dial time (see
+// createFetcher), and persistence layers dedupe before storing.
 const validateProxyFallbackList = async (entries: readonly ProxyFallbackEntry[]): Promise<{ ok: true } | { ok: false; error: string }> => {
-  const ids = entries.map(e => e.id).filter(id => id !== DIRECT_PROXY_ID);
+  const ids = entries.map(e => e.id).filter(id => !isDirectFallbackId(id));
   if (ids.length === 0) return { ok: true };
   const proxies = await getRepo().proxies.list();
   const known = new Set(proxies.map(p => p.id));

--- a/packages/gateway/src/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes_test.ts
@@ -1305,14 +1305,14 @@ test('POST /api/upstreams accepts proxy_fallback_list and surfaces it in the res
 
   const resp = await requestApp(
     '/api/upstreams',
-    authed(adminSession, createBody({ proxy_fallback_list: [{ id: 'p_fallback' }, { id: 'direct' }] })),
+    authed(adminSession, createBody({ proxy_fallback_list: [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }] })),
   );
   assertEquals(resp.status, 201);
   const created = (await resp.json()) as JsonObject;
-  assertEquals(created.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct' }]);
+  assertEquals(created.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }]);
 
   const stored = await repo.upstreams.getById(created.id);
-  assertEquals(stored?.proxyFallbackList, [{ id: 'p_fallback' }, { id: 'direct' }]);
+  assertEquals(stored?.proxyFallbackList, [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }]);
 });
 
 test('POST /api/upstreams normalises proxy_fallback_list duplicates so the response matches what GET returns', async () => {
@@ -1322,19 +1322,19 @@ test('POST /api/upstreams normalises proxy_fallback_list duplicates so the respo
 
   const resp = await requestApp(
     '/api/upstreams',
-    authed(adminSession, createBody({ proxy_fallback_list: [{ id: 'p_fallback' }, { id: 'direct' }, { id: 'p_fallback' }, { id: 'direct' }] })),
+    authed(adminSession, createBody({ proxy_fallback_list: [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }, { id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }] })),
   );
   assertEquals(resp.status, 201);
   const created = (await resp.json()) as JsonObject;
   // Without the API-layer normalize, the response would echo the duplicates
   // while the saved row only kept one of each — operators would see a
   // different list on POST vs the next GET.
-  assertEquals(created.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct' }]);
+  assertEquals(created.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }]);
 
   const get = await requestApp('/api/upstreams', authed(adminSession));
   const list = (await get.json()) as JsonObject[];
   const fresh = list.find(u => u.id === created.id);
-  assertEquals(fresh!.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct' }]);
+  assertEquals(fresh!.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }]);
 });
 
 test('PATCH /api/upstreams sets proxy_fallback_list', async () => {
@@ -1349,11 +1349,11 @@ test('PATCH /api/upstreams sets proxy_fallback_list', async () => {
   const patch = await requestApp(`/api/upstreams/${created.id}`, {
     method: 'PATCH',
     headers: { 'content-type': 'application/json', 'x-floway-session': adminSession },
-    body: JSON.stringify({ proxy_fallback_list: [{ id: 'p_fallback' }, { id: 'direct' }] }),
+    body: JSON.stringify({ proxy_fallback_list: [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }] }),
   });
   assertEquals(patch.status, 200);
   const updated = (await patch.json()) as JsonObject;
-  assertEquals(updated.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct' }]);
+  assertEquals(updated.proxy_fallback_list, [{ id: 'p_fallback' }, { id: 'direct_connect' }, { id: 'direct_fetch' }]);
 });
 
 test('PATCH /api/upstreams rejects proxy_fallback_list referencing an unknown proxy id', async () => {
@@ -2041,7 +2041,7 @@ test('spec invariant (3): POST /api/upstreams/claude-code/probe does not persist
   const originalList = (await getRecord(repo, created.id)).proxyFallbackList;
 
   const envelope = envelopeFromRecord(await getRecord(repo, created.id));
-  envelope.proxy_fallback_list = [{ id: 'direct' }];
+  envelope.proxy_fallback_list = [{ id: 'direct_fetch' }];
 
   await withMockedFetch(
     () => jsonResponse(usageProbeBody),

--- a/packages/gateway/src/dial/fetcher.ts
+++ b/packages/gateway/src/dial/fetcher.ts
@@ -1,10 +1,10 @@
-import { DIRECT_PROXY_ID, entryMatchesColo } from '../repo/proxy-fallback-list.ts';
+import { DIRECT_CONNECT_ID, DIRECT_FETCH_ID, entryMatchesColo } from '../repo/proxy-fallback-list.ts';
 import type { Repo } from '../repo/types.ts';
 import type { HttpRequest } from '@floway-dev/http';
 import { normalizeDialHost } from '@floway-dev/platform';
 import type { Fetcher, ProxyFallbackEntry } from '@floway-dev/provider';
 import { isAbortError } from '@floway-dev/provider';
-import { ProxyDialError, type ProxyConfig, type ProxyRequestTarget, type RunProxiedRequestOptions, type SocketDial } from '@floway-dev/proxy';
+import { ProxyDialError, type ProxyConfig, type ProxyRequestTarget, type RunDirectConnectRequestOptions, type RunProxiedRequestOptions, type SocketDial } from '@floway-dev/proxy';
 
 // Pairs the parsed wire config with an optional per-proxy dial deadline so
 // a slow but real proxy can be granted more time without raising the bar
@@ -31,12 +31,18 @@ interface CreateFetcherInput {
     request: HttpRequest,
     options: RunProxiedRequestOptions,
   ) => Promise<Response>;
-  // Per-request indirection for the 'direct' sentinel.
-  runDirect: (url: string, init: RequestInit) => Promise<Response>;
+  // Per-request indirection for the runtime-native fetch sentinel.
+  runDirectFetch: (url: string, init: RequestInit) => Promise<Response>;
+  // Runtime-agnostic raw TCP + userspace-TLS request runner.
+  runDirectConnect: (
+    target: ProxyRequestTarget,
+    request: HttpRequest,
+    options: RunDirectConnectRequestOptions,
+  ) => Promise<Response>;
   /**
    * Platform-injected raw TCP dial primitive, threaded into runProxied.
-   * Lazily evaluated — only invoked when a non-direct fallback entry is
-   * actually attempted, so direct-only call sites can run without an
+   * Lazily evaluated — only invoked when a socket-backed fallback entry is
+   * actually attempted, so direct-fetch-only call sites can run without an
    * installed SocketDial impl.
    */
   socketDial: () => SocketDial;
@@ -48,7 +54,7 @@ interface CreateFetcherInput {
  * (method/path/headers/body) so the dial layer and request-shaping layer
  * each receive only what they need.
  */
-interface ProxiedRequest {
+interface MaterializedRequest {
   target: ProxyRequestTarget;
   request: HttpRequest;
 }
@@ -56,7 +62,7 @@ interface ProxiedRequest {
 interface ReplayableRequest {
   readonly signal: AbortSignal | undefined;
   directInit(): RequestInit;
-  proxied(): Promise<ProxiedRequest>;
+  materialized(): Promise<MaterializedRequest>;
 }
 
 // Two-pass dial strategy. First pass walks the fallback list skipping any
@@ -68,35 +74,37 @@ interface ReplayableRequest {
 // in pass 2; doing so would double the backoff fail-count for every real
 // failure and warp the geometric schedule.
 //
-// Body buffering is deferred until a non-`direct` proxy actually needs it;
-// the direct-only fast path passes `init` straight to runtime `fetch`,
+// Body buffering is deferred until a proxy or direct-connect candidate needs
+// it; the direct-fetch-only fast path passes `init` straight to runtime `fetch`,
 // which is how non-buffered shapes like FormData stay supported.
 export const createFetcher = (input: CreateFetcherInput): Fetcher => {
-  // Colo filter precedes the implicit-['direct'] collapse so a fully-excluded
+  // Colo filter precedes the implicit direct-fetch collapse so a fully-excluded
   // list behaves like an empty list and gets the direct fallback, rather than
   // throwing because pass 1 had no candidates.
   const matched = input.fallbackList.filter(entry => entryMatchesColo(entry, input.runtimeLocation));
-  const list = matched.length > 0 ? matched.map(entry => entry.id) : [DIRECT_PROXY_ID];
-  // If `direct` precedes any non-direct entry, runtime fetch may take
+  const list = matched.length > 0 ? matched.map(entry => entry.id) : [DIRECT_FETCH_ID];
+  // If direct-fetch precedes any materialized transport, runtime fetch may take
   // ownership of `init.body` and consume its underlying stream/Blob.
   // Buffer the body up-front so a runtime that re-streams a Blob can't
   // strand a later proxy attempt with empty bytes. The fast path
-  // (direct-only list) keeps the runtime's native body handling intact —
+  // (direct-fetch-only list) keeps the runtime's native body handling intact —
   // FormData, Blob, etc. don't need to be buffered.
-  const hasNonDirect = list.some(id => id !== DIRECT_PROXY_ID);
-  const hasDirect = list.includes(DIRECT_PROXY_ID);
-  const directBeforeProxy = hasNonDirect && hasDirect && list.indexOf(DIRECT_PROXY_ID) < list.length - 1;
+  const hasMaterializedTransport = list.some(id => id !== DIRECT_FETCH_ID);
+  const hasDirectFetch = list.includes(DIRECT_FETCH_ID);
+  const directFetchBeforeMaterialized = hasMaterializedTransport
+    && hasDirectFetch
+    && list.indexOf(DIRECT_FETCH_ID) < list.length - 1;
   return (url, init) => {
-    // Reject streaming bodies upfront whenever any non-direct entry is in
+    // Reject streaming bodies upfront whenever any materialized entry is in
     // play. The two-pass dial can replay a request and a stream is
-    // single-shot; for a list like ['a','direct'] where 'a' is in active
+    // single-shot; for a list like ['a','direct_fetch'] where 'a' is in active
     // backoff, pass 1 would consume the stream via the runtime fetch and
     // strand pass 2 with empty bytes.
-    if (hasNonDirect && init.body instanceof ReadableStream) {
-      return Promise.reject(new Error('streaming request bodies are not supported through proxies — buffer before calling'));
+    if (hasMaterializedTransport && init.body instanceof ReadableStream) {
+      return Promise.reject(new Error('streaming request bodies are not replayable through direct-connect or proxy transports'));
     }
 
-    return runFallbacks(input, list, url, createReplayableRequest(url, init), directBeforeProxy);
+    return runFallbacks(input, list, url, createReplayableRequest(url, init), directFetchBeforeMaterialized);
   };
 };
 
@@ -105,11 +113,12 @@ const runFallbacks = async (
   list: readonly string[],
   url: string,
   request: ReplayableRequest,
-  directBeforeProxy: boolean,
+  directFetchBeforeMaterialized: boolean,
 ): Promise<Response> => {
-  // A direct attempt before any proxy can consume Blob/FormData bodies. Build
-  // the replayable byte form first so every later attempt observes one body.
-  if (directBeforeProxy) await request.proxied();
+  // A direct-fetch attempt before a materialized transport can consume
+  // Blob/FormData bodies. Build the replayable byte form first so every later
+  // attempt observes one body.
+  if (directFetchBeforeMaterialized) await request.materialized();
   const errors: unknown[] = [];
 
   const active = await input.repo.proxyBackoffs.listForUpstream(input.upstreamId);
@@ -145,7 +154,7 @@ const runFallbacks = async (
 class ReplayableRequestOwner implements ReplayableRequest {
   readonly signal: AbortSignal | undefined;
   private direct: RequestInit;
-  private materialized: ProxiedRequest | undefined;
+  private materializedRequest: MaterializedRequest | undefined;
   private rebuildDirectBody = false;
 
   constructor(
@@ -158,31 +167,31 @@ class ReplayableRequestOwner implements ReplayableRequest {
 
   directInit(): RequestInit {
     if (this.rebuildDirectBody) {
-      this.direct = rebuildInitFromProxied(this.direct, this.materialized!);
+      this.direct = rebuildInitFromMaterialized(this.direct, this.materializedRequest!);
       this.rebuildDirectBody = false;
     }
     return this.direct;
   }
 
-  async proxied(): Promise<ProxiedRequest> {
-    if (this.materialized !== undefined) return this.materialized;
-    this.materialized = await buildProxiedRequest(this.url, this.direct);
+  async materialized(): Promise<MaterializedRequest> {
+    if (this.materializedRequest !== undefined) return this.materializedRequest;
+    this.materializedRequest = await buildMaterializedRequest(this.url, this.direct);
     // Once bytes exist, the original BodyInit must not remain captured for the
     // duration of the upstream request. A later direct fallback rebuilds its
     // owned byte body lazily, so a successful proxy does not retain a second
     // full buffer merely because `direct` appears later in the list.
     this.direct = { ...this.direct, body: null };
     this.rebuildDirectBody = true;
-    return this.materialized;
+    return this.materializedRequest;
   }
 }
 
 const createReplayableRequest = (url: string, init: RequestInit): ReplayableRequest =>
   new ReplayableRequestOwner(url, init);
 
-const rebuildInitFromProxied = (original: RequestInit, proxied: ProxiedRequest): RequestInit => {
+const rebuildInitFromMaterialized = (original: RequestInit, materialized: MaterializedRequest): RequestInit => {
   const headers = new Headers(original.headers);
-  const targetCt = proxied.request.headers['content-type'];
+  const targetCt = materialized.request.headers['content-type'];
   if (targetCt !== undefined && !headers.has('content-type')) {
     headers.set('content-type', targetCt);
   }
@@ -191,9 +200,9 @@ const rebuildInitFromProxied = (original: RequestInit, proxied: ProxiedRequest):
   // the buffer we hand to runtime fetch never aliases a backing buffer
   // that's also referenced elsewhere.
   let body: Uint8Array<ArrayBuffer> | null = null;
-  if (proxied.request.body) {
-    const owned = new Uint8Array(proxied.request.body.byteLength);
-    owned.set(proxied.request.body);
+  if (materialized.request.body) {
+    const owned = new Uint8Array(materialized.request.body.byteLength);
+    owned.set(materialized.request.body);
     body = owned;
   }
   return {
@@ -211,10 +220,18 @@ const tryOne = async (
   errors: unknown[],
 ): Promise<Response | null> => {
   try {
-    if (id === DIRECT_PROXY_ID) {
+    if (id === DIRECT_FETCH_ID) {
       // Direct egress is the runtime's fetch — it never raises ProxyDialError,
       // so we don't touch the backoff table for this entry.
-      return await input.runDirect(url, request.directInit());
+      return await input.runDirectFetch(url, request.directInit());
+    }
+    if (id === DIRECT_CONNECT_ID) {
+      const materialized = await request.materialized();
+      return await input.runDirectConnect(
+        materialized.target,
+        materialized.request,
+        { socketDial: input.socketDial(), signal: request.signal },
+      );
     }
     const config = input.proxyById.get(id);
     if (!config) {
@@ -228,7 +245,7 @@ const tryOne = async (
       errors.push(new ProxyDialError(`unknown proxy id in fallback list: ${id}`, 'config'));
       return null;
     }
-    const proxied = await request.proxied();
+    const materialized = await request.materialized();
     // Caller cancellation flows through init.signal into the dialer's
     // combined controller so a disconnected client tears down any
     // in-flight handshake instead of waiting for the per-proxy deadline.
@@ -239,8 +256,8 @@ const tryOne = async (
     if (config.dialTimeoutMs !== null) options.dialTimeoutMs = config.dialTimeoutMs;
     const response = await input.runProxied(
       config.config,
-      proxied.target,
-      proxied.request,
+      materialized.target,
+      materialized.request,
       options,
     );
     // A successful dial after a previous failure must clear the backoff so
@@ -262,7 +279,7 @@ const tryOne = async (
     if (isAbortError(err)) {
       throw err;
     }
-    if (id === DIRECT_PROXY_ID) {
+    if (id === DIRECT_FETCH_ID) {
       // Direct egress can fail for the same dial-shaped reasons a proxy can
       // (TCP refused, GFW SNI reset, DNS, connect timeout). Runtime fetch
       // surfaces those as plain Errors / TypeErrors, not ProxyDialError, but
@@ -272,6 +289,13 @@ const tryOne = async (
       // throttle here).
       errors.push(err);
       return null;
+    }
+    if (id === DIRECT_CONNECT_ID) {
+      if (err instanceof ProxyDialError) {
+        errors.push(err);
+        return null;
+      }
+      throw err;
     }
     if (err instanceof ProxyDialError) {
       errors.push(err);
@@ -291,7 +315,7 @@ const tryOne = async (
   }
 };
 
-const buildProxiedRequest = async (url: string, init: RequestInit): Promise<ProxiedRequest> => {
+const buildMaterializedRequest = async (url: string, init: RequestInit): Promise<MaterializedRequest> => {
   const u = new URL(url);
   const collected = await collectBody(init.body);
   const headers = extractHeaders(init.headers);
@@ -364,5 +388,5 @@ const collectBody = async (
     const contentType = req.headers.get('content-type') ?? undefined;
     return { body: buffer, contentType };
   }
-  throw new Error('unsupported BodyInit shape for proxied request');
+  throw new Error('unsupported BodyInit shape for materialized request');
 };

--- a/packages/gateway/src/dial/fetcher.ts
+++ b/packages/gateway/src/dial/fetcher.ts
@@ -61,7 +61,7 @@ interface MaterializedRequest {
 
 interface ReplayableRequest {
   readonly signal: AbortSignal | undefined;
-  directInit(): RequestInit;
+  fetchInit(): RequestInit;
   materialized(): Promise<MaterializedRequest>;
 }
 
@@ -79,7 +79,7 @@ interface ReplayableRequest {
 // which is how non-buffered shapes like FormData stay supported.
 export const createFetcher = (input: CreateFetcherInput): Fetcher => {
   // Colo filter precedes the implicit direct-fetch collapse so a fully-excluded
-  // list behaves like an empty list and gets the direct fallback, rather than
+  // list behaves like an empty list and gets the direct-fetch fallback, rather than
   // throwing because pass 1 had no candidates.
   const matched = input.fallbackList.filter(entry => entryMatchesColo(entry, input.runtimeLocation));
   const list = matched.length > 0 ? matched.map(entry => entry.id) : [DIRECT_FETCH_ID];
@@ -153,35 +153,35 @@ const runFallbacks = async (
 
 class ReplayableRequestOwner implements ReplayableRequest {
   readonly signal: AbortSignal | undefined;
-  private direct: RequestInit;
+  private fetch: RequestInit;
   private materializedRequest: MaterializedRequest | undefined;
-  private rebuildDirectBody = false;
+  private rebuildFetchBody = false;
 
   constructor(
     private readonly url: string,
     init: RequestInit,
   ) {
     this.signal = init.signal ?? undefined;
-    this.direct = init;
+    this.fetch = init;
   }
 
-  directInit(): RequestInit {
-    if (this.rebuildDirectBody) {
-      this.direct = rebuildInitFromMaterialized(this.direct, this.materializedRequest!);
-      this.rebuildDirectBody = false;
+  fetchInit(): RequestInit {
+    if (this.rebuildFetchBody) {
+      this.fetch = rebuildInitFromMaterialized(this.fetch, this.materializedRequest!);
+      this.rebuildFetchBody = false;
     }
-    return this.direct;
+    return this.fetch;
   }
 
   async materialized(): Promise<MaterializedRequest> {
     if (this.materializedRequest !== undefined) return this.materializedRequest;
-    this.materializedRequest = await buildMaterializedRequest(this.url, this.direct);
+    this.materializedRequest = await buildMaterializedRequest(this.url, this.fetch);
     // Once bytes exist, the original BodyInit must not remain captured for the
-    // duration of the upstream request. A later direct fallback rebuilds its
+    // duration of the upstream request. A later direct-fetch fallback rebuilds its
     // owned byte body lazily, so a successful proxy does not retain a second
-    // full buffer merely because `direct` appears later in the list.
-    this.direct = { ...this.direct, body: null };
-    this.rebuildDirectBody = true;
+    // full buffer merely because `direct_fetch` appears later in the list.
+    this.fetch = { ...this.fetch, body: null };
+    this.rebuildFetchBody = true;
     return this.materializedRequest;
   }
 }
@@ -223,7 +223,7 @@ const tryOne = async (
     if (id === DIRECT_FETCH_ID) {
       // Direct egress is the runtime's fetch — it never raises ProxyDialError,
       // so we don't touch the backoff table for this entry.
-      return await input.runDirectFetch(url, request.directInit());
+      return await input.runDirectFetch(url, request.fetchInit());
     }
     if (id === DIRECT_CONNECT_ID) {
       const materialized = await request.materialized();
@@ -238,8 +238,8 @@ const tryOne = async (
       // The proxies catalog was loaded once at the top of the request, but
       // an admin can delete a row mid-flight. Treat the missing id as a
       // dial-shaped failure for THIS entry so the fallback chain advances
-      // instead of killing the whole call (and any healthy `direct` /
-      // sibling entries further down the list). We don't write to backoff
+      // instead of killing the whole call (and any healthy built-in or proxy
+      // siblings further down the list). We don't write to backoff
       // here — the row is gone, and the upstream's fallback_list will
       // surface the dangling reference next time the dashboard renders it.
       errors.push(new ProxyDialError(`unknown proxy id in fallback list: ${id}`, 'config'));

--- a/packages/gateway/src/dial/fetcher_test.ts
+++ b/packages/gateway/src/dial/fetcher_test.ts
@@ -28,17 +28,18 @@ describe('createFetcher', () => {
     const fetcher = createFetcher({
       repo,
       upstreamId: 'u',
-      fallbackList: [{ id: 'a' }, { id: 'b' }, { id: 'direct' }],
+      fallbackList: [{ id: 'a' }, { id: 'b' }, { id: 'direct_fetch' }],
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA], ['b', proxyB]]),
       runProxied: async (config: ProxyConfig) => {
         calls.push(config.host);
         return new Response('ok');
       },
-      runDirect: async () => {
+      runDirectFetch: async () => {
         calls.push('direct');
         return new Response('direct');
       },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const res = await fetcher('https://api.openai.com/v1/models', { method: 'GET' });
@@ -55,7 +56,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async () => { throw new ProxyDialError('boom', 'tcp-connect'); },
-      runDirect: async () => new Response('ok'),
+      runDirectFetch: async () => new Response('ok'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await expect(fetcher('https://api.openai.com', { method: 'GET' })).rejects.toBeInstanceOf(ProxyDialError);
@@ -77,7 +79,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async () => new Response('ok'),
-      runDirect: async () => new Response('ok'),
+      runDirectFetch: async () => new Response('ok'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     // first-pass skips a (in backoff). second-pass ignores backoff and succeeds.
@@ -101,7 +104,8 @@ describe('createFetcher', () => {
         if (order.length < 2) throw new ProxyDialError('still bad', 'tcp-connect');
         return new Response('ok');
       },
-      runDirect: async () => new Response('ok'),
+      runDirectFetch: async () => new Response('ok'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await fetcher('https://api.openai.com', { method: 'GET' });
@@ -120,7 +124,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async () => { throw new ProxyDialError('still bad', 'tcp-connect'); },
-      runDirect: async () => new Response('ok'),
+      runDirectFetch: async () => new Response('ok'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     // Pass 1 skips 'a' (in backoff). Pass 2 retries it and fails — the
@@ -140,11 +145,12 @@ describe('createFetcher', () => {
       // 'p_unknown' is in the list but not in proxyById — simulating a
       // mid-request DELETE between catalog load and dial. The chain must
       // advance to 'direct' rather than killing the whole call.
-      fallbackList: [{ id: 'p_unknown' }, { id: 'direct' }],
+      fallbackList: [{ id: 'p_unknown' }, { id: 'direct_fetch' }],
       runtimeLocation: 'TEST',
       proxyById: new Map(),
       runProxied: async () => new Response('proxy'),
-      runDirect: async () => { directCalls++; return new Response('direct'); },
+      runDirectFetch: async () => { directCalls++; return new Response('direct'); },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const res = await fetcher('https://api.openai.com', { method: 'GET' });
@@ -164,7 +170,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map(),
       runProxied: async () => new Response('proxy'),
-      runDirect: async () => { throw new Error('unreachable'); },
+      runDirectFetch: async () => { throw new Error('unreachable'); },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await expect(
@@ -193,7 +200,8 @@ describe('createFetcher', () => {
         calls.push(config.host);
         throw new ProxyDialError('fail', 'tcp-connect');
       },
-      runDirect: async () => new Response('ok'),
+      runDirectFetch: async () => new Response('ok'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await expect(fetcher('https://api.openai.com', { method: 'GET' })).rejects.toBeInstanceOf(AggregateError);
@@ -212,14 +220,15 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async () => { throw new Error('upstream 500'); },
-      runDirect: async () => new Response('ok'),
+      runDirectFetch: async () => new Response('ok'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await expect(fetcher('https://api.openai.com', { method: 'GET' })).rejects.toThrow('upstream 500');
     expect(await repo.proxyBackoffs.listForUpstream('u')).toEqual([]);
   });
 
-  it('empty fallback list defaults to ["direct"]', async () => {
+  it('empty fallback list defaults to ["direct_fetch"]', async () => {
     const repo = new InMemoryRepo();
     let directCalled = false;
     const fetcher = createFetcher({
@@ -229,12 +238,78 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map(),
       runProxied: async () => new Response('proxy'),
-      runDirect: async () => { directCalled = true; return new Response('direct'); },
+      runDirectFetch: async () => { directCalled = true; return new Response('direct'); },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const res = await fetcher('https://api.openai.com', { method: 'GET' });
     expect(directCalled).toBe(true);
     expect(await res.text()).toBe('direct');
+  });
+
+  it('runs direct-connect as a built-in materialized transport', async () => {
+    const repo = new InMemoryRepo();
+    let observedTarget: ProxyRequestTarget | undefined;
+    let observedRequest: HttpRequest | undefined;
+    let observedSocketDial: SocketDial | undefined;
+    const fetcher = createFetcher({
+      repo,
+      upstreamId: 'u',
+      fallbackList: [{ id: 'direct_connect' }],
+      runtimeLocation: 'TEST',
+      proxyById: new Map(),
+      runProxied: async () => new Response('proxy'),
+      runDirectFetch: async () => new Response('direct fetch'),
+      runDirectConnect: async (target, request, options) => {
+        observedTarget = target;
+        observedRequest = request;
+        observedSocketDial = options.socketDial;
+        return new Response('direct connect');
+      },
+      socketDial: () => stubSocketDial,
+    });
+
+    const response = await fetcher('https://api.openai.com/v1/responses?stream=1', {
+      method: 'POST',
+      body: 'request body',
+    });
+
+    expect(await response.text()).toBe('direct connect');
+    expect(observedTarget).toEqual({ host: 'api.openai.com', port: 443, tls: true });
+    if (observedRequest === undefined) throw new Error('direct-connect request was not observed');
+    expect(observedRequest?.method).toBe('POST');
+    expect(observedRequest?.path).toBe('/v1/responses?stream=1');
+    expect(new TextDecoder().decode(observedRequest.body)).toBe('request body');
+    expect(observedSocketDial).toBe(stubSocketDial);
+    expect(await repo.proxyBackoffs.listForUpstream('u')).toEqual([]);
+  });
+
+  it('falls through from a direct-connect dial failure without writing proxy backoff', async () => {
+    const repo = new InMemoryRepo();
+    const calls: string[] = [];
+    const fetcher = createFetcher({
+      repo,
+      upstreamId: 'u',
+      fallbackList: [{ id: 'direct_connect' }, { id: 'direct_fetch' }],
+      runtimeLocation: 'TEST',
+      proxyById: new Map(),
+      runProxied: async () => new Response('proxy'),
+      runDirectConnect: async () => {
+        calls.push('direct_connect');
+        throw new ProxyDialError('socket unavailable', 'tcp-connect');
+      },
+      runDirectFetch: async () => {
+        calls.push('direct_fetch');
+        return new Response('ok');
+      },
+      socketDial: () => stubSocketDial,
+    });
+
+    const response = await fetcher('https://api.openai.com', { method: 'GET' });
+
+    expect(await response.text()).toBe('ok');
+    expect(calls).toEqual(['direct_connect', 'direct_fetch']);
+    expect(await repo.proxyBackoffs.listForUpstream('u')).toEqual([]);
   });
 
   it('skips entries whose colos whitelist excludes the current colo', async () => {
@@ -246,7 +321,7 @@ describe('createFetcher', () => {
       fallbackList: [
         { id: 'a', colos: ['NRT'] },          // wrong colo — skip
         { id: 'b', colos: ['HKG', 'NRT'] },   // matches — attempt
-        { id: 'direct' },                     // no whitelist — attempt
+        { id: 'direct_fetch' },                     // no whitelist — attempt
       ],
       runtimeLocation: 'HKG',
       proxyById: new Map([['a', proxyA], ['b', proxyB]]),
@@ -254,10 +329,11 @@ describe('createFetcher', () => {
         calls.push(config.host);
         return new Response('ok');
       },
-      runDirect: async () => {
+      runDirectFetch: async () => {
         calls.push('direct');
         return new Response('direct');
       },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const res = await fetcher('https://api.openai.com', { method: 'GET' });
@@ -287,7 +363,8 @@ describe('createFetcher', () => {
         calls.push(config.host);
         throw new ProxyDialError('boom', 'tcp-connect');
       },
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await expect(fetcher('https://api.openai.com', { method: 'GET' })).rejects.toBeInstanceOf(ProxyDialError);
@@ -296,7 +373,7 @@ describe('createFetcher', () => {
     expect(calls).toEqual(['b']);
   });
 
-  it('collapses to implicit ["direct"] when every entry is colo-filtered out', async () => {
+  it('collapses to implicit ["direct_fetch"] when every entry is colo-filtered out', async () => {
     const repo = new InMemoryRepo();
     let directCalled = false;
     const fetcher = createFetcher({
@@ -309,7 +386,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'HKG',
       proxyById: new Map([['a', proxyA], ['b', proxyB]]),
       runProxied: async () => new Response('proxy'),
-      runDirect: async () => { directCalled = true; return new Response('direct'); },
+      runDirectFetch: async () => { directCalled = true; return new Response('direct'); },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const res = await fetcher('https://api.openai.com', { method: 'GET' });
@@ -323,17 +401,18 @@ describe('createFetcher', () => {
     const fetcher = createFetcher({
       repo,
       upstreamId: 'u',
-      fallbackList: [{ id: 'direct' }, { id: 'a' }],
+      fallbackList: [{ id: 'direct_fetch' }, { id: 'a' }],
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async (config: ProxyConfig) => {
         calls.push(`proxy:${config.host}`);
         return new Response('proxy-should-not-be-called');
       },
-      runDirect: async () => {
+      runDirectFetch: async () => {
         calls.push('direct');
         throw new DOMException('client gone', 'AbortError');
       },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await expect(fetcher('https://api.openai.com', { method: 'GET' }))
@@ -349,17 +428,18 @@ describe('createFetcher', () => {
     const fetcher = createFetcher({
       repo,
       upstreamId: 'u',
-      fallbackList: [{ id: 'a' }, { id: 'direct' }],
+      fallbackList: [{ id: 'a' }, { id: 'direct_fetch' }],
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async (_config, _target, request) => {
         expect(new TextDecoder().decode(request.body)).toBe('request body');
         throw new ProxyDialError('proxy unavailable', 'tcp-connect');
       },
-      runDirect: async (_url, init) => {
+      runDirectFetch: async (_url, init) => {
         directBody = init.body;
         return new Response('direct');
       },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const init: RequestInit = { method: 'POST', body: 'request body' };
@@ -375,21 +455,22 @@ describe('createFetcher', () => {
   it('materializes before a leading direct attempt without mutating the caller init', async () => {
     const repo = new InMemoryRepo();
     let directBody: BodyInit | null | undefined;
-    let proxiedBody: Uint8Array | undefined;
+    let materializedBody: Uint8Array | undefined;
     const fetcher = createFetcher({
       repo,
       upstreamId: 'u',
-      fallbackList: [{ id: 'direct' }, { id: 'a' }],
+      fallbackList: [{ id: 'direct_fetch' }, { id: 'a' }],
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async (_config, _target, request) => {
-        proxiedBody = request.body;
+        materializedBody = request.body;
         return new Response('proxy');
       },
-      runDirect: async (_url, init) => {
+      runDirectFetch: async (_url, init) => {
         directBody = init.body;
         throw new TypeError('direct dial failed');
       },
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const init: RequestInit = { method: 'POST', body: 'request body' };
@@ -399,7 +480,7 @@ describe('createFetcher', () => {
     expect(await response.text()).toBe('proxy');
     expect(directBody).toBeInstanceOf(Uint8Array);
     expect(new TextDecoder().decode(directBody as Uint8Array)).toBe('request body');
-    expect(new TextDecoder().decode(proxiedBody)).toBe('request body');
+    expect(new TextDecoder().decode(materializedBody)).toBe('request body');
     expect(init.body).toBe('request body');
   });
 
@@ -416,7 +497,8 @@ describe('createFetcher', () => {
         observedSignal = options.signal;
         return new Response('ok');
       },
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const ac = new AbortController();
@@ -434,7 +516,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async (_config, _target, request) => { captured.push(request); return new Response('ok'); },
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const fd = new FormData();
@@ -455,7 +538,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async (_config, _target, request) => { captured.push(request); return new Response('ok'); },
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const fd = new FormData();
@@ -477,7 +561,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async () => new Response('ok'),
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const stream = new ReadableStream({
@@ -499,7 +584,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async () => { throw new ProxyDialError('cert mismatch', 'inner-tls'); },
-      runDirect: async () => new Response('ok'),
+      runDirectFetch: async () => new Response('ok'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await expect(fetcher('https://api.openai.com', { method: 'GET' })).rejects.toBeInstanceOf(ProxyDialError);
@@ -525,7 +611,8 @@ describe('createFetcher', () => {
       runtimeLocation: 'TEST',
       proxyById: new Map([['a', proxyA]]),
       runProxied: async () => new Response('ok'),
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const res = await fetcher('https://api.openai.com', { method: 'GET' });
@@ -549,7 +636,8 @@ describe('createFetcher', () => {
         captured = target;
         return new Response('ok');
       },
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     await fetcher('https://[::1]:8443/v1/models', { method: 'GET' });
@@ -579,7 +667,8 @@ describe('createFetcher', () => {
         await new Promise(resolve => setTimeout(resolve, 20));
         return new Response('ok');
       },
-      runDirect: async () => new Response('direct'),
+      runDirectFetch: async () => new Response('direct'),
+      runDirectConnect: async () => new Response('direct connect'),
       socketDial: () => stubSocketDial,
     });
     const res = await fetcher('https://api.openai.com', { method: 'GET' });

--- a/packages/gateway/src/dial/fetcher_test.ts
+++ b/packages/gateway/src/dial/fetcher_test.ts
@@ -144,7 +144,7 @@ describe('createFetcher', () => {
       upstreamId: 'u',
       // 'p_unknown' is in the list but not in proxyById — simulating a
       // mid-request DELETE between catalog load and dial. The chain must
-      // advance to 'direct' rather than killing the whole call.
+      // advance to direct-fetch rather than killing the whole call.
       fallbackList: [{ id: 'p_unknown' }, { id: 'direct_fetch' }],
       runtimeLocation: 'TEST',
       proxyById: new Map(),
@@ -163,7 +163,7 @@ describe('createFetcher', () => {
     const fetcher = createFetcher({
       repo,
       upstreamId: 'u',
-      // No 'direct' fallback — the only entry is the unknown id, so the
+      // No direct-fetch fallback — the only entry is the unknown id, so the
       // call fails and the typed ProxyDialError surfaces directly (single-
       // entry chains skip the AggregateError wrapper).
       fallbackList: [{ id: 'p_unknown' }],

--- a/packages/gateway/src/dial/per-request.ts
+++ b/packages/gateway/src/dial/per-request.ts
@@ -50,7 +50,7 @@ export const createPerRequestFetcher = async (
 
   return upstreamId => {
     // Fail loud on an unknown upstream id. Silently substituting `[]`
-    // would route the request through `direct` only, masking a stale
+    // would route the request through direct-fetch only, masking a stale
     // api-key→upstream binding or a typo in the caller as a working
     // proxy-bypass.
     const list = fallbackById.get(upstreamId);

--- a/packages/gateway/src/dial/per-request.ts
+++ b/packages/gateway/src/dial/per-request.ts
@@ -1,9 +1,9 @@
 import { createFetcher, type ProxyEntry } from './fetcher.ts';
 import { getRepo } from '../repo/index.ts';
-import { DIRECT_PROXY_ID } from '../repo/proxy-fallback-list.ts';
+import { isDirectFallbackId } from '../repo/proxy-fallback-list.ts';
 import { getSocketDial } from '@floway-dev/platform';
 import { directFetcher, type Fetcher, type UpstreamRecord } from '@floway-dev/provider';
-import { parseProxyUri, type ProxyUriError, runProxiedRequest } from '@floway-dev/proxy';
+import { parseProxyUri, type ProxyUriError, runDirectConnectRequest, runProxiedRequest } from '@floway-dev/proxy';
 
 // Parse failures on individual proxy rows are isolated to the upstreams that
 // actually reference them: a single malformed URL must not take down every
@@ -24,7 +24,7 @@ export const createPerRequestFetcher = async (
   const referencedProxyIds = new Set<string>();
   for (const list of fallbackById.values()) {
     for (const entry of list) {
-      if (entry.id !== DIRECT_PROXY_ID) referencedProxyIds.add(entry.id);
+      if (!isDirectFallbackId(entry.id)) referencedProxyIds.add(entry.id);
     }
   }
 
@@ -72,7 +72,8 @@ export const createPerRequestFetcher = async (
       runtimeLocation,
       proxyById,
       runProxied: runProxiedRequest,
-      runDirect: directFetcher,
+      runDirectFetch: directFetcher,
+      runDirectConnect: runDirectConnectRequest,
       socketDial: getSocketDial,
     });
   };

--- a/packages/gateway/src/dial/per-request_test.ts
+++ b/packages/gateway/src/dial/per-request_test.ts
@@ -66,9 +66,10 @@ describe('createPerRequestFetcher', () => {
     const repo = new InMemoryRepo();
     initRepo(repo);
     // A malformed row sitting unreferenced in the table must not break
-    // direct-only upstreams: we only parse rows that are reachable via some
+    // built-in-only upstreams: we only parse rows that are reachable via some
     // upstream's fallback list.
-    await repo.upstreams.save(upstream('u_direct', []));
+    await repo.upstreams.save(upstream('u_direct_fetch', []));
+    await repo.upstreams.save(upstream('u_direct_connect', [{ id: 'direct_connect' }]));
     await repo.proxies.insert({ id: 'p_bad', name: 'Bad', url: 'gibberish-no-scheme', dialTimeoutSeconds: null });
 
     let proxyListCalls = 0;

--- a/packages/gateway/src/repo/proxies_test.ts
+++ b/packages/gateway/src/repo/proxies_test.ts
@@ -49,9 +49,9 @@ for (const [backend, makeRepo] of REPO_BACKENDS) {
   test(`[${backend}] proxies repo findUpstreamsReferencing returns ids of upstreams whose fallback list contains the proxy`, async () => {
     const repo = await makeRepo();
     await repo.proxies.insert({ id: 'p', name: 'P', url: 'socks5://host:1080', dialTimeoutSeconds: null });
-    await repo.upstreams.save(upstreamFixture('up_1', [{ id: 'p' }, { id: 'direct' }]));
-    await repo.upstreams.save(upstreamFixture('up_2', [{ id: 'direct' }, { id: 'p' }]));
-    await repo.upstreams.save(upstreamFixture('up_3', [{ id: 'direct' }]));
+    await repo.upstreams.save(upstreamFixture('up_1', [{ id: 'p' }, { id: 'direct_fetch' }]));
+    await repo.upstreams.save(upstreamFixture('up_2', [{ id: 'direct_fetch' }, { id: 'p' }]));
+    await repo.upstreams.save(upstreamFixture('up_3', [{ id: 'direct_fetch' }]));
 
     const ids = (await repo.proxies.findUpstreamsReferencing('p')).toSorted();
     assertEquals(ids, ['up_1', 'up_2']);

--- a/packages/gateway/src/repo/proxy-fallback-list.ts
+++ b/packages/gateway/src/repo/proxy-fallback-list.ts
@@ -1,8 +1,14 @@
 import type { ProxyFallbackEntry } from '@floway-dev/provider';
 
-// Sentinel for "no proxy — connect directly"; the only legal non-id `entry.id`
-// value in a proxy_fallback_list entry.
-export const DIRECT_PROXY_ID = 'direct';
+// Built-in egress candidates occupy the same ordered fallback list as
+// operator-managed proxies, but do not resolve through the proxies table.
+export const DIRECT_FETCH_ID = 'direct_fetch';
+export const DIRECT_CONNECT_ID = 'direct_connect';
+
+export const DIRECT_FALLBACK_IDS = [DIRECT_FETCH_ID, DIRECT_CONNECT_ID] as const;
+
+export const isDirectFallbackId = (id: string): id is typeof DIRECT_FALLBACK_IDS[number] =>
+  id === DIRECT_FETCH_ID || id === DIRECT_CONNECT_ID;
 
 // Treat the list as a SET by `id` semantics: a duplicate entry has no meaning
 // beyond "try once", so silently drop repeats. The first occurrence's `colos`

--- a/packages/gateway/src/repo/proxy-fallback-list_test.ts
+++ b/packages/gateway/src/repo/proxy-fallback-list_test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { entryMatchesColo, normalizeProxyFallbackList } from './proxy-fallback-list.ts';
+import { entryMatchesColo, isDirectFallbackId, normalizeProxyFallbackList } from './proxy-fallback-list.ts';
+
+describe('isDirectFallbackId', () => {
+  it('recognizes only the two built-in direct transports', () => {
+    expect(isDirectFallbackId('direct_fetch')).toBe(true);
+    expect(isDirectFallbackId('direct_connect')).toBe(true);
+    expect(isDirectFallbackId('proxy_a')).toBe(false);
+  });
+});
 
 describe('entryMatchesColo', () => {
   it('treats missing colos as "active in all colos"', () => {

--- a/packages/gateway/src/repo/upstreams_test.ts
+++ b/packages/gateway/src/repo/upstreams_test.ts
@@ -828,6 +828,43 @@ test('migration 0048 rebuckets Codex quota snapshots by active limit', async () 
   }
 });
 
+test('migration 0055 names existing direct fallback entries direct_fetch', async () => {
+  const db = await createMigratedSqlJsDatabase();
+  try {
+    for (const filename of [...migrationSqlByFilename.keys()].filter(f => f >= '0010_unified_upstreams.sql' && f < '0055_direct_transport_fallbacks.sql').toSorted()) {
+      applySqlJsFile(db, filename);
+    }
+
+    db.run(`INSERT INTO upstreams (id, provider, name, enabled, sort_order, created_at, updated_at, config_json, flag_overrides, disabled_public_model_ids, proxy_fallback_list_json)
+            VALUES
+              ('up_direct', 'custom', 'Direct', 1, 0, '2026-07-14T00:00:00.000Z', '2026-07-14T00:00:00.000Z',
+                json_object('baseUrl', 'https://a.example', 'apiKey', 'k', 'authStyle', 'bearer'),
+                '[]', '[]', '[{"id":"p_first"},{"id":"direct","colos":["SIN"]},{"id":"p_last"}]'),
+              ('up_proxy_only', 'custom', 'Proxy only', 1, 1, '2026-07-14T00:00:00.000Z', '2026-07-14T00:00:00.000Z',
+                json_object('baseUrl', 'https://b.example', 'apiKey', 'k', 'authStyle', 'bearer'),
+                '[]', '[]', '[{"id":"p_only"}]'),
+              ('up_empty', 'custom', 'Empty', 1, 2, '2026-07-14T00:00:00.000Z', '2026-07-14T00:00:00.000Z',
+                json_object('baseUrl', 'https://c.example', 'apiKey', 'k', 'authStyle', 'bearer'),
+                '[]', '[]', '[]')`);
+
+    applySqlJsFile(db, '0055_direct_transport_fallbacks.sql');
+
+    const rows = sqlJsRows<{ id: string; fallback: string }>(
+      db,
+      'SELECT id, proxy_fallback_list_json AS fallback FROM upstreams ORDER BY id',
+    );
+    assertEquals(JSON.parse(rows.find(row => row.id === 'up_direct')!.fallback), [
+      { id: 'p_first' },
+      { id: 'direct_fetch', colos: ['SIN'] },
+      { id: 'p_last' },
+    ]);
+    assertEquals(JSON.parse(rows.find(row => row.id === 'up_proxy_only')!.fallback), [{ id: 'p_only' }]);
+    assertEquals(JSON.parse(rows.find(row => row.id === 'up_empty')!.fallback), []);
+  } finally {
+    db.close();
+  }
+});
+
 type FakeUpstreamRow = {
   id: string;
   provider: string;

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -58,7 +58,8 @@ export const normalizeUpstreamColor = (value: unknown): UpstreamColor | null => 
 };
 
 // One entry in `UpstreamRecord.proxyFallbackList`. `id` is the proxy id from
-// the proxies catalog or the literal 'direct' sentinel. `colos` is an
+// the proxies catalog or a built-in transport (`direct_fetch`,
+// `direct_connect`). `colos` is an
 // optional whitelist of location tags (Cloudflare colos / the Node
 // `RUNTIME_LOCATION` env var); when set, the dial layer only attempts this
 // entry from a request that landed in one of the listed locations. Missing

--- a/packages/proxy/src/dialer.ts
+++ b/packages/proxy/src/dialer.ts
@@ -9,7 +9,7 @@ import { dialSocks5 } from './protocols/socks5.ts';
 import { dialTrojan } from './protocols/trojan.ts';
 import { dialVlessTcpTls, dialVlessWsTls } from './protocols/vless.ts';
 import type { ProxyConfig } from './proxy-config.ts';
-import type { DialOptions, DialResult, DialTarget, ProxyRequestTarget } from './types.ts';
+import { connectOrDialError, type DialedSocket, type DialOptions, type DialResult, type DialTarget, type ProxyRequestTarget } from './types.ts';
 import { fetchOnStream, signalAbortReason, userspaceTls, type DuplexStream, type HttpRequest, type TlsStream } from '@floway-dev/http';
 
 /**
@@ -22,7 +22,21 @@ export const dial = async (
   config: ProxyConfig,
   target: DialTarget,
   options: DialOptions,
-): Promise<DialResult> => {
+): Promise<DialResult> =>
+  await withDialDeadline(
+    options,
+    () => new ProxyDialError(
+      `${config.kind}: dial to ${config.host}:${config.port} → ${target.host}:${target.port} exceeded deadline of ${options.dialTimeoutMs ?? DEFAULT_DIAL_DEADLINE_MS}ms`,
+      'tcp-connect',
+    ),
+    innerOptions => dispatchDial(config, target, innerOptions),
+  );
+
+const withDialDeadline = async <T>(
+  options: DialOptions,
+  timeoutError: () => ProxyDialError,
+  run: (options: DialOptions) => Promise<T>,
+): Promise<T> => {
   const deadlineMs = options.dialTimeoutMs ?? DEFAULT_DIAL_DEADLINE_MS;
   const callerSignal = options.signal;
   if (callerSignal?.aborted) {
@@ -41,10 +55,7 @@ export const dial = async (
     callerSignal.addEventListener('abort', onCallerAbort, { once: true });
   }
   const timer = setTimeout(
-    () => internal.abort(new ProxyDialError(
-      `${config.kind}: dial to ${config.host}:${config.port} → ${target.host}:${target.port} exceeded deadline of ${deadlineMs}ms`,
-      'tcp-connect',
-    )),
+    () => internal.abort(timeoutError()),
     deadlineMs,
   );
   const innerOptions: DialOptions = {
@@ -52,7 +63,7 @@ export const dial = async (
     signal: internal.signal,
   };
   try {
-    return await dispatchDial(config, target, innerOptions);
+    return await run(innerOptions);
   } catch (err) {
     if (internal.signal.aborted && internal.signal.reason instanceof ProxyDialError) {
       throw internal.signal.reason;
@@ -90,6 +101,7 @@ const dispatchDial = async (config: ProxyConfig, target: DialTarget, options: Di
 };
 
 export type RunProxiedRequestOptions = DialOptions;
+export type RunDirectConnectRequestOptions = DialOptions;
 
 /**
  * Compose `dial` → optional `userspaceTls` → `fetchOnStream` into a single
@@ -107,6 +119,49 @@ export const runProxiedRequest = async (
   options: RunProxiedRequestOptions,
 ): Promise<Response> => {
   const dialed = await dial(config, target, options);
+  return await runRequestOnStream(dialed, target, request, options);
+};
+
+/**
+ * Run one HTTP request on a raw runtime TCP socket. This deliberately shares
+ * the post-dial TLS and HTTP/1.1 pipeline with proxy-backed requests; only the
+ * transport that produces the first duplex stream differs.
+ */
+export const runDirectConnectRequest = async (
+  target: ProxyRequestTarget,
+  request: HttpRequest,
+  options: RunDirectConnectRequestOptions,
+): Promise<Response> => {
+  const deadlineMs = options.dialTimeoutMs ?? DEFAULT_DIAL_DEADLINE_MS;
+  const socket = await withDialDeadline(
+    options,
+    () => new ProxyDialError(
+      `direct-connect: dial to ${target.host}:${target.port} exceeded deadline of ${deadlineMs}ms`,
+      'tcp-connect',
+    ),
+    innerOptions => connectOrDialError(
+      innerOptions.socketDial,
+      target.host,
+      target.port,
+      { signal: innerOptions.signal },
+    ),
+  );
+
+  try {
+    const response = await runRequestOnStream(socket, target, request, options);
+    return closeSocketWithResponse(response, socket);
+  } catch (error) {
+    await socket.close().catch(() => {});
+    throw error;
+  }
+};
+
+const runRequestOnStream = async (
+  dialed: DialResult,
+  target: ProxyRequestTarget,
+  request: HttpRequest,
+  options: RunProxiedRequestOptions,
+): Promise<Response> => {
   let stream: DuplexStream = { readable: dialed.readable, writable: dialed.writable };
   try {
     // Route DialResult.prefix to the next byte sink: as the userspace-TLS
@@ -161,4 +216,48 @@ export const runProxiedRequest = async (
     void stream.readable.cancel(err).catch(() => {});
     throw err;
   }
+};
+
+const closeSocketWithResponse = (response: Response, socket: DialedSocket): Response => {
+  let closePromise: Promise<void> | null = null;
+  const close = (): Promise<void> => {
+    closePromise ??= socket.close().catch(() => {});
+    return closePromise;
+  };
+
+  if (response.body === null) {
+    void close();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          controller.close();
+          await close();
+        } else {
+          controller.enqueue(result.value);
+        }
+      } catch (error) {
+        controller.error(error);
+        await close();
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        await close();
+      }
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 };

--- a/packages/proxy/src/dialer.ts
+++ b/packages/proxy/src/dialer.ts
@@ -237,13 +237,13 @@ const closeSocketWithResponse = (response: Response, socket: DialedSocket): Resp
         const result = await reader.read();
         if (result.done) {
           controller.close();
-          await close();
+          void close();
         } else {
           controller.enqueue(result.value);
         }
       } catch (error) {
         controller.error(error);
-        await close();
+        void close();
       }
     },
     async cancel(reason) {

--- a/packages/proxy/src/dialer_test.ts
+++ b/packages/proxy/src/dialer_test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { dial, runProxiedRequest } from './dialer.ts';
+import { dial, runDirectConnectRequest, runProxiedRequest } from './dialer.ts';
 import { dialHttpConnect } from './protocols/http-connect.ts';
 import { dialReality } from './protocols/reality.ts';
 import { dialShadowsocks2022 } from './protocols/shadowsocks-2022.ts';
@@ -169,6 +169,91 @@ describe('runProxiedRequest — post-dial teardown', () => {
     ).rejects.toBeInstanceOf(Error);
     expect(cancelCalls).toBeGreaterThan(0);
     expect(lastCancelReason).toBeInstanceOf(Error);
+  });
+});
+
+describe('runDirectConnectRequest', () => {
+  const makeSocketDial = (responseHead: string, connect: () => void = () => {}): {
+    socketDial: SocketDial;
+    written: () => string;
+    closeCalls: () => number;
+  } => {
+    let writeBuf = new Uint8Array(0);
+    let closes = 0;
+    return {
+      written: () => new TextDecoder().decode(writeBuf),
+      closeCalls: () => closes,
+      socketDial: {
+        connect: async () => {
+          connect();
+          return {
+            writable: new WritableStream<Uint8Array>({
+              write(chunk) {
+                const next = new Uint8Array(writeBuf.byteLength + chunk.byteLength);
+                next.set(writeBuf, 0);
+                next.set(chunk, writeBuf.byteLength);
+                writeBuf = next;
+              },
+            }),
+            readable: new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(responseHead));
+                controller.close();
+              },
+            }),
+            close: async () => { closes++; },
+          };
+        },
+      },
+    };
+  };
+
+  it('sends HTTP directly to the target and closes its socket after the body ends', async () => {
+    const direct = makeSocketDial('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok');
+    const response = await runDirectConnectRequest(
+      { host: 'api.example.com', port: 80, tls: false },
+      { method: 'POST', path: '/responses?stream=1', headers: {}, body: new TextEncoder().encode('body') },
+      { socketDial: direct.socketDial },
+    );
+
+    expect(await response.text()).toBe('ok');
+    expect(direct.written()).toContain('POST /responses?stream=1 HTTP/1.1\r\n');
+    expect(direct.written()).toContain('Host: api.example.com\r\n');
+    expect(direct.written()).toContain('Content-Length: 4\r\n');
+    expect(direct.written().endsWith('\r\n\r\nbody')).toBe(true);
+    expect(direct.closeCalls()).toBe(1);
+  });
+
+  it('closes its socket when the response body is cancelled', async () => {
+    const direct = makeSocketDial('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok');
+    const response = await runDirectConnectRequest(
+      { host: 'api.example.com', port: 80, tls: false },
+      { method: 'GET', path: '/', headers: {} },
+      { socketDial: direct.socketDial },
+    );
+
+    await response.body!.cancel('client gone');
+    expect(direct.closeCalls()).toBe(1);
+  });
+
+  it('bounds the raw TCP connect with the direct-connect dial deadline', async () => {
+    const socketDial: SocketDial = {
+      connect: async (_host, _port, options) => {
+        return await new Promise<never>((_, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal!.reason), { once: true });
+        });
+      },
+    };
+
+    await expect(runDirectConnectRequest(
+      { host: 'api.example.com', port: 443, tls: true },
+      { method: 'GET', path: '/', headers: {} },
+      { socketDial, dialTimeoutMs: 20 },
+    )).rejects.toMatchObject({
+      name: 'ProxyDialError',
+      stage: 'tcp-connect',
+      message: expect.stringContaining('direct-connect'),
+    });
   });
 });
 

--- a/packages/proxy/src/dialer_test.ts
+++ b/packages/proxy/src/dialer_test.ts
@@ -236,6 +236,18 @@ describe('runDirectConnectRequest', () => {
     expect(direct.closeCalls()).toBe(1);
   });
 
+  it('closes its socket when the response body errors', async () => {
+    const direct = makeSocketDial('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n');
+    const response = await runDirectConnectRequest(
+      { host: 'api.example.com', port: 80, tls: false },
+      { method: 'GET', path: '/', headers: {} },
+      { socketDial: direct.socketDial },
+    );
+
+    await expect(response.text()).rejects.toThrow('upstream EOF');
+    expect(direct.closeCalls()).toBe(1);
+  });
+
   it('bounds the raw TCP connect with the direct-connect dial deadline', async () => {
     const socketDial: SocketDial = {
       connect: async (_host, _port, options) => {

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -10,5 +10,5 @@ export type { ProxyConfig } from './proxy-config.ts';
 
 export { ProxyDialError, ProxyUriError } from './errors.ts';
 
-export { runProxiedRequest } from './dialer.ts';
-export type { RunProxiedRequestOptions } from './dialer.ts';
+export { runDirectConnectRequest, runProxiedRequest } from './dialer.ts';
+export type { RunDirectConnectRequestOptions, RunProxiedRequestOptions } from './dialer.ts';


### PR DESCRIPTION
## Summary

- replace the former built-in direct entry with explicit `direct_fetch` and `direct_connect` transport entries
- run `direct_connect` over the platform `SocketDial`, userspace TLS, and the existing HTTP/1.1 streaming parser
- migrate persisted `direct` entries to `direct_fetch` while preserving order and colo scopes
- expose both built-in transports in the dashboard's existing Proxy Fallback List editor

## Motivation

Cloudflare's runtime-native `fetch()` path enforces an upstream response read-idle boundary that can truncate valid long-running Copilot Responses streams after HTTP 200 has already started. Cloudflare TCP Sockets do not pass the response body through that HTTP proxy path.

`Proxy Fallback List` remains the name of the existing ordered policy surface. This change keeps runtime fetch as the default direct transport and adds direct TCP as an explicitly selectable transport in that policy. No upstream starts using direct TCP merely by applying the migration.

References:

- https://developers.cloudflare.com/fundamentals/reference/connection-limits/
- https://developers.cloudflare.com/workers/runtime-apis/tcp-sockets/

## Experimental evidence

The transport was validated in temporary isolated Workers with no production bindings or routes. The Workers, their secrets, and all local probe files were deleted after the experiments; the production Worker deployment did not change.

The observations below are **transport-outcome evidence, not latency comparisons**. Each request triggered an independent, stochastic model generation, so their total durations must not be compared as if only the transport changed.

The runs used the same Copilot account and the same 1,041,085-byte workload derived from the captured request by retaining 253 non-account-bound input items.

### Native fetch cutoff

One runtime-native `fetch()` request:

- received HTTP 200 and `response.created` at 33.536s
- then reached exactly 120,000ms of reported upstream body idle
- failed at 158.770s with `Network connection lost.`
- never received a terminal Responses event

This reproduces the production failure shape after the response has already started.

### Hostname TCP long-idle completion

A hostname `cloudflare:sockets` + userspace-TLS request:

- received HTTP 200 headers at 33.484s
- emitted its last pre-idle events (`response.in_progress` + `keepalive`) at 33.935s
- received its next raw upstream chunk at 267.380s
- remained connected across **233.445s of measured raw silence**
- received `response.completed` and clean EOF at 268.620s
- delivered 285 chunks / 341,795 response bytes
- closed the socket normally

This directly demonstrates that hostname direct-connect can survive well beyond the native fetch read-idle boundary and still deliver a complete terminal response.

`direct_connect` always dials the hostname from the upstream URL; no IP is pinned or exposed in the dashboard.

## Proxy fallback list behavior and migration

- an empty list still means `[direct_fetch]`
- migration 0055 rewrites persisted `direct` entries to `direct_fetch`; runtime code does not retain a compatibility alias
- `direct_fetch` preserves runtime-native body handling and HTTP behavior
- `direct_connect` materializes replayable request bytes and uses raw TCP → optional userspace TLS → HTTP/1.1
- both built-in transport entries support ordering and per-location `colos` filters
- built-in transports never create proxy backoff rows
- a direct-connect `ProxyDialError` advances to the next list entry; protocol/parser failures retain the existing fail-loud behavior
- response completion, body failure, and consumer cancellation all tear down the owned raw socket

## Tradeoffs

- direct-connect uses a fresh HTTP/1.1/TLS connection rather than the runtime fetch pool and HTTP/2
- userspace TLS adds Worker CPU, memory, and byte-copy overhead
- request bodies must be materializable when any direct-connect or proxy entry is present
- Cloudflare TCP Sockets expose no configurable keepalive/idle timeout, so the live long-idle result is the evidence for this path
- hostname dialing is used; no GitHub IP is pinned

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run build:web`
- [x] Browser: log into the zero-config local dashboard and verify the Proxy Fallback List offers `DIRECT fetch()` and `DIRECT connect()` with correct default and add-entry states
