### PR TITLE
fix(docker): declare compose network explicitly

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,3 +52,4 @@ volumes:
 
 networks:
   floway:
+    name: floway

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,12 @@
 name: floway
 
+# `web`'s nginx proxies to `http://server:8788`, so the two containers must
+# share a network whose embedded DNS resolves `server` to the gateway. The
+# Compose spec's implicit `default` network handles this on Docker Compose,
+# but some Compose-compatible runtimes (CasaOS-style app stores, other
+# third-party engines) don't auto-provision it and the web container then
+# fails with `host not found in upstream "server"`. Declaring the network
+# explicitly makes the topology unambiguous across every implementation.
 services:
   server:
     build:
@@ -23,6 +30,8 @@ services:
       retries: 12
       start_period: 15s
     restart: unless-stopped
+    networks:
+      - floway
 
   web:
     build:
@@ -35,6 +44,11 @@ services:
     ports:
       - "${FLOWAY_WEB_PORT:-18088}:80"
     restart: unless-stopped
+    networks:
+      - floway
 
 volumes:
   floway-data:
+
+networks:
+  floway:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,11 +2,11 @@ name: floway
 
 # `web`'s nginx proxies to `http://server:8788`, so the two containers must
 # share a network whose embedded DNS resolves `server` to the gateway. The
-# Compose spec's implicit `default` network handles this on Docker Compose,
-# but some Compose-compatible runtimes (CasaOS-style app stores, other
-# third-party engines) don't auto-provision it and the web container then
-# fails with `host not found in upstream "server"`. Declaring the network
-# explicitly makes the topology unambiguous across every implementation.
+# Compose spec's implicit `default` network handles this on Docker Compose
+# itself, but some third-party Compose parsers don't reliably auto-provision
+# it and the web container then fails with `host not found in upstream
+# "server"`. Declaring the network explicitly makes the topology unambiguous
+# across every implementation.
 services:
   server:
     build:


### PR DESCRIPTION
## Summary

- `web`'s nginx proxies to `http://server:8788`, which requires the two containers to share a network whose embedded DNS resolves `server` to the gateway. The Compose spec's implicit `default` network handles this on Docker Compose itself, but some third-party Compose parsers (embedded in other container-orchestration UIs / app-store runtimes) don't reliably auto-provision it, and the web container then fails to start with `host not found in upstream "server"` from nginx.
- Declaring an explicit `floway` network and attaching both services to it makes the topology unambiguous across every implementation, without changing behavior under vanilla Docker Compose.
- Pinning `name: floway` on the network keeps the underlying Docker network named exactly `floway` (rather than the auto-scoped `<project>_<key>` = `floway_floway`) — nicer in `docker network ls`, and sidesteps third-party Compose parsers that mishandle the project-prefix rule.

## Test plan

- [x] Compose file parses; `services.server.networks` and `services.web.networks` both list `floway`, and a top-level `networks.floway` with `name: floway` is declared.
- [x] `ADMIN_KEY=<secret> docker compose -f docker/docker-compose.yml up --build -d` on vanilla Docker Compose — `server` reaches `healthy`, `web` resolves `server` via embedded DNS, dashboard loads at `http://localhost:18088`, and `docker network ls` shows a `floway` network.