### PR TITLE
fix(translate): preserve Anthropic refusal semantics

### DIFF
--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -106,6 +106,52 @@ service. Every other open-string tier is preserved byte-for-byte. Gemini
 candidate and thought counts remain disjoint in `usageMetadata`; thought tokens
 are billed as reasoning/output exactly once.
 
+## Safety Refusals And Model Fallback
+
+Anthropic Messages classifier refusals are successful Messages transports with
+`stop_reason: "refusal"` and structured `stop_details`. The category is an open
+string: current values are `cyber`, `bio`, `frontier_llm`,
+`reasoning_extraction`, `general_harms`, and `null`, but future values must
+survive native Messages parsing and reassembly unchanged. The human-readable
+`explanation` is display text, not a stable discriminator.
+
+Source protocols expose that terminal condition according to their own wire:
+
+- Responses Via Messages is Codex-first. A `cyber` refusal becomes
+  `response.failed` with `error.code: "cyber_policy"`; `bio` becomes
+  `bio_policy`; every other or future category becomes the non-retryable public
+  `invalid_prompt`. The upstream explanation becomes the error message. The
+  biology message retains Codex's recognized biology prefix so its dedicated
+  Trusted Access surface is selected. A refusal never becomes an empty
+  `response.completed`.
+- Chat Completions Via Messages emits the standard scalar `delta.refusal` and
+  ends with `finish_reason: "stop"`. Non-stream assembly places the text in
+  `message.refusal` with `message.content: null` when there was no partial text.
+- Gemini Via Messages ends the candidate with `finishReason: "SAFETY"` and
+  carries the explanation in standard `finishMessage`. It does not fabricate
+  `safetyRatings`: Anthropic policy categories do not map honestly to Gemini's
+  harm-category probabilities.
+- Native Messages streaming and non-streaming preserve `stop_details`, beta
+  fallback-credit fields, fallback content blocks, and `usage.iterations`.
+
+Public OpenAI refusal output remains supported independently of the Codex
+policy-failure adaptation. Responses refusal parts use the native
+`response.refusal.delta` / `.done` lifecycle; Chat refusal uses
+`delta.refusal`. The reverse translators restore a Messages refusal and
+`stop_details.explanation` rather than turning refusal text into an ordinary
+assistant text block. A Responses `cyber_policy` or `bio_policy` failure maps
+back to the matching Messages category.
+
+Anthropic server-side fallback is distinct from final refusal. A successful
+fallback block updates the effective model used by translated Responses and
+Chat output and is not emitted as user-visible text. Native Messages retains
+the boundary at its original content position. OpenAI `safety_buffering` is a
+Codex-private "still checking" signal, not an automatic-reroute record, so
+Floway does not synthesize it. Floway also does not synthesize Codex's
+`OpenAI-Model` cyber-reroute signal for Anthropic models because the current
+Codex notice is OpenAI-model-specific. Cross-protocol clients therefore see the
+fallback model and its content but not a fabricated OpenAI safety notice.
+
 ## Gemini Source
 
 Request mapping shared by the Gemini source translation pairs:
@@ -156,6 +202,8 @@ Response mapping shared by the Gemini source translation pairs:
   part. Responses targets do not emit opaque Gemini signatures; only readable
   reasoning summaries become thought-summary parts.
 - Target tool/function calls become Gemini `functionCall` parts.
+- Messages classifier refusal becomes `finishReason: "SAFETY"`; its
+  human-readable explanation becomes candidate `finishMessage`.
 - Target usage maps to Gemini `usageMetadata`; cache reads and writes remain
   separate, while reasoning/thinking tokens map to `thoughtsTokenCount` and do
   not overlap `candidatesTokenCount`.
@@ -185,7 +233,8 @@ Known losses:
 - `candidateCount > 1` is not represented by the pairwise chat target paths; the
   gateway returns one candidate.
 - Gemini response safety ratings, grounding metadata, and citation metadata are
-  not synthesized from ordinary target output.
+  not synthesized from ordinary target output. Anthropic refusal categories
+  likewise do not become invented Gemini safety ratings.
 
 ## Messages Via Responses
 
@@ -228,6 +277,10 @@ Response mapping:
   the id round-trips to a downstream Messages client.
 - Responses message output text becomes Messages text blocks, and
   `function_call` output becomes Messages `tool_use`.
+- Responses refusal parts become terminal Messages refusal metadata; their text
+  becomes `stop_details.explanation`, not a visible text block. Responses
+  `cyber_policy` and `bio_policy` failures become the corresponding Messages
+  classifier-refusal categories.
 - Output is emitted in Responses `output_index` order even when later text
   arrives before an earlier reasoning/tool item completes.
 - completed output with a function call maps to Messages `tool_use`; other
@@ -305,7 +358,12 @@ Response mapping:
   Responses URL-citation annotations when they carry enough cited text to
   anchor an output span.
 - Messages `tool_use` stop produces a completed response with function calls;
-  `max_tokens` produces max-output incomplete; other normal stops complete.
+  `max_tokens` produces max-output incomplete. Classifier refusal produces a
+  failed response with the Codex-compatible policy code described in "Safety
+  Refusals And Model Fallback"; other normal stops complete.
+- `message_start.message.model` is authoritative. A fallback boundary switches
+  subsequent and terminal Responses envelopes to its `to.model` without
+  becoming an output item.
 - disjoint Messages cache counts are folded into inclusive Responses input
   usage while the 1-hour subset remains in the billing sidecar. Messages
   `speed: "fast"` returns as Responses `service_tier: "fast"`; otherwise
@@ -361,13 +419,16 @@ Response mapping:
 - Chat content becomes Messages text blocks; tool calls become `tool_use`
   blocks. Text interleaved inside streamed tool arguments is deferred until the
   tool block closes so trailing argument fragments remain valid.
+- Chat `delta.refusal` is accumulated into Messages
+  `stop_details.explanation`; its terminal stop reason is `refusal`, even though
+  native Chat ends a generated refusal with `finish_reason: "stop"`.
 - inclusive Chat prompt usage is split into plain input, cache-read, and
   cache-write Messages fields; 1-hour cache-write detail is retained. Target
   `service_tier: "fast"` maps to Messages `speed: "fast"`; other non-null tiers
   map to Messages `service_tier`.
 - Chat `tool_calls` finish maps to Messages `tool_use`, `length` maps to
-  `max_tokens`, `content_filter` maps to `refusal`, and `stop` maps to
-  `end_turn`.
+  `max_tokens`, and `content_filter` maps to `refusal`. A `stop` carrying prior
+  refusal deltas also maps to `refusal`; an ordinary `stop` maps to `end_turn`.
 
 Known losses:
 
@@ -404,6 +465,9 @@ Response mapping:
 
 - Messages text deltas become Chat assistant `content`; `tool_use` blocks become
   indexed Chat `tool_calls`.
+- Messages classifier refusal becomes Chat `delta.refusal`, followed by the
+  standard terminal `finish_reason: "stop"`. It is not flattened into visible
+  assistant content or mislabeled as `content_filter`.
 - only the first Messages thinking/redacted-thinking block is projected into the
   scalar Chat `reasoning_text` / `reasoning_opaque` fields. Opaque-only state
   remains opaque rather than becoming fake readable reasoning.
@@ -412,8 +476,9 @@ Response mapping:
   `speed: "fast"` returns as Chat `service_tier: "fast"`; otherwise Messages
   `service_tier` passes through.
 - Messages `tool_use` stop maps to Chat `tool_calls`, `max_tokens` maps to
-  `length`, and other terminal reasons map to `stop`. The Messages terminal
-  becomes the Chat `[DONE]` sentinel.
+  `length`, and other terminal reasons map to `stop`. A fallback boundary
+  updates the serving model on subsequent chunks. The Messages terminal becomes
+  the Chat `[DONE]` sentinel.
 
 Known losses:
 
@@ -456,8 +521,9 @@ Response mapping:
 - every readable Responses reasoning output item is preserved in Chat
   `reasoning_items[]`; the first scalar-eligible group also projects to
   `reasoning_text`. No Chat `reasoning_opaque` is synthesized.
-- Responses message output text and refusal text become visible Chat assistant
-  content; function calls become Chat `tool_calls`.
+- Responses message output text becomes Chat assistant content; Responses
+  refusal parts become Chat `delta.refusal`. Function calls become Chat
+  `tool_calls`.
 - Responses output is held in `output_index` order when later visible output
   finishes before earlier reasoning/tool output.
 - max-output incomplete maps to Chat `finish_reason: "length"`; completed with
@@ -511,6 +577,9 @@ Response mapping:
   ignored.
 - Chat assistant content becomes one Responses message output item, and Chat
   tool calls become Responses `function_call` output items.
+- Chat `delta.refusal` becomes a Responses message item with refusal content and
+  the native `response.refusal.delta` / `.done` lifecycle. Refusal text does not
+  enter the Responses `output_text` convenience projection.
 - output items are emitted in source order by `output_index`.
 - Chat `finish_reason: "length"` maps to Responses incomplete; other finish
   reasons produce a completed response.
@@ -575,6 +644,9 @@ history unchanged.
   usage-only chunk only when the caller requested it.
 - Responses-shaped streams use named Responses SSE events with monotonically
   increasing `sequence_number`.
+- Responses refusal content uses the complete output-item/content-part/refusal
+  lifecycle. Codex policy failures instead terminate with `response.failed`;
+  they never emit a contradictory `response.completed`.
 - Chat Completions Via Responses buffers scalar reasoning until it knows whether
   `reasoning_items[]` will be used, avoiding orphan or duplicated Responses
   reasoning items.

--- a/packages/gateway/__tests__/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/serve_test.ts
@@ -501,6 +501,59 @@ test('generate falls through translate-out to messages target', async () => {
   assertEquals(callMessages.mock.calls.length, 1);
 });
 
