### PR TITLE
fix: treat a deleted upstream or proxy reference as inert

### DIFF
--- a/apps/web/__tests__/components/upstreams/UpstreamPicker_test.ts
+++ b/apps/web/__tests__/components/upstreams/UpstreamPicker_test.ts
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+
+import UpstreamPicker, { type UpstreamPickerValue } from '../../../src/components/upstreams/UpstreamPicker.vue';
+import type { UpstreamOption } from '../../../src/composables/useUpstreamOptions.ts';
+
+const option = (id: string, name: string): UpstreamOption => ({ id, name, kind: 'custom', enabled: true, color: null });
+
+const mountPicker = (value: UpstreamPickerValue, available: UpstreamOption[]) => mount(UpstreamPicker, {
+  props: {
+    modelValue: value,
+    available,
+    title: 'Override Available Upstreams',
+    inheritDescription: 'When off, this key inherits the global upstream order.',
+  },
+});
+
+test('selected options lead, in the stored order, and the rest follow unselected', () => {
+  const wrapper = mountPicker({ override: true, ids: ['up_b', 'up_a'] }, [option('up_a', 'Alpha'), option('up_b', 'Bravo')]);
+  const rows = wrapper.findAll('li');
+  expect(rows.map(row => row.find('code').text())).toEqual(['up_b', 'up_a']);
+});
+
+test('an id the caller does not offer contributes no row', () => {
+  const wrapper = mountPicker({ override: true, ids: ['up_gone', 'up_a'] }, [option('up_a', 'Alpha')]);
+  const rows = wrapper.findAll('li');
+  expect(rows.map(row => row.find('code').text())).toEqual(['up_a']);
+  expect(wrapper.text()).not.toContain('up_gone');
+  expect(wrapper.text()).not.toContain('Unknown');
+});
+
+test('toggling a row rewrites the selection from the rendered rows', async () => {
+  const wrapper = mountPicker({ override: true, ids: ['up_a'] }, [option('up_a', 'Alpha'), option('up_b', 'Bravo')]);
+  // Switch 0 is the override itself; the row switches follow in render order.
+  await wrapper.findAll('button[role="switch"]')[2]!.trigger('click');
+  const emitted = wrapper.emitted('update:modelValue')!.at(-1)![0] as UpstreamPickerValue;
+  expect(emitted.ids).toEqual(['up_a', 'up_b']);
+});

