### PR TITLE
refactor(gateway): unify model catalog dispatch

### DIFF
--- a/packages/gateway/src/data-plane/codex/catalog.ts
+++ b/packages/gateway/src/data-plane/codex/catalog.ts
@@ -46,9 +46,11 @@ export interface CodexCatalogResolution {
 }
 
 // Codex uses its active originator as the User-Agent product token, followed
-// by the app-server build version. This covers CLI, Desktop, IDE, and legacy
-// `codex_exec` originators without coupling catalog resolution to one surface.
-// https://github.com/openai/codex/blob/2deed3fb9c00c74dac3d177ea700d6fb7a94539d/codex-rs/login/src/auth/default_client.rs#L161-L172
+// by the app-server build version. Current TUI requests start with `codex-tui`;
+// the same formatter covers Desktop, IDE, `codex_cli_rs`, and `codex_exec`
+// originators without coupling catalog resolution to one surface.
+// https://github.com/openai/codex/blob/fd51e505401b7b2da958edc269e4d7280be86bd5/codex-rs/login/src/auth/default_client.rs#L159-L183
+// https://github.com/openai/codex/blob/fd51e505401b7b2da958edc269e4d7280be86bd5/codex-rs/tui/src/lib.rs#L553-L574
 const VERSION_FROM_USER_AGENT = /^codex[^/]*\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)/i;
 
 const inMemoryCache = new Map<string, CodexCatalogResolution>();
