### PR TITLE
fix(responses): discard null-content affinity carriers

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/affinity/ingress_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/affinity/ingress_test.ts
@@ -104,7 +104,7 @@ test('removes an empty originless reasoning prefix but preserves a reasoning ite
   const prepared = await prepareResponsesAffinity({
     model: 'model',
     input: [
-      { type: 'reasoning', id: 'rs_prefix', summary: [], encrypted_content: carrier },
+      { type: 'reasoning', id: 'rs_prefix', summary: [], content: null, encrypted_content: carrier } as unknown as CanonicalResponsesPayload['input'][number],
       {
         type: 'reasoning',
         id: 'rs_visible',

--- a/packages/gateway/src/data-plane/chat/responses/affinity/ingress.ts
+++ b/packages/gateway/src/data-plane/chat/responses/affinity/ingress.ts
@@ -102,8 +102,8 @@ const isEmptyOriginlessReasoningCarrier = (
     && location.decoded.kind === 'owned'
     && location.decoded.value === undefined
     && !selected.present);
-  if (!originlessTopLevel) return false;
-  return Object.keys(item).every(key => ['type', 'id', 'summary', 'encrypted_content'].includes(key));
+  if (!originlessTopLevel || (item.content !== undefined && item.content !== null)) return false;
+  return Object.keys(item).every(key => ['type', 'id', 'summary', 'content', 'encrypted_content'].includes(key));
 };
 
 export const prepareResponsesAffinity = async (


### PR DESCRIPTION
## Summary

- recognize Codex-replayed synthetic reasoning carriers with `content: null`
- remove these originless affinity-only items before provider dispatch
- preserve reasoning items that contain summaries, non-null content, or other payload fields

## Verification

- `pnpm --filter @floway-dev/gateway exec vitest run __tests__/data-plane/chat/responses/affinity/ingress_test.ts`
- `pnpm --filter @floway-dev/gateway run typecheck`