### PR TITLE
feat(telemetry): scope telemetry reads by what they expose

### DIFF
--- a/apps/web/src/components/settings/ImportSection.vue
+++ b/apps/web/src/components/settings/ImportSection.vue
@@ -20,7 +20,7 @@ interface ExportPayload {
 
 // The dashboard only round-trips the current export format. Older exports are
 // rejected rather than silently coerced.
-const EXPORT_VERSION = 16 as const;
+const EXPORT_VERSION = 17 as const;
 
 const api = useApi();
 

--- a/apps/web/src/components/users/UserDialog.vue
+++ b/apps/web/src/components/users/UserDialog.vue
@@ -25,7 +25,6 @@ const api = useApi();
 const username = ref('');
 const password = ref('');
 const isAdmin = ref(false);
-const canViewGlobalTelemetry = ref(false);
 const upstreamSelection = ref<UpstreamPickerValue>({ override: false, ids: [] });
 const saving = ref(false);
 const error = ref<string | null>(null);
@@ -35,13 +34,11 @@ const reset = () => {
     username.value = '';
     password.value = '';
     isAdmin.value = false;
-    canViewGlobalTelemetry.value = false;
     upstreamSelection.value = { override: false, ids: [] };
   } else {
     username.value = props.user.username;
     password.value = '';
     isAdmin.value = props.user.isAdmin;
-    canViewGlobalTelemetry.value = props.user.canViewGlobalTelemetry;
     upstreamSelection.value = props.user.upstreamIds === null
       ? { override: false, ids: [] }
       : { override: true, ids: props.user.upstreamIds };
@@ -54,7 +51,6 @@ watch(open, v => { if (v) reset(); }, { immediate: true });
 const isUserOne = computed(() => props.mode === 'edit' && props.user.id === 1);
 const isSelf = computed(() => props.mode === 'edit' && props.user.id === props.actorUserId);
 const adminLocked = computed(() => isUserOne.value || isSelf.value);
-const globalTelemetryLocked = computed(() => isAdmin.value);
 const usernameValid = computed(() => /^[a-zA-Z0-9_.\-]{1,64}$/.test(username.value.trim()));
 
 const titleText = computed(() => props.mode === 'create' ? 'New user' : `Edit — ${props.user.username}`);
@@ -83,7 +79,6 @@ const submit = async () => {
           username: username.value.trim(),
           password: password.value,
           isAdmin: isAdmin.value,
-          canViewGlobalTelemetry: canViewGlobalTelemetry.value,
           upstreamIds,
         },
       }),
@@ -96,10 +91,9 @@ const submit = async () => {
   }
 
   const target = props.user;
-  const body: { username?: string; isAdmin?: boolean; canViewGlobalTelemetry?: boolean; upstreamIds: string[] | null } = { upstreamIds };
+  const body: { username?: string; isAdmin?: boolean; upstreamIds: string[] | null } = { upstreamIds };
   if (username.value.trim() !== target.username) body.username = username.value.trim();
   if (!adminLocked.value && isAdmin.value !== target.isAdmin) body.isAdmin = isAdmin.value;
-  if (canViewGlobalTelemetry.value !== target.canViewGlobalTelemetry) body.canViewGlobalTelemetry = canViewGlobalTelemetry.value;
   const { error: err } = await callApi(
     () => api.api.users[':id'].$patch({ param: { id: String(target.id) }, json: body }),
   );
@@ -124,33 +118,17 @@ const submit = async () => {
         <SecretInput v-model="password" />
       </div>
 
-      <div class="grid gap-3 sm:grid-cols-2">
-        <label class="flex items-center justify-between rounded-md border border-white/[0.06] bg-surface-800/40 px-3 py-2.5">
-          <span>
-            <p class="text-sm text-white">Administrator</p>
-            <p class="text-xs text-gray-500">
-              <template v-if="isUserOne">User 1 cannot be demoted.</template>
-              <template v-else-if="isSelf">You cannot demote yourself.</template>
-              <template v-else>Manages users, upstreams, search config, import/export.</template>
-            </p>
-          </span>
-          <Switch v-model="isAdmin" :disabled="adminLocked" />
-        </label>
-        <label class="flex items-center justify-between rounded-md border border-white/[0.06] bg-surface-800/40 px-3 py-2.5">
-          <span>
-            <p class="text-sm text-white">Global telemetry visibility</p>
-            <p class="text-xs text-gray-500">
-              <template v-if="globalTelemetryLocked">Admins always see global telemetry.</template>
-              <template v-else>Allow viewing other users' performance. Usage stays admin-only.</template>
-            </p>
-          </span>
-          <Switch
-            :model-value="isAdmin || canViewGlobalTelemetry"
-            :disabled="globalTelemetryLocked"
-            @update:model-value="v => canViewGlobalTelemetry = !!v"
-          />
-        </label>
-      </div>
+      <label class="flex items-center justify-between rounded-md border border-white/[0.06] bg-surface-800/40 px-3 py-2.5">
+        <span>
+          <p class="text-sm text-white">Administrator</p>
+          <p class="text-xs text-gray-500">
+            <template v-if="isUserOne">User 1 cannot be demoted.</template>
+            <template v-else-if="isSelf">You cannot demote yourself.</template>
+            <template v-else>Manages users, upstreams, search config, import/export. Also the only role that can read usage across users and break performance down by user.</template>
+          </p>
+        </span>
+        <Switch v-model="isAdmin" :disabled="adminLocked" />
+      </label>
 
       <UpstreamPicker
         v-model="upstreamSelection"

--- a/apps/web/src/components/users/UserDialog.vue
+++ b/apps/web/src/components/users/UserDialog.vue
@@ -141,7 +141,7 @@ const submit = async () => {
             <p class="text-sm text-white">Global telemetry visibility</p>
             <p class="text-xs text-gray-500">
               <template v-if="globalTelemetryLocked">Admins always see global telemetry.</template>
-              <template v-else>Allow viewing other users' usage and performance.</template>
+              <template v-else>Allow viewing other users' performance. Usage stays admin-only.</template>
             </p>
           </span>
           <Switch

--- a/apps/web/src/components/users/UsersTable.vue
+++ b/apps/web/src/components/users/UsersTable.vue
@@ -30,7 +30,6 @@ const isProtected = (id: number) => id === 1 || id === props.actorUserId;
         <tr class="border-b border-white/5">
           <th class="text-left py-2 pr-4 pl-2 text-xs font-medium text-gray-500 uppercase tracking-widest">Username</th>
           <th class="text-left py-2 pr-4 text-xs font-medium text-gray-500 uppercase tracking-widest">Admin</th>
-          <th class="text-left py-2 pr-4 text-xs font-medium text-gray-500 uppercase tracking-widest">Global telemetry</th>
           <th class="text-left py-2 pr-4 text-xs font-medium text-gray-500 uppercase tracking-widest">Created</th>
           <th class="text-right py-2 pr-2 text-xs font-medium text-gray-500 uppercase tracking-widest">Actions</th>
         </tr>
@@ -47,11 +46,6 @@ const isProtected = (id: number) => id === 1 || id === props.actorUserId;
           <td class="py-3 pr-4">
             <span class="inline-block pointer-events-none" aria-hidden="true">
               <Switch :model-value="u.isAdmin" />
-            </span>
-          </td>
-          <td class="py-3 pr-4">
-            <span class="inline-block pointer-events-none" aria-hidden="true">
-              <Switch :model-value="u.canViewGlobalTelemetry || u.isAdmin" />
             </span>
           </td>
           <td class="py-3 pr-4">

--- a/apps/web/src/components/users/types.ts
+++ b/apps/web/src/components/users/types.ts
@@ -3,6 +3,5 @@ export interface WireUser {
   username: string;
   isAdmin: boolean;
   upstreamIds: string[] | null;
-  canViewGlobalTelemetry: boolean;
   createdAt: string;
 }

--- a/apps/web/src/composables/useDumpSubscription_test.ts
+++ b/apps/web/src/composables/useDumpSubscription_test.ts
@@ -90,7 +90,6 @@ const setup = () => {
       id: 1,
       username: 'op',
       isAdmin: true,
-      canViewGlobalTelemetry: true,
       upstreamIds: null,
     },
   });

--- a/apps/web/src/composables/useModels_test.ts
+++ b/apps/web/src/composables/useModels_test.ts
@@ -11,7 +11,6 @@ const authenticate = (token: string, id: number) => {
       id,
       username: `user-${id}`,
       isAdmin: id === 1,
-      canViewGlobalTelemetry: false,
       upstreamIds: null,
     },
   });

--- a/apps/web/src/pages/dashboard/keys/index_test.ts
+++ b/apps/web/src/pages/dashboard/keys/index_test.ts
@@ -25,7 +25,6 @@ const currentUser = {
   id: 1,
   username: 'admin',
   isAdmin: true,
-  canViewGlobalTelemetry: true,
   upstreamIds: null as string[] | null,
 };
 

--- a/apps/web/src/pages/dashboard/performance-helpers.ts
+++ b/apps/web/src/pages/dashboard/performance-helpers.ts
@@ -167,9 +167,14 @@ export const serializeUrlState = (state: UrlState): Record<string, string> => {
   return out;
 };
 
