### PR TITLE
fix(responses): align advanced item wire contracts

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/affinity/egress.ts
+++ b/packages/gateway/src/data-plane/chat/responses/affinity/egress.ts
@@ -82,7 +82,8 @@ const wrapNaturalResponsesAffinity = async function* (
       continue;
     }
     if (
-      event.type === 'response.created'
+      event.type === 'response.queued'
+      || event.type === 'response.created'
       || event.type === 'response.in_progress'
       || event.type === 'response.completed'
       || event.type === 'response.incomplete'
@@ -268,7 +269,7 @@ const wrapResponsesFirstCarrier = async function* (
       return;
     }
 
-    if (event.type === 'response.created' || event.type === 'response.in_progress') {
+    if (event.type === 'response.queued' || event.type === 'response.created' || event.type === 'response.in_progress') {
       yield* discoverFirstFromSnapshot(event.response, event.sequence_number);
       const response = await rewriteResponse(event.response, false);
       yield eventFrame(addSequenceOffset({ ...event, response }, sequenceOffset));

--- a/packages/gateway/src/data-plane/chat/responses/affinity/egress.ts
+++ b/packages/gateway/src/data-plane/chat/responses/affinity/egress.ts
@@ -269,7 +269,13 @@ const wrapResponsesFirstCarrier = async function* (
       return;
     }
 
-    if (event.type === 'response.queued' || event.type === 'response.created' || event.type === 'response.in_progress') {
+    if (event.type === 'response.queued') {
+      const response = await rewriteResponse(event.response, false);
+      yield eventFrame(addSequenceOffset({ ...event, response }, sequenceOffset));
+      continue;
+    }
+
+    if (event.type === 'response.created' || event.type === 'response.in_progress') {
       yield* discoverFirstFromSnapshot(event.response, event.sequence_number);
       const response = await rewriteResponse(event.response, false);
       yield eventFrame(addSequenceOffset({ ...event, response }, sequenceOffset));

--- a/packages/gateway/src/data-plane/chat/responses/affinity/egress_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/affinity/egress_test.ts
@@ -44,6 +44,23 @@ describe('Responses affinity egress', () => {
     });
   });
 
+  test('does not emit synthetic output before a queued non-carrier snapshot', async () => {
+    const message = {
+      type: 'message' as const,
+      id: 'msg_queued',
+      role: 'assistant' as const,
+      content: [{ type: 'output_text' as const, text: 'waiting' }],
+    };
+    const output: ProtocolFrame<ResponsesStreamEvent>[] = [];
+    for await (const frame of wrapResponsesAffinityEgress(frames([
+      eventFrame({ type: 'response.queued', response: response([message], 'queued'), sequence_number: 0 }),
+    ]), { codec: immediateCodec, affinity })) output.push(frame);
+
+    expect(output).toEqual([
+      eventFrame({ type: 'response.queued', response: response([message], 'queued'), sequence_number: 0 }),
+    ]);
+  });
+
   test('streams visible reasoning before wrapping and reuses one natural carrier', async () => {
     const calls: Array<{ value: string | undefined; resolve: (value: string) => void }> = [];
     const codec: AffinityEgressCodec = {

--- a/packages/gateway/src/data-plane/chat/responses/affinity/egress_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/affinity/egress_test.ts
@@ -27,6 +27,23 @@ const response = (output: ResponsesResult['output'], status: ResponsesResult['st
 });
 
 describe('Responses affinity egress', () => {
+  test('wraps natural blobs inside queued response output', async () => {
+    const reasoning: ResponsesOutputReasoning = {
+      type: 'reasoning',
+      id: 'rs_queued',
+      summary: [],
+      encrypted_content: 'opaque',
+    };
+    const output: ProtocolFrame<ResponsesStreamEvent>[] = [];
+    for await (const frame of wrapResponsesAffinityEgress(frames([
+      eventFrame({ type: 'response.queued', response: response([reasoning], 'queued') }),
+    ]), { codec: immediateCodec, affinity })) output.push(frame);
+
+    expect(output[0]).toMatchObject({
+      event: { type: 'response.queued', response: { output: [{ encrypted_content: 'wrapped:opaque' }] } },
+    });
+  });
+
   test('streams visible reasoning before wrapping and reuses one natural carrier', async () => {
     const calls: Array<{ value: string | undefined; resolve: (value: string) => void }> = [];
     const codec: AffinityEgressCodec = {

--- a/packages/gateway/src/data-plane/chat/responses/affinity/roundtrip_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/affinity/roundtrip_test.ts
@@ -63,7 +63,8 @@ test('affinity selects the route while item storage independently restores the n
     if (frame.type === 'event' && frame.event.type === 'response.completed') clientResponse = frame.event.response;
   }
   if (clientResponse === undefined) throw new Error('Expected completed client response');
-  const publicProgram = clientResponse.output[1] as ResponsesInputItem;
+  const publicProgram = clientResponse.output[1];
+  if (publicProgram.type !== 'program_output') throw new Error('Expected program output');
   expect(publicProgram.id).not.toBe(programOutput.id);
 
   const input = clientResponse.output as unknown as ResponsesInputItem[];

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/canonicalize-output-items.ts
@@ -51,7 +51,7 @@ const canonicalizeOutputItems = async function* (
 
     if (event.type === 'response.output_item.done') {
       canonical.set(event.output_index, {
-        id: event.item.id,
+        id: typeof event.item.id === 'string' ? event.item.id : undefined,
         encryptedContent: (event.item as { encrypted_content?: string }).encrypted_content,
       });
       yield frame;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy.ts
@@ -37,7 +37,7 @@ const isCyberPolicyFrame = (frame: ProtocolFrame<ResponsesStreamEvent>): boolean
   frame.type === 'event' && valueHasCyberPolicyCode(frame.event);
 
 const isRetryProbePrologue = (frame: ProtocolFrame<ResponsesStreamEvent>): boolean =>
-  frame.type === 'event' && (frame.event.type === 'response.created' || frame.event.type === 'response.in_progress');
+  frame.type === 'event' && (frame.event.type === 'response.queued' || frame.event.type === 'response.created' || frame.event.type === 'response.in_progress');
 
 const isDownstreamAborted = (ctx: GatewayCtx): boolean => ctx.abortSignal?.aborted === true;
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/retry-cyber-policy_test.ts
@@ -230,16 +230,21 @@ test('withCyberPolicyRetried buffers converted fallback prologue frames before r
       return Promise.resolve(
         protocolResult([
           {
-            type: 'response.created',
+            type: 'response.queued',
             sequence_number: 0,
+            response: { ...inProgressResponse('resp_blocked'), status: 'queued' },
+          },
+          {
+            type: 'response.created',
+            sequence_number: 1,
             response: inProgressResponse('resp_blocked'),
           },
           {
             type: 'response.in_progress',
-            sequence_number: 1,
+            sequence_number: 2,
             response: inProgressResponse('resp_blocked'),
           },
-          cyberPolicyEvent('resp_blocked', 2),
+          cyberPolicyEvent('resp_blocked', 3),
         ]),
       );
     }

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -324,14 +324,15 @@ export const parseServerToolArguments = (argumentsJson: string): Record<string, 
   return parsed as Record<string, unknown>;
 };
 
-const syntheticInProgressResponse = (
+const syntheticPrologueResponse = (
   state: MergeState,
   id: string,
   model: string,
   active: readonly ActiveServerTool[],
+  status: 'queued' | 'in_progress',
 ): ResponsesResult => {
   if (state.upstreamResponseSnapshot === undefined) {
-    throw new Error('Server-tool shim cannot synthesize a Responses in-progress envelope before upstream `response.created` is captured.');
+    throw new Error('Server-tool shim cannot synthesize a Responses prologue envelope before an upstream response snapshot is captured.');
   }
   const snapshot = state.upstreamResponseSnapshot;
   const restoredTools = restoreEchoedTools(snapshot.tools, active);
@@ -342,7 +343,7 @@ const syntheticInProgressResponse = (
     object: 'response',
     model,
     output: [],
-    status: 'in_progress',
+    status,
     error: null,
     incomplete_details: null,
     ...(restoredTools !== undefined ? { tools: restoredTools } : {}),
@@ -492,6 +493,20 @@ export const consumeTurnStreaming = async function* (
     }
     const event = frame.event;
 
+    if (event.type === 'response.queued') {
+      const reportedModel = event.response.model;
+      if (typeof reportedModel === 'string' && reportedModel.length > 0) merge.lastSeenModel = reportedModel;
+      merge.upstreamResponseSnapshot = event.response;
+      ensureModel();
+      if (isFirstTurn) {
+        yield stamp({
+          type: 'response.queued',
+          response: syntheticPrologueResponse(merge, merge.synthesizedResponseId, ensureModel(), active, 'queued'),
+        });
+      }
+      continue;
+    }
+
     if (event.type === 'response.created') {
       const reportedModel = event.response.model;
       if (typeof reportedModel === 'string' && reportedModel.length > 0) merge.lastSeenModel = reportedModel;
@@ -500,7 +515,7 @@ export const consumeTurnStreaming = async function* (
       if (isFirstTurn) {
         yield stamp({
           type: 'response.created',
-          response: syntheticInProgressResponse(merge, merge.synthesizedResponseId, ensureModel(), active),
+          response: syntheticPrologueResponse(merge, merge.synthesizedResponseId, ensureModel(), active, 'in_progress'),
         });
       }
       continue;
@@ -510,7 +525,7 @@ export const consumeTurnStreaming = async function* (
       if (isFirstTurn) {
         yield stamp({
           type: 'response.in_progress',
-          response: syntheticInProgressResponse(merge, merge.synthesizedResponseId, ensureModel(), active),
+          response: syntheticPrologueResponse(merge, merge.synthesizedResponseId, ensureModel(), active, 'in_progress'),
         });
       }
       continue;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -493,30 +493,17 @@ export const consumeTurnStreaming = async function* (
     }
     const event = frame.event;
 
-    if (event.type === 'response.queued') {
+    if (event.type === 'response.queued' || event.type === 'response.created') {
       const reportedModel = event.response.model;
       if (typeof reportedModel === 'string' && reportedModel.length > 0) merge.lastSeenModel = reportedModel;
       merge.upstreamResponseSnapshot = event.response;
       ensureModel();
       if (isFirstTurn) {
+        const status = event.type === 'response.queued' ? 'queued' : 'in_progress';
         yield stamp({
-          type: 'response.queued',
-          response: syntheticPrologueResponse(merge, merge.synthesizedResponseId, ensureModel(), active, 'queued'),
-        });
-      }
-      continue;
-    }
-
-    if (event.type === 'response.created') {
-      const reportedModel = event.response.model;
-      if (typeof reportedModel === 'string' && reportedModel.length > 0) merge.lastSeenModel = reportedModel;
-      merge.upstreamResponseSnapshot = event.response;
-      ensureModel();
-      if (isFirstTurn) {
-        yield stamp({
-          type: 'response.created',
-          response: syntheticPrologueResponse(merge, merge.synthesizedResponseId, ensureModel(), active, 'in_progress'),
-        });
+          type: event.type,
+          response: syntheticPrologueResponse(merge, merge.synthesizedResponseId, ensureModel(), active, status),
+        } as ResponsesStreamEvent);
       }
       continue;
     }

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -68,6 +68,12 @@ const mkResponseCreated = (responseId = 'upstream_test'): ProtocolFrame<Response
     response: emptyResult(responseId, 'in_progress'),
   });
 
+const mkResponseQueued = (responseId = 'upstream_test'): ProtocolFrame<ResponsesStreamEvent> =>
+  eventFrame({
+    type: 'response.queued',
+    response: emptyResult(responseId, 'queued'),
+  });
+
 const mkResponseInProgress = (responseId = 'upstream_test'): ProtocolFrame<ResponsesStreamEvent> =>
   eventFrame({
     type: 'response.in_progress',
@@ -4677,6 +4683,27 @@ const consumeTurn = async (
     records,
   );
 };
+
+test('consumeTurn forwards queued only from the first upstream turn', async () => {
+  const firstState = createMergeState();
+  const first = await consumeTurn(
+    framesOf(mkResponseQueued('queued_first'), mkResponseCreated('created_first'), mkResponseCompleted()),
+    firstState,
+    true,
+  );
+  assertEquals(eventTypesOf(first.downstreamFrames), ['response.queued', 'response.created']);
+  const queued = first.downstreamFrames[0];
+  assert(queued.type === 'event' && queued.event.type === 'response.queued');
+  assertEquals(queued.event.response.id, firstState.synthesizedResponseId);
+  assertEquals(queued.event.response.status, 'queued');
+
+  const later = await consumeTurn(
+    framesOf(mkResponseQueued('queued_later'), mkResponseCreated('created_later'), mkResponseCompleted()),
+    createMergeState(),
+    false,
+  );
+  assertEquals(later.downstreamFrames, []);
+});
 
 test('consumeTurn first turn synthesizes response.created with the once-per-request synthesized id (not the upstream id)', async () => {
   const state = createMergeState();

--- a/packages/gateway/src/data-plane/chat/responses/items/format.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/format.ts
@@ -78,15 +78,15 @@ export const createResponsesItemId = (itemType: string): string => {
 export const isResponsesItemId = (value: string): boolean =>
   isValidResponsesId(value, prefix => knownPrefixes.has(prefix));
 
-export const responsesItemId = (item: { id?: unknown }): string | null => {
-  const id = item.id;
+export const responsesItemId = (item: object): string | null => {
+  const id = 'id' in item ? item.id : undefined;
   return typeof id === 'string' && id.length > 0 ? id : null;
 };
 
 export const canonicalResponsesItemType = (itemType: string): string =>
   itemType === 'compaction_summary' ? 'compaction' : itemType;
 
-export const hashResponsesItemContent = async (item: ResponsesInputItem): Promise<string> =>
+export const hashResponsesItemContent = async (item: unknown): Promise<string> =>
   await sha256Hex(JSON.stringify(sortJson(item)));
 
 export const createTemporaryResponsesItemId = (itemType: string): string => `${prefixForItemType(itemType)}_tmp_${randomBody()}`;

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -17,7 +17,7 @@ import { responsesResultToEvents, type ResponsesOutputItem, type ResponsesResult
 //
 // Wrap is also the single source of truth for the response envelope id the
 // client sees. The caller mints a `resp_<crc>_<body>` once and passes it
-// in here; every envelope event (`response.created`, `response.in_progress`,
+// in here; every envelope event (`response.queued`, `response.created`, `response.in_progress`,
 // `response.completed`, `response.incomplete`, `response.failed`) yielded
 // downstream has its `response.id` rewritten to it, and the snapshot is
 // committed under the same id. Whatever id the upstream produced
@@ -125,7 +125,7 @@ export const wrapResponsesClientOutput = async function* (
     // forwarder, snapshot collector) sees them. Item-level events
     // (`response.output_item.*`, delta events) do not carry `response.id`
     // and are handled below.
-    if (event.type === 'response.created' || event.type === 'response.in_progress') {
+    if (event.type === 'response.queued' || event.type === 'response.created' || event.type === 'response.in_progress') {
       yield eventFrame({ ...event, response: rewriteEnvelopeIds(event.response) });
       continue;
     }

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -2,7 +2,7 @@ import { canonicalResponsesItemType, createResponsesItemId, hashResponsesItemCon
 import type { StatefulResponsesStore } from './store.ts';
 import type { StoredResponsesItem } from '../../../../repo/types.ts';
 import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import { responsesResultToEvents, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { responsesResultToEvents, type ResponsesOutputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 // Mints gateway-owned item ids and presents finalized client items to the
 // configured state store when it has a write target; without one (HTTP
@@ -74,7 +74,7 @@ export const wrapResponsesClientOutput = async function* (
     return clientId;
   };
 
-  const persistFinalizedItem = async (originalItem: ResponsesInputItem, newId: string, outputIndex: number): Promise<void> => {
+  const persistFinalizedItem = async (originalItem: ResponsesOutputItem, newId: string, outputIndex: number): Promise<void> => {
     if (!store.writesState) return;
     const wireId = responsesItemId(originalItem);
     const source = wireId === null ? null : store.outputItemSource(wireId);
@@ -82,7 +82,7 @@ export const wrapResponsesClientOutput = async function* (
     // Attaching it lets a later turn restore the real success/failure state
     // even when the client stripped fields from the echoed wire item.
     const privatePayload = wireId === null ? undefined : store.getPrivatePayload(wireId);
-    const clientItem = { ...originalItem, id: newId } as ResponsesInputItem;
+    const clientItem = { ...originalItem, id: newId } as ResponsesOutputItem;
     const persistedPayload = privatePayload !== undefined ? { item: clientItem, private: privatePayload } : { item: clientItem };
     const now = Date.now();
     const row: StoredResponsesItem = {
@@ -143,20 +143,20 @@ export const wrapResponsesClientOutput = async function* (
       if (upstreamId !== null) seenItemTypes.set(upstreamId, event.item.type);
       const newId = clientIdForOutput(upstreamId, event.item.type, event.output_index);
       if (isCompactionItemType(event.item.type)) sawCompactionItem = true;
-      await persistFinalizedItem(event.item as unknown as ResponsesInputItem, newId, event.output_index);
+        await persistFinalizedItem(event.item, newId, event.output_index);
       yield eventFrame({ ...event, item: { ...event.item, id: newId } });
       continue;
     }
 
     if (event.type === 'response.completed' || event.type === 'response.incomplete') {
-      const output: ResponsesInputItem[] = [];
+        const output: ResponsesOutputItem[] = [];
       for (const [outputIndex, item] of event.response.output.entries()) {
         if (isCompactionItemType(item.type)) sawCompactionItem = true;
         const upstreamId = responsesItemId(item);
         if (upstreamId !== null) seenItemTypes.set(upstreamId, item.type);
         const newId = clientIdForOutput(upstreamId, item.type, outputIndex);
-        await persistFinalizedItem(item as unknown as ResponsesInputItem, newId, outputIndex);
-        output.push({ ...(item as unknown as ResponsesInputItem), id: newId });
+          await persistFinalizedItem(item, newId, outputIndex);
+          output.push({ ...item, id: newId } as ResponsesOutputItem);
       }
       const rewritten = eventFrame({
         ...event,

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -143,20 +143,20 @@ export const wrapResponsesClientOutput = async function* (
       if (upstreamId !== null) seenItemTypes.set(upstreamId, event.item.type);
       const newId = clientIdForOutput(upstreamId, event.item.type, event.output_index);
       if (isCompactionItemType(event.item.type)) sawCompactionItem = true;
-        await persistFinalizedItem(event.item, newId, event.output_index);
+      await persistFinalizedItem(event.item, newId, event.output_index);
       yield eventFrame({ ...event, item: { ...event.item, id: newId } });
       continue;
     }
 
     if (event.type === 'response.completed' || event.type === 'response.incomplete') {
-        const output: ResponsesOutputItem[] = [];
+      const output: ResponsesOutputItem[] = [];
       for (const [outputIndex, item] of event.response.output.entries()) {
         if (isCompactionItemType(item.type)) sawCompactionItem = true;
         const upstreamId = responsesItemId(item);
         if (upstreamId !== null) seenItemTypes.set(upstreamId, item.type);
         const newId = clientIdForOutput(upstreamId, item.type, outputIndex);
-          await persistFinalizedItem(item, newId, outputIndex);
-          output.push({ ...item, id: newId } as ResponsesOutputItem);
+        await persistFinalizedItem(item, newId, outputIndex);
+        output.push({ ...item, id: newId } as ResponsesOutputItem);
       }
       const rewritten = eventFrame({
         ...event,

--- a/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest';
 
-import { isResponsesItemId } from './format.ts';
+import { isResponsesItemId, responsesItemId } from './format.ts';
 import { wrapResponsesClientOutput } from './output.ts';
 import { createResponsesHttpStore } from './store.ts';
 import { initRepo } from '../../../../repo/index.ts';
@@ -189,7 +189,7 @@ test('client output persists a completed item before forwarding an error event',
     store,
     responseId: 'resp_public',
   })) {
-    if (frame.type === 'event' && frame.event.type === 'response.output_item.done') clientId = frame.event.item.id;
+    if (frame.type === 'event' && frame.event.type === 'response.output_item.done') clientId = responsesItemId(frame.event.item) ?? undefined;
   }
 
   expect(clientId).toEqual(expect.any(String));
@@ -210,7 +210,7 @@ test('client output does not persist a partial item without output_item.done', a
     store,
     responseId: 'resp_public',
   })) {
-    if (frame.type === 'event' && frame.event.type === 'response.output_item.added') clientId = frame.event.item.id;
+    if (frame.type === 'event' && frame.event.type === 'response.output_item.added') clientId = responsesItemId(frame.event.item) ?? undefined;
   }
 
   expect(clientId).toEqual(expect.any(String));
@@ -232,7 +232,7 @@ test('client output persists completed items before rethrowing an iterator error
       store,
       responseId: 'resp_public',
     })) {
-      if (frame.type === 'event' && frame.event.type === 'response.output_item.done') clientId = frame.event.item.id;
+      if (frame.type === 'event' && frame.event.type === 'response.output_item.done') clientId = responsesItemId(frame.event.item) ?? undefined;
     }
   };
 
@@ -255,7 +255,7 @@ test('client output persists completed items when the source ends without a term
     store,
     responseId: 'resp_public',
   })) {
-    if (frame.type === 'event' && frame.event.type === 'response.output_item.done') clientId = frame.event.item.id;
+    if (frame.type === 'event' && frame.event.type === 'response.output_item.done') clientId = responsesItemId(frame.event.item) ?? undefined;
   }
 
   expect(clientId).toEqual(expect.any(String));

--- a/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output_test.ts
@@ -28,6 +28,34 @@ const memoryOutputHarness = () => {
   return { repo, store: createResponsesHttpStore('key-a', true) };
 };
 
+test('client output rewrites response and item ids inside queued envelopes', async () => {
+  const { store } = memoryOutputHarness();
+  const queued: ResponsesResult = {
+    id: 'resp_upstream',
+    object: 'response',
+    model: 'model',
+    status: 'queued',
+    output: [completedReasoningItem],
+    error: null,
+    incomplete_details: null,
+  };
+  const input = (async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+    yield eventFrame({ type: 'response.queued', response: queued });
+  })();
+  const output: ProtocolFrame<ResponsesStreamEvent>[] = [];
+  for await (const frame of wrapResponsesClientOutput(input, { store, responseId: 'resp_public' })) output.push(frame);
+
+  expect(output[0]).toMatchObject({
+    event: {
+      type: 'response.queued',
+      response: { id: 'resp_public', output: [{ type: 'reasoning' }] },
+    },
+  });
+  const frame = output[0];
+  if (frame.type !== 'event' || frame.event.type !== 'response.queued') throw new Error('expected queued event');
+  expect(frame.event.response.output[0].id).not.toBe('rs_upstream');
+});
+
 test('client output rewrites ids and persists the exact complete item before terminal', async () => {
   const { repo, store } = memoryOutputHarness();
   const result: ResponsesResult = {

--- a/packages/protocols/src/responses/from-result.ts
+++ b/packages/protocols/src/responses/from-result.ts
@@ -3,11 +3,16 @@ import type { ResponsesOutputCustomToolCall, ResponsesOutputFunctionCall, Respon
 import { webSearchCallLifecycleEvents } from './web-search-lifecycle.ts';
 import { type EventFrame, eventFrame } from '../common/index.ts';
 
-const getTerminalEventName = (response: ResponsesResult): 'response.failed' | 'response.incomplete' | 'response.in_progress' | 'response.completed' => {
-  if (response.status === 'failed') return 'response.failed';
-  if (response.status === 'incomplete') return 'response.incomplete';
-  if (response.status === 'in_progress') return 'response.in_progress';
-  return 'response.completed';
+const getTerminalEventName = (response: ResponsesResult): 'response.failed' | 'response.incomplete' | 'response.completed' => {
+  switch (response.status) {
+  case 'completed': return 'response.completed';
+  case 'failed': return 'response.failed';
+  case 'incomplete': return 'response.incomplete';
+  case 'queued':
+  case 'in_progress':
+  case 'cancelled':
+    throw new TypeError(`Cannot expand nonterminal Responses status '${response.status}' into terminal events`);
+  }
 };
 
 const responsesStartSnapshot = (response: ResponsesResult): ResponsesResult => {

--- a/packages/protocols/src/responses/from-result_test.ts
+++ b/packages/protocols/src/responses/from-result_test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 
 import { responsesResultToEvents } from './from-result.ts';
-import type { ResponsesResult } from './index.ts';
+import type { ResponsesOutputItem, ResponsesResult } from './index.ts';
 import { assertEquals, assertFalse } from '../test-assert.ts';
 
 const completedResponse: ResponsesResult = {
@@ -194,6 +194,123 @@ test('responsesResultToEvents propagates the real function_call item id to the a
     .map(event => event.item_id);
   assertEquals(childItemIds.length, 2);
   for (const itemId of childItemIds) assertEquals(itemId, 'fc_real');
+});
+
+test('responsesResultToEvents preserves advanced tool item wire fields', () => {
+  const output = [
+    {
+      type: 'computer_call',
+      id: 'cu_1',
+      call_id: 'call_computer',
+      status: 'completed',
+      actions: [{ type: 'screenshot' }],
+    },
+    {
+      type: 'computer_call_output',
+      id: 'cuo_1',
+      call_id: 'call_computer',
+      output: { type: 'computer_screenshot', image_url: 'data:image/png;base64,AA==' },
+      status: 'completed',
+    },
+    {
+      type: 'tool_search_call',
+      id: 'tsc_1',
+      call_id: 'call_search',
+      arguments: { query: 'lookup', limit: 3 },
+      execution: 'client',
+      status: 'completed',
+    },
+    {
+      type: 'tool_search_output',
+      id: 'tso_1',
+      call_id: 'call_search',
+      execution: 'client',
+      status: 'completed',
+      tools: [{ type: 'function', name: 'lookup', parameters: {}, strict: true }],
+    },
+    {
+      type: 'code_interpreter_call',
+      id: 'ci_1',
+      code: 'print(1)',
+      container_id: 'cntr_1',
+      outputs: [{ type: 'logs', logs: '1' }],
+      status: 'completed',
+    },
+    {
+      type: 'shell_call',
+      id: 'sh_1',
+      call_id: 'call_shell',
+      action: { commands: ['pwd'], max_output_length: 1024, timeout_ms: 1000 },
+      environment: { type: 'local' },
+      status: 'completed',
+    },
+    {
+      type: 'shell_call_output',
+      id: 'sho_1',
+      call_id: 'call_shell',
+      max_output_length: 1024,
+      output: [{ stdout: '/tmp', stderr: '', outcome: { type: 'exit', exit_code: 0 } }],
+      status: 'completed',
+    },
+    {
+      type: 'apply_patch_call',
+      id: 'apc_1',
+      call_id: 'call_patch',
+      operation: { type: 'update_file', path: 'a.ts', diff: '@@' },
+      status: 'completed',
+    },
+    {
+      type: 'apply_patch_call_output',
+      id: 'apco_1',
+      call_id: 'call_patch',
+      status: 'completed',
+      output: 'Done',
+    },
+    {
+      type: 'mcp_call',
+      id: 'mcp_1',
+      arguments: '{}',
+      name: 'lookup',
+      server_label: 'docs',
+      output: 'result',
+      status: 'completed',
+    },
+    {
+      type: 'mcp_list_tools',
+      id: 'mcpl_1',
+      server_label: 'docs',
+      tools: [{ name: 'lookup', input_schema: {} }],
+    },
+    {
+      type: 'mcp_approval_request',
+      id: 'mcpr_1',
+      arguments: '{}',
+      name: 'lookup',
+      server_label: 'docs',
+    },
+    {
+      type: 'mcp_approval_response',
+      id: 'mcpa_1',
+      approval_request_id: 'mcpr_1',
+      approve: true,
+    },
+  ] satisfies ResponsesOutputItem[];
+
+  const frames = Array.from(responsesResultToEvents({
+    ...completedResponse,
+    output,
+  }));
+  const added = frames
+    .map(frame => frame.event)
+    .filter(event => event.type === 'response.output_item.added')
+    .map(event => event.item);
+  const done = frames
+    .map(frame => frame.event)
+    .filter(event => event.type === 'response.output_item.done')
+    .map(event => event.item);
+
+  assertEquals(added, output);
+  assertEquals(done, output);
 });
 
 test('responsesResultToEvents surfaces a missing function_call item id instead of inventing one', () => {

--- a/packages/protocols/src/responses/from-result_test.ts
+++ b/packages/protocols/src/responses/from-result_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { responsesResultToEvents } from './from-result.ts';
 import type { ResponsesOutputItem, ResponsesResult } from './index.ts';
-import { assertEquals, assertFalse } from '../test-assert.ts';
+import { assertEquals, assertFalse, assertThrows } from '../test-assert.ts';
 
 const completedResponse: ResponsesResult = {
   id: 'resp_completed',
@@ -22,6 +22,14 @@ const completedResponse: ResponsesResult = {
   incomplete_details: null,
   usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
 };
+
+test.each(['queued', 'in_progress', 'cancelled'] as const)('responsesResultToEvents rejects nonterminal status %s', status => {
+  assertThrows(
+    () => Array.from(responsesResultToEvents({ ...completedResponse, status })),
+    TypeError,
+    `Cannot expand nonterminal Responses status '${status}'`,
+  );
+});
 
 test('responsesResultToEvents projects terminal JSON into Responses stream events', () => {
   const frames = Array.from(responsesResultToEvents(completedResponse));
@@ -226,7 +234,13 @@ test('responsesResultToEvents preserves advanced tool item wire fields', () => {
       call_id: 'call_search',
       execution: 'client',
       status: 'completed',
-      tools: [{ type: 'function', name: 'lookup', parameters: {}, strict: true }],
+      tools: [
+        { type: 'function', name: 'lookup', parameters: {}, strict: true },
+        { type: 'file_search', vector_store_ids: ['vs_1'] },
+        { type: 'computer' },
+        { type: 'computer_use_preview', display_height: 768, display_width: 1024, environment: 'browser' },
+        { type: 'local_shell' },
+      ],
     },
     {
       type: 'code_interpreter_call',

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -348,6 +348,7 @@ export interface ResponsesComputerSafetyCheck {
 // `pending_safety_checks`; the legacy `computer_use_preview` shape uses the
 // singular `action` plus safety checks. Keep both wire generations explicit.
 // https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L1990-L2035
+// https://github.com/Menci/Floway/pull/246#issuecomment-5028154071
 interface ResponsesComputerCallItemBase {
   type: 'computer_call';
   id: string;
@@ -475,6 +476,7 @@ export interface ResponsesInputMultiAgentCallOutputItem {
 // Legacy RemoteCompactionV2 history shape. Current OpenAI Responses uses
 // `compaction_trigger` input and `compaction` output; Codex still deserializes
 // this form when replaying older rollouts.
+// https://github.com/openai/codex/blob/9e552e9d15ba52bed7077d5357f3e18e330f8f38/codex-rs/protocol/src/models.rs#L1135-L1148
 export interface ResponsesContextCompactionItem extends ResponsesPermissiveItem<'context_compaction'> {
   encrypted_content?: string;
   internal_chat_message_metadata_passthrough?: Record<string, unknown>;
@@ -488,10 +490,8 @@ export interface ResponsesCompactionItem {
   created_by?: string;
 }
 
-// Trailing input item recognised by codex's RemoteCompactionV2: the upstream
-// turns a normal `/responses` call into a compaction round-trip and replies
-// with a single `compaction` output item. Payload-free on the wire (any extra
-// keys are tolerated by the permissive base).
+// Payload-free trailing input item for a RemoteCompactionV2 round trip.
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L4894-L4902
 export interface ResponsesCompactionTriggerItem {
   type: 'compaction_trigger';
 }
@@ -509,6 +509,9 @@ export interface ResponsesCodeInterpreterCallItem {
   status: string;
 }
 
+// Legacy local-shell output is opaque text correlated by `call_id`; modern
+// shell output uses structured stdout/stderr/outcome chunks below.
+// https://github.com/openai/openai-agents-python/blob/2fa463571e76dae8ff267622f1018eaf06ffeb9f/tests/test_local_shell_tool.py#L46-L92
 export interface ResponsesLocalShellCallItem {
   type: 'local_shell_call';
   id: string;
@@ -796,15 +799,28 @@ export type ResponsesTool =
   | ResponsesShellTool
   | ResponsesApplyPatchTool;
 
-// https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L1302-L1307
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L8250-L8400
 export type ResponsesToolChoice =
   | 'auto'
   | 'none'
   | 'required'
   | { type: 'function'; name: string }
   | { type: 'custom'; name: string }
+  | { type: 'mcp'; server_label: string; name?: string | null }
+  | { type: 'allowed_tools'; mode: 'auto' | 'required'; tools: Array<Record<string, unknown>> }
+  | { type: 'shell' }
+  | { type: 'apply_patch' }
   | { type: 'programmatic_tool_calling' }
-  | { type: ResponsesHostedToolType };
+  | {
+    type:
+      | ResponsesHostedToolType
+      | 'file_search'
+      | 'computer'
+      | 'computer_use_preview'
+      | 'computer_use'
+      | 'code_interpreter'
+      | 'mcp';
+  };
 
 // ── Response types ──
 

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -974,6 +974,8 @@ export interface ResponsesOutputImageGenerationCall {
 export type ResponsesStreamEvent = ResponsesStreamEventVariant & { sequence_number?: number };
 
 type ResponsesStreamEventVariant =
+  // https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L6456-L6471
+  | { type: 'response.queued'; response: ResponsesResult }
   | { type: 'response.created'; response: ResponsesResult }
   | { type: 'response.in_progress'; response: ResponsesResult }
   | {
@@ -1148,7 +1150,7 @@ export const isResponsesTerminalEvent = (event: Pick<ResponsesStreamEvent, 'type
   event.type === 'response.completed' || event.type === 'response.incomplete' || event.type === 'response.failed' || event.type === 'error';
 
 // Typed accessor for the `response` payload carried on lifecycle envelopes
-// (`response.created`, `response.in_progress`, `response.completed`,
+// (`response.queued`, `response.created`, `response.in_progress`, `response.completed`,
 // `response.incomplete`, `response.failed`). Returns null on every other
 // event type so callers don't have to reproduce the variant check.
 export const responsesResultFromStreamEvent = (event: ResponsesStreamEvent): ResponsesResult | null =>

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -309,32 +309,81 @@ export interface ResponsesPermissiveItem<TType extends string> {
   [key: string]: unknown;
 }
 
-export interface ResponsesFileSearchCallItem extends ResponsesPermissiveItem<'file_search_call'> {
-  queries?: string[];
-  results?: unknown[];
+export interface ResponsesFileSearchResult {
+  attributes?: Record<string, string | number | boolean> | null;
+  file_id?: string;
+  filename?: string;
+  score?: number;
+  text?: string;
 }
 
-export interface ResponsesComputerCallItem extends ResponsesPermissiveItem<'computer_call'> {
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L2909-L2980
+export interface ResponsesFileSearchCallItem {
+  type: 'file_search_call';
+  id: string;
+  queries: string[];
+  status: string;
+  results?: ResponsesFileSearchResult[] | null;
+}
+
+export type ResponsesComputerAction = Record<string, unknown> & { type: string };
+
+export interface ResponsesComputerSafetyCheck {
+  id: string;
+  code?: string | null;
+  message?: string | null;
+}
+
+// Modern `computer` emits `actions` and rejects even an empty
+// `pending_safety_checks`; the legacy `computer_use_preview` shape uses the
+// singular `action` plus safety checks. Keep both wire generations explicit.
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L1990-L2035
+export interface ResponsesComputerCallItem {
+  type: 'computer_call';
+  id: string;
   call_id: string;
-  action?: unknown;
-  pending_safety_checks?: unknown[];
+  status: string;
+  action?: ResponsesComputerAction;
+  actions?: ResponsesComputerAction[];
+  pending_safety_checks?: ResponsesComputerSafetyCheck[];
 }
 
-export interface ResponsesComputerCallOutputItem extends ResponsesPermissiveItem<'computer_call_output'> {
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L2280-L2359
+export interface ResponsesComputerCallOutputItem {
+  type: 'computer_call_output';
+  id?: string | null;
   call_id: string;
-  output?: unknown;
-  acknowledged_safety_checks?: unknown[];
+  output: {
+    type: 'computer_screenshot';
+    file_id?: string;
+    image_url?: string;
+  };
+  acknowledged_safety_checks?: ResponsesComputerSafetyCheck[] | null;
+  status?: string | null;
+  created_by?: string;
 }
 
-export interface ResponsesToolSearchCallItem extends ResponsesPermissiveItem<'tool_search_call'> {
-  call_id?: string;
-  query?: string;
-  results?: unknown[];
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L7119-L7223
+export interface ResponsesToolSearchCallItem {
+  type: 'tool_search_call';
+  arguments: unknown;
+  id?: string | null;
+  call_id?: string | null;
+  execution?: 'server' | 'client';
+  status?: string | null;
+  created_by?: string;
+  internal_chat_message_metadata_passthrough?: Record<string, unknown>;
 }
 
-export interface ResponsesToolSearchOutputItem extends ResponsesPermissiveItem<'tool_search_output'> {
-  call_id?: string;
-  output?: unknown;
+export interface ResponsesToolSearchOutputItem {
+  type: 'tool_search_output';
+  tools: ResponsesTool[];
+  id?: string | null;
+  call_id?: string | null;
+  execution?: 'server' | 'client';
+  status?: string | null;
+  created_by?: string;
+  internal_chat_message_metadata_passthrough?: Record<string, unknown>;
 }
 
 // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L4265-L4285
@@ -403,77 +452,168 @@ export interface ResponsesInputMultiAgentCallOutputItem {
   agent?: { agent_name: string } | null;
 }
 
+// Legacy RemoteCompactionV2 history shape. Current OpenAI Responses uses
+// `compaction_trigger` input and `compaction` output; Codex still deserializes
+// this form when replaying older rollouts.
 export interface ResponsesContextCompactionItem extends ResponsesPermissiveItem<'context_compaction'> {
   encrypted_content?: string;
   internal_chat_message_metadata_passthrough?: Record<string, unknown>;
 }
 
-export type ResponsesCompactionItem = ResponsesPermissiveItem<'compaction'>;
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L1918-L1963
+export interface ResponsesCompactionItem {
+  type: 'compaction';
+  id?: string | null;
+  encrypted_content: string;
+  created_by?: string;
+}
 
 // Trailing input item recognised by codex's RemoteCompactionV2: the upstream
 // turns a normal `/responses` call into a compaction round-trip and replies
 // with a single `compaction` output item. Payload-free on the wire (any extra
 // keys are tolerated by the permissive base).
-export type ResponsesCompactionTriggerItem = ResponsesPermissiveItem<'compaction_trigger'>;
-
-export interface ResponsesCodeInterpreterCallItem extends ResponsesPermissiveItem<'code_interpreter_call'> {
-  call_id?: string;
-  code?: string;
-  results?: unknown[];
+export interface ResponsesCompactionTriggerItem {
+  type: 'compaction_trigger';
 }
 
-export interface ResponsesLocalShellCallItem extends ResponsesPermissiveItem<'local_shell_call'> {
-  call_id: string;
-  command?: string;
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L1852-L1915
+export interface ResponsesCodeInterpreterCallItem {
+  type: 'code_interpreter_call';
+  id: string;
+  code: string | null;
+  container_id: string;
+  outputs: Array<
+    | { type: 'logs'; logs: string }
+    | { type: 'image'; url: string }
+  > | null;
+  status: string;
 }
 
-export interface ResponsesLocalShellCallOutputItem extends ResponsesPermissiveItem<'local_shell_call_output'> {
+export interface ResponsesLocalShellCallItem {
+  type: 'local_shell_call';
+  id: string;
   call_id: string;
-  output?: unknown;
+  action: {
+    type: 'exec';
+    command: string[];
+    env: Record<string, string>;
+    timeout_ms?: number | null;
+    user?: string | null;
+    working_directory?: string | null;
+  };
+  status: string;
 }
 
-export interface ResponsesShellCallItem extends ResponsesPermissiveItem<'shell_call'> {
+export interface ResponsesLocalShellCallOutputItem {
+  type: 'local_shell_call_output';
+  id?: string | null;
   call_id: string;
-  command?: string;
+  output: string;
+  status?: string | null;
+}
+
+export type ResponsesShellEnvironment =
+  | { type: 'local' }
+  | { type: 'container_reference'; container_id: string };
+
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L3154-L3344
+export interface ResponsesShellCallItem {
+  type: 'shell_call';
+  id?: string | null;
+  call_id: string;
+  action: {
+    commands: string[];
+    max_output_length?: number | null;
+    timeout_ms?: number | null;
+  };
+  environment?: ResponsesShellEnvironment | null;
+  status?: string | null;
   caller?: ResponsesToolCaller | null;
+  created_by?: string;
 }
 
-export interface ResponsesShellCallOutputItem extends ResponsesPermissiveItem<'shell_call_output'> {
+export interface ResponsesShellCallOutputItem {
+  type: 'shell_call_output';
+  id?: string | null;
   call_id: string;
-  output?: unknown;
+  max_output_length?: number | null;
+  output: Array<{
+    stdout: string;
+    stderr: string;
+    outcome: { type: 'timeout' } | { type: 'exit'; exit_code: number };
+    created_by?: string;
+  }>;
+  status?: string | null;
   caller?: ResponsesToolCaller | null;
+  created_by?: string;
 }
 
-export interface ResponsesApplyPatchCallItem extends ResponsesPermissiveItem<'apply_patch_call'> {
+export type ResponsesApplyPatchOperation =
+  | { type: 'create_file'; path: string; diff: string }
+  | { type: 'delete_file'; path: string }
+  | { type: 'update_file'; path: string; diff: string };
+
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L1472-L1643
+export interface ResponsesApplyPatchCallItem {
+  type: 'apply_patch_call';
+  id?: string | null;
   call_id: string;
-  patch?: string;
+  operation: ResponsesApplyPatchOperation;
+  status: 'in_progress' | 'completed';
   caller?: ResponsesToolCaller | null;
+  created_by?: string;
 }
 
-export interface ResponsesApplyPatchCallOutputItem extends ResponsesPermissiveItem<'apply_patch_call_output'> {
+export interface ResponsesApplyPatchCallOutputItem {
+  type: 'apply_patch_call_output';
+  id?: string | null;
   call_id: string;
-  output?: unknown;
+  status: 'completed' | 'failed';
+  output?: string | null;
   caller?: ResponsesToolCaller | null;
+  created_by?: string;
 }
 
-export interface ResponsesMcpCallItem extends ResponsesPermissiveItem<'mcp_call'> {
-  call_id: string;
-  name?: string;
-  arguments?: unknown;
-  output?: unknown;
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L4727-L4892
+export interface ResponsesMcpCallItem {
+  type: 'mcp_call';
+  id: string;
+  arguments: string;
+  name: string;
+  server_label: string;
+  approval_request_id?: string | null;
+  error?: string | null;
+  output?: string | null;
+  status?: string;
 }
 
-export interface ResponsesMcpListToolsItem extends ResponsesPermissiveItem<'mcp_list_tools'> {
-  tools?: unknown[];
+export interface ResponsesMcpListToolsItem {
+  type: 'mcp_list_tools';
+  id: string;
+  server_label: string;
+  tools: Array<{
+    input_schema: unknown;
+    name: string;
+    annotations?: unknown | null;
+    description?: string | null;
+  }>;
+  error?: string | null;
 }
 
-export interface ResponsesMcpApprovalRequestItem extends ResponsesPermissiveItem<'mcp_approval_request'> {
-  call_id?: string;
+export interface ResponsesMcpApprovalRequestItem {
+  type: 'mcp_approval_request';
+  id: string;
+  arguments: string;
+  name: string;
+  server_label: string;
 }
 
-export interface ResponsesMcpApprovalResponseItem extends ResponsesPermissiveItem<'mcp_approval_response'> {
-  call_id?: string;
-  output?: unknown;
+export interface ResponsesMcpApprovalResponseItem {
+  type: 'mcp_approval_response';
+  id?: string | null;
+  approval_request_id: string;
+  approve: boolean;
+  reason?: string | null;
 }
 
 export interface ResponsesInputImageGenerationCall {

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -326,7 +326,17 @@ export interface ResponsesFileSearchCallItem {
   results?: ResponsesFileSearchResult[] | null;
 }
 
-export type ResponsesComputerAction = Record<string, unknown> & { type: string };
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L298-L535
+export type ResponsesComputerAction =
+  | { type: 'click'; button: 'left' | 'right' | 'wheel' | 'back' | 'forward'; x: number; y: number; keys?: string[] | null }
+  | { type: 'double_click'; keys: string[] | null; x: number; y: number }
+  | { type: 'drag'; path: Array<{ x: number; y: number }>; keys?: string[] | null }
+  | { type: 'keypress'; keys: string[] }
+  | { type: 'move'; x: number; y: number; keys?: string[] | null }
+  | { type: 'screenshot' }
+  | { type: 'scroll'; scroll_x: number; scroll_y: number; x: number; y: number; keys?: string[] | null }
+  | { type: 'type'; text: string }
+  | { type: 'wait' };
 
 export interface ResponsesComputerSafetyCheck {
   id: string;
@@ -338,15 +348,25 @@ export interface ResponsesComputerSafetyCheck {
 // `pending_safety_checks`; the legacy `computer_use_preview` shape uses the
 // singular `action` plus safety checks. Keep both wire generations explicit.
 // https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L1990-L2035
-export interface ResponsesComputerCallItem {
+interface ResponsesComputerCallItemBase {
   type: 'computer_call';
   id: string;
   call_id: string;
   status: string;
-  action?: ResponsesComputerAction;
-  actions?: ResponsesComputerAction[];
-  pending_safety_checks?: ResponsesComputerSafetyCheck[];
 }
+
+export type ResponsesComputerCallItem = ResponsesComputerCallItemBase & (
+  | {
+    actions: ResponsesComputerAction[];
+    action?: never;
+    pending_safety_checks?: never;
+  }
+  | {
+    action: ResponsesComputerAction;
+    actions?: never;
+    pending_safety_checks: ResponsesComputerSafetyCheck[];
+  }
+);
 
 // https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L2280-L2359
 export interface ResponsesComputerCallOutputItem {
@@ -719,6 +739,36 @@ export interface ResponsesCodeInterpreterTool {
   allowed_callers?: ResponsesToolAllowedCaller[] | null;
 }
 
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L541-L577
+export interface ResponsesComputerTool {
+  type: 'computer';
+}
+
+export interface ResponsesComputerUsePreviewTool {
+  type: 'computer_use_preview';
+  display_height: number;
+  display_width: number;
+  environment: 'windows' | 'mac' | 'linux' | 'ubuntu' | 'browser';
+}
+
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L729-L806
+export interface ResponsesFileSearchTool {
+  type: 'file_search';
+  vector_store_ids: string[];
+  filters?: Record<string, unknown> | null;
+  max_num_results?: number;
+  ranking_options?: {
+    hybrid_search?: { embedding_weight: number; text_weight: number };
+    ranker?: 'auto' | 'default-2024-11-15';
+    score_threshold?: number;
+  };
+}
+
+// https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L8239-L8247
+export interface ResponsesLocalShellTool {
+  type: 'local_shell';
+}
+
 // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L803-L815
 export interface ResponsesShellTool {
   type: 'shell';
@@ -739,6 +789,10 @@ export type ResponsesTool =
   | ResponsesProgrammaticTool
   | ResponsesMcpTool
   | ResponsesCodeInterpreterTool
+  | ResponsesComputerTool
+  | ResponsesComputerUsePreviewTool
+  | ResponsesFileSearchTool
+  | ResponsesLocalShellTool
   | ResponsesShellTool
   | ResponsesApplyPatchTool;
 
@@ -770,7 +824,8 @@ export interface ResponsesResult {
   // that happen to emit it (some OpenAPI implementations do) are
   // preserved as-is on pass-through.
   output_text?: string;
-  status: 'queued' | 'completed' | 'incomplete' | 'failed' | 'in_progress';
+  // https://github.com/openai/openai-node/blob/39a15b412fc129df15339ebd6e3e6547854aa81f/src/resources/responses/responses.ts#L6866-L6870
+  status: 'queued' | 'completed' | 'incomplete' | 'failed' | 'in_progress' | 'cancelled';
   // `error` and `incomplete_details` are REQUIRED on the wire shape
   // per the OpenAI Responses spec (both can be null). Reference:
   // https://github.com/openai/openai-openapi/blob/master/openapi.yaml

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -770,7 +770,7 @@ export interface ResponsesResult {
   // that happen to emit it (some OpenAPI implementations do) are
   // preserved as-is on pass-through.
   output_text?: string;
-  status: 'completed' | 'incomplete' | 'failed' | 'in_progress';
+  status: 'queued' | 'completed' | 'incomplete' | 'failed' | 'in_progress';
   // `error` and `incomplete_details` are REQUIRED on the wire shape
   // per the OpenAI Responses spec (both can be null). Reference:
   // https://github.com/openai/openai-openapi/blob/master/openapi.yaml

--- a/packages/protocols/src/responses/stream.ts
+++ b/packages/protocols/src/responses/stream.ts
@@ -7,15 +7,16 @@ export interface ParseResponsesStreamOptions {
   signal?: AbortSignal;
 }
 
-// Deny-list: anything that is not a wrapper (`response.created` /
-// `response.in_progress` / `ping`) and not terminal is treated as content-
+// Deny-list: anything that is not a wrapper (`response.queued` /
+// `response.created` / `response.in_progress` / `ping`) and not terminal is treated as content-
 // bearing. `ping` is a transport-level keep-alive with no content semantics,
 // so its presence must not commit us out of the fast-path. Future Responses
 // event types fall through as structured by default, which is safer than
 // missing an allow-list entry and incorrectly triggering the fast-path
 // expansion below.
 const isStructuredResponsesEvent = (event: { type: string }): boolean =>
-  event.type !== 'response.created'
+  event.type !== 'response.queued'
+  && event.type !== 'response.created'
   && event.type !== 'response.in_progress'
   && event.type !== 'ping'
   && !isResponsesTerminalEvent(event as ResponsesStreamEvent);
@@ -96,7 +97,7 @@ export const parseResponsesStream = (
       sawStructured = true;
     }
 
-    if (!sawStructured && (event.type === 'response.created' || event.type === 'response.in_progress')) sentWrapperTypes.add(event.type);
+    if (!sawStructured && (event.type === 'response.queued' || event.type === 'response.created' || event.type === 'response.in_progress')) sentWrapperTypes.add(event.type);
     yield eventFrame(stamp(event));
   }
 })();

--- a/packages/protocols/src/responses/stream_test.ts
+++ b/packages/protocols/src/responses/stream_test.ts
@@ -153,7 +153,6 @@ test('parseResponsesStream passes queued/created/in-progress wrappers through be
       'done',
     ],
   );
-  // The wrappers reach downstream verbatim with their original sequence numbers.
   assertEquals((frames[0] as { event: { sequence_number: number } }).event.sequence_number, 0);
   assertEquals((frames[2] as { event: { sequence_number: number } }).event.sequence_number, 2);
 });

--- a/packages/protocols/src/responses/stream_test.ts
+++ b/packages/protocols/src/responses/stream_test.ts
@@ -124,12 +124,13 @@ test('parseResponsesStream expands upstream fast-path (created+in_progress+compl
   assertEquals(frames.at(-1)?.type, 'done');
 });
 
-test('parseResponsesStream passes wrapper frames through before fast-path expansion synthesises the structured events', async () => {
+test('parseResponsesStream passes queued/created/in-progress wrappers through before fast-path expansion', async () => {
   const response = makeResponse('completed');
   const frames = await collect(parse(
-    sseFrame(JSON.stringify({ response: { ...response, status: 'in_progress' }, sequence_number: 0 }), 'response.created'),
-    sseFrame(JSON.stringify({ response: { ...response, status: 'in_progress' }, sequence_number: 1 }), 'response.in_progress'),
-    sseFrame(JSON.stringify({ response, sequence_number: 2 }), 'response.completed'),
+    sseFrame(JSON.stringify({ response: { ...response, status: 'queued' }, sequence_number: 0 }), 'response.queued'),
+    sseFrame(JSON.stringify({ response: { ...response, status: 'in_progress' }, sequence_number: 1 }), 'response.created'),
+    sseFrame(JSON.stringify({ response: { ...response, status: 'in_progress' }, sequence_number: 2 }), 'response.in_progress'),
+    sseFrame(JSON.stringify({ response, sequence_number: 3 }), 'response.completed'),
     sseFrame('[DONE]'),
   ));
 
@@ -139,6 +140,7 @@ test('parseResponsesStream passes wrapper frames through before fast-path expans
   assertEquals(
     frames.map(frame => (frame.type === 'event' ? frame.event.type : frame.type)),
     [
+      'response.queued',
       'response.created',
       'response.in_progress',
       'response.output_item.added',
@@ -151,10 +153,9 @@ test('parseResponsesStream passes wrapper frames through before fast-path expans
       'done',
     ],
   );
-  // The two wrappers we wrote on the wire reach downstream verbatim — same
-  // payload (in_progress snapshot), same sequence number.
+  // The wrappers reach downstream verbatim with their original sequence numbers.
   assertEquals((frames[0] as { event: { sequence_number: number } }).event.sequence_number, 0);
-  assertEquals((frames[1] as { event: { sequence_number: number } }).event.sequence_number, 1);
+  assertEquals((frames[2] as { event: { sequence_number: number } }).event.sequence_number, 2);
 });
 
 test('parseResponsesStream passes structured upstream events through unchanged when upstream already streams them', async () => {

--- a/packages/protocols/src/responses/tool-choice_test.ts
+++ b/packages/protocols/src/responses/tool-choice_test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'vitest';
+
+import type { ResponsesTool, ResponsesToolChoice } from './index.ts';
+
+const builtInPairs = [
+  {
+    tool: { type: 'file_search', vector_store_ids: ['vs_1'] },
+    choice: { type: 'file_search' },
+  },
+  {
+    tool: { type: 'computer' },
+    choice: { type: 'computer' },
+  },
+  {
+    tool: { type: 'computer_use_preview', display_height: 768, display_width: 1024, environment: 'browser' },
+    choice: { type: 'computer_use_preview' },
+  },
+  {
+    tool: { type: 'code_interpreter', container: 'auto' },
+    choice: { type: 'code_interpreter' },
+  },
+  {
+    tool: { type: 'mcp', server_label: 'docs' },
+    choice: { type: 'mcp', server_label: 'docs' },
+  },
+] as const satisfies ReadonlyArray<{ tool: ResponsesTool; choice: ResponsesToolChoice }>;
+
+test('built-in tool declarations admit their forced tool choices', () => {
+  expect(builtInPairs).toHaveLength(5);
+});

--- a/packages/translate/src/shared/responses-via/responses-event-builder.ts
+++ b/packages/translate/src/shared/responses-via/responses-event-builder.ts
@@ -156,12 +156,19 @@ export const started = (state: ResponsesSequenceState, response: ResponsesResult
   ]);
 
 export const terminal = (state: ResponsesSequenceState, response: ResponsesResult) => {
-  if (response.status === 'in_progress') {
-    throw new Error('Cannot emit a terminal Responses event for in_progress');
+  let type: 'response.completed' | 'response.incomplete' | 'response.failed';
+  switch (response.status) {
+  case 'completed': type = 'response.completed'; break;
+  case 'incomplete': type = 'response.incomplete'; break;
+  case 'failed': type = 'response.failed'; break;
+  case 'queued':
+  case 'in_progress':
+  case 'cancelled':
+    throw new TypeError(`Cannot emit a terminal Responses event for status '${response.status}'`);
   }
   return seq(state, [
     {
-      type: response.status === 'incomplete' ? 'response.incomplete' : response.status === 'failed' ? 'response.failed' : 'response.completed',
+      type,
       response,
     },
   ]);

--- a/packages/translate/src/shared/responses-via/responses-event-builder_test.ts
+++ b/packages/translate/src/shared/responses-via/responses-event-builder_test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+
+import { terminal } from './responses-event-builder.ts';
+import type { ResponsesResult } from '@floway-dev/protocols/responses';
+
+const response = (status: ResponsesResult['status']): ResponsesResult => ({
+  id: 'resp_test',
+  object: 'response',
+  model: 'test-model',
+  output: [],
+  status,
+  error: null,
+  incomplete_details: null,
+});
+
+test.each(['queued', 'in_progress', 'cancelled'] as const)('terminal builder rejects nonterminal status %s', status => {
+  expect(() => terminal({ sequenceNumber: 0 }, response(status)))
+    .toThrow(`Cannot emit a terminal Responses event for status '${status}'`);
+});


### PR DESCRIPTION
## Summary

Align the Responses protocol types with the live upstream wire contracts for
the advanced output/input items, and model the queued lifecycle as a
first-class response envelope.

- Replace the permissive placeholder shapes for computer / computer_use_preview,
  tool-search call/output, code-interpreter, local-shell call/output,
  apply-patch, file-search, and MCP call/list-tools/approval items with their
  current live Responses contracts. Each vendor constant carries a pinned
  upstream reference, and the input/output optionality that round-tripped
  continuation items require is preserved.
- Keep strict payload-free request controls (e.g. `compaction_trigger`) distinct
  from output items, so item-id readers no longer invent an id slot; the
  client-output pipeline is typed as Responses output items.
- Drop the standalone `compaction_summary` type, retaining only the Codex
  deserialize alias onto `compaction`.
- Complete the built-in `tool_choice` union so every declared built-in tool can
  be forced, guarded by compile-time fixtures.
- Treat `response.queued` as an official response envelope across stream
  parsing, affinity wrapping, client response-id rewriting, retry prologue
  detection, and the server-tool shim, so its nested output cannot bypass the
  identity membranes. Reject the nonterminal `queued` / `in_progress` /
  `cancelled` statuses in the terminal builders, so a queued or cancelled
  snapshot can never be mis-emitted as `completed`.

## Test Plan

- [x] `pnpm run test` — 380 files pass
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`

## Stack

1 of 4. The next PR moves gateway-created items to producer-owned random IDs.
