### PR TITLE
docs: normalize CHANGELOG.md markdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,9 +537,11 @@ Each entry carries one of three levels:
   a concrete follow-up action.
 
 The date heading format is `## YYYY-MM-DD · hard`,
-`## YYYY-MM-DD · minor`, or `## YYYY-MM-DD · advisory`. Recommended operations
-may appear in any level; they do not need a separate advisory entry when they
-belong to the same hard or minor change.
+`## YYYY-MM-DD · minor`, or `## YYYY-MM-DD · advisory`, followed by a
+`### Short title` heading naming the change and then its description. Unlike
+this file, `CHANGELOG.md` is not hard-wrapped: each paragraph is one line.
+Recommended operations may appear in any level; they do not need a separate
+advisory entry when they belong to the same hard or minor change.
 
 A change qualifies as a breaking change when it causes previously working
 user-facing behavior to stop working or behave differently in a way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,73 +1,35 @@
 # Deployment Notes
 
-This file records user-facing breaking changes and recommended deployment
-operations by date. New entries go at the top, below this header. Each entry
-states its impact level and what users need to know or do.
+This file records user-facing breaking changes and recommended deployment operations by date. New entries go at the top, below this header. Each entry states its impact level and what users need to know or do.
 
 Impact levels:
 
-- **hard** — all users are affected; previously working functionality fails or
-  behaves differently.
-- **minor** — specific behaviors, fields, or integration patterns change;
-  users who depend on them need to adapt, but the primary functionality
-  continues to work.
-- **advisory** — no behavior breaks, but an agent or operator should consider a
-  concrete deployment-related follow-up action.
+- **hard** — all users are affected; previously working functionality fails or behaves differently.
+- **minor** — specific behaviors, fields, or integration patterns change; users who depend on them need to adapt, but the primary functionality continues to work.
+- **advisory** — no behavior breaks, but an agent or operator should consider a concrete deployment-related follow-up action.
 
-Hard and minor entries may include recommended actions; those actions do not
-need a separate advisory entry.
-
----
+Hard and minor entries may include recommended actions; those actions do not need a separate advisory entry.
 
 ## 2026-07-24 · advisory
 
-**Audit dump files created before payload-file tracking.**
+### Audit dump files created before payload-file tracking
 
-Before dump files were tracked in the shared `spilled_files` registry, an
-interrupted write could leave an unreferenced object under `dumps/v1/`.
-Runtime maintenance deliberately does not scan file prefixes. After the
-rolling deployment has settled and no request served by the pre-migration
-Worker remains in flight, an operator may reclaim that historical storage by
-listing `dumps/v1/` and deleting only exact keys that are neither referenced by
-a `dump_records` request/response body descriptor nor present in
-`spilled_files`. Do not delete the prefix or any other files. If an AI agent
-performs this audit, it must explain the safety conditions and ask the user
-before deleting anything.
+Before dump files were tracked in the shared `spilled_files` registry, an interrupted write could leave an unreferenced object under `dumps/v1/`. Runtime maintenance deliberately does not scan file prefixes. After the rolling deployment has settled and no request served by the pre-migration Worker remains in flight, an operator may reclaim that historical storage by listing `dumps/v1/` and deleting only exact keys that are neither referenced by a `dump_records` request/response body descriptor nor present in `spilled_files`. Do not delete the prefix or any other files. If an AI agent performs this audit, it must explain the safety conditions and ask the user before deleting anything.
 
 ## 2026-07-23 · hard
 
-**Stateful Responses persistence reset and made opt-in.**
+### Stateful Responses persistence reset and made opt-in
 
-The migration drops every existing Responses item and snapshot. Old
-`previous_response_id` and stored `item_reference` chains no longer resolve;
-clients must start new chains after deployment.
+The migration drops every existing Responses item and snapshot. Old `previous_response_id` and stored `item_reference` chains no longer resolve; clients must start new chains after deployment.
 
-New API keys and all migrated keys start with durable persistence disabled.
-Users who need cross-request Stateful Responses must configure a whole-day
-retention duration of at least one day for each API key. Reuse refreshes an
-item's lifetime at most once per UTC day; expiration allows one additional day
-so this write reduction never expires state early. Stored item IDs are now the
-exact IDs present on emitted items rather than a gateway namespace.
+New API keys and all migrated keys start with durable persistence disabled. Users who need cross-request Stateful Responses must configure a whole-day retention duration of at least one day for each API key. Reuse refreshes an item's lifetime at most once per UTC day; expiration allows one additional day so this write reduction never expires state early. Stored item IDs are now the exact IDs present on emitted items rather than a gateway namespace.
 
-Immediately after deploying through this migration, the database contains no
-stored Responses items, and no new ones are persisted until an API key is
-manually opted in. We recommend manually deleting every object under the
-file-storage `responses-items/` namespace at that point; do not delete other
-stored files. The database can no longer reference these objects, so retaining
-them only consumes storage. This is an additional manual step after the
-automated deployment, not part of deploy automation. If an AI agent reads this
-entry, it must explain why this cleanup is recommended and ask the user whether
-to do it, without deleting the objects automatically.
+Immediately after deploying through this migration, the database contains no stored Responses items, and no new ones are persisted until an API key is manually opted in. We recommend manually deleting every object under the file-storage `responses-items/` namespace at that point; do not delete other stored files. The database can no longer reference these objects, so retaining them only consumes storage. This is an additional manual step after the automated deployment, not part of deploy automation. If an AI agent reads this entry, it must explain why this cleanup is recommended and ask the user whether to do it, without deleting the objects automatically.
 
 ## 2026-07-18 · hard
 
-**Affinity and Responses state reset.**
+### Affinity and Responses state reset
 
-The client-carried affinity mechanism was redesigned from scratch. Existing
-conversations that previously routed requests to a specific upstream model via
-affinity context lose that routing; subsequent messages may be dispatched to a
-different upstream than the one that produced the prior turns.
+The client-carried affinity mechanism was redesigned from scratch. Existing conversations that previously routed requests to a specific upstream model via affinity context lose that routing; subsequent messages may be dispatched to a different upstream than the one that produced the prior turns.
 
-All Responses API items and snapshots stored before this date are discarded.
-References to old `previous_response_id` values no longer resolve; clients must
-start new response chains.
+All Responses API items and snapshots stored before this date are discarded. References to old `previous_response_id` values no longer resolve; clients must start new response chains.


### PR DESCRIPTION
`CHANGELOG.md` was hard-wrapped at roughly 78 columns and used bold paragraphs as entry titles. Hard wrapping made every wording edit reflow the lines around it, and emphasis-as-heading left the titles without heading semantics — no outline, no anchors, no way to link one entry.

Reformat the file as canonical Markdown:

- Every paragraph is a single line; nothing is hard-wrapped.
- Each entry title is a `### ` heading under its `## YYYY-MM-DD · level` heading, without the trailing period a heading should not carry.
- The thematic break between the file header and the first entry is gone, because the date headings already delimit entries.
- The prose itself is unchanged.

`AGENTS.md` records the entry structure (date heading → title heading → description) and the no-hard-wrap rule, so later entries keep the same shape.

## Test Plan

- [x] Prose preservation — normalizing whitespace and heading syntax on both revisions and diffing them shows `origin/main:CHANGELOG.md` and the branch version to be textually identical.
- [x] Rendered structure — `POST /markdown` in GFM mode yields one `<h1>`, three `<h2>` date headings, three `<h3>` entry titles, no `<hr>`, and no bold-paragraph pseudo-heading.
- [x] No consumer breakage — nothing outside `AGENTS.md` reads `CHANGELOG.md`, and CI only builds Docker images.