### PR TITLE
fix(protocols): accept the null tool_calls that real upstreams send

### DIFF
--- a/packages/protocols/src/chat-completions/index.ts
+++ b/packages/protocols/src/chat-completions/index.ts
@@ -139,12 +139,14 @@ interface ChatCompletionsChoiceStreaming {
 export interface ChatCompletionsDelta {
   content?: string | null;
   role?: string;
-  tool_calls?: {
-    index: number;
-    id?: string;
-    type?: 'function';
-    function?: { name?: string; arguments?: string };
-  }[];
+  tool_calls?:
+    | {
+      index: number;
+      id?: string;
+      type?: 'function';
+      function?: { name?: string; arguments?: string };
+    }[]
+    | null;
   /** Human-readable reasoning text delta */
   reasoning_text?: string | null;
   /** Opaque reasoning token/signature delta */

--- a/packages/protocols/src/chat-completions/reassemble.ts
+++ b/packages/protocols/src/chat-completions/reassemble.ts
@@ -39,7 +39,7 @@ const createChoiceAccumulator = (index: number): ChoiceAccumulator => ({
 });
 
 const accumulateToolCalls = (choice: ChoiceAccumulator, value: ChatCompletionsDelta['tool_calls']): void => {
-  if (value === undefined) return;
+  if (value == null) return;
 
   for (const toolCall of value) {
     const fn = toolCall.function;

--- a/packages/protocols/src/chat-completions/reassemble_test.ts
+++ b/packages/protocols/src/chat-completions/reassemble_test.ts
@@ -560,3 +560,31 @@ test('reassembleChatCompletionsEvents holds first non-empty system_fingerprint w
   const result = await reassembleChatCompletionsEvents(body);
   assertEquals(result.system_fingerprint, 'fp_late');
 });
+
+test('reassembleChatCompletionsEvents treats a null tool_calls as carrying no call', async () => {
+  const body = makeEvents([
+    {
+      data: {
+        id: 'cmpl_null',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'sglang-test',
+        choices: [{ index: 0, delta: { role: 'assistant', content: null, tool_calls: null }, finish_reason: null }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_null',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'sglang-test',
+        choices: [{ index: 0, delta: { content: 'hi', tool_calls: null }, finish_reason: 'stop' }],
+      },
+    },
+  ]);
+
+  const result = await reassembleChatCompletionsEvents(body);
+
+  assertEquals(result.choices[0].message.content, 'hi');
+  assertEquals('tool_calls' in result.choices[0].message, false);
+});


### PR DESCRIPTION
## Problem

`ChatCompletionsDelta.tool_calls` was typed as an optional array, but SGLang declares the field `Optional` with a `None` default and serializes it on **every** delta rather than omitting it:

https://github.com/sgl-project/sglang/blob/e14068d161a7de7b70bf309716e1df86830e208e/python/sglang/srt/entrypoints/openai/protocol.py#L1108-L1120

The Chat Completions stream parser casts upstream JSON without validating it, so that `null` reaches gateway code that the type says can only see an array. A non-streaming request against such an upstream hit `accumulateToolCalls` with `null` and threw `TypeError: value is not iterable`, failing the whole response.

Reproduced directly against the reassembler before the fix:

```
CRASH: TypeError value is not iterable
```

## Fix

Widen the declared type to match the wire, then let the compiler locate the crash sites. It found exactly one — the reassembler. The Messages, Gemini and Responses translators already guard with optional chaining or truthiness and needed no change, which the same typecheck confirms.

- `packages/protocols/src/chat-completions/index.ts` — `tool_calls` becomes nullable
- `packages/protocols/src/chat-completions/reassemble.ts` — `accumulateToolCalls` treats nullish as carrying no call
- `reassemble_test.ts` — regression test over an SGLang-shaped stream

## Verification

`pnpm run lint`, `pnpm run typecheck` and `pnpm run test` all pass — 396 test files, 4845 tests (baseline 4844, +1 from the new regression test).

## Notes

No `CHANGELOG.md` entry: nothing that previously worked changes behavior. The affected path could only ever throw.