### PR TITLE
feat(codex): enable Ultra reasoning for compatible clients

### DIFF
--- a/packages/gateway/src/data-plane/codex/catalog.ts
+++ b/packages/gateway/src/data-plane/codex/catalog.ts
@@ -22,11 +22,27 @@ import bundledCatalog from './catalog/bundled.json' with { type: 'json' };
 
 export interface CatalogModel {
   slug: string;
+  multi_agent_version?: string | null;
+  supported_reasoning_levels?: CodexReasoningLevel[];
   [key: string]: unknown;
+}
+
+export interface CodexReasoningLevel {
+  effort: string;
+  description: string;
 }
 
 export interface CodexCatalog {
   models: CatalogModel[];
+}
+
+export interface CodexCatalogCapabilities {
+  ultraReasoningLevel?: CodexReasoningLevel;
+}
+
+export interface CodexCatalogResolution {
+  catalog: CodexCatalog;
+  capabilities: CodexCatalogCapabilities;
 }
 
 // Codex uses its active originator as the User-Agent product token, followed
@@ -35,9 +51,26 @@ export interface CodexCatalog {
 // https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/login/src/auth/default_client.rs#L161-L172
 const VERSION_FROM_USER_AGENT = /^codex[^/]*\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)/i;
 
-const inMemoryCache = new Map<string, CodexCatalog>();
+const inMemoryCache = new Map<string, CodexCatalogResolution>();
 
 const bundled = bundledCatalog as unknown as CodexCatalog;
+
+// Floway may extend Ultra to other Max-capable models only after the exact
+// client-version catalog proves that this Codex build supports the v2 Ultra
+// semantics. A bundled fallback cannot prove anything about the caller.
+// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/models-manager/models.json#L19-L58
+// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/core/src/session/multi_agents.rs#L39-L54
+// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/core/src/client.rs#L175-L180
+const capabilitiesFromExactCatalog = (catalog: CodexCatalog): CodexCatalogCapabilities => {
+  for (const model of catalog.models) {
+    if (model.multi_agent_version !== 'v2') continue;
+    const ultraReasoningLevel = model.supported_reasoning_levels?.find(level => level.effort === 'ultra');
+    if (ultraReasoningLevel !== undefined) return { ultraReasoningLevel };
+  }
+  return {};
+};
+
+const bundledFallback = (): CodexCatalogResolution => ({ catalog: bundled, capabilities: {} });
 
 const parseCodexVersion = (userAgent: string | undefined): string | null =>
   userAgent?.match(VERSION_FROM_USER_AGENT)?.[1] ?? null;
@@ -49,15 +82,17 @@ const fetchCodexCatalog = async (version: string): Promise<CodexCatalog | null> 
   return (await resp.json()) as CodexCatalog;
 };
 
-export const resolveCodexCatalog = async (userAgent: string | undefined): Promise<CodexCatalog> => {
+export const resolveCodexCatalog = async (userAgent: string | undefined): Promise<CodexCatalogResolution> => {
   const version = parseCodexVersion(userAgent);
-  if (version === null) return bundled;
+  if (version === null) return bundledFallback();
 
   const cached = inMemoryCache.get(version);
   if (cached !== undefined) return cached;
 
   const fetched = await fetchCodexCatalog(version).catch(() => null);
-  const resolved = fetched ?? bundled;
+  const resolved = fetched === null
+    ? bundledFallback()
+    : { catalog: fetched, capabilities: capabilitiesFromExactCatalog(fetched) };
   inMemoryCache.set(version, resolved);
   return resolved;
 };

--- a/packages/gateway/src/data-plane/codex/catalog.ts
+++ b/packages/gateway/src/data-plane/codex/catalog.ts
@@ -1,7 +1,7 @@
 // Resolve a codex models catalog for a given codex client version.
 //
 // Strategy:
-//   1. Parse `codex_exec/<version>` from the request user-agent
+//   1. Parse `<codex-originator>/<version>` from the request user-agent
 //   2. In-memory cache by version (catalog of a released codex tag is immutable)
 //   3. On cache miss, fetch the matching tag from
 //      `https://raw.githubusercontent.com/openai/codex/rust-v<version>/codex-rs/models-manager/models.json`
@@ -29,7 +29,11 @@ export interface CodexCatalog {
   models: CatalogModel[];
 }
 
-const VERSION_FROM_USER_AGENT = /codex_exec\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)/;
+// Codex uses its active originator as the User-Agent product token, followed
+// by the app-server build version. This covers CLI, Desktop, IDE, and legacy
+// `codex_exec` originators without coupling catalog resolution to one surface.
+// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/login/src/auth/default_client.rs#L161-L172
+const VERSION_FROM_USER_AGENT = /^codex[^/]*\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)/i;
 
 const inMemoryCache = new Map<string, CodexCatalog>();
 

