### PR TITLE
fix(dashboard): inline Models Cache next to Fetch button

### DIFF
--- a/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
@@ -138,17 +138,18 @@ const setAuthStyle = (style: CustomAuthStyle) => {
           @click="emit('fetch-models')"
         >Fetch</Button>
       </div>
+      <!-- Live `last fetched / last error` snapshot injected by the parent —
+           rendered immediately under the button row so the outcome reads as
+           the button's result row (transient fetch error / disabled warning
+           below sit as a footnote, not between button and result). -->
+      <div v-if="$slots['cache-status']" class="mt-1.5">
+        <slot name="cache-status" />
+      </div>
       <p v-if="fetchError" class="mt-1.5 text-[11px] text-accent-rose">{{ fetchError }}</p>
       <p v-else-if="!draft.modelsFetch.enabled" class="mt-1.5 text-[11px] text-accent-amber">
         Fetch disabled — auto models are hidden and dropped on save. Only manual rows persist.
       </p>
     </div>
-
-    <!-- Slot for the live `last fetched / last error` snapshot, injected by the
-         parent between Fetch and Path Overrides so the outcome sits directly
-         under the button that produced it (Path Overrides is layout tail, not
-         a fetch input). Empty when this upstream has no cache (create mode). -->
-    <slot name="cache-status" />
 
     <div>
       <p class="mb-2 text-xs font-medium text-gray-500">Path Overrides</p>

--- a/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/CustomConfigPanel.vue
@@ -144,6 +144,12 @@ const setAuthStyle = (style: CustomAuthStyle) => {
       </p>
     </div>
 
+    <!-- Slot for the live `last fetched / last error` snapshot, injected by the
+         parent between Fetch and Path Overrides so the outcome sits directly
+         under the button that produced it (Path Overrides is layout tail, not
+         a fetch input). Empty when this upstream has no cache (create mode). -->
+    <slot name="cache-status" />
+
     <div>
       <p class="mb-2 text-xs font-medium text-gray-500">Path Overrides</p>
       <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">

--- a/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
@@ -66,12 +66,14 @@ const emit = defineEmits<{ 'fetch-models': [] }>();
           >Fetch</Button>
         </div>
       </div>
+      <!-- Live `last fetched / last error` snapshot injected by the parent —
+           rendered immediately under the button row so the outcome reads as
+           the button's result row (any transient fetch error below sits as a
+           footnote, not between button and result). -->
+      <div v-if="$slots['cache-status']" class="mt-1.5">
+        <slot name="cache-status" />
+      </div>
       <p v-if="fetchError" class="mt-1.5 text-[11px] text-accent-rose">{{ fetchError }}</p>
     </div>
-
-    <!-- Slot for the live `last fetched / last error` snapshot, injected by the
-         parent so the outcome sits directly under the Fetch button that
-         produced it. Empty when this upstream has no cache (create mode). -->
-    <slot name="cache-status" />
   </div>
 </template>

--- a/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/OllamaConfigPanel.vue
@@ -68,5 +68,10 @@ const emit = defineEmits<{ 'fetch-models': [] }>();
       </div>
       <p v-if="fetchError" class="mt-1.5 text-[11px] text-accent-rose">{{ fetchError }}</p>
     </div>
+
+    <!-- Slot for the live `last fetched / last error` snapshot, injected by the
+         parent so the outcome sits directly under the Fetch button that
+         produced it. Empty when this upstream has no cache (create mode). -->
+    <slot name="cache-status" />
   </div>
 </template>

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -161,7 +161,11 @@ onBeforeUnmount(() => floorObserver?.disconnect());
           :fetch-error="fetchError"
           :fetch-status="fetchStatus"
           @fetch-models="$emit('fetch-models')"
-        />
+        >
+          <template v-if="modelsCache" #cache-status>
+            <ModelsCacheStatus :models-cache="modelsCache" />
+          </template>
+        </CustomConfigPanel>
       </section>
 
       <section v-else-if="draft.kind === 'azure'" class="shrink-0">
@@ -181,7 +185,11 @@ onBeforeUnmount(() => floorObserver?.disconnect());
           :fetch-error="fetchError"
           :fetch-status="fetchStatus"
           @fetch-models="$emit('fetch-models')"
-        />
+        >
+          <template v-if="modelsCache" #cache-status>
+            <ModelsCacheStatus :models-cache="modelsCache" />
+          </template>
+        </OllamaConfigPanel>
       </section>
 
       <section v-else-if="draft.kind === 'copilot'" class="shrink-0">
@@ -213,12 +221,13 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         />
       </section>
 
