### PR TITLE
refactor(responses): mint item IDs at producer boundaries

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -416,7 +416,7 @@ Request mapping:
   unpacked from the `${encrypted_content}@${id}` shape this gateway emits: the
   Responses reasoning id and any opaque `encrypted_content` are recovered. A
   native signature carrying no `@` is preserved verbatim as `encrypted_content`
-  with a synthesized `rs_${index}` id; it is never overwritten.
+  with a fresh random `rs_` id; it is never overwritten.
 - `max_tokens`, `temperature`, `top_p`, `metadata`, and `stream` pass through
   when present.
 - `output_config.effort` maps directly to `reasoning.effort`; disabled thinking
@@ -497,7 +497,7 @@ Response mapping:
 - Responses output items are converted in output order.
 - `reasoning` maps to a Messages thinking carrier; the upstream's genuine
   `signature` (or `redacted_thinking` `data`) is carried verbatim as the
-  reasoning item's `encrypted_content`, with a synthesized `rs_${index}` id.
+  reasoning item's `encrypted_content`, with a fresh random `rs_` id.
 - `message` content maps to text. `refusal` content is kept visible as text
   because Messages has no local refusal block.
 - `function_call` maps to `tool_use`.

--- a/packages/gateway/src/data-plane/chat/responses/affinity/egress.ts
+++ b/packages/gateway/src/data-plane/chat/responses/affinity/egress.ts
@@ -1,7 +1,6 @@
 import type { AffinityEgressOptions } from '../../shared/affinity/index.ts';
-import { createTemporaryResponsesItemId } from '../items/format.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesOutputItem, ResponsesOutputReasoning, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, type ResponsesOutputItem, type ResponsesOutputReasoning, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 const canonicalItemType = (itemType: string): string =>
   itemType === 'compaction_summary' ? 'compaction' : itemType;