--- a/apps/web/src/components/keys/EditKeyDialog.vue
+++ b/apps/web/src/components/keys/EditKeyDialog.vue
@@ -61,9 +61,15 @@ const reset = () => {
     customKey.value = '';
   } else {
     name.value = props.apiKey.name;
+    // A key keeps the ids it was created with even after an admin narrows the
+    // owning user's cap, so a stored id can fall outside what this account may
+    // route to. An empty catalog means the option list is unavailable rather
+    // than genuinely empty — an empty deployment leaves nothing to drop anyway.
+    const stored = props.apiKey.upstream_ids ?? [];
+    const offered = new Set(visibleUpstreams.value.map(upstream => upstream.id));
     upstreamSelection.value = {
       override: props.apiKey.upstream_ids !== null,
-      ids: props.apiKey.upstream_ids ?? [],
+      ids: props.upstreams.length === 0 ? [...stored] : stored.filter(id => offered.has(id)),
     };
     dumpRetention.value = props.apiKey.dump_retention_seconds;
     responsesRetention.value = props.apiKey.responses_retention_seconds;

--- a/apps/web/src/components/keys/KeysTable.vue
+++ b/apps/web/src/components/keys/KeysTable.vue
@@ -45,10 +45,9 @@ interface UpstreamsCell {
 const classifyUpstreams = (k: ApiKey): UpstreamsCell => {
   if (!k.upstream_ids) return { text: 'All', title: 'Inherits the global upstream order', class: 'text-gray-500' };
   if (k.upstream_ids.length === 0) return { text: 'None', title: 'No upstreams', class: 'text-accent-rose' };
-  const names = k.upstream_ids.map(id => upstreamById.value.get(id)?.name).filter((n): n is string => !!n);
+  const names = k.upstream_ids.map(id => upstreamById.value.get(id)?.name ?? id);
   const text = names.length <= 2 ? names.join(', ') : `${names.slice(0, 2).join(', ')} +${names.length - 2}`;
-  const title = k.upstream_ids.map(id => upstreamById.value.get(id)?.name ?? id).join('\n');
-  return { text, title, class: 'text-accent-cyan' };
+  return { text, title: names.join('\n'), class: 'text-accent-cyan' };
 };
 
 const rows = computed(() => props.keys.map(key => ({ key, upstreams: classifyUpstreams(key) })));

--- a/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
+++ b/apps/web/src/components/upstream-edit/ProxyFallbackListPanel.vue
@@ -60,19 +60,14 @@ const builtInTransportsNotInList = computed(() => {
   return BUILT_IN_TRANSPORTS.filter(transport => !used.has(transport.id));
 });
 
+// The upstream read path drops entries whose proxy is gone, so an unresolved
+// id here only means the proxies store has not answered yet; show the raw id
+// for that beat rather than holding the whole list back.
 const labelFor = (entry: ProxyFallbackEntry): string => {
   const builtIn = BUILT_IN_TRANSPORTS.find(transport => transport.id === entry.id);
   if (builtIn) return builtIn.label;
-  return proxiesById.value.get(entry.id)!.name;
+  return proxiesById.value.get(entry.id)?.name ?? entry.id;
 };
-
-// True for entries that name a proxy id we don't know about — typically a
-// row that was hand-removed from the proxies table after this upstream
-// referenced it. We render these distinctively and let the operator
-// remove them in one click instead of silently masquerading as a normal
-// entry whose label happens to be a UUID.
-const isOrphan = (entry: ProxyFallbackEntry): boolean =>
-  !isBuiltInTransport(entry.id) && !proxiesById.value.has(entry.id);
 
 const now = useNow({ interval: 1000 });
 
@@ -202,14 +197,9 @@ const toggleCurrentColoAt = (index: number) => {
           <div class="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
             <span
               class="min-w-0 truncate"
-              :class="[
-                isBuiltInTransport(entry.id) ? 'font-mono text-gray-300' : (isOrphan(entry) ? 'font-mono text-accent-rose' : 'text-white'),
-              ]"
+              :class="isBuiltInTransport(entry.id) ? 'font-mono text-gray-300' : 'text-white'"
               :title="BUILT_IN_TRANSPORTS.find(transport => transport.id === entry.id)?.title ?? entry.id"
-            >
-              <template v-if="isOrphan(entry)">Unknown proxy · {{ entry.id }}</template>
-              <template v-else>{{ labelFor(entry) }}</template>
-            </span>
+            >{{ labelFor(entry) }}</span>
 
             <PopoverRoot v-if="coloAware">
               <PopoverTrigger as-child>

--- a/apps/web/src/components/upstreams/UpstreamPicker.vue
+++ b/apps/web/src/components/upstreams/UpstreamPicker.vue
@@ -15,7 +15,7 @@ export interface UpstreamPickerValue {
 interface RowState {
   id: string;
   name: string;
-  kind: UpstreamProviderKind | null;
+  kind: UpstreamProviderKind;
   color: UpstreamColor | null;
   enabled: boolean;
 }
@@ -30,22 +30,18 @@ const value = defineModel<UpstreamPickerValue>({ required: true });
 
 const rows = ref<RowState[]>([]);
 
+// Selected ids are resolved against the options rather than rendered on their
+// own: the read path already drops ids whose upstream is gone, so anything
+// left unresolved here is an option list that has not loaded yet.
 const reset = () => {
-  const orderedIds = value.value.ids;
-  const orderedSet = new Set(orderedIds);
-  const rest = props.available.filter(u => !orderedSet.has(u.id));
+  const optionById = new Map(props.available.map(option => [option.id, option]));
+  const selected = value.value.ids.map(id => optionById.get(id)).filter(option => option !== undefined);
+  const selectedIds = new Set(selected.map(option => option.id));
+  const toRow = (option: UpstreamOption, enabled: boolean): RowState =>
+    ({ id: option.id, name: option.name, kind: option.kind, color: option.color, enabled });
   rows.value = [
-    ...orderedIds.map(id => {
-      const u = props.available.find(x => x.id === id);
-      return {
-        id,
-        name: u?.name ?? `Unknown (${id})`,
-        kind: u?.kind ?? null,
-        color: u?.color ?? null,
-        enabled: true,
-      };
-    }),
-    ...rest.map(u => ({ id: u.id, name: u.name, kind: u.kind, color: u.color, enabled: false })),
+    ...selected.map(option => toRow(option, true)),
+    ...props.available.filter(option => !selectedIds.has(option.id)).map(option => toRow(option, false)),
   ];
 };
 
@@ -65,11 +61,6 @@ const toggleRow = (id: string, enabled: boolean) => {
 };
 
 const badgeCount = computed(() => value.value.override ? rows.value.filter(r => r.enabled).length : props.available.length);
-
-// Deleted-upstream rows retain a saved id but have no matching option, so
-// `kind` goes null. Show a plain neutral badge for those.
-const kindLabel = (kind: UpstreamProviderKind | null): string =>
-  kind === null ? 'Unknown' : providerMeta(kind).label;
 </script>
 
 <template>
@@ -105,17 +96,12 @@ const kindLabel = (kind: UpstreamProviderKind | null): string =>
           </button>
           <Switch :model-value="row.enabled" @update:model-value="v => toggleRow(row.id, !!v)" />
           <UpstreamBadge
-            v-if="row.kind !== null"
             :kind="row.kind"
             :color="row.color"
             variant="badge"
             size="sm"
             class="shrink-0 !rounded !uppercase tracking-wide"
-          >{{ kindLabel(row.kind) }}</UpstreamBadge>
-          <span
-            v-else
-            class="shrink-0 rounded border border-white/[0.1] bg-surface-700 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-300"
-          >Unknown</span>
+          >{{ providerMeta(row.kind).label }}</UpstreamBadge>
           <span class="min-w-0 flex-1 truncate text-sm text-white">{{ row.name }}</span>
           <code class="text-xs text-gray-500">{{ row.id }}</code>
         </li>

--- a/apps/web/src/components/upstreams/UpstreamPicker.vue
+++ b/apps/web/src/components/upstreams/UpstreamPicker.vue
@@ -30,9 +30,10 @@ const value = defineModel<UpstreamPickerValue>({ required: true });
 
 const rows = ref<RowState[]>([]);
 
-// Selected ids are resolved against the options rather than rendered on their
-// own: the read path already drops ids whose upstream is gone, so anything
-// left unresolved here is an option list that has not loaded yet.
+// Rows are built from the offered options: a selected id the caller does not
+// offer has no renderable row. reset() leaves it in the model, but the first
+// row edit rewrites the ids from the rows and drops it. Seeding a displayable
+// selection is the caller's job.
 const reset = () => {
   const optionById = new Map(props.available.map(option => [option.id, option]));
   const selected = value.value.ids.map(id => optionById.get(id)).filter(option => option !== undefined);

--- a/packages/gateway/__tests__/control-plane/api-keys/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/api-keys/routes_test.ts
@@ -141,7 +141,7 @@ test('PATCH /api/keys/:id leaves name unchanged when only upstream_ids is sent',
   assertEquals(stored.name, apiKey.name);
 });
 
-test('PATCH /api/keys/:id leaves upstream_ids unchanged (stale ids included) when only name is sent', async () => {
+test('PATCH /api/keys/:id keeps a stored deleted-upstream id but hides it from the response', async () => {
   const { repo, apiKey } = await setupAppTest();
   await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_x', name: 'X' }));
   // Stale id surviving from a prior write; only touched by writes that target upstream_ids.
@@ -149,10 +149,31 @@ test('PATCH /api/keys/:id leaves upstream_ids unchanged (stale ids included) whe
 
   const response = await ownerPatch(apiKey.id, { name: 'renamed' }, apiKey.key);
   assertEquals(response.status, 200);
+  assertEquals(((await response.json()) as { upstream_ids: string[] }).upstream_ids, ['up_x']);
   const stored = await repo.apiKeys.getById(apiKey.id);
   assertExists(stored);
   assertEquals(stored.name, 'renamed');
   assertEquals(stored.upstreamIds, ['up_x', 'up_gone']);
+});
+
+test('GET /api/keys drops deleted-upstream ids so the editor cannot re-submit them', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_x', name: 'X' }));
+  await repo.apiKeys.save({ ...apiKey, upstreamIds: ['up_gone', 'up_x'] });
+
+  const response = await requestApp('/api/keys', { headers: { 'x-api-key': apiKey.key } });
+  assertEquals(response.status, 200);
+  const body = (await response.json()) as Array<{ id: string; upstream_ids: string[] }>;
+  assertEquals(body.find(row => row.id === apiKey.id)?.upstream_ids, ['up_x']);
+});
+
+test('GET /api/keys projects a wholly deleted cap to an empty list, never to inherit-all', async () => {
+  const { repo, apiKey } = await setupAppTest();
+  await repo.apiKeys.save({ ...apiKey, upstreamIds: ['up_gone'] });
+
+  const response = await requestApp('/api/keys', { headers: { 'x-api-key': apiKey.key } });
+  const body = (await response.json()) as Array<{ id: string; upstream_ids: string[] | null }>;
+  assertEquals(body.find(row => row.id === apiKey.id)?.upstream_ids, []);
 });
 
 test('PATCH /api/keys/:id is owner-only — admins are not privileged on other users\' keys', async () => {

--- a/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
@@ -1373,6 +1373,30 @@ test('PATCH /api/upstreams rejects proxy_fallback_list referencing an unknown pr
   assertEquals(body.error.toLowerCase().includes('unknown proxy id'), true);
 });
 
+test('GET /api/upstreams drops a fallback entry whose proxy is gone, keeping direct transports', async () => {
+  const { repo, adminSession } = await setupAppTest();
+  await repo.upstreams.deleteAll();
+  await repo.proxies.insert({ id: 'p_live', name: 'Live', url: 'socks5://198.51.100.10:1080', dialTimeoutSeconds: null });
+
+  const create = await requestApp('/api/upstreams', authed(adminSession, createBody({ proxy_fallback_list: [{ id: 'p_live' }, { id: 'direct_fetch' }] })));
+  const created = (await create.json()) as { id: string };
+  // A proxy delete is refused while an upstream still names it, so reach past
+  // the route to reproduce a raced delete or a hand-edited row.
+  const stored = await repo.upstreams.getById(created.id);
+  await repo.upstreams.save({ ...stored!, proxyFallbackList: [{ id: 'p_gone' }, { id: 'p_live' }, { id: 'direct_fetch' }] });
+
+  const single = await requestApp(`/api/upstreams/${created.id}`, { headers: { 'x-floway-session': adminSession } });
+  assertEquals(single.status, 200);
+  assertEquals(((await single.json()) as JsonObject).proxy_fallback_list, [{ id: 'p_live' }, { id: 'direct_fetch' }]);
+
+  const list = await requestApp('/api/upstreams', { headers: { 'x-floway-session': adminSession } });
+  const rows = (await list.json()) as JsonObject[];
+  assertEquals(rows.find(row => row.id === created.id)?.proxy_fallback_list, [{ id: 'p_live' }, { id: 'direct_fetch' }]);
+
+  // The stored row keeps the entry: only a write that targets the list rewrites it.
+  assertEquals((await repo.upstreams.getById(created.id))?.proxyFallbackList.map(entry => entry.id), ['p_gone', 'p_live', 'direct_fetch']);
+});
+
 test('DELETE /api/upstreams sweeps orphaned proxy backoff rows', async () => {
   const { repo, adminSession } = await setupAppTest();
   await repo.upstreams.deleteAll();

--- a/packages/gateway/__tests__/control-plane/users/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/users/routes_test.ts
@@ -3,8 +3,8 @@ import { expect, test } from 'vitest';
 import { initDumpBroker, initDumpStore } from '../../../src/dump/registry.ts';
 import { hashPassword } from '../../../src/shared/passwords.ts';
 import { installDumpStubs } from '../../dump/test-fixtures.ts';
-import { requestApp, setupAppTest } from '../../test-utils/app.ts';
-import { assertEquals } from '@floway-dev/test-utils';
+import { buildCustomUpstreamRecord, requestApp, setupAppTest } from '../../test-utils/app.ts';
+import { assertEquals, assertExists } from '@floway-dev/test-utils';
 
 const adminPost = (sessionId: string, body: unknown) => requestApp('/api/users', {
   method: 'POST',
@@ -192,4 +192,21 @@ test('PATCH /api/users/me/password rejects API key auth (must be a session)', as
     body: JSON.stringify({ currentPassword: 'x', newPassword: 'y' }),
   });
   assertEquals(response.status, 401);
+});
+
+test('GET /api/users and /auth/me drop a cap entry whose upstream was deleted', async () => {
+  const { adminSession, repo } = await setupAppTest();
+  await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_x', name: 'X' }));
+  const admin = await repo.users.getById(1);
+  assertExists(admin);
+  await repo.users.save({ ...admin, upstreamIds: ['up_gone', 'up_x'] });
+
+  const list = await requestApp('/api/users', { headers: { 'x-floway-session': adminSession } });
+  assertEquals(list.status, 200);
+  const users = (await list.json()) as Array<{ id: number; upstreamIds: string[] | null }>;
+  assertEquals(users.find(user => user.id === 1)?.upstreamIds, ['up_x']);
+
+  const me = await requestApp('/auth/me', { headers: { 'x-floway-session': adminSession } });
+  assertEquals(me.status, 200);
+  assertEquals(((await me.json()) as { user: { upstreamIds: string[] } }).user.upstreamIds, ['up_x']);
 });

--- a/packages/gateway/__tests__/data-plane/providers/registry_test.ts
+++ b/packages/gateway/__tests__/data-plane/providers/registry_test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { test } from 'vitest';
 
 import { listModelProviders } from '../../../src/data-plane/providers/registry.ts';
 import { buildCopilotUpstreamRecord, buildCustomUpstreamRecord, setupAppTest } from '../../test-utils/app.ts';
@@ -74,12 +74,13 @@ test('listModelProviders silently drops disabled upstreams from a whitelist', as
   assertEquals(providers.map(p => p.upstreamId), ['up_a']);
 });
 
-test('listModelProviders throws on unknown upstream ids in the whitelist', async () => {
-  // Unknown ids are a caller-side configuration error, not a runtime state;
-  // surface them instead of silently serving a smaller subset.
+test('listModelProviders silently drops deleted upstreams from a whitelist', async () => {
+  // Deleting an upstream does not prune the caps that reference it, so a
+  // dangling id narrows the cap instead of failing the principal's requests.
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
   await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_a', name: 'A', sortOrder: 10 }));
 
-  await expect(listModelProviders(['up_ghost', 'up_a'])).rejects.toThrow(/up_ghost/);
+  const providers = await listModelProviders(['up_ghost', 'up_a']);
+  assertEquals(providers.map(p => p.upstreamId), ['up_a']);
 });

--- a/packages/gateway/__tests__/data-plane/providers/resolution_test.ts
+++ b/packages/gateway/__tests__/data-plane/providers/resolution_test.ts
@@ -413,8 +413,8 @@ test('enumerateModelCandidates returns the empty triple when the visible upstrea
   clearInFlightForTesting();
   const { repo } = await setupAppTest();
   await repo.upstreams.deleteAll();
-  // Save one upstream so `listModelProviders([])` (empty filter) can return
-  // an empty selection without throwing on "unknown id".
+  // A populated catalog is the case under test: the empty cap, not an empty
+  // catalog, is what yields the empty triple.
   await repo.upstreams.save(buildCustomUpstreamRecord({ id: 'up_a', name: 'A', sortOrder: 1 }));
 
   const resolved = await enumerateModelCandidates({

--- a/packages/gateway/src/control-plane/api-keys/routes.ts
+++ b/packages/gateway/src/control-plane/api-keys/routes.ts
@@ -7,17 +7,17 @@ import { CUSTOM_API_KEY_MAX_LENGTH, generateApiKeyToken, type KeySource } from '
 import { generateServerSecret } from '../../shared/server-secret.ts';
 import type { createKeyBody, rotateKeyBody, updateKeyBody } from '../schemas.ts';
 import { ownedKeyOr404 } from '../shared/owned-key.ts';
-import { validateUpstreamIdsExist } from '../shared/upstream-ids.ts';
+import { loadKnownUpstreamIds, pruneDeletedUpstreamIds, unknownUpstreamIdsError } from '../shared/upstream-ids.ts';
 
 const GENERATED_KEY_RETRIES = 5;
 
-const apiKeyToJson = (key: ApiKey) => ({
+const apiKeyToJson = (key: ApiKey, knownUpstreamIds: ReadonlySet<string>) => ({
   id: key.id,
   name: key.name,
   key: key.key,
   created_at: key.createdAt,
   last_used_at: key.lastUsedAt ?? null,
-  upstream_ids: key.upstreamIds,
+  upstream_ids: pruneDeletedUpstreamIds(key.upstreamIds, knownUpstreamIds),
   dump_retention_seconds: key.dumpRetentionSeconds,
   responses_retention_seconds: key.responsesRetentionSeconds,
 });
@@ -89,11 +89,12 @@ const writeKeyForRequest = async (
   return await saveGeneratedKey(template);
 };
 
-const validateUpstreamIdsAgainstUserCap = async (
+const validateUpstreamIdsAgainstUserCap = (
   c: AuthedContext,
   proposed: readonly string[] | null,
-): Promise<string | null> => {
-  const unknownUpstreamError = await validateUpstreamIdsExist(proposed);
+  knownUpstreamIds: ReadonlySet<string>,
+): string | null => {
+  const unknownUpstreamError = unknownUpstreamIdsError(proposed, knownUpstreamIds);
   if (unknownUpstreamError !== null) return unknownUpstreamError;
   if (proposed === null) return null;
 
@@ -108,15 +109,16 @@ const validateUpstreamIdsAgainstUserCap = async (
 
 export const listKeys = async (c: AuthedContext) => {
   const userId = userFromContext(c).id;
-  const keys = await getRepo().apiKeys.listByUserId(userId);
-  return c.json(keys.map(apiKeyToJson));
+  const [keys, knownUpstreamIds] = await Promise.all([getRepo().apiKeys.listByUserId(userId), loadKnownUpstreamIds()]);
+  return c.json(keys.map(key => apiKeyToJson(key, knownUpstreamIds)));
 };
 
 export const createKey = async (c: CtxWithJson<typeof createKeyBody>) => {
   const userId = userFromContext(c).id;
   const body = c.req.valid('json');
 
-  const upstreamErr = await validateUpstreamIdsAgainstUserCap(c, body.upstream_ids ?? null);
+  const knownUpstreamIds = await loadKnownUpstreamIds();
+  const upstreamErr = validateUpstreamIdsAgainstUserCap(c, body.upstream_ids ?? null, knownUpstreamIds);
   if (upstreamErr) return c.json({ error: upstreamErr }, 400);
 
   const template = {
@@ -133,7 +135,7 @@ export const createKey = async (c: CtxWithJson<typeof createKeyBody>) => {
 
   const key = await writeKeyForRequest(template, body);
   if (key instanceof Response) return key;
-  return c.json(apiKeyToJson(key), 201);
+  return c.json(apiKeyToJson(key, knownUpstreamIds), 201);
 };
 
 export const deleteKey = async (c: AuthedContext) => {
@@ -155,7 +157,7 @@ export const rotateKey = async (c: CtxWithJson<typeof rotateKeyBody>) => {
 
   const updated = await writeKeyForRequest(owned, c.req.valid('json'));
   if (updated instanceof Response) return updated;
-  return c.json(apiKeyToJson(updated));
+  return c.json(apiKeyToJson(updated, await loadKnownUpstreamIds()));
 };
 
 export const updateKey = async (c: CtxWithJson<typeof updateKeyBody>) => {
@@ -169,8 +171,9 @@ export const updateKey = async (c: CtxWithJson<typeof updateKeyBody>) => {
   const owned = await ownedKeyOr404(c, id);
   if (owned instanceof Response) return owned;
 
+  const knownUpstreamIds = await loadKnownUpstreamIds();
   if (body.upstream_ids !== undefined) {
-    const err = await validateUpstreamIdsAgainstUserCap(c, body.upstream_ids);
+    const err = validateUpstreamIdsAgainstUserCap(c, body.upstream_ids, knownUpstreamIds);
     if (err) return c.json({ error: err }, 400);
   }
 
@@ -188,5 +191,5 @@ export const updateKey = async (c: CtxWithJson<typeof updateKeyBody>) => {
     if (next === null && previous !== null) await notifyDisabledBestEffort(id, 'updateKey retention disable');
   }
 
-  return c.json(apiKeyToJson(updated));
+  return c.json(apiKeyToJson(updated, knownUpstreamIds));
 };

--- a/packages/gateway/src/control-plane/auth/routes.ts
+++ b/packages/gateway/src/control-plane/auth/routes.ts
@@ -7,6 +7,7 @@ import { isProductionRequest } from '../../runtime/is-production-request.ts';
 import { dummyPasswordHash, verifyPassword } from '../../shared/passwords.ts';
 import { timingSafeEqual } from '../../shared/timing-safe-equal.ts';
 import type { authLoginBody } from '../schemas.ts';
+import { loadKnownUpstreamIds } from '../shared/upstream-ids.ts';
 import { userToSessionWire } from '../users/wire.ts';
 import { getEnvOptional } from '@floway-dev/platform';
 
@@ -45,8 +46,8 @@ const resolveLoginUser = async (c: CtxWithJson<typeof authLoginBody>): Promise<U
 export const authLogin = async (c: CtxWithJson<typeof authLoginBody>) => {
   const user = await resolveLoginUser(c);
   if (!user) return c.json({ error: 'Invalid username or password' }, 401);
-  const session = await getRepo().sessions.create(user.id);
-  return c.json({ token: session.id, user: userToSessionWire(user) });
+  const [session, knownUpstreamIds] = await Promise.all([getRepo().sessions.create(user.id), loadKnownUpstreamIds()]);
+  return c.json({ token: session.id, user: userToSessionWire(user, knownUpstreamIds) });
 };
 
 export const authLogout = async (c: AuthedContext) => {
@@ -60,7 +61,7 @@ export const authMe = async (c: AuthedContext) => {
   const sessionId = sessionIdFromContext(c);
   const apiKey = c.get('apiKey');
   return c.json({
-    user: userToSessionWire(user),
+    user: userToSessionWire(user, await loadKnownUpstreamIds()),
     viaApiKey: !sessionId,
     apiKey: apiKey ? { id: apiKey.id, name: apiKey.name } : null,
   });

--- a/packages/gateway/src/control-plane/shared/upstream-ids.ts
+++ b/packages/gateway/src/control-plane/shared/upstream-ids.ts
@@ -24,10 +24,23 @@ export const parseUpstreamIdsValue = (raw: unknown): ParseUpstreamIdsResult => {
   return { ok: true, value: ids };
 };
 
-export const validateUpstreamIdsExist = async (ids: readonly string[] | null): Promise<string | null> => {
+export const loadKnownUpstreamIds = async (): Promise<ReadonlySet<string>> =>
+  new Set((await getRepo().upstreams.list()).map(upstream => upstream.id));
+
+export const unknownUpstreamIdsError = (ids: readonly string[] | null, known: ReadonlySet<string>): string | null => {
   if (ids === null) return null;
-  const upstreams = await getRepo().upstreams.list();
-  const known = new Set(upstreams.map(upstream => upstream.id));
   const unknown = ids.filter(id => !known.has(id));
   return unknown.length ? `Unknown upstream(s): ${unknown.join(', ')}` : null;
 };
+
+// Deleting an upstream leaves its id behind in every user and api-key cap that
+// named it — nothing cascades, and the data plane treats such an id as inert.
+// Reads project a stored cap through the live catalog so the dashboard never
+// renders a dangling entry and never re-submits one into the write path, which
+// rejects unknown ids. A cap whose ids are all gone projects to an empty list:
+// that is what it grants now. Widening it to null would read as "inherit" and
+// hand the principal the entire catalog.
+export const pruneDeletedUpstreamIds = (
+  ids: readonly string[] | null,
+  known: ReadonlySet<string>,
+): string[] | null => ids === null ? null : ids.filter(id => known.has(id));

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -46,20 +46,36 @@ const codexQuotaForResponse = async (record: UpstreamRecord): Promise<CodexQuota
   };
 };
 
+const loadKnownProxyIds = async (): Promise<ReadonlySet<string>> =>
+  new Set((await getRepo().proxies.list()).map(proxy => proxy.id));
+
+// Deleting a proxy is refused while an upstream still names it, so a dangling
+// entry only arises from a raced delete or a hand-edited row. Reads drop those
+// entries instead of handing the edit form a chip it cannot resolve and would
+// re-submit into a write path that rejects the whole list. Dial time already
+// skips an unresolvable entry and advances the chain.
+const pruneDeletedProxyEntries = (
+  entries: readonly { id: string; colos?: string[] }[],
+  knownProxyIds: ReadonlySet<string>,
+) => entries.filter(entry => isDirectFallbackId(entry.id) || knownProxyIds.has(entry.id));
+
 // These projections need repository/provider I/O, which serialize.ts excludes
 // so it stays a pure persisted-record transform. The optional baseSerialize
 // override lets callers swap in upstreamRecordToFullJson to round-trip
 // unredacted secrets instead of the redacted default.
 const serializeForResponse = async (
   record: UpstreamRecord,
+  knownProxyIds: ReadonlySet<string>,
   baseSerialize: (r: UpstreamRecord) => SerializedUpstreamRecord = upstreamRecordToJson,
 ): Promise<UpstreamWithCacheResponse> => {
   const [cacheRow, codexQuota] = await Promise.all([
     getRepo().modelsCache.get(record.id),
     codexQuotaForResponse(record),
   ]);
+  const serialized = baseSerialize(record);
   return {
-    ...baseSerialize(record),
+    ...serialized,
+    proxy_fallback_list: pruneDeletedProxyEntries(serialized.proxy_fallback_list, knownProxyIds),
     modelsCache: {
       fetchedAt: cacheRow?.fetchedAt ?? null,
       lastError: cacheRow?.lastError ?? null,
@@ -134,20 +150,20 @@ const normalizeModelPrefixField = (input: unknown): ValidationResult<ModelPrefix
 // Built-in direct transports are always valid entry ids; every other id must
 // reference an existing proxy row. List order matters at dial time (see
 // createFetcher), and persistence layers dedupe before storing.
-const validateProxyFallbackList = async (entries: readonly ProxyFallbackEntry[]): Promise<{ ok: true } | { ok: false; error: string }> => {
-  const ids = entries.map(e => e.id).filter(id => !isDirectFallbackId(id));
-  if (ids.length === 0) return { ok: true };
-  const proxies = await getRepo().proxies.list();
-  const known = new Set(proxies.map(p => p.id));
-  for (const id of ids) {
-    if (!known.has(id)) return { ok: false, error: `unknown proxy id in fallback list: ${id}` };
+const validateProxyFallbackList = (
+  entries: readonly ProxyFallbackEntry[],
+  knownProxyIds: ReadonlySet<string>,
+): { ok: true } | { ok: false; error: string } => {
+  for (const entry of entries) {
+    if (isDirectFallbackId(entry.id) || knownProxyIds.has(entry.id)) continue;
+    return { ok: false, error: `unknown proxy id in fallback list: ${entry.id}` };
   }
   return { ok: true };
 };
 
 export const listUpstreams = async (c: Context) => {
-  const items = await getRepo().upstreams.list();
-  return c.json(await Promise.all(items.map(record => serializeForResponse(record))));
+  const [items, knownProxyIds] = await Promise.all([getRepo().upstreams.list(), loadKnownProxyIds()]);
+  return c.json(await Promise.all(items.map(record => serializeForResponse(record, knownProxyIds))));
 };
 
 // Picker dataset for the per-key upstream whitelist editor. Non-admin users
@@ -195,14 +211,15 @@ export const getUpstream = async (c: AuthedContext<'/:id'>) => {
   const id = c.req.param('id');
   const record = await getRepo().upstreams.getById(id);
   if (!record) return c.json({ error: 'upstream not found' }, 404);
-  return c.json(await serializeForResponse(record, upstreamRecordToFullJson));
+  return c.json(await serializeForResponse(record, await loadKnownProxyIds(), upstreamRecordToFullJson));
 };
 
 export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) => {
   const body = c.req.valid('json');
 
   const proxyFallbackList = normalizeProxyFallbackList(body.proxy_fallback_list ?? []);
-  const fallbackCheck = await validateProxyFallbackList(proxyFallbackList);
+  const knownProxyIds = await loadKnownProxyIds();
+  const fallbackCheck = validateProxyFallbackList(proxyFallbackList, knownProxyIds);
   if (!fallbackCheck.ok) return c.json({ error: fallbackCheck.error }, 400);
 
   const modelPrefixResult = normalizeModelPrefixField(body.model_prefix);
@@ -258,7 +275,7 @@ export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) 
   const record = { ...upstream, config: config.value };
   await getRepo().upstreams.save(record);
   await warmModelsCache(record, c);
-  return c.json(await serializeForResponse(record), 201);
+  return c.json(await serializeForResponse(record, knownProxyIds), 201);
 };
 
 export const updateUpstream = async (c: CtxWithJson<typeof updateUpstreamBody, '/:id'>) => {
@@ -282,6 +299,7 @@ export const updateUpstream = async (c: CtxWithJson<typeof updateUpstreamBody, '
     return c.json({ error: `Use POST ${endpoint} to update ${existing.kind} credentials` }, 400);
   }
 
+  const knownProxyIds = await loadKnownProxyIds();
   let next: UpstreamRecord = { ...existing, updatedAt: new Date().toISOString() };
   if (body.name !== undefined) next = { ...next, name: body.name };
   if (body.enabled !== undefined) next = { ...next, enabled: body.enabled };
@@ -290,7 +308,7 @@ export const updateUpstream = async (c: CtxWithJson<typeof updateUpstreamBody, '
   if (body.disabled_public_model_ids !== undefined) next = { ...next, disabledPublicModelIds: body.disabled_public_model_ids };
   if (body.proxy_fallback_list !== undefined) {
     const normalized = normalizeProxyFallbackList(body.proxy_fallback_list);
-    const fallbackCheck = await validateProxyFallbackList(normalized);
+    const fallbackCheck = validateProxyFallbackList(normalized, knownProxyIds);
     if (!fallbackCheck.ok) return c.json({ error: fallbackCheck.error }, 400);
     next = { ...next, proxyFallbackList: normalized };
   }
@@ -312,7 +330,7 @@ export const updateUpstream = async (c: CtxWithJson<typeof updateUpstreamBody, '
 
   await getRepo().upstreams.save(next);
   await warmModelsCache(next, c);
-  return c.json(await serializeForResponse(next));
+  return c.json(await serializeForResponse(next, knownProxyIds));
 };
 
 export const deleteUpstream = async (c: AuthedContext<'/:id'>) => {

--- a/packages/gateway/src/control-plane/upstreams/routes.ts
+++ b/packages/gateway/src/control-plane/upstreams/routes.ts
@@ -55,9 +55,9 @@ const loadKnownProxyIds = async (): Promise<ReadonlySet<string>> =>
 // re-submit into a write path that rejects the whole list. Dial time already
 // skips an unresolvable entry and advances the chain.
 const pruneDeletedProxyEntries = (
-  entries: readonly { id: string; colos?: string[] }[],
+  entries: readonly ProxyFallbackEntry[],
   knownProxyIds: ReadonlySet<string>,
-) => entries.filter(entry => isDirectFallbackId(entry.id) || knownProxyIds.has(entry.id));
+): ProxyFallbackEntry[] => entries.filter(entry => isDirectFallbackId(entry.id) || knownProxyIds.has(entry.id));
 
 // These projections need repository/provider I/O, which serialize.ts excludes
 // so it stays a pure persisted-record transform. The optional baseSerialize
@@ -209,9 +209,9 @@ export const getUpstreamBlueprint = (c: Context): Response => {
 // render the "last fetched / last error" panel on mount.
 export const getUpstream = async (c: AuthedContext<'/:id'>) => {
   const id = c.req.param('id');
-  const record = await getRepo().upstreams.getById(id);
+  const [record, knownProxyIds] = await Promise.all([getRepo().upstreams.getById(id), loadKnownProxyIds()]);
   if (!record) return c.json({ error: 'upstream not found' }, 404);
-  return c.json(await serializeForResponse(record, await loadKnownProxyIds(), upstreamRecordToFullJson));
+  return c.json(await serializeForResponse(record, knownProxyIds, upstreamRecordToFullJson));
 };
 
 export const createUpstream = async (c: CtxWithJson<typeof createUpstreamBody>) => {

--- a/packages/gateway/src/control-plane/users/routes.ts
+++ b/packages/gateway/src/control-plane/users/routes.ts
@@ -9,7 +9,7 @@ import { generateApiKeyToken } from '../../shared/api-key-tokens.ts';
 import { hashPassword, verifyPassword } from '../../shared/passwords.ts';
 import { generateServerSecret } from '../../shared/server-secret.ts';
 import type { changeOwnPasswordBody, createUserBody, updateUserBody } from '../schemas.ts';
-import { validateUpstreamIdsExist } from '../shared/upstream-ids.ts';
+import { loadKnownUpstreamIds, unknownUpstreamIdsError } from '../shared/upstream-ids.ts';
 
 const parseUserId = (raw: string): number | null => {
   const n = Number(raw);
@@ -17,19 +17,20 @@ const parseUserId = (raw: string): number | null => {
 };
 
 export const listUsers = async (c: AuthedContext) => {
-  const users = await getRepo().users.list();
-  return c.json(users.map(userToAdminWire));
+  const [users, knownUpstreamIds] = await Promise.all([getRepo().users.list(), loadKnownUpstreamIds()]);
+  return c.json(users.map(user => userToAdminWire(user, knownUpstreamIds)));
 };
 
 export const createUser = async (c: CtxWithJson<typeof createUserBody>) => {
   const body = c.req.valid('json');
   const repo = getRepo();
+  const knownUpstreamIds = await loadKnownUpstreamIds();
 
   if (await repo.users.findByUsername(body.username)) {
     return c.json({ error: 'That username is already taken (usernames are case-insensitive).' }, 400);
   }
   if (body.upstreamIds !== undefined) {
-    const upstreamErr = await validateUpstreamIdsExist(body.upstreamIds);
+    const upstreamErr = unknownUpstreamIdsError(body.upstreamIds, knownUpstreamIds);
     if (upstreamErr) return c.json({ error: upstreamErr }, 400);
   }
 
@@ -56,7 +57,7 @@ export const createUser = async (c: CtxWithJson<typeof createUserBody>) => {
   };
   await repo.apiKeys.save(defaultKey);
 
-  return c.json({ user: userToAdminWire(user) }, 201);
+  return c.json({ user: userToAdminWire(user, knownUpstreamIds) }, 201);
 };
 
 export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
@@ -65,6 +66,7 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
   const body = c.req.valid('json');
   const actorId = userFromContext(c).id;
   const repo = getRepo();
+  const knownUpstreamIds = await loadKnownUpstreamIds();
 
   const existing = await repo.users.getById(id);
   if (!existing) return c.json({ error: 'user not found' }, 404);
@@ -78,7 +80,7 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
     if (dup && dup.id !== id) return c.json({ error: 'username taken' }, 400);
   }
   if (body.upstreamIds !== undefined) {
-    const err = await validateUpstreamIdsExist(body.upstreamIds);
+    const err = unknownUpstreamIdsError(body.upstreamIds, knownUpstreamIds);
     if (err) return c.json({ error: err }, 400);
   }
 
@@ -96,7 +98,7 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
     else await repo.sessions.deleteByUserId(id);
   }
 
-  return c.json(userToAdminWire(next));
+  return c.json(userToAdminWire(next, knownUpstreamIds));
 };
 
 export const deleteUser = async (c: AuthedContext) => {

--- a/packages/gateway/src/control-plane/users/routes.ts
+++ b/packages/gateway/src/control-plane/users/routes.ts
@@ -24,11 +24,11 @@ export const listUsers = async (c: AuthedContext) => {
 export const createUser = async (c: CtxWithJson<typeof createUserBody>) => {
   const body = c.req.valid('json');
   const repo = getRepo();
-  const knownUpstreamIds = await loadKnownUpstreamIds();
 
   if (await repo.users.findByUsername(body.username)) {
     return c.json({ error: 'That username is already taken (usernames are case-insensitive).' }, 400);
   }
+  const knownUpstreamIds = await loadKnownUpstreamIds();
   if (body.upstreamIds !== undefined) {
     const upstreamErr = unknownUpstreamIdsError(body.upstreamIds, knownUpstreamIds);
     if (upstreamErr) return c.json({ error: upstreamErr }, 400);
@@ -66,7 +66,6 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
   const body = c.req.valid('json');
   const actorId = userFromContext(c).id;
   const repo = getRepo();
-  const knownUpstreamIds = await loadKnownUpstreamIds();
 
   const existing = await repo.users.getById(id);
   if (!existing) return c.json({ error: 'user not found' }, 404);
@@ -79,6 +78,7 @@ export const updateUser = async (c: CtxWithJson<typeof updateUserBody>) => {
     const dup = await repo.users.findByUsername(body.username);
     if (dup && dup.id !== id) return c.json({ error: 'username taken' }, 400);
   }
+  const knownUpstreamIds = await loadKnownUpstreamIds();
   if (body.upstreamIds !== undefined) {
     const err = unknownUpstreamIdsError(body.upstreamIds, knownUpstreamIds);
     if (err) return c.json({ error: err }, 400);

--- a/packages/gateway/src/control-plane/users/wire.ts
+++ b/packages/gateway/src/control-plane/users/wire.ts
@@ -1,14 +1,17 @@
 import type { User } from '../../repo/types.ts';
+import { pruneDeletedUpstreamIds } from '../shared/upstream-ids.ts';
 
-// The self-description returned by /auth/login and /auth/me.
-export const userToSessionWire = (user: User) => ({
+// The self-description returned by /auth/login and /auth/me. The live upstream
+// catalog is a required argument rather than an optional one so a new caller
+// cannot forget it and emit a cap the write path would refuse to take back.
+export const userToSessionWire = (user: User, knownUpstreamIds: ReadonlySet<string>) => ({
   id: user.id,
   username: user.username,
   isAdmin: user.isAdmin,
-  upstreamIds: user.upstreamIds,
+  upstreamIds: pruneDeletedUpstreamIds(user.upstreamIds, knownUpstreamIds),
 });
 
-export const userToAdminWire = (user: User) => ({
-  ...userToSessionWire(user),
+export const userToAdminWire = (user: User, knownUpstreamIds: ReadonlySet<string>) => ({
+  ...userToSessionWire(user, knownUpstreamIds),
   createdAt: user.createdAt,
 });

--- a/packages/gateway/src/data-plane/providers/registry.ts
+++ b/packages/gateway/src/data-plane/providers/registry.ts
@@ -36,29 +36,20 @@ export const listModelProviders = async (
 ): Promise<Provider[]> => {
   const upstreams = preFetchedUpstreams ?? await getRepo().upstreams.list();
   const enabledById = new Map<string, UpstreamRecord>();
-  const knownIds = new Set<string>();
   for (const upstream of upstreams) {
-    knownIds.add(upstream.id);
     if (upstream.enabled) enabledById.set(upstream.id, upstream);
   }
 
-  let selection: UpstreamRecord[];
-  if (upstreamFilter) {
-    // Unknown ids are a caller-side configuration error (the filter is the
-    // intersection of per-user + per-api-key caps; both reference upstreams
-    // by id); surface them so the operator notices instead of silently
-    // serving a smaller subset. Disabled-but-known ids stay silent: a user
-    // cap may legitimately mention an upstream the operator just disabled.
-    const unknown = upstreamFilter.filter(id => !knownIds.has(id));
-    if (unknown.length > 0) {
-      throw new Error(`Unknown upstream id(s) in filter: ${unknown.join(', ')}`);
-    }
-    selection = upstreamFilter
-      .map(id => enabledById.get(id))
-      .filter((u): u is UpstreamRecord => u !== undefined);
-  } else {
-    selection = [...enabledById.values()];
-  }
+  // The filter is the intersection of the per-user and per-api-key caps, both
+  // of which reference upstreams by id. Deleting or disabling an upstream does
+  // not prune those lists, so an id that no longer resolves is inert rather
+  // than fatal: it narrows the scope and drops out on the next write to the
+  // user or key. The principal keeps serving on the rest of its cap, and a
+  // selection emptied this way surfaces downstream as "no upstream provider
+  // configured".
+  const selection = upstreamFilter
+    ? upstreamFilter.map(id => enabledById.get(id)).filter((u): u is UpstreamRecord => u !== undefined)
+    : [...enabledById.values()];
 
   return selection.map(createProvider);
 };

--- a/packages/gateway/src/dial/fetcher.ts
+++ b/packages/gateway/src/dial/fetcher.ts
@@ -156,8 +156,7 @@ const tryOne = async (
       // dial-shaped failure for THIS entry so the fallback chain advances
       // instead of killing the whole call (and any healthy built-in or proxy
       // siblings further down the list). We don't write to backoff
-      // here — the row is gone, and the upstream's fallback_list will
-      // surface the dangling reference next time the dashboard renders it.
+      // here — the row is gone.
       errors.push(new ProxyDialError(`unknown proxy id in fallback list: ${id}`, 'config'));
       return null;
     }


### PR DESCRIPTION
Deleting an upstream leaves its id behind in every user and api-key cap that named it; nothing cascades. An upstream's proxy fallback list can outlive a raced proxy delete the same way. Both cases dead-ended the operator.

## Data plane

`listModelProviders` threw `Unknown upstream id(s) in filter: …` on a cap entry absent from the upstreams table, while a known-but-disabled entry was silently dropped. That function is the single choke point for every scoped read, so one deleted upstream took down the whole principal: `/v1/models` and the dashboard model catalog answered 502, and every chat request failed.

An unresolvable entry is now inert, exactly like a disabled one — it narrows the scope and drops out on the next write, which is the contract `migrations/0015_api_key_upstreams.sql` states in its own header. A cap emptied that way surfaces downstream as the existing "no upstream provider configured".

## Control plane

Reads handed the dangling id straight to the dashboard. The upstream picker rendered it as `Unknown (<id>)` and the proxy fallback editor as a rose `Unknown proxy · <id>` chip — both still selected, both re-submitted verbatim on save. The write path rightly rejects unknown ids, so an admin editing an unrelated field got a 400 and could only escape by spotting the placeholder and removing it by hand.

Reads now project stored references through the live catalog. `userToSessionWire` / `userToAdminWire` / `apiKeyToJson` take the known upstream ids, and the upstream response serializer drops fallback entries whose proxy is gone, keeping the direct-transport sentinels. Each set is loaded once per request and shared with the write-side validators, which become pure functions over the same set. The catalog is required rather than optional, so a new caller cannot forget it.

A cap whose ids are all gone projects to an empty list, never to `null`: `null` reads as "inherit" and would hand the principal the entire catalog. Export still emits records verbatim — a backup is not a dashboard read.

Write-time validation is unchanged and still answers 400 on an unknown id. The caller supplied that id and can fix it; tolerance belongs on the read side, where the data is already persisted and erroring only breaks a live principal.

## Dashboard

Both placeholders are gone. An unresolved id can now only mean the option list has not arrived, so the picker renders what resolves and the proxy editor shows the raw id for that beat — which also retires a non-null assertion that only the removed guard kept safe.

The key editor seeds the picker from the options it actually offers. A key keeps ids it was created with after an admin narrows the owning user's cap, and those are unrenderable now that placeholders are gone, so without this they would ride invisibly into the save and be rejected there. An unloaded catalog is left alone rather than mistaken for an empty one.

## Test Plan

- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Live Node instance on a fresh SQLite database: give a user and a key a two-upstream cap, delete one upstream, then confirm `/api/keys`, `/api/users`, and `/auth/me` return only the survivor while the stored rows still carry both ids, and that `/v1/models` answers 200 with the surviving model instead of 502
- [ ] Dashboard rendering driven through a headless browser — not run; the SPA dev server's proxy target is a fixed port already owned by another local instance. Covered instead by the new `UpstreamPicker` component suite and the upstream read-route assertions