-      <!-- Models Cache sits directly under the per-provider config panel so the
-           "last fetched / last error" snapshot reads as the result of the
-           Fetch button embedded in that panel (Custom / Ollama). Other saved
-           providers show the same cache snapshot right under their connection
-           fields. Null in create mode and for Azure (no fetch step). -->
-      <section v-if="modelsCache" class="shrink-0">
+      <!-- Cache snapshot for OAuth-driven providers (Copilot / Codex / Claude
+           Code) — they have no in-panel Fetch button, so the snapshot sits at
+           the top level right under the provider panel. Custom / Ollama inject
+           theirs into the provider panel's `#cache-status` slot instead, so the
+           snapshot sits directly under the Fetch button. Null in create mode
+           and for Azure (no fetch step). -->
+      <section v-if="modelsCache && draft.kind !== 'custom' && draft.kind !== 'ollama'" class="shrink-0">
         <p class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-gray-500">Models Cache</p>
         <ModelsCacheStatus :models-cache="modelsCache" />
       </section>

--- a/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
+++ b/apps/web/src/components/upstream-edit/UpstreamConfigPanel.vue
@@ -213,13 +213,18 @@ onBeforeUnmount(() => floorObserver?.disconnect());
         />
       </section>
 
-      <section class="shrink-0">
-        <ModelPrefixEditor v-model="modelPrefix" @update:invalid="v => $emit('update:model-prefix-invalid', v)" />
-      </section>
-
+      <!-- Models Cache sits directly under the per-provider config panel so the
+           "last fetched / last error" snapshot reads as the result of the
+           Fetch button embedded in that panel (Custom / Ollama). Other saved
+           providers show the same cache snapshot right under their connection
+           fields. Null in create mode and for Azure (no fetch step). -->
       <section v-if="modelsCache" class="shrink-0">
         <p class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-gray-500">Models Cache</p>
         <ModelsCacheStatus :models-cache="modelsCache" />
+      </section>
+
+      <section class="shrink-0">
+        <ModelPrefixEditor v-model="modelPrefix" @update:invalid="v => $emit('update:model-prefix-invalid', v)" />
       </section>
 
       <section class="shrink-0">


### PR DESCRIPTION
## Summary

- **Inline the Models Cache snapshot into the provider panel, immediately below the Fetch button row.** #228 unified the model re-fetch trigger into the per-provider Fetch button inside `CustomConfigPanel` / `OllamaConfigPanel`, but the `ModelsCacheStatus` panel — the passive reflection of that fetch — was still rendered by the parent `UpstreamConfigPanel` as a separate top-level section. On Custom in particular that put ~360px of Path Overrides between the Fetch button and its own "last fetched / last error" snapshot, so the panel read as an unrelated block instead of the button's outcome.
- **The fix is a `#cache-status` slot on both `CustomConfigPanel` and `OllamaConfigPanel`, into which `UpstreamConfigPanel` injects `<ModelsCacheStatus>`.** The slot is placed inside the Fetch section itself, directly underneath the button row (`mt-1.5`, ~6px). Any transient fetch-error message and the "Fetch disabled" warning are demoted to footnotes below the cache line, so the reader's eye goes button → result → note rather than button → note → result. Wrapping the slot in `v-if="$slots['cache-status']"` keeps create-mode (no cache) from rendering an empty div.
- **OAuth providers (Copilot / Codex / Claude Code) keep the pre-existing top-level Models Cache section** under the provider panel, with its "Models Cache" heading — they have no in-panel Fetch button, so there is nothing for the snapshot to be adjacent to. The top-level section is now conditioned on `kind !== 'custom' && kind !== 'ollama'` so it only fires for those providers.

The `showCacheStatus` gate in `UpstreamEditPage` and the `ModelsCacheStatus` props / behavior are untouched — the change is purely where the component renders.

## Test plan

- [x] Open a saved Custom upstream edit page → "last fetched …" line renders directly under the Fetch button row (~6px gap). Any "Fetch disabled" warning sits below the cache line, not between button and cache.
- [x] Open a saved Ollama upstream edit page → "last fetched …" renders directly under the Fetch button row inside the Fetch section (Fetch is Ollama's last section), no separate "Models Cache" heading.
- [x] Open a saved Copilot / Codex / Claude Code upstream edit page → top-level "Models Cache" section renders directly under the provider panel (no in-panel Fetch button, so no adjacency requirement).
- [x] Open an Azure upstream edit page → Models Cache panel absent (`showCacheStatus` excludes it).
- [x] Create-mode (new Custom / Ollama) → slot is empty and its wrapper `<div>` is not rendered; no Models Cache panel renders (`showCacheStatus` requires `!isCreate`).
- [x] Click Fetch on a Custom/Ollama panel → `fetchStatus` ("N returned · just now") appears next to the Fetch button and the "last fetched" snapshot updates in place, still adjacent to the Fetch button.