### PR TITLE
fix(gateway): make D1 state migrations deployable

### DIFF
--- a/packages/gateway/migrations/0062_usage_billing_metrics.sql
+++ b/packages/gateway/migrations/0062_usage_billing_metrics.sql
@@ -10,15 +10,18 @@ CREATE TABLE usage_new (
   unit_price TEXT
 );
 
-WITH formatted_usage AS (
+WITH distinct_prices AS MATERIALIZED (
+  SELECT unit_price, typeof(unit_price) AS decimal_type
+  FROM usage
+  WHERE unit_price IS NOT NULL
+  GROUP BY unit_price, typeof(unit_price)
+), formatted_prices AS (
   SELECT
-    key_id, model, upstream, model_key, hour, pricing_selector,
-    dimension, tokens, typeof(tokens) AS quantity_type, unit_price,
-    typeof(unit_price) AS decimal_type,
+    unit_price,
+    decimal_type,
     CASE
-      WHEN unit_price IS NULL THEN NULL
-      WHEN typeof(unit_price) = 'integer' THEN CAST(unit_price AS TEXT)
-      WHEN typeof(unit_price) != 'real' THEN NULL
+      WHEN decimal_type = 'integer' THEN CAST(unit_price AS TEXT)
+      WHEN decimal_type != 'real' THEN NULL
       ELSE (
         WITH RECURSIVE precisions(digit_count) AS (
           VALUES (1)
@@ -32,8 +35,8 @@ WITH formatted_usage AS (
         LIMIT 1
       )
     END AS decimal_text
-  FROM usage
-), usage_mantissas AS (
+  FROM distinct_prices
+), price_mantissas AS (
   SELECT
     *,
     CASE
@@ -44,14 +47,14 @@ WITH formatted_usage AS (
       WHEN instr(lower(decimal_text), 'e') > 0 THEN CAST(substr(decimal_text, instr(lower(decimal_text), 'e') + 1) AS INTEGER)
       ELSE 0
     END AS source_exponent
-  FROM formatted_usage
-), usage_decimal_parts AS (
+  FROM formatted_prices
+), price_decimal_parts AS (
   SELECT
     *,
     CASE WHEN substr(mantissa, 1, 1) = '-' THEN '-' ELSE '' END AS sign,
     CASE WHEN substr(mantissa, 1, 1) = '-' THEN substr(mantissa, 2) ELSE mantissa END AS unsigned_mantissa
-  FROM usage_mantissas
-), shifted_usage AS (
+  FROM price_mantissas
+), shifted_prices AS (
   SELECT
     *,
     rtrim(replace(unsigned_mantissa, '.', ''), '0') AS digits,
@@ -59,20 +62,31 @@ WITH formatted_usage AS (
       WHEN instr(unsigned_mantissa, '.') > 0 THEN instr(unsigned_mantissa, '.') - 1
       ELSE length(unsigned_mantissa)
     END) + source_exponent - 6 AS decimal_position
-  FROM usage_decimal_parts
+  FROM price_decimal_parts
+), canonical_prices AS MATERIALIZED (
+  SELECT
+    unit_price,
+    CASE
+      WHEN decimal_type NOT IN ('integer', 'real') OR unit_price < 0 OR decimal_text IS NULL THEN json('invalid legacy usage unit price')
+      WHEN unit_price = 0 THEN '0'
+      WHEN decimal_position <= 0 THEN sign || '0.' || printf('%0*d', -decimal_position, 0) || digits
+      WHEN decimal_position >= length(digits) THEN sign || digits || printf('%0*d', decimal_position - length(digits), 0)
+      ELSE sign || substr(digits, 1, decimal_position) || '.' || substr(digits, decimal_position + 1)
+    END AS canonical_unit_price
+  FROM shifted_prices
 )
 INSERT INTO usage_new (
   key_id, model, upstream, model_key, hour, pricing_selector,
   metric, quantity, unit_price
 )
 SELECT
-  key_id,
-  model,
-  upstream,
-  model_key,
-  hour,
-  pricing_selector,
-  CASE dimension
+  usage.key_id,
+  usage.model,
+  usage.upstream,
+  usage.model_key,
+  usage.hour,
+  usage.pricing_selector,
+  CASE usage.dimension
     WHEN 'input' THEN 'input_tokens'
     WHEN 'input_cache_read' THEN 'input_cache_read_tokens'
     WHEN 'input_cache_write' THEN 'input_cache_write_tokens'
@@ -82,18 +96,15 @@ SELECT
     WHEN 'output_image' THEN 'output_image_tokens'
   END,
   CASE
-    WHEN quantity_type = 'integer' AND tokens >= 0 THEN CAST(tokens AS TEXT)
+    WHEN typeof(usage.tokens) = 'integer' AND usage.tokens >= 0 THEN CAST(usage.tokens AS TEXT)
     ELSE json('invalid legacy usage quantity')
   END,
   CASE
-    WHEN unit_price IS NULL THEN NULL
-    WHEN decimal_type NOT IN ('integer', 'real') OR unit_price < 0 OR decimal_text IS NULL THEN json('invalid legacy usage unit price')
-    WHEN unit_price = 0 THEN '0'
-    WHEN decimal_position <= 0 THEN sign || '0.' || printf('%0*d', -decimal_position, 0) || digits
-    WHEN decimal_position >= length(digits) THEN sign || digits || printf('%0*d', decimal_position - length(digits), 0)
-    ELSE sign || substr(digits, 1, decimal_position) || '.' || substr(digits, decimal_position + 1)
+    WHEN usage.unit_price IS NULL THEN NULL
+    ELSE canonical_prices.canonical_unit_price
   END
-FROM shifted_usage;
+FROM usage
+LEFT JOIN canonical_prices ON canonical_prices.unit_price = usage.unit_price;
 
 DROP TABLE usage;
 ALTER TABLE usage_new RENAME TO usage;

--- a/packages/gateway/migrations/0065_responses_state.sql
+++ b/packages/gateway/migrations/0065_responses_state.sql
@@ -116,14 +116,15 @@ CREATE TRIGGER responses_items_validate_payload_insert
 BEFORE INSERT ON responses_items
 WHEN NEW.payload_file_key IS NOT NULL
 BEGIN
-  SELECT CASE WHEN NOT EXISTS (
+  SELECT RAISE(ABORT, 'Responses payload file was not staged for this item')
+  WHERE NOT EXISTS (
     SELECT 1 FROM spilled_files
     WHERE file_key = NEW.payload_file_key
       AND owner_kind = 'responses-item'
       AND owner_key = json_array(NEW.api_key_id, NEW.id)
       AND state = 'staged'
       AND claim_token IS NULL
-  ) THEN RAISE(ABORT, 'Responses payload file was not staged for this item') END;
+  );
 END;
 
 CREATE TRIGGER responses_items_adopt_payload_insert
@@ -143,21 +144,23 @@ CREATE TRIGGER responses_items_validate_payload_update
 BEFORE UPDATE OF payload_file_key ON responses_items
 WHEN OLD.payload_file_key IS NOT NEW.payload_file_key
 BEGIN
-  SELECT CASE WHEN OLD.payload_file_key IS NOT NULL AND NOT EXISTS (
+  SELECT RAISE(ABORT, 'Owned Responses payload file is missing')
+  WHERE OLD.payload_file_key IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM spilled_files
     WHERE file_key = OLD.payload_file_key
       AND owner_kind = 'responses-item'
       AND owner_key = json_array(OLD.api_key_id, OLD.id)
       AND state = 'owned'
-  ) THEN RAISE(ABORT, 'Owned Responses payload file is missing') END;
-  SELECT CASE WHEN NEW.payload_file_key IS NOT NULL AND NOT EXISTS (
+  );
+  SELECT RAISE(ABORT, 'Replacement Responses payload file was not staged for this item')
+  WHERE NEW.payload_file_key IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM spilled_files
     WHERE file_key = NEW.payload_file_key
       AND owner_kind = 'responses-item'
       AND owner_key = json_array(NEW.api_key_id, NEW.id)
       AND state = 'staged'
       AND claim_token IS NULL
-  ) THEN RAISE(ABORT, 'Replacement Responses payload file was not staged for this item') END;
+  );
 END;
 
 CREATE TRIGGER responses_items_replace_payload
@@ -180,13 +183,14 @@ CREATE TRIGGER responses_items_validate_payload_delete
 BEFORE DELETE ON responses_items
 WHEN OLD.payload_file_key IS NOT NULL
 BEGIN
-  SELECT CASE WHEN NOT EXISTS (
+  SELECT RAISE(ABORT, 'Owned Responses payload file is missing')
+  WHERE NOT EXISTS (
     SELECT 1 FROM spilled_files
     WHERE file_key = OLD.payload_file_key
       AND owner_kind = 'responses-item'
       AND owner_key = json_array(OLD.api_key_id, OLD.id)
       AND state = 'owned'
-  ) THEN RAISE(ABORT, 'Owned Responses payload file is missing') END;
+  );
 END;
 
 CREATE TRIGGER responses_items_retire_payload

--- a/packages/gateway/migrations/0066_expiration_sweeps.sql
+++ b/packages/gateway/migrations/0066_expiration_sweeps.sql
@@ -39,11 +39,11 @@ BEGIN
     'responses',
     NEW.api_key_id,
     COALESCE((
-      SELECT CASE
-        WHEN deleted_at IS NULL AND responses_retention_seconds > 0
-          THEN NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1
-        ELSE 0
-      END
+      SELECT iif(
+        deleted_at IS NULL AND responses_retention_seconds > 0,
+        NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1,
+        0
+      )
       FROM api_keys WHERE id = NEW.api_key_id
     ), 0)
   )
@@ -62,11 +62,11 @@ BEGIN
     'responses',
     NEW.api_key_id,
     COALESCE((
-      SELECT CASE
-        WHEN deleted_at IS NULL AND responses_retention_seconds > 0
-          THEN NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1
-        ELSE 0
-      END
+      SELECT iif(
+        deleted_at IS NULL AND responses_retention_seconds > 0,
+        NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1,
+        0
+      )
       FROM api_keys WHERE id = NEW.api_key_id
     ), 0)
   )