@@ -170,7 +169,7 @@ const wrapResponsesFirstCarrier = async function* (
     if (prefix !== undefined) return;
     const added: ResponsesOutputReasoning = {
       type: 'reasoning',
-      id: createTemporaryResponsesItemId('reasoning'),
+      id: createRandomResponsesItemId('reasoning'),
       summary: [],
     };
     const item: ResponsesOutputReasoning = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -56,7 +56,7 @@ import { isJsonObject } from '../../../../shared/json-helpers.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { syntheticEventsFromResult } from '../items/output.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { collectResponsesProtocolEventsToResult, createRandomResponsesItemId, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { providerModelOf, type ExecuteResult } from '@floway-dev/provider';
 
 // The two vendored constants below (SUMMARIZATION_PROMPT and SUMMARY_PREFIX)
@@ -322,7 +322,7 @@ const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGate
 
   const collected = await collectResponsesProtocolEventsToResult(upstreamResult.events);
   const summaryText = extractTextFromResult(collected);
-  const cmpId = `cmp_${crypto.randomUUID()}`;
+  const cmpId = createRandomResponsesItemId('compaction');
   const synthesized = buildCompactionEnvelope(cmpId, summaryText, collected);
 
   return {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -6,16 +6,17 @@ import { truncatePreservingCodePoints } from '../../shared/text.ts';
 import type { StatefulResponsesStore } from '../items/store.ts';
 import type { InterceptorRun } from '@floway-dev/interceptor';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type {
-  CanonicalResponsesPayload,
-  ResponsesFunctionTool,
-  ResponsesHostedTool,
-  ResponsesInputItem,
-  ResponsesOutputItem,
-  ResponsesResult,
-  ResponsesStreamEvent,
-  ResponsesTool,
-  ResponsesToolChoice,
+import {
+  createRandomResponsesItemId,
+  type CanonicalResponsesPayload,
+  type ResponsesFunctionTool,
+  type ResponsesHostedTool,
+  type ResponsesInputItem,
+  type ResponsesOutputItem,
+  type ResponsesResult,
+  type ResponsesStreamEvent,
+  type ResponsesTool,
+  type ResponsesToolChoice,
 } from '@floway-dev/protocols/responses';
 import type { EventResultMetadata, ExecuteResult } from '@floway-dev/provider';
 
@@ -584,7 +585,7 @@ export const consumeTurnStreaming = async function* (
       const itemId = typeof upstreamItemId === 'string' && upstreamItemId.length > 0
         ? upstreamItemId
         : item.type === 'message'
-          ? `msg_${downstreamIndex}`
+          ? createRandomResponsesItemId('message')
           : undefined;
       if (itemId !== undefined) openItemIds.set(upstreamIndex, itemId);
       yield stamp({

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -687,7 +687,7 @@ test('synthesized web_search_call ids retain request-private replay state', asyn
   const store = ctx.store;
   assert(wsCallDoneIds.length > 0, 'expected a synthesized web_search_call');
   for (const id of wsCallDoneIds) {
-    assert(id.startsWith('ws_gw_'));
+    assert(/^ws_[0-9a-f]{32}$/.test(id));
     assert(store.getPrivatePayload(id) !== undefined, `expected ${id} to retain private replay state`);
   }
   for (const e of doneEvents.filter(e => e.item.type === 'message')) {
@@ -3355,7 +3355,7 @@ test('input preprocessor: web_search_call without an action is replaced by a pla
   assert(fco.output.includes('"id":"ws_no_action"'));
 });
 
-test('input preprocessor: web_search_call with empty id has its id synthesized and produces an upstream pair (codex CLI strips ws_gw_ ids on session persist)', async () => {
+test('input preprocessor: web_search_call with empty id has its id synthesized and produces an upstream pair', async () => {
   makeStubDeps();
   const shim = withResponsesWebSearchShim;
   const inv = makeInvocation({
@@ -5207,13 +5207,18 @@ test('consumeTurn forwards content_part / output_text / annotation events live w
     'response.output_item.done',
   ]);
 
-  // Message-child events get item_id rewritten onto the
-  // downstream-minted `msg_<downstreamIndex>` (0 here).
+  const addedFrame = result.downstreamFrames.find(frame =>
+    frame.type === 'event' && frame.event.type === 'response.output_item.added');
+  assert(addedFrame?.type === 'event');
+  const messageId = (addedFrame.event as { item: { id?: string } }).item.id;
+  assert(messageId !== undefined && /^msg_[0-9a-f]{32}$/.test(messageId));
+
+  // Message-child events carry the id minted when the output item opened.
   for (const f of result.downstreamFrames) {
     if (f.type !== 'event') continue;
     const ev = f.event as { item_id?: string };
     if (ev.item_id !== undefined) {
-      assertEquals(ev.item_id, 'msg_0');
+      assertEquals(ev.item_id, messageId);
     }
   }
 });
@@ -5241,7 +5246,12 @@ test('consumeTurn rewrites any structurally indexed child event without an event
     f.type === 'event' && (f.event as { type: string }).type === 'response.future_child.delta');
   assert(futureFrame?.type === 'event');
   assertEquals((futureFrame.event as { output_index: number }).output_index, 0);
-  assertEquals((futureFrame.event as { item_id: string }).item_id, 'msg_0');
+  const addedFrame = result.downstreamFrames.find(f =>
+    f.type === 'event' && f.event.type === 'response.output_item.added');
+  assert(addedFrame?.type === 'event');
+  const messageId = (addedFrame.event as { item: { id?: string } }).item.id;
+  assert(messageId !== undefined && /^msg_[0-9a-f]{32}$/.test(messageId));
+  assertEquals((futureFrame.event as { item_id: string }).item_id, messageId);
 });
 
 test('consumeTurn swallows future indexed events attached to an intercepted server tool call', async () => {
@@ -5303,7 +5313,7 @@ test('consumeTurn preserves upstream message item.id (no fabrication) when upstr
     true,
   );
 
-  // Child events keep upstream's id verbatim, not rewritten to msg_0.
+  // Child events keep the upstream id verbatim.
   const deltaFrame = result.downstreamFrames.find(f =>
     f.type === 'event' && f.event.type === 'response.output_text.delta');
   assert(deltaFrame?.type === 'event');

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -5213,7 +5213,6 @@ test('consumeTurn forwards content_part / output_text / annotation events live w
   const messageId = (addedFrame.event as { item: { id?: string } }).item.id;
   assert(messageId !== undefined && /^msg_[0-9a-f]{32}$/.test(messageId));
 
-  // Message-child events carry the id minted when the output item opened.
   for (const f of result.downstreamFrames) {
     if (f.type !== 'event') continue;
     const ev = f.event as { item_id?: string };
@@ -5313,7 +5312,6 @@ test('consumeTurn preserves upstream message item.id (no fabrication) when upstr
     true,
   );
 
-  // Child events keep the upstream id verbatim.
   const deltaFrame = result.downstreamFrames.find(f =>
     f.type === 'event' && f.event.type === 'response.output_text.delta');
   assert(deltaFrame?.type === 'event');

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation.ts
@@ -8,16 +8,17 @@ import { stampUpstreamCallStart, type AttemptState } from '../../../shared/gatew
 import type { ServerToolLifecycleEvent, ServerToolOutputItem, ServerToolRegistration, ServerToolTerminal } from '../server-tool-shim.ts';
 import { dimensionsFromBytes, getImageProcessor, type BackgroundScheduler } from '@floway-dev/platform';
 import { parseSSEStream } from '@floway-dev/protocols/common';
-import type {
-  ResponsesFunctionCallOutputItem,
-  ResponsesFunctionTool,
-  ResponsesFunctionToolCallItem,
-  ResponsesHostedTool,
-  ResponsesInputImage,
-  ResponsesInputImageGenerationCall,
-  ResponsesInputItem,
-  ResponsesOutputImageGenerationCall,
-  ResponsesTool,
+import {
+  createRandomResponsesItemId,
+  type ResponsesFunctionCallOutputItem,
+  type ResponsesFunctionTool,
+  type ResponsesFunctionToolCallItem,
+  type ResponsesHostedTool,
+  type ResponsesInputImage,
+  type ResponsesInputImageGenerationCall,
+  type ResponsesInputItem,
+  type ResponsesOutputImageGenerationCall,
+  type ResponsesTool,
 } from '@floway-dev/protocols/responses';
 import { providerModelOf, type Fetcher, type ImagesEditsRequest, type Provider, type ModelCandidate, type ProviderModel } from '@floway-dev/provider';
 
@@ -484,7 +485,7 @@ export const buildImageGenerationFunctionTool = (_canonical: ResponsesHostedTool
 });
 
 export const synthesizeImageGenerationCallId = (): string =>
-  `ig_gw_${crypto.randomUUID().replace(/-/g, '')}`;
+  createRandomResponsesItemId('image_generation_call');
 
 // Collect all image sources from the request input in forward declaration
 // order: inline/remote `input_image` blocks in messages and function/custom

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/image-generation_test.ts
@@ -609,10 +609,9 @@ test('parseRetryAfterMs skips an unparseable retry-after-ms and falls through to
 
 // ── synthesizeImageGenerationCallId ──
 
-test('synthesizeImageGenerationCallId produces an ig_gw_-prefixed id', () => {
+test('synthesizeImageGenerationCallId produces a canonical image-generation id', () => {
   const id = synthesizeImageGenerationCallId();
-  assert(id.startsWith('ig_gw_'));
-  assert(id.length > 'ig_gw_'.length);
+  assert(/^ig_[0-9a-f]{32}$/.test(id));
 });
 
 // ── imageGenerationServerTool: unsupported input format (C) ──

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -321,8 +321,8 @@ const isWebSearchCallPrivatePayload = (value: unknown): value is WebSearchCallPr
 
 export const synthesizeWebSearchCallId = (): string => createRandomResponsesItemId('web_search_call');
 
-// Distinct id namespace (cc_replay_*) from synthesized wsc ids (ws_gw_*)
-// so a replay call_id never reads as a wsc id in logs.
+// Distinct id namespace (cc_replay_*) from web-search item ids (ws_*) so a
+// replay call_id never reads as a web-search item id in logs.
 const synthesizeReplayCallId = (): string => shortId('cc_replay');
 
 // Re-serializes a wire `action` back into the shim's JSON arguments

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -26,7 +26,7 @@ import type { ConfiguredWebSearchProvider } from '../../../../tools/web-search/t
 import { truncatePreservingCodePoints } from '../../../shared/text.ts';
 import { type ServerToolLoopState, type ServerToolOutputItem, type ServerToolRegistration } from '../server-tool-shim.ts';
 import type { ResponsesFunctionTool, ResponsesFunctionToolCallItem, ResponsesHostedTool, ResponsesInputItem, ResponsesOutputWebSearchCall, ResponsesTool, ResponsesWebSearchAction } from '@floway-dev/protocols/responses';
-import { WEB_SEARCH_HOSTED_TYPE_NAMES } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, WEB_SEARCH_HOSTED_TYPE_NAMES } from '@floway-dev/protocols/responses';
 import { providerModelOf } from '@floway-dev/provider';
 
 // Runtime set derived from the canonical tuple declared next to
@@ -319,7 +319,7 @@ const isWebSearchCallPrivatePayload = (value: unknown): value is WebSearchCallPr
   return irObj.action !== undefined && Array.isArray(irObj.results);
 };
 
-export const synthesizeWebSearchCallId = (): string => shortId('ws_gw');
+export const synthesizeWebSearchCallId = (): string => createRandomResponsesItemId('web_search_call');
 
 // Distinct id namespace (cc_replay_*) from synthesized wsc ids (ws_gw_*)
 // so a replay call_id never reads as a wsc id in logs.

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search_test.ts
@@ -172,11 +172,11 @@ test('parseWebSearchOperations: wrong-typed open / find surface as wrong-type op
 
 // ── IR builders (private to web-search.ts; exercised end-to-end below) ──
 
-test('synthesizeWebSearchCallId produces unique ws_gw_ prefixed ids', () => {
+test('synthesizeWebSearchCallId produces unique canonical web-search ids', () => {
   const a = synthesizeWebSearchCallId();
   const b = synthesizeWebSearchCallId();
-  assert(a.startsWith('ws_gw_'));
-  assert(b.startsWith('ws_gw_'));
+  assert(/^ws_[0-9a-f]{32}$/.test(a));
+  assert(/^ws_[0-9a-f]{32}$/.test(b));
   assert(a !== b);
 });
 

--- a/packages/gateway/src/data-plane/chat/responses/items/format.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/format.ts
@@ -89,10 +89,6 @@ export const canonicalResponsesItemType = (itemType: string): string =>
 export const hashResponsesItemContent = async (item: unknown): Promise<string> =>
   await sha256Hex(JSON.stringify(sortJson(item)));
 
-export const createTemporaryResponsesItemId = (itemType: string): string => `${prefixForItemType(itemType)}_tmp_${randomBody()}`;
-
-export const isTemporaryResponsesItemId = (value: string): boolean => /_tmp_[A-Za-z0-9_-]{22}$/.test(value);
-
 // Gateway-owned response envelope id. A response from this gateway is not
 // a 1:1 wrapper for an upstream response — the server-tool runtime can
 // drive multiple upstream calls behind a single client-visible response —

--- a/packages/gateway/src/data-plane/chat/responses/items/format_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/format_test.ts
@@ -2,7 +2,6 @@ import { test } from 'vitest';
 
 import {
   createResponsesItemId,
-  createTemporaryResponsesItemId,
   hashResponsesItemContent,
   isResponsesItemId,
 } from './format.ts';
@@ -67,7 +66,6 @@ test('generates a valid client id for every explicit supported item type', () =>
 
 test.each(['unknown_item', '__proto__', 'constructor', 'toString'])('throws for unknown item type %s instead of using a generic fallback prefix', itemType => {
   assertThrows(() => createResponsesItemId(itemType), TypeError, 'Unknown Responses item type');
-  assertThrows(() => createTemporaryResponsesItemId(itemType), TypeError, 'Unknown Responses item type');
 });
 
 // `compaction_trigger` is intentionally absent from the prefix map. It is a
@@ -77,7 +75,6 @@ test.each(['unknown_item', '__proto__', 'constructor', 'toString'])('throws for 
 // that nobody adds a prefix back without also re-introducing a use case.
 test('rejects compaction_trigger — a control signal that should never be stored', () => {
   assertThrows(() => createResponsesItemId('compaction_trigger'), TypeError, 'Unknown Responses item type');
-  assertThrows(() => createTemporaryResponsesItemId('compaction_trigger'), TypeError, 'Unknown Responses item type');
 });
 
 test('successive client ids for the same item type collide-free under random body', () => {
@@ -88,12 +85,6 @@ test('successive client ids for the same item type collide-free under random bod
     seen.add(id);
     assert(isResponsesItemId(id));
   }
-});
-
-test('temporary ids use the item prefix without becoming client ids', () => {
-  const temporary = createTemporaryResponsesItemId('reasoning');
-  assert(/^rs_tmp_[A-Za-z0-9_-]{22}$/.test(temporary), temporary);
-  assertFalse(isResponsesItemId(temporary));
 });
 
 test('input content hashing includes the item id', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -1,4 +1,4 @@
-import { canonicalResponsesItemType, createResponsesItemId, hashResponsesItemContent, isResponsesItemId, isTemporaryResponsesItemId, responsesItemId } from './format.ts';
+import { canonicalResponsesItemType, createResponsesItemId, hashResponsesItemContent, isResponsesItemId, responsesItemId } from './format.ts';
 import { getRepo } from '../../../../repo/index.ts';
 import { cloneStoredResponsesItem, cloneStoredResponsesSnapshot, compareResponsesItemsByFreshness, scopedResponsesKey } from '../../../../repo/responses-clone.ts';
 import type { Repo, StoredResponsesItem, StoredResponsesSnapshot } from '../../../../repo/types.ts';
@@ -186,7 +186,6 @@ export class LayeredStatefulResponsesStore implements StatefulResponsesStore {
     if (
       this.outputSource?.restoresItemIds !== true
       || this.syntheticItemIds.has(id)
-      || isTemporaryResponsesItemId(id)
     ) return null;
     return { upstreamId: this.outputSource.upstreamId, upstreamItemId: id };
   }

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -236,10 +236,8 @@ describe('StatefulResponsesStore', () => {
 
     store.addSyntheticItem('ws_aabbccdd', { value: 2 });
     expect(store.getPrivatePayload('ws_aabbccdd')).toEqual({ value: 2 });
-    // A gateway-minted synthetic item is never attributed to the upstream, and
-    // neither is a temporary cross-upstream id.
+    // A gateway-minted synthetic item is never attributed to the upstream.
     expect(store.outputItemSource('ws_aabbccdd')).toBeNull();
-    expect(store.outputItemSource('rs_tmp_0000000000000000000000')).toBeNull();
 
     store.beginAttempt(new Map(), { upstreamId: 'upstream-b', restoresItemIds: false });
     expect(store.getPrivatePayload('item')).toBeUndefined();

--- a/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store_test.ts
@@ -234,11 +234,11 @@ describe('StatefulResponsesStore', () => {
     expect(store.getPrivatePayload('item')).toEqual({ first: true });
     expect(store.outputItemSource('rs_upstream')).toEqual({ upstreamId: 'upstream-a', upstreamItemId: 'rs_upstream' });
 
-    store.addSyntheticItem('ws_gw_synthetic', { value: 2 });
-    expect(store.getPrivatePayload('ws_gw_synthetic')).toEqual({ value: 2 });
+    store.addSyntheticItem('ws_aabbccdd', { value: 2 });
+    expect(store.getPrivatePayload('ws_aabbccdd')).toEqual({ value: 2 });
     // A gateway-minted synthetic item is never attributed to the upstream, and
     // neither is a temporary cross-upstream id.
-    expect(store.outputItemSource('ws_gw_synthetic')).toBeNull();
+    expect(store.outputItemSource('ws_aabbccdd')).toBeNull();
     expect(store.outputItemSource('rs_tmp_0000000000000000000000')).toBeNull();
 
     store.beginAttempt(new Map(), { upstreamId: 'upstream-b', restoresItemIds: false });
@@ -253,8 +253,8 @@ describe('StatefulResponsesStore', () => {
     const store = createNonResponsesSourceStore('key-a');
     expect(store.writesState).toBe(false);
     store.beginAttempt(new Map());
-    store.addSyntheticItem('ws_gw_1', { ir: 'search result' });
-    expect(store.getPrivatePayload('ws_gw_1')).toEqual({ ir: 'search result' });
+    store.addSyntheticItem('ws_aabbccdd', { ir: 'search result' });
+    expect(store.getPrivatePayload('ws_aabbccdd')).toEqual({ ir: 'search result' });
     expect(store.getItemById('anything')).toBeUndefined();
     expect(await store.loadSnapshot('resp_x')).toBeNull();
   });

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -1233,5 +1233,6 @@ export { webSearchCallLifecycleEvents } from './web-search-lifecycle.ts';
 export { parseResponsesStream, type ParseResponsesStreamOptions } from './stream.ts';
 
 export { RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from './to-result.ts';
+export { createRandomResponsesItemId, type GeneratedResponsesItemType } from './item-id.ts';
 export { reassembleResponsesEvents } from './reassemble.ts';
 export { responsesProtocolFrameToSSEFrame } from './to-sse.ts';

--- a/packages/protocols/src/responses/item-id.ts
+++ b/packages/protocols/src/responses/item-id.ts
@@ -12,14 +12,18 @@ const generatedItemPrefixes = {
   function_call: 'fc',
   custom_tool_call: 'ctc',
   compaction: 'cmp',
-  // https://github.com/openai/openai-python/blob/d4dceb221b9a92c55c232d5b330ae89beb539415/src/openai/types/responses/response_output_item.py#L513-L537
+  // https://github.com/openai/codex/blob/8c41ed33ce3e39460e7b13b14c35e0c39bb5980d/codex-rs/protocol/src/models.rs#L1076-L1094
   image_generation_call: 'ig',
 } as const;
 
 export type GeneratedResponsesItemType = keyof typeof generatedItemPrefixes;
 
 export const createRandomResponsesItemId = (type: GeneratedResponsesItemType): string => {
+  if (!Object.hasOwn(generatedItemPrefixes, type)) {
+    throw new TypeError(`Unknown generated Responses item type: ${type as string}`);
+  }
+  const prefix = generatedItemPrefixes[type];
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `${generatedItemPrefixes[type]}_${[...bytes].map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
+  return `${prefix}_${[...bytes].map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
 };

--- a/packages/protocols/src/responses/item-id.ts
+++ b/packages/protocols/src/responses/item-id.ts
@@ -1,6 +1,5 @@
-// These are the Responses item types Floway itself can create. Native
-// Responses providers keep ownership of every id they return; this table is
-// intentionally not a catalog of every upstream item type.
+// These are only the Responses item types Floway itself can create, not a
+// catalog or validator for provider-returned item IDs.
 // OpenAI's wire examples use msg_/rs_/ws_/ctc_ for their corresponding item
 // lifecycles and fc_/cmp_ for function and compaction items.
 // https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L57042-L59599

--- a/packages/protocols/src/responses/item-id.ts
+++ b/packages/protocols/src/responses/item-id.ts
@@ -1,0 +1,25 @@
+// These are the Responses item types Floway itself can create. Native
+// Responses providers keep ownership of every id they return; this table is
+// intentionally not a catalog of every upstream item type.
+// OpenAI's wire examples use msg_/rs_/ws_/ctc_ for their corresponding item
+// lifecycles and fc_/cmp_ for function and compaction items.
+// https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L57042-L59599
+// https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L68023-L68281
+const generatedItemPrefixes = {
+  message: 'msg',
+  reasoning: 'rs',
+  web_search_call: 'ws',
+  function_call: 'fc',
+  custom_tool_call: 'ctc',
+  compaction: 'cmp',
+  // https://github.com/openai/openai-python/blob/d4dceb221b9a92c55c232d5b330ae89beb539415/src/openai/types/responses/response_output_item.py#L513-L537
+  image_generation_call: 'ig',
+} as const;
+
+export type GeneratedResponsesItemType = keyof typeof generatedItemPrefixes;
+
+export const createRandomResponsesItemId = (type: GeneratedResponsesItemType): string => {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return `${generatedItemPrefixes[type]}_${[...bytes].map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
+};

--- a/packages/protocols/src/responses/item-id_test.ts
+++ b/packages/protocols/src/responses/item-id_test.ts
@@ -20,3 +20,8 @@ test.each(Object.entries(expectedPrefixes))('creates unique %s ids with the cano
   expect(second).toMatch(new RegExp(`^${prefix}_[0-9a-f]{32}$`));
   expect(first).not.toBe(second);
 });
+
+test.each(['unknown', '__proto__', 'constructor', 'toString'])('rejects unsupported runtime item type %s', type => {
+  expect(() => createRandomResponsesItemId(type as GeneratedResponsesItemType))
+    .toThrow(`Unknown generated Responses item type: ${type}`);
+});

--- a/packages/protocols/src/responses/item-id_test.ts
+++ b/packages/protocols/src/responses/item-id_test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest';
+
+import { createRandomResponsesItemId, type GeneratedResponsesItemType } from './item-id.ts';
+
+const expectedPrefixes = {
+  message: 'msg',
+  reasoning: 'rs',
+  web_search_call: 'ws',
+  function_call: 'fc',
+  custom_tool_call: 'ctc',
+  compaction: 'cmp',
+  image_generation_call: 'ig',
+} as const satisfies Record<GeneratedResponsesItemType, string>;
+
+test.each(Object.entries(expectedPrefixes))('creates unique %s ids with the canonical prefix', (type, prefix) => {
+  const first = createRandomResponsesItemId(type as GeneratedResponsesItemType);
+  const second = createRandomResponsesItemId(type as GeneratedResponsesItemType);
+
+  expect(first).toMatch(new RegExp(`^${prefix}_[0-9a-f]{32}$`));
+  expect(second).toMatch(new RegExp(`^${prefix}_[0-9a-f]{32}$`));
+  expect(first).not.toBe(second);
+});

--- a/packages/provider-copilot/src/compaction_test.ts
+++ b/packages/provider-copilot/src/compaction_test.ts
@@ -55,6 +55,17 @@ test('normalizes every retained text part to input_text — assistant output_tex
   expect(userPart.type).toBe('input_text');
 });
 
+test('assigns final random ids to retained messages instead of reusing input ids', () => {
+  const result = compactionResponse(
+    [{ type: 'message', id: 'msg_input', role: 'user', content: 'hello' }],
+    generatedResult([compaction]),
+  );
+
+  const id = (result.output[0] as { id?: string }).id;
+  expect(id).toMatch(/^msg_[0-9a-f]{32}$/);
+  expect(id).not.toBe('msg_input');
+});
+
 test('throws when the trigger turn did not return exactly one compaction item', () => {
   expect(() => compactionResponse([], generatedResult([]))).toThrow(/exactly one compaction/);
   expect(() => compactionResponse([], generatedResult([compaction, { type: 'compaction', id: 'cmp_2', encrypted_content: 'X' }]))).toThrow(/exactly one compaction/);

--- a/packages/provider/src/compaction.ts
+++ b/packages/provider/src/compaction.ts
@@ -9,7 +9,7 @@
 //   codex-rs/core/src/compact_remote_v2.rs#L409-L457
 //   codex-rs/utils/string/src/truncate.rs#L71-L74
 
-import type { ResponsesCompactionTriggerItem, ResponsesInputContent, ResponsesInputItem, ResponsesInputMessage, ResponsesOutputItem, ResponsesResult } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, type ResponsesCompactionTriggerItem, type ResponsesInputContent, type ResponsesInputItem, type ResponsesInputMessage, type ResponsesOutputItem, type ResponsesResult } from '@floway-dev/protocols/responses';
 
 export const COMPACTION_TRIGGER: ResponsesCompactionTriggerItem = { type: 'compaction_trigger' };
 
@@ -45,12 +45,10 @@ const isRetainedMessage = (item: ResponsesInputItem): item is ResponsesInputMess
 // roles, so the final cast records that the compaction envelope's `output` is
 // deliberately input-shaped.
 //
-// A retained message with no id gets a synthetic one (so the store can mint a
-// stored id and persist it). Retained messages persist as upstream-owned with
-// an id the upstream never issued (giving them `portable` affinity); the
-// compaction blob carries the real `forcing` affinity. Benign: retained
-// messages are resent as full content rather than `item_reference`s, so the
-// synthetic id is never replayed to the upstream.
+// Retained messages are newly synthesized output items, so they receive their
+// final public ids here instead of inheriting an input id. They are resent as
+// full content rather than item references; the compaction blob carries the
+// state needed for the next turn.
 export const compactionResponse = (input: ResponsesInputItem[], generated: ResponsesResult): ResponsesResult => {
   const kept: ResponsesInputMessage[] = [];
   let used = 0;
@@ -68,7 +66,7 @@ export const compactionResponse = (input: ResponsesInputItem[], generated: Respo
 
     kept.push({
       type: 'message',
-      id: item.id ?? `msg_${crypto.randomUUID().replace(/-/g, '')}`,
+      id: createRandomResponsesItemId('message'),
       status: item.status ?? 'completed',
       role: item.role,
       content,

--- a/packages/provider/src/compaction.ts
+++ b/packages/provider/src/compaction.ts
@@ -45,10 +45,10 @@ const isRetainedMessage = (item: ResponsesInputItem): item is ResponsesInputMess
 // roles, so the final cast records that the compaction envelope's `output` is
 // deliberately input-shaped.
 //
-// Retained messages are newly synthesized output items, so they receive their
-// final public ids here instead of inheriting an input id. They are resent as
-// full content rather than item references; the compaction blob carries the
-// state needed for the next turn.
+// Retained messages are newly synthesized output items, so their producer IDs
+// are assigned here instead of inherited from input. The current state-writing
+// client membrane may still alias them. They are resent as full content rather
+// than item references; the compaction blob carries next-turn state.
 export const compactionResponse = (input: ResponsesInputItem[], generated: ResponsesResult): ResponsesResult => {
   const kept: ResponsesInputMessage[] = [];
   let used = 0;

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -2,7 +2,7 @@ import { chatCompletionsContentToResponsesInputContent, chatCompletionsContentTo
 import { scalarToResponsesReasoningItem, translateChatCompletionsReasoningItems } from '../shared/chat-completions-and-responses/reasoning.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
-import { createRandomResponsesItemId, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesInputReasoning, type ResponsesTool, type ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputItem, ResponsesInputReasoning, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool[] | null =>
   tools?.length
@@ -48,7 +48,7 @@ export const translateChatCompletionsToResponses = (payload: ChatCompletionsPayl
 
     if (message.role === 'assistant') {
       const reasoningItems = translateChatCompletionsReasoningItems<ResponsesInputReasoning>(message.reasoning_items);
-      const scalarReasoning = scalarToResponsesReasoningItem<ResponsesInputReasoning>(message.reasoning_text, createRandomResponsesItemId('reasoning'));
+      const scalarReasoning = scalarToResponsesReasoningItem<ResponsesInputReasoning>(message.reasoning_text);
       if (reasoningItems) {
         input.push(...reasoningItems);
       } else if (scalarReasoning) {

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -2,7 +2,7 @@ import { chatCompletionsContentToResponsesInputContent, chatCompletionsContentTo
 import { scalarToResponsesReasoningItem, translateChatCompletionsReasoningItems } from '../shared/chat-completions-and-responses/reasoning.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
 import type { ChatCompletionsPayload, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
-import type { CanonicalResponsesPayload, ResponsesInputItem, ResponsesInputReasoning, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesInputReasoning, type ResponsesTool, type ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool[] | null =>
   tools?.length
@@ -47,8 +47,8 @@ export const translateChatCompletionsToResponses = (payload: ChatCompletionsPayl
     }
 
     if (message.role === 'assistant') {
-      const reasoningItems = translateChatCompletionsReasoningItems<ResponsesInputReasoning>(message.reasoning_items, () => input.length);
-      const scalarReasoning = scalarToResponsesReasoningItem<ResponsesInputReasoning>(message.reasoning_text, `rs_${input.length}`);
+      const reasoningItems = translateChatCompletionsReasoningItems<ResponsesInputReasoning>(message.reasoning_items);
+      const scalarReasoning = scalarToResponsesReasoningItem<ResponsesInputReasoning>(message.reasoning_text, createRandomResponsesItemId('reasoning'));
       if (reasoningItems) {
         input.push(...reasoningItems);
       } else if (scalarReasoning) {

--- a/packages/translate/src/chat-completions-via-responses/request_test.ts
+++ b/packages/translate/src/chat-completions-via-responses/request_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { translateChatCompletionsToResponses } from './request.ts';
 import { createChatCompletionsToResponsesStreamState, flushChatCompletionsToResponsesEvents, translateChatCompletionsChunkToResponsesEvents } from '../responses-via-chat-completions/events.ts';
@@ -49,7 +49,7 @@ test('translateChatCompletionsToResponses uses rs-prefixed ids for reasoning inp
   if (!Array.isArray(result.input)) throw new Error('expected input array');
   const reasoning = result.input[0] as ResponsesInputReasoning;
   assertEquals(reasoning.type, 'reasoning');
-  assertEquals(reasoning.id, 'rs_0');
+  expect(reasoning.id).toMatch(/^rs_[0-9a-f]{32}$/);
 });
 
 test('translateChatCompletionsToResponses preserves text-only scalar reasoning', () => {
@@ -67,7 +67,7 @@ test('translateChatCompletionsToResponses preserves text-only scalar reasoning',
   if (!Array.isArray(result.input)) throw new Error('expected input array');
   assertEquals(result.input[0], {
     type: 'reasoning',
-    id: 'rs_0',
+    id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
     summary: [{ type: 'summary_text', text: 'visible trace' }],
   });
 });
@@ -259,7 +259,7 @@ test('translateChatCompletionsChunkToResponsesEvents keeps late opaque with prio
   assertEquals(reasoningDoneEvents[0].output_index, 0);
   assertEquals(reasoningDoneEvents[0].item, {
     type: 'reasoning',
-    id: 'rs_0',
+    id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
     summary: [{ type: 'summary_text', text: 'trace' }],
   });
 });

--- a/packages/translate/src/chat-completions-via-responses/request_test.ts
+++ b/packages/translate/src/chat-completions-via-responses/request_test.ts
@@ -304,7 +304,7 @@ test('translateChatCompletionsChunkToResponsesEvents prefers reasoning_items ove
     },
     {
       type: 'message',
-      id: 'msg_1',
+      id: expect.stringMatching(/^msg_[0-9a-f]{32}$/),
       role: 'assistant',
       content: [{ type: 'output_text', text: 'answer' }],
     },
@@ -401,7 +401,7 @@ test('translateChatCompletionsChunkToResponsesEvents discards scalar reasoning w
     },
     {
       type: 'message',
-      id: 'msg_1',
+      id: expect.stringMatching(/^msg_[0-9a-f]{32}$/),
       role: 'assistant',
       content: [{ type: 'output_text', text: 'answer' }],
     },

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -130,7 +130,7 @@ const translateAssistantMessage = (message: MessagesAssistantMessage, messageIdx
 
     if (block.type === 'thinking' || block.type === 'redacted_thinking') {
       flushPendingContent(pendingContent, input, 'assistant');
-      input.push(messagesReasoningBlockToResponsesReasoning(block, input.length));
+      input.push(messagesReasoningBlockToResponsesReasoning(block));
       continue;
     }
 

--- a/packages/translate/src/messages-via-responses/request_test.ts
+++ b/packages/translate/src/messages-via-responses/request_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { translateMessagesToResponses } from './request.ts';
 import { packReasoningSignature } from '../shared/messages-and-responses/reasoning.ts';
@@ -22,7 +22,7 @@ test('translateMessagesToResponses preserves a native thinking signature as encr
   const reasoning = result.input[0] as ResponsesInputReasoning;
   assertEquals(reasoning, {
     type: 'reasoning',
-    id: 'rs_0',
+    id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
     summary: [{ type: 'summary_text', text: 'trace' }],
     encrypted_content: 'sig',
   });
@@ -302,7 +302,7 @@ test('translateMessagesToResponses preserves redacted_thinking as a native-signa
   assertEquals(result.input, [
     {
       type: 'reasoning',
-      id: 'rs_0',
+      id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
       summary: [],
       encrypted_content: 'opaque_sig',
     },
@@ -348,7 +348,7 @@ test('translateMessagesToResponses preserves text-only thinking input', () => {
   const reasoning = result.input[0] as ResponsesInputReasoning;
   assertEquals(reasoning, {
     type: 'reasoning',
-    id: 'rs_0',
+    id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
     summary: [{ type: 'summary_text', text: 'trace' }],
   });
 });

--- a/packages/translate/src/responses-via-chat-completions/events.ts
+++ b/packages/translate/src/responses-via-chat-completions/events.ts
@@ -3,7 +3,7 @@ import { unwrapCustomToolInput } from '../shared/responses-via/custom-tool-wrap.
 import * as responses from '../shared/responses-via/responses-event-builder.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsResult } from '@floway-dev/protocols/chat-completions';
 import { eventFrame, splitInclusiveInputTokens, USAGE_BILLING, type ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesOutputItem, ResponsesOutputReasoning, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, type ResponsesOutputItem, type ResponsesOutputReasoning, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 const mapChatCompletionsUsageToResponsesUsage = (usage: ChatCompletionsResult['usage'] | undefined): ResponsesResult['usage'] | undefined => {
   if (!usage) return undefined;
@@ -154,7 +154,7 @@ const commitPendingScalarReasoning = (state: ChatCompletionsToResponsesStreamSta
   const reasoning = state.pendingScalarReasoning;
   state.pendingScalarReasoning = undefined;
   const outputIndex = state.outputIndex++;
-  const item = responses.reasoningItem(`rs_${outputIndex}`, reasoning.text);
+  const item = responses.reasoningItem(createRandomResponsesItemId('reasoning'), reasoning.text);
 
   return emitCompletedReasoningItem(item, outputIndex, state);
 };
@@ -208,7 +208,7 @@ const openText = (state: ChatCompletionsToResponsesStreamState): { item: Pending
   if (state.openText) return { item: state.openText, events: [] };
 
   const outputIndex = state.outputIndex++;
-  const itemId = `msg_${outputIndex}`;
+  const itemId = createRandomResponsesItemId('message');
   const item = { outputIndex, itemId, text: '' };
   state.openText = item;
 
@@ -227,7 +227,7 @@ const startFunctionCall = (current: PendingFunctionCallItem, state: ChatCompleti
   const outputIndex = state.outputIndex++;
   const streamItem: FunctionCallStreamItem = {
     outputIndex,
-    itemId: isCustom ? `ctc_${outputIndex}` : `fc_${outputIndex}`,
+    itemId: createRandomResponsesItemId(isCustom ? 'custom_tool_call' : 'function_call'),
     kind: isCustom ? 'custom' : 'function',
   };
   current.streamItem = streamItem;
@@ -345,7 +345,7 @@ export const translateChatCompletionsChunkToResponsesEvents = (chunk: ChatComple
 
       for (const item of readableReasoningItems) {
         const outputIndex = state.outputIndex++;
-        events.push(...emitCompletedReasoningItem(toResponsesReasoningItem<ResponsesOutputReasoning>(item, `rs_${outputIndex}`), outputIndex, state));
+        events.push(...emitCompletedReasoningItem(toResponsesReasoningItem<ResponsesOutputReasoning>(item, createRandomResponsesItemId('reasoning')), outputIndex, state));
       }
 
       if (hadPendingScalarReasoning) {

--- a/packages/translate/src/responses-via-chat-completions/events.ts
+++ b/packages/translate/src/responses-via-chat-completions/events.ts
@@ -345,7 +345,7 @@ export const translateChatCompletionsChunkToResponsesEvents = (chunk: ChatComple
 
       for (const item of readableReasoningItems) {
         const outputIndex = state.outputIndex++;
-        events.push(...emitCompletedReasoningItem(toResponsesReasoningItem<ResponsesOutputReasoning>(item, createRandomResponsesItemId('reasoning')), outputIndex, state));
+        events.push(...emitCompletedReasoningItem(toResponsesReasoningItem<ResponsesOutputReasoning>(item), outputIndex, state));
       }
 
       if (hadPendingScalarReasoning) {

--- a/packages/translate/src/responses-via-chat-completions/events_test.ts
+++ b/packages/translate/src/responses-via-chat-completions/events_test.ts
@@ -70,7 +70,7 @@ test('translateChatCompletionsChunkToResponsesEvents preserves tool call deltas 
   assertEquals(completed?.response.output, [
     {
       type: 'function_call',
-      id: 'fc_0',
+      id: expect.stringMatching(/^fc_[0-9a-f]{32}$/),
       call_id: 'call_1',
       name: 'lookup',
       arguments: '{"q":"x"}',
@@ -110,7 +110,7 @@ test('translateChatCompletionsChunkToResponsesEvents replaces buffered scalar re
     },
     {
       type: 'message',
-      id: 'msg_1',
+      id: expect.stringMatching(/^msg_[0-9a-f]{32}$/),
       role: 'assistant',
       content: [{ type: 'output_text', text: 'answer' }],
     },

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -16,7 +16,7 @@ import type {
   MessagesTextCitation,
   MessagesUsageSnapshot,
 } from '@floway-dev/protocols/messages';
-import type { ResponsesOutputItem, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, type ResponsesOutputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 const UPSTREAM_MESSAGES_MISSING_TERMINAL_MESSAGE = 'Upstream Messages stream ended without a message_stop event.';
 
@@ -139,7 +139,7 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
   switch (event.content_block.type) {
   case 'thinking': {
     const outputIndex = state.outputIndex++;
-    const itemId = `rs_${outputIndex}`;
+    const itemId = createRandomResponsesItemId('reasoning');
     state.blockMap.set(event.index, {
       type: 'thinking',
       outputIndex,
@@ -154,7 +154,7 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
     // `data` and no readable text. Surface it as a Responses reasoning item
     // whose `encrypted_content` round-trips that opaque blob.
     const outputIndex = state.outputIndex++;
-    const itemId = `rs_${outputIndex}`;
+    const itemId = createRandomResponsesItemId('reasoning');
     state.blockMap.set(event.index, {
       type: 'thinking',
       outputIndex,
@@ -167,7 +167,7 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
   }
   case 'text': {
     const outputIndex = state.outputIndex++;
-    const itemId = `msg_${outputIndex}`;
+    const itemId = createRandomResponsesItemId('message');
     state.blockMap.set(event.index, {
       type: 'text',
       outputIndex,
@@ -181,7 +181,7 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
   case 'tool_use': {
     const outputIndex = state.outputIndex++;
     if (state.customToolNames.has(event.content_block.name)) {
-      const itemId = `ctc_${outputIndex}`;
+      const itemId = createRandomResponsesItemId('custom_tool_call');
       state.blockMap.set(event.index, {
         type: 'custom_tool_use',
         outputIndex,
@@ -194,7 +194,7 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
       return responses.itemAdded(state, outputIndex, responses.customToolCallItem(itemId, event.content_block.id, event.content_block.name, ''));
     }
 
-    const itemId = `fc_${outputIndex}`;
+    const itemId = createRandomResponsesItemId('function_call');
     const info: OutputBlockInfo = {
       type: 'tool_use',
       outputIndex,

--- a/packages/translate/src/responses-via-messages/events_test.ts
+++ b/packages/translate/src/responses-via-messages/events_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { createMessagesToResponsesStreamState, translateMessagesEventToResponsesEvents } from './events.ts';
 import { assertEquals } from '../test-assert.ts';
@@ -152,7 +152,7 @@ test('redacted_thinking stream block round-trips its opaque data as encrypted_co
   assertEquals(state.completedItems, [
     {
       type: 'reasoning',
-      id: 'rs_0',
+      id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
       summary: [],
       encrypted_content: 'opaque_sig',
     },
@@ -191,7 +191,7 @@ test('thinking stream block carries the upstream signature verbatim as encrypted
   assertEquals(state.completedItems, [
     {
       type: 'reasoning',
-      id: 'rs_0',
+      id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
       summary: [{ type: 'summary_text', text: 'trace' }],
       encrypted_content: 'upstream-opaque-signature',
     },
@@ -218,7 +218,7 @@ test('thinking stream block start emits a plain reasoning item', () => {
     throw new Error('expected reasoning item');
   }
 
-  assertEquals(added.item, { type: 'reasoning', id: 'rs_0', summary: [] });
+  assertEquals(added.item, { type: 'reasoning', id: expect.stringMatching(/^rs_[0-9a-f]{32}$/), summary: [] });
 });
 
 test('thinking stream block stop emits a plain reasoning item', () => {
@@ -252,7 +252,7 @@ test('thinking stream block stop emits a plain reasoning item', () => {
 
   assertEquals(done.item, {
     type: 'reasoning',
-    id: 'rs_0',
+    id: expect.stringMatching(/^rs_[0-9a-f]{32}$/),
     summary: [{ type: 'summary_text', text: 'trace' }],
   });
 });
@@ -455,7 +455,7 @@ test('search_result_location citation_delta becomes one url_citation annotation'
   const [annotation] = annotations;
   assertEquals(annotation.output_index, 0);
   assertEquals(annotation.content_index, 0);
-  assertEquals(annotation.item_id, 'msg_0');
+  expect(annotation.item_id).toMatch(/^msg_[0-9a-f]{32}$/);
   assertEquals(annotation.annotation_index, 0);
   assertEquals(annotation.annotation, {
     type: 'url_citation',
@@ -741,11 +741,11 @@ test('synthesized message item carries a stable id consistent across added, chil
   const doneId = itemIdOf(stopEvents, 'response.output_item.done');
   const allChildIds = [...childItemIds(startEvents), ...childItemIds(deltaEvents), ...childItemIds(stopEvents)];
 
-  assertEquals(addedId, 'msg_0');
-  assertEquals(doneId, 'msg_0');
-  assertEquals(new Set(allChildIds), new Set(['msg_0']));
+  expect(addedId).toMatch(/^msg_[0-9a-f]{32}$/);
+  assertEquals(doneId, addedId);
+  assertEquals(new Set(allChildIds), new Set([addedId]));
   assertEquals(state.completedItems, [
-    { type: 'message', id: 'msg_0', role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] },
+    { type: 'message', id: addedId, role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] },
   ]);
 });
 
@@ -766,11 +766,11 @@ test('synthesized function_call item carries a stable id consistent across added
   const doneId = itemIdOf(stopEvents, 'response.output_item.done');
   const allChildIds = [...childItemIds(startEvents), ...childItemIds(deltaEvents), ...childItemIds(stopEvents)];
 
-  assertEquals(addedId, 'fc_0');
-  assertEquals(doneId, 'fc_0');
-  assertEquals(new Set(allChildIds), new Set(['fc_0']));
+  expect(addedId).toMatch(/^fc_[0-9a-f]{32}$/);
+  assertEquals(doneId, addedId);
+  assertEquals(new Set(allChildIds), new Set([addedId]));
   assertEquals(state.completedItems, [
-    { type: 'function_call', id: 'fc_0', call_id: 'toolu_1', name: 'lookup', arguments: '{"q":"x"}', status: 'completed' },
+    { type: 'function_call', id: addedId, call_id: 'toolu_1', name: 'lookup', arguments: '{"q":"x"}', status: 'completed' },
   ]);
 });
 

--- a/packages/translate/src/shared/chat-completions-and-responses/reasoning.ts
+++ b/packages/translate/src/shared/chat-completions-and-responses/reasoning.ts
@@ -30,19 +30,19 @@ export const chatCompletionsReasoningProjectionFields = (projection: ChatComplet
   ...(projection.items.length > 0 ? { reasoning_items: projection.items } : {}),
 });
 
-export const toResponsesReasoningItem = <T extends ResponsesReasoningItem>(item: ChatCompletionsReasoningItem, fallbackId: string): T =>
+export const toResponsesReasoningItem = <T extends ResponsesReasoningItem>(item: ChatCompletionsReasoningItem): T =>
   ({
     type: 'reasoning',
-    id: item.id ?? fallbackId,
+    id: item.id ?? createRandomResponsesItemId('reasoning'),
     summary: item.summary ?? [],
   } as T);
 
-export const scalarToResponsesReasoningItem = <T extends ResponsesReasoningItem>(reasoningText: string | null | undefined, id: string): T | null => {
+export const scalarToResponsesReasoningItem = <T extends ResponsesReasoningItem>(reasoningText: string | null | undefined): T | null => {
   if (!reasoningText) return null;
 
   return {
     type: 'reasoning',
-    id,
+    id: createRandomResponsesItemId('reasoning'),
     summary: reasoningText ? [{ type: 'summary_text', text: reasoningText }] : [],
   } as T;
 };
@@ -58,6 +58,6 @@ export const translateChatCompletionsReasoningItems = <T extends ResponsesReason
   // References:
   // - https://github.com/BerriAI/litellm/blob/70492cee4282541256fb9ac963be94412b1a109c/litellm/completion_extras/litellm_responses_transformation/transformation.py#L59-L104
   // - https://github.com/BerriAI/litellm/blob/70492cee4282541256fb9ac963be94412b1a109c/litellm/completion_extras/litellm_responses_transformation/transformation.py#L1322-L1355
-  const translated = reasoningItems.flatMap(item => (hasReadableSummary(item) ? [toResponsesReasoningItem<T>(item, createRandomResponsesItemId('reasoning'))] : []));
+  const translated = reasoningItems.flatMap(item => (hasReadableSummary(item) ? [toResponsesReasoningItem<T>(item)] : []));
   return translated.length > 0 ? translated : null;
 };

--- a/packages/translate/src/shared/chat-completions-and-responses/reasoning.ts
+++ b/packages/translate/src/shared/chat-completions-and-responses/reasoning.ts
@@ -1,5 +1,5 @@
 import type { ChatCompletionsReasoningItem } from '@floway-dev/protocols/chat-completions';
-import type { ResponsesInputItem, ResponsesOutputReasoning, ResponsesReasoningItem } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, type ResponsesInputItem, type ResponsesOutputReasoning, type ResponsesReasoningItem } from '@floway-dev/protocols/responses';
 
 export type ChatCompletionsReasoningSourceItem = Extract<ResponsesInputItem, { type: 'reasoning' }> | ResponsesOutputReasoning;
 
@@ -49,7 +49,7 @@ export const scalarToResponsesReasoningItem = <T extends ResponsesReasoningItem>
 
 export const hasReadableSummary = (item: ChatCompletionsReasoningItem): boolean => item.summary?.some(part => part.text) === true;
 
-export const translateChatCompletionsReasoningItems = <T extends ResponsesReasoningItem>(reasoningItems: ChatCompletionsReasoningItem[] | null | undefined, nextIdIndex: () => number): T[] | null => {
+export const translateChatCompletionsReasoningItems = <T extends ResponsesReasoningItem>(reasoningItems: ChatCompletionsReasoningItem[] | null | undefined): T[] | null => {
   if (!reasoningItems?.length) return null;
 
   // `reasoning_items[]` is a LiteLLM-inspired compatibility workaround for
@@ -58,7 +58,6 @@ export const translateChatCompletionsReasoningItems = <T extends ResponsesReason
   // References:
   // - https://github.com/BerriAI/litellm/blob/70492cee4282541256fb9ac963be94412b1a109c/litellm/completion_extras/litellm_responses_transformation/transformation.py#L59-L104
   // - https://github.com/BerriAI/litellm/blob/70492cee4282541256fb9ac963be94412b1a109c/litellm/completion_extras/litellm_responses_transformation/transformation.py#L1322-L1355
-  const startIndex = nextIdIndex();
-  const translated = reasoningItems.flatMap((item, index) => (hasReadableSummary(item) ? [toResponsesReasoningItem<T>(item, `rs_${startIndex + index}`)] : []));
+  const translated = reasoningItems.flatMap(item => (hasReadableSummary(item) ? [toResponsesReasoningItem<T>(item, createRandomResponsesItemId('reasoning'))] : []));
   return translated.length > 0 ? translated : null;
 };

--- a/packages/translate/src/shared/chat-completions-and-responses/reasoning_test.ts
+++ b/packages/translate/src/shared/chat-completions-and-responses/reasoning_test.ts
@@ -1,0 +1,22 @@
+import { expect, test, vi } from 'vitest';
+
+import { scalarToResponsesReasoningItem, toResponsesReasoningItem } from './reasoning.ts';
+import type { ResponsesInputReasoning } from '@floway-dev/protocols/responses';
+
+test('reasoning fallback IDs are generated only when an item needs one', () => {
+  const random = vi.spyOn(crypto, 'getRandomValues');
+
+  expect(scalarToResponsesReasoningItem<ResponsesInputReasoning>(undefined)).toBeNull();
+  expect(toResponsesReasoningItem<ResponsesInputReasoning>({
+    type: 'reasoning',
+    id: 'rs_existing',
+    summary: [{ type: 'summary_text', text: 'trace' }],
+  }).id).toBe('rs_existing');
+  expect(random).not.toHaveBeenCalled();
+
+  expect(toResponsesReasoningItem<ResponsesInputReasoning>({
+    type: 'reasoning',
+    summary: [{ type: 'summary_text', text: 'trace' }],
+  }).id).toMatch(/^rs_[0-9a-f]{32}$/);
+  expect(random).toHaveBeenCalledOnce();
+});

--- a/packages/translate/src/shared/messages-and-responses/reasoning.ts
+++ b/packages/translate/src/shared/messages-and-responses/reasoning.ts
@@ -1,5 +1,5 @@
 import type { MessagesRedactedThinkingBlock, MessagesThinkingBlock } from '@floway-dev/protocols/messages';
-import type { ResponsesInputReasoning, ResponsesReasoningItem } from '@floway-dev/protocols/responses';
+import { createRandomResponsesItemId, type ResponsesInputReasoning, type ResponsesReasoningItem } from '@floway-dev/protocols/responses';
 
 export type MessagesReasoningBlock = MessagesThinkingBlock | MessagesRedactedThinkingBlock;
 
@@ -47,7 +47,7 @@ export const packReasoningSignature = (id: string, encryptedContent: string): st
  * - `opaque-sig` (no `@`) → `{ id: null, encryptedContent: 'opaque-sig' }` —
  *   a genuine upstream signature (native Anthropic encrypted reasoning, or a
  *   base64 blob that contains no `@`). It is preserved verbatim and the caller
- *   synthesizes an `rs_${index}` id; we NEVER fabricate or overwrite it.
+ *   synthesizes a fresh reasoning id; we NEVER overwrite the signature.
  * - `enc@` (trailing `@`, empty id) → treated as a native signature.
  *
  * Splitting on the LAST `@` is safe because genuine upstream signatures are
@@ -66,17 +66,17 @@ export const unpackReasoningSignature = (signature: string): { id: string | null
  * Project a Messages reasoning carrier echoed by a downstream Messages CLIENT
  * into a Responses reasoning item bound for the Responses UPSTREAM. Unpacks the
  * carrier so the upstream sees the original id and a clean `encrypted_content`
- * blob. `rs_${index}` is the synthetic fallback id used when the carrier holds
- * a genuine (unpacked) upstream signature.
+ * blob. A fresh random id is used when the carrier holds a genuine (unpacked)
+ * upstream signature.
  */
-export const messagesReasoningBlockToResponsesReasoning = (block: MessagesReasoningBlock, index: number): ResponsesInputReasoning => {
+export const messagesReasoningBlockToResponsesReasoning = (block: MessagesReasoningBlock): ResponsesInputReasoning => {
   const carrier = block.type === 'thinking' ? block.signature : block.data;
   const { id, encryptedContent } = carrier !== undefined ? unpackReasoningSignature(carrier) : { id: null, encryptedContent: undefined };
   const summary = block.type === 'thinking' && block.thinking ? [{ type: 'summary_text' as const, text: block.thinking }] : [];
 
   return {
     type: 'reasoning',
-    id: id ?? `rs_${index}`,
+    id: id ?? createRandomResponsesItemId('reasoning'),
     summary,
     ...(encryptedContent !== undefined ? { encrypted_content: encryptedContent } : {}),
   };


### PR DESCRIPTION
## Summary

Every Responses item the gateway itself synthesizes now mints a final, random
producer ID at the point it is created, replacing the positional placeholders
(`rs_0`, `msg_0`, `fc_0`) and the ad-hoc `_gw`/UUID schemes.

- The Messages→Responses and Chat-Completions→Responses translators, plus the
  shared reasoning projections, mint an item's ID when it opens.
- Hosted tools (web search, image generation), the server-tool shim, the
  affinity reasoning prefix, compact output, and retained compact messages all
  receive producer-owned random IDs at creation.
- One ID stays stable across a stream item's `added`, child/delta, `done`, and
  terminal-snapshot frames.
- A single `createRandomResponsesItemId` helper owns the canonical prefixes and
  hard-fails on unsupported runtime item types; reasoning fallback IDs are drawn
  only when the source item genuinely lacks one.
- With every synthetic producer on a normal producer ID, the orphaned `_tmp_`
  marker and the `outputItemSource` guard that recognized it are removed. The
  affinity reasoning prefix stays excluded from upstream attribution because
  ingress always strips the originless carrier before candidate-time restoration
  could read it.

The state-writing client membrane may still alias these producer IDs; #249
removes that membrane, at which point they become the client-visible IDs.

## Test Plan

- [x] `pnpm run test` — 382 files pass
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`

## Stack

1 of 3 remaining. #246 was squash-merged into `main`; #248 is stacked next.