-export const buildOverviewQuery = (state: UrlState, view: PerformanceView, at: number): Record<string, string> => {
+// The optional filters make this a plain string map, but the backend requires
+// `view`, so it is pinned in the type rather than dissolving into the map —
+// otherwise the RPC client rejects the call.
+export type OverviewQuery = Record<string, string> & { view: PerformanceView };
+
+export const buildOverviewQuery = (state: UrlState, view: PerformanceView, at: number): OverviewQuery => {
   const { start, end, bucket } = dashboardRangeQuery(state.range, at);
-  const q: Record<string, string> = {
+  const q: OverviewQuery = {
     start, end, bucket,
     timezone_offset_minutes: String(new Date().getTimezoneOffset()),
     view,

--- a/apps/web/src/pages/dashboard/performance-helpers.ts
+++ b/apps/web/src/pages/dashboard/performance-helpers.ts
@@ -72,6 +72,7 @@ export const emptyDisplayRecord = (bucket: string, group: string): PerformanceDi
 // so refreshing / copying the URL restores the same view. Only non-default
 // values are written so pristine URLs stay clean.
 export const GROUP_BY_VALUES = ['model', 'upstream', 'operation', 'runtimeLocation', 'keyId', 'userId'] as const;
+const DEFAULT_GROUP_BY = 'model';
 export const METRIC_VALUES = ['ttft', 'tokPerSec'] as const;
 export const PERCENTILE_VALUES = ['p50', 'p95', 'p99'] as const;
 export const RANGE_VALUES = ['today', '7d', '30d'] as const;
@@ -131,7 +132,7 @@ const listField = (urlKey: string): UrlField<string[]> => ({
 export const URL_FIELDS = {
   metric: enumField('m', METRIC_VALUES, 'ttft'),
   percentile: enumField('pct', PERCENTILE_VALUES, 'p95'),
-  groupBy: enumField('g', GROUP_BY_VALUES, 'model'),
+  groupBy: enumField('g', GROUP_BY_VALUES, DEFAULT_GROUP_BY),
   range: enumField('r', RANGE_VALUES, 'today'),
   filterModel: stringField('fm'),
   filterUpstream: stringField('fu'),
@@ -165,6 +166,23 @@ export const serializeUrlState = (state: UrlState): Record<string, string> => {
   }
   return out;
 };
+
+// The backend answers 403 to `group_by=userId` and `filter_user_id` from a
+// non-administrator, and the page renders neither control for them — so a
+// shared or bookmarked URL carrying either would strand them on an error with
+// nothing to click. Drop that state on read; the URL-sync watcher then rewrites
+// the address clean. Dropping the By-User axis takes the hidden-series set with
+// it, since those ids were captured against that axis and mean nothing on the
+// one we fall back to.
+export const clampToPermissions = (state: UrlState, canAttributeUsers: boolean): UrlState =>
+  canAttributeUsers
+    ? state
+    : {
+        ...state,
+        groupBy: state.groupBy === 'userId' ? DEFAULT_GROUP_BY : state.groupBy,
+        hidden: state.groupBy === 'userId' ? [] : state.hidden,
+        filterUserId: '',
+      };
 
 export const buildOverviewQuery = (state: UrlState, at: number): Record<string, string> => {
   const { start, end, bucket } = dashboardRangeQuery(state.range, at);

--- a/apps/web/src/pages/dashboard/performance-helpers.ts
+++ b/apps/web/src/pages/dashboard/performance-helpers.ts
@@ -7,7 +7,6 @@ import type { PerformanceDisplayRecord } from '@floway-dev/gateway/control-plane
 // .vue so they can be exercised by Vitest without mounting Vue, the auth
 // store, or chart libs.
 
-export type PerformanceView = 'all-by-user' | 'self-by-key';
 export type GroupBy = 'keyId' | 'userId' | 'model' | 'upstream' | 'operation' | 'runtimeLocation';
 export type MetricView = 'ttft' | 'tokPerSec';
 export type PercentileKey = 'p50' | 'p95' | 'p99';
@@ -167,17 +166,11 @@ export const serializeUrlState = (state: UrlState): Record<string, string> => {
   return out;
 };
 
-// The optional filters make this a plain string map, but the backend requires
-// `view`, so it is pinned in the type rather than dissolving into the map —
-// otherwise the RPC client rejects the call.
-export type OverviewQuery = Record<string, string> & { view: PerformanceView };
-
-export const buildOverviewQuery = (state: UrlState, view: PerformanceView, at: number): OverviewQuery => {
+export const buildOverviewQuery = (state: UrlState, at: number): Record<string, string> => {
   const { start, end, bucket } = dashboardRangeQuery(state.range, at);
-  const q: OverviewQuery = {
+  const q: Record<string, string> = {
     start, end, bucket,
     timezone_offset_minutes: String(new Date().getTimezoneOffset()),
-    view,
     group_by: state.groupBy,
   };
   if (state.filterModel !== '') q.filter_model = state.filterModel;

--- a/apps/web/src/pages/dashboard/performance-helpers_test.ts
+++ b/apps/web/src/pages/dashboard/performance-helpers_test.ts
@@ -3,6 +3,7 @@ import type { LocationQuery } from 'vue-router';
 
 import {
   buildOverviewQuery,
+  clampToPermissions,
   emptyDisplayRecord,
   emptyOverview,
   parseUrlState,
@@ -175,6 +176,30 @@ describe('emptyOverview + emptyDisplayRecord', () => {
       tpotUsP95: null,
       tpotUsP99: null,
     });
+  });
+});
+
+describe('clampToPermissions', () => {
+  it('leaves an administrator\'s state untouched', () => {
+    const admin = state({ groupBy: 'userId', filterUserId: '42', hidden: ['3'] });
+    expect(clampToPermissions(admin, true)).toEqual(state({ groupBy: 'userId', filterUserId: '42', hidden: ['3'] }));
+  });
+
+  it('drops the By-User grouping, its hidden series, and the user filter for everyone else', () => {
+    const clamped = clampToPermissions(state({ groupBy: 'userId', filterUserId: '42', hidden: ['3', '7'] }), false);
+    expect(clamped.groupBy).toBe('model');
+    expect(clamped.filterUserId).toBe('');
+    // Those ids were user ids on the discarded axis; they would silently hide
+    // unrelated groups on the fallback one.
+    expect(clamped.hidden).toEqual([]);
+  });
+
+  it('leaves every other breakdown and filter alone', () => {
+    const clamped = clampToPermissions(state({ groupBy: 'keyId', filterKeyId: 'k-1', filterModel: 'gpt-5', hidden: ['k-9'] }), false);
+    expect(clamped.groupBy).toBe('keyId');
+    expect(clamped.filterKeyId).toBe('k-1');
+    expect(clamped.filterModel).toBe('gpt-5');
+    expect(clamped.hidden).toEqual(['k-9']);
   });
 });
 

--- a/apps/web/src/pages/dashboard/performance-helpers_test.ts
+++ b/apps/web/src/pages/dashboard/performance-helpers_test.ts
@@ -181,10 +181,9 @@ describe('emptyOverview + emptyDisplayRecord', () => {
 describe('buildOverviewQuery', () => {
   const fixedNow = Date.UTC(2026, 6, 12, 12, 0, 0);
 
-  it('always emits start/end/bucket/view/group_by/timezone_offset_minutes', () => {
-    const q = buildOverviewQuery(state(), 'all-by-user', fixedNow);
+  it('always emits start/end/bucket/group_by/timezone_offset_minutes', () => {
+    const q = buildOverviewQuery(state(), fixedNow);
     expect(q).toMatchObject({
-      view: 'all-by-user',
       group_by: 'model',
       bucket: 'hour',
     });
@@ -194,14 +193,14 @@ describe('buildOverviewQuery', () => {
   });
 
   it('bucket tracks the range: today=hour, 7d=4h, 30d=day', () => {
-    expect(buildOverviewQuery(state({ range: 'today' }), 'self-by-key', fixedNow).bucket).toBe('hour');
-    expect(buildOverviewQuery(state({ range: '7d' }), 'self-by-key', fixedNow).bucket).toBe('4h');
-    expect(buildOverviewQuery(state({ range: '30d' }), 'self-by-key', fixedNow).bucket).toBe('day');
+    expect(buildOverviewQuery(state({ range: 'today' }), fixedNow).bucket).toBe('hour');
+    expect(buildOverviewQuery(state({ range: '7d' }), fixedNow).bucket).toBe('4h');
+    expect(buildOverviewQuery(state({ range: '30d' }), fixedNow).bucket).toBe('day');
   });
 
   it('every empty filter is elided; every non-empty filter reaches the query with its backend key', () => {
     // Empty baseline: none of the filter_* keys appear.
-    const empty = buildOverviewQuery(state(), 'all-by-user', fixedNow);
+    const empty = buildOverviewQuery(state(), fixedNow);
     expect(empty.filter_model).toBeUndefined();
     expect(empty.filter_upstream).toBeUndefined();
     expect(empty.filter_operation).toBeUndefined();
@@ -216,7 +215,7 @@ describe('buildOverviewQuery', () => {
       filterRuntime: 'sfo',
       filterUserId: '42',
       filterKeyId: 'k-1',
-    }), 'all-by-user', fixedNow);
+    }), fixedNow);
     expect(populated.filter_model).toBe('gpt-5');
     expect(populated.filter_upstream).toBe('copilot');
     expect(populated.filter_operation).toBe('chat');

--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -17,7 +17,6 @@ import {
   type MetricView,
   type PercentileKey,
   type PerformanceOverviewResponse,
-  type PerformanceView,
   type SortDir,
   type TableSortKey,
   type UrlState,
@@ -35,9 +34,8 @@ import { OverlayScrollbars, Spinner } from '@floway-dev/ui';
 export const usePerformancePageData = defineBasicLoader('/dashboard/performance', async route => {
   const api = useApi();
   const auth = useAuthStore();
-  const view: PerformanceView = auth.canViewGlobalTelemetry ? 'all-by-user' : 'self-by-key';
   const initial = parseUrlState(route.query);
-  const query = buildOverviewQuery(initial, view, Date.now());
+  const query = buildOverviewQuery(initial, Date.now());
   // Load upstream names in parallel with the perf overview so By-Upstream tables
   // and chart legends can resolve upstream ids to human-readable names. Store is
   // module-scoped, so this is a no-op when the user has already visited Settings.
@@ -55,7 +53,6 @@ export const usePerformancePageData = defineBasicLoader('/dashboard/performance'
         }),
   ]);
   return {
-    view,
     // Per-user breakdowns are administrator-only. The backend rejects
     // group_by=userId and filter_user_id for everyone else and returns no
     // By-User rows, so the page must not offer either control.
@@ -73,12 +70,9 @@ const route = useRoute();
 const router = useRouter();
 const initialOverview = usePerformancePageData();
 
-// View and per-user attribution are both resolved once from the caller's
-// permissions — global telemetry opens every user's rows in aggregate, while
-// naming the users behind them stays administrator-only. The dashboard doesn't
-// expose a toggle; the underlying backend `view` param is still threaded
-// through.
-const performanceView: PerformanceView = initialOverview.data.value.view;
+// Resolved once from the caller's permissions: naming the users behind the
+// rows is administrator-only, so both the By-User grouping and the user filter
+// disappear for everyone else.
 const attributeUsers: boolean = initialOverview.data.value.attributeUsers;
 
 // Initialize every ref from the URL so the page opens in the same state that
@@ -133,7 +127,7 @@ const load = async () => {
   const requestedRange = performanceRange.value;
   const requestedAt = Date.now();
   performanceLoading.value = true;
-  const query = buildOverviewQuery(currentUrlState(), performanceView, requestedAt);
+  const query = buildOverviewQuery(currentUrlState(), requestedAt);
   const { data, error: err } = await callApi<PerformanceOverviewResponse>(() => api.api.performance.overview.$get({ query }));
   if (requestId !== performanceRequestId) return;
   performanceLoading.value = false;
@@ -193,8 +187,9 @@ watchEffect(() => {
   void router.replace({ query: serializeUrlState(currentUrlState()) });
 });
 
-// By User is administrator-only. By API Key is always scoped to the actor's
-// own keys, including inside the global view.
+// The breakdown doubles as the scope selector: By API Key narrows the whole
+// page to the actor's own traffic, every other one spans all users. By User is
+// administrator-only.
 const groupByOptions: { value: GroupBy; label: string }[] = [
   { value: 'model', label: 'By Model' },
   { value: 'upstream', label: 'By Upstream' },

--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -56,6 +56,10 @@ export const usePerformancePageData = defineBasicLoader('/dashboard/performance'
   ]);
   return {
     view,
+    // Per-user breakdowns are administrator-only. The backend rejects
+    // group_by=userId and filter_user_id for everyone else and returns no
+    // By-User rows, so the page must not offer either control.
+    attributeUsers: auth.isAdmin,
     overview: overviewRes.data ?? emptyOverview(),
     error: overviewRes.error ? overviewRes.error.message : null,
   };
@@ -69,10 +73,13 @@ const route = useRoute();
 const router = useRouter();
 const initialOverview = usePerformancePageData();
 
-// View is resolved once from the caller's permission — admins see all users'
-// data, regular users see only their own keys. The dashboard doesn't expose
-// a toggle; the underlying backend `view` param is still threaded through.
+// View and per-user attribution are both resolved once from the caller's
+// permissions — global telemetry opens every user's rows in aggregate, while
+// naming the users behind them stays administrator-only. The dashboard doesn't
+// expose a toggle; the underlying backend `view` param is still threaded
+// through.
 const performanceView: PerformanceView = initialOverview.data.value.view;
+const attributeUsers: boolean = initialOverview.data.value.attributeUsers;
 
 // Initialize every ref from the URL so the page opens in the same state that
 // was captured when the URL was minted (bookmark / share). The URL-sync
@@ -186,15 +193,15 @@ watchEffect(() => {
   void router.replace({ query: serializeUrlState(currentUrlState()) });
 });
 
-// By User is available only with global telemetry access. By API Key is
-// always scoped to the actor's own keys, including inside the global view.
+// By User is administrator-only. By API Key is always scoped to the actor's
+// own keys, including inside the global view.
 const groupByOptions: { value: GroupBy; label: string }[] = [
   { value: 'model', label: 'By Model' },
   { value: 'upstream', label: 'By Upstream' },
   { value: 'operation', label: 'By Operation' },
   { value: 'runtimeLocation', label: 'By Region' },
   { value: 'keyId', label: 'By API Key' },
-  ...(performanceView === 'all-by-user' ? [{ value: 'userId' as const, label: 'By User' }] : []),
+  ...(attributeUsers ? [{ value: 'userId' as const, label: 'By User' }] : []),
 ];
 
 const performanceSeriesIsolation = createSeriesIsolation();
@@ -476,7 +483,7 @@ const performanceSummary = computed<PerformanceDisplayRecord>(() => overview.val
             <option v-for="v in overview.dimensionValues.runtimeLocations" :key="v" :value="v">{{ v }}</option>
           </select>
         </label>
-        <label v-if="performanceView === 'all-by-user' && performanceGroupBy !== 'userId' && performanceGroupBy !== 'keyId'" class="flex items-center gap-1.5 text-xs text-gray-500">
+        <label v-if="attributeUsers && performanceGroupBy !== 'userId' && performanceGroupBy !== 'keyId'" class="flex items-center gap-1.5 text-xs text-gray-500">
           <span>User:</span>
           <select v-model="filterUserId" class="shrink-0 rounded-lg bg-surface-800 px-3 py-1.5 text-xs font-medium text-gray-300 outline-none">
             <option value="">All</option>

--- a/apps/web/src/pages/dashboard/performance.vue
+++ b/apps/web/src/pages/dashboard/performance.vue
@@ -8,6 +8,7 @@ import { useRoute, useRouter } from 'vue-router';
 
 import {
   buildOverviewQuery,
+  clampToPermissions,
   emptyDisplayRecord,
   emptyOverview,
   parseUrlState,
@@ -33,8 +34,7 @@ import { OverlayScrollbars, Spinner } from '@floway-dev/ui';
 
 export const usePerformancePageData = defineBasicLoader('/dashboard/performance', async route => {
   const api = useApi();
-  const auth = useAuthStore();
-  const initial = parseUrlState(route.query);
+  const initial = clampToPermissions(parseUrlState(route.query), useAuthStore().isAdmin);
   const query = buildOverviewQuery(initial, Date.now());
   // Load upstream names in parallel with the perf overview so By-Upstream tables
   // and chart legends can resolve upstream ids to human-readable names. Store is
@@ -53,10 +53,6 @@ export const usePerformancePageData = defineBasicLoader('/dashboard/performance'
         }),
   ]);
   return {
-    // Per-user breakdowns are administrator-only. The backend rejects
-    // group_by=userId and filter_user_id for everyone else and returns no
-    // By-User rows, so the page must not offer either control.
-    attributeUsers: auth.isAdmin,
     overview: overviewRes.data ?? emptyOverview(),
     error: overviewRes.error ? overviewRes.error.message : null,
   };
@@ -70,15 +66,15 @@ const route = useRoute();
 const router = useRouter();
 const initialOverview = usePerformancePageData();
 
-// Resolved once from the caller's permissions: naming the users behind the
-// rows is administrator-only, so both the By-User grouping and the user filter
-// disappear for everyone else.
-const attributeUsers: boolean = initialOverview.data.value.attributeUsers;
+// The backend returns no By-User rows to a non-administrator, so the page
+// offers neither the By-User breakdown nor the user filter. Read once: the page
+// is never kept alive, so every entry to the route re-reads the store.
+const attributeUsers = useAuthStore().isAdmin;
 
 // Initialize every ref from the URL so the page opens in the same state that
 // was captured when the URL was minted (bookmark / share). The URL-sync
 // watchEffect below writes changes back so refreshing preserves them.
-const initial = parseUrlState(route.query);
+const initial = clampToPermissions(parseUrlState(route.query), attributeUsers);
 const filterModel = ref<string>(initial.filterModel);
 const filterUpstream = ref<string>(initial.filterUpstream);
 const filterOperation = ref<string>(initial.filterOperation);
@@ -188,8 +184,7 @@ watchEffect(() => {
 });
 
 // The breakdown doubles as the scope selector: By API Key narrows the whole
-// page to the actor's own traffic, every other one spans all users. By User is
-// administrator-only.
+// page to the actor's own traffic, every other one spans all users.
 const groupByOptions: { value: GroupBy; label: string }[] = [
   { value: 'model', label: 'By Model' },
   { value: 'upstream', label: 'By Upstream' },

--- a/apps/web/src/pages/dashboard/usage.vue
+++ b/apps/web/src/pages/dashboard/usage.vue
@@ -93,7 +93,7 @@ const fetchUsageForView = async (
 export const useUsagePageData = defineBasicLoader(async () => {
   const api = useApi();
   const auth = useAuthStore();
-  const view: UsageView = auth.canViewGlobalTelemetry ? 'all-by-user' : 'self-by-key';
+  const view: UsageView = auth.isAdmin ? 'all-by-user' : 'self-by-key';
   const { start, end } = dashboardRangeQuery('today', Date.now());
   const [{ usage, search }] = await Promise.all([
     fetchUsageForView(api, view, start, end),
@@ -651,7 +651,7 @@ const formatChartCost = (v: number | null) => {
       <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
         <div class="flex items-center gap-3">
           <span class="text-xs font-medium text-gray-500 uppercase tracking-widest">Token Usage</span>
-          <div v-if="auth.canViewGlobalTelemetry" class="inline-flex rounded-md bg-surface-800 p-0.5" role="tablist">
+          <div v-if="auth.isAdmin" class="inline-flex rounded-md bg-surface-800 p-0.5" role="tablist">
             <button
               type="button"
               class="px-2 py-1 text-[11px] font-medium rounded transition-colors"

--- a/apps/web/src/pages/dashboard/users.vue
+++ b/apps/web/src/pages/dashboard/users.vue
@@ -71,9 +71,9 @@ const resetPassword = (u: WireUser) => {
 
 const onUserSaved = async (savedId: number) => {
   await reload();
-  // The actor edited their own row; refresh the in-memory user so admin
-  // flag, telemetry visibility, and upstream cap reflect the saved values
-  // without having to reload the page (where main.ts would re-hydrate).
+  // The actor edited their own row; refresh the in-memory user so the admin
+  // flag and upstream cap reflect the saved values without having to reload
+  // the page (where main.ts would re-hydrate).
   if (savedId === actorUserId.value) {
     const { data, error: err } = await callApi<{ user: AuthUser }>(() => api.auth.me.$get());
     if (err) { error.value = err.message; return; }

--- a/apps/web/src/pages/login_test.ts
+++ b/apps/web/src/pages/login_test.ts
@@ -31,7 +31,6 @@ const loginResult = {
     id: 1,
     username: 'admin',
     isAdmin: true,
-    canViewGlobalTelemetry: true,
     upstreamIds: null,
   },
 };

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -6,22 +6,19 @@ export interface AuthUser {
   id: number;
   username: string;
   isAdmin: boolean;
-  canViewGlobalTelemetry: boolean;
   upstreamIds: string[] | null;
 }
 
-// Only the session token is persisted. Everything else (admin flag, telemetry
-// visibility, upstream cap) is server-authoritative and must be re-fetched
-// from /auth/me on every app boot — caching it in localStorage lets stale
-// permissions linger after an admin promotes/demotes the actor or rotates
-// their upstream cap.
+// Only the session token is persisted. Everything else (admin flag, upstream
+// cap) is server-authoritative and must be re-fetched from /auth/me on every
+// app boot — caching it in localStorage lets stale permissions linger after an
+// admin promotes/demotes the actor or rotates their upstream cap.
 export const useAuthStore = defineStore('auth', () => {
   const token = useLocalStorage<string | null>('floway-token', null);
   const user = ref<AuthUser | null>(null);
 
   const isAuthenticated = computed(() => token.value !== null && user.value !== null);
   const isAdmin = computed(() => user.value?.isAdmin === true);
-  const canViewGlobalTelemetry = computed(() => user.value?.canViewGlobalTelemetry === true);
   const currentUser = computed(() => user.value);
   const authToken = computed(() => token.value);
 
@@ -43,7 +40,6 @@ export const useAuthStore = defineStore('auth', () => {
     isAdmin,
     authToken,
     currentUser,
-    canViewGlobalTelemetry,
     setAuth,
     setUser,
     clearAuth,

--- a/packages/gateway/migrations/0067_drop_global_telemetry_grant.sql
+++ b/packages/gateway/migrations/0067_drop_global_telemetry_grant.sql
@@ -6,7 +6,7 @@
 -- statement on tables in the older on-disk format (see migration 0051); the
 -- rebuild works regardless. Column definitions and the partial unique index are
 -- carried over verbatim from migration 0028, minus the dropped column. No table
--- declares a foreign key, so replacing this one strands nothing.
+-- declares a foreign key to `users`, so replacing it strands nothing.
 
 CREATE TABLE users_new (
   id INTEGER PRIMARY KEY,

--- a/packages/gateway/migrations/0067_drop_global_telemetry_grant.sql
+++ b/packages/gateway/migrations/0067_drop_global_telemetry_grant.sql
@@ -1,0 +1,31 @@
+-- Drop the per-user global-telemetry grant. Performance telemetry is readable
+-- by every user, and attributing rows to individual users — like every
+-- cross-user usage view — follows `is_admin`, so the column has no reader left.
+--
+-- Rebuilt rather than ALTER TABLE ... DROP COLUMN because D1 rejects that
+-- statement on tables in the older on-disk format (see migration 0051); the
+-- rebuild works regardless. Column definitions and the partial unique index are
+-- carried over verbatim from migration 0028, minus the dropped column. No table
+-- declares a foreign key, so replacing this one strands nothing.
+
+CREATE TABLE users_new (
+  id INTEGER PRIMARY KEY,
+  -- NOCASE so usernames are matched case-insensitively everywhere: the
+  -- `WHERE username = ?` login lookup and the active-username unique index
+  -- below both inherit this collation, so "Admin" and "admin" are the same
+  -- account and cannot coexist.
+  username TEXT NOT NULL COLLATE NOCASE,
+  password_hash TEXT,
+  is_admin INTEGER NOT NULL DEFAULT 0,
+  upstream_ids TEXT,
+  created_at TEXT NOT NULL,
+  deleted_at TEXT
+);
+
+INSERT INTO users_new (id, username, password_hash, is_admin, upstream_ids, created_at, deleted_at)
+  SELECT id, username, password_hash, is_admin, upstream_ids, created_at, deleted_at FROM users;
+
+DROP TABLE users;
+ALTER TABLE users_new RENAME TO users;
+
+CREATE UNIQUE INDEX idx_users_username_active ON users(username) WHERE deleted_at IS NULL;

--- a/packages/gateway/src/app-control_test.ts
+++ b/packages/gateway/src/app-control_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { DEFAULT_SEARCH_CONFIG } from './data-plane/tools/web-search/search-config.ts';
 import { tokenUsageMetrics } from './repo/usage-metrics.ts';
-import { requestApp, setupAppTest } from './test-helpers.ts';
+import { grantGlobalTelemetry, requestApp, setupAppTest } from './test-helpers.ts';
 import { assertEquals, assertExists } from '@floway-dev/test-utils';
 
 const displayQuantity = (record: { metrics: Array<{ metric: string; quantity: string }> }, tokenCategory: string) =>
@@ -211,13 +211,56 @@ test('/api/token-usage all-by-user view aggregates across keys per user', async 
   assertEquals(displayQuantity(body[0], 'input'), '10');
 });
 
-test('/api/token-usage rejects all-by-user from a user without canViewGlobalTelemetry', async () => {
+test('/api/token-usage rejects all-by-user from a non-admin user', async () => {
   const { apiKey } = await setupAppTest();
   const response = await requestApp(
     '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00&view=all-by-user',
     { headers: { 'x-api-key': apiKey.key } },
   );
   assertEquals(response.status, 403);
+});
+
+test('/api/token-usage stays admin-only for a non-admin holding canViewGlobalTelemetry', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await grantGlobalTelemetry(repo, apiKey.userId);
+  await repo.apiKeys.save({
+    id: 'key_admin_owned',
+    userId: 1,
+    name: 'Admin owned',
+    key: 'raw_admin_owned',
+    serverSecret: '00'.repeat(32),
+    createdAt: '2026-03-15T00:00:00.000Z',
+    upstreamIds: null,
+    deletedAt: null,
+    dumpRetentionSeconds: null,
+    responsesRetentionSeconds: 0,
+  });
+  const shared = {
+    model: 'gpt-5',
+    upstream: null,
+    modelKey: 'gpt-5',
+    hour: '2026-03-15T10',
+    pricingSelector: {},
+    requests: 1,
+    metrics: tokenUsageMetrics({ input: 10, output: 5 }, null),
+  };
+  await repo.usage.set({ ...shared, keyId: apiKey.id });
+  await repo.usage.set({ ...shared, keyId: 'key_admin_owned' });
+
+  const explicit = await requestApp(
+    '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00&view=all-by-user',
+    { headers: { 'x-api-key': apiKey.key } },
+  );
+  assertEquals(explicit.status, 403);
+
+  // The flag must not flip the default view to the global shape either.
+  const defaulted = await requestApp(
+    '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00',
+    { headers: { 'x-api-key': apiKey.key } },
+  );
+  assertEquals(defaulted.status, 200);
+  const body = await defaulted.json();
+  assertEquals(body.map((r: { keyId: string }) => r.keyId), [apiKey.id]);
 });
 
 test('/api/token-usage merges Claude variants into backend base model records', async () => {

--- a/packages/gateway/src/app-control_test.ts
+++ b/packages/gateway/src/app-control_test.ts
@@ -133,7 +133,7 @@ test('/api/token-usage scopes to the actor\'s keys when called with an API key',
     metrics: tokenUsageMetrics({ input: 20, output: 8, input_cache_read: 6, input_cache_write: 2 }, null),
   });
 
-  const response = await requestApp('/api/token-usage?start=2026-03-15T00&end=2026-03-16T00', {
+  const response = await requestApp('/api/token-usage?start=2026-03-15T00&end=2026-03-16T00&view=self-by-key', {
     headers: { 'x-api-key': apiKey.key },
   });
 
@@ -173,7 +173,7 @@ test('/api/token-usage in self-by-key mode includes per-key metadata for the act
     metrics: tokenUsageMetrics({ input: 20, output: 8 }, null),
   });
 
-  const response = await requestApp('/api/token-usage?start=2026-03-16T00&end=2026-03-17T00&include_key_metadata=1', {
+  const response = await requestApp('/api/token-usage?start=2026-03-16T00&end=2026-03-17T00&include_key_metadata=1&view=self-by-key', {
     headers: { 'x-api-key': apiKey.key },
   });
 
@@ -209,6 +209,20 @@ test('/api/token-usage all-by-user view aggregates across keys per user', async 
   assertEquals(body.length, 1);
   assertEquals(body[0].userId, apiKey.userId);
   assertEquals(displayQuantity(body[0], 'input'), '10');
+});
+
+test('telemetry endpoints require an explicit view', async () => {
+  const { apiKey } = await setupAppTest();
+  const paths = [
+    '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00',
+    '/api/search-usage?start=2026-03-15T00&end=2026-03-16T00',
+    '/api/performance/overview?start=2026-03-15T00&end=2026-03-16T00',
+  ];
+  for (const path of paths) {
+    const response = await requestApp(path, { headers: { 'x-api-key': apiKey.key } });
+    assertEquals(response.status, 400, path);
+    assertEquals(await response.json(), { error: "view must be 'all-by-user' or 'self-by-key'" }, path);
+  }
 });
 
 test('/api/token-usage rejects all-by-user from a non-admin user', async () => {
@@ -253,13 +267,13 @@ test('/api/token-usage stays admin-only for a non-admin holding canViewGlobalTel
   );
   assertEquals(explicit.status, 403);
 
-  // The flag must not flip the default view to the global shape either.
-  const defaulted = await requestApp(
-    '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00',
+  // Nor may the flag widen what a self-by-key request returns.
+  const selfView = await requestApp(
+    '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00&view=self-by-key',
     { headers: { 'x-api-key': apiKey.key } },
   );
-  assertEquals(defaulted.status, 200);
-  const body = await defaulted.json();
+  assertEquals(selfView.status, 200);
+  const body = await selfView.json();
   assertEquals(body.map((r: { keyId: string }) => r.keyId), [apiKey.id]);
 });
 
@@ -296,7 +310,7 @@ test('/api/token-usage merges Claude variants into backend base model records', 
     metrics: tokenUsageMetrics({ input: 3, output: 4 }, null),
   });
 
-  const response = await requestApp('/api/token-usage?start=2026-03-17T00&end=2026-03-18T00', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/token-usage?start=2026-03-17T00&end=2026-03-18T00&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();

--- a/packages/gateway/src/app-control_test.ts
+++ b/packages/gateway/src/app-control_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { DEFAULT_SEARCH_CONFIG } from './data-plane/tools/web-search/search-config.ts';
 import { tokenUsageMetrics } from './repo/usage-metrics.ts';
-import { grantGlobalTelemetry, requestApp, setupAppTest } from './test-helpers.ts';
+import { requestApp, setupAppTest } from './test-helpers.ts';
 import { assertEquals, assertExists } from '@floway-dev/test-utils';
 
 const displayQuantity = (record: { metrics: Array<{ metric: string; quantity: string }> }, tokenCategory: string) =>
@@ -211,12 +211,11 @@ test('/api/token-usage all-by-user view aggregates across keys per user', async 
   assertEquals(displayQuantity(body[0], 'input'), '10');
 });
 
-test('telemetry endpoints require an explicit view', async () => {
+test('usage endpoints require an explicit view', async () => {
   const { apiKey } = await setupAppTest();
   const paths = [
     '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00',
     '/api/search-usage?start=2026-03-15T00&end=2026-03-16T00',
-    '/api/performance/overview?start=2026-03-15T00&end=2026-03-16T00',
   ];
   for (const path of paths) {
     const response = await requestApp(path, { headers: { 'x-api-key': apiKey.key } });
@@ -232,49 +231,6 @@ test('/api/token-usage rejects all-by-user from a non-admin user', async () => {
     { headers: { 'x-api-key': apiKey.key } },
   );
   assertEquals(response.status, 403);
-});
-
-test('/api/token-usage stays admin-only for a non-admin holding canViewGlobalTelemetry', async () => {
-  const { repo, apiKey } = await setupAppTest();
-  await grantGlobalTelemetry(repo, apiKey.userId);
-  await repo.apiKeys.save({
-    id: 'key_admin_owned',
-    userId: 1,
-    name: 'Admin owned',
-    key: 'raw_admin_owned',
-    serverSecret: '00'.repeat(32),
-    createdAt: '2026-03-15T00:00:00.000Z',
-    upstreamIds: null,
-    deletedAt: null,
-    dumpRetentionSeconds: null,
-    responsesRetentionSeconds: 0,
-  });
-  const shared = {
-    model: 'gpt-5',
-    upstream: null,
-    modelKey: 'gpt-5',
-    hour: '2026-03-15T10',
-    pricingSelector: {},
-    requests: 1,
-    metrics: tokenUsageMetrics({ input: 10, output: 5 }, null),
-  };
-  await repo.usage.set({ ...shared, keyId: apiKey.id });
-  await repo.usage.set({ ...shared, keyId: 'key_admin_owned' });
-
-  const explicit = await requestApp(
-    '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00&view=all-by-user',
-    { headers: { 'x-api-key': apiKey.key } },
-  );
-  assertEquals(explicit.status, 403);
-
-  // Nor may the flag widen what a self-by-key request returns.
-  const selfView = await requestApp(
-    '/api/token-usage?start=2026-03-15T00&end=2026-03-16T00&view=self-by-key',
-    { headers: { 'x-api-key': apiKey.key } },
-  );
-  assertEquals(selfView.status, 200);
-  const body = await selfView.json();
-  assertEquals(body.map((r: { keyId: string }) => r.keyId), [apiKey.id]);
 });
 
 test('/api/token-usage merges Claude variants into backend base model records', async () => {

--- a/packages/gateway/src/control-plane/auth/routes.ts
+++ b/packages/gateway/src/control-plane/auth/routes.ts
@@ -5,7 +5,7 @@ import type { User } from '../../repo/types.ts';
 import { isProductionRequest } from '../../shared/is-production-request.ts';
 import { dummyPasswordHash, timingSafeEqual, verifyPassword } from '../../shared/passwords.ts';
 import type { authLoginBody } from '../schemas.ts';
-import { userToEffectiveWire } from '../users/wire.ts';
+import { userToSessionWire } from '../users/wire.ts';
 import { getEnvOptional } from '@floway-dev/platform';
 
 const resolveLoginUser = async (c: CtxWithJson<typeof authLoginBody>): Promise<User | null> => {
@@ -44,7 +44,7 @@ export const authLogin = async (c: CtxWithJson<typeof authLoginBody>) => {
   const user = await resolveLoginUser(c);
   if (!user) return c.json({ error: 'Invalid username or password' }, 401);
   const session = await getRepo().sessions.create(user.id);
-  return c.json({ token: session.id, user: userToEffectiveWire(user) });
+  return c.json({ token: session.id, user: userToSessionWire(user) });
 };
 
 export const authLogout = async (c: AuthedContext) => {
@@ -58,7 +58,7 @@ export const authMe = async (c: AuthedContext) => {
   const sessionId = sessionIdFromContext(c);
   const apiKey = c.get('apiKey');
   return c.json({
-    user: userToEffectiveWire(user),
+    user: userToSessionWire(user),
     viaApiKey: !sessionId,
     apiKey: apiKey ? { id: apiKey.id, name: apiKey.name } : null,
   });

--- a/packages/gateway/src/control-plane/auth/routes_test.ts
+++ b/packages/gateway/src/control-plane/auth/routes_test.ts
@@ -154,7 +154,6 @@ test('/auth/login with username + matching password issues a session', async () 
     passwordHash: await hashPassword('hunter2'),
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });
@@ -178,7 +177,6 @@ test('/auth/login matches the username case-insensitively', async () => {
     passwordHash: await hashPassword('hunter2'),
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });
@@ -201,7 +199,6 @@ test('/auth/login with wrong password is rejected', async () => {
     passwordHash: await hashPassword('hunter2'),
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });
@@ -222,7 +219,6 @@ test('/auth/login refuses a user with no password set (must use admin reset path
     passwordHash: null,
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });
@@ -260,10 +256,9 @@ test('/auth/me returns the current user shape with viaApiKey:false for sessions'
   });
 
   assertEquals(response.status, 200);
-  const body = (await response.json()) as { user: { id: number; isAdmin: boolean; canViewGlobalTelemetry: boolean }; viaApiKey: boolean; apiKey: unknown };
+  const body = (await response.json()) as { user: { id: number; isAdmin: boolean }; viaApiKey: boolean; apiKey: unknown };
   assertEquals(body.user.id, 1);
   assertEquals(body.user.isAdmin, true);
-  assertEquals(body.user.canViewGlobalTelemetry, true);
   assertEquals(body.viaApiKey, false);
   assertEquals(body.apiKey, null);
 });

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -51,7 +51,7 @@ interface SerializedProxy {
 }
 
 interface ExportPayload {
-  version: 16;
+  version: 17;
   exportedAt: string;
   data: {
     users: User[];
@@ -66,7 +66,7 @@ interface ExportPayload {
   };
 }
 
-const EXPORT_VERSION = 16;
+const EXPORT_VERSION = 17;
 const SEARCH_USAGE_HOUR_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}$/;
 const PERFORMANCE_METRICS = new Set<PerformanceMetric>(['ttft_ms', 'tpot_us']);
 const UPSTREAM_PROVIDERS = new Set<UpstreamProviderKind>(ALL_PROVIDER_KINDS);
@@ -332,7 +332,6 @@ const parseUserRecords = (value: unknown): { type: 'ok'; records: User[] } | { t
         throw new Error(`passwordHash must be null or start with ${PASSWORD_HASH_SCHEME}$`);
       }
       if (typeof record.isAdmin !== 'boolean') throw new Error('isAdmin must be a boolean');
-      if (typeof record.canViewGlobalTelemetry !== 'boolean') throw new Error('canViewGlobalTelemetry must be a boolean');
 
       if (record.upstreamIds === undefined) throw new Error('upstreamIds must be present (null or array)');
       const upstreamIdsParsed = parseUpstreamIdsValue(record.upstreamIds);
@@ -347,7 +346,6 @@ const parseUserRecords = (value: unknown): { type: 'ok'; records: User[] } | { t
         passwordHash: record.passwordHash,
         isAdmin: record.isAdmin,
         upstreamIds: upstreamIdsParsed.value,
-        canViewGlobalTelemetry: record.canViewGlobalTelemetry,
         createdAt: nonEmptyString(record.createdAt, 'createdAt'),
         deletedAt: record.deletedAt,
       });

--- a/packages/gateway/src/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes_test.ts
@@ -60,7 +60,6 @@ const SEED_ADMIN: User = {
   passwordHash: null,
   isAdmin: true,
   upstreamIds: null,
-  canViewGlobalTelemetry: true,
   createdAt: '2026-01-01T00:00:00.000Z',
   deletedAt: null,
 };
@@ -71,7 +70,6 @@ const USER_BOB: User = {
   passwordHash: 'pbkdf2-sha256$600000$c2FsdA==$aGFzaA==',
   isAdmin: false,
   upstreamIds: null,
-  canViewGlobalTelemetry: false,
   createdAt: '2026-02-01T00:00:00.000Z',
   deletedAt: null,
 };
@@ -292,7 +290,7 @@ const doExport = async (app: Hono, includePerformance = false) => {
   return (await resp.json()) as Record<string, any>;
 };
 
-const doImport = async (app: Hono, mode: string, data: unknown, version: unknown = 16) => {
+const doImport = async (app: Hono, mode: string, data: unknown, version: unknown = 17) => {
   const resp = await app.request('/import', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -330,13 +328,13 @@ test('import validates generic pricing selectors', async () => {
   assertEquals(String(fractional.body.error).includes('positive safe integer'), true);
 });
 
-test('export emits the v16 envelope with users and upstreams', async () => {
+test('export emits the v17 envelope with users and upstreams', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
 
   const result = await doExport(app);
 
-  assertEquals(result.version, 16);
+  assertEquals(result.version, 17);
   assertEquals(typeof result.exportedAt, 'string');
   assertEquals(result.data.users, [SEED_ADMIN]);
   assertEquals(result.data.apiKeys, []);
@@ -401,7 +399,7 @@ test('import rejects any version other than the current one before deleting data
   await repo.apiKeys.save(KEY_A);
   await repo.upstreams.save(CUSTOM_UPSTREAM);
 
-  const VERSION_ERROR = 'version must be 16 — older export formats are not supported; re-export from the current deployment';
+  const VERSION_ERROR = 'version must be 17 — older export formats are not supported; re-export from the current deployment';
   const previousV11 = await doImport(app, 'replace', latestImportData(), 11);
   const ancientVersion = await doImport(app, 'replace', { apiKeys: [] }, 1);
   const missingVersionResponse = await app.request('/import', {
@@ -739,7 +737,7 @@ test('import rejects negative historical unit prices with a metric-specific erro
   assertEquals(result.body.error, 'invalid usage at index 0: metric unitPrice must be non-negative: "-0.01"');
 });
 
-test('v16 import validates usage metric rows', async () => {
+test('v17 import validates usage metric rows', async () => {
   const { app } = setup();
   const missingMetrics = await doImport(app, 'replace', latestImportData({
     usage: [{ ...USAGE_2, metrics: undefined }],
@@ -903,7 +901,7 @@ test('import preserves a positive dumpRetentionSeconds on api keys', async () =>
   assertEquals(restored?.dumpRetentionSeconds, 3600);
 });
 
-test('v16 import preserves and validates Responses retention', async () => {
+test('v17 import preserves and validates Responses retention', async () => {
   const { app, repo } = setup();
   const retained = await doImport(app, 'replace', latestImportData({
     apiKeys: [{ ...KEY_A, responsesRetentionSeconds: 7 * 24 * 60 * 60 }],
@@ -989,7 +987,7 @@ test('import rejects legacy enabled_fixes payloads before mutating', async () =>
   assertEquals(await repo.upstreams.list(), [CUSTOM_UPSTREAM]);
 });
 
-test('import rejects missing latest-v16 arrays before clearing existing data', async () => {
+test('import rejects missing latest-v17 arrays before clearing existing data', async () => {
   const { app, repo } = setup();
   await repo.apiKeys.save(KEY_A);
   await repo.upstreams.save(CUSTOM_UPSTREAM);
@@ -1015,14 +1013,14 @@ test('import rejects missing latest-v16 arrays before clearing existing data', a
 test('import validates mode and data before mutating', async () => {
   const { app } = setup();
 
-  const invalidMode = await doImport(app, 'invalid', {}, 16);
+  const invalidMode = await doImport(app, 'invalid', {}, 17);
   const missingData = await app.request('/import', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ mode: 'replace', version: 16 }),
+    body: JSON.stringify({ mode: 'replace', version: 17 }),
   });
-  const missingUpstreams = await doImport(app, 'merge', {}, 16);
-  const emptyMerge = await doImport(app, 'merge', latestImportData(), 16);
+  const missingUpstreams = await doImport(app, 'merge', {}, 17);
+  const emptyMerge = await doImport(app, 'merge', latestImportData(), 17);
 
   assertEquals(invalidMode.status, 400);
   assertEquals(invalidMode.body.error, "mode must be 'merge' or 'replace'");
@@ -1174,7 +1172,7 @@ test('import replace wipes proxy_upstream_backoffs alongside the proxies it cool
   assertEquals(await repo.proxyBackoffs.listAll(), []);
 });
 
-test('v16 export/import round-trips users and per-key user_id', async () => {
+test('v17 export/import round-trips users and per-key user_id', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
   await repo.users.save(USER_BOB);
@@ -1182,10 +1180,10 @@ test('v16 export/import round-trips users and per-key user_id', async () => {
   await repo.apiKeys.save({ ...KEY_B, userId: USER_BOB.id });
 
   const exportResult = await doExport(app);
-  assertEquals(exportResult.version, 16);
+  assertEquals(exportResult.version, 17);
   assertEquals(exportResult.data.users.map((u: any) => u.id).sort(), [SEED_ADMIN.id, USER_BOB.id]);
 
-  const result = await doImport(app, 'replace', exportResult.data, 16);
+  const result = await doImport(app, 'replace', exportResult.data, 17);
   assertEquals(result.status, 200);
   assertEquals(result.body.imported.users, 2);
   assertEquals(result.body.imported.apiKeys, 2);
@@ -1196,7 +1194,7 @@ test('v16 export/import round-trips users and per-key user_id', async () => {
   assertEquals(restoredKey?.userId, USER_BOB.id);
 });
 
-test('v16 import rejects api_keys whose user_id does not appear in the payload', async () => {
+test('v17 import rejects api_keys whose user_id does not appear in the payload', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
 
@@ -1208,13 +1206,13 @@ test('v16 import rejects api_keys whose user_id does not appear in the payload',
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 16);
+  }, 17);
 
   assertEquals(result.status, 400);
   assertEquals(result.body.error, 'invalid apiKeys at index 0: user_id 99 does not match any user in the payload');
 });
 
-test('v16 import rejects malformed users (bad username, bad password_hash)', async () => {
+test('v17 import rejects malformed users (bad username, bad password_hash)', async () => {
   const { app } = setup();
 
   const badUsername = await doImport(app, 'replace', {
@@ -1225,7 +1223,7 @@ test('v16 import rejects malformed users (bad username, bad password_hash)', asy
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 16);
+  }, 17);
   assertEquals(badUsername.status, 400);
   assertEquals(String(badUsername.body.error).startsWith('invalid users at index 0:'), true);
 
@@ -1237,7 +1235,7 @@ test('v16 import rejects malformed users (bad username, bad password_hash)', asy
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 16);
+  }, 17);
   assertEquals(badHash.status, 400);
   assertEquals(String(badHash.body.error).includes('passwordHash'), true);
 });
@@ -1259,7 +1257,7 @@ test('import rejects a pre-accounts v3 export instead of coercing its legacy api
   }, 3);
 
   assertEquals(result.status, 400);
-  assertEquals(String(result.body.error).includes('version must be 16'), true);
+  assertEquals(String(result.body.error).includes('version must be 17'), true);
   // Rejected at the version gate, before touching any data.
   assertEquals(await repo.apiKeys.list(), [KEY_A]);
   assertEquals((await repo.users.list()).map(u => u.id), [SEED_ADMIN.id]);
@@ -1280,7 +1278,7 @@ test('replace-mode import clears sessions before writing users', async () => {
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 16);
+  }, 17);
 
   assertEquals(result.status, 200);
   // No public listAll on sessions; create a fresh session and check the
@@ -1289,7 +1287,7 @@ test('replace-mode import clears sessions before writing users', async () => {
   assertEquals(await repo.sessions.deleteByUserId(USER_BOB.id), 0);
 });
 
-test('v16 import rejects users[i].upstreamIds === undefined', async () => {
+test('v17 import rejects users[i].upstreamIds === undefined', async () => {
   const { app } = setup();
   const result = await doImport(app, 'replace', {
     users: [SEED_ADMIN, { ...USER_BOB, upstreamIds: undefined }],
@@ -1299,12 +1297,12 @@ test('v16 import rejects users[i].upstreamIds === undefined', async () => {
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 16);
+  }, 17);
   assertEquals(result.status, 400);
   expect(result.body.error).toMatch(/upstreamIds/);
 });
 
-test('v16 import rejects users[i].deletedAt of non-string non-null type', async () => {
+test('v17 import rejects users[i].deletedAt of non-string non-null type', async () => {
   const { app } = setup();
   const result = await doImport(app, 'replace', {
     users: [SEED_ADMIN, { ...USER_BOB, deletedAt: 42 }],
@@ -1314,12 +1312,12 @@ test('v16 import rejects users[i].deletedAt of non-string non-null type', async 
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 16);
+  }, 17);
   assertEquals(result.status, 400);
   expect(result.body.error).toMatch(/deletedAt/);
 });
 
-test('v16 replace import refuses payload missing user 1', async () => {
+test('v17 replace import refuses payload missing user 1', async () => {
   const { app } = setup();
   const result = await doImport(app, 'replace', {
     users: [USER_BOB],
@@ -1329,12 +1327,12 @@ test('v16 replace import refuses payload missing user 1', async () => {
     searchUsage: [],
     performanceIncluded: false,
     searchConfig: DEFAULT_SEARCH_CONFIG,
-  }, 16);
+  }, 17);
   assertEquals(result.status, 400);
   expect(result.body.error).toMatch(/user 1/);
 });
 
-test('a full v16 export re-imports verbatim — the export→import round trip is closed', async () => {
+test('a full v17 export re-imports verbatim — the export→import round trip is closed', async () => {
   const { app, repo } = setup();
   await repo.users.save(SEED_ADMIN);
   await repo.users.save(USER_BOB);
@@ -1360,12 +1358,12 @@ test('a full v16 export re-imports verbatim — the export→import round trip i
   await repo.searchConfig.save(config);
 
   const exported = await doExport(app, true);
-  assertEquals(exported.version, 16);
+  assertEquals(exported.version, 17);
 
   // Replace-import the export's own `data`, verbatim. If the export emits any
   // shape the import parser rejects, this 400s — the round trip is the
   // invariant, so this test fails the moment the two sides drift.
-  const result = await doImport(app, 'replace', exported.data, 16);
+  const result = await doImport(app, 'replace', exported.data, 17);
   assertEquals(result.status, 200);
   assertEquals(result.body.imported, { users: 2, apiKeys: 2, upstreams: 4, proxies: 0, usage: 2, searchUsage: 2, performance: 2 });
 
@@ -1398,10 +1396,10 @@ test('any data bearing a historical version is rejected on the version gate, bef
     searchConfig: DEFAULT_SEARCH_CONFIG,
   };
 
-  for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]) {
+  for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]) {
     const result = await doImport(app, 'replace', wellFormed, version);
     assertEquals(result.status, 400);
-    assertEquals(String(result.body.error).includes('version must be 16'), true);
+    assertEquals(String(result.body.error).includes('version must be 17'), true);
   }
 
   // Nothing was touched — the version gate runs before any delete or write.

--- a/packages/gateway/src/control-plane/models/routes_test.ts
+++ b/packages/gateway/src/control-plane/models/routes_test.ts
@@ -115,7 +115,6 @@ test('/api/models is scoped to the caller\'s effective upstreams — a removed u
     passwordHash: null,
     isAdmin: false,
     upstreamIds: ['up_copilot', 'up_custom_models'],
-    canViewGlobalTelemetry: false,
     createdAt: '2026-03-15T00:00:00.000Z',
     deletedAt: null,
   });
@@ -161,7 +160,6 @@ test('/api/models for an admin session returns the gateway-wide catalog, bypassi
     passwordHash: null,
     isAdmin: true,
     upstreamIds: ['up_copilot', 'up_custom_models'],
-    canViewGlobalTelemetry: true,
     createdAt: '2026-03-15T00:00:00.000Z',
     deletedAt: null,
   });
@@ -205,7 +203,6 @@ test('/api/models — admin sees raw alias.targets; non-admin sees the caller-na
     passwordHash: null,
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-03-15T00:00:00.000Z',
     deletedAt: null,
   });
@@ -285,7 +282,7 @@ test('/api/models — admin self-restriction does NOT leak per-alias metadata va
   // Non-admin user scoped to ONLY the big-window upstream.
   await repo.users.save({
     id: 2, username: 'tester', passwordHash: null, isAdmin: false,
-    upstreamIds: ['up_big'], canViewGlobalTelemetry: false,
+    upstreamIds: ['up_big'],
     createdAt: '2026-03-15T00:00:00.000Z', deletedAt: null,
   });
   const nonAdminSession = (await repo.sessions.create(2)).id;

--- a/packages/gateway/src/control-plane/performance/routes.ts
+++ b/packages/gateway/src/control-plane/performance/routes.ts
@@ -78,7 +78,7 @@ const resolveView = (
   c: Ctx,
   params: PerformanceQueryParams,
 ): ResolvedTelemetryView | { error: 'forbidden' | 'bad_request'; message: string } => {
-  const resolved = resolveTelemetryView(c, c.req.valid('query').view, params.keyId);
+  const resolved = resolveTelemetryView(c, 'performance', c.req.valid('query').view, params.keyId);
   if ('error' in resolved) return resolved;
   if (resolved.view === 'self-by-key' && params.groupBy === 'userId') {
     return { error: 'bad_request', message: 'group_by=userId is not allowed in self-by-key mode' };

--- a/packages/gateway/src/control-plane/performance/routes.ts
+++ b/packages/gateway/src/control-plane/performance/routes.ts
@@ -2,11 +2,11 @@
 // six per-dimension breakdown tables, and dropdown menus, all built from a
 // single raw record query.
 //
-// There is no view parameter: the requested breakdown decides the scope.
-// `group_by=keyId` is inherently a question about the actor's own traffic, so
-// it aggregates the actor's keys (active + soft-deleted) alone; every other
-// breakdown aggregates all users' rows. Latency is not sensitive on its own,
-// so that global read is open to every user.
+// The requested breakdown decides the scope. `group_by=keyId` is inherently a
+// question about the actor's own traffic, so it aggregates the actor's keys
+// (active + soft-deleted) alone; every other breakdown — including the `model`
+// default — aggregates all users' rows. Latency is not sensitive on its own, so
+// that cross-user read is open to every user.
 //
 // Per-user attribution is the administrator-only part — the By-User rows, the
 // username listing, the userId dropdown, `group_by=userId`, and
@@ -76,14 +76,6 @@ const readPerformanceQuery = (
       },
     },
   };
-};
-
-// The two user-dimension knobs, refused for non-administrators. Named so the
-// rejection quotes the exact parameter the caller passed.
-const userDimensionKnob = (params: PerformanceQueryParams): string | null => {
-  if (params.groupBy === 'userId') return 'group_by=userId';
-  if (params.filters.userId !== undefined) return 'filter_user_id';
-  return null;
 };
 
 // Distinct values per dimension observed in the UNFILTERED record set so the
@@ -157,36 +149,34 @@ const partitionRecords = (
 export const performanceOverview = async (c: Ctx) => {
   const params = readPerformanceQuery(c);
   if (params.type === 'error') return c.json({ error: params.error }, 400);
+  const { start, end, bucket, groupBy, timezoneOffsetMinutes, filters } = params.value;
 
-  const attributeUsers = userFromContext(c).isAdmin;
-  if (!attributeUsers) {
-    const knob = userDimensionKnob(params.value);
-    if (knob !== null) return c.json({ error: `${knob} requires administrator privileges` }, 403);
+  const actor = userFromContext(c);
+  if (!actor.isAdmin) {
+    if (groupBy === 'userId') return c.json({ error: 'group_by=userId requires administrator privileges' }, 403);
+    if (filters.userId !== undefined) return c.json({ error: 'filter_user_id requires administrator privileges' }, 403);
   }
 
   const repo = getRepo();
   const allKeys = await repo.apiKeys.listIncludingDeleted();
-  const actorUserId = userFromContext(c).id;
-  const ownedKeys = allKeys.filter(key => key.userId === actorUserId);
+  const ownedKeys = allKeys.filter(key => key.userId === actor.id);
   const ownedKeyIds = new Set(ownedKeys.map(key => key.id));
-  if (params.value.filters.keyId !== undefined && !ownedKeyIds.has(params.value.filters.keyId)) {
+  if (filters.keyId !== undefined && !ownedKeyIds.has(filters.keyId)) {
     return c.json({ error: 'Unknown filter_key_id' }, 404);
   }
 
-  const rawRecords = await repo.performance.query({ start: params.value.start, end: params.value.end });
-  // By API Key asks about the actor's own traffic, so it narrows the whole
-  // aggregate — summary and every other axis included — to the actor's rows.
-  const scopedRecords = params.value.groupBy === 'keyId'
+  const rawRecords = await repo.performance.query({ start, end });
+  const scopedRecords = groupBy === 'keyId'
     ? rawRecords.filter(r => ownedKeyIds.has(r.keyId))
     : rawRecords;
 
-  const users = attributeUsers ? await repo.users.listIncludingDeleted() : [];
+  const users = actor.isAdmin ? await repo.users.listIncludingDeleted() : [];
   const keyToUser = buildKeyToUserMap(allKeys);
-  const { filtered, dimensionValues } = partitionRecords(scopedRecords, params.value.filters, keyToUser, ownedKeyIds, attributeUsers);
+  const { filtered, dimensionValues } = partitionRecords(scopedRecords, filters, keyToUser, ownedKeyIds, actor.isAdmin);
 
-  const tzOnly = { timezoneOffsetMinutes: params.value.timezoneOffsetMinutes };
+  const tzOnly = { timezoneOffsetMinutes };
   const { series, ...axes } = aggregatePerformanceForDisplay(filtered, {
-    series: { ...tzOnly, bucket: params.value.bucket, groupBy: params.value.groupBy },
+    series: { ...tzOnly, bucket, groupBy },
     // 'none' axis carries the summary row.
     none: { ...tzOnly, bucket: 'all', groupBy: 'none' as const },
     model: { ...tzOnly, bucket: 'all', groupBy: 'model' as const },
@@ -197,8 +187,6 @@ export const performanceOverview = async (c: Ctx) => {
     userId: { ...tzOnly, bucket: 'all', groupBy: 'userId' as const },
   }, keyToUser, ownedKeyIds);
 
-  // Per-user attribution exposes the username listing for By User, while key
-  // metadata remains actor-owned for By API Key and its filter.
   const userMetadata = users
     .map(u => ({ id: u.id, username: u.username }))
     .sort((a, b) => a.id - b.id);
@@ -210,7 +198,7 @@ export const performanceOverview = async (c: Ctx) => {
     series,
     axes: {
       ...axes,
-      userId: attributeUsers ? axes.userId : [],
+      userId: actor.isAdmin ? axes.userId : [],
     },
     dimensionValues,
     users: userMetadata,

--- a/packages/gateway/src/control-plane/performance/routes.ts
+++ b/packages/gateway/src/control-plane/performance/routes.ts
@@ -2,16 +2,18 @@
 // six per-dimension breakdown tables, and dropdown menus, all built from a
 // single raw record query.
 //
-// View semantics mirror /api/token-usage and /api/search-usage:
-// - `self-by-key` scopes every axis to the actor's keys (active +
-//   soft-deleted).
-// - `all-by-user` uses every row for global and per-user axes, while API-key
-//   axes, metadata, and filters remain scoped to the actor's own keys.
+// There is no view parameter: the requested breakdown decides the scope.
+// `group_by=keyId` is inherently a question about the actor's own traffic, so
+// it aggregates the actor's keys (active + soft-deleted) alone; every other
+// breakdown aggregates all users' rows. Latency is not sensitive on its own,
+// so that global read is open to every user.
 //
-// Per-user attribution is a separate, administrator-only capability on top of
-// the global view: a user granted global telemetry sees everyone's latency in
-// aggregate, never who produced it. That covers the By-User rows, the username
-// listing, the userId dropdown, `group_by=userId`, and `filter_user_id`.
+// Per-user attribution is the administrator-only part — the By-User rows, the
+// username listing, the userId dropdown, `group_by=userId`, and
+// `filter_user_id`. A regular user sees the whole picture without learning who
+// produced which row. API-key axes, key metadata, and `filter_key_id` stay
+// scoped to the actor's own keys in every breakdown, so other users' key ids
+// never surface either.
 
 import { aggregatePerformanceForDisplay, type PerformanceBucketGranularity, type PerformanceGroupBy } from './aggregate.ts';
 import { userFromContext } from '../../middleware/auth.ts';
@@ -19,7 +21,7 @@ import { type CtxWithQuery } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { PerformanceTelemetryRecord } from '../../repo/types.ts';
 import type { performanceQuery } from '../schemas.ts';
-import { buildKeyToUserMap, loadTelemetryKeys, resolveTelemetryView, type ResolvedTelemetryView } from '../telemetry-view.ts';
+import { buildKeyToUserMap } from '../telemetry-view.ts';
 
 type Ctx = CtxWithQuery<typeof performanceQuery>;
 
@@ -33,7 +35,6 @@ interface PerformanceFilters {
 }
 
 interface PerformanceQueryParams {
-  keyId: string | undefined;
   start: string;
   end: string;
   bucket: PerformanceBucketGranularity;
@@ -60,7 +61,6 @@ const readPerformanceQuery = (
   return {
     type: 'ok',
     value: {
-      keyId: blank(query.key_id),
       start: query.start,
       end: query.end,
       bucket: query.bucket ?? 'hour',
@@ -78,59 +78,12 @@ const readPerformanceQuery = (
   };
 };
 
-// The resolved view carrying the per-user attribution capability that rides on
-// top of it. Both the request gate (which query knobs are legal) and the
-// response shape (which axes and metadata are populated) read that flag.
-type PerformanceScope = ResolvedTelemetryView & { attributeUsers: boolean };
-
-const resolveScope = (
-  c: Ctx,
-  params: PerformanceQueryParams,
-): PerformanceScope | { error: 'forbidden' | 'bad_request'; message: string } => {
-  const resolved = resolveTelemetryView(c, 'performance', c.req.valid('query').view, params.keyId);
-  if ('error' in resolved) return resolved;
-
-  // Both knobs below name a user dimension. In self-by-key every row already
-  // belongs to the actor, so the dimension is meaningless rather than
-  // privileged — administrators are refused there too.
-  const attributeUsers = resolved.view === 'all-by-user' && userFromContext(c).isAdmin;
-  if (!attributeUsers) {
-    const knob = params.groupBy === 'userId'
-      ? 'group_by=userId'
-      : params.filters.userId !== undefined
-        ? 'filter_user_id'
-        : null;
-    if (knob !== null) {
-      return resolved.view === 'self-by-key'
-        ? { error: 'bad_request', message: `${knob} is not allowed in self-by-key mode` }
-        : { error: 'forbidden', message: `${knob} requires administrator privileges` };
-    }
-  }
-  return { ...resolved, attributeUsers };
-};
-
-const queryRecordsForView = async (
-  resolved: ResolvedTelemetryView,
-  params: PerformanceQueryParams,
-  ownedKeyIds: ReadonlySet<string>,
-): Promise<readonly PerformanceTelemetryRecord[] | null> => {
-  const repo = getRepo();
-  if (resolved.view === 'all-by-user') {
-    return await repo.performance.query({
-      start: params.start,
-      end: params.end,
-    });
-  }
-
-  if (params.keyId !== undefined && !ownedKeyIds.has(params.keyId)) {
-    return null;
-  }
-  const rows = await repo.performance.query({
-    keyId: params.keyId,
-    start: params.start,
-    end: params.end,
-  });
-  return params.keyId !== undefined ? rows : rows.filter(r => ownedKeyIds.has(r.keyId));
+// The two user-dimension knobs, refused for non-administrators. Named so the
+// rejection quotes the exact parameter the caller passed.
+const userDimensionKnob = (params: PerformanceQueryParams): string | null => {
+  if (params.groupBy === 'userId') return 'group_by=userId';
+  if (params.filters.userId !== undefined) return 'filter_user_id';
+  return null;
 };
 
 // Distinct values per dimension observed in the UNFILTERED record set so the
@@ -205,24 +158,31 @@ export const performanceOverview = async (c: Ctx) => {
   const params = readPerformanceQuery(c);
   if (params.type === 'error') return c.json({ error: params.error }, 400);
 
-  const scope = resolveScope(c, params.value);
-  if ('error' in scope) return c.json({ error: scope.message }, scope.error === 'forbidden' ? 403 : 400);
+  const attributeUsers = userFromContext(c).isAdmin;
+  if (!attributeUsers) {
+    const knob = userDimensionKnob(params.value);
+    if (knob !== null) return c.json({ error: `${knob} requires administrator privileges` }, 403);
+  }
 
   const repo = getRepo();
-  const allKeys = await loadTelemetryKeys(repo, scope);
+  const allKeys = await repo.apiKeys.listIncludingDeleted();
   const actorUserId = userFromContext(c).id;
   const ownedKeys = allKeys.filter(key => key.userId === actorUserId);
   const ownedKeyIds = new Set(ownedKeys.map(key => key.id));
-  if (scope.view === 'all-by-user' && params.value.filters.keyId !== undefined && !ownedKeyIds.has(params.value.filters.keyId)) {
+  if (params.value.filters.keyId !== undefined && !ownedKeyIds.has(params.value.filters.keyId)) {
     return c.json({ error: 'Unknown filter_key_id' }, 404);
   }
 
-  const rawRecords = await queryRecordsForView(scope, params.value, ownedKeyIds);
-  if (rawRecords === null) return c.json({ error: 'Unknown key_id' }, 404);
+  const rawRecords = await repo.performance.query({ start: params.value.start, end: params.value.end });
+  // By API Key asks about the actor's own traffic, so it narrows the whole
+  // aggregate — summary and every other axis included — to the actor's rows.
+  const scopedRecords = params.value.groupBy === 'keyId'
+    ? rawRecords.filter(r => ownedKeyIds.has(r.keyId))
+    : rawRecords;
 
-  const users = scope.attributeUsers ? await repo.users.listIncludingDeleted() : [];
+  const users = attributeUsers ? await repo.users.listIncludingDeleted() : [];
   const keyToUser = buildKeyToUserMap(allKeys);
-  const { filtered, dimensionValues } = partitionRecords(rawRecords, params.value.filters, keyToUser, ownedKeyIds, scope.attributeUsers);
+  const { filtered, dimensionValues } = partitionRecords(scopedRecords, params.value.filters, keyToUser, ownedKeyIds, attributeUsers);
 
   const tzOnly = { timezoneOffsetMinutes: params.value.timezoneOffsetMinutes };
   const { series, ...axes } = aggregatePerformanceForDisplay(filtered, {
@@ -250,7 +210,7 @@ export const performanceOverview = async (c: Ctx) => {
     series,
     axes: {
       ...axes,
-      userId: scope.attributeUsers ? axes.userId : [],
+      userId: attributeUsers ? axes.userId : [],
     },
     dimensionValues,
     users: userMetadata,

--- a/packages/gateway/src/control-plane/performance/routes.ts
+++ b/packages/gateway/src/control-plane/performance/routes.ts
@@ -4,10 +4,14 @@
 //
 // View semantics mirror /api/token-usage and /api/search-usage:
 // - `self-by-key` scopes every axis to the actor's keys (active +
-//   soft-deleted). `group_by=userId` is rejected because every row belongs to
-//   the actor.
+//   soft-deleted).
 // - `all-by-user` uses every row for global and per-user axes, while API-key
 //   axes, metadata, and filters remain scoped to the actor's own keys.
+//
+// Per-user attribution is a separate, administrator-only capability on top of
+// the global view: a user granted global telemetry sees everyone's latency in
+// aggregate, never who produced it. That covers the By-User rows, the username
+// listing, the userId dropdown, `group_by=userId`, and `filter_user_id`.
 
 import { aggregatePerformanceForDisplay, type PerformanceBucketGranularity, type PerformanceGroupBy } from './aggregate.ts';
 import { userFromContext } from '../../middleware/auth.ts';
@@ -74,16 +78,35 @@ const readPerformanceQuery = (
   };
 };
 
-const resolveView = (
+// The resolved view carrying the per-user attribution capability that rides on
+// top of it. Both the request gate (which query knobs are legal) and the
+// response shape (which axes and metadata are populated) read that flag.
+type PerformanceScope = ResolvedTelemetryView & { attributeUsers: boolean };
+
+const resolveScope = (
   c: Ctx,
   params: PerformanceQueryParams,
-): ResolvedTelemetryView | { error: 'forbidden' | 'bad_request'; message: string } => {
+): PerformanceScope | { error: 'forbidden' | 'bad_request'; message: string } => {
   const resolved = resolveTelemetryView(c, 'performance', c.req.valid('query').view, params.keyId);
   if ('error' in resolved) return resolved;
-  if (resolved.view === 'self-by-key' && params.groupBy === 'userId') {
-    return { error: 'bad_request', message: 'group_by=userId is not allowed in self-by-key mode' };
+
+  // Both knobs below name a user dimension. In self-by-key every row already
+  // belongs to the actor, so the dimension is meaningless rather than
+  // privileged — administrators are refused there too.
+  const attributeUsers = resolved.view === 'all-by-user' && userFromContext(c).isAdmin;
+  if (!attributeUsers) {
+    const knob = params.groupBy === 'userId'
+      ? 'group_by=userId'
+      : params.filters.userId !== undefined
+        ? 'filter_user_id'
+        : null;
+    if (knob !== null) {
+      return resolved.view === 'self-by-key'
+        ? { error: 'bad_request', message: `${knob} is not allowed in self-by-key mode` }
+        : { error: 'forbidden', message: `${knob} requires administrator privileges` };
+    }
   }
-  return resolved;
+  return { ...resolved, attributeUsers };
 };
 
 const queryRecordsForView = async (
@@ -119,8 +142,8 @@ interface DimensionValues {
   operations: string[];
   runtimeLocations: string[];
   // The frontend joins these raw ids to the users/keys metadata below.
-  // keyIds always belongs to the actor; userIds spans all users only in the
-  // global view and stays empty in self-view.
+  // keyIds always belongs to the actor; userIds is populated only when the
+  // caller may attribute rows to users, and stays empty otherwise.
   keyIds: string[];
   userIds: number[];
 }
@@ -182,25 +205,24 @@ export const performanceOverview = async (c: Ctx) => {
   const params = readPerformanceQuery(c);
   if (params.type === 'error') return c.json({ error: params.error }, 400);
 
-  const resolved = resolveView(c, params.value);
-  if ('error' in resolved) return c.json({ error: resolved.message }, resolved.error === 'forbidden' ? 403 : 400);
+  const scope = resolveScope(c, params.value);
+  if ('error' in scope) return c.json({ error: scope.message }, scope.error === 'forbidden' ? 403 : 400);
 
   const repo = getRepo();
-  const allKeys = await loadTelemetryKeys(repo, resolved);
+  const allKeys = await loadTelemetryKeys(repo, scope);
   const actorUserId = userFromContext(c).id;
   const ownedKeys = allKeys.filter(key => key.userId === actorUserId);
   const ownedKeyIds = new Set(ownedKeys.map(key => key.id));
-  if (resolved.view === 'all-by-user' && params.value.filters.keyId !== undefined && !ownedKeyIds.has(params.value.filters.keyId)) {
+  if (scope.view === 'all-by-user' && params.value.filters.keyId !== undefined && !ownedKeyIds.has(params.value.filters.keyId)) {
     return c.json({ error: 'Unknown filter_key_id' }, 404);
   }
 
-  const rawRecords = await queryRecordsForView(resolved, params.value, ownedKeyIds);
+  const rawRecords = await queryRecordsForView(scope, params.value, ownedKeyIds);
   if (rawRecords === null) return c.json({ error: 'Unknown key_id' }, 404);
 
-  const includeUserRows = resolved.view === 'all-by-user';
-  const users = includeUserRows ? await repo.users.listIncludingDeleted() : [];
+  const users = scope.attributeUsers ? await repo.users.listIncludingDeleted() : [];
   const keyToUser = buildKeyToUserMap(allKeys);
-  const { filtered, dimensionValues } = partitionRecords(rawRecords, params.value.filters, keyToUser, ownedKeyIds, includeUserRows);
+  const { filtered, dimensionValues } = partitionRecords(rawRecords, params.value.filters, keyToUser, ownedKeyIds, scope.attributeUsers);
 
   const tzOnly = { timezoneOffsetMinutes: params.value.timezoneOffsetMinutes };
   const { series, ...axes } = aggregatePerformanceForDisplay(filtered, {
@@ -215,8 +237,8 @@ export const performanceOverview = async (c: Ctx) => {
     userId: { ...tzOnly, bucket: 'all', groupBy: 'userId' as const },
   }, keyToUser, ownedKeyIds);
 
-  // Global views expose user metadata for By User, while key metadata remains
-  // actor-owned for By API Key and its filter.
+  // Per-user attribution exposes the username listing for By User, while key
+  // metadata remains actor-owned for By API Key and its filter.
   const userMetadata = users
     .map(u => ({ id: u.id, username: u.username }))
     .sort((a, b) => a.id - b.id);
@@ -228,7 +250,7 @@ export const performanceOverview = async (c: Ctx) => {
     series,
     axes: {
       ...axes,
-      userId: includeUserRows ? axes.userId : [],
+      userId: scope.attributeUsers ? axes.userId : [],
     },
     dimensionValues,
     users: userMetadata,

--- a/packages/gateway/src/control-plane/performance/routes_test.ts
+++ b/packages/gateway/src/control-plane/performance/routes_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { grantGlobalTelemetry, requestApp, setupAppTest } from '../../test-helpers.ts';
+import { requestApp, setupAppTest } from '../../test-helpers.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 test('/api/performance/overview modelRows carry backend-aggregated base-model percentiles', async () => {
@@ -26,7 +26,7 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
     await repo.performance.recordSample({ ...sample, ttftMs: 300 });
   }
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -49,10 +49,10 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
   ]);
 });
 
-test('/api/performance/overview scopes to actor\'s keys in self-by-key mode', async () => {
+test('/api/performance/overview narrows the whole aggregate to the actor under group_by=keyId', async () => {
   const { repo, apiKey } = await setupAppTest();
-  // A key owned by user 1 with usage in the same window — must NOT surface to
-  // the actor (user 2) under the self-by-key view.
+  // A key owned by user 1 with traffic in the same window. By API Key asks
+  // about the actor's own data, so neither its rows nor its id may surface.
   await repo.apiKeys.save({
     id: 'key_other',
     userId: 1,
@@ -79,13 +79,53 @@ test('/api/performance/overview scopes to actor\'s keys in self-by-key mode', as
   await repo.performance.recordSample({ ...sample, keyId: apiKey.id, ttftMs: 50 });
   await repo.performance.recordSample({ ...sample, keyId: 'key_other', ttftMs: 250 });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&group_by=keyId', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
   assertEquals(body.axes.keyId.map((r: { group: string }) => r.group), [apiKey.id]);
   assertEquals(body.dimensionValues.keyIds, [apiKey.id]);
   assertEquals(body.keys.map((key: { id: string }) => key.id), [apiKey.id]);
+  // Every other axis narrows with it — the summary counts one request, not two.
+  assertEquals(body.axes.none.map((r: { requests: number }) => r.requests), [1]);
+});
+
+test('/api/performance/overview keeps API-key axes actor-scoped under a cross-user breakdown', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await repo.apiKeys.save({
+    id: 'key_other',
+    userId: 1,
+    name: 'Other key',
+    key: 'raw_other_key',
+    serverSecret: '00'.repeat(32),
+    createdAt: '2026-04-30T00:00:00.000Z',
+    upstreamIds: null,
+    deletedAt: null,
+    dumpRetentionSeconds: null,
+    responsesRetentionSeconds: 0,
+  });
+
+  const sample = {
+    hour: '2026-04-30T10',
+    model: 'gpt-5',
+    upstream: 'copilot:1',
+    operation: 'chat' as const,
+    runtimeLocation: 'LOCAL',
+    tpotUs: 500,
+    success: true,
+  };
+  await repo.performance.recordSample({ ...sample, keyId: apiKey.id, ttftMs: 50 });
+  await repo.performance.recordSample({ ...sample, keyId: 'key_other', ttftMs: 250 });
+
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&group_by=model', { headers: { 'x-api-key': apiKey.key } });
+
+  assertEquals(response.status, 200);
+  const body = await response.json();
+  // Both users' rows feed the model breakdown...
+  assertEquals(body.axes.model.map((r: { requests: number }) => r.requests), [2]);
+  // ...while the key dimension still names only the actor's own key.
+  assertEquals(body.axes.keyId.map((r: { group: string }) => r.group), [apiKey.id]);
+  assertEquals(body.dimensionValues.keyIds, [apiKey.id]);
 });
 
 test('/api/performance/overview always returns key metadata', async () => {
@@ -102,7 +142,7 @@ test('/api/performance/overview always returns key metadata', async () => {
     success: true,
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -115,10 +155,10 @@ test('/api/performance/overview always returns key metadata', async () => {
   ]);
 });
 
-test('/api/performance/overview all-by-user view aggregates over every key', async () => {
+test('/api/performance/overview aggregates over every user\'s keys', async () => {
   const { repo, adminSession, apiKey } = await setupAppTest();
   // Two users' rows in the same hour. Both must contribute to the same
-  // `model` group under the admin session's all-by-user view.
+  // `model` group, which spans every user's rows.
   await repo.apiKeys.save({
     id: 'key_other',
     userId: 1,
@@ -145,7 +185,7 @@ test('/api/performance/overview all-by-user view aggregates over every key', asy
   await repo.performance.recordSample({ ...sample, keyId: apiKey.id });
   await repo.performance.recordSample({ ...sample, keyId: 'key_other' });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=all-by-user', { headers: { 'x-floway-session': adminSession } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-floway-session': adminSession } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -154,15 +194,8 @@ test('/api/performance/overview all-by-user view aggregates over every key', asy
   assertEquals(body.axes.model[0].requests, 2);
 });
 
-test('/api/performance/overview rejects all-by-user from a user without canViewGlobalTelemetry', async () => {
-  const { apiKey } = await setupAppTest();
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user', { headers: { 'x-api-key': apiKey.key } });
-  assertEquals(response.status, 403);
-});
-
-test('/api/performance/overview gives a non-admin holding canViewGlobalTelemetry the aggregate without per-user attribution', async () => {
+test('/api/performance/overview gives a non-admin the global aggregate without per-user attribution', async () => {
   const { repo, apiKey } = await setupAppTest();
-  await grantGlobalTelemetry(repo, apiKey.userId);
   await repo.apiKeys.save({
     id: 'key_admin_owned',
     userId: 1,
@@ -189,7 +222,7 @@ test('/api/performance/overview gives a non-admin holding canViewGlobalTelemetry
   await repo.performance.recordSample({ ...sample, keyId: apiKey.id });
   await repo.performance.recordSample({ ...sample, keyId: 'key_admin_owned' });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=all-by-user', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -202,27 +235,25 @@ test('/api/performance/overview gives a non-admin holding canViewGlobalTelemetry
   assertEquals(body.dimensionValues.userIds, []);
 });
 
-test('/api/performance/overview rejects group_by=userId from a non-admin in all-by-user view', async () => {
-  const { repo, apiKey } = await setupAppTest();
-  await grantGlobalTelemetry(repo, apiKey.userId);
+test('/api/performance/overview rejects group_by=userId from a non-admin', async () => {
+  const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user&group_by=userId', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&group_by=userId', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 403);
   assertEquals(await response.json(), { error: 'group_by=userId requires administrator privileges' });
 });
 
-test('/api/performance/overview rejects filter_user_id from a non-admin in all-by-user view', async () => {
-  const { repo, apiKey } = await setupAppTest();
-  await grantGlobalTelemetry(repo, apiKey.userId);
+test('/api/performance/overview rejects filter_user_id from a non-admin', async () => {
+  const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user&filter_user_id=1', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=1', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 403);
   assertEquals(await response.json(), { error: 'filter_user_id requires administrator privileges' });
 });
 
-test('/api/performance/overview keeps API-key data self-scoped in all-by-user view', async () => {
+test('/api/performance/overview narrows an administrator to their own keys under group_by=keyId too', async () => {
   const { repo, adminSession, apiKey } = await setupAppTest();
   await repo.apiKeys.save({
     id: 'key_admin',
@@ -250,7 +281,7 @@ test('/api/performance/overview keeps API-key data self-scoped in all-by-user vi
   await repo.performance.recordSample({ ...sample, keyId: apiKey.id });
   await repo.performance.recordSample({ ...sample, keyId: 'key_admin' });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user&group_by=keyId', { headers: { 'x-floway-session': adminSession } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&group_by=keyId', { headers: { 'x-floway-session': adminSession } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -262,31 +293,31 @@ test('/api/performance/overview keeps API-key data self-scoped in all-by-user vi
     name: 'Admin owned',
     createdAt: '2026-04-30T00:00:00.000Z',
   }]);
-  assertEquals(body.axes.model[0].requests, 2);
-  assertEquals(body.axes.userId.map((r: { group: string; requests: number }) => [r.group, r.requests]).sort(), [['1', 1], ['2', 1]]);
+  // By API Key means "my data" for administrators as well: the other user's
+  // row is out of scope, so every cross-cutting axis counts one request.
+  assertEquals(body.axes.model[0].requests, 1);
+  assertEquals(body.axes.userId.map((r: { group: string; requests: number }) => [r.group, r.requests]), [['1', 1]]);
 });
 
-test('/api/performance/overview rejects another user\'s API-key filter in all-by-user view', async () => {
+test('/api/performance/overview rejects an API-key filter the actor does not own', async () => {
   const { adminSession, apiKey } = await setupAppTest();
 
-  const response = await requestApp(`/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user&filter_key_id=${apiKey.id}`, { headers: { 'x-floway-session': adminSession } });
+  const response = await requestApp(`/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_key_id=${apiKey.id}`, { headers: { 'x-floway-session': adminSession } });
 
   assertEquals(response.status, 404);
   assertEquals(await response.json(), { error: 'Unknown filter_key_id' });
 });
 
-test('/api/performance/overview treats an unknown self-view API-key filter as an empty selection', async () => {
+test('/api/performance/overview rejects an unknown API-key filter', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_key_id=unknown&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_key_id=unknown', { headers: { 'x-api-key': apiKey.key } });
 
-  assertEquals(response.status, 200);
-  const body = await response.json();
-  assertEquals(body.series, []);
-  assertEquals(body.axes.none, []);
+  assertEquals(response.status, 404);
+  assertEquals(await response.json(), { error: 'Unknown filter_key_id' });
 });
 
-test('/api/performance/overview all-by-user userRows split rows per user', async () => {
+test('/api/performance/overview userRows split rows per user', async () => {
   const { repo, adminSession, apiKey } = await setupAppTest();
   await repo.apiKeys.save({
     id: 'key_other',
@@ -315,7 +346,7 @@ test('/api/performance/overview all-by-user userRows split rows per user', async
   await repo.performance.recordSample({ ...sample, keyId: apiKey.id });
   await repo.performance.recordSample({ ...sample, keyId: 'key_other' });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user', { headers: { 'x-floway-session': adminSession } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00', { headers: { 'x-floway-session': adminSession } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -323,15 +354,7 @@ test('/api/performance/overview all-by-user userRows split rows per user', async
   assertEquals(groups, [['1', 1], ['2', 2]]);
 });
 
-test('/api/performance/overview rejects group_by=userId in self-by-key mode', async () => {
-  const { apiKey } = await setupAppTest();
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&group_by=userId&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
-  assertEquals(response.status, 400);
-  const body = await response.json();
-  assertEquals(body.error, 'group_by=userId is not allowed in self-by-key mode');
-});
-
-test('/api/performance/overview series stays per-model under all-by-user view', async () => {
+test('/api/performance/overview series stays per-model under a cross-user breakdown', async () => {
   const { repo, adminSession, apiKey } = await setupAppTest();
   await repo.apiKeys.save({
     id: 'key_other',
@@ -359,7 +382,7 @@ test('/api/performance/overview series stays per-model under all-by-user view', 
   await repo.performance.recordSample({ ...sample, keyId: apiKey.id });
   await repo.performance.recordSample({ ...sample, keyId: 'key_other' });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&group_by=model&view=all-by-user', { headers: { 'x-floway-session': adminSession } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&group_by=model', { headers: { 'x-floway-session': adminSession } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -373,7 +396,7 @@ test('/api/performance/overview series stays per-model under all-by-user view', 
   assertEquals(body.dimensionValues.userIds.sort((a: number, b: number) => a - b), [1, 2]);
 });
 
-test('/api/performance/overview leaves dimensionValues.userIds empty under self-by-key view', async () => {
+test('/api/performance/overview leaves dimensionValues.userIds empty for a non-admin', async () => {
   const { repo, apiKey } = await setupAppTest();
   await repo.performance.recordSample({
     hour: '2026-04-30T10',
@@ -387,7 +410,7 @@ test('/api/performance/overview leaves dimensionValues.userIds empty under self-
     success: true,
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -419,7 +442,7 @@ test('/api/performance/overview returns dashboard aggregates from one repo query
     success: true,
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -442,7 +465,7 @@ test('/api/performance/overview counts failed attempts in dashboard request tota
     runtimeLocation: 'SJC',
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -458,7 +481,7 @@ test('/api/performance/overview counts failed attempts in dashboard request tota
 test('/api/performance/overview rejects out-of-range timezone offsets', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=day&timezone_offset_minutes=100000000000000000000&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=day&timezone_offset_minutes=100000000000000000000', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -469,7 +492,7 @@ test('/api/performance/overview rejects out-of-range timezone offsets', async ()
 test('/api/performance/overview rejects non-numeric filter_user_id at the schema boundary', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=abc&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=abc', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -480,7 +503,7 @@ test('/api/performance/overview rejects non-numeric filter_user_id at the schema
 test('/api/performance/overview rejects negative filter_user_id', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=-5&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=-5', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -491,7 +514,7 @@ test('/api/performance/overview rejects negative filter_user_id', async () => {
 test('/api/performance/overview rejects filter_user_id=0 (user ids start at 1)', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=0&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=0', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -502,7 +525,7 @@ test('/api/performance/overview rejects filter_user_id=0 (user ids start at 1)',
 test('/api/performance/overview rejects filter_user_id with a leading zero', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=01&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=01', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -513,23 +536,12 @@ test('/api/performance/overview rejects filter_user_id with a leading zero', asy
 test('/api/performance/overview accepts numeric filter_user_id from an admin', async () => {
   const { adminSession } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=42&view=all-by-user', { headers: { 'x-floway-session': adminSession } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=42', { headers: { 'x-floway-session': adminSession } });
 
   assertEquals(response.status, 200);
 });
 
-test('/api/performance/overview rejects filter_user_id in self-by-key mode', async () => {
-  const { adminSession } = await setupAppTest();
-
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=42&view=self-by-key', { headers: { 'x-floway-session': adminSession } });
-
-  assertEquals(response.status, 400);
-  assertEquals(await response.json(), {
-    error: 'filter_user_id is not allowed in self-by-key mode',
-  });
-});
-
-test('/api/performance/overview all-by-user attributes soft-deleted keys to their original owner', async () => {
+test('/api/performance/overview attributes soft-deleted keys to their original owner', async () => {
   const { repo, adminSession, apiKey } = await setupAppTest();
   // Latency sample on apiKey, then soft-delete the key. The aggregator must
   // still resolve the row to apiKey.userId rather than the synthetic userId 0
@@ -548,7 +560,7 @@ test('/api/performance/overview all-by-user attributes soft-deleted keys to thei
   await repo.apiKeys.softDelete(apiKey.id);
 
   const response = await requestApp(
-    '/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user',
+    '/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00',
     { headers: { 'x-floway-session': adminSession } },
   );
 
@@ -558,7 +570,7 @@ test('/api/performance/overview all-by-user attributes soft-deleted keys to thei
   assertEquals(groups, [[String(apiKey.userId), 1]]);
 });
 
-test('/api/performance/overview self-by-key surfaces soft-deleted keys metadata to their owner', async () => {
+test('/api/performance/overview surfaces soft-deleted keys metadata to their owner', async () => {
   const { repo, apiKey } = await setupAppTest();
   await repo.performance.recordSample({
     hour: '2026-04-30T10',
@@ -588,7 +600,7 @@ test('/api/performance/overview self-by-key surfaces soft-deleted keys metadata 
   });
 
   const response = await requestApp(
-    '/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=self-by-key',
+    '/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00',
     { headers: { 'x-api-key': 'raw_fresh_key' } },
   );
 
@@ -633,7 +645,7 @@ test('/api/performance/overview returns operationRows grouped by operation value
     runtimeLocation: 'LOCAL',
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();

--- a/packages/gateway/src/control-plane/performance/routes_test.ts
+++ b/packages/gateway/src/control-plane/performance/routes_test.ts
@@ -26,7 +26,7 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
     await repo.performance.recordSample({ ...sample, ttftMs: 300 });
   }
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -52,7 +52,7 @@ test('/api/performance/overview modelRows carry backend-aggregated base-model pe
 test('/api/performance/overview scopes to actor\'s keys in self-by-key mode', async () => {
   const { repo, apiKey } = await setupAppTest();
   // A key owned by user 1 with usage in the same window — must NOT surface to
-  // the actor (user 2) under the default self-by-key view.
+  // the actor (user 2) under the self-by-key view.
   await repo.apiKeys.save({
     id: 'key_other',
     userId: 1,
@@ -79,7 +79,7 @@ test('/api/performance/overview scopes to actor\'s keys in self-by-key mode', as
   await repo.performance.recordSample({ ...sample, keyId: apiKey.id, ttftMs: 50 });
   await repo.performance.recordSample({ ...sample, keyId: 'key_other', ttftMs: 250 });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -102,7 +102,7 @@ test('/api/performance/overview always returns key metadata', async () => {
     success: true,
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -117,9 +117,8 @@ test('/api/performance/overview always returns key metadata', async () => {
 
 test('/api/performance/overview all-by-user view aggregates over every key', async () => {
   const { repo, adminSession, apiKey } = await setupAppTest();
-  // Two users' rows in the same hour. The admin session has
-  // canViewGlobalTelemetry=true and defaults to all-by-user; both rows must
-  // contribute to the same `model` group.
+  // Two users' rows in the same hour. Both must contribute to the same
+  // `model` group under the admin session's all-by-user view.
   await repo.apiKeys.save({
     id: 'key_other',
     userId: 1,
@@ -161,7 +160,7 @@ test('/api/performance/overview rejects all-by-user from a user without canViewG
   assertEquals(response.status, 403);
 });
 
-test('/api/performance/overview grants all-by-user to a non-admin holding canViewGlobalTelemetry', async () => {
+test('/api/performance/overview gives a non-admin holding canViewGlobalTelemetry the aggregate without per-user attribution', async () => {
   const { repo, apiKey } = await setupAppTest();
   await grantGlobalTelemetry(repo, apiKey.userId);
   await repo.apiKeys.save({
@@ -194,8 +193,33 @@ test('/api/performance/overview grants all-by-user to a non-admin holding canVie
 
   assertEquals(response.status, 200);
   const body = await response.json();
+  // Both users' rows land in the aggregate...
   assertEquals(body.axes.model.length, 1);
   assertEquals(body.axes.model[0].requests, 2);
+  // ...but nothing in the payload names who produced them.
+  assertEquals(body.axes.userId, []);
+  assertEquals(body.users, []);
+  assertEquals(body.dimensionValues.userIds, []);
+});
+
+test('/api/performance/overview rejects group_by=userId from a non-admin in all-by-user view', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await grantGlobalTelemetry(repo, apiKey.userId);
+
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user&group_by=userId', { headers: { 'x-api-key': apiKey.key } });
+
+  assertEquals(response.status, 403);
+  assertEquals(await response.json(), { error: 'group_by=userId requires administrator privileges' });
+});
+
+test('/api/performance/overview rejects filter_user_id from a non-admin in all-by-user view', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await grantGlobalTelemetry(repo, apiKey.userId);
+
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user&filter_user_id=1', { headers: { 'x-api-key': apiKey.key } });
+
+  assertEquals(response.status, 403);
+  assertEquals(await response.json(), { error: 'filter_user_id requires administrator privileges' });
 });
 
 test('/api/performance/overview keeps API-key data self-scoped in all-by-user view', async () => {
@@ -254,7 +278,7 @@ test('/api/performance/overview rejects another user\'s API-key filter in all-by
 test('/api/performance/overview treats an unknown self-view API-key filter as an empty selection', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_key_id=unknown', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_key_id=unknown&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -301,7 +325,7 @@ test('/api/performance/overview all-by-user userRows split rows per user', async
 
 test('/api/performance/overview rejects group_by=userId in self-by-key mode', async () => {
   const { apiKey } = await setupAppTest();
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&group_by=userId', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&group_by=userId&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
   assertEquals(response.status, 400);
   const body = await response.json();
   assertEquals(body.error, 'group_by=userId is not allowed in self-by-key mode');
@@ -363,7 +387,7 @@ test('/api/performance/overview leaves dimensionValues.userIds empty under self-
     success: true,
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -395,7 +419,7 @@ test('/api/performance/overview returns dashboard aggregates from one repo query
     success: true,
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -418,7 +442,7 @@ test('/api/performance/overview counts failed attempts in dashboard request tota
     runtimeLocation: 'SJC',
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();
@@ -434,7 +458,7 @@ test('/api/performance/overview counts failed attempts in dashboard request tota
 test('/api/performance/overview rejects out-of-range timezone offsets', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=day&timezone_offset_minutes=100000000000000000000', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=day&timezone_offset_minutes=100000000000000000000&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -445,7 +469,7 @@ test('/api/performance/overview rejects out-of-range timezone offsets', async ()
 test('/api/performance/overview rejects non-numeric filter_user_id at the schema boundary', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=abc', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=abc&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -456,7 +480,7 @@ test('/api/performance/overview rejects non-numeric filter_user_id at the schema
 test('/api/performance/overview rejects negative filter_user_id', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=-5', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=-5&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -467,7 +491,7 @@ test('/api/performance/overview rejects negative filter_user_id', async () => {
 test('/api/performance/overview rejects filter_user_id=0 (user ids start at 1)', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=0', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=0&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -478,7 +502,7 @@ test('/api/performance/overview rejects filter_user_id=0 (user ids start at 1)',
 test('/api/performance/overview rejects filter_user_id with a leading zero', async () => {
   const { apiKey } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=01', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=01&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 400);
   assertEquals(await response.json(), {
@@ -486,12 +510,23 @@ test('/api/performance/overview rejects filter_user_id with a leading zero', asy
   });
 });
 
-test('/api/performance/overview accepts numeric filter_user_id', async () => {
-  const { apiKey } = await setupAppTest();
+test('/api/performance/overview accepts numeric filter_user_id from an admin', async () => {
+  const { adminSession } = await setupAppTest();
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=42', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=42&view=all-by-user', { headers: { 'x-floway-session': adminSession } });
 
   assertEquals(response.status, 200);
+});
+
+test('/api/performance/overview rejects filter_user_id in self-by-key mode', async () => {
+  const { adminSession } = await setupAppTest();
+
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&filter_user_id=42&view=self-by-key', { headers: { 'x-floway-session': adminSession } });
+
+  assertEquals(response.status, 400);
+  assertEquals(await response.json(), {
+    error: 'filter_user_id is not allowed in self-by-key mode',
+  });
 });
 
 test('/api/performance/overview all-by-user attributes soft-deleted keys to their original owner', async () => {
@@ -553,7 +588,7 @@ test('/api/performance/overview self-by-key surfaces soft-deleted keys metadata 
   });
 
   const response = await requestApp(
-    '/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00',
+    '/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=self-by-key',
     { headers: { 'x-api-key': 'raw_fresh_key' } },
   );
 
@@ -598,7 +633,7 @@ test('/api/performance/overview returns operationRows grouped by operation value
     runtimeLocation: 'LOCAL',
   });
 
-  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour', { headers: { 'x-api-key': apiKey.key } });
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
 
   assertEquals(response.status, 200);
   const body = await response.json();

--- a/packages/gateway/src/control-plane/performance/routes_test.ts
+++ b/packages/gateway/src/control-plane/performance/routes_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { requestApp, setupAppTest } from '../../test-helpers.ts';
+import { grantGlobalTelemetry, requestApp, setupAppTest } from '../../test-helpers.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 test('/api/performance/overview modelRows carry backend-aggregated base-model percentiles', async () => {
@@ -159,6 +159,43 @@ test('/api/performance/overview rejects all-by-user from a user without canViewG
   const { apiKey } = await setupAppTest();
   const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&view=all-by-user', { headers: { 'x-api-key': apiKey.key } });
   assertEquals(response.status, 403);
+});
+
+test('/api/performance/overview grants all-by-user to a non-admin holding canViewGlobalTelemetry', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await grantGlobalTelemetry(repo, apiKey.userId);
+  await repo.apiKeys.save({
+    id: 'key_admin_owned',
+    userId: 1,
+    name: 'Admin owned',
+    key: 'raw_admin_owned',
+    serverSecret: '00'.repeat(32),
+    createdAt: '2026-04-30T00:00:00.000Z',
+    upstreamIds: null,
+    deletedAt: null,
+    dumpRetentionSeconds: null,
+    responsesRetentionSeconds: 0,
+  });
+
+  const sample = {
+    hour: '2026-04-30T10',
+    model: 'gpt-5',
+    upstream: 'copilot:1',
+    operation: 'chat' as const,
+    runtimeLocation: 'LOCAL',
+    ttftMs: 100,
+    tpotUs: 500,
+    success: true,
+  };
+  await repo.performance.recordSample({ ...sample, keyId: apiKey.id });
+  await repo.performance.recordSample({ ...sample, keyId: 'key_admin_owned' });
+
+  const response = await requestApp('/api/performance/overview?start=2026-04-30T00&end=2026-05-01T00&bucket=hour&view=all-by-user', { headers: { 'x-api-key': apiKey.key } });
+
+  assertEquals(response.status, 200);
+  const body = await response.json();
+  assertEquals(body.axes.model.length, 1);
+  assertEquals(body.axes.model[0].requests, 2);
 });
 
 test('/api/performance/overview keeps API-key data self-scoped in all-by-user view', async () => {

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -714,8 +714,7 @@ export const exportQuery = z.object({
 // payload shapes, so deriving one from the caller's capability would make the
 // same URL answer differently per user — and silently widen as soon as
 // someone's role changes. Declaring it required in the schema also makes the
-// RPC client demand it at compile time. Performance carries no view at all:
-// its scope follows `group_by` (see performance/routes.ts).
+// RPC client demand it at compile time.
 //
 // start/end stay optional in the schema (rather than `.min(1)`) so the
 // handler can return the canonical "start and end query parameters are
@@ -723,13 +722,9 @@ export const exportQuery = z.object({
 // inform the RPC client of the available fields, not duplicate the
 // required-ness check.
 
-const telemetryRangeQuery = {
+const usageBaseQuery = {
   start: z.string().optional(),
   end: z.string().optional(),
-};
-
-const usageBaseQuery = {
-  ...telemetryRangeQuery,
   key_id: z.string().optional(),
   include_key_metadata: z.string().optional(),
   include_user_metadata: z.string().optional(),
@@ -755,7 +750,8 @@ export const searchUsageQuery = z.object({
 });
 
 export const performanceQuery = z.object({
-  ...telemetryRangeQuery,
+  start: z.string().optional(),
+  end: z.string().optional(),
   group_by: z.enum(['keyId', 'userId', 'model', 'upstream', 'operation', 'runtimeLocation']).optional(),
   bucket: z.enum(['hour', '4h', '8h', 'day', 'all']).optional(),
   timezone_offset_minutes: z.string().optional(),

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -242,7 +242,6 @@ export const createUserBody = z.object({
   password: passwordSchema,
   isAdmin: z.boolean().optional(),
   upstreamIds: upstreamIdsValueSchema.optional(),
-  canViewGlobalTelemetry: z.boolean().optional(),
 });
 
 export const updateUserBody = z.object({
@@ -250,7 +249,6 @@ export const updateUserBody = z.object({
   password: passwordSchema.optional(),
   isAdmin: z.boolean().optional(),
   upstreamIds: upstreamIdsValueSchema.optional(),
-  canViewGlobalTelemetry: z.boolean().optional(),
 });
 
 export const changeOwnPasswordBody = z.object({
@@ -701,7 +699,7 @@ export const updateAliasBody = aliasBodyCore.superRefine(aliasBodyRulesRefinemen
 // --- data transfer ---
 
 export const importBody = z.object({
-  version: z.literal(16, { error: 'version must be 16 — older export formats are not supported; re-export from the current deployment' }),
+  version: z.literal(17, { error: 'version must be 17 — older export formats are not supported; re-export from the current deployment' }),
   mode: z.enum(['merge', 'replace'], { error: "mode must be 'merge' or 'replace'" }),
   data: z.unknown().optional(),
 });
@@ -712,11 +710,12 @@ export const exportQuery = z.object({
 
 // --- query strings (token-usage, search-usage, performance) ---
 //
-// `view` is required. The two views return different payload shapes, so
-// deriving one from the caller's capability would make the same URL answer
-// differently per user — and silently widen as soon as someone is granted a
-// flag. Declaring it required in the schema also makes the RPC client demand
-// it at compile time.
+// `view` is required on the usage endpoints. The two views return different
+// payload shapes, so deriving one from the caller's capability would make the
+// same URL answer differently per user — and silently widen as soon as
+// someone's role changes. Declaring it required in the schema also makes the
+// RPC client demand it at compile time. Performance carries no view at all:
+// its scope follows `group_by` (see performance/routes.ts).
 //
 // start/end stay optional in the schema (rather than `.min(1)`) so the
 // handler can return the canonical "start and end query parameters are
@@ -724,9 +723,13 @@ export const exportQuery = z.object({
 // inform the RPC client of the available fields, not duplicate the
 // required-ness check.
 
-const usageBaseQuery = {
+const telemetryRangeQuery = {
   start: z.string().optional(),
   end: z.string().optional(),
+};
+
+const usageBaseQuery = {
+  ...telemetryRangeQuery,
   key_id: z.string().optional(),
   include_key_metadata: z.string().optional(),
   include_user_metadata: z.string().optional(),
@@ -751,7 +754,8 @@ export const searchUsageQuery = z.object({
   provider: z.string().optional(),
 });
 
-export const performanceQuery = z.object(usageBaseQuery).omit({ include_key_metadata: true, include_user_metadata: true }).extend({
+export const performanceQuery = z.object({
+  ...telemetryRangeQuery,
   group_by: z.enum(['keyId', 'userId', 'model', 'upstream', 'operation', 'runtimeLocation']).optional(),
   bucket: z.enum(['hour', '4h', '8h', 'day', 'all']).optional(),
   timezone_offset_minutes: z.string().optional(),

--- a/packages/gateway/src/control-plane/schemas.ts
+++ b/packages/gateway/src/control-plane/schemas.ts
@@ -712,9 +712,15 @@ export const exportQuery = z.object({
 
 // --- query strings (token-usage, search-usage, performance) ---
 //
+// `view` is required. The two views return different payload shapes, so
+// deriving one from the caller's capability would make the same URL answer
+// differently per user — and silently widen as soon as someone is granted a
+// flag. Declaring it required in the schema also makes the RPC client demand
+// it at compile time.
+//
 // start/end stay optional in the schema (rather than `.min(1)`) so the
 // handler can return the canonical "start and end query parameters are
-// required" message its tests assert on. The schema's job here is to
+// required" message its tests assert on. The schema's job there is to
 // inform the RPC client of the available fields, not duplicate the
 // required-ness check.
 
@@ -724,7 +730,7 @@ const usageBaseQuery = {
   key_id: z.string().optional(),
   include_key_metadata: z.string().optional(),
   include_user_metadata: z.string().optional(),
-  view: z.enum(['all-by-user', 'self-by-key']).optional(),
+  view: z.enum(['all-by-user', 'self-by-key'], { error: "view must be 'all-by-user' or 'self-by-key'" }),
 };
 
 export const tokenUsageQuery = z.object(usageBaseQuery);

--- a/packages/gateway/src/control-plane/search-usage/routes.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes.ts
@@ -11,7 +11,7 @@ import { type CtxWithQuery } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
 import { isWebSearchProviderName } from '../../shared/web-search-providers.ts';
 import type { searchUsageQuery } from '../schemas.ts';
-import { loadTelemetryKeys, resolveTelemetryView, buildKeyToUserMap } from '../telemetry-view.ts';
+import { resolveTelemetryView, buildKeyToUserMap } from '../telemetry-view.ts';
 
 export const searchUsage = async (c: CtxWithQuery<typeof searchUsageQuery>) => {
   const query = c.req.valid('query');
@@ -36,7 +36,7 @@ export const searchUsage = async (c: CtxWithQuery<typeof searchUsageQuery>) => {
     const [rawRecords, users, keys] = await Promise.all([
       queryWebSearchUsage({ provider, start, end }),
       repo.users.listIncludingDeleted(),
-      loadTelemetryKeys(repo, resolved),
+      repo.apiKeys.listIncludingDeleted(),
     ]);
     const records = aggregateSearchUsageByUser(rawRecords, buildKeyToUserMap(keys));
 
@@ -53,7 +53,7 @@ export const searchUsage = async (c: CtxWithQuery<typeof searchUsageQuery>) => {
   }
 
   // self-by-key: scope rows to the actor's keys (active + soft-deleted).
-  const keys = await loadTelemetryKeys(repo, resolved);
+  const keys = await repo.apiKeys.listByUserIdIncludingDeleted(resolved.scopeUserId);
   const ownedSet = new Set(keys.map(k => k.id));
   const explicitKeyId = query.key_id === '' ? undefined : query.key_id;
   if (explicitKeyId !== undefined && !ownedSet.has(explicitKeyId)) {

--- a/packages/gateway/src/control-plane/search-usage/routes.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes.ts
@@ -1,9 +1,8 @@
 // GET /api/search-usage — query per-key or per-user web search usage records.
 //
 // Mirrors the token-usage endpoint: the `view` query parameter selects between
-// `self-by-key` (the actor's own keys) and `all-by-user` (cross-user aggregate
-// for callers with `canViewGlobalTelemetry`). Default view is determined by
-// capability.
+// `self-by-key` (the actor's own keys) and `all-by-user` (cross-user aggregate,
+// administrators only). Default view is determined by capability.
 
 import { aggregateSearchUsageByKey, aggregateSearchUsageByUser } from './aggregate.ts';
 import { loadSearchConfig } from '../../data-plane/tools/web-search/search-config.ts';
@@ -26,7 +25,7 @@ export const searchUsage = async (c: CtxWithQuery<typeof searchUsageQuery>) => {
     return c.json({ error: "provider must be 'tavily' or 'microsoft-grounding'" }, 400);
   }
 
-  const resolved = resolveTelemetryView(c, query.view, query.key_id);
+  const resolved = resolveTelemetryView(c, 'usage', query.view, query.key_id);
   if ('error' in resolved) {
     return c.json({ error: resolved.message }, resolved.error === 'forbidden' ? 403 : 400);
   }

--- a/packages/gateway/src/control-plane/search-usage/routes.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes.ts
@@ -1,8 +1,8 @@
 // GET /api/search-usage — query per-key or per-user web search usage records.
 //
-// Mirrors the token-usage endpoint: the `view` query parameter selects between
-// `self-by-key` (the actor's own keys) and `all-by-user` (cross-user aggregate,
-// administrators only). Default view is determined by capability.
+// Mirrors the token-usage endpoint: the required `view` query parameter selects
+// between `self-by-key` (the actor's own keys) and `all-by-user` (cross-user
+// aggregate, administrators only).
 
 import { aggregateSearchUsageByKey, aggregateSearchUsageByUser } from './aggregate.ts';
 import { loadSearchConfig } from '../../data-plane/tools/web-search/search-config.ts';

--- a/packages/gateway/src/control-plane/search-usage/routes.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes.ts
@@ -25,7 +25,7 @@ export const searchUsage = async (c: CtxWithQuery<typeof searchUsageQuery>) => {
     return c.json({ error: "provider must be 'tavily' or 'microsoft-grounding'" }, 400);
   }
 
-  const resolved = resolveTelemetryView(c, 'usage', query.view, query.key_id);
+  const resolved = resolveTelemetryView(c, query.view, query.key_id);
   if ('error' in resolved) {
     return c.json({ error: resolved.message }, resolved.error === 'forbidden' ? 403 : 400);
   }

--- a/packages/gateway/src/control-plane/search-usage/routes_test.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { grantGlobalTelemetry, requestApp, setupAppTest } from '../../test-helpers.ts';
+import { requestApp, setupAppTest } from '../../test-helpers.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 const seedSearchUsage = async (repo: import('../../repo/memory.ts').InMemoryRepo, primaryKeyId: string) => {
@@ -117,25 +117,6 @@ test('/api/search-usage rejects all-by-user from a non-admin user', async () => 
     headers: { 'x-api-key': apiKey.key },
   });
   assertEquals(response.status, 403);
-});
-
-test('/api/search-usage stays admin-only for a non-admin holding canViewGlobalTelemetry', async () => {
-  const { repo, apiKey } = await setupAppTest();
-  await seedSearchUsage(repo, apiKey.id);
-  await grantGlobalTelemetry(repo, apiKey.userId);
-
-  const explicit = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&view=all-by-user', {
-    headers: { 'x-api-key': apiKey.key },
-  });
-  assertEquals(explicit.status, 403);
-
-  // Nor may the flag widen what a self-by-key request returns.
-  const selfView = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&view=self-by-key', {
-    headers: { 'x-api-key': apiKey.key },
-  });
-  assertEquals(selfView.status, 200);
-  const body = await selfView.json();
-  assertEquals([...new Set(body.map((r: { keyId: string }) => r.keyId))], [apiKey.id]);
 });
 
 test('/api/search-usage filters by provider and rejects invalid provider', async () => {

--- a/packages/gateway/src/control-plane/search-usage/routes_test.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { requestApp, setupAppTest } from '../../test-helpers.ts';
+import { grantGlobalTelemetry, requestApp, setupAppTest } from '../../test-helpers.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 const seedSearchUsage = async (repo: import('../../repo/memory.ts').InMemoryRepo, primaryKeyId: string) => {
@@ -111,12 +111,31 @@ test('/api/search-usage all-by-user view with include_user_metadata=1 includes u
   assertEquals(body.users.find((u: { id: number }) => u.id === 2).username, 'tester');
 });
 
-test('/api/search-usage rejects all-by-user from a user without canViewGlobalTelemetry', async () => {
+test('/api/search-usage rejects all-by-user from a non-admin user', async () => {
   const { apiKey } = await setupAppTest();
   const response = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&view=all-by-user', {
     headers: { 'x-api-key': apiKey.key },
   });
   assertEquals(response.status, 403);
+});
+
+test('/api/search-usage stays admin-only for a non-admin holding canViewGlobalTelemetry', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await seedSearchUsage(repo, apiKey.id);
+  await grantGlobalTelemetry(repo, apiKey.userId);
+
+  const explicit = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&view=all-by-user', {
+    headers: { 'x-api-key': apiKey.key },
+  });
+  assertEquals(explicit.status, 403);
+
+  // The flag must not flip the default view to the global shape either.
+  const defaulted = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00', {
+    headers: { 'x-api-key': apiKey.key },
+  });
+  assertEquals(defaulted.status, 200);
+  const body = await defaulted.json();
+  assertEquals([...new Set(body.map((r: { keyId: string }) => r.keyId))], [apiKey.id]);
 });
 
 test('/api/search-usage filters by provider and rejects invalid provider', async () => {

--- a/packages/gateway/src/control-plane/search-usage/routes_test.ts
+++ b/packages/gateway/src/control-plane/search-usage/routes_test.ts
@@ -26,7 +26,7 @@ test('/api/search-usage scopes to the actor\'s keys when called with an API key'
   const { repo, apiKey } = await setupAppTest();
   await seedSearchUsage(repo, apiKey.id);
 
-  const response = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00', {
+  const response = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&view=self-by-key', {
     headers: { 'x-api-key': apiKey.key },
   });
 
@@ -54,7 +54,7 @@ test('/api/search-usage in self-by-key mode includes per-key metadata for the ac
     passthroughOpenAiSearch: { enabled: false, upstreamId: '', model: '' },
   });
 
-  const response = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&include_key_metadata=1', {
+  const response = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&include_key_metadata=1&view=self-by-key', {
     headers: { 'x-api-key': apiKey.key },
   });
 
@@ -129,12 +129,12 @@ test('/api/search-usage stays admin-only for a non-admin holding canViewGlobalTe
   });
   assertEquals(explicit.status, 403);
 
-  // The flag must not flip the default view to the global shape either.
-  const defaulted = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00', {
+  // Nor may the flag widen what a self-by-key request returns.
+  const selfView = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&view=self-by-key', {
     headers: { 'x-api-key': apiKey.key },
   });
-  assertEquals(defaulted.status, 200);
-  const body = await defaulted.json();
+  assertEquals(selfView.status, 200);
+  const body = await selfView.json();
   assertEquals([...new Set(body.map((r: { keyId: string }) => r.keyId))], [apiKey.id]);
 });
 
@@ -142,7 +142,7 @@ test('/api/search-usage filters by provider and rejects invalid provider', async
   const { repo, apiKey } = await setupAppTest();
   await seedSearchUsage(repo, apiKey.id);
 
-  const filtered = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&provider=tavily', {
+  const filtered = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&provider=tavily&view=self-by-key', {
     headers: { 'x-api-key': apiKey.key },
   });
   assertEquals(filtered.status, 200);
@@ -150,7 +150,7 @@ test('/api/search-usage filters by provider and rejects invalid provider', async
     { provider: 'tavily', keyId: apiKey.id, hour: '2026-03-15T10', requests: 5 },
   ]);
 
-  const invalid = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&provider=disabled', {
+  const invalid = await requestApp('/api/search-usage?start=2026-03-15T00&end=2026-03-16T00&provider=disabled&view=self-by-key', {
     headers: { 'x-api-key': apiKey.key },
   });
   assertEquals(invalid.status, 400);
@@ -159,11 +159,11 @@ test('/api/search-usage filters by provider and rejects invalid provider', async
 test('/api/search-usage requires start and end', async () => {
   const { apiKey } = await setupAppTest();
 
-  const missingStart = await requestApp('/api/search-usage?end=2026-03-16T00', { headers: { 'x-api-key': apiKey.key } });
+  const missingStart = await requestApp('/api/search-usage?end=2026-03-16T00&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
   assertEquals(missingStart.status, 400);
   assertEquals(await missingStart.json(), { error: 'start and end query parameters are required (e.g. 2026-03-09T00)' });
 
-  const missingEnd = await requestApp('/api/search-usage?start=2026-03-15T00', { headers: { 'x-api-key': apiKey.key } });
+  const missingEnd = await requestApp('/api/search-usage?start=2026-03-15T00&view=self-by-key', { headers: { 'x-api-key': apiKey.key } });
   assertEquals(missingEnd.status, 400);
   assertEquals(await missingEnd.json(), { error: 'start and end query parameters are required (e.g. 2026-03-09T00)' });
 });

--- a/packages/gateway/src/control-plane/telemetry-view.ts
+++ b/packages/gateway/src/control-plane/telemetry-view.ts
@@ -1,7 +1,15 @@
-import { type AuthedContext, canViewGlobalTelemetry, userFromContext } from '../middleware/auth.ts';
-import type { ApiKey, Repo } from '../repo/types.ts';
+import { type AuthedContext, userFromContext } from '../middleware/auth.ts';
+import type { ApiKey, Repo, User } from '../repo/types.ts';
 
 export type TelemetryView = 'all-by-user' | 'self-by-key';
+
+// The telemetry surface a cross-user view is being asked for. Usage exposes
+// other users' request volume and spend, so it stays an administrator
+// privilege; the per-user flag opens global visibility for performance only.
+export type TelemetryDomain = 'usage' | 'performance';
+
+export const canViewGlobalTelemetry = (user: User, domain: TelemetryDomain): boolean =>
+  user.isAdmin || (domain === 'performance' && user.canViewGlobalTelemetry);
 
 // Discriminated union so callers narrow scopeUserId without non-null assertions.
 export type ResolvedTelemetryView =
@@ -10,18 +18,21 @@ export type ResolvedTelemetryView =
 
 export const resolveTelemetryView = (
   c: AuthedContext,
+  domain: TelemetryDomain,
   rawView: TelemetryView | undefined,
   rawKeyId: string | undefined,
 ): ResolvedTelemetryView | { error: 'forbidden' | 'bad_request'; message: string } => {
   const user = userFromContext(c);
-  const canViewGlobal = canViewGlobalTelemetry(user);
+  const canViewGlobal = canViewGlobalTelemetry(user, domain);
 
   const view = rawView ?? (canViewGlobal ? 'all-by-user' : 'self-by-key');
 
   if (view === 'all-by-user' && !canViewGlobal) {
     return {
       error: 'forbidden',
-      message: 'You do not have permission to view global telemetry',
+      message: domain === 'usage'
+        ? 'Viewing usage across users requires administrator privileges'
+        : 'You do not have permission to view global telemetry',
     };
   }
   if (view === 'all-by-user' && rawKeyId !== undefined && rawKeyId !== '') {

--- a/packages/gateway/src/control-plane/telemetry-view.ts
+++ b/packages/gateway/src/control-plane/telemetry-view.ts
@@ -1,15 +1,9 @@
 import { type AuthedContext, userFromContext } from '../middleware/auth.ts';
-import type { ApiKey, Repo, User } from '../repo/types.ts';
+import type { ApiKey, Repo } from '../repo/types.ts';
 
+// The two shapes the usage endpoints answer in. Performance carries no view:
+// its scope follows the requested breakdown instead.
 export type TelemetryView = 'all-by-user' | 'self-by-key';
-
-// The telemetry surface a cross-user view is being asked for. Usage exposes
-// other users' request volume and spend, so it stays an administrator
-// privilege; the per-user flag opens global visibility for performance only.
-export type TelemetryDomain = 'usage' | 'performance';
-
-export const canViewGlobalTelemetry = (user: User, domain: TelemetryDomain): boolean =>
-  user.isAdmin || (domain === 'performance' && user.canViewGlobalTelemetry);
 
 // Discriminated union so callers narrow scopeUserId without non-null assertions.
 export type ResolvedTelemetryView =
@@ -18,7 +12,6 @@ export type ResolvedTelemetryView =
 
 export const resolveTelemetryView = (
   c: AuthedContext,
-  domain: TelemetryDomain,
   view: TelemetryView,
   rawKeyId: string | undefined,
 ): ResolvedTelemetryView | { error: 'forbidden' | 'bad_request'; message: string } => {
@@ -26,12 +19,11 @@ export const resolveTelemetryView = (
 
   if (view === 'self-by-key') return { view: 'self-by-key', scopeUserId: user.id };
 
-  if (!canViewGlobalTelemetry(user, domain)) {
+  // Cross-user usage exposes other users' request volume and spend.
+  if (!user.isAdmin) {
     return {
       error: 'forbidden',
-      message: domain === 'usage'
-        ? 'Viewing usage across users requires administrator privileges'
-        : 'You do not have permission to view global telemetry',
+      message: 'Viewing usage across users requires administrator privileges',
     };
   }
   if (rawKeyId !== undefined && rawKeyId !== '') {
@@ -50,7 +42,7 @@ export const loadTelemetryKeys = async (
   ? await repo.apiKeys.listIncludingDeleted()
   : await repo.apiKeys.listByUserIdIncludingDeleted(resolved.scopeUserId);
 
-// Only callers that fan telemetry rows out across users (all-by-user views,
+// Only callers that fan telemetry rows out across users (all-by-user usage,
 // or performance's cross-cutting group_by=userId) need this map. self-by-key
 // callers pay nothing since every row's user is fixed by construction.
 export const buildKeyToUserMap = (

--- a/packages/gateway/src/control-plane/telemetry-view.ts
+++ b/packages/gateway/src/control-plane/telemetry-view.ts
@@ -1,12 +1,11 @@
 import { type AuthedContext, userFromContext } from '../middleware/auth.ts';
-import type { ApiKey, Repo } from '../repo/types.ts';
+import type { ApiKey } from '../repo/types.ts';
 
-// The two shapes the usage endpoints answer in. Performance carries no view:
-// its scope follows the requested breakdown instead.
-export type TelemetryView = 'all-by-user' | 'self-by-key';
+// The two shapes the usage endpoints answer in.
+type TelemetryView = 'all-by-user' | 'self-by-key';
 
 // Discriminated union so callers narrow scopeUserId without non-null assertions.
-export type ResolvedTelemetryView =
+type ResolvedTelemetryView =
   | { view: 'self-by-key'; scopeUserId: number }
   | { view: 'all-by-user' };
 
@@ -35,16 +34,8 @@ export const resolveTelemetryView = (
   return { view: 'all-by-user' };
 };
 
-export const loadTelemetryKeys = async (
-  repo: Repo,
-  resolved: ResolvedTelemetryView,
-): Promise<readonly ApiKey[]> => resolved.view === 'all-by-user'
-  ? await repo.apiKeys.listIncludingDeleted()
-  : await repo.apiKeys.listByUserIdIncludingDeleted(resolved.scopeUserId);
-
-// Only callers that fan telemetry rows out across users (all-by-user usage,
-// or performance's cross-cutting group_by=userId) need this map. self-by-key
-// callers pay nothing since every row's user is fixed by construction.
+// Telemetry rows carry a key id, not a user id — this is the join that
+// attributes them to a user.
 export const buildKeyToUserMap = (
   keys: readonly ApiKey[],
 ): ReadonlyMap<string, number> => new Map(keys.map(k => [k.id, k.userId] as const));

--- a/packages/gateway/src/control-plane/telemetry-view.ts
+++ b/packages/gateway/src/control-plane/telemetry-view.ts
@@ -19,15 +19,14 @@ export type ResolvedTelemetryView =
 export const resolveTelemetryView = (
   c: AuthedContext,
   domain: TelemetryDomain,
-  rawView: TelemetryView | undefined,
+  view: TelemetryView,
   rawKeyId: string | undefined,
 ): ResolvedTelemetryView | { error: 'forbidden' | 'bad_request'; message: string } => {
   const user = userFromContext(c);
-  const canViewGlobal = canViewGlobalTelemetry(user, domain);
 
-  const view = rawView ?? (canViewGlobal ? 'all-by-user' : 'self-by-key');
+  if (view === 'self-by-key') return { view: 'self-by-key', scopeUserId: user.id };
 
-  if (view === 'all-by-user' && !canViewGlobal) {
+  if (!canViewGlobalTelemetry(user, domain)) {
     return {
       error: 'forbidden',
       message: domain === 'usage'
@@ -35,16 +34,13 @@ export const resolveTelemetryView = (
         : 'You do not have permission to view global telemetry',
     };
   }
-  if (view === 'all-by-user' && rawKeyId !== undefined && rawKeyId !== '') {
+  if (rawKeyId !== undefined && rawKeyId !== '') {
     return {
       error: 'bad_request',
       message: 'key_id is not allowed in all-by-user mode',
     };
   }
-
-  return view === 'self-by-key'
-    ? { view: 'self-by-key', scopeUserId: user.id }
-    : { view: 'all-by-user' };
+  return { view: 'all-by-user' };
 };
 
 export const loadTelemetryKeys = async (

--- a/packages/gateway/src/control-plane/telemetry-view_test.ts
+++ b/packages/gateway/src/control-plane/telemetry-view_test.ts
@@ -1,8 +1,8 @@
 import { describe, test } from 'vitest';
 
-import { buildKeyToUserMap, loadTelemetryKeys } from './telemetry-view.ts';
+import { buildKeyToUserMap, canViewGlobalTelemetry, loadTelemetryKeys } from './telemetry-view.ts';
 import { InMemoryRepo } from '../repo/memory.ts';
-import type { ApiKey } from '../repo/types.ts';
+import type { ApiKey, User } from '../repo/types.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 // Zero-value ApiKey defaults so a case only names what it exercises.
@@ -16,6 +16,38 @@ const stubKey = (overrides: Partial<ApiKey> & Pick<ApiKey, 'id' | 'userId'>): Ap
   dumpRetentionSeconds: null,
   responsesRetentionSeconds: 0,
   ...overrides,
+});
+
+const stubUser = (overrides: Partial<User>): User => ({
+  id: 7,
+  username: 'tester',
+  passwordHash: null,
+  isAdmin: false,
+  upstreamIds: null,
+  canViewGlobalTelemetry: false,
+  createdAt: '2026-04-30T00:00:00.000Z',
+  deletedAt: null,
+  ...overrides,
+});
+
+describe('canViewGlobalTelemetry', () => {
+  test('the per-user flag opens performance without opening usage', () => {
+    const flagged = stubUser({ canViewGlobalTelemetry: true });
+    assertEquals(canViewGlobalTelemetry(flagged, 'performance'), true);
+    assertEquals(canViewGlobalTelemetry(flagged, 'usage'), false);
+  });
+
+  test('admins reach both domains without the flag', () => {
+    const admin = stubUser({ isAdmin: true });
+    assertEquals(canViewGlobalTelemetry(admin, 'performance'), true);
+    assertEquals(canViewGlobalTelemetry(admin, 'usage'), true);
+  });
+
+  test('a plain user reaches neither domain', () => {
+    const plain = stubUser({});
+    assertEquals(canViewGlobalTelemetry(plain, 'performance'), false);
+    assertEquals(canViewGlobalTelemetry(plain, 'usage'), false);
+  });
 });
 
 const seedKeys = async (repo: InMemoryRepo, keys: readonly ApiKey[]): Promise<void> => {

--- a/packages/gateway/src/control-plane/telemetry-view_test.ts
+++ b/packages/gateway/src/control-plane/telemetry-view_test.ts
@@ -1,7 +1,6 @@
 import { describe, test } from 'vitest';
 
-import { buildKeyToUserMap, loadTelemetryKeys } from './telemetry-view.ts';
-import { InMemoryRepo } from '../repo/memory.ts';
+import { buildKeyToUserMap } from './telemetry-view.ts';
 import type { ApiKey } from '../repo/types.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
@@ -16,69 +15,6 @@ const stubKey = (overrides: Partial<ApiKey> & Pick<ApiKey, 'id' | 'userId'>): Ap
   dumpRetentionSeconds: null,
   responsesRetentionSeconds: 0,
   ...overrides,
-});
-
-const seedKeys = async (repo: InMemoryRepo, keys: readonly ApiKey[]): Promise<void> => {
-  for (const k of keys) await repo.apiKeys.save(k);
-};
-
-describe('loadTelemetryKeys', () => {
-  test('self-by-key scopes to the actor\'s keys (other users\' keys stay hidden)', async () => {
-    const repo = new InMemoryRepo();
-    await seedKeys(repo, [
-      stubKey({ id: 'key_actor_1', userId: 7 }),
-      stubKey({ id: 'key_actor_2', userId: 7 }),
-      stubKey({ id: 'key_other', userId: 8 }),
-    ]);
-
-    const keys = await loadTelemetryKeys(repo, { view: 'self-by-key', scopeUserId: 7 });
-
-    assertEquals(keys.map(k => k.id).sort(), ['key_actor_1', 'key_actor_2']);
-  });
-
-  test('all-by-user returns every key including other users\' rows', async () => {
-    const repo = new InMemoryRepo();
-    await seedKeys(repo, [
-      stubKey({ id: 'key_1', userId: 1 }),
-      stubKey({ id: 'key_2', userId: 2 }),
-    ]);
-
-    const keys = await loadTelemetryKeys(repo, { view: 'all-by-user' });
-
-    assertEquals(keys.map(k => k.id).sort(), ['key_1', 'key_2']);
-  });
-
-  test('empty repo returns empty keys', async () => {
-    const repo = new InMemoryRepo();
-    const keys = await loadTelemetryKeys(repo, { view: 'all-by-user' });
-    assertEquals(keys, []);
-  });
-
-  test('single-key single-user roundtrips through both views', async () => {
-    const repo = new InMemoryRepo();
-    await seedKeys(repo, [stubKey({ id: 'key_solo', userId: 5 })]);
-
-    const global = await loadTelemetryKeys(repo, { view: 'all-by-user' });
-    assertEquals(global.map(k => k.id), ['key_solo']);
-
-    const scoped = await loadTelemetryKeys(repo, { view: 'self-by-key', scopeUserId: 5 });
-    assertEquals(scoped.map(k => k.id), ['key_solo']);
-
-    // A scoped view for a user with no keys collapses to empty.
-    const otherScope = await loadTelemetryKeys(repo, { view: 'self-by-key', scopeUserId: 99 });
-    assertEquals(otherScope, []);
-  });
-
-  test('soft-deleted keys stay in both scopes so historic telemetry keeps its user attribution', async () => {
-    const repo = new InMemoryRepo();
-    await seedKeys(repo, [
-      stubKey({ id: 'key_live', userId: 3 }),
-      stubKey({ id: 'key_gone', userId: 3, deletedAt: '2026-04-01T00:00:00.000Z' }),
-    ]);
-
-    const scoped = await loadTelemetryKeys(repo, { view: 'self-by-key', scopeUserId: 3 });
-    assertEquals(scoped.map(k => k.id).sort(), ['key_gone', 'key_live']);
-  });
 });
 
 describe('buildKeyToUserMap', () => {

--- a/packages/gateway/src/control-plane/telemetry-view_test.ts
+++ b/packages/gateway/src/control-plane/telemetry-view_test.ts
@@ -1,8 +1,8 @@
 import { describe, test } from 'vitest';
 
-import { buildKeyToUserMap, canViewGlobalTelemetry, loadTelemetryKeys } from './telemetry-view.ts';
+import { buildKeyToUserMap, loadTelemetryKeys } from './telemetry-view.ts';
 import { InMemoryRepo } from '../repo/memory.ts';
-import type { ApiKey, User } from '../repo/types.ts';
+import type { ApiKey } from '../repo/types.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 // Zero-value ApiKey defaults so a case only names what it exercises.
@@ -16,38 +16,6 @@ const stubKey = (overrides: Partial<ApiKey> & Pick<ApiKey, 'id' | 'userId'>): Ap
   dumpRetentionSeconds: null,
   responsesRetentionSeconds: 0,
   ...overrides,
-});
-
-const stubUser = (overrides: Partial<User>): User => ({
-  id: 7,
-  username: 'tester',
-  passwordHash: null,
-  isAdmin: false,
-  upstreamIds: null,
-  canViewGlobalTelemetry: false,
-  createdAt: '2026-04-30T00:00:00.000Z',
-  deletedAt: null,
-  ...overrides,
-});
-
-describe('canViewGlobalTelemetry', () => {
-  test('the per-user flag opens performance without opening usage', () => {
-    const flagged = stubUser({ canViewGlobalTelemetry: true });
-    assertEquals(canViewGlobalTelemetry(flagged, 'performance'), true);
-    assertEquals(canViewGlobalTelemetry(flagged, 'usage'), false);
-  });
-
-  test('admins reach both domains without the flag', () => {
-    const admin = stubUser({ isAdmin: true });
-    assertEquals(canViewGlobalTelemetry(admin, 'performance'), true);
-    assertEquals(canViewGlobalTelemetry(admin, 'usage'), true);
-  });
-
-  test('a plain user reaches neither domain', () => {
-    const plain = stubUser({});
-    assertEquals(canViewGlobalTelemetry(plain, 'performance'), false);
-    assertEquals(canViewGlobalTelemetry(plain, 'usage'), false);
-  });
 });
 
 const seedKeys = async (repo: InMemoryRepo, keys: readonly ApiKey[]): Promise<void> => {

--- a/packages/gateway/src/control-plane/token-usage/routes.ts
+++ b/packages/gateway/src/control-plane/token-usage/routes.ts
@@ -8,7 +8,7 @@ import { aggregateUsageByUserForDisplay, aggregateUsageForDisplay } from './aggr
 import { type CtxWithQuery } from '../../middleware/zod-validator.ts';
 import { getRepo } from '../../repo/index.ts';
 import type { tokenUsageQuery } from '../schemas.ts';
-import { buildKeyToUserMap, loadTelemetryKeys, resolveTelemetryView } from '../telemetry-view.ts';
+import { buildKeyToUserMap, resolveTelemetryView } from '../telemetry-view.ts';
 
 export const tokenUsage = async (c: CtxWithQuery<typeof tokenUsageQuery>) => {
   const query = c.req.valid('query');
@@ -28,7 +28,7 @@ export const tokenUsage = async (c: CtxWithQuery<typeof tokenUsageQuery>) => {
     const [rawRecords, users, keys] = await Promise.all([
       repo.usage.query({ start, end }),
       repo.users.listIncludingDeleted(),
-      loadTelemetryKeys(repo, resolved),
+      repo.apiKeys.listIncludingDeleted(),
     ]);
     const records = aggregateUsageByUserForDisplay(rawRecords, buildKeyToUserMap(keys));
 
@@ -40,7 +40,7 @@ export const tokenUsage = async (c: CtxWithQuery<typeof tokenUsageQuery>) => {
   }
 
   // Sequential so an invalid key_id short-circuits to 404 before spending the usage.query read.
-  const keys = await loadTelemetryKeys(repo, resolved);
+  const keys = await repo.apiKeys.listByUserIdIncludingDeleted(resolved.scopeUserId);
   const ownedSet = new Set(keys.map(k => k.id));
   const explicitKeyId = query.key_id === '' ? undefined : query.key_id;
   if (explicitKeyId !== undefined && !ownedSet.has(explicitKeyId)) {

--- a/packages/gateway/src/control-plane/token-usage/routes.ts
+++ b/packages/gateway/src/control-plane/token-usage/routes.ts
@@ -1,8 +1,8 @@
 // GET /api/token-usage — query per-key or per-user usage records.
 //
 // The `view` query parameter selects between two shapes: `self-by-key` returns
-// the actor's own keys, while `all-by-user` aggregates across users for admins
-// and users granted the `canViewGlobalTelemetry` flag.
+// the actor's own keys, while `all-by-user` aggregates across users and is
+// reserved for administrators.
 
 import { aggregateUsageByUserForDisplay, aggregateUsageForDisplay } from './aggregate.ts';
 import { type CtxWithQuery } from '../../middleware/zod-validator.ts';
@@ -17,7 +17,7 @@ export const tokenUsage = async (c: CtxWithQuery<typeof tokenUsageQuery>) => {
   }
   const { start, end } = query;
 
-  const resolved = resolveTelemetryView(c, query.view, query.key_id);
+  const resolved = resolveTelemetryView(c, 'usage', query.view, query.key_id);
   if ('error' in resolved) {
     return c.json({ error: resolved.message }, resolved.error === 'forbidden' ? 403 : 400);
   }

--- a/packages/gateway/src/control-plane/token-usage/routes.ts
+++ b/packages/gateway/src/control-plane/token-usage/routes.ts
@@ -1,8 +1,8 @@
 // GET /api/token-usage — query per-key or per-user usage records.
 //
-// The `view` query parameter selects between two shapes: `self-by-key` returns
-// the actor's own keys, while `all-by-user` aggregates across users and is
-// reserved for administrators.
+// The required `view` query parameter selects between two shapes: `self-by-key`
+// returns the actor's own keys, while `all-by-user` aggregates across users and
+// is reserved for administrators.
 
 import { aggregateUsageByUserForDisplay, aggregateUsageForDisplay } from './aggregate.ts';
 import { type CtxWithQuery } from '../../middleware/zod-validator.ts';

--- a/packages/gateway/src/control-plane/token-usage/routes.ts
+++ b/packages/gateway/src/control-plane/token-usage/routes.ts
@@ -17,7 +17,7 @@ export const tokenUsage = async (c: CtxWithQuery<typeof tokenUsageQuery>) => {
   }
   const { start, end } = query;
 
-  const resolved = resolveTelemetryView(c, 'usage', query.view, query.key_id);
+  const resolved = resolveTelemetryView(c, query.view, query.key_id);
   if ('error' in resolved) {
     return c.json({ error: resolved.message }, resolved.error === 'forbidden' ? 403 : 400);
   }

--- a/packages/gateway/src/control-plane/token-usage/routes_test.ts
+++ b/packages/gateway/src/control-plane/token-usage/routes_test.ts
@@ -64,7 +64,7 @@ test('/api/token-usage self-by-key surfaces soft-deleted keys metadata to their 
   });
 
   const response = await requestApp(
-    '/api/token-usage?start=2026-04-30T00&end=2026-05-01T00&include_key_metadata=1',
+    '/api/token-usage?start=2026-04-30T00&end=2026-05-01T00&include_key_metadata=1&view=self-by-key',
     { headers: { 'x-api-key': 'raw_fresh_key' } },
   );
 

--- a/packages/gateway/src/control-plane/users/routes.ts
+++ b/packages/gateway/src/control-plane/users/routes.ts
@@ -1,4 +1,4 @@
-import { userToRawWire } from './wire.ts';
+import { userToAdminWire } from './wire.ts';
 import { notifyDisabledBestEffort } from '../../dump/registry.ts';
 import { type AuthedContext, sessionIdFromContext, userFromContext } from '../../middleware/auth.ts';
 import { type CtxWithJson } from '../../middleware/zod-validator.ts';
@@ -24,7 +24,7 @@ const parseUserId = (raw: string): number | null => {
 
 export const listUsers = async (c: AuthedContext) => {
   const users = await getRepo().users.list();
-  return c.json(users.map(userToRawWire));
+  return c.json(users.map(userToAdminWire));
 };
 
 export const createUser = async (c: CtxWithJson<typeof createUserBody>) => {
@@ -44,7 +44,6 @@ export const createUser = async (c: CtxWithJson<typeof createUserBody>) => {
     passwordHash: await hashPassword(body.password),
     isAdmin: body.isAdmin ?? false,
     upstreamIds: body.upstreamIds ?? null,
-    canViewGlobalTelemetry: body.canViewGlobalTelemetry ?? false,
     createdAt: new Date().toISOString(),
     deletedAt: null,
   });
@@ -63,7 +62,7 @@ export const createUser = async (c: CtxWithJson<typeof createUserBody>) => {
   };
   await repo.apiKeys.save(defaultKey);
 
-  return c.json({ user: userToRawWire(user) }, 201);
+  return c.json({ user: userToAdminWire(user) }, 201);
 };
 
 export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
@@ -94,7 +93,6 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
   if (body.password !== undefined) overrides.passwordHash = await hashPassword(body.password);
   if (body.isAdmin !== undefined) overrides.isAdmin = body.isAdmin;
   if (body.upstreamIds !== undefined) overrides.upstreamIds = body.upstreamIds;
-  if (body.canViewGlobalTelemetry !== undefined) overrides.canViewGlobalTelemetry = body.canViewGlobalTelemetry;
   const next: User = { ...existing, ...overrides };
   await repo.users.save(next);
 
@@ -104,7 +102,7 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
     else await repo.sessions.deleteByUserId(id);
   }
 
-  return c.json(userToRawWire(next));
+  return c.json(userToAdminWire(next));
 };
 
 export const deleteUser = async (c: AuthedContext) => {

--- a/packages/gateway/src/control-plane/users/routes_test.ts
+++ b/packages/gateway/src/control-plane/users/routes_test.ts
@@ -87,7 +87,6 @@ test('admin password reset on another user revokes that user\'s sessions', async
     passwordHash: await hashPassword('old-pw'),
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });
@@ -106,16 +105,14 @@ test('PATCH /api/users/:id can demote and revoke global-telemetry on a non-self 
     passwordHash: await hashPassword('pw'),
     isAdmin: true,
     upstreamIds: null,
-    canViewGlobalTelemetry: true,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });
 
-  const response = await adminPatch(adminSession, 3, { isAdmin: false, canViewGlobalTelemetry: false });
+  const response = await adminPatch(adminSession, 3, { isAdmin: false });
   assertEquals(response.status, 200);
   const bob = await repo.users.getById(3);
   expect(bob?.isAdmin).toBe(false);
-  expect(bob?.canViewGlobalTelemetry).toBe(false);
 });
 
 test('DELETE /api/users/:id cascades to api_keys (soft) + sessions', async () => {
@@ -158,7 +155,6 @@ test('PATCH /api/users/me/password requires session and a correct current passwo
     passwordHash: await hashPassword('old-pw'),
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });

--- a/packages/gateway/src/control-plane/users/routes_test.ts
+++ b/packages/gateway/src/control-plane/users/routes_test.ts
@@ -97,7 +97,7 @@ test('admin password reset on another user revokes that user\'s sessions', async
   expect(await repo.sessions.getByIdAndTouch(bobSession.id)).toBeNull();
 });
 
-test('PATCH /api/users/:id can demote and revoke global-telemetry on a non-self admin', async () => {
+test('PATCH /api/users/:id can demote a non-self admin', async () => {
   const { adminSession, repo } = await setupAppTest();
   await repo.users.save({
     id: 3,

--- a/packages/gateway/src/control-plane/users/wire.ts
+++ b/packages/gateway/src/control-plane/users/wire.ts
@@ -1,7 +1,6 @@
 import type { User } from '../../repo/types.ts';
 
-// What an authenticated actor is told about itself on login and /auth/me:
-// identity plus the two facts the dashboard branches on.
+// The self-description returned by /auth/login and /auth/me.
 export const userToSessionWire = (user: User) => ({
   id: user.id,
   username: user.username,
@@ -9,8 +8,6 @@ export const userToSessionWire = (user: User) => ({
   upstreamIds: user.upstreamIds,
 });
 
-// The admin user-management listing row — the session shape plus the account's
-// creation time, which only that table shows.
 export const userToAdminWire = (user: User) => ({
   ...userToSessionWire(user),
   createdAt: user.createdAt,

--- a/packages/gateway/src/control-plane/users/wire.ts
+++ b/packages/gateway/src/control-plane/users/wire.ts
@@ -1,10 +1,14 @@
 import type { User } from '../../repo/types.ts';
+import { canViewGlobalTelemetry } from '../telemetry-view.ts';
 
+// The effective shape reports what the actor may actually see. The stored flag
+// only reaches performance, so that is the capability projected here; global
+// usage follows `isAdmin`, which the dashboard reads directly.
 export const userToEffectiveWire = (user: User) => ({
   id: user.id,
   username: user.username,
   isAdmin: user.isAdmin,
-  canViewGlobalTelemetry: user.isAdmin || user.canViewGlobalTelemetry,
+  canViewGlobalTelemetry: canViewGlobalTelemetry(user, 'performance'),
   upstreamIds: user.upstreamIds,
 });
 

--- a/packages/gateway/src/control-plane/users/wire.ts
+++ b/packages/gateway/src/control-plane/users/wire.ts
@@ -1,22 +1,17 @@
 import type { User } from '../../repo/types.ts';
-import { canViewGlobalTelemetry } from '../telemetry-view.ts';
 
-// The effective shape reports what the actor may actually see. The stored flag
-// only reaches performance, so that is the capability projected here; global
-// usage follows `isAdmin`, which the dashboard reads directly.
-export const userToEffectiveWire = (user: User) => ({
+// What an authenticated actor is told about itself on login and /auth/me:
+// identity plus the two facts the dashboard branches on.
+export const userToSessionWire = (user: User) => ({
   id: user.id,
   username: user.username,
   isAdmin: user.isAdmin,
-  canViewGlobalTelemetry: canViewGlobalTelemetry(user, 'performance'),
   upstreamIds: user.upstreamIds,
 });
 
-export const userToRawWire = (user: User) => ({
-  id: user.id,
-  username: user.username,
-  isAdmin: user.isAdmin,
-  canViewGlobalTelemetry: user.canViewGlobalTelemetry,
-  upstreamIds: user.upstreamIds,
+// The admin user-management listing row — the session shape plus the account's
+// creation time, which only that table shows.
+export const userToAdminWire = (user: User) => ({
+  ...userToSessionWire(user),
   createdAt: user.createdAt,
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/http_test.ts
@@ -57,7 +57,6 @@ const buildUser = (overrides: Partial<User> = {}): User => ({
   passwordHash: null,
   isAdmin: false,
   upstreamIds: null,
-  canViewGlobalTelemetry: false,
   createdAt: '2026-01-01T00:00:00.000Z',
   deletedAt: null,
   ...overrides,

--- a/packages/gateway/src/data-plane/chat/gemini/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/http_test.ts
@@ -58,7 +58,6 @@ const buildUser = (overrides: Partial<User> = {}): User => ({
   passwordHash: null,
   isAdmin: false,
   upstreamIds: null,
-  canViewGlobalTelemetry: false,
   createdAt: '2026-01-01T00:00:00.000Z',
   deletedAt: null,
   ...overrides,

--- a/packages/gateway/src/data-plane/chat/messages/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/messages/http_test.ts
@@ -57,7 +57,6 @@ const buildUser = (overrides: Partial<User> = {}): User => ({
   passwordHash: null,
   isAdmin: false,
   upstreamIds: null,
-  canViewGlobalTelemetry: false,
   createdAt: '2026-01-01T00:00:00.000Z',
   deletedAt: null,
   ...overrides,

--- a/packages/gateway/src/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http_test.ts
@@ -77,7 +77,6 @@ const buildUser = (overrides: Partial<User> = {}): User => ({
   passwordHash: null,
   isAdmin: false,
   upstreamIds: null,
-  canViewGlobalTelemetry: false,
   createdAt: '2026-01-01T00:00:00.000Z',
   deletedAt: null,
   ...overrides,

--- a/packages/gateway/src/data-plane/chat/shared/gateway-ctx_test.ts
+++ b/packages/gateway/src/data-plane/chat/shared/gateway-ctx_test.ts
@@ -31,7 +31,6 @@ const buildUser = (overrides: Partial<User> = {}): User => ({
   passwordHash: null,
   isAdmin: false,
   upstreamIds: null,
-  canViewGlobalTelemetry: false,
   createdAt: '2026-01-01T00:00:00.000Z',
   deletedAt: null,
   ...overrides,

--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -122,11 +122,6 @@ export const userFromContext = (c: AuthedContext): User => {
 
 export const sessionIdFromContext = (c: AuthedContext): string | undefined => c.get('sessionId');
 
-// Pure derivation off the User row — admins inherit global-telemetry
-// access, regular users carry the explicit flag. Lives next to the auth
-// helpers so the rule has one home.
-export const canViewGlobalTelemetry = (user: User): boolean => user.isAdmin || user.canViewGlobalTelemetry;
-
 // Per-user upstream cap. null = unrestricted at the user level.
 export const userUpstreamIdsFromContext = (c: AuthedContext): readonly string[] | null =>
   c.get('user')?.upstreamIds ?? null;

--- a/packages/gateway/src/middleware/auth_test.ts
+++ b/packages/gateway/src/middleware/auth_test.ts
@@ -55,7 +55,6 @@ test('session token for a deleted user is invalidated', async () => {
     passwordHash: 'pbkdf2-sha256$600000$YQ==$YQ==',
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });
@@ -81,7 +80,6 @@ test('API key whose owner was deleted is rejected', async () => {
     passwordHash: null,
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     deletedAt: null,
   });

--- a/packages/gateway/src/repo/memory.ts
+++ b/packages/gateway/src/repo/memory.ts
@@ -68,7 +68,6 @@ const SEED_ADMIN_USER: User = {
   passwordHash: null,
   isAdmin: true,
   upstreamIds: null,
-  canViewGlobalTelemetry: true,
   createdAt: new Date(0).toISOString(),
   deletedAt: null,
 };

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -250,12 +250,11 @@ interface UserRow {
   password_hash: string | null;
   is_admin: number;
   upstream_ids: string | null;
-  can_view_global_telemetry: number;
   created_at: string;
   deleted_at: string | null;
 }
 
-const USER_COLUMNS = 'id, username, password_hash, is_admin, upstream_ids, can_view_global_telemetry, created_at, deleted_at';
+const USER_COLUMNS = 'id, username, password_hash, is_admin, upstream_ids, created_at, deleted_at';
 
 const toUser = (row: UserRow): User => ({
   id: row.id,
@@ -263,7 +262,6 @@ const toUser = (row: UserRow): User => ({
   passwordHash: row.password_hash,
   isAdmin: row.is_admin === 1,
   upstreamIds: parseUpstreamIds(row.upstream_ids, `users.id=${row.id}`),
-  canViewGlobalTelemetry: row.can_view_global_telemetry === 1,
   createdAt: row.created_at,
   deletedAt: row.deleted_at,
 });
@@ -307,8 +305,8 @@ class SqlUsersRepo implements UsersRepo {
     // pick distinct ids.
     const row = await this.db
       .prepare(
-        `INSERT INTO users (id, username, password_hash, is_admin, upstream_ids, can_view_global_telemetry, created_at, deleted_at)
-         SELECT COALESCE(MAX(id), 0) + 1, ?, ?, ?, ?, ?, ?, ? FROM users
+        `INSERT INTO users (id, username, password_hash, is_admin, upstream_ids, created_at, deleted_at)
+         SELECT COALESCE(MAX(id), 0) + 1, ?, ?, ?, ?, ?, ? FROM users
          RETURNING id`,
       )
       .bind(
@@ -316,7 +314,6 @@ class SqlUsersRepo implements UsersRepo {
         template.passwordHash,
         template.isAdmin ? 1 : 0,
         serializeUpstreamIds(template.upstreamIds),
-        template.canViewGlobalTelemetry ? 1 : 0,
         template.createdAt,
         template.deletedAt,
       )
@@ -328,13 +325,12 @@ class SqlUsersRepo implements UsersRepo {
   async save(user: User): Promise<void> {
     await this.db
       .prepare(
-        `INSERT INTO users (${USER_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO users (${USER_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (id) DO UPDATE SET
            username = excluded.username,
            password_hash = excluded.password_hash,
            is_admin = excluded.is_admin,
            upstream_ids = excluded.upstream_ids,
-           can_view_global_telemetry = excluded.can_view_global_telemetry,
            deleted_at = excluded.deleted_at`,
       )
       .bind(
@@ -343,7 +339,6 @@ class SqlUsersRepo implements UsersRepo {
         user.passwordHash,
         user.isAdmin ? 1 : 0,
         serializeUpstreamIds(user.upstreamIds),
-        user.canViewGlobalTelemetry ? 1 : 0,
         user.createdAt,
         user.deletedAt,
       )

--- a/packages/gateway/src/repo/types.ts
+++ b/packages/gateway/src/repo/types.ts
@@ -35,6 +35,8 @@ export interface User {
   // null = unrestricted at the user level; an array intersects with the
   // per-key whitelist when both are present.
   upstreamIds: string[] | null;
+  // Grants cross-user telemetry visibility for performance only. Usage is
+  // administrator-only, so this flag never widens it.
   canViewGlobalTelemetry: boolean;
   createdAt: string;
   deletedAt: string | null;

--- a/packages/gateway/src/repo/types.ts
+++ b/packages/gateway/src/repo/types.ts
@@ -35,9 +35,6 @@ export interface User {
   // null = unrestricted at the user level; an array intersects with the
   // per-key whitelist when both are present.
   upstreamIds: string[] | null;
-  // Grants cross-user telemetry visibility for performance only. Usage is
-  // administrator-only, so this flag never widens it.
-  canViewGlobalTelemetry: boolean;
   createdAt: string;
   deletedAt: string | null;
 }

--- a/packages/gateway/src/repo/users_test.ts
+++ b/packages/gateway/src/repo/users_test.ts
@@ -11,7 +11,6 @@ const sampleUser = (over: Partial<User> = {}): User => ({
   passwordHash: 'pbkdf2-sha256$600000$YQ==$YQ==',
   isAdmin: false,
   upstreamIds: null,
-  canViewGlobalTelemetry: false,
   createdAt: '2026-06-07T00:00:00.000Z',
   deletedAt: null,
   ...over,

--- a/packages/gateway/src/test-helpers.ts
+++ b/packages/gateway/src/test-helpers.ts
@@ -131,7 +131,6 @@ export async function setupAppTest(options: SetupOptions = {}): Promise<AppTestC
     passwordHash: null,
     isAdmin: false,
     upstreamIds: null,
-    canViewGlobalTelemetry: false,
     createdAt: '2026-03-15T00:00:00.000Z',
     deletedAt: null,
   });
@@ -172,14 +171,6 @@ export async function setupAppTest(options: SetupOptions = {}): Promise<AppTestC
   const adminSession = (await repo.sessions.create(1)).id;
 
   return { repo, adminKey: adminKey ?? '', adminSession, apiKey, githubAccount, copilotUpstream };
-}
-
-// Raises the seeded non-admin user to a global-telemetry holder, so a test can
-// pin down exactly how far that flag reaches.
-export async function grantGlobalTelemetry(repo: InMemoryRepo, userId: number): Promise<void> {
-  const user = await repo.users.getById(userId);
-  if (!user) throw new Error(`grantGlobalTelemetry: no user ${userId}`);
-  await repo.users.save({ ...user, canViewGlobalTelemetry: true });
 }
 
 export function sseResponse(chunks: SSEChunk[], status = 200): Response {

--- a/packages/gateway/src/test-helpers.ts
+++ b/packages/gateway/src/test-helpers.ts
@@ -174,6 +174,14 @@ export async function setupAppTest(options: SetupOptions = {}): Promise<AppTestC
   return { repo, adminKey: adminKey ?? '', adminSession, apiKey, githubAccount, copilotUpstream };
 }
 
+// Raises the seeded non-admin user to a global-telemetry holder, so a test can
+// pin down exactly how far that flag reaches.
+export async function grantGlobalTelemetry(repo: InMemoryRepo, userId: number): Promise<void> {
+  const user = await repo.users.getById(userId);
+  if (!user) throw new Error(`grantGlobalTelemetry: no user ${userId}`);
+  await repo.users.save({ ...user, canViewGlobalTelemetry: true });
+}
+
 export function sseResponse(chunks: SSEChunk[], status = 200): Response {
   const text = `${chunks
     .map(chunk => {


### PR DESCRIPTION
## Goal

A single per-user `canViewGlobalTelemetry` flag governed cross-user reads of both usage and performance. Those are not the same kind of data — usage is billing volume and spend, while latency is not sensitive on its own — so one grant covering both was either too generous or too strict depending on which you cared about. This replaces the flag with a rule that follows the data.

| Read | Who |
| --- | --- |
| Usage across users | administrators |
| Performance across users | everyone |
| Who produced a performance row | administrators |

## Usage is administrator-only

`view=all-by-user` on `/api/token-usage` and `/api/search-usage` now requires `isAdmin`. The usage page's *All by user / My keys* toggle follows the same flag.

`view` also became a **required** query parameter on both. It previously defaulted to the widest view the caller was allowed, so one URL returned different payload shapes to different users and would silently widen the moment someone's role changed. Omitting it is a 400. Declaring it in the schema also makes the Hono RPC client demand it at compile time.

## Performance is cross-user for everyone, and has no view

`/api/performance/overview` has neither a `view` nor a `key_id` parameter. The requested breakdown already answers the scope question:

- `group_by=keyId` is a question about the actor's own traffic, so it narrows **every** axis — summary included — to the actor's keys. Administrators are narrowed the same way.
- Every other breakdown, including the `model` default, spans all users.

API-key axes, key metadata, and `filter_key_id` stay scoped to the actor's own keys in all breakdowns, so other users' key ids never surface. An unknown or foreign `filter_key_id` is a 404.

Per-user attribution is the administrator-only part. For everyone else `group_by=userId` and `filter_user_id` are 403, and `axes.userId`, `users`, and `dimensionValues.userIds` come back empty — the whole picture, without learning who produced which row. The dashboard drops the *By User* breakdown and the User filter for them, and clamps both out of the URL on read so a link shared by an administrator lands on a working page instead of an error banner with no control to clear it.

## The flag is gone

`canViewGlobalTelemetry` had nothing left to grant and is removed: DB column, `User` field, create/update inputs, `/auth/me` and user-list wire fields, the admin toggle, and the users-table column.

Migration `0067` rebuilds `users` without the column rather than issuing `ALTER TABLE ... DROP COLUMN`, which D1 rejects on tables in the older on-disk format. Column definitions and the partial unique index carry over verbatim from `0028`.

The export envelope moves to **version 17**, so exports saved from an earlier deployment are rejected on the version gate rather than importing a user shape that no longer exists.

## Test Plan

- [x] `pnpm run test` — 396 files, 4844 tests
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] All 68 migrations apply in order against SQLite; `users` ends with the expected columns, keeps its `NOCASE` collation and partial unique index, and case-insensitive username uniqueness still rejects a duplicate
- [x] Headless dashboard check against the Node target + Vite dev server, as an administrator and as a regular user: the administrator sees the *By User* breakdown and the User filter; the regular user sees neither; and `?g=userId&fusr=1&hide=3,7` loads clean for the regular user with the URL rewritten to `/dashboard/performance` and no privilege error