@@ -85,11 +85,11 @@ BEGIN
     'responses',
     NEW.api_key_id,
     COALESCE((
-      SELECT CASE
-        WHEN deleted_at IS NULL AND responses_retention_seconds > 0
-          THEN NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1
-        ELSE 0
-      END
+      SELECT iif(
+        deleted_at IS NULL AND responses_retention_seconds > 0,
+        NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1,
+        0
+      )
       FROM api_keys WHERE id = NEW.api_key_id
     ), 0)
   )
@@ -108,11 +108,11 @@ BEGIN
     'responses',
     NEW.api_key_id,
     COALESCE((
-      SELECT CASE
-        WHEN deleted_at IS NULL AND responses_retention_seconds > 0
-          THEN NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1
-        ELSE 0
-      END
+      SELECT iif(
+        deleted_at IS NULL AND responses_retention_seconds > 0,
+        NEW.refreshed_at + responses_retention_seconds * 1000 + 86400000 + 1,
+        0
+      )
       FROM api_keys WHERE id = NEW.api_key_id
     ), 0)
   )
@@ -126,18 +126,19 @@ END;
 CREATE TRIGGER dump_records_validate_spilled_files
 BEFORE INSERT ON dump_records
 BEGIN
-  SELECT CASE WHEN NEW.request_body_descriptor IS NOT NULL
-    AND json_type(NEW.request_body_descriptor, '$.key') IS NOT 'text'
-  THEN RAISE(ABORT, 'Dump request body file key must be text') END;
-  SELECT CASE WHEN NEW.response_body_descriptor IS NOT NULL
-    AND json_type(NEW.response_body_descriptor, '$.key') IS NOT 'text'
-  THEN RAISE(ABORT, 'Dump response body file key must be text') END;
+  SELECT RAISE(ABORT, 'Dump request body file key must be text')
+  WHERE NEW.request_body_descriptor IS NOT NULL
+    AND json_type(NEW.request_body_descriptor, '$.key') IS NOT 'text';
+  SELECT RAISE(ABORT, 'Dump response body file key must be text')
+  WHERE NEW.response_body_descriptor IS NOT NULL
+    AND json_type(NEW.response_body_descriptor, '$.key') IS NOT 'text';
 
   -- Migrations run before the new Worker is published, so an old writer may
   -- still insert its deterministic path without a staged registry row. Only
   -- the exact path derived from that row is accepted directly; per-write
   -- unique paths still require staging, and a collector claim always wins.
