### PR TITLE
feat(gateway): complete Codex web search paths

### DIFF
--- a/packages/gateway/__tests__/data-plane/alpha-search/routes_test.ts
+++ b/packages/gateway/__tests__/data-plane/alpha-search/routes_test.ts
@@ -5,6 +5,7 @@ import { mountAlphaSearchRoutes } from '../../../src/data-plane/alpha-search/rou
 import { resolveConfiguredWebSearchProvider } from '../../../src/data-plane/tools/web-search/provider.ts';
 import type { WebSearchConfig, WebSearchFetchPageRequest, WebSearchFetchPageResult, WebSearchProvider, WebSearchProviderRequest, WebSearchProviderResult } from '../../../src/data-plane/tools/web-search/types.ts';
 import { type AuthVars, authMiddleware } from '../../../src/middleware/auth.ts';
+import { internalErrorResponse } from '../../../src/middleware/internal-error-response.ts';
 import { buildCustomUpstreamRecord, setupAppTest } from '../../test-utils/app.ts';
 import { withMockedFetch } from '@floway-dev/test-utils';
 
@@ -60,6 +61,7 @@ const makeStubProvider = (overrides: ProviderOverrides = {}): { provider: WebSea
 
 const buildAlphaSearchApp = () => {
   const app = new Hono<{ Variables: AuthVars }>();
+  app.onError(internalErrorResponse);
   app.use('*', authMiddleware);
   mountAlphaSearchRoutes(app);
   return app;
@@ -288,7 +290,7 @@ describe('/alpha/search data plane', () => {
       expect(blocks.length).toBeGreaterThan(1);
     });
 
-    it('renders unimplemented command kinds as deterministic text without hitting the provider', async () => {
+    it('rejects unimplemented command kinds without hitting the provider', async () => {
       const { apiKey } = await setupAppTest({ webSearchConfig: TAVILY_CONFIG });
       const stub = makeStubProvider();
       mockResolveConfigured.mockReturnValue({ type: 'enabled', provider: 'tavily', impl: stub.provider });
@@ -297,10 +299,9 @@ describe('/alpha/search data plane', () => {
       const response = await postSearch(app, apiKey.key, {
         commands: { screenshot: [{ ref_id: 'https://example.com', pageno: 0 }], response_length: 'short' },
       });
-      expect(response.status).toBe(200);
-      const body = await response.json() as SearchResponseBody;
-      expect(body.output).toContain('the `screenshot` sub-property is not supported');
-      expect(body.output).toContain('the `response_length` sub-property is not supported');
+      expect(response.status).toBe(500);
+      const body = await response.json() as { error: { message: string } };
+      expect(body.error.message).toBe('The configured web search provider does not implement OpenAI search feature `commands.screenshot`.');
       expect(stub.calls).toHaveLength(0);
     });
 

--- a/packages/gateway/__tests__/data-plane/alpha-search/routes_test.ts
+++ b/packages/gateway/__tests__/data-plane/alpha-search/routes_test.ts
@@ -290,7 +290,7 @@ describe('/alpha/search data plane', () => {
       expect(blocks.length).toBeGreaterThan(1);
     });
 
-    it('rejects unimplemented command kinds without hitting the provider', async () => {
+    it('returns unimplemented command kinds as exact model-facing output without hitting the provider', async () => {
       const { apiKey } = await setupAppTest({ webSearchConfig: TAVILY_CONFIG });
       const stub = makeStubProvider();
       mockResolveConfigured.mockReturnValue({ type: 'enabled', provider: 'tavily', impl: stub.provider });
@@ -299,9 +299,9 @@ describe('/alpha/search data plane', () => {
       const response = await postSearch(app, apiKey.key, {
         commands: { screenshot: [{ ref_id: 'https://example.com', pageno: 0 }], response_length: 'short' },
       });
-      expect(response.status).toBe(500);
-      const body = await response.json() as { error: { message: string } };
-      expect(body.error.message).toBe('The configured web search provider does not implement OpenAI search feature `commands.screenshot`.');
+      expect(response.status).toBe(200);
+      const body = await response.json() as SearchResponseBody;
+      expect(body.output).toBe('The configured web search provider does not implement OpenAI search feature `commands.screenshot`.');
       expect(stub.calls).toHaveLength(0);
     });
 

--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -3940,7 +3940,7 @@ test('responses target with flag on: function_call_output is plain-text formatte
   assert(text.startsWith('Search results for "q1":'));
 });
 
-test('responses target with OpenAI passthrough uses the selected alpha search dispatcher', async () => {
+test('responses target with OpenAI passthrough forwards the complete alpha-search command and settings shapes', async () => {
   makeStubDeps();
   await getRepo().webSearchConfig.save({
     provider: 'tavily',
@@ -3958,16 +3958,79 @@ test('responses target with OpenAI passthrough uses the selected alpha search di
   const inv = makeInvocation({
     targetApi: 'responses',
     enabledFlags: new Set<FlagId>(['responses-web-search-shim']),
+    payload: {
+      tools: [{
+        type: 'web_search',
+        user_location: { type: 'approximate', country: 'SG' },
+        image_settings: { max_results: 4, caption: true },
+        allowed_callers: ['direct'],
+        external_web_access: 'live',
+      }],
+    },
   });
+  const commands = {
+    image_query: [{ q: 'Floway logo', recency: 7, domains: ['floway.dev'] }],
+    finance: [{ ticker: 'OPENAI', type: 'equity', market: 'USA' }],
+    response_length: 'long',
+  };
   const script = scriptedRun([
-    searchCallTurn(0, 'call_1', 'alpha query'),
+    fcTurn(0, 'call_1', SHIM_TOOL_NAME, JSON.stringify(commands)),
     messageTurn('done', 0),
   ]);
 
   await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
 
   assertEquals(lastFunctionCallOutput(inv.payload.input as ResponsesInputItem[]), 'alpha output');
-  assertEquals(call.mock.calls[0]?.[0].commands, { search_query: [{ q: 'alpha query' }] });
+  assertEquals(call.mock.calls[0]?.[0].commands, commands);
+  assertEquals(call.mock.calls[0]?.[0].settings, {
+    user_location: { type: 'approximate', country: 'SG' },
+    image_settings: { max_results: 4, caption: true },
+    allowed_callers: ['direct'],
+    external_web_access: 'live',
+  });
+});
+
+test('local and cascaded Floway unsupported commands produce the same agent-visible error', async () => {
+  makeStubDeps();
+  const commands = { image_query: [{ q: 'Floway logo' }] };
+  const expected = 'Upstream stream failed mid-response: The configured web search provider does not implement OpenAI search feature `commands.image_query`.';
+  const runUnsupported = async (): Promise<string> => {
+    const inv = makeInvocation({
+      targetApi: 'responses',
+      enabledFlags: new Set<FlagId>(['responses-web-search-shim']),
+    });
+    const script = scriptedRun([
+      fcTurn(0, 'call_unsupported', SHIM_TOOL_NAME, JSON.stringify(commands)),
+    ]);
+    const { frames } = await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
+    const failed = eventPayloads(frames).find(
+      (event): event is Extract<ResponsesStreamEvent, { type: 'response.failed' }> => event.type === 'response.failed',
+    );
+    assert(failed !== undefined);
+    assert(failed.response.error !== null && failed.response.error !== undefined);
+    return failed.response.error.message;
+  };
+
+  const localMessage = await runUnsupported();
+
+  await getRepo().webSearchConfig.save({
+    provider: 'tavily',
+    tavily: { apiKey: 'test-key' },
+    microsoftGrounding: { apiKey: '' },
+    jina: { apiKey: '' },
+    passthroughOpenAiSearch: { enabled: true, upstreamId: 'up_floway', model: 'gpt-search' },
+  } satisfies WebSearchConfig);
+  mockResolveAlpha.mockResolvedValue(async () => new Response(JSON.stringify({
+    error: {
+      type: 'internal_error',
+      name: 'UnsupportedLocalWebSearchFeatureError',
+      message: 'The configured web search provider does not implement OpenAI search feature `commands.image_query`.',
+    },
+  }), { status: 500, headers: { 'content-type': 'application/json' } }));
+
+  const cascadedMessage = await runUnsupported();
+  assertEquals(localMessage, expected);
+  assertEquals(cascadedMessage, expected);
 });
 
 test('chat-completions target: function_call_output is plain-text formatted search results', async () => {

--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -3993,7 +3993,7 @@ test('responses target with OpenAI passthrough forwards the complete alpha-searc
 test('local and cascaded Floway unsupported commands produce the same agent-visible error', async () => {
   makeStubDeps();
   const commands = { image_query: [{ q: 'Floway logo' }] };
-  const expected = 'Upstream stream failed mid-response: The configured web search provider does not implement OpenAI search feature `commands.image_query`.';
+  const expected = 'The configured web search provider does not implement OpenAI search feature `commands.image_query`.';
   const runUnsupported = async (): Promise<string> => {
     const inv = makeInvocation({
       targetApi: 'responses',
@@ -4001,14 +4001,10 @@ test('local and cascaded Floway unsupported commands produce the same agent-visi
     });
     const script = scriptedRun([
       fcTurn(0, 'call_unsupported', SHIM_TOOL_NAME, JSON.stringify(commands)),
+      messageTurn('model repeated the tool error', 0),
     ]);
-    const { frames } = await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
-    const failed = eventPayloads(frames).find(
-      (event): event is Extract<ResponsesStreamEvent, { type: 'response.failed' }> => event.type === 'response.failed',
-    );
-    assert(failed !== undefined);
-    assert(failed.response.error !== null && failed.response.error !== undefined);
-    return failed.response.error.message;
+    await runShimAndDrain(withResponsesWebSearchShim, inv, makeGatewayCtx(), script.run);
+    return lastFunctionCallOutput(inv.payload.input as ResponsesInputItem[]);
   };
 
   const localMessage = await runUnsupported();

--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tools/web-search_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tools/web-search_test.ts
@@ -2,6 +2,8 @@ import { test } from 'vitest';
 
 import { resolveServerToolName } from '../../../../../../src/data-plane/chat/responses/interceptors/server-tool-shim.ts';
 import {
+  alphaSearchSettingsFromHosted,
+  buildShimFunctionTool,
   isHostedWebSearchTool,
   prepareToolsForShim,
   SHIM_TOOL_NAME,
@@ -10,9 +12,9 @@ import {
   WEB_SEARCH_HOSTED_TYPES,
   type WebSearchCallPrivatePayload,
 } from '../../../../../../src/data-plane/chat/responses/interceptors/server-tools/web-search.ts';
-import { findMatches, formatMatches, isUrlAllowed, parseWebSearchOperations, type WebSearchOperation } from '../../../../../../src/data-plane/tools/web-search/operations.ts';
-import type { ResponsesTool, ResponsesWebSearchAction, ResponsesWebSearchResult } from '@floway-dev/protocols/responses';
-import { assert, assertEquals } from '@floway-dev/test-utils';
+import { assertLocalWebSearchSupport, findMatches, formatMatches, isUrlAllowed, parseWebSearchOperations, type WebSearchOperation } from '../../../../../../src/data-plane/tools/web-search/operations.ts';
+import type { ResponsesHostedTool, ResponsesTool, ResponsesWebSearchAction, ResponsesWebSearchResult } from '@floway-dev/protocols/responses';
+import { assert, assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 // ── Shim call argument parsing (parseWebSearchOperations) ──
 
@@ -21,6 +23,92 @@ const opsOf = (args: Record<string, unknown> | null): WebSearchOperation[] => {
   assert(parsed.kind === 'ops');
   return parsed.ops;
 };
+
+test('injected web_search function exposes the complete OpenAI alpha-search command shape', () => {
+  const functionTool = buildShimFunctionTool({ type: 'web_search' }, SHIM_TOOL_NAME);
+  const properties = (functionTool.parameters as { properties: Record<string, unknown> }).properties;
+  assertEquals(Object.keys(properties), [
+    'search_query',
+    'image_query',
+    'open',
+    'click',
+    'find',
+    'screenshot',
+    'finance',
+    'weather',
+    'sports',
+    'time',
+    'response_length',
+  ]);
+  const requiredByCommand = Object.fromEntries(
+    Object.entries(properties)
+      .filter(([name]) => name !== 'response_length')
+      .map(([name, schema]) => [name, (schema as { items: { required: string[] } }).items.required]),
+  );
+  assertEquals(requiredByCommand, {
+    search_query: ['q'],
+    image_query: ['q'],
+    open: ['ref_id'],
+    click: ['ref_id', 'id'],
+    find: ['ref_id', 'pattern'],
+    screenshot: ['ref_id', 'pageno'],
+    finance: ['ticker', 'type'],
+    weather: ['location'],
+    sports: ['fn', 'league'],
+    time: ['utc_offset'],
+  });
+  assertEquals(
+    ((properties.search_query as { items: { properties: Record<string, unknown> } }).items.properties),
+    {
+      q: { type: 'string', description: 'The search query.' },
+      recency: { type: 'integer', minimum: 0, description: 'Limit results to this many recent days.' },
+      domains: { type: 'array', items: { type: 'string' }, description: 'Limit results to these domains.' },
+    },
+  );
+  const financeProperties = (properties.finance as { items: { properties: Record<string, { enum?: string[] }> } }).items.properties;
+  assertEquals(financeProperties.type.enum, ['equity', 'fund', 'crypto', 'index']);
+  const sportsProperties = (properties.sports as { items: { properties: Record<string, { enum?: string[] }> } }).items.properties;
+  assertEquals(sportsProperties.fn.enum, ['schedule', 'standings']);
+  assertEquals(sportsProperties.league.enum, ['nba', 'wnba', 'nfl', 'nhl', 'mlb', 'epl', 'ncaamb', 'ncaawb', 'ipl']);
+  assertEquals((properties.response_length as { enum: string[] }).enum, ['short', 'medium', 'long']);
+});
+
+test('alpha-search settings preserve every OpenAI setting supported by passthrough', () => {
+  const hosted: ResponsesHostedTool = {
+    type: 'web_search',
+    user_location: { type: 'approximate', country: 'SG' },
+    search_context_size: 'high',
+    filters: { allowed_domains: ['example.com'] },
+    image_settings: { max_results: 4, caption: true },
+    allowed_callers: ['direct', 'shell'],
+    external_web_access: 'live',
+    search_content_types: ['text', 'image'],
+    return_token_budget: 'unlimited',
+  };
+  assertEquals(alphaSearchSettingsFromHosted(hosted), {
+    user_location: hosted.user_location,
+    search_context_size: 'high',
+    filters: hosted.filters,
+    image_settings: hosted.image_settings,
+    allowed_callers: hosted.allowed_callers,
+    external_web_access: 'live',
+  });
+});
+
+test('local provider support rejects unsupported commands and nested parameters', () => {
+  assertLocalWebSearchSupport({ search_query: [{ q: 'supported' }], open: [], find: [] });
+  for (const [commands, path] of [
+    [{ image_query: [{ q: 'cat' }] }, 'commands.image_query'],
+    [{ search_query: [{ q: 'news', recency: 2 }] }, 'commands.search_query[0].recency'],
+    [{ open: [{ ref_id: 'https://example.com', lineno: 10 }] }, 'commands.open[0].lineno'],
+  ] as const) {
+    assertThrows(
+      () => assertLocalWebSearchSupport(commands),
+      Error,
+      `The configured web search provider does not implement OpenAI search feature \`${path}\`.`,
+    );
+  }
+});
 
 test('parseWebSearchOperations returns ops:[] for empty object', () => {
   assertEquals(parseWebSearchOperations({}), { kind: 'ops', ops: [] });

--- a/packages/gateway/__tests__/data-plane/tools/web-search/alpha-search/execution_test.ts
+++ b/packages/gateway/__tests__/data-plane/tools/web-search/alpha-search/execution_test.ts
@@ -41,3 +41,22 @@ test('executeAlphaSearch exposes upstream failure without fallback', async () =>
     signal: undefined,
   })).rejects.toThrow('HTTP 503');
 });
+
+test('executeAlphaSearch preserves a cascaded Floway error message', async () => {
+  const message = 'The configured web search provider does not implement OpenAI search feature `commands.image_query`.';
+  await expect(executeAlphaSearch({
+    dispatcher: async () => new Response(JSON.stringify({
+      error: {
+        type: 'internal_error',
+        name: 'UnsupportedLocalWebSearchFeatureError',
+        message,
+      },
+    }), { status: 500, headers: { 'content-type': 'application/json' } }),
+    sessionId: 'session-search',
+    commands: { image_query: [{ q: 'cat' }] },
+    settings: {},
+    input: [],
+    action: { type: 'search', query: 'image_query' },
+    signal: undefined,
+  })).rejects.toThrow(message);
+});

--- a/packages/gateway/__tests__/data-plane/tools/web-search/alpha-search/execution_test.ts
+++ b/packages/gateway/__tests__/data-plane/tools/web-search/alpha-search/execution_test.ts
@@ -42,9 +42,9 @@ test('executeAlphaSearch exposes upstream failure without fallback', async () =>
   })).rejects.toThrow('HTTP 503');
 });
 
-test('executeAlphaSearch preserves a cascaded Floway error message', async () => {
+test('executeAlphaSearch returns a cascaded Floway capability error as exact model-facing output', async () => {
   const message = 'The configured web search provider does not implement OpenAI search feature `commands.image_query`.';
-  await expect(executeAlphaSearch({
+  const ir = await executeAlphaSearch({
     dispatcher: async () => new Response(JSON.stringify({
       error: {
         type: 'internal_error',
@@ -58,5 +58,12 @@ test('executeAlphaSearch preserves a cascaded Floway error message', async () =>
     input: [],
     action: { type: 'search', query: 'image_query' },
     signal: undefined,
-  })).rejects.toThrow(message);
+  });
+  assertEquals(ir.outputText, message);
+  assertEquals(ir.results, [{
+    type: 'text_result',
+    url: '',
+    title: 'Unsupported search feature',
+    snippet: message,
+  }]);
 });

--- a/packages/gateway/src/data-plane/alpha-search/routes.ts
+++ b/packages/gateway/src/data-plane/alpha-search/routes.ts
@@ -25,35 +25,44 @@ import { getRuntimeLocation } from '../../runtime/runtime-info.ts';
 import { relayFetchedResponse } from '../tools/web-search/alpha-search/relay-response.ts';
 import { resolveAlphaSearchDispatcher } from '../tools/web-search/alpha-search/upstream.ts';
 import { loadWebSearchConfig } from '../tools/web-search/config.ts';
-import { executeOperationToText, maxResultsForContextSize, parseWebSearchOperations, startBatchFetch, type WebSearchExecutionSession, type WebSearchFilters } from '../tools/web-search/operations.ts';
+import { assertLocalWebSearchSupport, executeOperationToText, maxResultsForContextSize, parseWebSearchOperations, startBatchFetch, type WebSearchExecutionSession, type WebSearchFilters } from '../tools/web-search/operations.ts';
 import { resolveConfiguredWebSearchProvider } from '../tools/web-search/provider.ts';
 import type { ConfiguredWebSearchProvider } from '../tools/web-search/types.ts';
 
 const domainListSchema = z.array(z.string());
 
-// `filters` / `user_location` / `search_context_size` are the only settings
-// that steer command execution; `looseObject` keeps the request tolerant of
-// the settings a real backend would read but we don't (`image_settings`,
-// `allowed_callers`, `external_web_access`).
+// This is OpenAI Codex's complete SearchSettings shape. The loose object keeps
+// future fields intact for passthrough; local providers consume the routing
+// fields they implement while accepting Codex metadata such as allowed_callers.
+// https://github.com/openai/codex/blob/2f19a57704fb7b1db032bc38cf995034254eaebb/codex-rs/codex-api/src/search.rs#L215-L295
 const searchSettingsSchema = z.looseObject({
   filters: z.looseObject({
     allowed_domains: domainListSchema.optional(),
     blocked_domains: domainListSchema.optional(),
   }).optional(),
   user_location: z.looseObject({
+    type: z.literal('approximate').optional(),
     city: z.string().optional(),
     region: z.string().optional(),
     country: z.string().optional(),
     timezone: z.string().optional(),
   }).optional(),
   search_context_size: z.enum(['low', 'medium', 'high']).optional(),
+  image_settings: z.looseObject({
+    max_results: z.number().int().nonnegative().optional(),
+    caption: z.boolean().optional(),
+  }).optional(),
+  allowed_callers: z.array(z.enum(['direct', 'shell', 'code_interpreter'])).optional(),
+  external_web_access: z.union([
+    z.boolean(),
+    z.enum(['cached', 'indexed', 'live']),
+  ]).optional(),
 });
 
 // `commands` is validated only as "an object" — the per-kind arrays are
-// parsed and diagnosed by `parseWebSearchOperations`, which already emits
-// deterministic text for missing args, non-URL refs, wrong-typed keys, and
-// unsupported command kinds. `looseObject` preserves the unimplemented keys
-// so they reach that parser as unsupported ops.
+// parsed by the shared command engine. `looseObject` preserves every OpenAI
+// command and nested parameter so passthrough stays lossless and the local
+// capability gate can reject unimplemented fields explicitly.
 const alphaSearchRequestSchema = z.looseObject({
   commands: z.looseObject({}).optional(),
   settings: searchSettingsSchema.optional(),
@@ -96,6 +105,8 @@ const alphaSearch = async (c: CtxWithJson<typeof alphaSearchRequestSchema>): Pro
     return relayFetchedResponse(response);
   }
 
+  assertLocalWebSearchSupport(body.commands ?? {});
+
   let configuredProvider: Promise<ConfiguredWebSearchProvider> | undefined;
   const session: WebSearchExecutionSession = {
     getProvider: () => {
@@ -121,8 +132,8 @@ const alphaSearch = async (c: CtxWithJson<typeof alphaSearchRequestSchema>): Pro
 
   // One batched provider.fetchPage covers every open/find URL; each op then
   // renders its own text block. The shared parser's canonical order is
-  // search_query → open → find → unsupported keys, preserving array order
-  // within each command kind.
+  // search_query → open → find, preserving array order within each command
+  // kind.
   const batch = await startBatchFetch(parsed, session);
   const blocks = await Promise.all(parsed.ops.map(op => executeOperationToText(op, session, batch)));
 

--- a/packages/gateway/src/data-plane/alpha-search/routes.ts
+++ b/packages/gateway/src/data-plane/alpha-search/routes.ts
@@ -25,7 +25,7 @@ import { getRuntimeLocation } from '../../runtime/runtime-info.ts';
 import { relayFetchedResponse } from '../tools/web-search/alpha-search/relay-response.ts';
 import { resolveAlphaSearchDispatcher } from '../tools/web-search/alpha-search/upstream.ts';
 import { loadWebSearchConfig } from '../tools/web-search/config.ts';
-import { assertLocalWebSearchSupport, executeOperationToText, maxResultsForContextSize, parseWebSearchOperations, startBatchFetch, type WebSearchExecutionSession, type WebSearchFilters } from '../tools/web-search/operations.ts';
+import { assertLocalWebSearchSupport, executeOperationToText, maxResultsForContextSize, parseWebSearchOperations, startBatchFetch, UnsupportedLocalWebSearchFeatureError, type WebSearchExecutionSession, type WebSearchFilters } from '../tools/web-search/operations.ts';
 import { resolveConfiguredWebSearchProvider } from '../tools/web-search/provider.ts';
 import type { ConfiguredWebSearchProvider } from '../tools/web-search/types.ts';
 
@@ -105,7 +105,14 @@ const alphaSearch = async (c: CtxWithJson<typeof alphaSearchRequestSchema>): Pro
     return relayFetchedResponse(response);
   }
 
-  assertLocalWebSearchSupport(body.commands ?? {});
+  try {
+    assertLocalWebSearchSupport(body.commands ?? {});
+  } catch (error) {
+    if (error instanceof UnsupportedLocalWebSearchFeatureError) {
+      return c.json({ encrypted_output: null, output: error.message });
+    }
+    throw error;
+  }
 
   let configuredProvider: Promise<ConfiguredWebSearchProvider> | undefined;
   const session: WebSearchExecutionSession = {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -6,6 +6,7 @@ import { loadWebSearchConfig } from '../../../../tools/web-search/config.ts';
 import { normalizeDomainEntry } from '../../../../tools/web-search/domain-normalize.ts';
 import {
   actionSearchQueries,
+  assertLocalWebSearchSupport,
   CONTEXT_SIZE_TO_MAX_RESULTS,
   DEFAULT_SEARCH_CONTEXT_SIZE,
   executeOperationToIr,
@@ -52,18 +53,18 @@ const formatUserLocation = (loc: NonNullable<WebSearchFilters['userLocation']>):
   return joined.length === 0 ? `(timezone: ${loc.timezone})` : `${joined} (timezone: ${loc.timezone})`;
 };
 
-// `web.run` shim call shape: 13 sub-properties on a single tool. The
-// shim implements 3 (`search_query`, `open`, `find`); the other 10
-// surface as per-entry error IRs at dispatch time. The description
-// deliberately omits the unsupported ones.
-//   https://github.com/openai/harmony/blob/abd677f7ac962629c808197caa1feb9e3e95d2b0/src/chat.rs#L259-L313
-const buildShimFunctionTool = (
+// The injected function mirrors the complete command object accepted by
+// OpenAI's alpha-search endpoint. Alpha passthrough can execute every field;
+// local Tavily, Jina, and Microsoft Grounding execution rejects the fields it
+// cannot implement before dispatch.
+// https://github.com/openai/codex/blob/2f19a57704fb7b1db032bc38cf995034254eaebb/codex-rs/codex-api/src/search.rs#L31-L213
+export const buildShimFunctionTool = (
   canonical: ResponsesHostedTool,
   name: string,
 ): ResponsesFunctionTool => {
   const userLocation = canonical.user_location;
   const baseDescription
-    = 'Accesses the web through three actions: searching, opening a page, and finding text inside a page. '
+    = 'Accesses OpenAI web search through text and image search, page navigation, screenshots, finance, weather, sports, and time operations. '
     + 'Multiple sub-property arrays may be populated in one call to dispatch several operations in parallel.';
   const hasUserLocation = userLocation !== undefined && (
     (userLocation.city !== undefined && userLocation.city.length > 0)
@@ -89,6 +90,22 @@ const buildShimFunctionTool = (
             type: 'object',
             properties: {
               q: { type: 'string', description: 'The search query.' },
+              recency: { type: 'integer', minimum: 0, description: 'Limit results to this many recent days.' },
+              domains: { type: 'array', items: { type: 'string' }, description: 'Limit results to these domains.' },
+            },
+            required: ['q'],
+            additionalProperties: false,
+          },
+        },
+        image_query: {
+          type: 'array',
+          description: 'Run one or more image searches.',
+          items: {
+            type: 'object',
+            properties: {
+              q: { type: 'string', description: 'The image search query.' },
+              recency: { type: 'integer', minimum: 0, description: 'Limit results to this many recent days.' },
+              domains: { type: 'array', items: { type: 'string' }, description: 'Limit results to these domains.' },
             },
             required: ['q'],
             additionalProperties: false,
@@ -100,9 +117,23 @@ const buildShimFunctionTool = (
           items: {
             type: 'object',
             properties: {
-              ref_id: { type: 'string', description: 'An HTTP or HTTPS URL.' },
+              ref_id: { type: 'string', description: 'A result reference id or HTTP(S) URL.' },
+              lineno: { type: 'integer', minimum: 0, description: 'Line number at which to position the page.' },
             },
             required: ['ref_id'],
+            additionalProperties: false,
+          },
+        },
+        click: {
+          type: 'array',
+          description: 'Open numbered links from previously opened pages.',
+          items: {
+            type: 'object',
+            properties: {
+              ref_id: { type: 'string', description: 'Reference id of the page containing the link.' },
+              id: { type: 'integer', minimum: 0, description: 'Numbered link id.' },
+            },
+            required: ['ref_id', 'id'],
             additionalProperties: false,
           },
         },
@@ -118,6 +149,84 @@ const buildShimFunctionTool = (
             required: ['ref_id', 'pattern'],
             additionalProperties: false,
           },
+        },
+        screenshot: {
+          type: 'array',
+          description: 'Take screenshots of PDF pages.',
+          items: {
+            type: 'object',
+            properties: {
+              ref_id: { type: 'string', description: 'Reference id or URL of the PDF.' },
+              pageno: { type: 'integer', minimum: 0, description: 'Zero-indexed PDF page number.' },
+            },
+            required: ['ref_id', 'pageno'],
+            additionalProperties: false,
+          },
+        },
+        finance: {
+          type: 'array',
+          description: 'Look up market prices for financial assets.',
+          items: {
+            type: 'object',
+            properties: {
+              ticker: { type: 'string', description: 'Ticker symbol.' },
+              type: { type: 'string', enum: ['equity', 'fund', 'crypto', 'index'], description: 'Asset type.' },
+              market: { type: 'string', description: 'ISO 3166-1 alpha-3 country code, OTC, or an empty string for cryptocurrency.' },
+            },
+            required: ['ticker', 'type'],
+            additionalProperties: false,
+          },
+        },
+        weather: {
+          type: 'array',
+          description: 'Look up weather forecasts.',
+          items: {
+            type: 'object',
+            properties: {
+              location: { type: 'string', description: 'Location in Country, Area, City format.' },
+              start: { type: 'string', description: 'Start date in YYYY-MM-DD format.' },
+              duration: { type: 'integer', minimum: 0, description: 'Number of forecast days.' },
+            },
+            required: ['location'],
+            additionalProperties: false,
+          },
+        },
+        sports: {
+          type: 'array',
+          description: 'Look up sports schedules and standings.',
+          items: {
+            type: 'object',
+            properties: {
+              tool: { type: 'string', enum: ['sports'] },
+              fn: { type: 'string', enum: ['schedule', 'standings'] },
+              league: { type: 'string', enum: ['nba', 'wnba', 'nfl', 'nhl', 'mlb', 'epl', 'ncaamb', 'ncaawb', 'ipl'] },
+              team: { type: 'string' },
+              opponent: { type: 'string' },
+              date_from: { type: 'string', description: 'Start date in YYYY-MM-DD format.' },
+              date_to: { type: 'string', description: 'End date in YYYY-MM-DD format.' },
+              num_games: { type: 'integer', minimum: 0 },
+              locale: { type: 'string' },
+            },
+            required: ['fn', 'league'],
+            additionalProperties: false,
+          },
+        },
+        time: {
+          type: 'array',
+          description: 'Get the time at one or more UTC offsets.',
+          items: {
+            type: 'object',
+            properties: {
+              utc_offset: { type: 'string', description: 'UTC offset formatted like +03:00.' },
+            },
+            required: ['utc_offset'],
+            additionalProperties: false,
+          },
+        },
+        response_length: {
+          type: 'string',
+          enum: ['short', 'medium', 'long'],
+          description: 'Requested search response length.',
         },
       },
       additionalProperties: false,
@@ -149,14 +258,33 @@ export const isHostedWebSearchTool = (tool: ResponsesTool): tool is ResponsesHos
 export const canonicalizeWebSearchTool = (raw: ResponsesTool): ResponsesHostedTool | undefined => {
   if (!isHostedWebSearchTool(raw)) return undefined;
   const canonical: ResponsesHostedTool = {
+    ...raw,
     type: raw.type,
     search_context_size: raw.search_context_size ?? DEFAULT_SEARCH_CONTEXT_SIZE,
     search_content_types: raw.search_content_types ?? ['text'],
     return_token_budget: raw.return_token_budget ?? 'default',
   };
-  if (raw.filters !== undefined) canonical.filters = raw.filters;
-  if (raw.user_location !== undefined) canonical.user_location = raw.user_location;
   return canonical;
+};
+
+const ALPHA_SEARCH_SETTING_KEYS = [
+  'user_location',
+  'search_context_size',
+  'filters',
+  'image_settings',
+  'allowed_callers',
+  'external_web_access',
+] as const satisfies readonly (keyof ResponsesHostedTool)[];
+
+export const alphaSearchSettingsFromHosted = (
+  hosted: ResponsesHostedTool | undefined,
+): Record<string, unknown> => {
+  if (hosted === undefined) return {};
+  const settings: Record<string, unknown> = {};
+  for (const key of ALPHA_SEARCH_SETTING_KEYS) {
+    if (hosted[key] !== undefined) settings[key] = hosted[key];
+  }
+  return settings;
 };
 
 const extractFilters = (tool: ResponsesHostedTool): WebSearchFilters => {
@@ -504,6 +632,12 @@ const planShimSlots = (
     return { id: synthesizeWebSearchCallId(), promise: state.executeAlpha(commands, action) };
   }
 
+  try {
+    assertLocalWebSearchSupport(commands);
+  } catch (error) {
+    return { id: synthesizeWebSearchCallId(), promise: Promise.reject(error) };
+  }
+
   // Multi-`search_query` entries collapse into one wsc with a multi-query
   // action (`{type:'search', queries:[...]}`) — protocol-native and the
   // only same-kind shape that fits in one wsc. Require every entry to
@@ -563,6 +697,8 @@ export const webSearchServerTool: ServerToolRegistration = async (invocation, ga
   const webSearchConfig = await loadWebSearchConfig();
   const includeArray = Array.isArray(invocation.payload.include) ? invocation.payload.include : [];
   let configuredProvider: Promise<ConfiguredWebSearchProvider> | undefined;
+  const hosted = tools.filter(isHostedWebSearchTool).at(-1);
+  const settings = alphaSearchSettingsFromHosted(hosted);
   const state: ShimState = {
     filters,
     pageCache: new Map(),
@@ -583,12 +719,6 @@ export const webSearchServerTool: ServerToolRegistration = async (invocation, ga
       runtimeLocation: gatewayCtx.runtimeLocation,
     });
     const sessionId = crypto.randomUUID();
-    const hosted = tools.filter(isHostedWebSearchTool).at(-1);
-    const settings: Record<string, unknown> = {
-      ...(hosted?.search_context_size === undefined ? {} : { search_context_size: hosted.search_context_size }),
-      ...(hosted?.filters === undefined ? {} : { filters: hosted.filters }),
-      ...(hosted?.user_location === undefined ? {} : { user_location: hosted.user_location }),
-    };
     state.executeAlpha = async (commands, action) => await executeAlphaSearch({
       dispatcher: await dispatcher,
       sessionId,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -17,6 +17,8 @@ import {
   runBackendSearchMulti,
   schemaErrorIr,
   startBatchFetch,
+  UnsupportedLocalWebSearchFeatureError,
+  unsupportedLocalWebSearchFeatureIr,
   type ParsedWebSearchOperations,
   type WebSearchCallIR,
   type WebSearchExecutionSession,
@@ -636,6 +638,15 @@ const planShimSlots = (
   try {
     assertLocalWebSearchSupport(commands);
   } catch (error) {
+    if (error instanceof UnsupportedLocalWebSearchFeatureError) {
+      return {
+        id: synthesizeWebSearchCallId(),
+        resolve: async () => unsupportedLocalWebSearchFeatureIr(
+          { type: 'search', query: Object.keys(commands).join(', ') },
+          error.message,
+        ),
+      };
+    }
     return {
       id: synthesizeWebSearchCallId(),
       resolve: async () => { throw error; },

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -591,30 +591,31 @@ const planShimSlots = (
   toolName: string,
   state: ShimState,
   loopState: ServerToolLoopState,
-): { id: string; promise: Promise<WebSearchCallIR> } => {
+): { id: string; resolve: () => Promise<WebSearchCallIR> } => {
   if (loopState.iterationCount > ITERATION_CAP) {
     return {
       id: synthesizeWebSearchCallId(),
-      promise: Promise.resolve(schemaErrorIr(
+      resolve: async () => schemaErrorIr(
         'tool budget exhausted',
         'Tool call budget exhausted',
         `Web search iteration limit (${ITERATION_CAP}) reached. Further web_search calls in this response will return this same error. Summarize what you have already learned, and continue the task using other available tools (shell, file inspection, prior knowledge) or directly answer based on what you've gathered.`,
-      )),
+      ),
     };
   }
 
   if (parsed.kind === 'malformed' || parsed.ops.length === 0) {
     return {
       id: synthesizeWebSearchCallId(),
-      promise: Promise.resolve(schemaErrorIr(
+      resolve: async () => schemaErrorIr(
         'malformed shim call arguments',
         'Malformed arguments',
         'Error: arguments must be a JSON object with sub-property arrays (search_query[], open[], find[]).',
-      )),
+      ),
     };
   }
 
-  if (state.executeAlpha !== undefined) {
+  const executeAlpha = state.executeAlpha;
+  if (executeAlpha !== undefined) {
     const first = parsed.ops[0];
     let action: ResponsesWebSearchAction;
     if (first.kind === 'search') {
@@ -629,13 +630,16 @@ const planShimSlots = (
     } else {
       action = { type: 'search', query: Object.keys(commands).join(', ') };
     }
-    return { id: synthesizeWebSearchCallId(), promise: state.executeAlpha(commands, action) };
+    return { id: synthesizeWebSearchCallId(), resolve: async () => await executeAlpha(commands, action) };
   }
 
   try {
     assertLocalWebSearchSupport(commands);
   } catch (error) {
-    return { id: synthesizeWebSearchCallId(), promise: Promise.reject(error) };
+    return {
+      id: synthesizeWebSearchCallId(),
+      resolve: async () => { throw error; },
+    };
   }
 
   // Multi-`search_query` entries collapse into one wsc with a multi-query
@@ -647,7 +651,7 @@ const planShimSlots = (
     const searchOps = parsed.ops as Array<Extract<WebSearchOperation, { kind: 'search' }>>;
     return {
       id: synthesizeWebSearchCallId(),
-      promise: runBackendSearchMulti(searchOps, state),
+      resolve: async () => await runBackendSearchMulti(searchOps, state),
     };
   }
 
@@ -658,19 +662,19 @@ const planShimSlots = (
   if (parsed.ops.length > 1) {
     return {
       id: synthesizeWebSearchCallId(),
-      promise: Promise.resolve(schemaErrorIr(
+      resolve: async () => schemaErrorIr(
         'ambiguous shim call',
         'Ambiguous tool call',
         `Error: ambiguous \`${toolName}\` tool call — each function_call maps to one web_search_call. `
         + 'Multiple `search_query` entries are fine (they collapse into one search). '
         + 'For `open`/`find`, or any mix of kinds, split into one call per `open[]` entry, `find[]` entry, or `search_query[]` batch.',
-      )),
+      ),
     };
   }
 
   return {
     id: synthesizeWebSearchCallId(),
-    promise: startBatchFetch(parsed, state).then(batch => executeOperationToIr(parsed.ops[0], state, batch)),
+    resolve: async () => await executeOperationToIr(parsed.ops[0], state, await startBatchFetch(parsed, state)),
   };
 };
 
@@ -762,7 +766,7 @@ export const webSearchServerTool: ServerToolRegistration = async (invocation, ga
                   { type: 'response.web_search_call.searching' },
                 ],
                 run: async function* run() {
-                  const ir = await slot.promise;
+                  const ir = await slot.resolve();
                   // `results` is gated on the client's `include`
                   // opt-in to match native Responses' default wire
                   // shape; the IR keeps them either way for the

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tools/web-search.ts
@@ -587,6 +587,18 @@ interface ShimState extends WebSearchExecutionSession {
 
 const ITERATION_CAP = 30;
 
+const eagerResolver = <T>(promise: Promise<T>): (() => Promise<T>) => {
+  const settled = promise.then(
+    value => ({ ok: true as const, value }),
+    error => ({ ok: false as const, error }),
+  );
+  return async () => {
+    const result = await settled;
+    if (result.ok) return result.value;
+    throw result.error;
+  };
+};
+
 const planShimSlots = (
   parsed: ParsedWebSearchOperations,
   commands: Record<string, unknown>,
@@ -632,7 +644,7 @@ const planShimSlots = (
     } else {
       action = { type: 'search', query: Object.keys(commands).join(', ') };
     }
-    return { id: synthesizeWebSearchCallId(), resolve: async () => await executeAlpha(commands, action) };
+    return { id: synthesizeWebSearchCallId(), resolve: eagerResolver(executeAlpha(commands, action)) };
   }
 
   try {
@@ -662,7 +674,7 @@ const planShimSlots = (
     const searchOps = parsed.ops as Array<Extract<WebSearchOperation, { kind: 'search' }>>;
     return {
       id: synthesizeWebSearchCallId(),
-      resolve: async () => await runBackendSearchMulti(searchOps, state),
+      resolve: eagerResolver(runBackendSearchMulti(searchOps, state)),
     };
   }
 
@@ -685,7 +697,7 @@ const planShimSlots = (
 
   return {
     id: synthesizeWebSearchCallId(),
-    resolve: async () => await executeOperationToIr(parsed.ops[0], state, await startBatchFetch(parsed, state)),
+    resolve: eagerResolver(startBatchFetch(parsed, state).then(async batch => await executeOperationToIr(parsed.ops[0], state, batch))),
   };
 };
 

--- a/packages/gateway/src/data-plane/tools/web-search/alpha-search/execution.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/alpha-search/execution.ts
@@ -2,6 +2,20 @@ import type { AlphaSearchDispatcher } from './upstream.ts';
 import type { WebSearchCallIR } from '../operations.ts';
 import type { ResponsesInputItem, ResponsesWebSearchAction } from '@floway-dev/protocols/responses';
 
+const upstreamErrorMessage = (raw: string): string | undefined => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== 'object') return undefined;
+  const error = (parsed as { error?: unknown }).error;
+  if (error === null || typeof error !== 'object') return undefined;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message : undefined;
+};
+
 export const executeAlphaSearch = async ({
   dispatcher,
   sessionId,
@@ -26,7 +40,9 @@ export const executeAlphaSearch = async ({
     settings,
   }, signal, new Headers());
   const raw = await response.text();
-  if (!response.ok) throw new Error(`OpenAI search upstream returned HTTP ${response.status}: ${raw.slice(0, 512)}`);
+  if (!response.ok) {
+    throw new Error(upstreamErrorMessage(raw) ?? `OpenAI search upstream returned HTTP ${response.status}: ${raw}`);
+  }
 
   let parsed: unknown;
   try {

--- a/packages/gateway/src/data-plane/tools/web-search/alpha-search/execution.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/alpha-search/execution.ts
@@ -1,8 +1,13 @@
 import type { AlphaSearchDispatcher } from './upstream.ts';
-import type { WebSearchCallIR } from '../operations.ts';
+import { type WebSearchCallIR, UNSUPPORTED_LOCAL_WEB_SEARCH_FEATURE_ERROR_NAME, unsupportedLocalWebSearchFeatureIr } from '../operations.ts';
 import type { ResponsesInputItem, ResponsesWebSearchAction } from '@floway-dev/protocols/responses';
 
-const upstreamErrorMessage = (raw: string): string | undefined => {
+interface UpstreamErrorDetails {
+  message: string;
+  name?: string;
+}
+
+const upstreamErrorDetails = (raw: string): UpstreamErrorDetails | undefined => {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -12,8 +17,12 @@ const upstreamErrorMessage = (raw: string): string | undefined => {
   if (parsed === null || typeof parsed !== 'object') return undefined;
   const error = (parsed as { error?: unknown }).error;
   if (error === null || typeof error !== 'object') return undefined;
-  const message = (error as { message?: unknown }).message;
-  return typeof message === 'string' ? message : undefined;
+  const { message, name } = error as { message?: unknown; name?: unknown };
+  if (typeof message !== 'string') return undefined;
+  return {
+    message,
+    ...(typeof name === 'string' ? { name } : {}),
+  };
 };
 
 export const executeAlphaSearch = async ({
@@ -41,7 +50,11 @@ export const executeAlphaSearch = async ({
   }, signal, new Headers());
   const raw = await response.text();
   if (!response.ok) {
-    throw new Error(upstreamErrorMessage(raw) ?? `OpenAI search upstream returned HTTP ${response.status}: ${raw}`);
+    const upstreamError = upstreamErrorDetails(raw);
+    if (upstreamError?.name === UNSUPPORTED_LOCAL_WEB_SEARCH_FEATURE_ERROR_NAME) {
+      return unsupportedLocalWebSearchFeatureIr(action, upstreamError.message);
+    }
+    throw new Error(upstreamError?.message ?? `OpenAI search upstream returned HTTP ${response.status}: ${raw}`);
   }
 
   let parsed: unknown;

--- a/packages/gateway/src/data-plane/tools/web-search/operations.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/operations.ts
@@ -123,6 +123,51 @@ const missingArgError = (field: string): string =>
 
 const SUPPORTED_KEYS: ReadonlySet<string> = new Set(['search_query', 'open', 'find']);
 
+const LOCAL_SUPPORTED_COMMAND_FIELDS: Readonly<Record<'search_query' | 'open' | 'find', ReadonlySet<string>>> = {
+  search_query: new Set(['q']),
+  open: new Set(['ref_id']),
+  find: new Set(['ref_id', 'pattern']),
+};
+
+export class UnsupportedLocalWebSearchFeatureError extends Error {
+  constructor(path: string) {
+    super(`The configured web search provider does not implement OpenAI search feature \`${path}\`.`);
+    this.name = 'UnsupportedLocalWebSearchFeatureError';
+  }
+}
+
+const assertObjectHasOnly = (
+  value: unknown,
+  allowed: ReadonlySet<string>,
+  path: string,
+): void => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return;
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new UnsupportedLocalWebSearchFeatureError(`${path}.${key}`);
+  }
+};
+
+// The local Tavily, Jina, and Microsoft Grounding adapters implement the
+// common text-search/open/find subset. OpenAI's complete command object remains
+// valid for alpha-search passthrough; reaching a local adapter with any other
+// command or nested command parameter is an explicit error so no request field
+// disappears.
+//
+// OpenAI Codex source of truth for SearchCommands:
+// https://github.com/openai/codex/blob/2f19a57704fb7b1db032bc38cf995034254eaebb/codex-rs/codex-api/src/search.rs#L31-L213
+export const assertLocalWebSearchSupport = (
+  commands: Record<string, unknown>,
+): void => {
+  for (const [key, value] of Object.entries(commands)) {
+    if (!SUPPORTED_KEYS.has(key)) throw new UnsupportedLocalWebSearchFeatureError(`commands.${key}`);
+    if (!Array.isArray(value)) continue;
+    const allowed = LOCAL_SUPPORTED_COMMAND_FIELDS[key as keyof typeof LOCAL_SUPPORTED_COMMAND_FIELDS];
+    for (let index = 0; index < value.length; index++) {
+      assertObjectHasOnly(value[index], allowed, `commands.${key}[${index}]`);
+    }
+  }
+};
+
 const stringField = (entry: unknown, key: string): string => {
   if (entry === null || typeof entry !== 'object') return '';
   const value = (entry as Record<string, unknown>)[key];
@@ -329,8 +374,8 @@ const searchFailedText = (providerMessage: string): string =>
 const openFailedText = (url: string, providerMessage: string): string =>
   `Error fetching URL \`${url}\`: ${providerMessage}`;
 
-const unsupportedOperationText = (subProperty: string): string =>
-  `Error: the \`${subProperty}\` sub-property is not supported by this gateway. Only \`search_query\`, \`open\`, and \`find\` are available.`;
+const unsupportedOperationError = (subProperty: string): UnsupportedLocalWebSearchFeatureError =>
+  new UnsupportedLocalWebSearchFeatureError(`commands.${subProperty}`);
 
 const wrongTypeOperationText = (subProperty: string, actualType: string): string =>
   `Error: the \`${subProperty}\` sub-property must be an array of objects; got ${actualType}.`;
@@ -793,9 +838,9 @@ const runBackendFind = async (
 };
 
 // Execute one operation into its `web_search_call` IR. `search`/`open`/
-// `find` hit the backend (open/find read the pre-issued batch map);
-// `unsupported`/`wrong-type` encode a diagnostic search IR so a Responses
-// wire item still parses.
+// `find` hit the backend (open/find read the pre-issued batch map). An
+// unsupported OpenAI command is a capability error; malformed supported
+// commands remain model-visible diagnostic IR.
 export const executeOperationToIr = (
   op: WebSearchOperation,
   session: WebSearchExecutionSession,
@@ -809,11 +854,7 @@ export const executeOperationToIr = (
   case 'find':
     return runBackendFind(op, batch);
   case 'unsupported':
-    return Promise.resolve(schemaErrorIr(
-      `unsupported action: ${op.subProperty}[${op.arrayIndex}]`,
-      'Unsupported action',
-      unsupportedOperationText(op.subProperty),
-    ));
+    return Promise.reject(unsupportedOperationError(op.subProperty));
   case 'wrong-type':
     return Promise.resolve(schemaErrorIr(
       `wrong-type sub-property: ${op.subProperty}`,
@@ -824,8 +865,8 @@ export const executeOperationToIr = (
 };
 
 // Execute one operation and render its model-visible text directly. The
-// Codex `/alpha/search` endpoint consumes only text, so `unsupported` /
-// `wrong-type` render as their bare diagnostic rather than the IR-wrapped
+// Codex `/alpha/search` endpoint consumes only text, so malformed supported
+// commands render as their bare diagnostic rather than the IR-wrapped
 // "Search results for …" form the Responses wire item needs.
 export const executeOperationToText = async (
   op: WebSearchOperation,
@@ -834,7 +875,7 @@ export const executeOperationToText = async (
 ): Promise<string> => {
   switch (op.kind) {
   case 'unsupported':
-    return unsupportedOperationText(op.subProperty);
+    throw unsupportedOperationError(op.subProperty);
   case 'wrong-type':
     return wrongTypeOperationText(op.subProperty, op.actualType);
   default: {

--- a/packages/gateway/src/data-plane/tools/web-search/operations.ts
+++ b/packages/gateway/src/data-plane/tools/web-search/operations.ts
@@ -129,10 +129,12 @@ const LOCAL_SUPPORTED_COMMAND_FIELDS: Readonly<Record<'search_query' | 'open' | 
   find: new Set(['ref_id', 'pattern']),
 };
 
+export const UNSUPPORTED_LOCAL_WEB_SEARCH_FEATURE_ERROR_NAME = 'UnsupportedLocalWebSearchFeatureError';
+
 export class UnsupportedLocalWebSearchFeatureError extends Error {
   constructor(path: string) {
     super(`The configured web search provider does not implement OpenAI search feature \`${path}\`.`);
-    this.name = 'UnsupportedLocalWebSearchFeatureError';
+    this.name = UNSUPPORTED_LOCAL_WEB_SEARCH_FEATURE_ERROR_NAME;
   }
 }
 
@@ -354,6 +356,15 @@ export const schemaErrorIr = (
 ): WebSearchCallIR => ({
   action: { type: 'search', query: queryLabel, queries: [queryLabel] },
   results: [{ type: 'text_result', url: '', title, snippet }],
+});
+
+export const unsupportedLocalWebSearchFeatureIr = (
+  action: ResponsesWebSearchAction,
+  message: string,
+): WebSearchCallIR => ({
+  action,
+  results: [{ type: 'text_result', url: '', title: 'Unsupported search feature', snippet: message }],
+  outputText: message,
 });
 
 // ── Error / not-supported text ──

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -196,6 +196,7 @@ export interface ResponsesFunctionToolCallItem {
   id?: string;
   call_id: string;
   name: string;
+  namespace?: string;
   arguments: string;
   status: 'completed' | 'in_progress' | 'incomplete';
   caller?: ResponsesToolCaller | null;
@@ -941,6 +942,7 @@ export interface ResponsesOutputFunctionCall {
   id?: string;
   call_id: string;
   name: string;
+  namespace?: string;
   arguments: string;
   status: string;
   caller?: ResponsesToolCaller | null;

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -657,13 +657,22 @@ export interface ResponsesHostedTool {
     blocked_domains?: string[];
   };
   user_location?: {
+    type?: 'approximate';
     city?: string;
     region?: string;
     country?: string;
     timezone?: string;
   };
   search_context_size?: 'low' | 'medium' | 'high';
-  external_web_access?: boolean;
+  // Settings forwarded when the hosted tool is executed through Codex's
+  // standalone `/alpha/search` API.
+  // https://github.com/openai/codex/blob/2f19a57704fb7b1db032bc38cf995034254eaebb/codex-rs/codex-api/src/search.rs#L215-L295
+  external_web_access?: boolean | 'cached' | 'indexed' | 'live';
+  image_settings?: {
+    max_results?: number;
+    caption?: boolean;
+  };
+  allowed_callers?: Array<'direct' | 'shell' | 'code_interpreter'>;
   search_content_types?: string[];
   return_token_budget?: 'default' | 'unlimited';
   name?: string;

--- a/packages/translate/__tests__/responses-via-messages/events_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/events_test.ts
@@ -768,6 +768,34 @@ test('synthesized function_call item carries a stable id consistent across added
   ]);
 });
 
+test('flattened namespace tool calls recover their source Responses name', () => {
+  const state = createMessagesToResponsesStreamState(
+    'resp_test',
+    'claude-test',
+    new Set(),
+    new Map([['web_run', 'web.run']]),
+  );
+
+  translateMessagesEventToResponsesEvents(
+    { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'toolu_web', name: 'web_run', input: {} } } as MessagesStreamEvent,
+    state,
+  );
+  translateMessagesEventToResponsesEvents(
+    { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"search_query":[]}' } } as MessagesStreamEvent,
+    state,
+  );
+  translateMessagesEventToResponsesEvents(
+    { type: 'content_block_stop', index: 0 } as MessagesStreamEvent,
+    state,
+  );
+
+  const [item] = state.completedItems;
+  assertEquals(item.type, 'function_call');
+  if (item.type !== 'function_call') throw new Error('expected function_call');
+  assertEquals(item.name, 'web.run');
+  assertEquals(item.arguments, '{"search_query":[]}');
+});
+
 // ── speed / service_tier pass-through ──
 
 test('Anthropic speed:fast maps to service_tier:fast on the Responses result', () => {

--- a/packages/translate/__tests__/responses-via-messages/events_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/events_test.ts
@@ -773,7 +773,7 @@ test('flattened namespace tool calls recover their source Responses name', () =>
     'resp_test',
     'claude-test',
     new Set(),
-    new Map([['web_run', 'web.run']]),
+    new Map([['web_run', { namespace: 'web', name: 'run' }]]),
   );
 
   translateMessagesEventToResponsesEvents(
@@ -792,7 +792,8 @@ test('flattened namespace tool calls recover their source Responses name', () =>
   const [item] = state.completedItems;
   assertEquals(item.type, 'function_call');
   if (item.type !== 'function_call') throw new Error('expected function_call');
-  assertEquals(item.name, 'web.run');
+  assertEquals(item.namespace, 'web');
+  assertEquals(item.name, 'run');
   assertEquals(item.arguments, '{"search_query":[]}');
 });
 

--- a/packages/translate/__tests__/responses-via-messages/request_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/request_test.ts
@@ -592,6 +592,55 @@ test('buildTargetRequest projects custom_tool_call history into wrapped tool_use
   });
 });
 
+test('buildTargetRequest flattens namespace functions collision-safely and maps replay history', async () => {
+  const namespaceTool: ResponsesTool = {
+    type: 'namespace',
+    name: 'web',
+    tools: [{
+      type: 'function',
+      name: 'run',
+      description: 'Access the web.',
+      parameters: { type: 'object', properties: { search_query: { type: 'array' } } },
+      strict: false,
+    }],
+  };
+  const result = await buildTargetRequest({
+    ...minimalPayload,
+    input: [
+      { type: 'message', role: 'user', content: 'search' },
+      { type: 'function_call', call_id: 'call_web', name: 'web.run', arguments: '{"search_query":[]}', status: 'completed' },
+    ],
+    tools: [
+      { type: 'function', name: 'web_run', parameters: { type: 'object' }, strict: false },
+      namespaceTool,
+    ],
+    tool_choice: { type: 'function', name: 'web.run' },
+  });
+
+  assertEquals(result.namespaceToolNames.sourceToTarget, new Map([['web.run', 'web_run_2']]));
+  assertEquals(result.namespaceToolNames.targetToSource, new Map([['web_run_2', 'web.run']]));
+  assertEquals(result.target.tools, [
+    {
+      name: 'web_run',
+      description: undefined,
+      input_schema: { type: 'object' },
+      strict: false,
+    },
+    {
+      name: 'web_run_2',
+      description: 'Access the web.',
+      input_schema: { type: 'object', properties: { search_query: { type: 'array' } } },
+      strict: false,
+      cache_control: { type: 'ephemeral' },
+    },
+  ]);
+  assertEquals(result.target.messages[1], {
+    role: 'assistant',
+    content: [{ type: 'tool_use', id: 'call_web', name: 'web_run_2', input: { search_query: [] } }],
+  });
+  assertEquals(result.target.tool_choice, { type: 'tool', name: 'web_run_2' });
+});
+
 test('buildTargetRequest keeps plain-text function_call_output as string content', async () => {
   const result = await buildTargetRequest({
     model: 'claude-test',

--- a/packages/translate/__tests__/responses-via-messages/request_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/request_test.ts
@@ -636,7 +636,13 @@ test('buildTargetRequest flattens namespace functions collision-safely and maps 
   ]);
   assertEquals(result.target.messages[1], {
     role: 'assistant',
-    content: [{ type: 'tool_use', id: 'call_web', name: 'web_run_2', input: { search_query: [] } }],
+    content: [{
+      type: 'tool_use',
+      id: 'call_web',
+      name: 'web_run_2',
+      input: { search_query: [] },
+      cache_control: { type: 'ephemeral' },
+    }],
   });
   assertEquals(result.target.tool_choice, { type: 'tool', name: 'web_run_2' });
 });

--- a/packages/translate/__tests__/responses-via-messages/request_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/request_test.ts
@@ -608,7 +608,7 @@ test('buildTargetRequest flattens namespace functions collision-safely and maps 
     ...minimalPayload,
     input: [
       { type: 'message', role: 'user', content: 'search' },
-      { type: 'function_call', call_id: 'call_web', name: 'web.run', arguments: '{"search_query":[]}', status: 'completed' },
+      { type: 'function_call', call_id: 'call_web', namespace: 'web', name: 'run', arguments: '{"search_query":[]}', status: 'completed' },
     ],
     tools: [
       { type: 'function', name: 'web_run', parameters: { type: 'object' }, strict: false },
@@ -618,7 +618,7 @@ test('buildTargetRequest flattens namespace functions collision-safely and maps 
   });
 
   assertEquals(result.namespaceToolNames.sourceToTarget, new Map([['web.run', 'web_run_2']]));
-  assertEquals(result.namespaceToolNames.targetToSource, new Map([['web_run_2', 'web.run']]));
+  assertEquals(result.namespaceToolNames.targetToSource, new Map([['web_run_2', { namespace: 'web', name: 'run' }]]));
   assertEquals(result.target.tools, [
     {
       name: 'web_run',

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -88,6 +88,7 @@ interface MessagesToResponsesStreamState {
   stopReason?: MessagesMessageDeltaEvent['delta']['stop_reason'];
   stopDetails?: MessagesRefusalStopDetails | null;
   customToolNames: ReadonlySet<string>;
+  namespaceTargetToSource: ReadonlyMap<string, string>;
 }
 
 const buildResult = (state: MessagesToResponsesStreamState, status: ResponsesResult['status']): ResponsesResult => {
@@ -197,12 +198,13 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
     }
 
     const itemId = createRandomResponsesItemId('function_call');
+    const sourceToolName = state.namespaceTargetToSource.get(event.content_block.name) ?? event.content_block.name;
     const info: OutputBlockInfo = {
       type: 'tool_use',
       outputIndex,
       itemId,
       toolCallId: event.content_block.id,
-      toolName: event.content_block.name,
+      toolName: sourceToolName,
       toolArguments: '',
     };
     state.blockMap.set(event.index, info);
@@ -352,7 +354,12 @@ const handleContentBlockStop = (event: MessagesContentBlockStopEvent, state: Mes
   return responses.functionCallDone(state, info.outputIndex, info.itemId, info.toolArguments, item);
 };
 
-export const createMessagesToResponsesStreamState = (responseId: string, model: string, customToolNames: ReadonlySet<string> = new Set()): MessagesToResponsesStreamState => ({
+export const createMessagesToResponsesStreamState = (
+  responseId: string,
+  model: string,
+  customToolNames: ReadonlySet<string> = new Set(),
+  namespaceTargetToSource: ReadonlyMap<string, string> = new Map(),
+): MessagesToResponsesStreamState => ({
   responseId,
   model,
   outputIndex: 0,
@@ -362,6 +369,7 @@ export const createMessagesToResponsesStreamState = (responseId: string, model: 
   completedItems: [],
   usage: messagesUsageSnapshot(),
   customToolNames,
+  namespaceTargetToSource,
 });
 
 export const translateMessagesEventToResponsesEvents = (event: MessagesStreamEvent, state: MessagesToResponsesStreamState): ResponsesStreamEvent[] => {
@@ -412,8 +420,9 @@ export const translateToSourceEvents = async function* (
   responseId: string,
   model: string,
   customToolNames: ReadonlySet<string> = new Set(),
+  namespaceTargetToSource: ReadonlyMap<string, string> = new Map(),
 ): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
-  const state = createMessagesToResponsesStreamState(responseId, model, customToolNames);
+  const state = createMessagesToResponsesStreamState(responseId, model, customToolNames, namespaceTargetToSource);
 
   for await (const event of upstreamMessagesEventsUntilTerminal(frames)) {
     for (const translated of translateMessagesEventToResponsesEvents(event, state)) {

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -65,6 +65,7 @@ type OutputBlockInfo =
     itemId: string;
     toolCallId: string;
     toolName: string;
+    toolNamespace?: string;
     toolArguments: string;
   }
   | {
@@ -88,7 +89,7 @@ interface MessagesToResponsesStreamState {
   stopReason?: MessagesMessageDeltaEvent['delta']['stop_reason'];
   stopDetails?: MessagesRefusalStopDetails | null;
   customToolNames: ReadonlySet<string>;
-  namespaceTargetToSource: ReadonlyMap<string, string>;
+  namespaceTargetToSource: ReadonlyMap<string, { namespace: string; name: string }>;
 }
 
 const buildResult = (state: MessagesToResponsesStreamState, status: ResponsesResult['status']): ResponsesResult => {
@@ -198,18 +199,19 @@ const handleContentBlockStart = (event: MessagesContentBlockStartEvent, state: M
     }
 
     const itemId = createRandomResponsesItemId('function_call');
-    const sourceToolName = state.namespaceTargetToSource.get(event.content_block.name) ?? event.content_block.name;
+    const sourceTool = state.namespaceTargetToSource.get(event.content_block.name);
     const info: OutputBlockInfo = {
       type: 'tool_use',
       outputIndex,
       itemId,
       toolCallId: event.content_block.id,
-      toolName: sourceToolName,
+      toolName: sourceTool?.name ?? event.content_block.name,
+      ...(sourceTool !== undefined ? { toolNamespace: sourceTool.namespace } : {}),
       toolArguments: '',
     };
     state.blockMap.set(event.index, info);
 
-    return responses.itemAdded(state, outputIndex, responses.functionCallItem(info.itemId, info.toolCallId, info.toolName, info.toolArguments, 'in_progress'));
+    return responses.itemAdded(state, outputIndex, responses.functionCallItem(info.itemId, info.toolCallId, info.toolName, info.toolArguments, 'in_progress', info.toolNamespace));
   }
   case 'fallback':
     state.model = event.content_block.to.model;
@@ -347,7 +349,7 @@ const handleContentBlockStop = (event: MessagesContentBlockStopEvent, state: Mes
     return responses.customToolCallDone(state, info.outputIndex, info.itemId, input, item);
   }
 
-  const item = responses.functionCallItem(info.itemId, info.toolCallId, info.toolName, info.toolArguments, 'completed');
+  const item = responses.functionCallItem(info.itemId, info.toolCallId, info.toolName, info.toolArguments, 'completed', info.toolNamespace);
 
   state.completedItems.push(item);
 
@@ -358,7 +360,7 @@ export const createMessagesToResponsesStreamState = (
   responseId: string,
   model: string,
   customToolNames: ReadonlySet<string> = new Set(),
-  namespaceTargetToSource: ReadonlyMap<string, string> = new Map(),
+  namespaceTargetToSource: ReadonlyMap<string, { namespace: string; name: string }> = new Map(),
 ): MessagesToResponsesStreamState => ({
   responseId,
   model,
@@ -420,7 +422,7 @@ export const translateToSourceEvents = async function* (
   responseId: string,
   model: string,
   customToolNames: ReadonlySet<string> = new Set(),
-  namespaceTargetToSource: ReadonlyMap<string, string> = new Map(),
+  namespaceTargetToSource: ReadonlyMap<string, { namespace: string; name: string }> = new Map(),
 ): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
   const state = createMessagesToResponsesStreamState(responseId, model, customToolNames, namespaceTargetToSource);
 

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -54,6 +54,10 @@ export interface TargetRequestResult {
    * `custom_tool_call` outputs.
    */
   customToolNames: Set<string>;
+  namespaceToolNames: {
+    sourceToTarget: Map<string, string>;
+    targetToSource: Map<string, string>;
+  };
 }
 
 const translateUserMessage = async (message: ResponsesInputMessage, loadRemoteImage: RemoteImageLoader): Promise<MessagesUserMessage> => {
@@ -189,7 +193,11 @@ const appendUserBlock = (messages: MessagesMessage[], block: MessagesToolResultB
   messages.push({ role: 'user', content: [block] });
 };
 
-const translateResponsesInput = async (input: ResponsesInputItem[], loadRemoteImage: RemoteImageLoader): Promise<{ messages: MessagesMessage[]; systemBlocks: MessagesTextBlock[] }> => {
+const translateResponsesInput = async (
+  input: ResponsesInputItem[],
+  loadRemoteImage: RemoteImageLoader,
+  namespaceSourceToTarget: ReadonlyMap<string, string>,
+): Promise<{ messages: MessagesMessage[]; systemBlocks: MessagesTextBlock[] }> => {
   // Hoist the leading contiguous run of system/developer input messages into
   // systemBlocks (→ top-level Messages.system), preserving each input_text
   // part as its own MessagesTextBlock so part boundaries survive the hoist.
@@ -238,7 +246,7 @@ const translateResponsesInput = async (input: ResponsesInputItem[], loadRemoteIm
       appendAssistantBlock(messages, {
         type: 'tool_use',
         id: item.call_id,
-        name: item.name,
+        name: namespaceSourceToTarget.get(item.name) ?? item.name,
         input: parseToolArgumentsObject(item.arguments),
       });
       break;
@@ -295,17 +303,46 @@ const translateResponsesInput = async (input: ResponsesInputItem[], loadRemoteIm
   return { messages, systemBlocks };
 };
 
-const translateTools = (tools: ResponsesTool[] | null | undefined, customToolNames: Set<string>): MessagesTool[] | undefined => {
-  // Translated Messages targets do not currently have a faithful bridge
-  // for hosted/deferred Responses tools (`web_search`, `tool_search`,
-  // `namespace`, `image_generation`, and future builtin names). Native
-  // Responses targets receive those entries unchanged; this translator
-  // narrows to function and Freeform `custom` tools, recording the latter
-  // in `customToolNames` so the events translator can reverse the wrap.
-  // The shim's web_search function tool reaches this code under
-  // its resolved name as an ordinary function tool — no special carve-out
-  // needed.
+const namespaceTargetName = (namespace: string, tool: string): string =>
+  `${namespace}_${tool}`.replaceAll(/[^a-zA-Z0-9_-]/g, '_');
+
+const uniqueToolName = (preferred: string, reserved: Set<string>): string => {
+  if (!reserved.has(preferred)) {
+    reserved.add(preferred);
+    return preferred;
+  }
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${preferred}_${suffix}`;
+    if (!reserved.has(candidate)) {
+      reserved.add(candidate);
+      return candidate;
+    }
+  }
+};
+
+const translateTools = (
+  tools: ResponsesTool[] | null | undefined,
+  customToolNames: Set<string>,
+): {
+  tools: MessagesTool[] | undefined;
+  namespaceToolNames: TargetRequestResult['namespaceToolNames'];
+} => {
+  // Messages has no namespace container. Flatten each namespace function to
+  // a collision-safe Messages tool name and retain a bidirectional map so
+  // request history and target events recover the source `namespace.tool`
+  // identity. Other hosted/deferred Responses tools still require their own
+  // boundary shim before this translator.
   const out: MessagesTool[] = [];
+  const namespaceToolNames: TargetRequestResult['namespaceToolNames'] = {
+    sourceToTarget: new Map(),
+    targetToSource: new Map(),
+  };
+  const reservedNames = new Set(
+    (tools ?? []).flatMap(tool =>
+      (tool.type === 'function' || tool.type === 'custom') && typeof tool.name === 'string'
+        ? [tool.name]
+        : []),
+  );
 
   for (const tool of tools ?? []) {
     if (tool.type === 'function') {
@@ -324,13 +361,51 @@ const translateTools = (tools: ResponsesTool[] | null | undefined, customToolNam
         description: tool.description,
         input_schema: buildCustomToolInputSchema(tool.format),
       });
+      continue;
+    }
+    if (tool.type !== 'namespace') continue;
+    if (typeof tool.name !== 'string' || !Array.isArray(tool.tools)) {
+      throw new TranslatorInputError('Cannot translate a namespace tool without a string name and tools array to Messages.');
+    }
+    for (const child of tool.tools) {
+      if (child === null || typeof child !== 'object' || (child as { type?: unknown }).type !== 'function') {
+        throw new TranslatorInputError(`Cannot translate non-function child in namespace '${tool.name}' to Messages.`);
+      }
+      const functionTool = child as {
+        name?: unknown;
+        description?: unknown;
+        parameters?: unknown;
+        strict?: unknown;
+      };
+      if (typeof functionTool.name !== 'string'
+        || functionTool.parameters === null
+        || typeof functionTool.parameters !== 'object'
+        || Array.isArray(functionTool.parameters)) {
+        throw new TranslatorInputError(`Cannot translate malformed function child in namespace '${tool.name}' to Messages.`);
+      }
+      const sourceName = `${tool.name}.${functionTool.name}`;
+      const targetName = uniqueToolName(namespaceTargetName(tool.name, functionTool.name), reservedNames);
+      namespaceToolNames.sourceToTarget.set(sourceName, targetName);
+      namespaceToolNames.targetToSource.set(targetName, sourceName);
+      out.push({
+        name: targetName,
+        ...(typeof functionTool.description === 'string' ? { description: functionTool.description } : {}),
+        input_schema: functionTool.parameters as Record<string, unknown>,
+        ...(typeof functionTool.strict === 'boolean' ? { strict: functionTool.strict } : {}),
+      });
     }
   }
 
-  return out.length > 0 ? out : undefined;
+  return {
+    tools: out.length > 0 ? out : undefined,
+    namespaceToolNames,
+  };
 };
 
-const translateToolChoice = (toolChoice: ResponsesToolChoice | null | undefined): MessagesPayload['tool_choice'] => {
+const translateToolChoice = (
+  toolChoice: ResponsesToolChoice | null | undefined,
+  namespaceSourceToTarget: ReadonlyMap<string, string>,
+): MessagesPayload['tool_choice'] => {
   if (!toolChoice) return undefined;
 
   if (typeof toolChoice === 'string') {
@@ -349,7 +424,7 @@ const translateToolChoice = (toolChoice: ResponsesToolChoice | null | undefined)
   // Both function and wrapped custom tools land on the target as named tool
   // choices since they share the function-tool wire shape after translation.
   if (toolChoice.type === 'function' || toolChoice.type === 'custom') {
-    return toolChoice.name ? { type: 'tool', name: toolChoice.name } : undefined;
+    return toolChoice.name ? { type: 'tool', name: namespaceSourceToTarget.get(toolChoice.name) ?? toolChoice.name } : undefined;
   }
   return undefined;
 };
@@ -358,8 +433,12 @@ export const buildTargetRequest = async (source: ResponsesRequestPayload, option
   const payload = canonicalizeResponsesPayload(source);
   rejectProgrammaticResponsesPayload(payload, 'Messages');
   const customToolNames = new Set<string>();
-  const { messages, systemBlocks: hoistedSystemBlocks } = await translateResponsesInput(payload.input, options.loadRemoteImage ?? unavailableRemoteImageLoader);
-  const tools = translateTools(payload.tools, customToolNames);
+  const { tools, namespaceToolNames } = translateTools(payload.tools, customToolNames);
+  const { messages, systemBlocks: hoistedSystemBlocks } = await translateResponsesInput(
+    payload.input,
+    options.loadRemoteImage ?? unavailableRemoteImageLoader,
+    namespaceToolNames.sourceToTarget,
+  );
   // `payload.instructions` is the Responses canonical system field; leading
   // system/developer input items contribute additional blocks immediately
   // after it. Each source — the instructions field and each leading input
@@ -409,11 +488,11 @@ export const buildTargetRequest = async (source: ResponsesRequestPayload, option
     ...(payload.top_p != null ? { top_p: payload.top_p } : {}),
     stream: true,
     tools,
-    tool_choice: translateToolChoice(payload.tool_choice),
+    tool_choice: translateToolChoice(payload.tool_choice, namespaceToolNames.sourceToTarget),
     ...(thinking ? { thinking } : {}),
     ...(hasOutputConfig ? { output_config: outputConfig } : {}),
     ...serviceTierFields,
   };
 
-  return { target, customToolNames };
+  return { target, customToolNames, namespaceToolNames };
 };

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -56,7 +56,7 @@ export interface TargetRequestResult {
   customToolNames: Set<string>;
   namespaceToolNames: {
     sourceToTarget: Map<string, string>;
-    targetToSource: Map<string, string>;
+    targetToSource: Map<string, { namespace: string; name: string }>;
   };
 }
 
@@ -242,14 +242,16 @@ const translateResponsesInput = async (
         content: agentMessageContent(item),
       }, loadRemoteImage));
       break;
-    case 'function_call':
+    case 'function_call': {
+      const sourceName = item.namespace === undefined ? item.name : `${item.namespace}.${item.name}`;
       appendAssistantBlock(messages, {
         type: 'tool_use',
         id: item.call_id,
-        name: namespaceSourceToTarget.get(item.name) ?? item.name,
+        name: namespaceSourceToTarget.get(sourceName) ?? item.name,
         input: parseToolArgumentsObject(item.arguments),
       });
       break;
+    }
     case 'function_call_output':
       appendUserBlock(messages, {
         type: 'tool_result',
@@ -386,7 +388,7 @@ const translateTools = (
       const sourceName = `${tool.name}.${functionTool.name}`;
       const targetName = uniqueToolName(namespaceTargetName(tool.name, functionTool.name), reservedNames);
       namespaceToolNames.sourceToTarget.set(sourceName, targetName);
-      namespaceToolNames.targetToSource.set(targetName, sourceName);
+      namespaceToolNames.targetToSource.set(targetName, { namespace: tool.name, name: functionTool.name });
       out.push({
         name: targetName,
         ...(typeof functionTool.description === 'string' ? { description: functionTool.description } : {}),

--- a/packages/translate/src/responses-via-messages/translate.ts
+++ b/packages/translate/src/responses-via-messages/translate.ts
@@ -14,16 +14,16 @@ export const translateResponsesViaMessages: TranslateTrip<
   { fallbackMaxOutputTokens?: number; loadRemoteImage: RemoteImageLoader }
 > = async (src, ctx) => {
   const responseId = synthesizeResponseId();
-  // customToolNames is produced inside the request translator (it sees the
-  // tools first) and read by the events translator so wrapped function calls
-  // can be projected back into `custom_tool_call` outputs.
-  const { target, customToolNames } = await buildTargetRequest(src, {
+  // Tool-name maps are produced inside the request translator (it sees the
+  // tools first) and read by the events translator so wrapped custom calls and
+  // flattened namespace calls recover their source Responses identities.
+  const { target, customToolNames, namespaceToolNames } = await buildTargetRequest(src, {
     fallbackMaxOutputTokens: ctx.fallbackMaxOutputTokens,
     loadRemoteImage: ctx.loadRemoteImage,
   });
 
   return {
     target,
-    events: frames => translateToSourceEvents(frames, responseId, ctx.model, customToolNames),
+    events: frames => translateToSourceEvents(frames, responseId, ctx.model, customToolNames, namespaceToolNames.targetToSource),
   };
 };

--- a/packages/translate/src/shared/responses-via/responses-event-builder.ts
+++ b/packages/translate/src/shared/responses-via/responses-event-builder.ts
@@ -147,11 +147,19 @@ export const reasoningItem = (id: string, summaryText: string, encryptedContent?
   ...(encryptedContent !== undefined ? { encrypted_content: encryptedContent } : {}),
 });
 
-export const functionCallItem = (id: string, callId: string, name: string, args: string, status: ResponsesOutputFunctionCall['status']): ResponsesOutputFunctionCall => ({
+export const functionCallItem = (
+  id: string,
+  callId: string,
+  name: string,
+  args: string,
+  status: ResponsesOutputFunctionCall['status'],
+  namespace?: string,
+): ResponsesOutputFunctionCall => ({
   type: 'function_call',
   id,
   call_id: callId,
   name,
+  ...(namespace !== undefined ? { namespace } : {}),
   arguments: args,
   status,
 });


### PR DESCRIPTION
## Summary

- align the hosted `web_search` shim with the complete current Codex `web.run` command shape: ten operation arrays plus `response_length`
- preserve the full supported `/alpha/search` settings shape for direct Codex or Custom upstream passthrough
- surface unsupported local-provider capabilities as exact model-visible output, including through cascaded Floway instances, while continuing to throw unknown upstream and transport failures
- bridge Responses namespace functions through Messages targets with collision-safe names and restore the original `namespace` plus `name` on returned function calls
- keep hosted-search backend work eager for accurate lifecycle timing while settling failures immediately to avoid unhandled rejections

## Research and decisions

- use the current OpenAI Codex [`SearchCommands`](https://github.com/openai/codex/blob/2f19a57704fb7b1db032bc38cf995034254eaebb/codex-rs/codex-api/src/search.rs#L31-L213) and [`SearchSettings`](https://github.com/openai/codex/blob/2f19a57704fb7b1db032bc38cf995034254eaebb/codex-rs/codex-api/src/search.rs#L215-L295) definitions as the wire source of truth
- keep alpha-search passthrough lossless; local Tavily, Jina, and Microsoft Grounding execution rejects commands or nested parameters it cannot implement
- return recognized capability failures inside the search tool contract so both GPT and Claude can reproduce the complete message; unrelated failures still propagate
- flatten namespace children only at the Responses-to-Messages boundary, then reverse the mapping on Responses events and replay history

## Live test environment

The native Codex matrix used isolated Node Floway instances, SQLite databases, Codex homes, and request-path capture. Model traffic used the production Copilot credential through its configured production proxy fallback; search traffic used the production Microsoft Grounding configuration. The cascade topology placed a front Floway Custom upstream in front of the back instance.

Codex 0.145 marks `gpt-5.6-sol` as Responses Lite, which intentionally suppresses hosted tools. The hosted Sol cases used a test-only catalog capability override (`use_responses_lite: false`) while preserving the exact `gpt-5.6-sol` wire model id. Claude and every client-owned `/alpha/search` case used their native catalog metadata.

## Test Plan

- [x] `pnpm run test` — 421 files, 4926 tests passed
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] single Floway happy path — `gpt-5.6-sol` and `claude-opus-5` each completed search + open through hosted `web_search` and client-owned `/alpha/search`
- [x] cascaded Floway happy path — the same 2 models × 2 paths completed through front → back Floway
- [x] single Floway invalid-parameter path — all 2 models × 2 paths called `search_query[].domains` and reproduced the complete error exactly
- [x] cascaded Floway invalid-parameter path — all 2 models × 2 paths reproduced the same complete error exactly through front → back Floway
- [x] path capture — hosted requests contained `type: "web_search"` with no inbound `/alpha/search`; client-owned requests contained namespace `web` and emitted `/alpha/search`
- [x] production proxy enforcement — the back instance retained only the selected production proxy fallback; every live request succeeded with no active proxy backoff
- [x] `git diff --check origin/main...HEAD`
