### PR TITLE
fix(web): allow zero-config development login

### DIFF
--- a/apps/web/src/pages/login.vue
+++ b/apps/web/src/pages/login.vue
@@ -19,13 +19,14 @@ const errorMessage = ref<string | null>(null);
 
 const [loading, submit] = useLoading(async () => {
   errorMessage.value = null;
-  if (!passwordInput.value) {
+  const username = usernameInput.value.trim();
+  if (username && !passwordInput.value) {
     errorMessage.value = 'Enter a password to continue.';
     return;
   }
 
   const { data, error } = await callApi<{ token: string; user: AuthUser }>(
-    () => api.auth.login.$post({ json: { username: usernameInput.value.trim(), password: passwordInput.value } }),
+    () => api.auth.login.$post({ json: { username, password: passwordInput.value } }),
   );
   if (error) {
     errorMessage.value = error.message;
@@ -57,7 +58,9 @@ const [loading, submit] = useLoading(async () => {
 
       <div class="glass-card glow-cyan p-8">
         <p class="mb-6 text-xs leading-relaxed text-gray-500">
-          Leave the username blank and use the deployment's <span class="text-gray-400">ADMIN_KEY</span> to log in as the default admin user.
+          Leave the username blank to sign in as the default admin user. In local development without an
+          <span class="text-gray-400">ADMIN_KEY</span>, leave the password blank too; otherwise enter the deployment's
+          <span class="text-gray-400">ADMIN_KEY</span>.
         </p>
 
         <form class="space-y-5" @submit.prevent="submit">
@@ -67,7 +70,7 @@ const [loading, submit] = useLoading(async () => {
               id="username"
               v-model="usernameInput"
               type="text"
-              placeholder="(leave blank for ADMIN_KEY login)"
+              placeholder="(leave blank for default admin)"
               autocomplete="username"
               autofocus
             />

--- a/apps/web/src/pages/login_test.ts
+++ b/apps/web/src/pages/login_test.ts
@@ -1,0 +1,75 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { loginSpy, replaceSpy, setAuthSpy } = vi.hoisted(() => ({
+  loginSpy: vi.fn(),
+  replaceSpy: vi.fn(),
+  setAuthSpy: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ replace: replaceSpy }),
+}));
+
+vi.mock('../api/client.ts', () => ({
+  useApi: () => ({ auth: { login: { $post: loginSpy } } }),
+  callApi: async <T>(fn: () => Promise<Response>) => {
+    const response = await fn();
+    return { data: await response.json() as T };
+  },
+}));
+
+vi.mock('../stores/auth.ts', () => ({
+  useAuthStore: () => ({ setAuth: setAuthSpy }),
+}));
+
+const { default: LoginPage } = await import('./login.vue');
+
+const loginResult = {
+  token: 'session-token',
+  user: {
+    id: 1,
+    username: 'admin',
+    isAdmin: true,
+    canViewGlobalTelemetry: true,
+    upstreamIds: null,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('definePage', vi.fn());
+  loginSpy.mockResolvedValue(Response.json(loginResult));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('login page', () => {
+  it('submits empty credentials for zero-config local development', async () => {
+    const wrapper = mount(LoginPage);
+
+    expect(wrapper.text()).toContain('In local development without an ADMIN_KEY, leave the password blank too');
+
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(loginSpy).toHaveBeenCalledExactlyOnceWith({ json: { username: '', password: '' } });
+    expect(setAuthSpy).toHaveBeenCalledExactlyOnceWith(loginResult);
+    expect(replaceSpy).toHaveBeenCalledExactlyOnceWith('/dashboard/settings');
+  });
+
+  it('still requires a password for a named account', async () => {
+    const wrapper = mount(LoginPage);
+
+    await wrapper.get('#username').setValue('alice');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Enter a password to continue.');
+    expect(loginSpy).not.toHaveBeenCalled();
+    expect(setAuthSpy).not.toHaveBeenCalled();
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Allow the login form to submit an empty password when the trimmed username is also empty, matching the zero-config local development auth contract.
- Keep the existing client-side password requirement for named accounts.
- Explain both blank-password local development login and deployment ADMIN_KEY login, with black-box component coverage for both validation branches.

## Risk

Low and limited to the login page's pre-submit validation. A blank username now reaches the existing server-side auth checks; production still rejects empty credentials, and deployments with ADMIN_KEY still require that key. Backend authentication behavior is unchanged.

## Verification

- `pnpm --filter @floway-dev/web exec vitest run src/pages/login_test.ts` (2 passed)
- `pnpm --filter @floway-dev/gateway exec vitest run src/control-plane/auth/routes_test.ts` (22 passed)
- `pnpm --filter @floway-dev/web run test` (216 passed)
- `pnpm --filter @floway-dev/web run typecheck`
- `pnpm exec eslint apps/web/src/pages/login.vue apps/web/src/pages/login_test.ts`