-  SELECT CASE WHEN NEW.request_body_descriptor IS NOT NULL AND NOT EXISTS (
+  SELECT RAISE(ABORT, 'Dump request body file was not staged')
+  WHERE NEW.request_body_descriptor IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM spilled_files
     WHERE file_key = json_extract(NEW.request_body_descriptor, '$.key')
       AND owner_kind = 'dump-request'
@@ -152,9 +153,9 @@ BEGIN
       WHERE file_key = json_extract(NEW.request_body_descriptor, '$.key')
         AND claim_token IS NOT NULL
     )
-  )
-  THEN RAISE(ABORT, 'Dump request body file was not staged') END;
-  SELECT CASE WHEN NEW.response_body_descriptor IS NOT NULL AND NOT EXISTS (
+  );
+  SELECT RAISE(ABORT, 'Dump response body file was not staged')
+  WHERE NEW.response_body_descriptor IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM spilled_files
     WHERE file_key = json_extract(NEW.response_body_descriptor, '$.key')
       AND owner_kind = 'dump-response'
@@ -169,8 +170,7 @@ BEGIN
       WHERE file_key = json_extract(NEW.response_body_descriptor, '$.key')
         AND claim_token IS NOT NULL
     )
-  )
-  THEN RAISE(ABORT, 'Dump response body file was not staged') END;
+  );
 END;
 
 CREATE TRIGGER dump_records_adopt_spilled_files
