### PR TITLE
fix(gateway): tighten alias.name character set

### DIFF
--- a/apps/web/src/components/alias-edit/AliasEditDialog.vue
+++ b/apps/web/src/components/alias-edit/AliasEditDialog.vue
@@ -197,7 +197,7 @@ const save = async () => {
     } else if (props.record) {
       const oldName = props.record.name;
       const { error } = await callApi(() => api.api.aliases[':name'].$put({
-        param: { name: oldName },
+        param: { name: encodeURIComponent(oldName) },
         json: body,
       }));
       if (error) { saveError.value = error.message; return; }

--- a/apps/web/src/components/settings/AliasesSettingsCard.vue
+++ b/apps/web/src/components/settings/AliasesSettingsCard.vue
@@ -22,7 +22,7 @@ const aliases = computed<ModelAlias[]>(() => aliasesStore.aliases.value ?? []);
 
 const deleteAlias = async (record: ModelAlias) => {
   if (!window.confirm(`Delete alias "${record.name}"?`)) return;
-  const { error } = await callApi(() => api.api.aliases[':name'].$delete({ param: { name: record.name } }));
+  const { error } = await callApi(() => api.api.aliases[':name'].$delete({ param: { name: encodeURIComponent(record.name) } }));
   if (error) {
     window.alert(`Delete failed: ${error.message}`);
     return;

--- a/packages/gateway/src/control-plane/model-aliases/routes_test.ts
+++ b/packages/gateway/src/control-plane/model-aliases/routes_test.ts
@@ -294,3 +294,74 @@ test('POST /api/aliases accepts adaptive=false alongside budget_tokens (force no
   );
   assertEquals(resp.status, 201);
 });
+
+test('POST /api/aliases enforces alias.name character set and length', async () => {
+  const { repo, adminSession } = await setupAppTest();
+
+  const accepted = [
+    'gpt-fast',
+    'openrouter/claude-4',
+    'a/b/c',
+    'gpt-4.1',
+    'x_1',
+    'models/foo',
+    'a'.repeat(128),
+  ];
+  const rejected = [
+    'has:colon',
+    'has?query',
+    'has#hash',
+    'has space',
+    'has\nnewline',
+    'has\0nul',
+    '/leading-slash',
+    'trailing-slash/',
+    'double//slash',
+    'a'.repeat(129),
+    '',
+    '   ',
+  ];
+
+  for (const name of accepted) {
+    await repo.modelAliases.deleteAll();
+    const resp = await requestApp('/api/aliases', authed(adminSession, baseBody({ name })));
+    if (resp.status !== 201) {
+      throw new Error(`expected 201 for name=${JSON.stringify(name)}, got ${resp.status}`);
+    }
+  }
+  for (const name of rejected) {
+    await repo.modelAliases.deleteAll();
+    const resp = await requestApp('/api/aliases', authed(adminSession, baseBody({ name })));
+    if (resp.status !== 400) {
+      throw new Error(`expected 400 for name=${JSON.stringify(name)}, got ${resp.status}`);
+    }
+  }
+});
+
+test('PUT /api/aliases/:name applies the same character set to a rename body', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.modelAliases.deleteAll();
+  await requestApp('/api/aliases', authed(adminSession, baseBody()));
+
+  const resp = await requestApp(
+    '/api/aliases/gpt-fast',
+    putAuthed(adminSession, baseBody({ name: 'has:colon' })),
+  );
+  assertEquals(resp.status, 400);
+});
+
+test('DELETE /api/aliases/:name decodes %2F back to the row name', async () => {
+  // A '/'-carrying alias name reaches the DELETE handler as a
+  // percent-encoded single path segment (`openrouter%2Fclaude-4-opus`).
+  // Hono's route matcher is `[^/]+`, and `HonoRequest.param()` then
+  // decodes the segment back so `repo.modelAliases.delete('openrouter/claude-4-opus')`
+  // hits the row. Without this decoding pass the row would be a
+  // create-only zombie.
+  const { repo, adminSession } = await setupAppTest();
+  await repo.modelAliases.deleteAll();
+  await requestApp('/api/aliases', authed(adminSession, baseBody({ name: 'openrouter/claude-4-opus' })));
+
+  const resp = await requestApp('/api/aliases/openrouter%2Fclaude-4-opus', deleteAuthed(adminSession));
+  assertEquals(resp.status, 204);
+  assertEquals(await repo.modelAliases.getByName('openrouter/claude-4-opus'), null);
+});

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -576,8 +576,24 @@ const announcedMetadataSchema = z.object({
   chat: chatSchema.optional(),
 });
 
