### PR TITLE
fix(deploy): stamp the deploy message inside the deploy script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,8 +398,7 @@ proceed straight to Step 4.
 **Step 4 — deploy with one chained command.** Migrate (when needed) and
 publish in the same command so the system spends as little time as
 possible in an inconsistent state. `pnpm run deploy` stamps the deploy
-message itself with the short commit revision of HEAD, so there is no
-message to pass and none to forget:
+message with the short commit revision of HEAD:
 
 ```bash
 pnpm run db:migrate:remote && pnpm run deploy
@@ -410,9 +409,7 @@ deploy stops halfway they can rerun the same command to recover —
 `wrangler d1 migrations apply --remote` is idempotent on already-applied
 migrations and `wrangler deploy` always publishes the current code. When
 there are no pending migrations, the command reduces to `pnpm run deploy`.
-Never pass `--dry-run`, and never append `--message` through `pnpm run` —
-pnpm forwards the `--` separator, which turns the flag into a positional
-argument that wrangler silently ignores.
+Never pass `--dry-run`.
 
 After the Worker is live, report every recommended operation collected from
 the new Deployment Notes. Perform read-only checks directly when they are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,9 +330,9 @@ diff this deploy would apply.
 
 **Step 2 — declare breaking changes and collect recommended actions.**
 Extract the deploy message of the currently active deployment from Step 1's
-output. The message is a short commit revision (recorded by the previous
-deploy's `--message` flag). Use it to diff `CHANGELOG.md` between that revision
-and the current working tree:
+output. The message is the short commit revision the deploy script stamped.
+Use it to diff `CHANGELOG.md` between that revision and the current working
+tree:
 
 ```bash
 git diff <PREVIOUS_COMMIT_REV> -- CHANGELOG.md
@@ -397,20 +397,22 @@ proceed straight to Step 4.
 
 **Step 4 — deploy with one chained command.** Migrate (when needed) and
 publish in the same command so the system spends as little time as
-possible in an inconsistent state. The deploy message is the short commit
-revision of HEAD at deploy time (`git rev-parse --short HEAD`):
+possible in an inconsistent state. `pnpm run deploy` stamps the deploy
+message itself with the short commit revision of HEAD, so there is no
+message to pass and none to forget:
 
 ```bash
-pnpm run db:migrate:remote && pnpm run deploy -- --message "$(git rev-parse --short HEAD)"
+pnpm run db:migrate:remote && pnpm run deploy
 ```
 
 Print this exact command before running it, and tell the user that if the
 deploy stops halfway they can rerun the same command to recover —
 `wrangler d1 migrations apply --remote` is idempotent on already-applied
 migrations and `wrangler deploy` always publishes the current code. When
-there are no pending migrations, the command reduces to
-`pnpm run deploy -- --message "$(git rev-parse --short HEAD)"`. Never pass
-`--dry-run`.
+there are no pending migrations, the command reduces to `pnpm run deploy`.
+Never pass `--dry-run`, and never append `--message` through `pnpm run` —
+pnpm forwards the `--` separator, which turns the flag into a positional
+argument that wrangler silently ignores.
 
 After the Worker is live, report every recommended operation collected from
 the new Deployment Notes. Perform read-only checks directly when they are

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:web": "pnpm --filter @floway-dev/web run dev",
     "dev:node": "pnpm --filter @floway-dev/platform-node run start",
     "build:web": "pnpm --filter @floway-dev/web run build",
-    "deploy": "pnpm install --frozen-lockfile && jiti scripts/check-wrangler.ts && pnpm run build:web && wrangler deploy",
+    "deploy": "pnpm install --frozen-lockfile && jiti scripts/check-wrangler.ts && pnpm run build:web && wrangler deploy --message \"$(git rev-parse --short HEAD)\"",
     "db:migrate": "wrangler d1 migrations apply $(node -p \"require('jsonc-parser').parse(require('fs').readFileSync('wrangler.jsonc','utf8')).d1_databases[0].database_name\")",
     "db:migrate:remote": "wrangler d1 migrations apply $(node -p \"require('jsonc-parser').parse(require('fs').readFileSync('wrangler.jsonc','utf8')).d1_databases[0].database_name\") --remote",
     "lint": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" eslint --cache .",


### PR DESCRIPTION
## The bug

Step 4 of the deployment flow was documented as:

```bash
pnpm run db:migrate:remote && pnpm run deploy -- --message "$(git rev-parse --short HEAD)"
```

pnpm forwards the `--` separator into the script, so wrangler is invoked as `wrangler deploy -- --message <rev>`. yargs files everything after `--` under positional arguments, so the flag is never read. Wrangler exits 0 and the deployment records no message.

Observed on the deploy of `9234dcaab`: the run reported success, and `wrangler deployments list` showed `Message: -`.

## Why it matters

Nothing fails at deploy time — the miss surfaces one deploy later. Step 2 reads the active deployment's message to recover the previously deployed revision and diff `CHANGELOG.md` against it. With no message it takes the documented fallback and treats the entire changelog as potentially unseen, putting every historical `hard` entry back in front of the user for confirmation. That is what happened on the deploy above.

## The fix

The message is invariably HEAD's short revision, so the deploy script stamps it rather than asking each caller to pass it correctly:

```
wrangler deploy --message "$(git rev-parse --short HEAD)"
```

Command substitution inside a package script is already how `db:migrate` and `db:migrate:remote` resolve the database name, so this introduces no new mechanism. Step 4 becomes `pnpm run db:migrate:remote && pnpm run deploy`, leaving no argument to get wrong.

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `package.json` parses, and the deploy script's final segment resolves through `sh` — as pnpm runs it — to `wrangler deploy --message <HEAD short rev>`
- [x] `pnpm run` does expand `$(...)` inside a package script: `pnpm run db:migrate:remote`, which resolves its database name the same way, ran successfully against the remote database on the deploy of `9234dcaab`
- [x] `wrangler deploy --message <rev>` records the message when the flag reaches wrangler directly: publishing unchanged code as `pnpm wrangler deploy --message "$(git rev-parse --short HEAD)"` produced version `baac5ac3-1fec-4c94-83b4-1e85b25160a8`, which `wrangler deployments list` shows with `Message: 9234dcaab`
- [ ] End-to-end `pnpm run deploy` — not run, because exercising it means publishing to production, which needs its own authorization. The three checks above cover both halves of the path: that the script resolves to the intended command line under pnpm, and that this command line records the message