@@ -244,11 +244,11 @@ BEGIN
     'dumps',
     NEW.key_id,
     COALESCE((
-      SELECT CASE
-        WHEN deleted_at IS NULL AND dump_retention_seconds IS NOT NULL
-          THEN NEW.created_at + dump_retention_seconds * 1000 + 1
-        ELSE 0
-      END
+      SELECT iif(
+        deleted_at IS NULL AND dump_retention_seconds IS NOT NULL,
+        NEW.created_at + dump_retention_seconds * 1000 + 1,
+        0
+      )
       FROM api_keys WHERE id = NEW.key_id
     ), 0)
   )


### PR DESCRIPTION
## Summary

Make the already-deployed D1 migrations reproducible through the standard migration command.

- Canonicalize each distinct legacy usage price once so migration 0062 remains within D1 CPU limits on large usage tables while preserving every row's metric, quantity, and canonical unit price.
- Express migration 0065 ownership validation with `WHERE`-guarded `RAISE(...)` statements so Wrangler preserves complete trigger bodies.
- Express migration 0066 scheduling conditions with `iif(...)` and dump validation with guarded `RAISE(...)`, preserving the original true/false/NULL behavior without internal `CASE ... END` tokens that confuse the migration splitter.
- Preserve spill staging, adoption, retirement, collector-claim precedence, legacy dump-writer compatibility, and expiration scheduling semantics.

## Test Plan

- [x] Run the 70 focused usage, pricing, Responses state, and expiration migration tests.
- [x] Verify Wrangler splits migrations 0062, 0065, and 0066 into 2, 25, and 18 complete statements, including all 18 triggers.
- [x] Restore the production D1 database to its pre-deploy bookmark and apply migrations 0061–0066 through `pnpm run db:migrate:remote`.
- [x] Verify the PR migrations are byte-identical to the files executed in production.
- [x] Compare all 18 production trigger definitions with the schema generated by the PR migrations.
- [x] Verify production usage quantities and unit prices are canonical text values and model pricing contains no numeric rates.
