### PR TITLE
feat(web): drop double-click legend isolate

### DIFF
--- a/apps/web/src/components/charts/series-selection.ts
+++ b/apps/web/src/components/charts/series-selection.ts
@@ -5,11 +5,6 @@ export type SeriesSelectionAction = 'all' | 'invert' | 'none';
 export const chartSeriesIds = (config: ChartConfiguration<'line'>): string[] =>
   config.data.datasets.map(dataset => (dataset as unknown as { seriesId: string }).seriesId);
 
-// Chart.js filters events reaching plugins through the `events` list. `dblclick`
-// isn't in the default set, so we opt in here — otherwise `legend.onClick` never
-// sees the second click of a double-click isolation gesture.
-export const chartEventsWithDoubleClick: (keyof HTMLElementEventMap)[] = ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove', 'dblclick'];
-
 export const applySeriesSelection = (hidden: Set<string>, ids: readonly string[], action: SeriesSelectionAction) => {
   if (action === 'all') {
     hidden.clear();
@@ -52,6 +47,6 @@ export const handleLegendClick = (
   id: string,
 ) => {
   const native = event.native;
-  if (native instanceof MouseEvent && (native.shiftKey || native.detail >= 2)) isolation.isolateOrSelectAll(hidden, ids, id);
+  if (native instanceof MouseEvent && native.shiftKey) isolation.isolateOrSelectAll(hidden, ids, id);
   else isolation.toggle(hidden, id);
 };

--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -26,7 +26,7 @@ import { callApi, useApi } from '../../api/client.ts';
 import ChartCanvas from '../../components/charts/ChartCanvas.vue';
 import ChartSeriesControls from '../../components/charts/ChartSeriesControls.vue';
 import { chartColor, chartColorByName, chartFont, chartXAxisTick, dashboardBuckets, type DashboardRange } from '../../components/charts/dashboard-chart.ts';
-import { applySeriesSelection, chartEventsWithDoubleClick, chartSeriesIds, createSeriesIsolation, handleLegendClick } from '../../components/charts/series-selection.ts';
+import { applySeriesSelection, chartSeriesIds, createSeriesIsolation, handleLegendClick } from '../../components/charts/series-selection.ts';
 import { useUpstreamsStore } from '../../composables/useUpstreams.ts';
 import { useAuthStore } from '../../stores/auth.ts';
 import type { PerformanceDisplayRecord } from '@floway-dev/gateway/control-plane/performance/aggregate';
@@ -335,7 +335,6 @@ const chartConfig = computed<ChartConfiguration<'line'>>(() => {
     type: 'line',
     data: { labels, datasets },
     options: {
-      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -10,7 +10,7 @@ import type { BillingDimension } from '../../api/types.ts';
 import ChartCanvas from '../../components/charts/ChartCanvas.vue';
 import ChartSeriesControls from '../../components/charts/ChartSeriesControls.vue';
 import { bucketKeyForUtcHour, chartColor, chartFont, chartXAxisTick, dashboardBuckets, dashboardRangeQuery, type DashboardRange } from '../../components/charts/dashboard-chart.ts';
-import { applySeriesSelection, chartEventsWithDoubleClick, chartSeriesIds, createSeriesIsolation, handleLegendClick } from '../../components/charts/series-selection.ts';
+import { applySeriesSelection, chartSeriesIds, createSeriesIsolation, handleLegendClick } from '../../components/charts/series-selection.ts';
 import UsageSummaryMetric from '../../components/usage/UsageSummaryMetric.vue';
 import { useModelsStore } from '../../composables/useModels.ts';
 import { useAuthStore } from '../../stores/auth.ts';
@@ -465,7 +465,6 @@ const buildStackedConfig = (groupKey: 'keyId' | 'model'): ChartConfiguration<'li
       }),
     },
     options: {
-      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
@@ -585,7 +584,6 @@ const searchByKeyConfig = computed<ChartConfiguration<'line'>>(() => {
       }),
     },
     options: {
-      events: chartEventsWithDoubleClick,
       responsive: true,
       maintainAspectRatio: false,
       animation: false,


### PR DESCRIPTION
## Summary

Drop the double-click-to-isolate gesture on chart legends across the Usage and Performance dashboards. Shift-click still isolates a single series, and the All / Invert / None buttons in `ChartSeriesControls` are unchanged.

## Motivation

Rapid repeat-clicking on a single legend item — clicking it several times in a row — turns out to be a natural way to read a chart: the animation-free redraw between hidden and visible is subtle, and a fast toggle sequence is how the eye picks up which line moves. In that mode of interaction the double-click branch of `handleLegendClick` fires as an unintended side effect: instead of another toggle, the whole chart snaps into isolate mode on that one series. It reads as the UI getting "stuck." I hit it enough times without realizing what was happening that I stopped attributing it to my clicks and started attributing it to the chart being flaky.

Since the same isolate gesture is still available via shift-click (and via the `Invert` button when what you want is the complement), losing the double-click path costs nothing and unblocks the rapid-toggle read.

## Changes

- `handleLegendClick`: remove the `native.detail >= 2` branch. Shift-click keeps the `isolateOrSelectAll` path.
- `chartEventsWithDoubleClick`: remove entirely. It existed only to opt `dblclick` into Chart.js's plugin event list; with the legend handler no longer consuming `dblclick`, the plugin event set falls back to Chart.js's default (`mousemove`, `mouseout`, `click`, `touchstart`, `touchmove`) — which is exactly what the constant was, minus `dblclick`.
- `performance.vue`, `usage.vue`: drop the `events:` overrides that referenced the deleted constant and drop the import symbol.

## Test plan

- [x] `pnpm run typecheck && pnpm run lint` — both green.
- [x] Rapid single clicks on the same series toggle hidden/visible each click, no isolation.
- [x] Shift-click a legend item — still isolates that series.
- [x] Shift-click the same isolated item again — returns to all-visible.
- [x] `Invert` / `None` / `All` buttons still work.
- [x] Same behavior on `/dashboard/performance`.

Verification was run against the live SPA (`pnpm run dev:node` + Vite on 5174, seed DB with a handful of api_keys and 24h of usage rows), driving the `series-selection.ts` module directly from a browser-side dynamic `import()` so every case ran the real ESM the app is serving. The interaction cases (5 rapid clicks → target hidden, other series untouched; a `detail: 2` click no longer isolates; shift-click isolates and un-isolates; `applySeriesSelection` for `all` / `invert` / `none`) each returned the expected `hidden` set. As a structural check the same run confirmed `chartEventsWithDoubleClick` is no longer exported from the module. Both `/dashboard/usage` (populated) and `/dashboard/performance` (empty by design of the seed) rendered without console errors.