+// Mirrors MODEL_PREFIX_REGEX in packages/provider/src/model-prefix.ts:27,
+// but without the trailing '/', because alias.name is the full published
+// model id — not a prefix. '/'-separated segments are allowed so an
+// operator can name a virtual model `openrouter/claude-4-opus`, the same
+// shape real upstream ids already carry. The regex incidentally rejects
+// URL-reserved characters (':', '?', '#', '%'), whitespace, control
+// characters (including NUL, which is the token-usage bucket key
+// separator in control-plane/token-usage/aggregate.ts), and any
+// non-ASCII code point, so the value passes safely through REST path
+// segments and every internal key that stores it verbatim.
+const ALIAS_NAME_REGEX = /^[a-zA-Z0-9._-]+(\/[a-zA-Z0-9._-]+)*$/;
+const ALIAS_NAME_MAX_LENGTH = 128;
+const aliasNameSchema = z.string()
+  .max(ALIAS_NAME_MAX_LENGTH, `alias name must be at most ${ALIAS_NAME_MAX_LENGTH} characters`)
+  .regex(ALIAS_NAME_REGEX, "alias name must be letters, digits, '.', '_', '-', optionally in '/'-separated segments");
+
 const aliasBaseShape = {
-  name: z.string().min(1),
+  name: aliasNameSchema,
   kind: z.enum(['chat', 'embedding', 'image']),
   selection: z.enum(['random', 'first-available']),
   display_name: z.string().min(1).nullable(),


### PR DESCRIPTION
## Summary

`aliasBaseShape.name` was `z.string().min(1)`, so an operator could create aliases whose names contained characters that break every downstream consumer. Because `alias.name` is simultaneously (a) a REST path segment on `PUT /api/aliases/:name` and `DELETE /api/aliases/:name`, (b) a downstream-visible model id served on `/v1/models`, and (c) a byte-precise component of internal keys like the token-usage aggregator's `${keyId}\0${model}\0${hour}` bucket key, several character classes were unsafe: `/` shattered Hono's `[^/]+` single-segment matcher and produced zombie rows the dashboard could neither edit nor delete; NUL collided with the token-usage separator; whitespace, `:`, `?`, `#`, `%`, and control characters corrupted URL path segments and telemetry labels.

This PR ships three tightly-scoped changes:

- **schema (`packages/gateway/src/control-plane/schemas.ts`)** — introduce `ALIAS_NAME_REGEX` and `ALIAS_NAME_MAX_LENGTH` mirroring `MODEL_PREFIX_REGEX` from `@floway-dev/provider` (minus the trailing `/`), and swap `aliasBaseShape.name` from `z.string().min(1)` to the new `aliasNameSchema`. Path-segment `/` is deliberately allowed so operators can name a virtual model with the same shape as real upstream ids (`openrouter/claude-4-opus`, `vendor/model`, `a/b/c`). All non-ASCII, whitespace, control characters, URL-reserved characters, and names longer than 128 characters are rejected at the wire boundary with a message naming the specific violation.
- **dashboard (`apps/web/src/components/settings/AliasesSettingsCard.vue`, `apps/web/src/components/alias-edit/AliasEditDialog.vue`)** — wrap the alias name in `encodeURIComponent` before passing it to the Hono RPC client's `replaceUrlParam`, which does zero encoding. Without this wrap a legitimate `/`-carrying alias name would still shatter into two URL segments on the client side and 404 against the server's single-segment matcher. `HonoRequest.param()` auto-decodes on receipt, so the server-side \`repo.modelAliases.update\`/\`delete\` calls continue to see the un-encoded name.
- **tests (`packages/gateway/src/control-plane/model-aliases/routes_test.ts`)** — three new cases lock the schema contract: a table-driven POST case enumerating accepted (`openrouter/claude-4`, `gpt-4.1`, 128-char boundary) and rejected (`:`, `?`, `#`, whitespace, `\n`, `\0`, leading/trailing `/`, `//`, 129 char, empty) shapes; a PUT rename case proving `body.name` walks the same schema; and a DELETE round-trip case proving `openrouter%2Fclaude-4-opus` decodes back to the row name on the server side.

## Backwards compatibility

This is a wire-contract narrowing on POST `/api/aliases` and PUT `/api/aliases/:name`. Any external caller previously creating aliases with names outside the new regex or longer than 128 characters now receives 400. No database migration accompanies this change: if a pre-branch instance ever stored an alias name that fails the new regex, that row remains listable and deletable, but PUT-edits from either the UI or the wire would 400 until the name is renamed to a compliant shape. The seed row (`codex-auto-review`) is compliant.

## Test plan

- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test model-aliases` — 22 tests pass (19 pre-existing + 3 new boundary cases)
- [ ] Manual dashboard smoke on `pnpm run dev`: create `openrouter/claude-4-opus`, edit the target, delete — confirm the network panel shows the `%2F`-encoded path segment on PUT/DELETE and both return 200/204
- [ ] Manual API smoke: `curl -X DELETE http://127.0.0.1:8788/api/aliases/openrouter%2Fclaude-4-opus -H 'x-floway-session: …'` returns 204