+test('Messages biology refusal becomes a non-retryable Codex Responses policy failure', async () => {
+  installRepo();
+  const callMessages = vi.fn(async (): Promise<ProviderStreamResult<MessagesStreamEvent>> => ({
+    ok: true,
+    events: makeProtocolFrames([
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_bio_refusal',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-fable-5',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 4, output_tokens: 0 },
+        },
+      },
+      {
+        type: 'message_delta',
+        delta: {
+          stop_reason: 'refusal',
+          stop_details: {
+            type: 'refusal',
+            category: 'bio',
+            explanation: 'This request could enable biological harm.',
+          },
+          stop_sequence: null,
+        },
+        usage: { output_tokens: 0 },
+      },
+      { type: 'message_stop' },
+    ]),
+    modelKey: 'messages-key',
+    headers: new Headers(),
+  }));
+  const candidate = makeCandidate({ upstream: 'up_m', endpoints: { messages: {} }, callMessages });
+  queueResolution([candidate]);
+
+  const result = await responsesServe.generate({ payload: makePayload(), ctx: makeGatewayCtx(), headers: new Headers() });
+  assertEquals(result.type, 'events');
+  if (result.type !== 'events') throw new Error('unreachable');
+  const events = await collectEvents(result.events);
+  const failed = events.find((event): event is Extract<ResponsesStreamEvent, { type: 'response.failed' }> => event.type === 'response.failed');
+
+  assertEquals(failed?.response.status, 'failed');
+  assertEquals(failed?.response.error, {
+    code: 'bio_policy',
+    message: 'This content was flagged for possible biological risk. This request could enable biological harm.',
+  });
+  assertEquals(callMessages.mock.calls.length, 1);
+});
+
 test('generate falls through translate-out to chat-completions target', async () => {
   installRepo();
   const callChatCompletions = vi.fn(async (): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => ({

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
@@ -8,6 +8,7 @@ import { runWebSearchAndRecordUsage } from '../../../tools/web-search/search.ts'
 import type { WebSearchProvider, WebSearchProviderName, WebSearchProviderRequest, WebSearchProviderResult } from '../../../tools/web-search/types.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
+  MessagesAssistantContentBlock,
   MessagesAssistantInputContentBlock,
   MessagesClientTool,
   MessagesMessage,

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/web-search-shim.ts
@@ -8,7 +8,7 @@ import { runWebSearchAndRecordUsage } from '../../../tools/web-search/search.ts'
 import type { WebSearchProvider, WebSearchProviderName, WebSearchProviderRequest, WebSearchProviderResult } from '../../../tools/web-search/types.ts';
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
-  MessagesAssistantContentBlock,
+  MessagesAssistantInputContentBlock,
   MessagesClientTool,
   MessagesMessage,
   MessagesNativeWebSearchTool,
@@ -212,7 +212,7 @@ const buildNativeWebSearchResultBlock = (result: Extract<WebSearchProviderResult
 // Error-only replay blocks do not carry our encoded payload marker, so the
 // safest replay rule is structural: only decode results that are paired with
 // a same-message `server_tool_use` we can turn back into upstream tool history.
-const collectOwnedReplayResultsByServerToolUseId = (content: MessagesAssistantContentBlock[]): Map<string, OwnedReplayToolResult> => {
+const collectOwnedReplayResultsByServerToolUseId = (content: MessagesAssistantInputContentBlock[]): Map<string, OwnedReplayToolResult> => {
   const pairedServerToolUseIds = new Set(content.flatMap(block => (block.type === 'server_tool_use' && block.name === WEB_SEARCH_TOOL_NAME ? [block.id] : [])));
   const ownedReplayResultsByServerToolUseId = new Map<string, OwnedReplayToolResult>();
 
@@ -270,7 +270,7 @@ const decodeOwnedReplayCitation = (citation: MessagesTextCitation): MessagesText
   };
 };
 
-const decodeOwnedReplayToolResult = (block: Extract<MessagesAssistantContentBlock, { type: 'web_search_tool_result' }>): OwnedReplayToolResult | null => {
+const decodeOwnedReplayToolResult = (block: Extract<MessagesAssistantInputContentBlock, { type: 'web_search_tool_result' }>): OwnedReplayToolResult | null => {
   if (Array.isArray(block.content)) {
     const decodedResults = block.content.map(result => ({
       result,
@@ -386,7 +386,7 @@ const prepareMessagesWebSearchReplay = (messages: MessagesMessage[]): PreparedMe
       pendingOwnedReplayToolResults.push(ownedReplayResult);
     }
 
-    const rewrittenContent = message.content.flatMap((block): MessagesAssistantContentBlock[] => {
+    const rewrittenContent = message.content.flatMap((block): MessagesAssistantInputContentBlock[] => {
       if (block.type === 'server_tool_use' && ownedReplayResultsByServerToolUseId.has(block.id)) {
         return [
           {

--- a/packages/protocols/__tests__/chat-completions/reassemble_test.ts
+++ b/packages/protocols/__tests__/chat-completions/reassemble_test.ts
@@ -623,3 +623,17 @@ test('reassembleChatCompletionsEvents accumulates refusal deltas separately from
   assertEquals(result.choices[0].message, { role: 'assistant', content: null, refusal: 'Cannot help.' });
   assertEquals(result.choices[0].finish_reason, 'stop');
 });
+
+test('reassembleChatCompletionsEvents preserves an observed empty refusal', async () => {
+  const result = await reassembleChatCompletionsEvents(makeEvents([{
+    data: {
+      id: 'cmpl_empty_refusal',
+      object: 'chat.completion.chunk',
+      created: 1000,
+      model: 'gpt-test',
+      choices: [{ index: 0, delta: { role: 'assistant', content: null, refusal: '' }, finish_reason: 'stop' }],
+    },
+  }]));
+
+  assertEquals(result.choices[0].message, { role: 'assistant', content: null, refusal: '' });
+});

--- a/packages/protocols/__tests__/chat-completions/reassemble_test.ts
+++ b/packages/protocols/__tests__/chat-completions/reassemble_test.ts
@@ -588,3 +588,38 @@ test('reassembleChatCompletionsEvents treats a null tool_calls as carrying no ca
   assertEquals(result.choices[0].message.content, 'hi');
   assertEquals('tool_calls' in result.choices[0].message, false);
 });
+
+test('reassembleChatCompletionsEvents accumulates refusal deltas separately from content', async () => {
+  const result = await reassembleChatCompletionsEvents(makeEvents([
+    {
+      data: {
+        id: 'cmpl_refusal',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        choices: [{ index: 0, delta: { role: 'assistant', content: null, refusal: '' }, finish_reason: null }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_refusal',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        choices: [{ index: 0, delta: { refusal: 'Cannot help.' }, finish_reason: null }],
+      },
+    },
+    {
+      data: {
+        id: 'cmpl_refusal',
+        object: 'chat.completion.chunk',
+        created: 1000,
+        model: 'gpt-test',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      },
+    },
+  ]));
+
+  assertEquals(result.choices[0].message, { role: 'assistant', content: null, refusal: 'Cannot help.' });
+  assertEquals(result.choices[0].finish_reason, 'stop');
+});

--- a/packages/protocols/__tests__/gemini/reassemble_test.ts
+++ b/packages/protocols/__tests__/gemini/reassemble_test.ts
@@ -52,6 +52,7 @@ test('reassembleGeminiEvents assembles candidate parts and final metadata', asyn
             parts: [{ text: ' signed', thoughtSignature: 'sig-1' }, { text: ' tail' }],
           },
           finishReason: 'STOP',
+          finishMessage: 'Finished normally.',
         },
       ],
       modelVersion: 'gemini-test',
@@ -74,6 +75,7 @@ test('reassembleGeminiEvents assembles candidate parts and final metadata', asyn
           parts: [{ text: 'Hello' }, { text: 'thinking', thought: true }, { text: ' signed', thoughtSignature: 'sig-1' }, { text: ' tail' }],
         },
         finishReason: 'STOP',
+        finishMessage: 'Finished normally.',
       },
       {
         index: 1,
@@ -94,6 +96,19 @@ test('reassembleGeminiEvents assembles candidate parts and final metadata', asyn
   };
 
   assertEquals(await reassembleGeminiEvents(eventsFrom(events)), expected);
+});
+
+test('reassembleGeminiEvents preserves terminal safety explanation', async () => {
+  const result = await reassembleGeminiEvents(eventsFrom([{
+    candidates: [{
+      index: 0,
+      content: { role: 'model', parts: [] },
+      finishReason: 'SAFETY',
+      finishMessage: 'This request could enable biological harm.',
+    }],
+  }]));
+
+  assertEquals(result.candidates?.[0].finishMessage, 'This request could enable biological harm.');
 });
 
 test('Gemini billing metadata survives reassembly without entering JSON', async () => {

--- a/packages/protocols/__tests__/messages/reassemble_test.ts
+++ b/packages/protocols/__tests__/messages/reassemble_test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest';
 
 import type {
+  MessagesAssistantMessage,
   MessagesResult,
   MessagesSearchResultBlock,
   MessagesSearchResultLocationCitation,
@@ -878,4 +879,20 @@ test('reassembleMessagesEvents preserves refusal details, fallback boundaries, a
     trigger: { type: 'refusal', category: 'future_policy' },
   }]);
   assertEquals(result.usage.iterations, [{ type: 'fallback_message', model: 'claude-opus-4-8', input_tokens: 5, output_tokens: 0 }]);
+});
+
+test('Messages assistant fallback history accepts omitted and opaque triggers', () => {
+  const messages: MessagesAssistantMessage[] = [
+    {
+      role: 'assistant',
+      content: [{ type: 'fallback', from: { model: 'claude-opus-5' }, to: { model: 'claude-opus-4-8' } }],
+    },
+    {
+      role: 'assistant',
+      content: [{ type: 'fallback', from: { model: 'claude-opus-5' }, to: { model: 'claude-opus-4-8' }, trigger: null }],
+    },
+  ];
+
+  assertEquals(messages[0].content[0], { type: 'fallback', from: { model: 'claude-opus-5' }, to: { model: 'claude-opus-4-8' } });
+  assertEquals(messages[1].content[0], { type: 'fallback', from: { model: 'claude-opus-5' }, to: { model: 'claude-opus-4-8' }, trigger: null });
 });

--- a/packages/protocols/__tests__/messages/reassemble_test.ts
+++ b/packages/protocols/__tests__/messages/reassemble_test.ts
@@ -815,3 +815,67 @@ test('reassembleMessagesEvents preserves unknown fields on a content_block', asy
   assertEquals(block.thinking, 'hello');
   assertEquals(block.vendor_trace, 'opaque-trace-123');
 });
+
+test('reassembleMessagesEvents preserves refusal details, fallback boundaries, and iteration usage', async () => {
+  const result = await reassembleMessagesEvents(makeEvents([
+    {
+      data: {
+        type: 'message_start',
+        message: {
+          id: 'msg_refusal',
+          type: 'message',
+          role: 'assistant',
+          model: 'claude-opus-5',
+          usage: { input_tokens: 5, output_tokens: 0 },
+        },
+      },
+    },
+    {
+      data: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'fallback',
+          from: { model: 'claude-opus-5' },
+          to: { model: 'claude-opus-4-8' },
+          trigger: { type: 'refusal', category: 'future_policy' },
+        },
+      },
+    },
+    { data: { type: 'content_block_stop', index: 0 } },
+    {
+      data: {
+        type: 'message_delta',
+        delta: {
+          stop_reason: 'refusal',
+          stop_details: {
+            type: 'refusal',
+            category: 'future_policy',
+            explanation: null,
+            recommended_model: 'claude-opus-4-8',
+          },
+          stop_sequence: null,
+        },
+        usage: {
+          output_tokens: 0,
+          iterations: [{ type: 'fallback_message', model: 'claude-opus-4-8', input_tokens: 5, output_tokens: 0 }],
+        },
+      },
+    },
+    { data: { type: 'message_stop' } },
+  ]));
+
+  assertEquals(result.stop_details, {
+    type: 'refusal',
+    category: 'future_policy',
+    explanation: null,
+    recommended_model: 'claude-opus-4-8',
+  });
+  assertEquals(result.content, [{
+    type: 'fallback',
+    from: { model: 'claude-opus-5' },
+    to: { model: 'claude-opus-4-8' },
+    trigger: { type: 'refusal', category: 'future_policy' },
+  }]);
+  assertEquals(result.usage.iterations, [{ type: 'fallback_message', model: 'claude-opus-4-8', input_tokens: 5, output_tokens: 0 }]);
+});

--- a/packages/protocols/__tests__/messages/usage_test.ts
+++ b/packages/protocols/__tests__/messages/usage_test.ts
@@ -44,3 +44,22 @@ test('Messages usage snapshots merge late counters and atomically replace the ti
     service_tier: 'priority',
   });
 });
+
+test('Messages usage snapshots preserve nullable iterations and isolate nested cache data', () => {
+  expect(messagesUsageSnapshot({ output_tokens: 0, iterations: null })).toEqual({ output_tokens: 0, iterations: null });
+
+  const source = [{
+    type: 'compaction',
+    input_tokens: 7,
+    cache_creation: { ephemeral_5m_input_tokens: 3 },
+  }];
+  const snapshot = messagesUsageSnapshot({ output_tokens: 0, iterations: source });
+  source[0].cache_creation.ephemeral_5m_input_tokens = 9;
+
+  expect(snapshot.iterations).toEqual([{
+    type: 'compaction',
+    input_tokens: 7,
+    cache_creation: { ephemeral_5m_input_tokens: 3 },
+  }]);
+  expect(mergeMessagesUsageSnapshot(snapshot, { output_tokens: 1, iterations: null }).iterations).toBeNull();
+});

--- a/packages/protocols/__tests__/responses/from-result_test.ts
+++ b/packages/protocols/__tests__/responses/from-result_test.ts
@@ -172,6 +172,37 @@ test('responsesResultToEvents propagates the real message item id to the added i
   for (const itemId of childItemIds) assertEquals(itemId, 'msg_real');
 });
 
+test('responsesResultToEvents expands refusal content with the native refusal lifecycle', () => {
+  const events = Array.from(responsesResultToEvents({
+    ...completedResponse,
+    output: [{
+      type: 'message',
+      id: 'msg_refusal',
+      role: 'assistant',
+      content: [{ type: 'refusal', refusal: 'Cannot help.' }],
+    }],
+  })).map(frame => frame.event);
+
+  assertEquals(events.filter(event => event.type.startsWith('response.refusal')), [
+    {
+      type: 'response.refusal.delta',
+      item_id: 'msg_refusal',
+      output_index: 0,
+      content_index: 0,
+      delta: 'Cannot help.',
+      sequence_number: 4,
+    },
+    {
+      type: 'response.refusal.done',
+      item_id: 'msg_refusal',
+      output_index: 0,
+      content_index: 0,
+      refusal: 'Cannot help.',
+      sequence_number: 5,
+    },
+  ]);
+});
+
 test('responsesResultToEvents propagates the real function_call item id to the added item and child frames', () => {
   const frames = Array.from(
     responsesResultToEvents({

--- a/packages/protocols/__tests__/responses/from-result_test.ts
+++ b/packages/protocols/__tests__/responses/from-result_test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 
 import { responsesResultToEvents } from '../../src/responses/from-result.ts';
-import type { ResponsesOutputItem, ResponsesResult } from '../../src/responses/index.ts';
+import type { ResponsesOutputItem, ResponsesResult, ResponsesStreamEvent } from '../../src/responses/index.ts';
 import { assertEquals, assertFalse, assertThrows } from '@floway-dev/test-utils';
 
 const completedResponse: ResponsesResult = {
@@ -182,6 +182,14 @@ test('responsesResultToEvents expands refusal content with the native refusal li
       content: [{ type: 'refusal', refusal: 'Cannot help.' }],
     }],
   })).map(frame => frame.event);
+
+  const added = events.find(event => event.type === 'response.output_item.added') as Extract<ResponsesStreamEvent, { type: 'response.output_item.added' }>;
+  assertEquals(added.item, {
+    type: 'message',
+    id: 'msg_refusal',
+    role: 'assistant',
+    content: [{ type: 'refusal', refusal: '' }],
+  });
 
   assertEquals(events.filter(event => event.type.startsWith('response.refusal')), [
     {

--- a/packages/protocols/src/chat-completions/index.ts
+++ b/packages/protocols/src/chat-completions/index.ts
@@ -53,6 +53,7 @@ export interface ChatCompletionsMessage {
   /** Opaque reasoning token/signature for round-tripping */
   reasoning_opaque?: string | null;
   reasoning_items?: ChatCompletionsReasoningItem[] | null;
+  refusal?: string | null;
 }
 
 export interface ChatCompletionsReasoningItem {
@@ -67,7 +68,7 @@ export interface ChatCompletionsToolCall {
   function: { name: string; arguments: string };
 }
 
-export type ChatCompletionsContentPart = ChatCompletionsTextPart | ChatCompletionsImagePart;
+export type ChatCompletionsContentPart = ChatCompletionsTextPart | ChatCompletionsImagePart | ChatCompletionsRefusalPart;
 
 interface ChatCompletionsTextPart {
   type: 'text';
@@ -77,6 +78,11 @@ interface ChatCompletionsTextPart {
 interface ChatCompletionsImagePart {
   type: 'image_url';
   image_url: { url: string; detail?: 'low' | 'high' | 'auto' };
+}
+
+interface ChatCompletionsRefusalPart {
+  type: 'refusal';
+  refusal: string;
 }
 
 // Response types

--- a/packages/protocols/src/chat-completions/index.ts
+++ b/packages/protocols/src/chat-completions/index.ts
@@ -126,6 +126,7 @@ export interface ChatCompletionsChoiceNonStreaming {
     reasoning_text?: string | null;
     reasoning_opaque?: string | null;
     reasoning_items?: ChatCompletionsReasoningItem[] | null;
+    refusal?: string | null;
   };
   finish_reason: 'stop' | 'length' | 'tool_calls' | 'content_filter';
 }
@@ -152,6 +153,7 @@ export interface ChatCompletionsDelta {
   /** Opaque reasoning token/signature delta */
   reasoning_opaque?: string | null;
   reasoning_items?: ChatCompletionsReasoningItem[] | null;
+  refusal?: string | null;
 }
 
 export * from './errors.ts';

--- a/packages/protocols/src/chat-completions/reassemble.ts
+++ b/packages/protocols/src/chat-completions/reassemble.ts
@@ -20,7 +20,7 @@ interface ChoiceAccumulator {
   content: string;
   reasoningText: string;
   reasoningOpaque?: string;
-  refusal: string;
+  refusal?: string;
   readonly reasoningItems: ChatCompletionsReasoningItem[];
   finishReason: ChatCompletionsChoiceNonStreaming['finish_reason'];
   readonly toolCalls: Map<number, ToolCallAccumulator>;
@@ -33,7 +33,6 @@ const createChoiceAccumulator = (index: number): ChoiceAccumulator => ({
   content: '',
   reasoningText: '',
   reasoningItems: [],
-  refusal: '',
   finishReason: 'stop',
   toolCalls: new Map(),
   choiceExtras: {},
@@ -73,7 +72,7 @@ const finalizeChoice = (choice: ChoiceAccumulator): ChatCompletionsChoiceNonStre
       ...(choice.reasoningText ? { reasoning_text: choice.reasoningText } : {}),
       ...(choice.reasoningOpaque !== undefined ? { reasoning_opaque: choice.reasoningOpaque } : {}),
       ...(choice.reasoningItems.length > 0 ? { reasoning_items: choice.reasoningItems } : {}),
-      ...(choice.refusal ? { refusal: choice.refusal } : {}),
+      ...(choice.refusal !== undefined ? { refusal: choice.refusal } : {}),
       ...choice.messageExtras,
     },
     finish_reason: choice.finishReason,
@@ -119,7 +118,7 @@ export async function reassembleChatCompletionsEvents(chunks: AsyncIterable<Chat
       if (typeof delta.content === 'string') choice.content += delta.content;
       if (typeof delta.reasoning_text === 'string') choice.reasoningText += delta.reasoning_text;
       if (typeof delta.reasoning_opaque === 'string') choice.reasoningOpaque = delta.reasoning_opaque;
-      if (typeof delta.refusal === 'string') choice.refusal += delta.refusal;
+      if (typeof delta.refusal === 'string') choice.refusal = (choice.refusal ?? '') + delta.refusal;
       if (Array.isArray(delta.reasoning_items)) {
         choice.reasoningItems.push(...delta.reasoning_items);
       }

--- a/packages/protocols/src/chat-completions/reassemble.ts
+++ b/packages/protocols/src/chat-completions/reassemble.ts
@@ -5,7 +5,7 @@ import { captureExtras } from '../common/reassemble-extras.ts';
 // Field-fidelity contract: every field an upstream emits must reach the
 // non-streaming result. Known streaming fields use their protocol semantics;
 // unknown fields fall through to captureExtras so future extensions survive.
-const KNOWN_DELTA_KEYS = new Set(['content', 'role', 'reasoning_text', 'reasoning_opaque', 'reasoning_items', 'tool_calls']);
+const KNOWN_DELTA_KEYS = new Set(['content', 'role', 'reasoning_text', 'reasoning_opaque', 'reasoning_items', 'refusal', 'tool_calls']);
 const KNOWN_CHOICE_KEYS = new Set(['index', 'delta', 'finish_reason']);
 const KNOWN_CHUNK_KEYS = new Set(['id', 'object', 'created', 'model', 'choices', 'usage', 'system_fingerprint', 'service_tier']);
 
@@ -20,6 +20,7 @@ interface ChoiceAccumulator {
   content: string;
   reasoningText: string;
   reasoningOpaque?: string;
+  refusal: string;
   readonly reasoningItems: ChatCompletionsReasoningItem[];
   finishReason: ChatCompletionsChoiceNonStreaming['finish_reason'];
   readonly toolCalls: Map<number, ToolCallAccumulator>;
@@ -32,6 +33,7 @@ const createChoiceAccumulator = (index: number): ChoiceAccumulator => ({
   content: '',
   reasoningText: '',
   reasoningItems: [],
+  refusal: '',
   finishReason: 'stop',
   toolCalls: new Map(),
   choiceExtras: {},
@@ -71,6 +73,7 @@ const finalizeChoice = (choice: ChoiceAccumulator): ChatCompletionsChoiceNonStre
       ...(choice.reasoningText ? { reasoning_text: choice.reasoningText } : {}),
       ...(choice.reasoningOpaque !== undefined ? { reasoning_opaque: choice.reasoningOpaque } : {}),
       ...(choice.reasoningItems.length > 0 ? { reasoning_items: choice.reasoningItems } : {}),
+      ...(choice.refusal ? { refusal: choice.refusal } : {}),
       ...choice.messageExtras,
     },
     finish_reason: choice.finishReason,
@@ -116,6 +119,7 @@ export async function reassembleChatCompletionsEvents(chunks: AsyncIterable<Chat
       if (typeof delta.content === 'string') choice.content += delta.content;
       if (typeof delta.reasoning_text === 'string') choice.reasoningText += delta.reasoning_text;
       if (typeof delta.reasoning_opaque === 'string') choice.reasoningOpaque = delta.reasoning_opaque;
+      if (typeof delta.refusal === 'string') choice.refusal += delta.refusal;
       if (Array.isArray(delta.reasoning_items)) {
         choice.reasoningItems.push(...delta.reasoning_items);
       }

--- a/packages/protocols/src/gemini/field-keys.ts
+++ b/packages/protocols/src/gemini/field-keys.ts
@@ -4,4 +4,4 @@ import type { GeminiCandidate, GeminiResult } from './index.ts';
 // transport. Keeping one definition for both stages ensures unknown upstream
 // fields remain extras until every stage gains typed handling for them.
 export const GEMINI_RESULT_KEYS: ReadonlySet<keyof GeminiResult> = new Set(['candidates', 'modelVersion', 'responseId', 'usageMetadata']);
-export const GEMINI_CANDIDATE_KEYS: ReadonlySet<keyof GeminiCandidate> = new Set(['index', 'content', 'finishReason']);
+export const GEMINI_CANDIDATE_KEYS: ReadonlySet<keyof GeminiCandidate> = new Set(['index', 'content', 'finishReason', 'finishMessage', 'safetyRatings']);

--- a/packages/protocols/src/gemini/index.ts
+++ b/packages/protocols/src/gemini/index.ts
@@ -86,7 +86,15 @@ export interface GeminiResult {
 export interface GeminiCandidate {
   content: GeminiContent;
   finishReason?: GeminiFinishReason;
+  finishMessage?: string;
+  safetyRatings?: GeminiSafetyRating[];
   index: number;
+}
+
+export interface GeminiSafetyRating {
+  category: string;
+  probability: string;
+  blocked?: boolean;
 }
 
 export type GeminiFinishReason = 'STOP' | 'MAX_TOKENS' | 'SAFETY' | 'RECITATION' | 'OTHER' | 'MALFORMED_FUNCTION_CALL' | 'FINISH_REASON_UNSPECIFIED';

--- a/packages/protocols/src/gemini/reassemble.ts
+++ b/packages/protocols/src/gemini/reassemble.ts
@@ -37,6 +37,8 @@ const mergeCandidate = (candidates: Map<number, GeminiCandidateWithExtras>, inco
         parts: [],
       },
       ...(incoming.finishReason !== undefined ? { finishReason: incoming.finishReason } : {}),
+      ...(incoming.finishMessage !== undefined ? { finishMessage: incoming.finishMessage } : {}),
+      ...(incoming.safetyRatings !== undefined ? { safetyRatings: incoming.safetyRatings.map(rating => ({ ...rating })) } : {}),
     };
     for (const part of incoming.content.parts) {
       appendPart(candidate.content.parts, part);
@@ -57,6 +59,8 @@ const mergeCandidate = (candidates: Map<number, GeminiCandidateWithExtras>, inco
   if (incoming.finishReason !== undefined) {
     existing.finishReason = incoming.finishReason;
   }
+  if (incoming.finishMessage !== undefined) existing.finishMessage = incoming.finishMessage;
+  if (incoming.safetyRatings !== undefined) existing.safetyRatings = incoming.safetyRatings.map(rating => ({ ...rating }));
   const extras = existing.__extras ?? {};
   captureExtras(incoming as unknown as Record<string, unknown>, GEMINI_CANDIDATE_KEYS, extras);
   if (Object.keys(extras).length > 0) existing.__extras = extras;

--- a/packages/protocols/src/messages/index.ts
+++ b/packages/protocols/src/messages/index.ts
@@ -211,6 +211,13 @@ export interface MessagesFallbackBlock {
   };
 }
 
+export interface MessagesFallbackBlockParam {
+  type: 'fallback';
+  from: { model: string };
+  to: { model: string };
+  trigger?: unknown;
+}
+
 export type MessagesUserContentBlock = MessagesTextBlock | MessagesImageBlock | MessagesToolResultBlock;
 
 export type MessagesAssistantContentBlock =
@@ -222,6 +229,10 @@ export type MessagesAssistantContentBlock =
   | MessagesRedactedThinkingBlock
   | MessagesFallbackBlock;
 
+export type MessagesAssistantInputContentBlock =
+  | Exclude<MessagesAssistantContentBlock, MessagesFallbackBlock>
+  | MessagesFallbackBlockParam;
+
 export interface MessagesUserMessage {
   role: 'user';
   content: string | MessagesUserContentBlock[];
@@ -229,7 +240,7 @@ export interface MessagesUserMessage {
 
 export interface MessagesAssistantMessage {
   role: 'assistant';
-  content: string | MessagesAssistantContentBlock[];
+  content: string | MessagesAssistantInputContentBlock[];
 }
 
 // The Anthropic Messages API role enum is "user" | "assistant" | "system"
@@ -362,7 +373,7 @@ export interface MessagesMessageDeltaEvent {
     service_tier?: 'standard' | 'priority' | 'batch' | (string & {});
     speed?: 'standard' | 'fast' | (string & {});
     server_tool_use?: MessagesUsageServerToolUse;
-    iterations?: MessagesUsageIteration[];
+    iterations?: MessagesUsageIteration[] | null;
   };
 }
 

--- a/packages/protocols/src/messages/index.ts
+++ b/packages/protocols/src/messages/index.ts
@@ -1,4 +1,4 @@
-import type { MessagesUsage, MessagesUsageServerToolUse } from './usage.ts';
+import type { MessagesUsage, MessagesUsageIteration, MessagesUsageServerToolUse } from './usage.ts';
 
 /**
  * Messages requires `max_tokens`, but the Chat Completions, Responses, and
@@ -176,6 +176,41 @@ export interface MessagesRedactedThinkingBlock {
   data: string;
 }
 
+// Anthropic classifier refusal categories. The wire is versioned additively,
+// so retain the open-string arm for categories introduced after this snapshot.
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/messages/messages.ts#L1458-L1491
+export type MessagesRefusalCategory =
+  | 'cyber'
+  | 'bio'
+  | 'frontier_llm'
+  | 'reasoning_extraction'
+  | 'general_harms'
+  | (string & {})
+  | null;
+
+export interface MessagesRefusalStopDetails {
+  type: 'refusal';
+  category: MessagesRefusalCategory;
+  explanation: string | null;
+  fallback_credit_token?: string | null;
+  fallback_has_prefill_claim?: boolean | null;
+  recommended_model?: string | null;
+}
+
+// Server-side refusal fallback boundary. It is a regular content block with
+// no deltas and must survive assistant-history round trips in its original
+// position.
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/beta/messages/messages.ts#L1566-L1633
+export interface MessagesFallbackBlock {
+  type: 'fallback';
+  from: { model: string };
+  to: { model: string };
+  trigger: {
+    type: 'refusal';
+    category: MessagesRefusalCategory;
+  };
+}
+
 export type MessagesUserContentBlock = MessagesTextBlock | MessagesImageBlock | MessagesToolResultBlock;
 
 export type MessagesAssistantContentBlock =
@@ -184,7 +219,8 @@ export type MessagesAssistantContentBlock =
   | MessagesServerToolUseBlock
   | MessagesWebSearchToolResultBlock
   | MessagesThinkingBlock
-  | MessagesRedactedThinkingBlock;
+  | MessagesRedactedThinkingBlock
+  | MessagesFallbackBlock;
 
 export interface MessagesUserMessage {
   role: 'user';
@@ -240,6 +276,7 @@ export {
   splitMessagesCacheCreationTokens,
   type MessagesCacheCreationUsage,
   type MessagesUsage,
+  type MessagesUsageIteration,
   type MessagesUsageServerToolUse,
   type MessagesUsageSnapshot,
 } from './usage.ts';
@@ -251,6 +288,7 @@ export interface MessagesResult {
   content: MessagesAssistantContentBlock[];
   model: string;
   stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | 'pause_turn' | 'refusal' | null;
+  stop_details?: MessagesRefusalStopDetails | null;
   stop_sequence: string | null;
   usage: MessagesUsage;
 }
@@ -285,7 +323,8 @@ export interface MessagesContentBlockStartEvent {
     | MessagesServerToolUseBlock
     | MessagesWebSearchToolResultBlock
     | { type: 'thinking'; thinking: string }
-    | { type: 'redacted_thinking'; data: string };
+    | { type: 'redacted_thinking'; data: string }
+    | MessagesFallbackBlock;
 }
 
 export interface MessagesContentBlockDeltaEvent {
@@ -308,6 +347,7 @@ export interface MessagesMessageDeltaEvent {
   type: 'message_delta';
   delta: {
     stop_reason?: MessagesResult['stop_reason'];
+    stop_details?: MessagesRefusalStopDetails | null;
     stop_sequence?: string | null;
   };
   usage?: {
@@ -322,6 +362,7 @@ export interface MessagesMessageDeltaEvent {
     service_tier?: 'standard' | 'priority' | 'batch' | (string & {});
     speed?: 'standard' | 'fast' | (string & {});
     server_tool_use?: MessagesUsageServerToolUse;
+    iterations?: MessagesUsageIteration[];
   };
 }
 

--- a/packages/protocols/src/messages/reassemble.ts
+++ b/packages/protocols/src/messages/reassemble.ts
@@ -109,7 +109,14 @@ const applyMessagesUsage = (usage: MessagesUsage, update: Partial<MessagesUsage>
   if (update.server_tool_use != null) {
     usage.server_tool_use = update.server_tool_use;
   }
-  if (update.iterations != null) usage.iterations = update.iterations.map(iteration => ({ ...iteration }));
+  if (update.iterations !== undefined) {
+    usage.iterations = update.iterations?.map(iteration => ({
+      ...iteration,
+      ...(iteration.cache_creation === undefined || iteration.cache_creation === null
+        ? {}
+        : { cache_creation: { ...iteration.cache_creation } }),
+    })) ?? null;
+  }
 };
 
 const createBlockAccumulator = (event: Extract<MessagesStreamEvent, { type: 'content_block_start' }>): MessagesBlockAccumulator => {

--- a/packages/protocols/src/messages/reassemble.ts
+++ b/packages/protocols/src/messages/reassemble.ts
@@ -1,6 +1,8 @@
 import type {
   MessagesAssistantContentBlock,
+  MessagesFallbackBlock,
   MessagesRedactedThinkingBlock,
+  MessagesRefusalStopDetails,
   MessagesResult,
   MessagesServerToolUseBlock,
   MessagesStreamEvent,
@@ -73,12 +75,12 @@ type MessagesToolUseBlockAccumulator = MessagesToolUseBlock & {
   inputJson: string;
 };
 
-type MessagesBlockAccumulator = (MessagesTextBlockAccumulator | MessagesToolUseBlockAccumulator | MessagesServerToolUseBlock | MessagesWebSearchToolResultBlock | MessagesThinkingBlock | MessagesRedactedThinkingBlock) & { extras?: Record<string, unknown> };
+type MessagesBlockAccumulator = (MessagesTextBlockAccumulator | MessagesToolUseBlockAccumulator | MessagesServerToolUseBlock | MessagesWebSearchToolResultBlock | MessagesThinkingBlock | MessagesRedactedThinkingBlock | MessagesFallbackBlock) & { extras?: Record<string, unknown> };
 
 // Field-fidelity contract — see {@link captureExtras}. Anything an upstream
 // emits on `message_start.message`, on a `content_block`, or on the assembled
 // result top-level beyond the typed schema below survives by default.
-const KNOWN_MESSAGE_KEYS = new Set(['id', 'type', 'role', 'content', 'model', 'stop_reason', 'stop_sequence', 'usage']);
+const KNOWN_MESSAGE_KEYS = new Set(['id', 'type', 'role', 'content', 'model', 'stop_reason', 'stop_details', 'stop_sequence', 'usage']);
 const KNOWN_BLOCK_KEYS_BY_TYPE: Record<string, ReadonlySet<string>> = {
   text: new Set(['type', 'text', 'citations']),
   tool_use: new Set(['type', 'id', 'name', 'input']),
@@ -86,6 +88,7 @@ const KNOWN_BLOCK_KEYS_BY_TYPE: Record<string, ReadonlySet<string>> = {
   redacted_thinking: new Set(['type', 'data']),
   server_tool_use: new Set(['type', 'id', 'name', 'input']),
   web_search_tool_result: new Set(['type', 'tool_use_id', 'content']),
+  fallback: new Set(['type', 'from', 'to', 'trigger']),
 };
 const FALLBACK_BLOCK_KNOWN = new Set(['type']);
 
@@ -106,6 +109,7 @@ const applyMessagesUsage = (usage: MessagesUsage, update: Partial<MessagesUsage>
   if (update.server_tool_use != null) {
     usage.server_tool_use = update.server_tool_use;
   }
+  if (update.iterations != null) usage.iterations = update.iterations.map(iteration => ({ ...iteration }));
 };
 
 const createBlockAccumulator = (event: Extract<MessagesStreamEvent, { type: 'content_block_start' }>): MessagesBlockAccumulator => {
@@ -149,6 +153,13 @@ const createBlockAccumulator = (event: Extract<MessagesStreamEvent, { type: 'con
     return withExtras({ type: 'thinking', thinking: block.thinking ?? '' });
   case 'redacted_thinking':
     return withExtras({ type: 'redacted_thinking', data: block.data });
+  case 'fallback':
+    return withExtras({
+      type: 'fallback',
+      from: { ...block.from },
+      to: { ...block.to },
+      trigger: { ...block.trigger },
+    });
   }
 };
 
@@ -226,6 +237,7 @@ export async function reassembleMessagesEvents(events: AsyncIterable<MessagesStr
     output_tokens: 0,
   };
   let stopReason: MessagesResult['stop_reason'] = null;
+  let stopDetails: MessagesRefusalStopDetails | null | undefined;
   let stopSequence: string | null = null;
 
   const blocks: Array<MessagesBlockAccumulator | undefined> = [];
@@ -236,6 +248,7 @@ export async function reassembleMessagesEvents(events: AsyncIterable<MessagesStr
     case 'message_start':
       id = event.message.id;
       model = event.message.model;
+      stopDetails = event.message.stop_details;
       applyMessagesUsage(usage, event.message.usage);
       captureExtras(event.message as unknown as Record<string, unknown>, KNOWN_MESSAGE_KEYS, resultExtras);
       break;
@@ -251,6 +264,9 @@ export async function reassembleMessagesEvents(events: AsyncIterable<MessagesStr
     case 'message_delta':
       if (event.delta.stop_reason != null) {
         stopReason = event.delta.stop_reason;
+      }
+      if ('stop_details' in event.delta) {
+        stopDetails = event.delta.stop_details;
       }
       if ('stop_sequence' in event.delta) {
         stopSequence = event.delta.stop_sequence as string | null;
@@ -274,6 +290,7 @@ export async function reassembleMessagesEvents(events: AsyncIterable<MessagesStr
     content,
     model,
     stop_reason: stopReason,
+    ...(stopDetails !== undefined ? { stop_details: stopDetails } : {}),
     stop_sequence: stopSequence,
     usage,
     ...resultExtras,

--- a/packages/protocols/src/messages/reassemble.ts
+++ b/packages/protocols/src/messages/reassemble.ts
@@ -12,9 +12,9 @@ import type {
   MessagesUsage,
   MessagesWebSearchToolResultBlock,
 } from './index.ts';
+import { cloneMessagesUsageIterations } from './usage.ts';
 import { isJsonObject } from '../common/json.ts';
 import { captureExtras } from '../common/reassemble-extras.ts';
-import { cloneMessagesUsageIterations } from './usage.ts';
 
 const normalizeMessagesTextCitation = (value: unknown): MessagesTextCitation | null => {
   if (!isJsonObject(value) || typeof value.type !== 'string') {

--- a/packages/protocols/src/messages/reassemble.ts
+++ b/packages/protocols/src/messages/reassemble.ts
@@ -14,6 +14,7 @@ import type {
 } from './index.ts';
 import { isJsonObject } from '../common/json.ts';
 import { captureExtras } from '../common/reassemble-extras.ts';
+import { cloneMessagesUsageIterations } from './usage.ts';
 
 const normalizeMessagesTextCitation = (value: unknown): MessagesTextCitation | null => {
   if (!isJsonObject(value) || typeof value.type !== 'string') {
@@ -110,12 +111,7 @@ const applyMessagesUsage = (usage: MessagesUsage, update: Partial<MessagesUsage>
     usage.server_tool_use = update.server_tool_use;
   }
   if (update.iterations !== undefined) {
-    usage.iterations = update.iterations?.map(iteration => ({
-      ...iteration,
-      ...(iteration.cache_creation === undefined || iteration.cache_creation === null
-        ? {}
-        : { cache_creation: { ...iteration.cache_creation } }),
-    })) ?? null;
+    usage.iterations = cloneMessagesUsageIterations(update.iterations);
   }
 };
 

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -2,6 +2,19 @@ export interface MessagesUsageServerToolUse {
   web_search_requests?: number;
 }
 
+export interface MessagesUsageIteration {
+  type: 'message' | 'fallback_message' | (string & {});
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation?: {
+    ephemeral_5m_input_tokens?: number;
+    ephemeral_1h_input_tokens?: number;
+  } | null;
+}
+
 export interface MessagesUsage {
   input_tokens: number;
   output_tokens: number;
@@ -20,6 +33,7 @@ export interface MessagesUsage {
   // https://docs.claude.com/en/build-with-claude/fast-mode
   speed?: 'standard' | 'fast' | (string & {});
   server_tool_use?: MessagesUsageServerToolUse;
+  iterations?: MessagesUsageIteration[];
 }
 
 export interface MessagesCacheCreationUsage {
@@ -36,6 +50,7 @@ export interface MessagesUsageSnapshot extends MessagesCacheCreationUsage {
   cache_read_input_tokens?: number;
   service_tier?: string;
   speed?: string;
+  iterations?: MessagesUsageIteration[];
 }
 
 export const messagesUsageSnapshot = (usage?: MessagesUsageSnapshot): MessagesUsageSnapshot => usage === undefined
@@ -43,6 +58,7 @@ export const messagesUsageSnapshot = (usage?: MessagesUsageSnapshot): MessagesUs
   : {
       ...usage,
       ...(usage.cache_creation === undefined ? {} : { cache_creation: { ...usage.cache_creation } }),
+      ...(usage.iterations === undefined ? {} : { iterations: usage.iterations.map(iteration => ({ ...iteration })) }),
     };
 
 export const mergeMessagesUsageSnapshot = (
@@ -55,6 +71,7 @@ export const mergeMessagesUsageSnapshot = (
   ...(delta.cache_read_input_tokens === undefined ? {} : { cache_read_input_tokens: delta.cache_read_input_tokens }),
   ...(delta.cache_creation_input_tokens === undefined ? {} : { cache_creation_input_tokens: delta.cache_creation_input_tokens }),
   ...(delta.cache_creation === undefined ? {} : { cache_creation: { ...delta.cache_creation } }),
+  ...(delta.iterations === undefined ? {} : { iterations: delta.iterations.map(iteration => ({ ...iteration })) }),
   ...(delta.speed === undefined && delta.service_tier === undefined
     ? {}
     : { speed: delta.speed, service_tier: delta.service_tier }),

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -16,7 +16,11 @@ export interface MessagesUsageIteration {
   [key: string]: unknown;
 }
 
-const cloneMessagesUsageIterations = (iterations: MessagesUsageIteration[] | null): MessagesUsageIteration[] | null =>
+// The beta usage union includes model attempts, advisor attempts, and
+// compaction entries, and remains additively extensible. Floway only needs an
+// isolated opaque snapshot, not a closed projection of those variants.
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/beta/messages/messages.ts#L1724-L1829
+export const cloneMessagesUsageIterations = (iterations: MessagesUsageIteration[] | null): MessagesUsageIteration[] | null =>
   iterations?.map(iteration => ({
     ...iteration,
     ...(iteration.cache_creation === undefined || iteration.cache_creation === null

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -3,17 +3,26 @@ export interface MessagesUsageServerToolUse {
 }
 
 export interface MessagesUsageIteration {
-  type: 'message' | 'fallback_message' | (string & {});
-  model: string;
-  input_tokens: number;
-  output_tokens: number;
+  type: string;
+  model?: string;
+  input_tokens?: number;
+  output_tokens?: number;
   cache_creation_input_tokens?: number;
   cache_read_input_tokens?: number;
   cache_creation?: {
     ephemeral_5m_input_tokens?: number;
     ephemeral_1h_input_tokens?: number;
   } | null;
+  [key: string]: unknown;
 }
+
+const cloneMessagesUsageIterations = (iterations: MessagesUsageIteration[] | null): MessagesUsageIteration[] | null =>
+  iterations?.map(iteration => ({
+    ...iteration,
+    ...(iteration.cache_creation === undefined || iteration.cache_creation === null
+      ? {}
+      : { cache_creation: { ...iteration.cache_creation } }),
+  })) ?? null;
 
 export interface MessagesUsage {
   input_tokens: number;
@@ -33,7 +42,7 @@ export interface MessagesUsage {
   // https://docs.claude.com/en/build-with-claude/fast-mode
   speed?: 'standard' | 'fast' | (string & {});
   server_tool_use?: MessagesUsageServerToolUse;
-  iterations?: MessagesUsageIteration[];
+  iterations?: MessagesUsageIteration[] | null;
 }
 
 export interface MessagesCacheCreationUsage {
@@ -50,7 +59,7 @@ export interface MessagesUsageSnapshot extends MessagesCacheCreationUsage {
   cache_read_input_tokens?: number;
   service_tier?: string;
   speed?: string;
-  iterations?: MessagesUsageIteration[];
+  iterations?: MessagesUsageIteration[] | null;
 }
 
 export const messagesUsageSnapshot = (usage?: MessagesUsageSnapshot): MessagesUsageSnapshot => usage === undefined
@@ -58,7 +67,7 @@ export const messagesUsageSnapshot = (usage?: MessagesUsageSnapshot): MessagesUs
   : {
       ...usage,
       ...(usage.cache_creation === undefined ? {} : { cache_creation: { ...usage.cache_creation } }),
-      ...(usage.iterations === undefined ? {} : { iterations: usage.iterations.map(iteration => ({ ...iteration })) }),
+      ...(usage.iterations === undefined ? {} : { iterations: cloneMessagesUsageIterations(usage.iterations) }),
     };
 
 export const mergeMessagesUsageSnapshot = (
@@ -71,7 +80,7 @@ export const mergeMessagesUsageSnapshot = (
   ...(delta.cache_read_input_tokens === undefined ? {} : { cache_read_input_tokens: delta.cache_read_input_tokens }),
   ...(delta.cache_creation_input_tokens === undefined ? {} : { cache_creation_input_tokens: delta.cache_creation_input_tokens }),
   ...(delta.cache_creation === undefined ? {} : { cache_creation: { ...delta.cache_creation } }),
-  ...(delta.iterations === undefined ? {} : { iterations: delta.iterations.map(iteration => ({ ...iteration })) }),
+  ...(delta.iterations === undefined ? {} : { iterations: cloneMessagesUsageIterations(delta.iterations) }),
   ...(delta.speed === undefined && delta.service_tier === undefined
     ? {}
     : { speed: delta.speed, service_tier: delta.service_tier }),

--- a/packages/protocols/src/responses/from-result.ts
+++ b/packages/protocols/src/responses/from-result.ts
@@ -57,7 +57,10 @@ const responsesMessageEvents = (item: ResponsesOutputMessage, outputIndex: numbe
         type: 'message',
         id: itemId,
         role: 'assistant',
-        content: item.content.map(part => (part.type === 'output_text' ? { type: 'output_text', text: '' } : part)),
+        content: item.content.map(part =>
+          part.type === 'output_text'
+            ? { type: 'output_text', text: '' }
+            : { type: 'refusal', refusal: '' }),
       },
     },
   ];

--- a/packages/protocols/src/responses/from-result.ts
+++ b/packages/protocols/src/responses/from-result.ts
@@ -104,7 +104,23 @@ const responsesMessageEvents = (item: ResponsesOutputMessage, outputIndex: numbe
       item_id: itemId,
       output_index: outputIndex,
       content_index: contentIndex,
-      part,
+      part: { type: 'refusal', refusal: '' },
+    });
+    if (part.refusal.length > 0) {
+      events.push({
+        type: 'response.refusal.delta',
+        item_id: itemId,
+        output_index: outputIndex,
+        content_index: contentIndex,
+        delta: part.refusal,
+      });
+    }
+    events.push({
+      type: 'response.refusal.done',
+      item_id: itemId,
+      output_index: outputIndex,
+      content_index: contentIndex,
+      refusal: part.refusal,
     });
     events.push({
       type: 'response.content_part.done',

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -133,7 +133,7 @@ export type CanonicalResponsesPayload = Omit<ResponsesPayload, 'input'> & {
   input: ResponsesInputItem[];
 };
 
-export type ResponsesInputContent = ResponsesInputText | ResponsesInputImage | ResponsesInputFile;
+export type ResponsesInputContent = ResponsesInputText | ResponsesInputImage | ResponsesInputFile | ResponsesOutputRefusal;
 
 // Explicit content breakpoints inherit their lifetime from
 // `prompt_cache_options.ttl`. The mode stays open-string for forward

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -922,7 +922,7 @@ interface ResponsesOutputText {
   text: string;
 }
 
-interface ResponsesOutputRefusal {
+export interface ResponsesOutputRefusal {
   type: 'refusal';
   refusal: string;
 }
@@ -1089,6 +1089,20 @@ type ResponsesStreamEventVariant =
     output_index: number;
     content_index: number;
     text: string;
+  }
+  | {
+    type: 'response.refusal.delta';
+    item_id: string;
+    output_index: number;
+    content_index: number;
+    delta: string;
+  }
+  | {
+    type: 'response.refusal.done';
+    item_id: string;
+    output_index: number;
+    content_index: number;
+    refusal: string;
   }
   | {
     type: 'response.output_text.annotation.added';

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -207,7 +207,7 @@ export interface ResponsesFunctionCallOutputItem {
   call_id: string;
   // Multimodal tool outputs carry an array of content parts (e.g. a screenshot
   // tool returning `input_image` parts) in addition to the plain-string form.
-  output: string | ResponsesInputContent[];
+  output: string | ResponsesToolOutputContent[];
   status?: 'completed' | 'incomplete';
   caller?: ResponsesToolCaller | null;
 }

--- a/packages/provider-copilot/__tests__/interceptors/responses/compress-images_test.ts
+++ b/packages/provider-copilot/__tests__/interceptors/responses/compress-images_test.ts
@@ -4,7 +4,7 @@ import { withInlineImagesCompressed } from '../../../src/interceptors/responses/
 import type { ResponsesBoundaryCtx } from '../../../src/interceptors/responses/types.ts';
 import { type ImageProcessor, initImageProcessor } from '@floway-dev/platform';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { CanonicalResponsesPayload, ResponsesInputContent, ResponsesInputImage, ResponsesInputItem, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputContent, ResponsesInputImage, ResponsesInputItem, ResponsesStreamEvent, ResponsesToolOutputContent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { eventResult } from '@floway-dev/provider';
 import { assert, assertEquals, stubProviderModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
@@ -27,8 +27,8 @@ const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx =>
 
 const contentContainers = {
   message: (content: ResponsesInputContent[]): ResponsesInputItem => ({ type: 'message', role: 'user', content }),
-  function_output: (output: ResponsesInputContent[]): ResponsesInputItem => ({ type: 'function_call_output', call_id: 'call_function', output }),
-  custom_output: (output: ResponsesInputContent[]): ResponsesInputItem => ({ type: 'custom_tool_call_output', call_id: 'call_custom', output }),
+  function_output: (output: ResponsesToolOutputContent[]): ResponsesInputItem => ({ type: 'function_call_output', call_id: 'call_function', output }),
+  custom_output: (output: ResponsesToolOutputContent[]): ResponsesInputItem => ({ type: 'custom_tool_call_output', call_id: 'call_custom', output }),
 };
 
 const imageUrlOf = (item: ResponsesInputItem): string | null | undefined => {

--- a/packages/provider-copilot/__tests__/interceptors/responses/set-vision-header_test.ts
+++ b/packages/provider-copilot/__tests__/interceptors/responses/set-vision-header_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { withVisionHeaderSet } from '../../../src/interceptors/responses/set-vision-header.ts';
 import type { ResponsesBoundaryCtx } from '../../../src/interceptors/responses/types.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { CanonicalResponsesPayload, ResponsesInputContent, ResponsesInputItem, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ResponsesInputContent, ResponsesInputItem, ResponsesStreamEvent, ResponsesToolOutputContent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { eventResult } from '@floway-dev/provider';
 import { assertEquals, stubProviderModel, testTelemetryModelIdentity } from '@floway-dev/test-utils';
@@ -22,8 +22,8 @@ const invocation = (payload: CanonicalResponsesPayload): ResponsesBoundaryCtx =>
 
 const contentContainers = {
   message: (content: ResponsesInputContent[]): ResponsesInputItem => ({ type: 'message', role: 'user', content }),
-  function_output: (output: ResponsesInputContent[]): ResponsesInputItem => ({ type: 'function_call_output', call_id: 'call_function', output }),
-  custom_output: (output: ResponsesInputContent[]): ResponsesInputItem => ({ type: 'custom_tool_call_output', call_id: 'call_custom', output }),
+  function_output: (output: ResponsesToolOutputContent[]): ResponsesInputItem => ({ type: 'function_call_output', call_id: 'call_function', output }),
+  custom_output: (output: ResponsesToolOutputContent[]): ResponsesInputItem => ({ type: 'custom_tool_call_output', call_id: 'call_custom', output }),
 };
 
 test.each(Object.entries(contentContainers))('Responses vision header detects images in %s', async (_name, wrap) => {

--- a/packages/provider-copilot/src/interceptors/messages/apply-top-level-cache-control.ts
+++ b/packages/provider-copilot/src/interceptors/messages/apply-top-level-cache-control.ts
@@ -1,6 +1,6 @@
 import type { CopilotMessagesBoundaryInterceptor } from './types.ts';
 import type {
-  MessagesAssistantContentBlock,
+  MessagesAssistantInputContentBlock,
   MessagesTextBlock,
   MessagesUserContentBlock,
 } from '@floway-dev/protocols/messages';
@@ -28,11 +28,11 @@ import type {
  */
 
 type CacheableBlock = Extract<
-  MessagesUserContentBlock | MessagesAssistantContentBlock,
+  MessagesUserContentBlock | MessagesAssistantInputContentBlock,
   { cache_control?: unknown }
 >;
 
-const isCacheableBlock = (block: MessagesUserContentBlock | MessagesAssistantContentBlock): block is CacheableBlock =>
+const isCacheableBlock = (block: MessagesUserContentBlock | MessagesAssistantInputContentBlock): block is CacheableBlock =>
   block.type === 'text' || block.type === 'image' || block.type === 'tool_use' || block.type === 'tool_result';
 
 export const withTopLevelCacheControlApplied: CopilotMessagesBoundaryInterceptor = async (ctx, _env, run) => {
@@ -47,7 +47,7 @@ export const withTopLevelCacheControlApplied: CopilotMessagesBoundaryInterceptor
 
     if (typeof message.content === 'string') {
       const block: MessagesTextBlock = { type: 'text', text: message.content, cache_control: topLevel };
-      message.content = [block] as MessagesUserContentBlock[] | MessagesAssistantContentBlock[];
+      message.content = [block] as MessagesUserContentBlock[] | MessagesAssistantInputContentBlock[];
       return await run();
     }
 

--- a/packages/provider-copilot/src/interceptors/responses/compress-images.ts
+++ b/packages/provider-copilot/src/interceptors/responses/compress-images.ts
@@ -1,7 +1,7 @@
 import { memoizedDataUrlCompressor } from '../image-compression.ts';
 import { targetSizeForResponsesChat } from '../image-size.ts';
 import type { ResponsesBoundaryCtx } from './types.ts';
-import type { ResponsesInputContent, ResponsesInputImage } from '@floway-dev/protocols/responses';
+import type { ResponsesInputContent, ResponsesInputImage, ResponsesToolOutputContent } from '@floway-dev/protocols/responses';
 import { isBase64ImageDataUrl } from '@floway-dev/provider';
 
 // A cyber-policy retry re-enters this boundary with the same nested image
@@ -49,8 +49,8 @@ const compressInlineImages = async (ctx: ResponsesBoundaryCtx): Promise<void> =>
     });
     return rewritten;
   };
-  const rewriteParts = (parts: ResponsesInputContent[]): ResponsesInputContent[] =>
-    parts.map(part => hasCompressedImage(part) ? rewriteImage(part) : part);
+  const rewriteParts = <TPart extends ResponsesInputContent | ResponsesToolOutputContent>(parts: TPart[]): TPart[] =>
+    parts.map(part => hasCompressedImage(part) ? rewriteImage(part) as TPart : part);
 
   ctx.payload = {
     ...ctx.payload,

--- a/packages/translate/__tests__/chat-completions-via-messages/events_test.ts
+++ b/packages/translate/__tests__/chat-completions-via-messages/events_test.ts
@@ -416,17 +416,51 @@ test('message_delta with pause_turn → finish_reason stop', () => {
   assertEquals((result as ChatCompletionsStreamEvent[])[0].choices[0].finish_reason, 'stop');
 });
 
-test('message_delta with refusal → finish_reason stop', () => {
+test('message_delta with refusal → refusal delta and finish_reason stop', () => {
   const state = createMessagesToChatCompletionsStreamState();
   translateMessagesEventToChatCompletionsChunks(MSG_START, state);
   const result = translateMessagesEventToChatCompletionsChunks(
     {
       type: 'message_delta',
-      delta: { stop_reason: 'refusal' },
+      delta: {
+        stop_reason: 'refusal',
+        stop_details: {
+          type: 'refusal',
+          category: 'cyber',
+          explanation: 'This request could enable cyber harm.',
+        },
+      },
     },
     state,
   );
-  assertEquals((result as ChatCompletionsStreamEvent[])[0].choices[0].finish_reason, 'stop');
+  assertEquals(result, [
+    {
+      ...(result as ChatCompletionsStreamEvent[])[0],
+      choices: [{ index: 0, delta: { refusal: 'This request could enable cyber harm.' }, finish_reason: null }],
+    },
+    {
+      ...(result as ChatCompletionsStreamEvent[])[1],
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    },
+  ]);
+});
+
+test('fallback block updates subsequent Chat chunks to the serving model', () => {
+  const state = createMessagesToChatCompletionsStreamState();
+  translateMessagesEventToChatCompletionsChunks(MSG_START, state);
+  const result = translateMessagesEventToChatCompletionsChunks({
+    type: 'content_block_start',
+    index: 0,
+    content_block: {
+      type: 'fallback',
+      from: { model: 'claude-opus-5' },
+      to: { model: 'claude-opus-4-8' },
+      trigger: { type: 'refusal', category: 'cyber' },
+    },
+  }, state);
+
+  assertEquals(result, []);
+  assertEquals(state.model, 'claude-opus-4-8');
 });
 
 test('message_delta without usage → no usage on chunk', () => {

--- a/packages/translate/__tests__/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/__tests__/chat-completions-via-messages/request_test.ts
@@ -43,6 +43,20 @@ function stubRemoteImageLoader(result: Awaited<ReturnType<RemoteImageLoader>>): 
   return () => Promise.resolve(result);
 }
 
+test('buildTargetRequest preserves scalar and content-part assistant refusals as history text', async () => {
+  const result = await buildTargetRequest(mkPayload({
+    messages: [
+      { role: 'assistant', content: null, refusal: 'Scalar refusal.' },
+      { role: 'assistant', content: [{ type: 'refusal', refusal: 'Part refusal.' }] },
+    ],
+  }));
+
+  assertEquals(result.messages, [
+    { role: 'assistant', content: [{ type: 'text', text: 'Scalar refusal.' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'Part refusal.' }] },
+  ]);
+});
+
 // ── service_tier → speed mapping ──
 
 test('buildTargetRequest maps service_tier:fast to speed:fast (no service_tier on target)', async () => {

--- a/packages/translate/__tests__/chat-completions-via-messages/request_test.ts
+++ b/packages/translate/__tests__/chat-completions-via-messages/request_test.ts
@@ -53,7 +53,7 @@ test('buildTargetRequest preserves scalar and content-part assistant refusals as
 
   assertEquals(result.messages, [
     { role: 'assistant', content: [{ type: 'text', text: 'Scalar refusal.' }] },
-    { role: 'assistant', content: [{ type: 'text', text: 'Part refusal.' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'Part refusal.', cache_control: { type: 'ephemeral' } }] },
   ]);
 });
 

--- a/packages/translate/__tests__/chat-completions-via-responses/events_test.ts
+++ b/packages/translate/__tests__/chat-completions-via-responses/events_test.ts
@@ -224,14 +224,14 @@ test('translateToSourceEvents preserves refusal text from JSON fallback', async 
     });
   }
 
-  const text: string[] = [];
+  const refusal: string[] = [];
 
   for await (const frame of translateToSourceEvents(stream())) {
     if (frame.type !== 'event') continue;
-    text.push(frame.event.choices[0]?.delta.content ?? '');
+    refusal.push(frame.event.choices[0]?.delta.refusal ?? '');
   }
 
-  assertEquals(text.join(''), 'No.');
+  assertEquals(refusal.join(''), 'No.');
 });
 
 test('translateToSourceEvents preserves deferred reasoning and stream usage', async () => {

--- a/packages/translate/__tests__/chat-completions-via-responses/request_test.ts
+++ b/packages/translate/__tests__/chat-completions-via-responses/request_test.ts
@@ -5,6 +5,21 @@ import type { ChatCompletionsMessage } from '@floway-dev/protocols/chat-completi
 import type { ResponsesInputReasoning } from '@floway-dev/protocols/responses';
 import { assertEquals, assertFalse, assertThrows } from '@floway-dev/test-utils';
 
+test('buildTargetRequest preserves scalar and content-part assistant refusals', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    messages: [
+      { role: 'assistant', content: null, refusal: 'Scalar refusal.' },
+      { role: 'assistant', content: [{ type: 'refusal', refusal: 'Part refusal.' }] },
+    ],
+  });
+
+  assertEquals(result.input, [
+    { type: 'message', role: 'assistant', content: [{ type: 'refusal', refusal: 'Scalar refusal.' }] },
+    { type: 'message', role: 'assistant', content: [{ type: 'refusal', refusal: 'Part refusal.' }] },
+  ]);
+});
+
 test('buildTargetRequest uses rs-prefixed ids for reasoning input items', () => {
   const result = buildTargetRequest({
     model: 'gpt-test',

--- a/packages/translate/__tests__/gemini-via-messages/events_test.ts
+++ b/packages/translate/__tests__/gemini-via-messages/events_test.ts
@@ -279,7 +279,17 @@ test('translateToSourceEvents maps max token and refusal finish reasons', async 
     }),
   ]);
 
-  const refusalFrames = await collect([eventFrame(messageStart()), eventFrame({ type: 'message_delta', delta: { stop_reason: 'refusal' } }), eventFrame({ type: 'message_stop' })]);
+  const refusalFrames = await collect([eventFrame(messageStart()), eventFrame({
+    type: 'message_delta',
+    delta: {
+      stop_reason: 'refusal',
+      stop_details: {
+        type: 'refusal',
+        category: 'bio',
+        explanation: 'This request could enable biological harm.',
+      },
+    },
+  }), eventFrame({ type: 'message_stop' })]);
 
   assertEquals(refusalFrames, [
     geminiFrame({
@@ -288,6 +298,7 @@ test('translateToSourceEvents maps max token and refusal finish reasons', async 
           index: 0,
           content: { role: 'model', parts: [] },
           finishReason: 'SAFETY',
+          finishMessage: 'This request could enable biological harm.',
         },
       ],
     }),

--- a/packages/translate/__tests__/messages-via-chat-completions/events_test.ts
+++ b/packages/translate/__tests__/messages-via-chat-completions/events_test.ts
@@ -25,6 +25,33 @@ const usageChunk = (): ChatCompletionsStreamEvent => ({
   },
 });
 
+test('Chat refusal deltas become Messages refusal stop details', () => {
+  const state = createChatCompletionsToMessagesStreamState();
+  const events = [
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({ role: 'assistant', content: null, refusal: '' }), state),
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({ refusal: 'I cannot help with that.' }), state),
+    ...translateChatCompletionsChunkToMessagesEvents(chunk({}, 'stop'), state),
+    ...translateChatCompletionsChunkToMessagesEvents(usageChunk(), state),
+  ];
+
+  assertEquals(events.slice(-2), [
+    {
+      type: 'message_delta',
+      delta: {
+        stop_reason: 'refusal',
+        stop_details: {
+          type: 'refusal',
+          category: null,
+          explanation: 'I cannot help with that.',
+        },
+        stop_sequence: null,
+      },
+      usage: { input_tokens: 12, output_tokens: 4 },
+    },
+    { type: 'message_stop' },
+  ]);
+});
+
 test('translateChatCompletionsChunkToMessagesEvents emits opaque-only reasoning as redacted_thinking at finish', () => {
   const state = createChatCompletionsToMessagesStreamState();
   const events = [

--- a/packages/translate/__tests__/messages-via-responses/events-protocol_test.ts
+++ b/packages/translate/__tests__/messages-via-responses/events-protocol_test.ts
@@ -92,7 +92,7 @@ test('translateToSourceEvents stops after Responses terminal', async () => {
   );
 });
 
-test('translateToSourceEvents preserves refusal text from JSON fallback', async () => {
+test('translateToSourceEvents preserves refusal semantics from JSON fallback', async () => {
   async function* stream() {
     yield* responsesResultToEvents({
       id: 'resp_refusal',
@@ -118,17 +118,18 @@ test('translateToSourceEvents preserves refusal text from JSON fallback', async 
     });
   }
 
-  const text: string[] = [];
+  let refusalDelta: Extract<MessagesStreamEvent, { type: 'message_delta' }> | undefined;
 
   for await (const frame of translateToSourceEvents(stream())) {
     if (frame.type !== 'event') continue;
-    if (frame.event.type !== 'content_block_delta') continue;
-    if (frame.event.delta.type !== 'text_delta') continue;
-
-    text.push(frame.event.delta.text);
+    if (frame.event.type === 'message_delta') refusalDelta = frame.event;
   }
 
-  assertEquals(text.join(''), 'No.');
+  assertEquals(refusalDelta?.delta, {
+    stop_reason: 'refusal',
+    stop_details: { type: 'refusal', category: null, explanation: 'No.' },
+    stop_sequence: null,
+  });
 });
 
 test('translateToSourceEvents translates Responses failed terminal to Messages error', async () => {

--- a/packages/translate/__tests__/messages-via-responses/events_test.ts
+++ b/packages/translate/__tests__/messages-via-responses/events_test.ts
@@ -835,3 +835,38 @@ test('stream `error` event with a mundane message → api_error carrying that me
     error: { type: 'api_error', message: 'transient upstream hiccup' },
   }]);
 });
+
+test('multiple Responses refusal parts compose one Messages explanation in output order', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = [
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.delta', item_id: 'msg_1', output_index: 1, content_index: 0, delta: 'later',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.done', item_id: 'msg_1', output_index: 1, content_index: 0, refusal: 'later',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.delta', item_id: 'msg_0', output_index: 0, content_index: 1, delta: 'second ',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.done', item_id: 'msg_0', output_index: 0, content_index: 1, refusal: 'second ',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.delta', item_id: 'msg_0', output_index: 0, content_index: 0, delta: 'first ',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.done', item_id: 'msg_0', output_index: 0, content_index: 0, refusal: 'first ',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.completed',
+      response: {
+        id: 'resp_refusal_parts', object: 'response', model: 'gpt-test', output: [], status: 'completed', error: null, incomplete_details: null,
+      },
+    }, state),
+  ];
+
+  const delta = events.find((event): event is MessagesMessageDeltaEvent => event.type === 'message_delta');
+  assertEquals(delta?.delta.stop_details, {
+    type: 'refusal', category: null, explanation: 'first second later',
+  });
+});

--- a/packages/translate/__tests__/messages-via-responses/events_test.ts
+++ b/packages/translate/__tests__/messages-via-responses/events_test.ts
@@ -6,6 +6,85 @@ import type { MessagesMessageDeltaEvent } from '@floway-dev/protocols/messages';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
 import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 
+const failedResponse = (code: string, message: string): ResponsesResult => ({
+  id: 'resp_failed',
+  object: 'response',
+  model: 'gpt-test',
+  output: [],
+  status: 'failed',
+  error: { code, message },
+  incomplete_details: null,
+});
+
+test.each([
+  ['cyber_policy', 'cyber'],
+  ['bio_policy', 'bio'],
+] as const)('Responses %s failure becomes a Messages %s refusal', (code, category) => {
+  const state = createResponsesToMessagesStreamState();
+  const events = translateResponsesStreamEventToMessagesEvents({
+    type: 'response.failed',
+    response: failedResponse(code, 'Policy refusal.'),
+  }, state);
+
+  assertEquals(events, [
+    {
+      type: 'message_delta',
+      delta: {
+        stop_reason: 'refusal',
+        stop_details: { type: 'refusal', category, explanation: 'Policy refusal.' },
+        stop_sequence: null,
+      },
+      usage: { input_tokens: 0, output_tokens: 0 },
+    },
+    { type: 'message_stop' },
+  ]);
+});
+
+test('Responses refusal lifecycle becomes Messages refusal metadata without visible text', () => {
+  const state = createResponsesToMessagesStreamState();
+  const events = [
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.delta',
+      item_id: 'msg_refusal',
+      output_index: 0,
+      content_index: 0,
+      delta: 'Cannot help.',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.refusal.done',
+      item_id: 'msg_refusal',
+      output_index: 0,
+      content_index: 0,
+      refusal: 'Cannot help.',
+    }, state),
+    ...translateResponsesStreamEventToMessagesEvents({
+      type: 'response.completed',
+      response: {
+        id: 'resp_refusal',
+        object: 'response',
+        model: 'gpt-test',
+        output: [],
+        status: 'completed',
+        error: null,
+        incomplete_details: null,
+      },
+    }, state),
+  ];
+
+  assertEquals(events, [
+    {
+      type: 'message_delta',
+      delta: {
+        stop_reason: 'refusal',
+        stop_details: { type: 'refusal', category: null, explanation: 'Cannot help.' },
+        stop_sequence: null,
+      },
+      usage: { input_tokens: 0, output_tokens: 0 },
+    },
+    { type: 'message_stop' },
+  ]);
+});
+
 test('Responses reasoning stream without readable summary emits a redacted_thinking carrier', () => {
   const state = createResponsesToMessagesStreamState();
 

--- a/packages/translate/__tests__/responses-via-chat-completions/events_test.ts
+++ b/packages/translate/__tests__/responses-via-chat-completions/events_test.ts
@@ -72,6 +72,21 @@ test('translateChatCompletionsChunkToResponsesEvents preserves refusal output li
   assertEquals(completed?.response.output_text, '');
 });
 
+test('translateChatCompletionsChunkToResponsesEvents preserves an empty refusal item', () => {
+  const events = translate([
+    chunk({ role: 'assistant', content: null, refusal: '' }),
+    chunk({}, 'stop'),
+  ]);
+  const completed = events.find(event => event.type === 'response.completed') as ResponsesCompletedEvent | undefined;
+
+  assertEquals(completed?.response.output, [{
+    type: 'message',
+    id: expect.stringMatching(/^msg_[0-9a-f]{32}$/),
+    role: 'assistant',
+    content: [{ type: 'refusal', refusal: '' }],
+  }]);
+});
+
 test('translateChatCompletionsChunkToResponsesEvents preserves tool call deltas and terminal output', () => {
   const events = translate([
     chunk({ role: 'assistant' }),

--- a/packages/translate/__tests__/responses-via-chat-completions/events_test.ts
+++ b/packages/translate/__tests__/responses-via-chat-completions/events_test.ts
@@ -53,6 +53,25 @@ const drain = async <T>(frames: AsyncIterable<T>): Promise<void> => {
   }
 };
 
+test('translateChatCompletionsChunkToResponsesEvents preserves refusal output lifecycle', () => {
+  const events = translate([
+    chunk({ role: 'assistant', content: null, refusal: '' }),
+    chunk({ refusal: 'Cannot ' }),
+    chunk({ refusal: 'help.' }),
+    chunk({}, 'stop'),
+  ]);
+  const completed = events.find(event => event.type === 'response.completed') as ResponsesCompletedEvent | undefined;
+
+  assertEquals(events.filter(event => event.type === 'response.refusal.delta').map(event => (event as Extract<ResponsesStreamEvent, { type: 'response.refusal.delta' }>).delta), ['Cannot ', 'help.']);
+  assertEquals(completed?.response.output, [{
+    type: 'message',
+    id: expect.stringMatching(/^msg_[0-9a-f]{32}$/),
+    role: 'assistant',
+    content: [{ type: 'refusal', refusal: 'Cannot help.' }],
+  }]);
+  assertEquals(completed?.response.output_text, '');
+});
+
 test('translateChatCompletionsChunkToResponsesEvents preserves tool call deltas and terminal output', () => {
   const events = translate([
     chunk({ role: 'assistant' }),

--- a/packages/translate/__tests__/responses-via-messages/events_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/events_test.ts
@@ -816,3 +816,77 @@ test('Messages delta atomically replaces tier and merges late cache accounting i
     [USAGE_BILLING]: { cacheWrite1hTokenCount: 5 },
   });
 });
+
+test.each([
+  ['cyber', 'cyber_policy', 'Cyber refusal.'],
+  ['bio', 'bio_policy', 'This content was flagged for possible biological risk. Bio refusal.'],
+  ['frontier_llm', 'invalid_prompt', 'Frontier refusal.'],
+  ['future_policy', 'invalid_prompt', 'Future refusal.'],
+] as const)('Messages %s refusal becomes a failed Codex Responses policy result', (category, code, message) => {
+  const state = createMessagesToResponsesStreamState('resp_refusal', 'claude-opus-5');
+  translateMessagesEventToResponsesEvents({
+    type: 'message_start',
+    message: {
+      id: 'msg_refusal',
+      type: 'message',
+      role: 'assistant',
+      content: [],
+      model: 'claude-opus-5',
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 0 },
+    },
+  }, state);
+  translateMessagesEventToResponsesEvents({
+    type: 'message_delta',
+    delta: {
+      stop_reason: 'refusal',
+      stop_details: {
+        type: 'refusal',
+        category,
+        explanation: category === 'bio' ? 'Bio refusal.' : `${category === 'cyber' ? 'Cyber' : category === 'frontier_llm' ? 'Frontier' : 'Future'} refusal.`,
+      },
+    },
+    usage: { output_tokens: 0 },
+  }, state);
+
+  const result = translateMessagesEventToResponsesEvents({ type: 'message_stop' }, state);
+  const failed = result.find((event): event is Extract<ResponsesStreamEvent, { type: 'response.failed' }> => event.type === 'response.failed');
+  assertEquals(failed?.response.status, 'failed');
+  assertEquals(failed?.response.error, { code, message });
+  assertEquals(failed?.response.output, []);
+});
+
+test('Messages fallback block changes the Responses serving model without becoming output', () => {
+  const state = createMessagesToResponsesStreamState('resp_fallback', 'claude-opus-5');
+  translateMessagesEventToResponsesEvents({
+    type: 'message_start',
+    message: {
+      id: 'msg_fallback',
+      type: 'message',
+      role: 'assistant',
+      content: [],
+      model: 'claude-opus-5',
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 0 },
+    },
+  }, state);
+  const boundary = translateMessagesEventToResponsesEvents({
+    type: 'content_block_start',
+    index: 0,
+    content_block: {
+      type: 'fallback',
+      from: { model: 'claude-opus-5' },
+      to: { model: 'claude-opus-4-8' },
+      trigger: { type: 'refusal', category: 'cyber' },
+    },
+  }, state);
+  translateMessagesEventToResponsesEvents({ type: 'message_delta', delta: { stop_reason: 'end_turn' } }, state);
+  const result = translateMessagesEventToResponsesEvents({ type: 'message_stop' }, state);
+  const completed = result.find((event): event is Extract<ResponsesStreamEvent, { type: 'response.completed' }> => event.type === 'response.completed');
+
+  assertEquals(boundary, []);
+  assertEquals(completed?.response.model, 'claude-opus-4-8');
+  assertEquals(completed?.response.output, []);
+});

--- a/packages/translate/__tests__/responses-via-messages/request_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/request_test.ts
@@ -22,6 +22,22 @@ const minimalPayload = {
   parallel_tool_calls: true,
 };
 
+test('buildTargetRequest preserves Responses assistant refusal history as Messages text', async () => {
+  const result = await buildTargetRequest({
+    ...minimalPayload,
+    input: [{
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'refusal', refusal: 'Cannot help.' }],
+    }],
+  });
+  const message = result.target.messages[0];
+
+  assertEquals(message.role, 'assistant');
+  assert(Array.isArray(message.content));
+  assertEquals(message.content[0], { type: 'text', text: 'Cannot help.', cache_control: { type: 'ephemeral' } });
+});
+
 test('buildTargetRequest accepts an implicit message discriminator', async () => {
   const result = await buildTargetRequest({
     ...minimalPayload,

--- a/packages/translate/src/chat-completions-via-messages/events.ts
+++ b/packages/translate/src/chat-completions-via-messages/events.ts
@@ -1,5 +1,6 @@
 import { openAIServiceTierFromMessagesUsage } from '../shared/via-messages/service-tier.ts';
 import { inclusiveMessagesInputUsage } from '../shared/via-messages/usage.ts';
+import { messagesRefusalExplanation } from '../shared/via-messages/refusal.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsResult, ChatCompletionsDelta } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, USAGE_BILLING, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { mergeMessagesUsageSnapshot, messagesUsageSnapshot, type MessagesResult, type MessagesStreamEvent, type MessagesUsageSnapshot } from '@floway-dev/protocols/messages';
@@ -140,6 +141,9 @@ export const translateMessagesEventToChatCompletionsChunks = (event: MessagesStr
     case 'server_tool_use':
     case 'web_search_tool_result':
       return [];
+    case 'fallback':
+      state.model = block.to.model;
+      return [];
     }
 
     return unexpectedMessagesVariant(block);
@@ -187,14 +191,18 @@ export const translateMessagesEventToChatCompletionsChunks = (event: MessagesStr
     return [];
 
   case 'message_delta': {
-    const chunk = makeChunk(state, {}, mapMessagesStopReasonToChatCompletionsFinishReason(event.delta.stop_reason ?? null));
+    const chunks: ChatCompletionsStreamEvent[] = [];
+    if (event.delta.stop_reason === 'refusal') {
+      chunks.push(makeChunk(state, { refusal: messagesRefusalExplanation(event.delta.stop_details) }));
+    }
+    chunks.push(makeChunk(state, {}, mapMessagesStopReasonToChatCompletionsFinishReason(event.delta.stop_reason ?? null)));
 
     if (event.usage) {
       state.usage = mergeMessagesUsageSnapshot(state.usage, event.usage);
-      return [chunk, makeUsageChunk(state)];
+      chunks.push(makeUsageChunk(state));
     }
 
-    return [chunk];
+    return chunks;
   }
 
   case 'message_stop':

--- a/packages/translate/src/chat-completions-via-messages/events.ts
+++ b/packages/translate/src/chat-completions-via-messages/events.ts
@@ -1,6 +1,6 @@
+import { messagesRefusalExplanation } from '../shared/via-messages/refusal.ts';
 import { openAIServiceTierFromMessagesUsage } from '../shared/via-messages/service-tier.ts';
 import { inclusiveMessagesInputUsage } from '../shared/via-messages/usage.ts';
-import { messagesRefusalExplanation } from '../shared/via-messages/refusal.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsResult, ChatCompletionsDelta } from '@floway-dev/protocols/chat-completions';
 import { doneFrame, eventFrame, USAGE_BILLING, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { mergeMessagesUsageSnapshot, messagesUsageSnapshot, type MessagesResult, type MessagesStreamEvent, type MessagesUsageSnapshot } from '@floway-dev/protocols/messages';

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -6,7 +6,7 @@ import { parseToolArgumentsObject } from '../shared/via-messages/tool-arguments.
 import { TranslatorInputError } from '../translator-input-error.ts';
 import type { RemoteImageLoader } from '../types.ts';
 import type { ChatCompletionsPayload, ChatCompletionsMessage, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
-import { MESSAGES_FALLBACK_MAX_TOKENS, type MessagesAssistantContentBlock, type MessagesMessage, type MessagesPayload, type MessagesTextBlock, type MessagesUserContentBlock } from '@floway-dev/protocols/messages';
+import { MESSAGES_FALLBACK_MAX_TOKENS, type MessagesAssistantInputContentBlock, type MessagesMessage, type MessagesPayload, type MessagesTextBlock, type MessagesUserContentBlock } from '@floway-dev/protocols/messages';
 
 interface BuildTargetRequestOptions {
   loadRemoteImage?: RemoteImageLoader;
@@ -19,15 +19,22 @@ interface BuildTargetRequestOptions {
   fallbackMaxOutputTokens?: number;
 }
 
-const buildAssistantBlocks = (message: ChatCompletionsMessage): MessagesAssistantContentBlock[] => {
-  const blocks: MessagesAssistantContentBlock[] = [];
+const buildAssistantBlocks = (message: ChatCompletionsMessage): MessagesAssistantInputContentBlock[] => {
+  const blocks: MessagesAssistantInputContentBlock[] = [];
   const thinkingBlock = messagesThinkingBlockFromChatCompletionsScalarReasoning(message.reasoning_text, message.reasoning_opaque);
 
   if (thinkingBlock) blocks.push(thinkingBlock);
 
-  if (typeof message.content === 'string' && message.content) {
-    blocks.push({ type: 'text', text: message.content });
+  if (typeof message.content === 'string') {
+    if (message.content) blocks.push({ type: 'text', text: message.content });
+  } else if (Array.isArray(message.content)) {
+    for (const part of message.content) {
+      if (part.type === 'text') blocks.push({ type: 'text', text: part.text });
+      else if (part.type === 'refusal') blocks.push({ type: 'text', text: part.refusal });
+    }
   }
+
+  if (message.refusal) blocks.push({ type: 'text', text: message.refusal });
 
   for (const toolCall of message.tool_calls ?? []) {
     blocks.push({

--- a/packages/translate/src/chat-completions-via-responses/events.ts
+++ b/packages/translate/src/chat-completions-via-responses/events.ts
@@ -230,6 +230,23 @@ export const translateResponsesEventToChatCompletionsChunks = (event: ResponsesS
     return [makeChunk(state, { content: text })];
   }
 
+  case 'response.refusal.delta': {
+    const { delta, output_index, content_index } = event as Extract<ResponsesStreamEvent, { type: 'response.refusal.delta' }>;
+    if (!delta) return [];
+
+    state.emittedTextContentKeys.add(responsesPartKey(output_index, content_index));
+    return [makeChunk(state, { refusal: delta })];
+  }
+
+  case 'response.refusal.done': {
+    const { refusal, output_index, content_index } = event as Extract<ResponsesStreamEvent, { type: 'response.refusal.done' }>;
+    const key = responsesPartKey(output_index, content_index);
+    if (!refusal || state.emittedTextContentKeys.has(key)) return [];
+
+    state.emittedTextContentKeys.add(key);
+    return [makeChunk(state, { refusal })];
+  }
+
   case 'response.content_part.done': {
     const { part, output_index, content_index } = event as Extract<ResponsesStreamEvent, { type: 'response.content_part.done' }>;
     if (part.type !== 'refusal') return [];
@@ -238,7 +255,7 @@ export const translateResponsesEventToChatCompletionsChunks = (event: ResponsesS
     if (!part.refusal || state.emittedTextContentKeys.has(key)) return [];
 
     state.emittedTextContentKeys.add(key);
-    return [makeChunk(state, { content: part.refusal })];
+    return [makeChunk(state, { refusal: part.refusal })];
   }
 
   case 'response.function_call_arguments.delta': {

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -1,8 +1,8 @@
 import { chatCompletionsContentToResponsesInputContent, chatCompletionsContentToText } from '../shared/chat-completions-and-responses/content.ts';
 import { scalarToResponsesReasoningItem, translateChatCompletionsReasoningItems } from '../shared/chat-completions-and-responses/reasoning.ts';
 import { TranslatorInputError } from '../translator-input-error.ts';
-import type { ChatCompletionsPayload, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
-import type { CanonicalResponsesPayload, ResponsesInputItem, ResponsesInputReasoning, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
+import type { ChatCompletionsMessage, ChatCompletionsPayload, ChatCompletionsTool } from '@floway-dev/protocols/chat-completions';
+import type { CanonicalResponsesPayload, ResponsesInputContent, ResponsesInputItem, ResponsesInputReasoning, ResponsesTool, ResponsesToolChoice } from '@floway-dev/protocols/responses';
 
 const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool[] | null =>
   tools?.length
@@ -19,6 +19,29 @@ const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool
 
 const translateChatToolChoice = (choice?: ChatCompletionsPayload['tool_choice']): ResponsesToolChoice =>
   choice == null ? 'auto' : typeof choice === 'string' ? choice : { type: 'function', name: choice.function.name };
+
+const translateAssistantContent = (message: ChatCompletionsMessage): ResponsesInputContent[] => {
+  const content: ResponsesInputContent[] = [];
+  let hasRefusalPart = false;
+
+  if (typeof message.content === 'string') {
+    if (message.content) content.push({ type: 'output_text', text: message.content });
+  } else if (Array.isArray(message.content)) {
+    for (const part of message.content) {
+      if (part.type === 'text') content.push({ type: 'output_text', text: part.text });
+      else if (part.type === 'refusal') {
+        content.push({ type: 'refusal', refusal: part.refusal });
+        hasRefusalPart = true;
+      }
+    }
+  }
+
+  if (message.refusal !== undefined && message.refusal !== null && !hasRefusalPart) {
+    content.push({ type: 'refusal', refusal: message.refusal });
+  }
+
+  return content;
+};
 
 export const buildTargetRequest = (payload: ChatCompletionsPayload): CanonicalResponsesPayload => {
   const instructions: string[] = [];
@@ -47,6 +70,7 @@ export const buildTargetRequest = (payload: ChatCompletionsPayload): CanonicalRe
     }
 
     if (message.role === 'assistant') {
+      const assistantContent = translateAssistantContent(message);
       const reasoningItems = translateChatCompletionsReasoningItems<ResponsesInputReasoning>(message.reasoning_items);
       const scalarReasoning = scalarToResponsesReasoningItem<ResponsesInputReasoning>(message.reasoning_text);
       if (reasoningItems) {
@@ -56,12 +80,11 @@ export const buildTargetRequest = (payload: ChatCompletionsPayload): CanonicalRe
       }
 
       if (message.tool_calls?.length) {
-        const text = chatCompletionsContentToText(message.content);
-        if (text) {
+        if (assistantContent.length > 0) {
           input.push({
             type: 'message',
             role: 'assistant',
-            content: [{ type: 'output_text', text }],
+            content: assistantContent,
           });
         }
 
@@ -78,11 +101,10 @@ export const buildTargetRequest = (payload: ChatCompletionsPayload): CanonicalRe
         continue;
       }
 
-      const text = chatCompletionsContentToText(message.content);
       input.push({
         type: 'message',
         role: 'assistant',
-        content: text ? [{ type: 'output_text', text }] : '',
+        content: assistantContent.length > 0 ? assistantContent : '',
       });
       continue;
     }

--- a/packages/translate/src/gemini-via-messages/events.ts
+++ b/packages/translate/src/gemini-via-messages/events.ts
@@ -1,5 +1,6 @@
 import { flushGeminiThoughtSignature, type GeminiThoughtSignatureState, geminiCandidateEvent, parseStrictJsonObject, setGeminiThoughtSignature, signGeminiPart } from '../shared/gemini-via/gemini.ts';
 import { inclusiveMessagesInputUsage } from '../shared/via-messages/usage.ts';
+import { messagesRefusalExplanation } from '../shared/via-messages/refusal.ts';
 import { billableServiceTier, eventFrame, splitInclusiveInputTokens, USAGE_BILLING, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiFinishReason, GeminiStreamEvent, GeminiUsageMetadata } from '@floway-dev/protocols/gemini';
 import { mergeMessagesUsageSnapshot, messagesUsageSnapshot, type MessagesStreamEvent, type MessagesUsageSnapshot } from '@floway-dev/protocols/messages';
@@ -183,6 +184,7 @@ export const translateToSourceEvents = async function* (frames: AsyncIterable<Pr
         flushGeminiThoughtSignature(state),
         messagesStopReasonToGemini(event.delta.stop_reason),
         mapUsage(state, event.usage !== undefined),
+        event.delta.stop_reason === 'refusal' ? messagesRefusalExplanation(event.delta.stop_details) : undefined,
       ));
       break;
     }

--- a/packages/translate/src/gemini-via-messages/events.ts
+++ b/packages/translate/src/gemini-via-messages/events.ts
@@ -1,6 +1,6 @@
 import { flushGeminiThoughtSignature, type GeminiThoughtSignatureState, geminiCandidateEvent, parseStrictJsonObject, setGeminiThoughtSignature, signGeminiPart } from '../shared/gemini-via/gemini.ts';
-import { inclusiveMessagesInputUsage } from '../shared/via-messages/usage.ts';
 import { messagesRefusalExplanation } from '../shared/via-messages/refusal.ts';
+import { inclusiveMessagesInputUsage } from '../shared/via-messages/usage.ts';
 import { billableServiceTier, eventFrame, splitInclusiveInputTokens, USAGE_BILLING, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type { GeminiFinishReason, GeminiStreamEvent, GeminiUsageMetadata } from '@floway-dev/protocols/gemini';
 import { mergeMessagesUsageSnapshot, messagesUsageSnapshot, type MessagesStreamEvent, type MessagesUsageSnapshot } from '@floway-dev/protocols/messages';

--- a/packages/translate/src/messages-via-chat-completions/events.ts
+++ b/packages/translate/src/messages-via-chat-completions/events.ts
@@ -109,6 +109,8 @@ interface ChatCompletionsToMessagesStreamState {
   // https://github.com/caozhiyuan/copilot-api/blob/main/src/routes/messages/stream-translation.ts#L240
   deferredContent?: string;
   pendingFinishReason?: ChatCompletionsStreamEvent['choices'][0]['finish_reason'];
+  refusalText: string;
+  sawRefusal: boolean;
   pendingUsage?: ChatCompletionsStreamEvent['usage'];
   // Captured from any chunk's service_tier for speed pass-through.
   upstreamServiceTier?: string;
@@ -332,11 +334,22 @@ const emitFinalMessageIfReady = (state: ChatCompletionsToMessagesStreamState, ev
   if (state.upstreamServiceTier === 'fast') usage.speed = 'fast';
   else if (state.upstreamServiceTier !== undefined) usage.service_tier = state.upstreamServiceTier;
 
+  const refused = state.sawRefusal || state.pendingFinishReason === 'content_filter';
+
   events.push(
     {
       type: 'message_delta',
       delta: {
-        stop_reason: mapChatCompletionsFinishReasonToMessagesStopReason(state.pendingFinishReason),
+        stop_reason: refused ? 'refusal' : mapChatCompletionsFinishReasonToMessagesStopReason(state.pendingFinishReason),
+        ...(refused
+          ? {
+              stop_details: {
+                type: 'refusal' as const,
+                category: null,
+                explanation: state.refusalText || null,
+              },
+            }
+          : {}),
         stop_sequence: null,
       },
       usage,
@@ -353,6 +366,8 @@ export const createChatCompletionsToMessagesStreamState = (): ChatCompletionsToM
   contentBlockIndex: 0,
   toolCalls: {},
   deferredAfterThinking: [],
+  refusalText: '',
+  sawRefusal: false,
 });
 
 export const translateChatCompletionsChunkToMessagesEvents = (chunk: ChatCompletionsStreamEvent, state: ChatCompletionsToMessagesStreamState): MessagesStreamEvent[] => {
@@ -394,6 +409,10 @@ export const translateChatCompletionsChunkToMessagesEvents = (chunk: ChatComplet
   handleReasoningDelta(choice.delta, state, events);
 
   const content = choice.delta.content;
+  if (choice.delta.refusal !== undefined && choice.delta.refusal !== null) {
+    state.sawRefusal = true;
+    state.refusalText += choice.delta.refusal;
+  }
   const toolCalls = choice.delta.tool_calls;
   const hasToolCallDelta = Boolean(toolCalls?.length);
 

--- a/packages/translate/src/messages-via-responses/events.ts
+++ b/packages/translate/src/messages-via-responses/events.ts
@@ -74,8 +74,7 @@ interface ResponsesToMessagesStreamState {
   emittedReasoningSummaryKeys: Set<string>;
   emittedReasoningSignatureOutputIndexes: Set<number>;
   emittedTextContentKeys: Set<string>;
-  refusalText: string;
-  sawRefusal: boolean;
+  refusalTexts: Map<number, Map<number, string>>;
   emittedFunctionArgumentOutputIndexes: Set<number>;
   outputOrder: ResponsesOutputOrderState;
   functionCallState: Map<
@@ -302,22 +301,25 @@ const handleContentPartDone = (event: Extract<ResponsesStreamEvent, { type: 'res
   const key = responsesPartKey(event.output_index, event.content_index);
   if (!event.part.refusal || state.emittedTextContentKeys.has(key)) return [];
 
-  state.sawRefusal = true;
-  state.refusalText = event.part.refusal;
+  const parts = state.refusalTexts.get(event.output_index) ?? new Map<number, string>();
+  parts.set(event.content_index, event.part.refusal);
+  state.refusalTexts.set(event.output_index, parts);
   state.emittedTextContentKeys.add(key);
   return [];
 };
 
 const handleRefusalDelta = (event: Extract<ResponsesStreamEvent, { type: 'response.refusal.delta' }>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] => {
-  state.sawRefusal = true;
-  state.refusalText += event.delta;
+  const parts = state.refusalTexts.get(event.output_index) ?? new Map<number, string>();
+  parts.set(event.content_index, (parts.get(event.content_index) ?? '') + event.delta);
+  state.refusalTexts.set(event.output_index, parts);
   state.emittedTextContentKeys.add(responsesPartKey(event.output_index, event.content_index));
   return [];
 };
 
 const handleRefusalDone = (event: Extract<ResponsesStreamEvent, { type: 'response.refusal.done' }>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] => {
-  state.sawRefusal = true;
-  state.refusalText = event.refusal;
+  const parts = state.refusalTexts.get(event.output_index) ?? new Map<number, string>();
+  parts.set(event.content_index, event.refusal);
+  state.refusalTexts.set(event.output_index, parts);
   state.emittedTextContentKeys.add(responsesPartKey(event.output_index, event.content_index));
   return [];
 };
@@ -364,17 +366,23 @@ const handleCompleted = (response: ResponsesResult, state: ResponsesToMessagesSt
   const events: MessagesStreamEvent[] = [];
   closeAllBlocks(state, events);
 
+  const refusalText = [...state.refusalTexts.entries()]
+    .sort(([left], [right]) => left - right)
+    .flatMap(([, parts]) => [...parts.entries()].sort(([left], [right]) => left - right).map(([, text]) => text))
+    .join('');
+  const refused = state.refusalTexts.size > 0;
+
   events.push(
     {
       type: 'message_delta',
       delta: {
-        stop_reason: state.sawRefusal ? 'refusal' : mapResponsesStopReason(response),
-        ...(state.sawRefusal
+        stop_reason: refused ? 'refusal' : mapResponsesStopReason(response),
+        ...(refused
           ? {
               stop_details: {
                 type: 'refusal' as const,
                 category: null,
-                explanation: state.refusalText || null,
+                explanation: refusalText,
               },
             }
           : {}),
@@ -454,8 +462,7 @@ export const createResponsesToMessagesStreamState = (): ResponsesToMessagesStrea
   emittedReasoningSummaryKeys: new Set(),
   emittedReasoningSignatureOutputIndexes: new Set(),
   emittedTextContentKeys: new Set(),
-  refusalText: '',
-  sawRefusal: false,
+  refusalTexts: new Map(),
   emittedFunctionArgumentOutputIndexes: new Set(),
   outputOrder: createResponsesOutputOrderState(),
   functionCallState: new Map(),

--- a/packages/translate/src/messages-via-responses/events.ts
+++ b/packages/translate/src/messages-via-responses/events.ts
@@ -74,6 +74,8 @@ interface ResponsesToMessagesStreamState {
   emittedReasoningSummaryKeys: Set<string>;
   emittedReasoningSignatureOutputIndexes: Set<number>;
   emittedTextContentKeys: Set<string>;
+  refusalText: string;
+  sawRefusal: boolean;
   emittedFunctionArgumentOutputIndexes: Set<number>;
   outputOrder: ResponsesOutputOrderState;
   functionCallState: Map<
@@ -300,15 +302,24 @@ const handleContentPartDone = (event: Extract<ResponsesStreamEvent, { type: 'res
   const key = responsesPartKey(event.output_index, event.content_index);
   if (!event.part.refusal || state.emittedTextContentKeys.has(key)) return [];
 
-  const events: MessagesStreamEvent[] = [];
-  const blockIndex = openTextBlock(state, event.output_index, event.content_index, events);
-  events.push({
-    type: 'content_block_delta',
-    index: blockIndex,
-    delta: { type: 'text_delta', text: event.part.refusal },
-  });
+  state.sawRefusal = true;
+  state.refusalText = event.part.refusal;
   state.emittedTextContentKeys.add(key);
-  return events;
+  return [];
+};
+
+const handleRefusalDelta = (event: Extract<ResponsesStreamEvent, { type: 'response.refusal.delta' }>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] => {
+  state.sawRefusal = true;
+  state.refusalText += event.delta;
+  state.emittedTextContentKeys.add(responsesPartKey(event.output_index, event.content_index));
+  return [];
+};
+
+const handleRefusalDone = (event: Extract<ResponsesStreamEvent, { type: 'response.refusal.done' }>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] => {
+  state.sawRefusal = true;
+  state.refusalText = event.refusal;
+  state.emittedTextContentKeys.add(responsesPartKey(event.output_index, event.content_index));
+  return [];
 };
 
 const handleFunctionArgumentsDelta = (event: Extract<ResponsesStreamEvent, { type: 'response.function_call_arguments.delta' }>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] => {
@@ -357,7 +368,16 @@ const handleCompleted = (response: ResponsesResult, state: ResponsesToMessagesSt
     {
       type: 'message_delta',
       delta: {
-        stop_reason: mapResponsesStopReason(response),
+        stop_reason: state.sawRefusal ? 'refusal' : mapResponsesStopReason(response),
+        ...(state.sawRefusal
+          ? {
+              stop_details: {
+                type: 'refusal' as const,
+                category: null,
+                explanation: state.refusalText || null,
+              },
+            }
+          : {}),
         stop_sequence: null,
       },
       usage: responsesUsageToMessagesUsage(response, response.usage?.output_tokens ?? 0),
@@ -393,8 +413,35 @@ const handleStreamError = (
   return events;
 };
 
-const handleFailed = (response: ResponsesResult, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] =>
-  handleStreamError(state, response.error ?? undefined, 'Response failed due to unknown error.');
+const handleFailed = (response: ResponsesResult, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] => {
+  const category = response.error?.code === 'cyber_policy'
+    ? 'cyber' as const
+    : response.error?.code === 'bio_policy' ? 'bio' as const : undefined;
+  if (category === undefined) {
+    return handleStreamError(state, response.error ?? undefined, 'Response failed due to unknown error.');
+  }
+
+  const events: MessagesStreamEvent[] = [];
+  closeAllBlocks(state, events);
+  events.push(
+    {
+      type: 'message_delta',
+      delta: {
+        stop_reason: 'refusal',
+        stop_details: {
+          type: 'refusal',
+          category,
+          explanation: response.error?.message ?? null,
+        },
+        stop_sequence: null,
+      },
+      usage: responsesUsageToMessagesUsage(response, response.usage?.output_tokens ?? 0),
+    },
+    { type: 'message_stop' },
+  );
+  state.messageCompleted = true;
+  return events;
+};
 
 const handleError = (event: Extract<ResponsesStreamEvent, { type: 'error' }>, state: ResponsesToMessagesStreamState): MessagesStreamEvent[] =>
   handleStreamError(state, { code: event.code, message: event.message }, 'An unexpected error occurred during streaming.');
@@ -407,6 +454,8 @@ export const createResponsesToMessagesStreamState = (): ResponsesToMessagesStrea
   emittedReasoningSummaryKeys: new Set(),
   emittedReasoningSignatureOutputIndexes: new Set(),
   emittedTextContentKeys: new Set(),
+  refusalText: '',
+  sawRefusal: false,
   emittedFunctionArgumentOutputIndexes: new Set(),
   outputOrder: createResponsesOutputOrderState(),
   functionCallState: new Map(),
@@ -430,6 +479,10 @@ const translateReadyResponsesEvent = (event: ResponsesStreamEvent, state: Respon
     return handleTextDelta(event as Extract<ResponsesStreamEvent, { type: 'response.output_text.delta' }>, state);
   case 'response.output_text.done':
     return handleTextDone(event as Extract<ResponsesStreamEvent, { type: 'response.output_text.done' }>, state);
+  case 'response.refusal.delta':
+    return handleRefusalDelta(event as Extract<ResponsesStreamEvent, { type: 'response.refusal.delta' }>, state);
+  case 'response.refusal.done':
+    return handleRefusalDone(event as Extract<ResponsesStreamEvent, { type: 'response.refusal.done' }>, state);
   case 'response.content_part.done':
     return handleContentPartDone(event as Extract<ResponsesStreamEvent, { type: 'response.content_part.done' }>, state);
   case 'response.function_call_arguments.delta':

--- a/packages/translate/src/responses-via-chat-completions/events.ts
+++ b/packages/translate/src/responses-via-chat-completions/events.ts
@@ -297,7 +297,10 @@ const emitRefusalDelta = (refusal: string, state: ChatCompletionsToResponsesStre
   const events = closeText(state);
   const opened = openRefusal(state);
   opened.item.refusal += refusal;
-  events.push(...opened.events, ...responses.refusalDelta(state, opened.item.outputIndex, opened.item.itemId, refusal));
+  events.push(...opened.events);
+  if (refusal.length > 0) {
+    events.push(...responses.refusalDelta(state, opened.item.outputIndex, opened.item.itemId, refusal));
+  }
   return events;
 };
 
@@ -433,7 +436,7 @@ export const translateChatCompletionsChunkToResponsesEvents = (chunk: ChatComple
       }
     }
 
-    if (choice.delta.refusal) {
+    if (choice.delta.refusal !== undefined && choice.delta.refusal !== null) {
       if (state.pendingScalarReasoning) {
         state.deferredAfterReasoning.push({
           type: 'refusal',

--- a/packages/translate/src/responses-via-chat-completions/events.ts
+++ b/packages/translate/src/responses-via-chat-completions/events.ts
@@ -48,6 +48,12 @@ interface PendingTextItem {
   text: string;
 }
 
+interface PendingRefusalItem {
+  outputIndex: number;
+  itemId: string;
+  refusal: string;
+}
+
 interface FunctionCallStreamItem {
   outputIndex: number;
   itemId: string;
@@ -71,7 +77,10 @@ type ChatCompletionsStreamDelta = ChatCompletionsStreamEvent['choices'][0]['delt
 type ChatCompletionsStreamToolCalls = NonNullable<ChatCompletionsStreamDelta['tool_calls']>;
 type ChatCompletionsFinishReason = NonNullable<ChatCompletionsStreamEvent['choices'][0]['finish_reason']>;
 
-type DeferredAfterReasoning = { type: 'content'; content: string } | { type: 'tool_calls'; toolCalls: ChatCompletionsStreamToolCalls };
+type DeferredAfterReasoning =
+  | { type: 'content'; content: string }
+  | { type: 'refusal'; refusal: string }
+  | { type: 'tool_calls'; toolCalls: ChatCompletionsStreamToolCalls };
 
 interface ChatCompletionsToResponsesStreamState {
   responseCreated: boolean;
@@ -83,6 +92,7 @@ interface ChatCompletionsToResponsesStreamState {
   completedItems: (ResponsesOutputItem | undefined)[];
   pendingScalarReasoning?: PendingScalarReasoningItem;
   openText?: PendingTextItem;
+  openRefusal?: PendingRefusalItem;
   openFunctionCalls: Map<number, PendingFunctionCallItem>;
   deferredAfterReasoning: DeferredAfterReasoning[];
   reasoningItemsSeen: boolean;
@@ -172,6 +182,18 @@ const closeText = (state: ChatCompletionsToResponsesStreamState): ResponsesStrea
   return responses.textDone(state, textItem.outputIndex, textItem.itemId, textItem.text, item);
 };
 
+const closeRefusal = (state: ChatCompletionsToResponsesStreamState): ResponsesStreamEvent[] => {
+  if (!state.openRefusal) return [];
+
+  const refusalItem = state.openRefusal;
+  state.openRefusal = undefined;
+
+  const item = responses.refusalItem(refusalItem.itemId, refusalItem.refusal);
+  state.completedItems[refusalItem.outputIndex] = item;
+
+  return responses.refusalDone(state, refusalItem.outputIndex, refusalItem.itemId, refusalItem.refusal, item);
+};
+
 const closeFunctionCalls = (state: ChatCompletionsToResponsesStreamState): ResponsesStreamEvent[] => {
   const events: ResponsesStreamEvent[] = [];
 
@@ -218,6 +240,20 @@ const openText = (state: ChatCompletionsToResponsesStreamState): { item: Pending
   };
 };
 
+const openRefusal = (state: ChatCompletionsToResponsesStreamState): { item: PendingRefusalItem; events: ResponsesStreamEvent[] } => {
+  if (state.openRefusal) return { item: state.openRefusal, events: [] };
+
+  const outputIndex = state.outputIndex++;
+  const itemId = createRandomResponsesItemId('message');
+  const item = { outputIndex, itemId, refusal: '' };
+  state.openRefusal = item;
+
+  return {
+    item,
+    events: responses.refusalStart(state, outputIndex, itemId),
+  };
+};
+
 const startFunctionCall = (current: PendingFunctionCallItem, state: ChatCompletionsToResponsesStreamState): ResponsesStreamEvent[] => {
   if (current.streamItem || !current.callId || !current.name) {
     return [];
@@ -248,17 +284,27 @@ const startFunctionCall = (current: PendingFunctionCallItem, state: ChatCompleti
 };
 
 const emitContentDelta = (content: string, state: ChatCompletionsToResponsesStreamState): ResponsesStreamEvent[] => {
-  const { item, events } = openText(state);
-  item.text += content;
+  const events = closeRefusal(state);
+  const opened = openText(state);
+  opened.item.text += content;
   state.outputText += content;
-  events.push(...responses.textDelta(state, item.outputIndex, item.itemId, content));
+  events.push(...opened.events, ...responses.textDelta(state, opened.item.outputIndex, opened.item.itemId, content));
 
+  return events;
+};
+
+const emitRefusalDelta = (refusal: string, state: ChatCompletionsToResponsesStreamState): ResponsesStreamEvent[] => {
+  const events = closeText(state);
+  const opened = openRefusal(state);
+  opened.item.refusal += refusal;
+  events.push(...opened.events, ...responses.refusalDelta(state, opened.item.outputIndex, opened.item.itemId, refusal));
   return events;
 };
 
 const emitToolCallsDelta = (toolCalls: ChatCompletionsStreamToolCalls, state: ChatCompletionsToResponsesStreamState): ResponsesStreamEvent[] => {
   const events: ResponsesStreamEvent[] = [];
   events.push(...closeText(state));
+  events.push(...closeRefusal(state));
 
   for (const toolCall of toolCalls) {
     const current = state.openFunctionCalls.get(toolCall.index) ?? {
@@ -300,7 +346,17 @@ const commitReasoningAndReplayDeferredDeltas = (state: ChatCompletionsToResponse
   state.deferredAfterReasoning = [];
 
   for (const item of deferred) {
-    events.push(...(item.type === 'content' ? emitContentDelta(item.content, state) : emitToolCallsDelta(item.toolCalls, state)));
+    switch (item.type) {
+    case 'content':
+      events.push(...emitContentDelta(item.content, state));
+      break;
+    case 'refusal':
+      events.push(...emitRefusalDelta(item.refusal, state));
+      break;
+    case 'tool_calls':
+      events.push(...emitToolCallsDelta(item.toolCalls, state));
+      break;
+    }
   }
 
   return events;
@@ -309,7 +365,7 @@ const commitReasoningAndReplayDeferredDeltas = (state: ChatCompletionsToResponse
 const finalize = (state: ChatCompletionsToResponsesStreamState): ResponsesStreamEvent[] => {
   if (state.completed || state.pendingFinishReason === undefined) return [];
 
-  const events = [...commitReasoningAndReplayDeferredDeltas(state), ...closeText(state), ...closeFunctionCalls(state)];
+  const events = [...commitReasoningAndReplayDeferredDeltas(state), ...closeText(state), ...closeRefusal(state), ...closeFunctionCalls(state)];
 
   state.completed = true;
   const incomplete = state.pendingFinishReason === 'length';
@@ -341,6 +397,7 @@ export const translateChatCompletionsChunkToResponsesEvents = (chunk: ChatComple
       } else {
         events.push(...commitReasoningAndReplayDeferredDeltas(state));
         events.push(...closeText(state));
+        events.push(...closeRefusal(state));
       }
 
       for (const item of readableReasoningItems) {
@@ -353,7 +410,10 @@ export const translateChatCompletionsChunkToResponsesEvents = (chunk: ChatComple
       }
     } else if (choice.delta.reasoning_text) {
       if (!state.reasoningItemsSeen) {
-        if (!state.pendingScalarReasoning) events.push(...closeText(state));
+        if (!state.pendingScalarReasoning) {
+          events.push(...closeText(state));
+          events.push(...closeRefusal(state));
+        }
         const reasoning = openScalarReasoning(state);
 
         if (choice.delta.reasoning_text) {
@@ -370,6 +430,17 @@ export const translateChatCompletionsChunkToResponsesEvents = (chunk: ChatComple
         });
       } else {
         events.push(...emitContentDelta(choice.delta.content, state));
+      }
+    }
+
+    if (choice.delta.refusal) {
+      if (state.pendingScalarReasoning) {
+        state.deferredAfterReasoning.push({
+          type: 'refusal',
+          refusal: choice.delta.refusal,
+        });
+      } else {
+        events.push(...emitRefusalDelta(choice.delta.refusal, state));
       }
     }
 

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -1,8 +1,8 @@
 import { unwrapCustomToolInput } from '../shared/responses-via/custom-tool-wrap.ts';
 import * as responses from '../shared/responses-via/responses-event-builder.ts';
+import { messagesRefusalResponsesError } from '../shared/via-messages/refusal.ts';
 import { openAIServiceTierFromMessagesUsage } from '../shared/via-messages/service-tier.ts';
 import { inclusiveMessagesInputUsage } from '../shared/via-messages/usage.ts';
-import { messagesRefusalResponsesError } from '../shared/via-messages/refusal.ts';
 import { eventFrame, USAGE_BILLING, type ProtocolFrame } from '@floway-dev/protocols/common';
 import {
   mergeMessagesUsageSnapshot,

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -2,6 +2,7 @@ import { unwrapCustomToolInput } from '../shared/responses-via/custom-tool-wrap.
 import * as responses from '../shared/responses-via/responses-event-builder.ts';
 import { openAIServiceTierFromMessagesUsage } from '../shared/via-messages/service-tier.ts';
 import { inclusiveMessagesInputUsage } from '../shared/via-messages/usage.ts';
+import { messagesRefusalResponsesError } from '../shared/via-messages/refusal.ts';
 import { eventFrame, USAGE_BILLING, type ProtocolFrame } from '@floway-dev/protocols/common';
 import {
   mergeMessagesUsageSnapshot,
@@ -13,6 +14,7 @@ import type {
   MessagesContentBlockStopEvent,
   MessagesMessageDeltaEvent,
   MessagesMessageStartEvent,
+  MessagesRefusalStopDetails,
   MessagesStreamEvent,
   MessagesTextCitation,
   MessagesUsageSnapshot,
@@ -84,6 +86,7 @@ interface MessagesToResponsesStreamState {
   completedItems: ResponsesOutputItem[];
   usage: MessagesUsageSnapshot;
   stopReason?: MessagesMessageDeltaEvent['delta']['stop_reason'];
+  stopDetails?: MessagesRefusalStopDetails | null;
   customToolNames: ReadonlySet<string>;
 }
 
@@ -121,10 +124,12 @@ const buildResult = (state: MessagesToResponsesStreamState, status: ResponsesRes
       ...(cacheWrite1h > 0 ? { [USAGE_BILLING]: { cacheWrite1hTokenCount: cacheWrite1h } } : {}),
     },
     ...(serviceTier !== undefined ? { serviceTier } : {}),
+    ...(status === 'failed' ? { error: messagesRefusalResponsesError(state.stopDetails) } : {}),
   });
 };
 
 const handleMessageStart = (event: MessagesMessageStartEvent, state: MessagesToResponsesStreamState): ResponsesStreamEvent[] => {
+  state.model = event.message.model;
   state.usage = messagesUsageSnapshot(event.message.usage);
 
   const response = buildResult(state, 'in_progress');
@@ -204,6 +209,9 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
 
     return responses.itemAdded(state, outputIndex, responses.functionCallItem(info.itemId, info.toolCallId, info.toolName, info.toolArguments, 'in_progress'));
   }
+  case 'fallback':
+    state.model = event.content_block.to.model;
+    return [];
   default:
     return [];
   }
@@ -370,13 +378,18 @@ export const translateMessagesEventToResponsesEvents = (event: MessagesStreamEve
     if (event.delta.stop_reason !== undefined) {
       state.stopReason = event.delta.stop_reason;
     }
+    if (event.delta.stop_details !== undefined) {
+      state.stopDetails = event.delta.stop_details;
+    }
     if (event.usage) {
       state.usage = mergeMessagesUsageSnapshot(state.usage, event.usage);
     }
     return [];
   }
   case 'message_stop': {
-    const status: ResponsesResult['status'] = state.stopReason === 'max_tokens' ? 'incomplete' : 'completed';
+    const status: ResponsesResult['status'] = state.stopReason === 'refusal'
+      ? 'failed'
+      : state.stopReason === 'max_tokens' ? 'incomplete' : 'completed';
     const response = buildResult(state, status);
 
     return responses.terminal(state, response);

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -12,6 +12,7 @@ import type { RemoteImageLoader } from '../types.ts';
 import {
   MESSAGES_FALLBACK_MAX_TOKENS,
   type MessagesAssistantContentBlock,
+  type MessagesAssistantInputContentBlock,
   type MessagesAssistantMessage,
   type MessagesMessage,
   type MessagesPayload,
@@ -72,6 +73,10 @@ const translateUserMessage = async (message: ResponsesInputMessage, loadRemoteIm
       throw new TranslatorInputError('Cannot translate input_file message content to Messages.');
     }
 
+    if (block.type === 'refusal') {
+      throw new TranslatorInputError('Cannot translate refusal content in a user message to Messages.');
+    }
+
     if (block.type !== 'input_image') continue;
 
     const imageUrl = (block as ResponsesInputImage).image_url;
@@ -101,6 +106,8 @@ const translateToolOutput = async (output: string | ResponsesInputContent[], loa
       if (image) blocks.push(image);
     } else if (part.type === 'input_file') {
       throw new TranslatorInputError('Cannot translate input_file tool output to Messages.');
+    } else if (part.type === 'refusal') {
+      throw new TranslatorInputError('Cannot translate refusal content in a tool output to Messages.');
     } else {
       blocks.push({ type: 'text', text: part.text });
     }
@@ -114,7 +121,7 @@ const translateAssistantMessage = (message: ResponsesInputMessage): MessagesAssi
     return { role: 'assistant', content: message.content };
   }
 
-  const content: MessagesAssistantContentBlock[] = [];
+  const content: MessagesAssistantInputContentBlock[] = [];
 
   for (const block of message.content) {
     if (block.type === 'input_image') {
@@ -122,6 +129,10 @@ const translateAssistantMessage = (message: ResponsesInputMessage): MessagesAssi
     }
     if (block.type === 'input_file') {
       throw new TranslatorInputError('Cannot translate input_file assistant content to Messages.');
+    }
+    if (block.type === 'refusal') {
+      content.push({ type: 'text', text: block.refusal });
+      continue;
     }
     if (block.type === 'input_text' || block.type === 'output_text') {
       content.push({ type: 'text', text: (block as ResponsesInputText).text });

--- a/packages/translate/src/shared/chat-completions-and-responses/content.ts
+++ b/packages/translate/src/shared/chat-completions-and-responses/content.ts
@@ -19,14 +19,20 @@ export const chatCompletionsContentToResponsesInputContent = (content: string | 
   if (!Array.isArray(content) || content.length === 0) return '';
 
   return content.map(
-    (part): ResponsesInputContent =>
-      part.type === 'text'
-        ? { type: 'input_text', text: part.text }
-        : {
+    (part): ResponsesInputContent => {
+      switch (part.type) {
+      case 'text':
+        return { type: 'input_text', text: part.text };
+      case 'refusal':
+        return { type: 'refusal', refusal: part.refusal };
+      case 'image_url':
+        return {
             type: 'input_image',
             image_url: part.image_url.url,
             detail: part.image_url.detail ?? 'auto',
-          },
+        };
+      }
+    },
   );
 };
 
@@ -38,7 +44,7 @@ export const responsesContentToChatCompletionsContent = (content: string | Respo
     throw new TranslatorInputError('Cannot translate input_file content to Chat Completions.');
   }
 
-  return content.some(part => part.type === 'input_image')
+  return content.some(part => part.type === 'input_image' || part.type === 'refusal')
     ? content.map(
         (part): ChatCompletionsContentPart => {
           if (part.type === 'input_image') {
@@ -61,6 +67,7 @@ export const responsesContentToChatCompletionsContent = (content: string | Respo
               },
             };
           }
+          if (part.type === 'refusal') return { type: 'refusal', refusal: part.refusal };
           return { type: 'text', text: part.text };
         },
       )

--- a/packages/translate/src/shared/chat-completions-and-responses/content.ts
+++ b/packages/translate/src/shared/chat-completions-and-responses/content.ts
@@ -27,9 +27,9 @@ export const chatCompletionsContentToResponsesInputContent = (content: string | 
         return { type: 'refusal', refusal: part.refusal };
       case 'image_url':
         return {
-            type: 'input_image',
-            image_url: part.image_url.url,
-            detail: part.image_url.detail ?? 'auto',
+          type: 'input_image',
+          image_url: part.image_url.url,
+          detail: part.image_url.detail ?? 'auto',
         };
       }
     },

--- a/packages/translate/src/shared/gemini-via/gemini.ts
+++ b/packages/translate/src/shared/gemini-via/gemini.ts
@@ -221,12 +221,13 @@ export const parseStrictJsonObject = (json: string, subject: string): Record<str
 
 // Shape a single-candidate Gemini stream event. Lives in shared because both
 // gemini-via-messages and gemini-via-responses produce the same envelope.
-export const geminiCandidateEvent = (parts: GeminiPart[], finishReason?: GeminiFinishReason, usageMetadata?: GeminiUsageMetadata): GeminiStreamEvent => ({
+export const geminiCandidateEvent = (parts: GeminiPart[], finishReason?: GeminiFinishReason, usageMetadata?: GeminiUsageMetadata, finishMessage?: string): GeminiStreamEvent => ({
   candidates: [
     {
       index: 0,
       content: { role: 'model', parts },
       ...(finishReason !== undefined ? { finishReason } : {}),
+      ...(finishMessage !== undefined ? { finishMessage } : {}),
     },
   ],
   ...(usageMetadata !== undefined ? { usageMetadata } : {}),

--- a/packages/translate/src/shared/responses-via/responses-event-builder.ts
+++ b/packages/translate/src/shared/responses-via/responses-event-builder.ts
@@ -14,11 +14,17 @@ export interface ResponsesSequenceState {
 }
 
 type OutputTextPart = Extract<ResponsesOutputContentBlock, { type: 'output_text' }>;
+type RefusalPart = Extract<ResponsesOutputContentBlock, { type: 'refusal' }>;
 type ResponsesUsage = NonNullable<ResponsesResult['usage']>;
 
 const textPart = (text: string): OutputTextPart => ({
   type: 'output_text',
   text,
+});
+
+const refusalPart = (refusal: string): RefusalPart => ({
+  type: 'refusal',
+  refusal,
 });
 
 const summaryPart = (text: string) => ({ type: 'summary_text' as const, text });
@@ -36,6 +42,15 @@ const outputTextEvent = (state: 'delta' | 'done', outputIndex: number, itemId: s
     output_index: outputIndex,
     content_index: 0,
     [state === 'delta' ? 'delta' : 'text']: text,
+  } as ResponsesStreamEvent);
+
+const refusalEvent = (state: 'delta' | 'done', outputIndex: number, itemId: string, refusal: string): ResponsesStreamEvent =>
+  ({
+    type: `response.refusal.${state}`,
+    item_id: itemId,
+    output_index: outputIndex,
+    content_index: 0,
+    [state === 'delta' ? 'delta' : 'refusal']: refusal,
   } as ResponsesStreamEvent);
 
 const functionCallArgumentsEvent = (state: 'delta' | 'done', outputIndex: number, itemId: string, text: string): ResponsesStreamEvent =>
@@ -91,6 +106,7 @@ export const result = (input: {
   status: ResponsesResult['status'];
   usage?: ResponsesUsage;
   incompleteDetails?: ResponsesResult['incomplete_details'];
+  error?: ResponsesResult['error'];
   serviceTier?: ResponsesResult['service_tier'];
 }): ResponsesResult => ({
   id: input.id,
@@ -102,7 +118,7 @@ export const result = (input: {
   // `error` and `incomplete_details` are spec-required on every
   // Response (both nullable). Default both to null; callers pass a
   // concrete value when the source carries one.
-  error: null,
+  error: input.error ?? null,
   incomplete_details: input.incompleteDetails ?? null,
   ...(input.usage !== undefined ? { usage: input.usage } : {}),
   ...(input.serviceTier !== undefined ? { service_tier: input.serviceTier } : {}),
@@ -115,6 +131,13 @@ export const messageItem = (id: string, text: string): ResponsesOutputMessage =>
   id,
   role: 'assistant',
   content: [textPart(text)],
+});
+
+export const refusalItem = (id: string, refusal: string): ResponsesOutputMessage => ({
+  type: 'message',
+  id,
+  role: 'assistant',
+  content: [refusalPart(refusal)],
 });
 
 export const reasoningItem = (id: string, summaryText: string, encryptedContent?: string): ResponsesOutputReasoning => ({
@@ -196,6 +219,34 @@ export const textDone = (state: ResponsesSequenceState, outputIndex: number, ite
       output_index: outputIndex,
       content_index: 0,
       part: textPart(text),
+    },
+    outputItemEvent('done', outputIndex, item),
+  ]);
+
+export const refusalStart = (state: ResponsesSequenceState, outputIndex: number, itemId: string) =>
+  seq(state, [
+    outputItemEvent('added', outputIndex, refusalItem(itemId, '')),
+    {
+      type: 'response.content_part.added',
+      item_id: itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      part: refusalPart(''),
+    },
+  ]);
+
+export const refusalDelta = (state: ResponsesSequenceState, outputIndex: number, itemId: string, delta: string) =>
+  seq(state, [refusalEvent('delta', outputIndex, itemId, delta)]);
+
+export const refusalDone = (state: ResponsesSequenceState, outputIndex: number, itemId: string, refusal: string, item: ResponsesOutputMessage) =>
+  seq(state, [
+    refusalEvent('done', outputIndex, itemId, refusal),
+    {
+      type: 'response.content_part.done',
+      item_id: itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      part: refusalPart(refusal),
     },
     outputItemEvent('done', outputIndex, item),
   ]);

--- a/packages/translate/src/shared/via-messages/refusal.ts
+++ b/packages/translate/src/shared/via-messages/refusal.ts
@@ -3,11 +3,14 @@ import type { ResponsesResult } from '@floway-dev/protocols/responses';
 
 const CODEX_BIO_POLICY_PREFIX = 'This content was flagged for possible biological risk.';
 
-const refusalCategoryLabel = (details: MessagesRefusalStopDetails | null | undefined): string =>
-  details?.category === null || details?.category === undefined ? 'an unspecified policy category' : `the ${details.category} policy category`;
+export const messagesRefusalExplanation = (details: MessagesRefusalStopDetails | null | undefined): string => {
+  if (details?.explanation !== null && details?.explanation !== undefined) return details.explanation;
 
-export const messagesRefusalExplanation = (details: MessagesRefusalStopDetails | null | undefined): string =>
-  details?.explanation ?? `Anthropic refused this request under ${refusalCategoryLabel(details)}.`;
+  const category = details?.category === null || details?.category === undefined
+    ? 'an unspecified policy category'
+    : `the ${details.category} policy category`;
+  return `Anthropic refused this request under ${category}.`;
+};
 
 export const messagesRefusalResponsesError = (
   details: MessagesRefusalStopDetails | null | undefined,

--- a/packages/translate/src/shared/via-messages/refusal.ts
+++ b/packages/translate/src/shared/via-messages/refusal.ts
@@ -1,0 +1,41 @@
+import type { MessagesRefusalStopDetails } from '@floway-dev/protocols/messages';
+import type { ResponsesResult } from '@floway-dev/protocols/responses';
+
+const CODEX_BIO_POLICY_PREFIX = 'This content was flagged for possible biological risk.';
+
+const refusalCategoryLabel = (details: MessagesRefusalStopDetails | null | undefined): string =>
+  details?.category === null || details?.category === undefined ? 'an unspecified policy category' : `the ${details.category} policy category`;
+
+export const messagesRefusalExplanation = (details: MessagesRefusalStopDetails | null | undefined): string =>
+  details?.explanation ?? `Anthropic refused this request under ${refusalCategoryLabel(details)}.`;
+
+export const messagesRefusalResponsesError = (
+  details: MessagesRefusalStopDetails | null | undefined,
+): NonNullable<ResponsesResult['error']> => {
+  const explanation = messagesRefusalExplanation(details);
+
+  // `bio_policy` and `invalid_prompt` are public Responses failure codes;
+  // `cyber_policy` is the first-party Codex backend extension that selects
+  // its dedicated cyber safety UI. Unknown codes are retryable in Codex, so
+  // all other current and future Anthropic categories deliberately converge
+  // on the non-retryable `invalid_prompt` carrier while the explanation keeps
+  // their upstream reason visible.
+  // https://github.com/openai/openai-node/blob/32ed4b595ee2e21ab2e2eed7e382cd10d72eb059/src/resources/responses/responses.ts#L2745-L2778
+  // https://github.com/openai/codex/blob/e8f0f64f2057740ca18d66dbeebe077156d7a2a9/codex-rs/codex-api/src/sse/responses.rs#L387-L421
+  switch (details?.category) {
+  case 'cyber':
+    return { code: 'cyber_policy', message: explanation };
+  case 'bio':
+    // Codex recognizes this exact first-party prefix as the biology safety
+    // surface and shows its dedicated Trusted Access notice. Keep Anthropic's
+    // explanation after the stable discriminator so the upstream reason stays
+    // visible without misclassifying it as cyber.
+    // https://github.com/openai/codex/blob/e8f0f64f2057740ca18d66dbeebe077156d7a2a9/codex-rs/tui/src/chatwidget/turn_runtime.rs#L8-L16
+    return {
+      code: 'bio_policy',
+      message: details.explanation ? `${CODEX_BIO_POLICY_PREFIX} ${details.explanation}` : CODEX_BIO_POLICY_PREFIX,
+    };
+  default:
+    return { code: 'invalid_prompt', message: explanation };
+  }
+};


### PR DESCRIPTION
## Summary

- Preserve Anthropic Messages refusal details, open policy categories, fallback boundaries, fallback-credit metadata, effective serving models, and iteration usage across streaming and non-streaming assembly.
- Translate classifier refusals into Codex-compatible Responses policy failures, standard Chat Completions refusal fields, and Gemini safety termination with a readable finish message.
- Complete public Chat Completions and Responses refusal lifecycles in both directions, including assistant-history replay, empty and multipart refusals, and JSON-to-stream expansion.
- Keep refusal content out of tool-output unions, preserve native fallback request blocks through Copilot interceptors, and document the final translation contracts.

## Test plan

- [x] `pnpm run test` — 421 files, 4919 tests passed
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `git diff --check 013a5e041..HEAD`