### PR TITLE
feat(pricing): add Claude Opus 5

### DIFF
--- a/packages/gateway/src/data-plane/providers/models-cache.ts
+++ b/packages/gateway/src/data-plane/providers/models-cache.ts
@@ -15,7 +15,7 @@ const HARD_MS = 24 * 60 * 60 * 1000;
 // Persisted ProviderModel rows contain code-derived metadata as well as the
 // upstream response. Increment this whenever that derived catalog contract or
 // its serialization changes so older rows become cold across deployments.
-export const MODEL_CATALOG_REVISION = 3;
+export const MODEL_CATALOG_REVISION = 4;
 
 export interface ModelsCacheFetchOptions {
   scheduler: BackgroundScheduler;

--- a/packages/provider-claude-code/src/pricing.ts
+++ b/packages/provider-claude-code/src/pricing.ts
@@ -5,8 +5,9 @@
 // https://docs.claude.com/en/docs/about-claude/pricing
 //
 // Prompt-cache ratios are input × 0.1 (read), × 1.25 (5-minute write), and
-// × 2 (1-hour write). Fast mode is an explicit `serviceTier: 'fast'` entry for
-// Opus 4.6–4.8; each entry records its own cache rates.
+// × 2 (1-hour write). Fast mode is an explicit `serviceTier: 'fast'` entry
+// priced as a flat multiple of base: 6× on Opus 4.6/4.7, lowered to 2× from
+// Opus 4.8 onward (Opus 4.8, Opus 5); each entry records its own cache rates.
 
 import { tokenBasePricing, tokenModelPricing, tokenPricingEntry as pricingEntry, type ModelPricing, type PriceVector } from '@floway-dev/protocols/common';
 
@@ -18,13 +19,14 @@ const SONNET_PRICING = tokenBasePricing({ input_tokens: '3', input_cache_read_to
 // Sonnet 5 introductory pricing runs through 2026-08-31.
 const SONNET_5_INTRO_PRICING = tokenBasePricing({ input_tokens: '2', input_cache_read_tokens: '0.2', input_cache_write_tokens: '2.5', input_cache_write_1h_tokens: '4', output_tokens: '10' });
 const OPUS_PRICING = tokenBasePricing(OPUS_RATES);
-const OPUS_46_47_PRICING = fastPricing(OPUS_RATES, { input_tokens: '30', input_cache_read_tokens: '3', input_cache_write_tokens: '37.5', input_cache_write_1h_tokens: '60', output_tokens: '150' });
-const OPUS_48_PRICING = fastPricing(OPUS_RATES, { input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', input_cache_write_1h_tokens: '20', output_tokens: '50' });
+const OPUS_FAST6X_PRICING = fastPricing(OPUS_RATES, { input_tokens: '30', input_cache_read_tokens: '3', input_cache_write_tokens: '37.5', input_cache_write_1h_tokens: '60', output_tokens: '150' });
+const OPUS_FAST2X_PRICING = fastPricing(OPUS_RATES, { input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', input_cache_write_1h_tokens: '20', output_tokens: '50' });
 
 const CLAUDE_CODE_MODEL_PRICING: Record<string, ModelPricing> = {
-  'claude-opus-4-8': OPUS_48_PRICING,
-  'claude-opus-4-7': OPUS_46_47_PRICING,
-  'claude-opus-4-6': OPUS_46_47_PRICING,
+  'claude-opus-5': OPUS_FAST2X_PRICING,
+  'claude-opus-4-8': OPUS_FAST2X_PRICING,
+  'claude-opus-4-7': OPUS_FAST6X_PRICING,
+  'claude-opus-4-6': OPUS_FAST6X_PRICING,
   'claude-sonnet-5': SONNET_5_INTRO_PRICING,
   'claude-sonnet-4-6': SONNET_PRICING,
   'claude-fable-5': tokenBasePricing({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', input_cache_write_1h_tokens: '20', output_tokens: '50' }),

--- a/packages/provider-claude-code/src/pricing_test.ts
+++ b/packages/provider-claude-code/src/pricing_test.ts
@@ -9,11 +9,13 @@ describe('pricingForClaudeCodeModelKey', () => {
   test('returns documented base rates for dated Opus and Fable', () => {
     expect(priceRequest(pricingForClaudeCodeModelKey('claude-sonnet-4-5-20250929'), { inputTokens: 0 }).rates).toEqual(published({ input_tokens: '3', input_cache_read_tokens: '0.3', input_cache_write_tokens: '3.75', input_cache_write_1h_tokens: '6', output_tokens: '15' }));
     expect(priceRequest(pricingForClaudeCodeModelKey('claude-opus-4-5-20251101'), { inputTokens: 0 }).rates).toEqual(published({ input_tokens: '5', input_cache_read_tokens: '0.5', input_cache_write_tokens: '6.25', input_cache_write_1h_tokens: '10', output_tokens: '25' }));
+    expect(priceRequest(pricingForClaudeCodeModelKey('claude-opus-5'), { inputTokens: 0 }).rates).toEqual(published({ input_tokens: '5', input_cache_read_tokens: '0.5', input_cache_write_tokens: '6.25', input_cache_write_1h_tokens: '10', output_tokens: '25' }));
     expect(priceRequest(pricingForClaudeCodeModelKey('claude-sonnet-5'), { inputTokens: 0 }).rates).toEqual(published({ input_tokens: '2', input_cache_read_tokens: '0.2', input_cache_write_tokens: '2.5', input_cache_write_1h_tokens: '4', output_tokens: '10' }));
     expect(priceRequest(pricingForClaudeCodeModelKey('claude-fable-5'), { inputTokens: 0 }).rates).toEqual(published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', input_cache_write_1h_tokens: '20', output_tokens: '50' }));
   });
 
   test('returns explicit fast entries for supported Opus models', () => {
+    expect(priceRequest(pricingForClaudeCodeModelKey('claude-opus-5'), { serviceTier: 'fast', inputTokens: 0 }).rates).toEqual(published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', input_cache_write_1h_tokens: '20', output_tokens: '50' }));
     expect(priceRequest(pricingForClaudeCodeModelKey('claude-opus-4-8'), { serviceTier: 'fast', inputTokens: 0 }).rates).toEqual(published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', input_cache_write_1h_tokens: '20', output_tokens: '50' }));
     expect(priceRequest(pricingForClaudeCodeModelKey('claude-opus-4-7'), { serviceTier: 'fast', inputTokens: 0 }).rates).toEqual(published({ input_tokens: '30', input_cache_read_tokens: '3', input_cache_write_tokens: '37.5', input_cache_write_1h_tokens: '60', output_tokens: '150' }));
     expect(priceRequest(pricingForClaudeCodeModelKey('claude-opus-4-6'), { serviceTier: 'fast', inputTokens: 0 }).rates).toEqual(published({ input_tokens: '30', input_cache_read_tokens: '3', input_cache_write_tokens: '37.5', input_cache_write_1h_tokens: '60', output_tokens: '150' }));

--- a/packages/provider-copilot/src/pricing.ts
+++ b/packages/provider-copilot/src/pricing.ts
@@ -27,6 +27,12 @@ const COPILOT_MODEL_PRICING: readonly PricingRule[] = [
     pricingEntry({ input_tokens: '5', input_cache_read_tokens: '0.5', input_cache_write_tokens: '6.25', output_tokens: '25' }),
     pricingEntry({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }, { serviceTier: 'fast' }),
   )],
+  // Opus 5 lists at Opus 4.8 rates; Copilot bills it at provider API list price.
+  // https://github.blog/changelog/2026-07-24-claude-opus-5-is-now-available-in-github-copilot/
+  ['claude-opus-5', tokenModelPricing(
+    pricingEntry({ input_tokens: '5', input_cache_read_tokens: '0.5', input_cache_write_tokens: '6.25', output_tokens: '25' }),
+    pricingEntry({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }, { serviceTier: 'fast' }),
+  )],
   ['claude-sonnet-5', tokenBasePricing({ input_tokens: '2', input_cache_read_tokens: '0.2', input_cache_write_tokens: '2.5', output_tokens: '10' })],
   [/^claude-sonnet-4(-[56])?$/, tokenBasePricing({ input_tokens: '3', input_cache_read_tokens: '0.3', input_cache_write_tokens: '3.75', output_tokens: '15' })],
   ['claude-haiku-4-5', tokenBasePricing({ input_tokens: '1', input_cache_read_tokens: '0.1', input_cache_write_tokens: '1.25', output_tokens: '5' })],

--- a/packages/provider-copilot/src/pricing_test.ts
+++ b/packages/provider-copilot/src/pricing_test.ts
@@ -12,6 +12,8 @@ test('Copilot Claude pricing uses explicit base and fast entries', () => {
   assertEquals(priceRequest(pricingForCopilotPublicModelId('claude-opus-4-5'), { serviceTier: 'fast', inputTokens: 0 }).rates, OPUS_BASE);
   assertEquals(priceRequest(pricingForCopilotPublicModelId('claude-opus-4-7'), { serviceTier: 'fast', inputTokens: 0 }).rates, published({ input_tokens: '30', input_cache_read_tokens: '3', input_cache_write_tokens: '37.5', output_tokens: '150' }));
   assertEquals(priceRequest(pricingForCopilotPublicModelId('claude-opus-4-8'), { serviceTier: 'fast', inputTokens: 0 }).rates, published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }));
+  assertEquals(priceRequest(pricingForCopilotPublicModelId('claude-opus-5'), { inputTokens: 0 }).rates, OPUS_BASE);
+  assertEquals(priceRequest(pricingForCopilotPublicModelId('claude-opus-5'), { serviceTier: 'fast', inputTokens: 0 }).rates, published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }));
 });
 
 test('Copilot GPT-5.6 pricing resolves standard short and long entries', () => {
@@ -54,4 +56,8 @@ test('pricingForCopilotModelKey strips Claude variant suffixes before lookup', (
     assertEquals(priceRequest(pricingForCopilotModelKey(id), { inputTokens: 0 }).rates, OPUS_BASE);
   }
   assertEquals(priceRequest(pricingForCopilotModelKey('claude-opus-4-7-fast'), { serviceTier: 'fast', inputTokens: 0 }).rates, published({ input_tokens: '30', input_cache_read_tokens: '3', input_cache_write_tokens: '37.5', output_tokens: '150' }));
+  for (const id of ['claude-opus-5', 'claude-opus-5-high', 'claude-opus-5-xhigh', 'claude-opus-5-1m']) {
+    assertEquals(priceRequest(pricingForCopilotModelKey(id), { inputTokens: 0 }).rates, OPUS_BASE);
+  }
+  assertEquals(priceRequest(pricingForCopilotModelKey('claude-opus-5-fast'), { serviceTier: 'fast', inputTokens: 0 }).rates, published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }));
 });


### PR DESCRIPTION
## What

Adds pricing for **Claude Opus 5** (`claude-opus-5`, launched 2026-07-24) to the Claude Code and Copilot rate cards.

Opus 5 lists at exactly the same rates as Opus 4.8 (Anthropic: input/output are "$5 per million input tokens and $25 per million output tokens (the same as Opus 4.8)"):

| Dimension | Base | Fast (`serviceTier: 'fast'`, 2× base) |
|---|---|---|
| input | $5.00 | $10.00 |
| cache read | $0.50 | $1.00 |
| cache write 5m | $6.25 | $12.50 |
| cache write 1h | $10.00 | $20.00 |
| output | $25.00 | $50.00 |

GitHub Copilot already exposes the model and bills it at provider API list price, so the Copilot card mirrors the Opus 4.8 base + fast entry.

## Changes

- **provider-claude-code**: add `claude-opus-5` (base + 2× fast). Renamed the two Opus fast-tier constants to `OPUS_FAST6X_PRICING` / `OPUS_FAST2X_PRICING` so the 6×→2× multiplier drop at Opus 4.8 is explicit and Opus 5 reads as a reuse of the current 2× tier.
- **provider-copilot**: add `claude-opus-5` (base + 2× fast), mirroring Opus 4.8.
- **models-cache**: bump `MODEL_CATALOG_REVISION` 3 → 4 so cached `ProviderModel` rows re-fetch the new pricing.
- Tests for both cards, including Copilot variant-suffix stripping (`-fast`, `-high`, `-xhigh`, `-1m`).

Not a breaking change (new model pricing only), so no `CHANGELOG.md` entry.

## Test Plan

- [x] `pnpm run test` — 4842 passed
- [x] `pnpm run typecheck` — all packages clean
- [x] `pnpm run lint` — clean

## Sources

- https://www.anthropic.com/news/claude-opus-5
- https://github.blog/changelog/2026-07-24-claude-opus-5-is-now-available-in-github-copilot/