@@ -74,6 +76,9 @@ const bundledFallback = (): CodexCatalogResolution => ({ catalog: bundled, capab
 
 const parseCodexVersion = (userAgent: string | undefined): string | null =>
   userAgent?.match(VERSION_FROM_USER_AGENT)?.[1] ?? null;
+
+export const isCodexUserAgent = (userAgent: string | undefined): boolean =>
+  parseCodexVersion(userAgent) !== null;
 
 const fetchCodexCatalog = async (version: string): Promise<CodexCatalog | null> => {
   const url = `https://raw.githubusercontent.com/openai/codex/rust-v${version}/codex-rs/models-manager/models.json`;

--- a/packages/gateway/src/data-plane/codex/catalog_test.ts
+++ b/packages/gateway/src/data-plane/codex/catalog_test.ts
@@ -13,6 +13,28 @@ describe('resolveCodexCatalog', () => {
     globalThis.fetch = originalFetch;
   });
 
+  it.each([
+    'codex-tui/0.145.0 (Mac OS 26.5.0; arm64)',
+    'codex_cli_rs/0.144.1 (Linux 6.8; x86_64)',
+    'codex_exec/0.144.1 (Linux 6.8; x86_64)',
+    'codex_vscode/0.144.1 (Windows 11; x86_64)',
+    'codex_desktop/0.145.0-alpha.18 (Windows 11; x86_64)',
+    'Codex Desktop/0.145.0 (Mac OS 26.5.0; arm64)',
+  ])('recognizes the Codex originator User-Agent %s', async userAgent => {
+    const { isCodexUserAgent } = await import('./catalog.ts');
+    expect(isCodexUserAgent(userAgent)).toBe(true);
+  });
+
+  it.each([
+    undefined,
+    'openai-python/1.42.0',
+    'claude-code/2.1.206',
+    'codex-tui/not-a-version',
+  ])('does not classify a non-Codex catalog caller %s', async userAgent => {
+    const { isCodexUserAgent } = await import('./catalog.ts');
+    expect(isCodexUserAgent(userAgent)).toBe(false);
+  });
+
   it('falls back to bundled when user-agent is missing', async () => {
     const { resolveCodexCatalog: resolve } = await import('./catalog.ts');
     const { catalog, capabilities } = await resolve(undefined);

--- a/packages/gateway/src/data-plane/codex/models.ts
+++ b/packages/gateway/src/data-plane/codex/models.ts
@@ -1,4 +1,4 @@
-// codex-internal `/models` shape.
+// Codex-internal `/models` shape assembled for the shared catalog handler.
 //
 // codex reads this via `OpenAiModelsManager::list_models` and replaces its
 // bundled catalog when AuthMode is Chatgpt / ChatgptAuthTokens /
@@ -14,14 +14,8 @@
 // overlays it announces, and capabilities proven by the exact client catalog
 // (see synthesize.ts for the exact field precedence rules).
 
-import type { Context } from 'hono';
-
 import { resolveCodexCatalog, type CatalogModel, type CodexCatalog, type CodexCatalogCapabilities } from './catalog.ts';
 import { synthesizeCatalogEntry } from './synthesize.ts';
-import { createPerRequestFetcher } from '../../dial/per-request.ts';
-import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
-import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
-import { getRuntimeLocation } from '../../runtime/runtime-info.ts';
 import { enumerateAddressableModelIds, type AddressableIdEntry } from '../shared/listing/addressable.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { Fetcher } from '@floway-dev/provider';
@@ -30,7 +24,7 @@ import type { Fetcher } from '@floway-dev/provider';
 // codex-shaped catalog (drops unlisted alternates and non-chat kinds).
 // Extracted so tests can drive the mapping logic without standing up the
 // addressable-enumeration pipeline.
-export const assembleCatalog = (
+export const assembleCodexCatalog = (
   catalog: CodexCatalog,
   addressable: readonly AddressableIdEntry[],
   capabilities: CodexCatalogCapabilities = {},
@@ -65,7 +59,7 @@ export const assembleCatalog = (
   return { models };
 };
 
-const computeCatalog = async (
+export const loadCodexCatalog = async (
   userAgent: string | undefined,
   upstreamIds: readonly string[] | null,
   fetcherForUpstream: (upstreamId: string) => Fetcher,
@@ -75,13 +69,5 @@ const computeCatalog = async (
     resolveCodexCatalog(userAgent),
     enumerateAddressableModelIds(upstreamIds, fetcherForUpstream, scheduler),
   ]);
-  return assembleCatalog(resolution.catalog, addressable, resolution.capabilities);
-};
-
-export const codexModels = async (c: Context): Promise<Response> => {
-  const userAgent = c.req.header('user-agent');
-  const upstreamIds = effectiveUpstreamIdsFromContext(c);
-  const fetcherForUpstream = await createPerRequestFetcher(getRuntimeLocation(c.req.raw));
-  const scheduler = backgroundSchedulerFromContext(c);
-  return Response.json(await computeCatalog(userAgent, upstreamIds, fetcherForUpstream, scheduler));
+  return assembleCodexCatalog(resolution.catalog, addressable, resolution.capabilities);
 };

--- a/packages/gateway/src/data-plane/codex/models_test.ts
+++ b/packages/gateway/src/data-plane/codex/models_test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import type { CodexCatalogCapabilities } from './catalog.ts';
-import { assembleCatalog } from './models.ts';
+import { assembleCodexCatalog } from './models.ts';
 import type { AddressableIdEntry } from '../shared/listing/addressable.ts';
 import type { InternalModel } from '@floway-dev/provider';
 
@@ -37,9 +37,9 @@ const ultraCapabilities: CodexCatalogCapabilities = {
   ultraReasoningLevel: { effort: 'ultra', description: 'Maximum reasoning with automatic task delegation' },
 };
 
-describe('assembleCatalog', () => {
+describe('assembleCodexCatalog', () => {
   test('bundled match: reuses bundled entry, slug=publicId, display_name from registry', () => {
-    const out = assembleCatalog(bundled, entries(chat('gpt-5.5', 'Custom Display Name', 200000)));
+    const out = assembleCodexCatalog(bundled, entries(chat('gpt-5.5', 'Custom Display Name', 200000)));
     expect(out.models).toHaveLength(1);
     const e = out.models[0];
     expect(e.slug).toBe('gpt-5.5');
@@ -50,13 +50,13 @@ describe('assembleCatalog', () => {
   });
 
   test('bundled match: registry display_name=undefined preserves the bundled display_name', () => {
-    const out = assembleCatalog(bundled, entries(chat('gpt-5.5')));     // chat() passes display_name: undefined
+    const out = assembleCodexCatalog(bundled, entries(chat('gpt-5.5')));     // chat() passes display_name: undefined
     expect(out.models).toHaveLength(1);
     expect(out.models[0].display_name).toBe('GPT-5.5');         // bundled's display_name
   });
 
   test('segment match via prefix and suffix', () => {
-    const out = assembleCatalog(bundled, entries(
+    const out = assembleCodexCatalog(bundled, entries(
       chat('openrouter/gpt-5.5:nitro'),
       chat('azure/gpt-5.4'),
     ));
@@ -69,12 +69,12 @@ describe('assembleCatalog', () => {
     // The model-prefix feature (packages/provider/src/model-prefix.ts) lets
     // operators republish an upstream model under a path-shaped prefix —
     // `openrouter/gpt-5.5`, `vendor/sub/region/gpt-5.5`. By the time the
-    // public id reaches assembleCatalog the prefix is already baked in, so
+    // public id reaches assembleCodexCatalog the prefix is already baked in, so
     // bundle-matching falls out of the segment splitter: the publicId is
     // split on `/` (model-prefix segments) and `:` (OpenRouter-style
     // `:variant` suffixes), and the segments are walked leaf-first against
     // the bundled slug map — the trailing model slug is tried first.
-    const out = assembleCatalog(bundled, entries(chat('vendor/sub/region/gpt-5.5', 'Sub-region GPT-5.5', 200000)));
+    const out = assembleCodexCatalog(bundled, entries(chat('vendor/sub/region/gpt-5.5', 'Sub-region GPT-5.5', 200000)));
     expect(out.models).toHaveLength(1);
     const e = out.models[0];
     expect(e.slug).toBe('vendor/sub/region/gpt-5.5');   // slug overridden to the prefixed publicId
@@ -84,7 +84,7 @@ describe('assembleCatalog', () => {
   });
 
   test('multiple bundled-matching ids of the same bundled slug coexist', () => {
-    const out = assembleCatalog(bundled, entries(chat('gpt-5.5'), chat('openrouter/gpt-5.5:nitro')));
+    const out = assembleCodexCatalog(bundled, entries(chat('gpt-5.5'), chat('openrouter/gpt-5.5:nitro')));
     expect(out.models).toHaveLength(2);
     expect(out.models.every(m => m.priority === 1)).toBe(true);
   });
@@ -93,12 +93,12 @@ describe('assembleCatalog', () => {
     // `openrouter/gpt-5.5/gpt-5.4` binds against gpt-5.4 — walking segments
     // leaf-first avoids binding against an earlier segment (`gpt-5.5`) that
     // happens to collide with a bundled slug.
-    const out = assembleCatalog(bundled, entries(chat('openrouter/gpt-5.5/gpt-5.4')));
+    const out = assembleCodexCatalog(bundled, entries(chat('openrouter/gpt-5.5/gpt-5.4')));
     expect(out.models[0].priority).toBe(2);  // gpt-5.4's priority
   });
 
   test('no match: synthesizes a new entry', () => {
-    const out = assembleCatalog(bundled, entries(chat('deepseek-v4-pro', 'DeepSeek V4 Pro', 128000)));
+    const out = assembleCodexCatalog(bundled, entries(chat('deepseek-v4-pro', 'DeepSeek V4 Pro', 128000)));
     expect(out.models).toHaveLength(1);
     const e = out.models[0];
     expect(e.slug).toBe('deepseek-v4-pro');
@@ -113,8 +113,8 @@ describe('assembleCatalog', () => {
       ...chat('deepseek-v4-pro'),
       chat: { reasoning: { effort: { supported: ['high', 'max'], default: 'high' } } },
     };
-    const withoutCapability = assembleCatalog(bundled, entries(maxModel));
-    const withCapability = assembleCatalog(bundled, entries(maxModel), ultraCapabilities);
+    const withoutCapability = assembleCodexCatalog(bundled, entries(maxModel));
+    const withCapability = assembleCodexCatalog(bundled, entries(maxModel), ultraCapabilities);
 
     expect(withoutCapability.models[0].supported_reasoning_levels).toEqual([
       { effort: 'high', description: '' },
@@ -130,7 +130,7 @@ describe('assembleCatalog', () => {
   });
 
   test('non-chat models are dropped', () => {
-    const out = assembleCatalog(bundled, [
+    const out = assembleCodexCatalog(bundled, [
       entry({ id: 'text-embedding-3', display_name: 'emb', kind: 'embedding', limits: {}, endpoints: {} } as InternalModel),
       entry(chat('gpt-5.5')),
     ]);
@@ -142,7 +142,7 @@ describe('assembleCatalog', () => {
     // A model reachable only via `modelPrefix.addressable` alternates (not
     // listed on /v1/models) also stays off the codex picker — the operator
     // opted out of the default listing surface on that side too.
-    const out = assembleCatalog(bundled, [
+    const out = assembleCodexCatalog(bundled, [
       entry(chat('gpt-5.5'), true),
       entry(chat('gpt-5.4')),
     ]);
@@ -154,12 +154,12 @@ describe('assembleCatalog', () => {
       ...chat('openrouter/gpt-5.5:nitro'),
       pricing: { entries: [{ rates: { input_tokens: '1' } }, { selector: { serviceTier: 'fast' }, rates: { input_tokens: '1' } }] },
     };
-    const out = assembleCatalog(bundled, entries(im));
+    const out = assembleCodexCatalog(bundled, entries(im));
     expect(out.models[0].service_tiers).toEqual([{ id: 'fast', name: 'fast', description: '' }]);
   });
 
   test('bundled reuse: no registry pricing.entries yields service_tiers: []', () => {
-    const out = assembleCatalog(bundled, entries(chat('openrouter/gpt-5.5:nitro')));
+    const out = assembleCodexCatalog(bundled, entries(chat('openrouter/gpt-5.5:nitro')));
     expect(out.models[0].service_tiers).toEqual([]);
   });
 });

--- a/packages/gateway/src/data-plane/codex/routes.ts
+++ b/packages/gateway/src/data-plane/codex/routes.ts
@@ -21,12 +21,12 @@
 
 import type { Hono } from 'hono';
 
-import { codexModels } from './models.ts';
 import type { AuthVars } from '../../middleware/auth.ts';
 import { mountAlphaSearchRoute } from '../alpha-search/routes.ts';
 import { responsesHttp } from '../chat/responses/http.ts';
 import { responsesWebSocket } from '../chat/responses/websocket.ts';
 import { imagesEdits, imagesGenerations } from '../images/serve.ts';
+import { serveModels } from '../models/serve.ts';
 
 const CODEX_BASE_PATH = '/azure-api.codex';
 
@@ -41,5 +41,5 @@ export const mountCodexRoutes = (app: Hono<{ Variables: AuthVars }>) => {
   app.post(`${CODEX_BASE_PATH}/images/generations`, imagesGenerations);
   app.post(`${CODEX_BASE_PATH}/images/edits`, imagesEdits);
 
-  app.get(`${CODEX_BASE_PATH}/models`, codexModels);
+  app.get(`${CODEX_BASE_PATH}/models`, serveModels);
 };

--- a/packages/gateway/src/data-plane/codex/routes_test.ts
+++ b/packages/gateway/src/data-plane/codex/routes_test.ts
@@ -25,8 +25,11 @@ const copilotFetch = (models: Array<{ id: string; maxContextWindowTokens?: numbe
     if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
       return jsonResponse(copilotModels(models));
     }
+    if (url.hostname === 'raw.githubusercontent.com') return new Response(null, { status: 404 });
     throw new Error(`Unhandled fetch ${request.url}`);
   };
+
+const CODEX_USER_AGENT = 'codex_cli_rs/0.0.1-unified.catalog';
 
 interface CodexModelsResponse {
   models: Array<{
@@ -95,7 +98,7 @@ describe('Codex model-provider routes', () => {
       copilotFetch([{ id: 'gpt-5.5', maxContextWindowTokens: 1050000 }]),
       async () => {
         const response = await buildCodexApp().request('/azure-api.codex/models', {
-          headers: { authorization: `Bearer ${apiKey.key}` },
+          headers: { authorization: `Bearer ${apiKey.key}`, 'user-agent': CODEX_USER_AGENT },
         });
         expect(response.status).toBe(200);
         return await response.json() as CodexModelsResponse;
@@ -115,7 +118,7 @@ describe('Codex model-provider routes', () => {
       copilotFetch([{ id: 'gpt-5.4', maxContextWindowTokens: 272000 }]),
       async () => {
         const response = await buildCodexApp().request('/azure-api.codex/models', {
-          headers: { authorization: `Bearer ${apiKey.key}` },
+          headers: { authorization: `Bearer ${apiKey.key}`, 'user-agent': CODEX_USER_AGENT },
         });
         expect(response.status).toBe(200);
         return await response.json() as CodexModelsResponse;
@@ -132,7 +135,7 @@ describe('Codex model-provider routes', () => {
     const body = await withMockedFetch(
       copilotFetch([{ id: 'gpt-5.5', maxContextWindowTokens: 1050000 }]),
       async () => await (await buildCodexApp().request('/azure-api.codex/models', {
-        headers: { authorization: `Bearer ${apiKey.key}` },
+        headers: { authorization: `Bearer ${apiKey.key}`, 'user-agent': CODEX_USER_AGENT },
       })).json() as CodexModelsResponse,
     );
 
@@ -144,7 +147,7 @@ describe('Codex model-provider routes', () => {
     const body = await withMockedFetch(
       copilotFetch([{ id: 'claude-sonnet-4', supported_endpoints: ['/v1/messages'] }]),
       async () => await (await buildCodexApp().request('/azure-api.codex/models', {
-        headers: { authorization: `Bearer ${apiKey.key}` },
+        headers: { authorization: `Bearer ${apiKey.key}`, 'user-agent': CODEX_USER_AGENT },
       })).json() as CodexModelsResponse,
     );
 

--- a/packages/gateway/src/data-plane/models/serve.ts
+++ b/packages/gateway/src/data-plane/models/serve.ts
@@ -1,11 +1,14 @@
-// OpenAI and Anthropic /models field names do not overlap, so one payload
-// satisfies both client shapes. The one exception is the Claude Code CLI
-// discovery caller — see toClaudeCodeShape below.
+// All OpenAI-compatible model-list paths terminate here. The request path is
+// deliberately absent from catalog selection: Codex and Claude Code identify
+// their private discovery formats through User-Agent, while every other caller
+// receives Floway's public OpenAI/Anthropic superset.
 
 import type { Context } from 'hono';
 
 import { loadModels } from './load.ts';
 import { MODEL_LISTING_FAILURE_MESSAGE } from './shared.ts';
+import { isCodexUserAgent } from '../codex/catalog.ts';
+import { loadCodexCatalog } from '../codex/models.ts';
 import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import { getRepo } from '../../repo/index.ts';
@@ -43,7 +46,7 @@ import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 // https://code.claude.com/docs/en/llm-gateway-protocol#model-discovery
 // https://docs.claude.com/en/api/models-list
 // https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/models.ts
-const toClaudeCodeShape = (response: PublicModelsResponse) => {
+const toClaudeCodeCatalog = (response: PublicModelsResponse) => {
   const CREATED_AT_UNKNOWN = '1970-01-01T00:00:00Z';
   const data = response.data.map(model => {
     const max = model.limits.max_context_window_tokens;
@@ -65,10 +68,21 @@ const toClaudeCodeShape = (response: PublicModelsResponse) => {
   };
 };
 
-export const models = async (c: Context) => {
+const isClaudeCodeUserAgent = (userAgent: string | undefined): boolean =>
+  userAgent?.startsWith('claude-code/') ?? false;
+
+export const serveModels = async (c: Context): Promise<Response> => {
   try {
+    const userAgent = c.req.header('user-agent');
     const fetcherForUpstream = await createPerRequestFetcher(getRuntimeLocation(c.req.raw));
-    const response = await loadModels(effectiveUpstreamIdsFromContext(c), fetcherForUpstream, backgroundSchedulerFromContext(c), getRepo().modelAliases);
+    const upstreamIds = effectiveUpstreamIdsFromContext(c);
+    const scheduler = backgroundSchedulerFromContext(c);
+
+    if (isCodexUserAgent(userAgent)) {
+      return Response.json(await loadCodexCatalog(userAgent, upstreamIds, fetcherForUpstream, scheduler));
+    }
+
+    const publicCatalog = await loadModels(upstreamIds, fetcherForUpstream, scheduler, getRepo().modelAliases);
     // The Claude Code CLI's model discovery request identifies itself with
     // a `claude-code/<version>` User-Agent (built from the CLI's `n_()`
     // helper — verified in the v2.1.206 binary). The CLI's other request
@@ -76,10 +90,9 @@ export const models = async (c: Context) => {
     // discovery UA specifically. Every other caller (OpenAI SDKs,
     // Anthropic SDKs, dashboards) receives the standard PublicModel
     // superset.
-    if (c.req.header('user-agent')?.startsWith('claude-code/')) {
-      return Response.json(toClaudeCodeShape(response));
-    }
-    return Response.json(response);
+    return Response.json(isClaudeCodeUserAgent(userAgent)
+      ? toClaudeCodeCatalog(publicCatalog)
+      : publicCatalog);
   } catch (e) {
     // Upstream HTTP/parse failures squash to a generic message so we do not
     // leak upstream identity. Other registry-thrown errors (e.g. the "no

--- a/packages/gateway/src/data-plane/models/serve.ts
+++ b/packages/gateway/src/data-plane/models/serve.ts
@@ -7,13 +7,13 @@ import type { Context } from 'hono';
 
 import { loadModels } from './load.ts';
 import { MODEL_LISTING_FAILURE_MESSAGE } from './shared.ts';
-import { isCodexUserAgent } from '../codex/catalog.ts';
-import { loadCodexCatalog } from '../codex/models.ts';
 import { createPerRequestFetcher } from '../../dial/per-request.ts';
 import { effectiveUpstreamIdsFromContext } from '../../middleware/auth.ts';
 import { getRepo } from '../../repo/index.ts';
 import { backgroundSchedulerFromContext } from '../../runtime/background.ts';
 import { getRuntimeLocation } from '../../runtime/runtime-info.ts';
+import { isCodexUserAgent } from '../codex/catalog.ts';
+import { loadCodexCatalog } from '../codex/models.ts';
 import type { PublicModelsResponse } from '@floway-dev/protocols/common';
 import { ProviderModelsUnavailableError } from '@floway-dev/provider';
 

--- a/packages/gateway/src/data-plane/models/serve_test.ts
+++ b/packages/gateway/src/data-plane/models/serve_test.ts
@@ -175,6 +175,54 @@ test('/v1/models returns merged model list from Copilot and custom upstreams', a
   );
 });
 
+test('Codex User-Agents receive the Codex catalog from root model-list paths', async () => {
+  const { apiKey } = await setupAppTest();
+
+  await withMockedFetch(
+    request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({
+          token: 'copilot-access-token',
+          expires_at: 4102444800,
+          refresh_in: 3600,
+          endpoints: { api: 'https://api.individual.githubcopilot.com' },
+        });
+      }
+      if (url.hostname === 'api.individual.githubcopilot.com' && url.pathname === '/models') {
+        return jsonResponse(copilotModels([{
+          id: 'gpt-5.4',
+          display_name: 'GPT-5.4',
+          supported_endpoints: ['/v1/chat/completions'],
+          maxContextWindowTokens: 272_000,
+        }]));
+      }
+      if (url.hostname === 'raw.githubusercontent.com') return new Response(null, { status: 404 });
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      for (const [path, userAgent] of [
+        ['/models', 'codex-tui/0.0.1-unified.catalog'],
+        ['/v1/models', 'codex_cli_rs/0.0.1-unified.catalog'],
+      ] as const) {
+        const codexResponse = await requestApp(path, {
+          headers: { 'x-api-key': apiKey.key, 'user-agent': userAgent },
+        });
+        assertEquals(codexResponse.status, 200);
+        const codexCatalog = await codexResponse.json() as {
+          object?: unknown;
+          data?: unknown;
+          models: Array<{ slug: string }>;
+        };
+        assertEquals(codexCatalog.object, undefined);
+        assertEquals(codexCatalog.data, undefined);
+        assertEquals(codexCatalog.models.map(model => model.slug), ['gpt-5.4']);
+      }
+    },
+  );
+});
+
 test('/models returns the same superset payload as /v1/models', async () => {
   const { apiKey, repo } = await setupAppTest();
   // Image-kind projection requires a non-Copilot id like gpt-image-* (matched

--- a/packages/gateway/src/data-plane/routes.ts
+++ b/packages/gateway/src/data-plane/routes.ts
@@ -7,7 +7,7 @@ import { completions } from './completions/serve.ts';
 import { embeddings } from './embeddings/serve.ts';
 import { imagesEdits, imagesGenerations } from './images/serve.ts';
 import { serveGeminiModelInfo, serveGeminiModels } from './models/gemini.ts';
-import { models } from './models/serve.ts';
+import { serveModels } from './models/serve.ts';
 import { rerank } from './rerank/serve.ts';
 import type { AuthVars } from '../middleware/auth.ts';
 
@@ -16,8 +16,8 @@ export const mountDataPlane = (app: Hono<{ Variables: AuthVars }>) => {
   mountChatRoutes(app);
   mountCodexRoutes(app);
 
-  app.get('/v1/models', models);
-  app.get('/models', models);
+  app.get('/v1/models', serveModels);
+  app.get('/models', serveModels);
   app.get('/v1beta/models', serveGeminiModels);
   app.get('/v1beta/models/:modelId{.+}', serveGeminiModelInfo);
   app.post('/v1/embeddings', embeddings);

--- a/packages/gateway/src/data-plane/shared/listing/alias.ts
+++ b/packages/gateway/src/data-plane/shared/listing/alias.ts
@@ -327,12 +327,12 @@ export const synthesizeListedAliases = (input: ListedAliasInputs): InternalModel
 
 // Compose real-model rows with visible alias rows into a single `InternalModel[]`.
 // Shared merge point across the alias-aware listing endpoints (OpenAI
-// `/v1/models`, Gemini `/v1beta/models`, dashboard `/api/models`); Codex
-// `/models` opts out by consuming the real-only catalog directly. Callers
-// project the returned rows onto their wire shape with a single mapper
-// that reads `.aliasedFrom` off the discriminated union to decide whether
-// to emit the alias sidecar. Collision handling is spelled out at the file
-// header.
+// `/v1/models`, Gemini `/v1beta/models`, dashboard `/api/models`); the Codex
+// wire-shape branch in the shared models handler opts out by consuming the
+// real-only catalog directly. Callers project the returned rows onto their
+// wire shape with a single mapper that reads `.aliasedFrom` off the
+// discriminated union to decide whether to emit the alias sidecar. Collision
+// handling is spelled out at the file header.
 export const mergeAliasesIntoModels = (input: {
   readonly realModels: readonly InternalModel[];
   readonly gatewayAddressableModelIds: readonly AddressableIdEntry[];


### PR DESCRIPTION
## Summary

- Route `/models`, `/v1/models`, and the Codex-compatible model path through one handler that selects Codex, Claude Code, or public wire shape exclusively from `User-Agent`.
- Convert the former Codex HTTP handler into a reusable catalog loader while retaining the existing semver-aware Codex originator matcher, including current `codex-tui` traffic.
- Verify Codex model discovery from root provider base URLs and preserve the namespaced path as a compatibility entry point.

## Test Plan

- [x] `pnpm run test` (393 test files, 4824 tests)
- [x] `pnpm run lint`
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
