### PR TITLE
fix(gateway): add X-Accel-Buffering: no to every SSE response

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -29,6 +29,25 @@ const projectList = [
   './packages/ui/tsconfig.json',
 ];
 
+// Shared across every `no-restricted-imports` block so re-listing them (a
+// flat-config requirement — rule option arrays are replaced, not deep-merged
+// — see the apps/web override below) stays a spread, not a hand-sync copy.
+const commonRestrictedImportPatterns = [
+  {
+    group: ['@floway-dev/*/src/**'],
+    message: 'Cross-package deep imports are forbidden. Use the package\'s public exports map.',
+  },
+  {
+    group: [
+      '@floway-dev/platform-cloudflare',
+      '@floway-dev/platform-cloudflare/*',
+      '@floway-dev/platform-node',
+      '@floway-dev/platform-node/*',
+    ],
+    message: 'Platform implementations are deployment-target apps, not libraries. They are reachable only from their own entry.ts via relative imports.',
+  },
+];
+
 const commonConfig: Linter.Config = {
   plugins: {
     import: importPlugin,
@@ -51,25 +70,7 @@ const commonConfig: Linter.Config = {
     'import/no-duplicates': 'error',
 
     'no-restricted-imports': ['error', {
-      patterns: [
-        {
-          group: ['@floway-dev/*/src/**'],
-          message: 'Cross-package deep imports are forbidden. Use the package\'s public exports map.',
-        },
-        {
-          group: [
-            '@floway-dev/platform-cloudflare',
-            '@floway-dev/platform-cloudflare/*',
-            '@floway-dev/platform-node',
-            '@floway-dev/platform-node/*',
-          ],
-          message: 'Platform implementations are deployment-target apps, not libraries. They are reachable only from their own entry.ts via relative imports.',
-        },
-        {
-          group: ['hono/streaming'],
-          message: 'Import streamSSE from packages/gateway/src/streaming/sse.ts instead — the wrapper adds X-Accel-Buffering: no so SSE flows through nginx reverse proxies without buffering.',
-        },
-      ],
+      patterns: commonRestrictedImportPatterns,
     }],
 
     // Belt-and-suspenders for the package-name ban above: relative imports
@@ -222,27 +223,15 @@ const config: Linter.Config[] = [
   {
     // Redefining a single rule replaces its whole option value (the
     // option array is not deep-merged with the earlier declaration), so
-    // the platform-impl patterns from commonConfig's `no-restricted-imports`
-    // must be re-listed here alongside the proxy-root ban. Other common
-    // rules still apply to apps/web via flat-config's per-rule merge
-    // across matching config objects.
+    // the common patterns are spread in from `commonRestrictedImportPatterns`
+    // alongside the proxy-root ban. Other common rules still apply to
+    // apps/web via flat-config's per-rule merge across matching config
+    // objects.
     files: ['apps/web/**/*.{ts,tsx,vue}'],
     rules: {
       'no-restricted-imports': ['error', {
         patterns: [
-          {
-            group: ['@floway-dev/*/src/**'],
-            message: 'Cross-package deep imports are forbidden. Use the package\'s public exports map.',
-          },
-          {
-            group: [
-              '@floway-dev/platform-cloudflare',
-              '@floway-dev/platform-cloudflare/*',
-              '@floway-dev/platform-node',
-              '@floway-dev/platform-node/*',
-            ],
-            message: 'Platform implementations are deployment-target apps, not libraries. They are reachable only from their own entry.ts via relative imports.',
-          },
+          ...commonRestrictedImportPatterns,
           {
             // Match the bare specifier only, not the `/url`, `/url-kind`,
             // etc. subpaths the dashboard is allowed to import.
@@ -261,6 +250,30 @@ const config: Linter.Config[] = [
       'no-restricted-syntax': ['error', {
         selector: 'ImportDeclaration[importKind!="type"][source.value=/^@floway-dev\\u002Fgateway($|\\u002F)/]',
         message: 'apps/web may only type-import from @floway-dev/gateway. The SPA bundle must not pull gateway runtime code.',
+      }],
+    },
+  },
+  {
+    // Gateway is the only package that touches Hono at all, and every SSE
+    // response needs `X-Accel-Buffering: no` so it flows through nginx
+    // reverse proxies without buffering. Funnel every `streamSSE` call
+    // through the wrapper (which sets the header before delegating);
+    // sibling helpers like `streamText` / `stream` are unaffected because
+    // they carry no buffering-behaviour contract. The wrapper file itself
+    // is `ignores`d so it can import `streamSSE` from Hono directly
+    // without an inline `eslint-disable`.
+    files: ['packages/gateway/**/*.{ts,tsx}'],
+    ignores: ['packages/gateway/src/streaming/sse.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: commonRestrictedImportPatterns,
+        paths: [
+          {
+            name: 'hono/streaming',
+            importNames: ['streamSSE'],
+            message: 'Import streamSSE from packages/gateway/src/streaming/sse.ts — the wrapper adds X-Accel-Buffering: no so SSE flows through nginx reverse proxies without buffering.',
+          },
+        ],
       }],
     },
   },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -65,6 +65,10 @@ const commonConfig: Linter.Config = {
           ],
           message: 'Platform implementations are deployment-target apps, not libraries. They are reachable only from their own entry.ts via relative imports.',
         },
+        {
+          group: ['hono/streaming'],
+          message: 'Import streamSSE from packages/gateway/src/streaming/sse.ts instead — the wrapper adds X-Accel-Buffering: no so SSE flows through nginx reverse proxies without buffering.',
+        },
       ],
     }],
 

--- a/packages/gateway/src/control-plane/dump.ts
+++ b/packages/gateway/src/control-plane/dump.ts
@@ -1,8 +1,8 @@
 import type { Context } from 'hono';
 import { Hono } from 'hono';
-import { streamSSE } from 'hono/streaming';
 import { z } from 'zod';
 
+import { streamSSE } from '../streaming/sse.ts';
 import { ownedKeyOr404 } from './shared/owned-key.ts';
 import { getDumpBroker, getDumpStore } from '../dump/registry.ts';
 import { dumpRecordToWire } from '../dump/wire.ts';

--- a/packages/gateway/src/control-plane/dump_test.ts
+++ b/packages/gateway/src/control-plane/dump_test.ts
@@ -136,6 +136,7 @@ test('GET /api/dump/keys/:keyId/stream sends snapshot then appended frames', asy
     headers: { 'x-api-key': apiKey.key },
   });
   assertEquals(response.status, 200);
+  assertEquals(response.headers.get('x-accel-buffering'), 'no');
   await stubs.broker.publish(apiKey.id, fakeMeta('01HZZ0000000000000000000A2', 2000));
 
   const frames = await readFrames(response, 2);

--- a/packages/gateway/src/data-plane/chat/chat-completions/respond.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/respond.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
-import { streamSSE } from 'hono/streaming';
 
 import { tokenUsageFromChatCompletionsUsage } from './usage.ts';
+import { streamSSE } from '../../../streaming/sse.ts';
 import { recordFailedRequest } from '../../shared/telemetry/performance.ts';
 import { settle } from '../../shared/telemetry/settle.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';

--- a/packages/gateway/src/data-plane/chat/gemini/respond.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/respond.ts
@@ -1,8 +1,8 @@
 import type { Context } from 'hono';
-import { streamSSE } from 'hono/streaming';
 
 import { geminiStatusForHttpStatus } from './errors.ts';
 import { tokenUsageFromGeminiUsageMetadata } from './usage.ts';
+import { streamSSE } from '../../../streaming/sse.ts';
 import { recordFailedRequest } from '../../shared/telemetry/performance.ts';
 import { settle } from '../../shared/telemetry/settle.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';

--- a/packages/gateway/src/data-plane/chat/messages/respond.ts
+++ b/packages/gateway/src/data-plane/chat/messages/respond.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono';
-import { streamSSE } from 'hono/streaming';
 
+import { streamSSE } from '../../../streaming/sse.ts';
 import { recordFailedRequest } from '../../shared/telemetry/performance.ts';
 import { settle } from '../../shared/telemetry/settle.ts';
 import { tokenUsage } from '../../shared/telemetry/usage.ts';

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
-import { streamSSE } from 'hono/streaming';
 
 import { tokenUsageFromResponsesResult } from './usage.ts';
+import { streamSSE } from '../../../streaming/sse.ts';
 import { recordFailedRequest } from '../../shared/telemetry/performance.ts';
 import { settle } from '../../shared/telemetry/settle.ts';
 import type { GatewayCtx } from '../shared/gateway-ctx.ts';

--- a/packages/gateway/src/data-plane/chat/shared/stream/sse.ts
+++ b/packages/gateway/src/data-plane/chat/shared/stream/sse.ts
@@ -1,4 +1,5 @@
-import type { SSEStreamingApi } from '../../../../streaming/sse.ts';
+import type { SSEStreamingApi } from 'hono/streaming';
+
 import type { SseFrame, SseWritableFrame } from '@floway-dev/protocols/common';
 
 export const DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS = 15_000;

--- a/packages/gateway/src/data-plane/chat/shared/stream/sse.ts
+++ b/packages/gateway/src/data-plane/chat/shared/stream/sse.ts
@@ -1,5 +1,4 @@
-import type { SSEStreamingApi } from 'hono/streaming';
-
+import type { SSEStreamingApi } from '../../../../streaming/sse.ts';
 import type { SseFrame, SseWritableFrame } from '@floway-dev/protocols/common';
 
 export const DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS = 15_000;

--- a/packages/gateway/src/data-plane/chat/shared/stream/sse_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/stream/sse_test.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
-import { streamSSE } from 'hono/streaming';
 import { test } from 'vitest';
 
 import { writeSSEFrames } from './sse.ts';
+import { streamSSE } from '../../../../streaming/sse.ts';
 import { FakeTime } from '../../../../test-time.ts';
 import { parseSSEStream } from '@floway-dev/protocols/common';
 import { sseCommentFrame, type SseFrame, sseFrame } from '@floway-dev/protocols/common';

--- a/packages/gateway/src/data-plane/shared/passthrough-serve.ts
+++ b/packages/gateway/src/data-plane/shared/passthrough-serve.ts
@@ -10,7 +10,6 @@
 // successful 200 from upstream into a 502.
 
 import type { Context } from 'hono';
-import { streamSSE } from 'hono/streaming';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 import type { PassthroughServeApiName } from './api-names.ts';
@@ -21,6 +20,7 @@ import { recordFailedRequest } from './telemetry/performance.ts';
 import { settle } from './telemetry/settle.ts';
 import type { AuthedContext } from '../../middleware/auth.ts';
 import type { TokenUsage } from '../../repo/types.ts';
+import { streamSSE } from '../../streaming/sse.ts';
 import type { GatewayCtx } from '../chat/shared/gateway-ctx.ts';
 import { type StreamCompletion, writeSSEFrames } from '../chat/shared/stream/sse.ts';
 import { enumerateModelCandidates } from '../providers/registry.ts';

--- a/packages/gateway/src/streaming/sse.ts
+++ b/packages/gateway/src/streaming/sse.ts
@@ -1,8 +1,5 @@
 import type { Context } from 'hono';
-// eslint-disable-next-line no-restricted-imports -- the whole point of this wrapper is to funnel every streamSSE call through here.
 import { streamSSE as honoStreamSSE, type SSEStreamingApi } from 'hono/streaming';
-
-export type { SSEStreamingApi };
 
 // nginx (and OpenResty / Tengine / other nginx-based reverse proxies) enable
 // `proxy_buffering` by default, which holds SSE chunks until the buffer fills

--- a/packages/gateway/src/streaming/sse.ts
+++ b/packages/gateway/src/streaming/sse.ts
@@ -2,6 +2,8 @@ import type { Context } from 'hono';
 // eslint-disable-next-line no-restricted-imports -- the whole point of this wrapper is to funnel every streamSSE call through here.
 import { streamSSE as honoStreamSSE, type SSEStreamingApi } from 'hono/streaming';
 
+export type { SSEStreamingApi };
+
 // nginx (and OpenResty / Tengine / other nginx-based reverse proxies) enable
 // `proxy_buffering` by default, which holds SSE chunks until the buffer fills
 // or upstream closes — visible to end users as long, silent gaps in the
@@ -9,8 +11,6 @@ import { streamSSE as honoStreamSSE, type SSEStreamingApi } from 'hono/streaming
 // Cloudflare's edge ignores the header, so it costs nothing on the Workers
 // deployment target and fixes the Node deployment target when it sits behind
 // nginx.
-export type { SSEStreamingApi };
-
 export const streamSSE = (
   c: Context,
   cb: (stream: SSEStreamingApi) => Promise<void>,

--- a/packages/gateway/src/streaming/sse.ts
+++ b/packages/gateway/src/streaming/sse.ts
@@ -1,0 +1,21 @@
+import type { Context } from 'hono';
+// eslint-disable-next-line no-restricted-imports -- the whole point of this wrapper is to funnel every streamSSE call through here.
+import { streamSSE as honoStreamSSE, type SSEStreamingApi } from 'hono/streaming';
+
+// nginx (and OpenResty / Tengine / other nginx-based reverse proxies) enable
+// `proxy_buffering` by default, which holds SSE chunks until the buffer fills
+// or upstream closes — visible to end users as long, silent gaps in the
+// stream. `X-Accel-Buffering: no` disables that buffering for the response.
+// Cloudflare's edge ignores the header, so it costs nothing on the Workers
+// deployment target and fixes the Node deployment target when it sits behind
+// nginx.
+export type { SSEStreamingApi };
+
+export const streamSSE = (
+  c: Context,
+  cb: (stream: SSEStreamingApi) => Promise<void>,
+  onError?: (e: Error, stream: SSEStreamingApi) => Promise<void>,
+): Response => {
+  c.header('X-Accel-Buffering', 'no');
+  return honoStreamSSE(c, cb, onError);
+};

--- a/packages/gateway/src/streaming/sse_test.ts
+++ b/packages/gateway/src/streaming/sse_test.ts
@@ -13,7 +13,6 @@ test('streamSSE wrapper sets X-Accel-Buffering plus the streamSSE defaults', asy
 
   const response = await app.request('/');
 
-  // nginx-buffering opt-out — the reason this wrapper exists.
   assertEquals(response.headers.get('x-accel-buffering'), 'no');
   // Hono's built-in headers survive the wrapper (regression guard against a
   // future refactor that stops delegating to honoStreamSSE).

--- a/packages/gateway/src/streaming/sse_test.ts
+++ b/packages/gateway/src/streaming/sse_test.ts
@@ -1,0 +1,24 @@
+import { Hono } from 'hono';
+import { test } from 'vitest';
+
+import { streamSSE } from './sse.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+test('streamSSE wrapper sets X-Accel-Buffering plus the streamSSE defaults', async () => {
+  const app = new Hono();
+  app.get('/', c =>
+    streamSSE(c, async stream => {
+      await stream.writeSSE({ data: 'hi' });
+    }));
+
+  const response = await app.request('/');
+
+  // nginx-buffering opt-out — the reason this wrapper exists.
+  assertEquals(response.headers.get('x-accel-buffering'), 'no');
+  // Hono's built-in headers survive the wrapper (regression guard against a
+  // future refactor that stops delegating to honoStreamSSE).
+  assertEquals(response.headers.get('content-type')?.split(';')[0], 'text/event-stream');
+  assertEquals(response.headers.get('cache-control'), 'no-cache');
+
+  await response.body?.cancel();
+});


### PR DESCRIPTION
## Summary

Every SSE response Floway emits now carries `X-Accel-Buffering: no`, so streams flow through nginx (and other nginx-based reverse proxies) without `proxy_buffering` holding chunks in the edge until the buffer fills. The header is a no-op on Cloudflare Workers, so the Workers deployment is unaffected; the Node deployment target behind nginx is where this fixes long silent gaps in Anthropic Messages / OpenAI Responses streams.

## What changed

- **New `packages/gateway/src/streaming/sse.ts`** — a thin wrapper around Hono's `streamSSE` that sets `X-Accel-Buffering: no` on the response header before delegating. Signature mirrors Hono's `streamSSE` exactly so it is a drop-in.
- All 6 existing SSE endpoints now import `streamSSE` from the wrapper: `GET /api/dump/keys/:keyId/stream` (control-plane), Anthropic Messages, Gemini `streamGenerateContent`, OpenAI Responses, OpenAI Chat Completions, and the passthrough SSE path (`/v1/completions` and friends).
- **ESLint enforcement** — a `no-restricted-imports` rule bans direct imports of `streamSSE` from `hono/streaming` inside `packages/gateway/**`; the wrapper file itself is in `ignores`. The ban uses `paths[importNames:['streamSSE']]` so sibling helpers like `streamText` and the raw `stream` helper are unaffected, and the type `SSEStreamingApi` can still be imported directly from `hono/streaming`. The common `no-restricted-imports` patterns (deep-import + platform-target bans) are extracted into a top-level `commonRestrictedImportPatterns` const so re-listing them in each override block stays a spread, not a hand-sync copy.
- **Tests** — new `streaming/sse_test.ts` locks all three response headers (`X-Accel-Buffering`, `Content-Type`, `Cache-Control`); one end-to-end assertion added to `dump_test.ts` covers the control-plane streaming path.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — all packages
- [x] `pnpm --filter @floway-dev/gateway test --run` — 152 files / 1937 tests
- [x] Adversarial: swapping any respond.ts back to `import { streamSSE } from 'hono/streaming'` triggers the ESLint ban with the expected message
- [ ] Manual smoke against `pnpm run dev:node` behind nginx: response headers include all three, stream chunks flush without buffering delay