### PR TITLE
feat(dashboard): unify upstream edit/create Fetch button UX

### DIFF
--- a/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
@@ -115,7 +115,7 @@ const setAuthStyle = (style: CustomAuthStyle) => {
     <div>
       <div class="mb-2 flex items-baseline justify-between gap-3">
         <p class="text-xs font-medium text-gray-500">Fetch <code class="font-mono">/models</code></p>
-        <p v-if="fetchStatus && !editMode" class="text-[11px] text-gray-500">{{ fetchStatus }}</p>
+        <p v-if="fetchStatus" class="text-[11px] text-gray-500">{{ fetchStatus }}</p>
       </div>
       <div class="flex items-center gap-2">
         <Switch
@@ -131,7 +131,6 @@ const setAuthStyle = (style: CustomAuthStyle) => {
           @update:model-value="v => draft = { ...draft, modelsFetch: { ...draft.modelsFetch, endpoint: v } }"
         />
         <Button
-          v-if="!editMode"
           variant="secondary"
           size="sm"
           :loading="fetchLoading"

--- a/apps/web/src/components/upstream-edit/ModelsCacheStatus.vue
+++ b/apps/web/src/components/upstream-edit/ModelsCacheStatus.vue
@@ -5,16 +5,12 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { computed, ref } from 'vue';
 
 import type { UpstreamRecord } from '../../api/types.ts';
-import { Button } from '@floway-dev/ui';
 
 dayjs.extend(relativeTime);
 
 const props = defineProps<{
   modelsCache: UpstreamRecord['modelsCache'];
-  refreshing: boolean;
 }>();
-
-defineEmits<{ refresh: [] }>();
 
 const now = useNow({ interval: 30_000 });
 const fetchedLabel = computed(() => props.modelsCache.fetchedAt === null
@@ -28,21 +24,18 @@ const errorOpen = ref(false);
 </script>
 
 <template>
-  <div class="flex flex-wrap items-center gap-3">
-    <div class="flex min-w-0 flex-1 flex-col gap-1">
-      <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs">
-        <span class="text-gray-300">last fetched <span class="text-white">{{ fetchedLabel }}</span></span>
-        <span
-          v-if="modelsCache.lastError"
-          class="cursor-pointer text-accent-rose hover:underline"
-          @click="errorOpen = !errorOpen"
-        >last error {{ errorAtLabel }} ({{ errorOpen ? 'hide' : 'show' }})</span>
-      </div>
-      <p
-        v-if="modelsCache.lastError && errorOpen"
-        class="rounded-md border border-accent-rose/40 bg-accent-rose/10 px-3 py-2 font-mono text-[11px] text-accent-rose"
-      >{{ modelsCache.lastError.message }}</p>
+  <div class="flex min-w-0 flex-col gap-1">
+    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs">
+      <span class="text-gray-300">last fetched <span class="text-white">{{ fetchedLabel }}</span></span>
+      <span
+        v-if="modelsCache.lastError"
+        class="cursor-pointer text-accent-rose hover:underline"
+        @click="errorOpen = !errorOpen"
+      >last error {{ errorAtLabel }} ({{ errorOpen ? 'hide' : 'show' }})</span>
     </div>
-    <Button variant="secondary" size="sm" :loading="refreshing" @click="$emit('refresh')">Refresh now</Button>
+    <p
+      v-if="modelsCache.lastError && errorOpen"
+      class="rounded-md border border-accent-rose/40 bg-accent-rose/10 px-3 py-2 font-mono text-[11px] text-accent-rose"
+    >{{ modelsCache.lastError.message }}</p>
   </div>
 </template>

--- a/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
@@ -3,11 +3,6 @@
 // optional bearer token. The catalog is always live-fetched from /api/tags +
 // /api/show — no toggle, no path overrides, no auth-style choice. The
 // model-overrides list lives in a separate panel.
-//
-// The Fetch button re-runs the live catalog fetch against the in-flight form
-// config (baseUrl / apiKey), so the operator can preview the resolved list
-// before saving on both create and edit. In edit mode an untyped apiKey
-// falls back to the stored secret (handled by the parent).
 
 import type { OllamaDraft } from './customConfig.ts';
 import SecretInput from '../shared/SecretInput.vue';
@@ -20,7 +15,7 @@ defineProps<{
   editMode: boolean;
   fetchLoading: boolean;
   fetchError: string | null;
-  /** Wall-clock summary of the last draft fetch, e.g. "35 returned · 1m ago". */
+  /** Wall-clock summary of the last fetch, e.g. "35 returned · 1m ago". */
   fetchStatus: string | null;
 }>();
 

--- a/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
@@ -4,9 +4,10 @@
 // /api/show — no toggle, no path overrides, no auth-style choice. The
 // model-overrides list lives in a separate panel.
 //
-// In create mode the panel exposes a Fetch button so the operator can preview
-// the upstream's resolved catalog before saving; on edit mode the cache-status
-// panel above already drives a force-refresh.
+// The Fetch button re-runs the live catalog fetch against the in-flight form
+// config (baseUrl / apiKey), so the operator can preview the resolved list
+// before saving on both create and edit. In edit mode an untyped apiKey
+// falls back to the stored secret (handled by the parent).
 
 import type { OllamaDraft } from './customConfig.ts';
 import SecretInput from '../shared/SecretInput.vue';
@@ -56,7 +57,7 @@ const emit = defineEmits<{ 'fetch-models': [] }>();
       </p>
     </div>
 
-    <div v-if="!editMode">
+    <div>
       <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
         <p class="text-xs font-medium text-gray-500">Fetch models</p>
         <div class="flex items-center gap-3">

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -41,9 +41,9 @@ const props = defineProps<{
   availableModelItems: { value: string; label: string }[];
   // Live cache snapshot for the saved upstream. Null in create mode and for
   // Azure (which has no fetch step) — `ModelsCacheStatus` is rendered only
-  // when this is provided.
+  // when this is provided. The panel is informational only; the "Fetch"
+  // button in the per-provider config panel is the sole re-fetch entry.
   modelsCache: UpstreamRecord['modelsCache'] | null;
-  refreshing: boolean;
   saving: boolean;
   coloAware: boolean;
   currentColo: string | null;
@@ -51,7 +51,6 @@ const props = defineProps<{
 
 defineEmits<{
   'fetch-models': [];
-  'refresh-cache': [];
   patched: [patch: { config?: unknown; state?: unknown }];
   'save-and-open-edit': [];
   error: [message: string];
@@ -208,11 +207,7 @@ onBeforeUnmount(() => floorObserver?.disconnect());
 
       <section v-if="modelsCache" class="shrink-0">
         <p class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-gray-500">Models Cache</p>
-        <ModelsCacheStatus
-          :models-cache="modelsCache"
-          :refreshing="refreshing"
-          @refresh="$emit('refresh-cache')"
-        />
+        <ModelsCacheStatus :models-cache="modelsCache" />
       </section>
 
       <section class="shrink-0">

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -14,6 +14,8 @@ import {
   blankCustomDraft,
   blankOllamaDraft,
   buildCustomConfigCore,
+  buildListModelsPreviewConfig,
+  buildOllamaConfig,
   type CustomDraft,
   type OllamaDraft,
   seedPathOverrides,
@@ -178,26 +180,7 @@ const listDraftModels = async () => {
   fetchLoading.value = true;
   fetchError.value = null;
   try {
-    // Merge the current form drafts into the payload so the preview
-    // reflects the in-flight edits (baseUrl, apiKey, models)
-    // rather than the record's persisted config.
-    const config: Record<string, unknown> = draft.value.kind === 'custom'
-      ? { ...buildCustomConfigCore(customDraft.value), models: customDraft.value.models }
-      : buildOllamaConfig();
-    // Edit mode: an operator who did not retype the API key expects the
-    // preview to probe with the stored secret — matching how `save()` (via
-    // the backend's patch-omit semantics) treats an empty apiKey as "keep
-    // existing". `list-models` receives a full record envelope rather than a
-    // patch, so replicate the fallback client-side to avoid hitting an
-    // unauthenticated upstream. Applies only when the operator didn't type
-    // anything AND (for custom) the auth style still expects a key.
-    if (!isCreate.value && config.apiKey === undefined) {
-      if (draft.value.kind === 'custom' && draft.value.config.authStyle !== 'none' && draft.value.config.apiKey) {
-        config.apiKey = draft.value.config.apiKey;
-      } else if (draft.value.kind === 'ollama' && draft.value.config.apiKey) {
-        config.apiKey = draft.value.config.apiKey;
-      }
-    }
+    const config = buildListModelsPreviewConfig(draft.value, customDraft.value, ollamaDraft.value, isCreate.value);
     const previewRecord = { ...toRecordEnvelope(draft.value), config };
     const { data, error } = await callApi<ListModelsResult>(
       () => api.api.upstreams['list-models'].$post({ json: { record: previewRecord } }),
@@ -319,15 +302,6 @@ const buildAzureConfig = () => {
   return config;
 };
 
-const buildOllamaConfig = () => {
-  const config: Record<string, unknown> = {
-    baseUrl: ollamaDraft.value.baseUrl.trim(),
-    models: ollamaDraft.value.models,
-  };
-  if (ollamaDraft.value.apiKey.trim()) config.apiKey = ollamaDraft.value.apiKey.trim();
-  return config;
-};
-
 // Editable providers (custom/azure/ollama) rebuild the config from the
 // per-provider form draft; OAuth providers hand back the credential slice
 // their wizards populated in draft.config / draft.state. In edit state the
@@ -336,7 +310,7 @@ const buildOllamaConfig = () => {
 const buildConfigForSave = (): unknown => {
   if (draft.value.kind === 'custom') return buildCustomConfig();
   if (draft.value.kind === 'azure') return buildAzureConfig();
-  if (draft.value.kind === 'ollama') return buildOllamaConfig();
+  if (draft.value.kind === 'ollama') return buildOllamaConfig(ollamaDraft.value);
   return draft.value.config;
 };
 

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -131,14 +131,9 @@ const modelPrefixInvalid = ref(false);
 const upstreamModels = ref<UpstreamModelConfig[]>([]);
 const upstreamModelsError = ref<string | null>(null);
 
-// Draft preview state for the inline "Fetch" button on the Custom and Ollama
-// panels: `POST /api/upstreams/list-models` returns the in-flight config's
-// catalog so rows can be picked before saving (create) or before persisting
-// edits (edit). `fetchedRaw` carries the Custom raw rows (translated through
-// the draft's endpoints by `customAutoModelsFromDraft`); Ollama rows land in
-// `upstreamModels` alongside the mount-time result — the two call sites
-// produce the same UpstreamModelConfig shape, so a single slot keeps the
-// display path uniform across create and edit.
+// `fetchedRaw` is the Custom-only raw slot — rows get translated through the
+// draft's endpoints via `customAutoModelsFromDraft`; Ollama's Fetch result
+// lands in `upstreamModels` alongside the mount-time prime.
 const fetchedRaw = ref<CustomRawModel[]>([]);
 const fetchLoading = ref(false);
 const fetchError = ref<string | null>(null);
@@ -175,9 +170,6 @@ const customAutoModelsFromDraft = computed<UpstreamModelConfig[]>(() => fetchedR
 // already-projected `UpstreamModelConfig`.
 type ListModelsResult = { data: UpstreamModelConfig[] } | { data: CustomRawModel[] };
 
-// Route the response into the ref that matches the current kind — custom
-// keeps a raw slot so the dashboard can retranslate through the draft's
-// endpoints; every other kind lands projected rows.
 const applyListModelsResult = (data: ListModelsResult['data']): void => {
   if (draft.value.kind === 'custom') fetchedRaw.value = data as CustomRawModel[];
   else upstreamModels.value = data as UpstreamModelConfig[];
@@ -250,14 +242,9 @@ const hasCredentialForFetch = computed<boolean>(() => {
 
 // Fetch the live model catalog for the current draft. Skipped for Azure
 // (operator-edited catalog, no upstream `/models` endpoint) and when the
-// draft has no credential yet (blueprint state). For custom the server
-// returns raw rows the dashboard translates through the draft's endpoints,
-// so route them into `fetchedRaw` — the same slot the unsaved draft
-// preview uses; every other kind receives already-projected
-// UpstreamModelConfig rows and lands in `upstreamModels`. Called once on
-// mount to prime ModelsPanel; the operator-driven "Fetch" button goes
-// through listDraftModels instead so it can post the in-flight form
-// config. Surfaces the error on `upstreamModelsError` on failure.
+// draft has no credential yet (blueprint state). Called once on mount to
+// prime ModelsPanel; the operator-driven "Fetch" button goes through
+// listDraftModels instead so it can post the in-flight form config.
 const fetchUpstreamModels = async () => {
   if (draft.value.kind === 'azure') return;
   if (!hasCredentialForFetch.value) return;

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -254,10 +254,10 @@ const hasCredentialForFetch = computed<boolean>(() => {
 // returns raw rows the dashboard translates through the draft's endpoints,
 // so route them into `fetchedRaw` — the same slot the unsaved draft
 // preview uses; every other kind receives already-projected
-// UpstreamModelConfig rows and lands in `upstreamModels`. Surfaces the
-// error on `upstreamModelsError` otherwise. Returns nothing — callers
-// wrap this with their own bookkeeping (mount-time prime, operator-driven
-// refresh).
+// UpstreamModelConfig rows and lands in `upstreamModels`. Called once on
+// mount to prime ModelsPanel; the operator-driven "Fetch" button goes
+// through listDraftModels instead so it can post the in-flight form
+// config. Surfaces the error on `upstreamModelsError` on failure.
 const fetchUpstreamModels = async () => {
   if (draft.value.kind === 'azure') return;
   if (!hasCredentialForFetch.value) return;

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -129,15 +129,15 @@ const modelPrefixInvalid = ref(false);
 const upstreamModels = ref<UpstreamModelConfig[]>([]);
 const upstreamModelsError = ref<string | null>(null);
 
-// Create-mode draft preview state for the inline "Fetch" button on the
-// Custom and Ollama panels: `POST /api/upstreams/list-models` returns the
-// unsaved config's catalog so rows can be picked before saving.
-// `fetchedRaw` carries the Custom raw rows (translated through the draft's
-// endpoints by `customAutoModelsFromDraft`); `fetchedOllamaModels` carries
-// the Ollama rows the backend already projected — no further translation
-// needed since the per-model endpoints fall out of upstream capabilities.
+// Draft preview state for the inline "Fetch" button on the Custom and Ollama
+// panels: `POST /api/upstreams/list-models` returns the in-flight config's
+// catalog so rows can be picked before saving (create) or before persisting
+// edits (edit). `fetchedRaw` carries the Custom raw rows (translated through
+// the draft's endpoints by `customAutoModelsFromDraft`); Ollama rows land in
+// `upstreamModels` alongside the mount-time result — the two call sites
+// produce the same UpstreamModelConfig shape, so a single slot keeps the
+// display path uniform across create and edit.
 const fetchedRaw = ref<CustomRawModel[]>([]);
-const fetchedOllamaModels = ref<UpstreamModelConfig[]>([]);
 const fetchLoading = ref(false);
 const fetchError = ref<string | null>(null);
 const fetchedAtMs = ref<number | null>(null);
@@ -181,9 +181,23 @@ const listDraftModels = async () => {
     // Merge the current form drafts into the payload so the preview
     // reflects the in-flight edits (baseUrl, apiKey, models)
     // rather than the record's persisted config.
-    const config = draft.value.kind === 'custom'
+    const config: Record<string, unknown> = draft.value.kind === 'custom'
       ? { ...buildCustomConfigCore(customDraft.value), models: customDraft.value.models }
       : buildOllamaConfig();
+    // Edit mode: an operator who did not retype the API key expects the
+    // preview to probe with the stored secret — matching how `save()` (via
+    // the backend's patch-omit semantics) treats an empty apiKey as "keep
+    // existing". `list-models` receives a full record envelope rather than a
+    // patch, so replicate the fallback client-side to avoid hitting an
+    // unauthenticated upstream. Applies only when the operator didn't type
+    // anything AND (for custom) the auth style still expects a key.
+    if (!isCreate.value && config.apiKey === undefined) {
+      if (draft.value.kind === 'custom' && draft.value.config.authStyle !== 'none' && draft.value.config.apiKey) {
+        config.apiKey = draft.value.config.apiKey;
+      } else if (draft.value.kind === 'ollama' && draft.value.config.apiKey) {
+        config.apiKey = draft.value.config.apiKey;
+      }
+    }
     const previewRecord = { ...toRecordEnvelope(draft.value), config };
     const { data, error } = await callApi<ListModelsResult>(
       () => api.api.upstreams['list-models'].$post({ json: { record: previewRecord } }),
@@ -196,10 +210,19 @@ const listDraftModels = async () => {
     if (draft.value.kind === 'custom') {
       fetchedRaw.value = data.data as CustomRawModel[];
     } else {
-      fetchedOllamaModels.value = data.data as UpstreamModelConfig[];
+      upstreamModels.value = data.data as UpstreamModelConfig[];
     }
     fetchedCount.value = data.data.length;
     fetchedAtMs.value = Date.now();
+    // Edit mode: the server-side list-models refreshed the SWR cache too
+    // (record.id !== '' branch in the handler), so reload the store and
+    // fold the freshest `modelsCache.fetchedAt / lastError` back into draft
+    // — the Models Cache info panel is a passive reflection of this state.
+    if (!isCreate.value) {
+      await upstreamsStore.load();
+      const refreshed = upstreamsStore.upstreams.value?.find(u => u.id === draft.value.id);
+      if (refreshed) draft.value = { ...draft.value, modelsCache: refreshed.modelsCache };
+    }
   } finally {
     fetchLoading.value = false;
   }
@@ -263,25 +286,9 @@ const fetchUpstreamModels = async () => {
   }
 };
 
-const refreshing = ref(false);
-const refreshCachedModels = async () => {
-  refreshing.value = true;
-  try {
-    await fetchUpstreamModels();
-    if (upstreamModelsError.value) return;
-    // The server-side list-models refreshed the SWR cache too; reload the
-    // store so the header's `modelsCache` summary reflects the freshest
-    // fetchedAt / lastError the gateway just wrote.
-    await upstreamsStore.load();
-    const refreshed = upstreamsStore.upstreams.value?.find(u => u.id === draft.value.id);
-    if (refreshed) draft.value = { ...draft.value, modelsCache: refreshed.modelsCache };
-  } finally {
-    refreshing.value = false;
-  }
-};
-
-// Prime on mount so ModelsPanel renders populated; refresh button reruns
-// the same call plus the store reload above.
+// Prime on mount so ModelsPanel renders populated; the operator-driven
+// "Fetch" button reruns list-models with the in-flight form config (see
+// listDraftModels).
 void fetchUpstreamModels();
 
 const saving = ref(false);
@@ -459,20 +466,15 @@ const modelsManualForActive = computed<UpstreamModelConfig[]>({
   },
 });
 
-// Auto rows are the live catalog the upstream itself decides. Saved rows
-// resolve through the SWR cache via `upstreamModels`; unsaved custom /
-// ollama drafts fall back to the inline list-models preview.
+// Auto rows are the live catalog the upstream itself decides. Ollama and the
+// OAuth kinds land the projected UpstreamModelConfig rows in `upstreamModels`
+// (populated by the mount-time prime and the inline "Fetch" preview alike);
+// Custom keeps a separate raw slot so the dashboard can translate through
+// the draft's endpoints.
 const autoForActive = computed<UpstreamModelConfig[]>(() => {
   if (draft.value.kind === 'custom') {
     if (!customDraft.value.modelsFetch.enabled) return [];
-    // Both saved and unsaved custom rows read the raw catalog from
-    // `fetchedRaw` and translate through the draft's endpoints — the
-    // server returns raw upstream rows uniformly for both call paths.
     return customAutoModelsFromDraft.value;
-  }
-  if (draft.value.kind === 'ollama') {
-    if (!isCreate.value) return upstreamModels.value;
-    return fetchedOllamaModels.value;
   }
   return upstreamModels.value;
 });
@@ -586,10 +588,8 @@ const workbenchStyle = computed(() => ({ '--right-pane-h': `${Math.ceil(rightCon
         :fetch-status="fetchStatus"
         :available-model-items="availableModelItems"
         :models-cache="showCacheStatus ? draft.modelsCache : null"
-        :refreshing="refreshing"
         :saving="saving"
         @fetch-models="listDraftModels"
-        @refresh-cache="refreshCachedModels"
         @patched="applyPatch"
         @save-and-open-edit="save({ openEdit: true })"
         @error="onError"

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -13,6 +13,7 @@ import {
   blankAzureDraft,
   blankCustomDraft,
   blankOllamaDraft,
+  buildAzureConfig,
   buildCustomConfigCore,
   buildListModelsPreviewConfig,
   buildOllamaConfig,
@@ -280,15 +281,6 @@ const buildCustomConfig = () => {
   return config;
 };
 
-const buildAzureConfig = () => {
-  const config: Record<string, unknown> = {
-    endpoint: azureDraft.value.endpoint.trim(),
-    models: azureDraft.value.models,
-  };
-  if (azureDraft.value.apiKey.trim()) config.apiKey = azureDraft.value.apiKey.trim();
-  return config;
-};
-
 // Editable providers (custom/azure/ollama) rebuild the config from the
 // per-provider form draft; OAuth providers hand back the credential slice
 // their wizards populated in draft.config / draft.state. In edit state the
@@ -296,7 +288,7 @@ const buildAzureConfig = () => {
 // pass here is ignored server-side — it's still safe to include.
 const buildConfigForSave = (): unknown => {
   if (draft.value.kind === 'custom') return buildCustomConfig();
-  if (draft.value.kind === 'azure') return buildAzureConfig();
+  if (draft.value.kind === 'azure') return buildAzureConfig(azureDraft.value);
   if (draft.value.kind === 'ollama') return buildOllamaConfig(ollamaDraft.value);
   return draft.value.config;
 };

--- a/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamEditPage.vue
@@ -175,6 +175,14 @@ const customAutoModelsFromDraft = computed<UpstreamModelConfig[]>(() => fetchedR
 // already-projected `UpstreamModelConfig`.
 type ListModelsResult = { data: UpstreamModelConfig[] } | { data: CustomRawModel[] };
 
+// Route the response into the ref that matches the current kind — custom
+// keeps a raw slot so the dashboard can retranslate through the draft's
+// endpoints; every other kind lands projected rows.
+const applyListModelsResult = (data: ListModelsResult['data']): void => {
+  if (draft.value.kind === 'custom') fetchedRaw.value = data as CustomRawModel[];
+  else upstreamModels.value = data as UpstreamModelConfig[];
+};
+
 const listDraftModels = async () => {
   if (draft.value.kind !== 'custom' && draft.value.kind !== 'ollama') return;
   fetchLoading.value = true;
@@ -190,11 +198,7 @@ const listDraftModels = async () => {
     // discard the late result rather than repopulating stale auto rows.
     if (draft.value.kind === 'custom' && !customDraft.value.modelsFetch.enabled) return;
     if (error) { fetchError.value = error.message; return; }
-    if (draft.value.kind === 'custom') {
-      fetchedRaw.value = data.data as CustomRawModel[];
-    } else {
-      upstreamModels.value = data.data as UpstreamModelConfig[];
-    }
+    applyListModelsResult(data.data);
     fetchedCount.value = data.data.length;
     fetchedAtMs.value = Date.now();
     // Edit mode: the server-side list-models refreshed the SWR cache too
@@ -262,11 +266,7 @@ const fetchUpstreamModels = async () => {
     () => api.api.upstreams['list-models'].$post({ json: { record: toRecordEnvelope(draft.value) } }),
   );
   if (error) { upstreamModelsError.value = error.message; return; }
-  if (draft.value.kind === 'custom') {
-    fetchedRaw.value = data.data as CustomRawModel[];
-  } else {
-    upstreamModels.value = data.data as UpstreamModelConfig[];
-  }
+  applyListModelsResult(data.data);
 };
 
 // Prime on mount so ModelsPanel renders populated; the operator-driven

--- a/apps/web/src/components/upstream-edit/customConfig.ts
+++ b/apps/web/src/components/upstream-edit/customConfig.ts
@@ -1,4 +1,4 @@
-import type { ModelEndpoints, UpstreamModelConfig } from '../../api/types.ts';
+import type { ModelEndpoints, UpstreamModelConfig, UpstreamRecord } from '../../api/types.ts';
 
 export const PATH_KEYS = [
   '/completions',
@@ -124,3 +124,39 @@ export const blankOllamaDraft = (): OllamaDraft => ({
   apiKey: '',
   models: [],
 });
+
+// Wire-shape projection of OllamaDraft. Shared by save() and the list-models
+// preview so the two paths cannot drift.
+export const buildOllamaConfig = (draft: OllamaDraft): Record<string, unknown> => {
+  const config: Record<string, unknown> = {
+    baseUrl: draft.baseUrl.trim(),
+    models: draft.models,
+  };
+  if (draft.apiKey.trim()) config.apiKey = draft.apiKey.trim();
+  return config;
+};
+
+// Wire-shape projection for POST /api/upstreams/list-models. Consolidates the
+// per-kind builder dispatch and the edit-mode stored-secret fallback so the
+// preview probes the same shape save() would write. Matches save()'s
+// backend-patch-omit semantics — an untyped apiKey in edit mode falls back to
+// the record's stored secret so the preview does not hit an unauthenticated
+// upstream when the operator merely tweaks non-credential fields.
+export const buildListModelsPreviewConfig = (
+  record: UpstreamRecord,
+  customDraft: CustomDraft,
+  ollamaDraft: OllamaDraft,
+  isCreate: boolean,
+): Record<string, unknown> => {
+  const config: Record<string, unknown> = record.kind === 'custom'
+    ? { ...buildCustomConfigCore(customDraft), models: customDraft.models }
+    : buildOllamaConfig(ollamaDraft);
+  if (!isCreate && config.apiKey === undefined) {
+    if (record.kind === 'custom' && record.config.authStyle !== 'none' && record.config.apiKey) {
+      config.apiKey = record.config.apiKey;
+    } else if (record.kind === 'ollama' && record.config.apiKey) {
+      config.apiKey = record.config.apiKey;
+    }
+  }
+  return config;
+};

--- a/apps/web/src/components/upstream-edit/customConfig.ts
+++ b/apps/web/src/components/upstream-edit/customConfig.ts
@@ -136,6 +136,17 @@ export const buildOllamaConfig = (draft: OllamaDraft): Record<string, unknown> =
   return config;
 };
 
+// Wire-shape projection of AzureDraft. Azure has no list-models path (the
+// catalog is operator-authored), so this only feeds save().
+export const buildAzureConfig = (draft: AzureDraft): Record<string, unknown> => {
+  const config: Record<string, unknown> = {
+    endpoint: draft.endpoint.trim(),
+    models: draft.models,
+  };
+  if (draft.apiKey.trim()) config.apiKey = draft.apiKey.trim();
+  return config;
+};
+
 // Wire-shape projection for POST /api/upstreams/list-models. Consolidates the
 // per-kind builder dispatch and the edit-mode stored-secret fallback so the
 // preview probes the same shape save() would write. Matches save()'s

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -85,10 +85,9 @@ const codexQuotaForResponse = async (record: UpstreamRecord): Promise<CodexQuota
 };
 
 // These projections need repository/provider I/O, which serialize.ts excludes
-// so it stays a pure persisted-record transform. Callers pick the base
-// serializer: list/create/update stay on the redacted default;
-// getUpstream passes upstreamRecordToFullJson so the edit page receives the
-// unredacted secrets it needs to round-trip.
+// so it stays a pure persisted-record transform. The optional baseSerialize
+// override lets callers swap in upstreamRecordToFullJson to round-trip
+// unredacted secrets instead of the redacted default.
 const serializeForResponse = async (
   record: UpstreamRecord,
   baseSerialize: (r: UpstreamRecord) => SerializedUpstreamRecord = upstreamRecordToJson,

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -247,15 +247,25 @@ export const getUpstreamBlueprint = (c: Context): Response => {
 // Single-record read for the edit page. Returns the FULL record — no
 // secret redaction — because every editor-scoped action posts the record
 // back to a helper endpoint that needs the same credentials the data plane
-// uses (refresh tokens, api keys, etc.). Codex quota is a response-only
-// projection, so it is attached here as well.
+// uses (refresh tokens, api keys, etc.). Codex quota and modelsCache are
+// response-only projections, so they are attached here alongside the
+// unredacted config/state — the edit page relies on `modelsCache` to
+// render the "last fetched / last error" panel on mount.
 export const getUpstream = async (c: AuthedContext<'/:id'>) => {
   const id = c.req.param('id');
   const record = await getRepo().upstreams.getById(id);
   if (!record) return c.json({ error: 'upstream not found' }, 404);
-  const response: UpstreamResponse = {
+  const [cacheRow, codexQuota] = await Promise.all([
+    getRepo().modelsCache.get(record.id),
+    codexQuotaForResponse(record),
+  ]);
+  const response: UpstreamWithCacheResponse = {
     ...upstreamRecordToFullJson(record),
-    ...await codexQuotaForResponse(record),
+    modelsCache: {
+      fetchedAt: cacheRow?.fetchedAt ?? null,
+      lastError: cacheRow?.lastError ?? null,
+    },
+    ...codexQuota,
   };
   return c.json(response);
 };

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -85,14 +85,20 @@ const codexQuotaForResponse = async (record: UpstreamRecord): Promise<CodexQuota
 };
 
 // These projections need repository/provider I/O, which serialize.ts excludes
-// so it stays a pure persisted-record transform.
-const serializeForResponse = async (record: UpstreamRecord): Promise<UpstreamWithCacheResponse> => {
+// so it stays a pure persisted-record transform. Callers pick the base
+// serializer: list/create/update stay on the redacted default;
+// getUpstream passes upstreamRecordToFullJson so the edit page receives the
+// unredacted secrets it needs to round-trip.
+const serializeForResponse = async (
+  record: UpstreamRecord,
+  baseSerialize: (r: UpstreamRecord) => SerializedUpstreamRecord = upstreamRecordToJson,
+): Promise<UpstreamWithCacheResponse> => {
   const [cacheRow, codexQuota] = await Promise.all([
     getRepo().modelsCache.get(record.id),
     codexQuotaForResponse(record),
   ]);
   return {
-    ...upstreamRecordToJson(record),
+    ...baseSerialize(record),
     modelsCache: {
       fetchedAt: cacheRow?.fetchedAt ?? null,
       lastError: cacheRow?.lastError ?? null,
@@ -205,7 +211,7 @@ const validateProxyFallbackList = async (entries: readonly ProxyFallbackEntry[])
 
 export const listUpstreams = async (c: Context) => {
   const items = await getRepo().upstreams.list();
-  return c.json(await Promise.all(items.map(serializeForResponse)));
+  return c.json(await Promise.all(items.map(record => serializeForResponse(record))));
 };
 
 // Picker dataset for the per-key upstream whitelist editor. Non-admin users
@@ -255,19 +261,7 @@ export const getUpstream = async (c: AuthedContext<'/:id'>) => {
   const id = c.req.param('id');
   const record = await getRepo().upstreams.getById(id);
   if (!record) return c.json({ error: 'upstream not found' }, 404);
-  const [cacheRow, codexQuota] = await Promise.all([
-    getRepo().modelsCache.get(record.id),
-    codexQuotaForResponse(record),
-  ]);
-  const response: UpstreamWithCacheResponse = {
-    ...upstreamRecordToFullJson(record),
-    modelsCache: {
-      fetchedAt: cacheRow?.fetchedAt ?? null,
-      lastError: cacheRow?.lastError ?? null,
-    },
-    ...codexQuota,
-  };
-  return c.json(response);
+  return c.json(await serializeForResponse(record, upstreamRecordToFullJson));
 };
 
 export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) => {


### PR DESCRIPTION
## Summary

- **Fix `getUpstream` handler** to include `modelsCache` in the initial edit-page load. Previously only `list`/`create`/`update` went through `serializeForResponse` (which attaches `modelsCache` + `codex_quota`); `getUpstream` inlined a projection without them, so the Models Cache panel stayed empty until the first Save. Fixed by parametrizing `serializeForResponse` over the base serializer and routing `getUpstream` through it with `upstreamRecordToFullJson`.
- **Expose the per-provider Fetch button in edit mode** on Custom + Ollama panels (previously only visible in create). Operators can now preview a re-fetch of the in-flight form config (baseUrl / apiKey) before saving. In edit mode an untyped apiKey falls back to the stored secret, matching how `save()` treats an empty apiKey via backend patch-omit semantics.
- **Turn `ModelsCacheStatus` into an info-only panel** (no button, no emit). The per-provider Fetch button is now the single re-fetch entry point; the cache panel is a passive reflection of the SWR row.
- **Payload-shape consolidation**: `buildOllamaConfig` / `buildAzureConfig` / `buildListModelsPreviewConfig` now live in `customConfig.ts` alongside `buildCustomConfigCore`, so form-draft-to-wire-shape projection has one home. `applyListModelsResult` closure factors out the custom-vs-projected fetch-result dispatch that used to be duplicated between `listDraftModels` and `fetchUpstreamModels`.
- **Peer-conformance sweeps** on comments: dropped caller names, aligned Ollama-panel comment density with sibling per-provider panels.

## Test plan

- [x] \`pnpm run typecheck\` — passes across all packages
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm run test\` — 3994/3994 passed
- [x] Manual E2E via Chrome DevTools on \`pnpm run dev:node\`:
  - Created a Custom upstream, opened edit page
  - Confirmed Models Cache section renders immediately on initial edit-page load (no Save needed)
  - Confirmed Fetch button visible in edit mode
  - Confirmed Fetch POST payload carries \`record.id\` (non-empty → backend force-refresh SWR) and \`config.apiKey\` auto-populated from stored secret when field left blank
  - Confirmed fetch errors render inline under the Fetch button (correct \`fetchError\` slot)