--- a/packages/gateway/src/data-plane/codex/catalog_test.ts
+++ b/packages/gateway/src/data-plane/codex/catalog_test.ts
@@ -15,14 +15,16 @@ describe('resolveCodexCatalog', () => {
 
   it('falls back to bundled when user-agent is missing', async () => {
     const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
-    const catalog = await resolve(undefined);
+    const { catalog, capabilities } = await resolve(undefined);
     expect(catalog.models.map(m => m.slug)).toEqual(bundled.models.map(m => m.slug));
+    expect(capabilities).toEqual({});
   });
 
   it('falls back to bundled when user-agent does not match the codex pattern', async () => {
     const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
-    const catalog = await resolve('curl/8.7.1');
+    const { catalog, capabilities } = await resolve('curl/8.7.1');
     expect(catalog.models.map(m => m.slug)).toEqual(bundled.models.map(m => m.slug));
+    expect(capabilities).toEqual({});
   });
 
   it('fetches openai/codex tag matching the parsed version and caches in-memory', async () => {
@@ -34,8 +36,9 @@ describe('resolveCodexCatalog', () => {
     const ua = 'codex_cli_rs/0.999.0 (Mac OS 15.0; arm64)';
     const first = await resolve(ua);
     const second = await resolve(ua);
-    expect(first).toEqual(fake);
-    expect(second).toEqual(fake);
+    expect(first.catalog).toEqual(fake);
+    expect(first.capabilities).toEqual({});
+    expect(second).toEqual(first);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe('https://raw.githubusercontent.com/openai/codex/rust-v0.999.0/codex-rs/models-manager/models.json');
   });
@@ -47,7 +50,7 @@ describe('resolveCodexCatalog', () => {
 
     const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
     const ua = 'codex_desktop/0.145.0-alpha.18 (Windows 10.0.28000; x86_64) unknown (codex_desktop; 1.2.3)';
-    expect(await resolve(ua)).toEqual(fake);
+    expect((await resolve(ua)).catalog).toEqual(fake);
     expect(fetchMock.mock.calls[0]?.[0]).toBe('https://raw.githubusercontent.com/openai/codex/rust-v0.145.0-alpha.18/codex-rs/models-manager/models.json');
   });
 
@@ -59,7 +62,8 @@ describe('resolveCodexCatalog', () => {
     const ua = 'codex_exec/0.998.0 (linux; x86_64)';
     const first = await resolve(ua);
     await resolve(ua);
-    expect(first.models.map(m => m.slug)).toEqual(bundled.models.map(m => m.slug));
+    expect(first.catalog.models.map(m => m.slug)).toEqual(bundled.models.map(m => m.slug));
+    expect(first.capabilities).toEqual({});
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -68,8 +72,38 @@ describe('resolveCodexCatalog', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
-    const catalog = await resolve('codex_exec/0.997.0 (test)');
+    const { catalog, capabilities } = await resolve('codex_exec/0.997.0 (test)');
     expect(catalog.models.map(m => m.slug)).toEqual(bundled.models.map(m => m.slug));
+    expect(capabilities).toEqual({});
+  });
+
+  it('derives Ultra synthesis capability only from a v2 entry in the exact client catalog', async () => {
+    const fake = {
+      models: [
+        {
+          slug: 'v1-max',
+          multi_agent_version: 'v1',
+          supported_reasoning_levels: [
+            { effort: 'max', description: 'Maximum' },
+          ],
+        },
+        {
+          slug: 'v2-ultra',
+          multi_agent_version: 'v2',
+          supported_reasoning_levels: [
+            { effort: 'max', description: 'Maximum' },
+            { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
+          ],
+        },
+      ],
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify(fake), { status: 200 })) as unknown as typeof fetch;
+
+    const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
+    const resolution = await resolve('codex_cli_rs/0.999.1 (Mac OS; arm64)');
+    expect(resolution.capabilities).toEqual({
+      ultraReasoningLevel: { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
+    });
   });
 
   it('parses prerelease versions like 1.0.52-0', async () => {

--- a/packages/gateway/src/data-plane/codex/catalog_test.ts
+++ b/packages/gateway/src/data-plane/codex/catalog_test.ts
@@ -31,13 +31,24 @@ describe('resolveCodexCatalog', () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
-    const ua = 'codex_exec/0.999.0 (Mac OS 15.0; arm64)';
+    const ua = 'codex_cli_rs/0.999.0 (Mac OS 15.0; arm64)';
     const first = await resolve(ua);
     const second = await resolve(ua);
     expect(first).toEqual(fake);
     expect(second).toEqual(fake);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe('https://raw.githubusercontent.com/openai/codex/rust-v0.999.0/codex-rs/models-manager/models.json');
+  });
+
+  it('parses the app-server version from the Codex Desktop originator', async () => {
+    const fake = { models: [{ slug: 'desktop-version' }] };
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(fake), { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
+    const ua = 'codex_desktop/0.145.0-alpha.18 (Windows 10.0.28000; x86_64) unknown (codex_desktop; 1.2.3)';
+    expect(await resolve(ua)).toEqual(fake);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://raw.githubusercontent.com/openai/codex/rust-v0.145.0-alpha.18/codex-rs/models-manager/models.json');
   });
 
   it('falls back to bundled on a 4xx response and still caches the negative result', async () => {

--- a/packages/gateway/src/data-plane/codex/models.ts
+++ b/packages/gateway/src/data-plane/codex/models.ts
@@ -6,17 +6,17 @@
 // (`{"models": [ModelInfo, ...]}`), not the OpenAI public catalog
 // (`{"object":"list","data":[...]}`) we serve at `/v1/models`.
 //
-// Pipeline: codex publishes a bundled catalog per release (see catalog.ts);
+// Pipeline: codex publishes a versioned catalog per release (see catalog.ts);
 // for each chat-kind model the registry lists as addressable, we call
-// `synthesizeCatalogEntry(model, base?)` with the segment-matched bundled
+// `synthesizeCatalogEntry(model, base?)` with the segment-matched client
 // entry as `base` (or `undefined` when no bundled entry matches). The
-// synthesizer builds the codex-shaped entry from that base plus the
-// registry-owned overlays it announces (see synthesize.ts for the exact
-// field precedence rules).
+// synthesizer builds the codex-shaped entry from that base, the registry-owned
+// overlays it announces, and capabilities proven by the exact client catalog
+// (see synthesize.ts for the exact field precedence rules).
 
 import type { Context } from 'hono';
 
-import { resolveCodexCatalog, type CatalogModel, type CodexCatalog } from './catalog.ts';
+import { resolveCodexCatalog, type CatalogModel, type CodexCatalog, type CodexCatalogCapabilities } from './catalog.ts';
 import { synthesizeCatalogEntry } from './synthesize.ts';
 import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
@@ -26,27 +26,28 @@ import { enumerateAddressableModelIds, type AddressableIdEntry } from '../shared
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { Fetcher } from '@floway-dev/provider';
 
-// Pure transformation: bundled catalog + addressable entries →
+// Pure transformation: client catalog + addressable entries →
 // codex-shaped catalog (drops unlisted alternates and non-chat kinds).
 // Extracted so tests can drive the mapping logic without standing up the
 // addressable-enumeration pipeline.
 export const assembleCatalog = (
-  bundled: CodexCatalog,
+  catalog: CodexCatalog,
   addressable: readonly AddressableIdEntry[],
+  capabilities: CodexCatalogCapabilities = {},
 ): CodexCatalog => {
-  const bundledBySlug = new Map<string, CatalogModel>();
-  for (const m of bundled.models) bundledBySlug.set(m.slug.toLowerCase(), m);
+  const catalogBySlug = new Map<string, CatalogModel>();
+  for (const model of catalog.models) catalogBySlug.set(model.slug.toLowerCase(), model);
 
-  // Match against bundled by walking segments from the trailing leaf back
+  // Match against the client catalog by walking segments from the trailing leaf back
   // toward the prefix, so a publicId like `openrouter/gpt-5.5/gpt-5.4`
   // binds against `gpt-5.4` rather than the earlier `gpt-5.5` segment that
   // happens to collide with a bundled slug. Split on both `/` (model-prefix
   // segments) and `:` (OpenRouter-style `:variant` suffixes) — a variant
   // tag on the leaf falls through the walk without accidentally binding.
-  const matchBundled = (publicId: string): CatalogModel | undefined => {
+  const matchCatalog = (publicId: string): CatalogModel | undefined => {
     const segments = publicId.toLowerCase().split(/[/:]/);
     for (let i = segments.length - 1; i >= 0; i--) {
-      const hit = bundledBySlug.get(segments[i]);
+      const hit = catalogBySlug.get(segments[i]);
       if (hit !== undefined) return hit;
     }
     return undefined;
@@ -59,7 +60,7 @@ export const assembleCatalog = (
     // request time but never surface as their own picker row.
     if (entry.unlisted !== undefined) continue;
     if (entry.model.kind !== 'chat') continue;
-    models.push(synthesizeCatalogEntry(entry.model, matchBundled(entry.model.id)));
+    models.push(synthesizeCatalogEntry(entry.model, matchCatalog(entry.model.id), capabilities));
   }
   return { models };
 };
@@ -70,11 +71,11 @@ const computeCatalog = async (
   fetcherForUpstream: (upstreamId: string) => Fetcher,
   scheduler: BackgroundScheduler,
 ): Promise<CodexCatalog> => {
-  const [bundled, addressable] = await Promise.all([
+  const [resolution, addressable] = await Promise.all([
     resolveCodexCatalog(userAgent),
     enumerateAddressableModelIds(upstreamIds, fetcherForUpstream, scheduler),
   ]);
-  return assembleCatalog(bundled, addressable);
+  return assembleCatalog(resolution.catalog, addressable, resolution.capabilities);
 };
 
 export const codexModels = async (c: Context): Promise<Response> => {

--- a/packages/gateway/src/data-plane/codex/models.ts
+++ b/packages/gateway/src/data-plane/codex/models.ts
@@ -9,7 +9,7 @@
 // Pipeline: codex publishes a versioned catalog per release (see catalog.ts);
 // for each chat-kind model the registry lists as addressable, we call
 // `synthesizeCatalogEntry(model, base?)` with the segment-matched client
-// entry as `base` (or `undefined` when no bundled entry matches). The
+// catalog entry as `base` (or `undefined` when no catalog entry matches). The
 // synthesizer builds the codex-shaped entry from that base, the registry-owned
 // overlays it announces, and capabilities proven by the exact client catalog
 // (see synthesize.ts for the exact field precedence rules).
@@ -41,7 +41,7 @@ export const assembleCatalog = (
   // Match against the client catalog by walking segments from the trailing leaf back
   // toward the prefix, so a publicId like `openrouter/gpt-5.5/gpt-5.4`
   // binds against `gpt-5.4` rather than the earlier `gpt-5.5` segment that
-  // happens to collide with a bundled slug. Split on both `/` (model-prefix
+  // happens to collide with a catalog slug. Split on both `/` (model-prefix
   // segments) and `:` (OpenRouter-style `:variant` suffixes) — a variant
   // tag on the leaf falls through the walk without accidentally binding.
   const matchCatalog = (publicId: string): CatalogModel | undefined => {

--- a/packages/gateway/src/data-plane/codex/models_test.ts
+++ b/packages/gateway/src/data-plane/codex/models_test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { assembleCatalog } from './models.ts';
+import type { CodexCatalogCapabilities } from './catalog.ts';
 import type { AddressableIdEntry } from '../shared/listing/addressable.ts';
 import type { InternalModel } from '@floway-dev/provider';
 
@@ -31,6 +32,10 @@ const entry = (model: InternalModel, unlisted?: true): AddressableIdEntry => ({
 });
 
 const entries = (...models: InternalModel[]): AddressableIdEntry[] => models.map(m => entry(m));
+
+const ultraCapabilities: CodexCatalogCapabilities = {
+  ultraReasoningLevel: { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
+};
 
 describe('assembleCatalog', () => {
   test('bundled match: reuses bundled entry, slug=publicId, display_name from registry', () => {
@@ -101,6 +106,27 @@ describe('assembleCatalog', () => {
     expect(e.context_window).toBe(128000);
     expect(e.shell_type).toBe('shell_command');     // hardcoded baseline
     expect(e.prefer_websockets).toBe(true);
+  });
+
+  test('threads exact-client Ultra capability into Max-capable synthesized entries', () => {
+    const maxModel: InternalModel = {
+      ...chat('deepseek-v4-pro'),
+      chat: { reasoning: { effort: { supported: ['high', 'max'], default: 'high' } } },
+    };
+    const withoutCapability = assembleCatalog(bundled, entries(maxModel));
+    const withCapability = assembleCatalog(bundled, entries(maxModel), ultraCapabilities);
+
+    expect(withoutCapability.models[0].supported_reasoning_levels).toEqual([
+      { effort: 'high', description: '' },
+      { effort: 'max', description: '' },
+    ]);
+    expect(withoutCapability.models[0].multi_agent_version).toBeUndefined();
+    expect(withCapability.models[0].supported_reasoning_levels).toEqual([
+      { effort: 'high', description: '' },
+      { effort: 'max', description: '' },
+      { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
+    ]);
+    expect(withCapability.models[0].multi_agent_version).toBe('v2');
   });
 
   test('non-chat models are dropped', () => {

--- a/packages/gateway/src/data-plane/codex/models_test.ts
+++ b/packages/gateway/src/data-plane/codex/models_test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
-import { assembleCatalog } from './models.ts';
 import type { CodexCatalogCapabilities } from './catalog.ts';
+import { assembleCatalog } from './models.ts';
 import type { AddressableIdEntry } from '../shared/listing/addressable.ts';
 import type { InternalModel } from '@floway-dev/provider';
 

--- a/packages/gateway/src/data-plane/codex/synthesize.ts
+++ b/packages/gateway/src/data-plane/codex/synthesize.ts
@@ -1,26 +1,26 @@
 // Build a Codex `models.json`-shaped catalog entry for a Floway chat model.
 //
-// Both branches of the pipeline — a bundled catalog match and a registry
-// model with no bundled equivalent — funnel through this one function.
-// `base` is the bundled entry when there is a match, `undefined` otherwise;
+// Both branches of the pipeline — a resolved client-catalog match and a
+// registry model with no catalog equivalent — funnel through this function.
+// `base` is the resolved entry when there is a match, `undefined` otherwise;
 // on `undefined` the hardcoded `BASELINE` fills in the same slot.
 //
 // Field precedence, per field family:
 //
-//   1. `slug` — always the registry public id (bundled base carries the
+//   1. `slug` — always the registry public id (the catalog base carries the
 //      upstream slug; we always overwrite with the operator-visible id).
 //   2. `display_name` — `model.display_name ?? source.display_name`. Registry
-//      wins when the operator set a label; else the bundled/base label
-//      rides through. Bundled-inherit is fine here because display_name is
+//      wins when the operator set a label; else the catalog/base label
+//      rides through. Catalog inheritance is fine here because display_name is
 //      pure UI — inheriting the vendored "GPT-5.5" string when the operator
 //      has not customized it is meaningful, unlike service_tiers below
 //      where a stale bundled value could mis-bill a real request.
 //   3. `service_tiers` — unconditional override with `deriveServiceTiers(model)`.
-//      No fallback to bundled: bundled entries may advertise OpenAI 1p tiers
+//      No fallback to the catalog: official entries may advertise OpenAI 1p tiers
 //      Floway cannot bill, so publishing them without registry-side unit
 //      prices would surface a toggle we could not honor.
 //   4. `context_window` / `max_context_window` — `registry ?? source ?? 128k`.
-//      Registry-supplied limits win; else preserve the base's value (bundled
+//      Registry-supplied limits win; else preserve the base's value (official
 //      entries carry a real OpenAI-vendored window); else the conservative
 //      default so codex's `(cw * 9) / 10` auto-compact math never sees zero.
 //   5. `input_modalities` (and its derived siblings `supports_image_detail_original`
@@ -35,7 +35,7 @@
 //      v2 Ultra semantics and the resulting model supports Max.
 //
 // Fields not listed above ride through from `source` unchanged: the base
-// pass supplies bundled defaults for bundled-hit and hardcoded baselines
+// pass supplies resolved catalog defaults for a hit and hardcoded baselines
 // for the miss path.
 
 import type { CatalogModel, CodexCatalogCapabilities, CodexReasoningLevel } from './catalog.ts';
@@ -49,9 +49,9 @@ import type { InternalModel, Modality } from '@floway-dev/provider';
 // sets `max_context_window_tokens` on the registry entry.
 const CONSERVATIVE_DEFAULT_CONTEXT_WINDOW = 128_000;
 
-// Hardcoded baseline for a codex catalog entry when no bundled match exists.
+// Hardcoded baseline for a codex catalog entry when no resolved match exists.
 // The synthesizer starts from this object (via a shallow spread) and layers
-// registry-derived overlays on top. Bundled matches use the bundled entry
+// registry-derived overlays on top. Catalog matches use the resolved entry
 // as the base and overlay the same fields, so both paths converge on one
 // field-precedence rule set (documented above).
 const BASELINE = {
@@ -116,7 +116,7 @@ export const synthesizeCatalogEntry = (
 
   // Overlay chain for every registry-derived field: `registry ?? source ?? BASELINE`.
   // BASELINE is always the ultimate fallback so a partially-populated `source`
-  // (e.g. a bundled entry from an older codex release that omits a field)
+  // (e.g. an entry from an older Codex release that omits a field)
   // still lands on a valid value.
   const inputModalities = (model.chat?.modalities?.input
     ?? source.input_modalities
@@ -175,7 +175,7 @@ export const synthesizeCatalogEntry = (
 
   // `default_reasoning_level` pairs with `supported_reasoning_levels` — both
   // come from the same source. When registry supplied `effort`, its schema
-  // requires both fields together; otherwise the bundled pair rides through
+  // requires both fields together; otherwise the catalog pair rides through
   // from the spread untouched.
   if (registryEffort !== undefined) {
     entry.default_reasoning_level = registryEffort.default;
@@ -184,8 +184,8 @@ export const synthesizeCatalogEntry = (
   // Miss-path `base_instructions` names the underlying model id so
   // introspection questions ("what model are you?") resolve against the
   // actual routed model instead of confabulating a GPT-5 lineage from the
-  // "Codex" persona. Bundled entries keep their upstream-vendored prompt
-  // (accurate for the GPT-5 family they were shipped for).
+  // "Codex" persona. Catalog matches keep the release-vendored prompt
+  // (accurate for that entry's GPT-5 family).
   if (base === undefined) {
     entry.base_instructions = synthesizedBaseInstructions(model.id, model.display_name ?? model.id);
   }

--- a/packages/gateway/src/data-plane/codex/synthesize.ts
+++ b/packages/gateway/src/data-plane/codex/synthesize.ts
@@ -40,6 +40,12 @@ import type { CatalogModel } from './catalog.ts';
 import { synthesizedBaseInstructions } from './synthesized-base-instructions.ts';
 import type { InternalModel, Modality } from '@floway-dev/provider';
 
+// Ultra selects proactive multi-agent v2 locally while Codex sends `max` on
+// the wire. Keep the catalog preset aligned with the official Codex catalog.
+// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/models-manager/models.json#L19-L58
+// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/core/src/session/multi_agents.rs#L39-L54
+const ULTRA_REASONING_LEVEL = { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' };
+
 // A synthesized (miss-path) entry with no registry-supplied
 // `max_context_window_tokens` still needs SOME window — codex's auto-compact
 // math (see `auto_compact_token_limit` in BASELINE for the source URL) blows
@@ -133,6 +139,8 @@ export const synthesizeCatalogEntry = (model: InternalModel, base?: CatalogModel
   const supportedReasoning = registryEffort !== undefined
     ? registryEffort.supported.map(effort => ({ effort, description: '' }))
     : (source.supported_reasoning_levels ?? BASELINE.supported_reasoning_levels);
+  const reasoningLevels = supportedReasoning as Array<{ effort: string; description: string }>;
+  const supportsMax = reasoningLevels.some(level => level.effort === 'max');
 
   const registryWindow = model.limits.max_context_window_tokens;
   const contextWindow = (registryWindow
@@ -149,7 +157,8 @@ export const synthesizeCatalogEntry = (model: InternalModel, base?: CatalogModel
     input_modalities: [...inputModalities],
     supports_image_detail_original: hasImage,
     web_search_tool_type: hasImage ? 'text_and_image' : 'text',
-    supported_reasoning_levels: supportedReasoning,
+    supported_reasoning_levels: supportsMax && !reasoningLevels.some(level => level.effort === 'ultra') ? [...reasoningLevels, ULTRA_REASONING_LEVEL] : reasoningLevels,
+    multi_agent_version: supportsMax ? 'v2' : source.multi_agent_version,
     service_tiers: deriveServiceTiers(model),
     context_window: contextWindow,
     max_context_window: maxContextWindow,

--- a/packages/gateway/src/data-plane/codex/synthesize.ts
+++ b/packages/gateway/src/data-plane/codex/synthesize.ts
@@ -112,7 +112,7 @@ export const synthesizeCatalogEntry = (
   base?: CatalogModel,
   capabilities: CodexCatalogCapabilities = {},
 ): CatalogModel => {
-  const source = base ?? BASELINE;
+  const source: CatalogModel = base ?? BASELINE;
 
   // Overlay chain for every registry-derived field: `registry ?? source ?? BASELINE`.
   // BASELINE is always the ultimate fallback so a partially-populated `source`

--- a/packages/gateway/src/data-plane/codex/synthesize.ts
+++ b/packages/gateway/src/data-plane/codex/synthesize.ts
@@ -31,20 +31,16 @@
 //      modality list so they cannot drift from it.
 //   6. `supported_reasoning_levels` / `default_reasoning_level` — same
 //      `chat.reasoning.effort ?? source's` precedence as the modalities.
+//      Ultra is appended only when the exact client-version catalog proves
+//      v2 Ultra semantics and the resulting model supports Max.
 //
 // Fields not listed above ride through from `source` unchanged: the base
 // pass supplies bundled defaults for bundled-hit and hardcoded baselines
 // for the miss path.
 
-import type { CatalogModel } from './catalog.ts';
+import type { CatalogModel, CodexCatalogCapabilities, CodexReasoningLevel } from './catalog.ts';
 import { synthesizedBaseInstructions } from './synthesized-base-instructions.ts';
 import type { InternalModel, Modality } from '@floway-dev/provider';
-
-// Ultra selects proactive multi-agent v2 locally while Codex sends `max` on
-// the wire. Keep the catalog preset aligned with the official Codex catalog.
-// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/models-manager/models.json#L19-L58
-// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/core/src/session/multi_agents.rs#L39-L54
-const ULTRA_REASONING_LEVEL = { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' };
 
 // A synthesized (miss-path) entry with no registry-supplied
 // `max_context_window_tokens` still needs SOME window — codex's auto-compact
@@ -111,7 +107,11 @@ const deriveServiceTiers = (model: InternalModel): { id: string; name: string; d
   return [...ids].map(id => ({ id, name: id, description: '' }));
 };
 
-export const synthesizeCatalogEntry = (model: InternalModel, base?: CatalogModel): CatalogModel => {
+export const synthesizeCatalogEntry = (
+  model: InternalModel,
+  base?: CatalogModel,
+  capabilities: CodexCatalogCapabilities = {},
+): CatalogModel => {
   const source = base ?? BASELINE;
 
   // Overlay chain for every registry-derived field: `registry ?? source ?? BASELINE`.
@@ -136,11 +136,12 @@ export const synthesizeCatalogEntry = (model: InternalModel, base?: CatalogModel
   // effort value into the appropriate upstream representation (e.g.
   // Anthropic `thinking.budget_tokens`).
   const registryEffort = model.chat?.reasoning?.effort;
-  const supportedReasoning = registryEffort !== undefined
+  const supportedReasoning: CodexReasoningLevel[] = registryEffort !== undefined
     ? registryEffort.supported.map(effort => ({ effort, description: '' }))
     : (source.supported_reasoning_levels ?? BASELINE.supported_reasoning_levels);
-  const reasoningLevels = supportedReasoning as Array<{ effort: string; description: string }>;
-  const supportsMax = reasoningLevels.some(level => level.effort === 'max');
+  const shouldEnableUltra = capabilities.ultraReasoningLevel !== undefined
+    && supportedReasoning.some(level => level.effort === 'max')
+    && !supportedReasoning.some(level => level.effort === 'ultra');
 
   const registryWindow = model.limits.max_context_window_tokens;
   const contextWindow = (registryWindow
@@ -157,12 +158,18 @@ export const synthesizeCatalogEntry = (model: InternalModel, base?: CatalogModel
     input_modalities: [...inputModalities],
     supports_image_detail_original: hasImage,
     web_search_tool_type: hasImage ? 'text_and_image' : 'text',
-    supported_reasoning_levels: supportsMax && !reasoningLevels.some(level => level.effort === 'ultra') ? [...reasoningLevels, ULTRA_REASONING_LEVEL] : reasoningLevels,
-    multi_agent_version: supportsMax ? 'v2' : source.multi_agent_version,
+    supported_reasoning_levels: shouldEnableUltra
+      ? [...supportedReasoning, capabilities.ultraReasoningLevel]
+      : supportedReasoning,
     service_tiers: deriveServiceTiers(model),
     context_window: contextWindow,
     max_context_window: maxContextWindow,
   };
+
+  // Ultra is a client-local v2 orchestration mode whose wire effort remains
+  // Max. The caller supplies this capability only from an exact Codex catalog;
+  // a model advertising Max alone does not establish either client behavior.
+  if (shouldEnableUltra) entry.multi_agent_version = 'v2';
 
   // `default_reasoning_level` pairs with `supported_reasoning_levels` — both
   // come from the same source. When registry supplied `effort`, its schema

--- a/packages/gateway/src/data-plane/codex/synthesize.ts
+++ b/packages/gateway/src/data-plane/codex/synthesize.ts
@@ -54,7 +54,7 @@ const CONSERVATIVE_DEFAULT_CONTEXT_WINDOW = 128_000;
 // registry-derived overlays on top. Bundled matches use the bundled entry
 // as the base and overlay the same fields, so both paths converge on one
 // field-precedence rule set (documented above).
-const BASELINE: CatalogModel = {
+const BASELINE = {
   slug: '',                                             // always overwritten
   description: '',
   truncation_policy: { mode: 'tokens', limit: 10000 },
@@ -97,7 +97,7 @@ const BASELINE: CatalogModel = {
   auto_compact_token_limit: null,
   context_window: CONSERVATIVE_DEFAULT_CONTEXT_WINDOW,
   max_context_window: CONSERVATIVE_DEFAULT_CONTEXT_WINDOW,
-};
+} satisfies CatalogModel;
 
 // Registry-derived: every distinct serviceTier selector is a billable wire-id.
 // Names mirror ids and descriptions are blank — Floway does not carry separate
@@ -139,9 +139,13 @@ export const synthesizeCatalogEntry = (
   const supportedReasoning: CodexReasoningLevel[] = registryEffort !== undefined
     ? registryEffort.supported.map(effort => ({ effort, description: '' }))
     : (source.supported_reasoning_levels ?? BASELINE.supported_reasoning_levels);
-  const shouldEnableUltra = capabilities.ultraReasoningLevel !== undefined
+  const ultraReasoningLevel = capabilities.ultraReasoningLevel;
+  const advertisedReasoning = ultraReasoningLevel !== undefined
     && supportedReasoning.some(level => level.effort === 'max')
-    && !supportedReasoning.some(level => level.effort === 'ultra');
+    && !supportedReasoning.some(level => level.effort === 'ultra')
+    ? [...supportedReasoning, ultraReasoningLevel]
+    : supportedReasoning;
+  const shouldEnableUltra = advertisedReasoning !== supportedReasoning;
 
   const registryWindow = model.limits.max_context_window_tokens;
   const contextWindow = (registryWindow
@@ -158,9 +162,7 @@ export const synthesizeCatalogEntry = (
     input_modalities: [...inputModalities],
     supports_image_detail_original: hasImage,
     web_search_tool_type: hasImage ? 'text_and_image' : 'text',
-    supported_reasoning_levels: shouldEnableUltra
-      ? [...supportedReasoning, capabilities.ultraReasoningLevel]
-      : supportedReasoning,
+    supported_reasoning_levels: advertisedReasoning,
     service_tiers: deriveServiceTiers(model),
     context_window: contextWindow,
     max_context_window: maxContextWindow,

--- a/packages/gateway/src/data-plane/codex/synthesize_test.ts
+++ b/packages/gateway/src/data-plane/codex/synthesize_test.ts
@@ -93,6 +93,19 @@ describe('synthesizeCatalogEntry', () => {
     expect(entry.default_reasoning_level).toBe('low');
   });
 
+  test('adds Ultra and multi-agent v2 when Max is supported', () => {
+    const entry = synthesizeCatalogEntry({
+      ...base,
+      chat: { reasoning: { effort: { supported: ['low', 'max'], default: 'low' } } },
+    });
+    expect(entry.supported_reasoning_levels).toEqual([
+      { effort: 'low', description: '' },
+      { effort: 'max', description: '' },
+      { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
+    ]);
+    expect(entry.multi_agent_version).toBe('v2');
+  });
+
   test('drops budget_tokens silently — no effort fields on output', () => {
     const entry = synthesizeCatalogEntry({
       ...base,
@@ -221,6 +234,22 @@ describe('synthesizeCatalogEntry', () => {
       }, bundledBase);
       expect(entry.supported_reasoning_levels).toEqual([{ effort: 'high', description: '' }]);
       expect(entry.default_reasoning_level).toBe('high');
+    });
+
+    test('preserves an existing Ultra preset without duplication', () => {
+      const entry = synthesizeCatalogEntry(base, {
+        ...bundledBase,
+        supported_reasoning_levels: [
+          { effort: 'max', description: 'Maximum' },
+          { effort: 'ultra', description: 'Existing Ultra' },
+        ],
+        multi_agent_version: 'v1',
+      });
+      expect(entry.supported_reasoning_levels).toEqual([
+        { effort: 'max', description: 'Maximum' },
+        { effort: 'ultra', description: 'Existing Ultra' },
+      ]);
+      expect(entry.multi_agent_version).toBe('v2');
     });
 
     test('bundled context_window preserved when registry omits max_context_window_tokens', () => {

--- a/packages/gateway/src/data-plane/codex/synthesize_test.ts
+++ b/packages/gateway/src/data-plane/codex/synthesize_test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import type { CatalogModel } from './catalog.ts';
+import type { CatalogModel, CodexCatalogCapabilities } from './catalog.ts';
 import { synthesizeCatalogEntry } from './synthesize.ts';
 import type { InternalModel } from '@floway-dev/provider';
 
@@ -11,6 +11,10 @@ const base: InternalModel = {
   limits: { max_context_window_tokens: 128000 },
   endpoints: { chatCompletions: {} },
   providerModels: {},
+};
+
+const ultraCapabilities: CodexCatalogCapabilities = {
+  ultraReasoningLevel: { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
 };
 
 describe('synthesizeCatalogEntry', () => {
@@ -93,11 +97,23 @@ describe('synthesizeCatalogEntry', () => {
     expect(entry.default_reasoning_level).toBe('low');
   });
 
-  test('adds Ultra and multi-agent v2 when Max is supported', () => {
+  test('does not infer Ultra support from Max alone', () => {
     const entry = synthesizeCatalogEntry({
       ...base,
       chat: { reasoning: { effort: { supported: ['low', 'max'], default: 'low' } } },
     });
+    expect(entry.supported_reasoning_levels).toEqual([
+      { effort: 'low', description: '' },
+      { effort: 'max', description: '' },
+    ]);
+    expect(entry.multi_agent_version).toBeUndefined();
+  });
+
+  test('adds Ultra and multi-agent v2 when the client supports Ultra and the model supports Max', () => {
+    const entry = synthesizeCatalogEntry({
+      ...base,
+      chat: { reasoning: { effort: { supported: ['low', 'max'], default: 'low' } } },
+    }, undefined, ultraCapabilities);
     expect(entry.supported_reasoning_levels).toEqual([
       { effort: 'low', description: '' },
       { effort: 'max', description: '' },
@@ -249,7 +265,7 @@ describe('synthesizeCatalogEntry', () => {
         { effort: 'max', description: 'Maximum' },
         { effort: 'ultra', description: 'Existing Ultra' },
       ]);
-      expect(entry.multi_agent_version).toBe('v2');
+      expect(entry.multi_agent_version).toBe('v1');
     });
 
     test('bundled context_window preserved when registry omits max_context_window_tokens', () => {


### PR DESCRIPTION
## Summary
Based on our discussion in https://github.com/Menci/Floway/issues/238 , we can add a fake ultra level for codex desktop (maybe also works for codex cli) to make client get more proactively subagent use and can defer agent to other models (which may reduce the cost and improve the speed).

Closed: #238 

## Detail
1. Add ultra levels for all gpt models which support max effort.
2. Fix the codex UA match logic. The real codex desktop app will send a "Codex Desktop" like UA.

## Test

Tested locally. It works. Please pay attention, this PR removed the UI changes (support ultra settings). If you think it's neccessary, please ping me I will create another PR to support it.
<img width="1361" height="348" alt="image" src="https://github.com/user-attachments/assets/57258d30-e5a1-4bdc-a9d3-c8ea1b65cc1e" />
