### PR TITLE
fix(platform): bind only value types every target accepts

### DIFF
--- a/apps/platform-node/__tests__/node-sqlite-repo_test.ts
+++ b/apps/platform-node/__tests__/node-sqlite-repo_test.ts
@@ -1,0 +1,76 @@
+import { test } from 'vitest';
+
+import { applyMigrations } from '../src/migrate.ts';
+import { createNodeSqliteDatabase } from '../src/node-sqlite-database.ts';
+import { SqlRepo } from '@floway-dev/gateway';
+import { assertEquals } from '@floway-dev/test-utils';
+
+// The repo layer's own suite runs against sql.js, which — like D1 — coerces a
+// JS boolean to 0/1. `node:sqlite` rejects it outright, so a bind the Workers
+// target tolerates surfaces only here. These drive the real repo through the
+// real driver over the real migrations.
+//
+// `:memory:` keeps the driver and its parameter binding exactly as a deployed
+// instance sees them while leaving no file to unlink — node:sqlite holds the
+// handle open for the process lifetime, which makes tempfile cleanup fail on
+// Windows.
+const withRepo = async (fn: (repo: SqlRepo) => Promise<void>): Promise<void> => {
+  const db = createNodeSqliteDatabase(':memory:');
+  await applyMigrations(db);
+  await fn(new SqlRepo(db));
+};
+
+const seedKey = (repo: SqlRepo): Promise<void> => repo.apiKeys.save({
+  id: 'key_node',
+  userId: 1,
+  name: 'Node key',
+  key: 'raw_node_key',
+  serverSecret: '00'.repeat(32),
+  createdAt: '2026-07-26T00:00:00.000Z',
+  upstreamIds: null,
+  deletedAt: null,
+  dumpRetentionSeconds: null,
+  responsesRetentionSeconds: 0,
+});
+
+test('api key update lands every patched column and leaves the rest alone', () => withRepo(async repo => {
+  await seedKey(repo);
+
+  // recordUsage() takes this path after every proxied request.
+  const touched = await repo.apiKeys.update('key_node', { lastUsedAt: '2026-07-26T12:00:00.000Z' });
+  assertEquals(touched?.lastUsedAt, '2026-07-26T12:00:00.000Z');
+  // The columns whose CASE WHEN guard is false must survive untouched.
+  assertEquals(touched?.name, 'Node key');
+  assertEquals(touched?.responsesRetentionSeconds, 0);
+
+  // The control-plane edits (PATCH /api/keys/:id, rotate) share the bind.
+  const edited = await repo.apiKeys.update('key_node', {
+    name: 'Renamed',
+    key: 'rotated_key',
+    upstreamIds: ['up-a'],
+    dumpRetentionSeconds: 3600,
+    responsesRetentionSeconds: 7 * 24 * 60 * 60,
+  });
+  assertEquals(edited?.name, 'Renamed');
+  assertEquals(edited?.upstreamIds, ['up-a']);
+  assertEquals(edited?.dumpRetentionSeconds, 3600);
+  // Not in the patch — the earlier value stays.
+  assertEquals(edited?.lastUsedAt, '2026-07-26T12:00:00.000Z');
+
+  assertEquals((await repo.apiKeys.getById('key_node'))?.name, 'Renamed');
+}));
+
+test('expiration sweep completion lands on both discriminants', () => withRepo(async repo => {
+  await seedKey(repo);
+
+  await repo.expirationSweeps.schedule('responses', 'key_node', 0);
+  const partialClaim = await repo.expirationSweeps.claim('claim-partial', 10, 0);
+  if (partialClaim === null) throw new Error('expected an expiration claim');
+  await repo.expirationSweeps.complete('claim-partial', partialClaim.revision, { kind: 'partial', retryAt: 5_000 });
+
+  const drainedClaim = await repo.expirationSweeps.claim('claim-drained', 10_000, 0);
+  if (drainedClaim === null) throw new Error('expected a re-claim after the partial retry');
+  await repo.expirationSweeps.complete('claim-drained', drainedClaim.revision, { kind: 'drained', nextDueAt: null });
+
+  assertEquals(await repo.expirationSweeps.claim('claim-empty', 20_000, 0), null);
+}));

--- a/apps/platform-node/src/node-sqlite-database.ts
+++ b/apps/platform-node/src/node-sqlite-database.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { DatabaseSync, type StatementSync } from 'node:sqlite';
 
-import type { SqlDatabase, SqlPreparedStatement, SqlResult } from '@floway-dev/platform';
+import type { SqlBindValue, SqlDatabase, SqlPreparedStatement, SqlResult } from '@floway-dev/platform';
 
 // node:sqlite's prepared statement is synchronous and returns plain rows.
 // We adapt it to the platform's async, enveloped contract. bind() returns a
@@ -11,10 +11,10 @@ import type { SqlDatabase, SqlPreparedStatement, SqlResult } from '@floway-dev/p
 class NodeSqlitePreparedStatement implements SqlPreparedStatement {
   constructor(
     private readonly stmt: StatementSync,
-    private readonly bound: readonly unknown[] = [],
+    private readonly bound: readonly SqlBindValue[] = [],
   ) {}
 
-  bind(...values: unknown[]): SqlPreparedStatement {
+  bind(...values: SqlBindValue[]): SqlPreparedStatement {
     return new NodeSqlitePreparedStatement(this.stmt, values);
   }
 

--- a/packages/gateway/__tests__/repo/test-sqlite.ts
+++ b/packages/gateway/__tests__/repo/test-sqlite.ts
@@ -1,6 +1,6 @@
 import initSqlJs from 'sql.js';
 
-import type { SqlDatabase, SqlPreparedStatement, SqlResult } from '@floway-dev/platform';
+import type { SqlBindValue, SqlDatabase, SqlPreparedStatement, SqlResult } from '@floway-dev/platform';
 
 export const migrationSqlByFilename = Object.entries(import.meta.glob('../../migrations/*.sql', { query: '?raw', import: 'default', eager: true }) as Record<string, string>)
   .map(([path, sql]) => [path.slice(path.lastIndexOf('/') + 1), sql] as const)
@@ -18,11 +18,22 @@ export const createSqliteTestDb = async (): Promise<SqlDatabase> => {
   return new SqlJsSqlDatabase(db);
 };
 
-class SqlJsPreparedStatement implements SqlPreparedStatement {
-  constructor(private readonly db: SqlJsDatabase, private readonly query: string, private readonly bound: readonly unknown[] = []) {}
+// sql.js binds through JavaScript and happily takes values neither deployment
+// target accepts, so it would pass a statement that fails in production. Reject
+// anything outside the contract's own union here instead.
+const assertBindable = (values: readonly SqlBindValue[]): readonly SqlBindValue[] => {
+  values.forEach((value, index) => {
+    if (value === null || typeof value === 'number' || typeof value === 'string' || value instanceof Uint8Array) return;
+    throw new TypeError(`SQL parameter ${index + 1} is a ${typeof value}, which no deployment target can bind`);
+  });
+  return values;
+};
 
-  bind(...values: unknown[]): SqlPreparedStatement {
-    return new SqlJsPreparedStatement(this.db, this.query, values);
+class SqlJsPreparedStatement implements SqlPreparedStatement {
+  constructor(private readonly db: SqlJsDatabase, private readonly query: string, private readonly bound: readonly SqlBindValue[] = []) {}
+
+  bind(...values: SqlBindValue[]): SqlPreparedStatement {
+    return new SqlJsPreparedStatement(this.db, this.query, assertBindable(values));
   }
 
   first<T = Record<string, unknown>>(): Promise<T | null> {

--- a/packages/gateway/src/repo/expiration-sweeps-sql.ts
+++ b/packages/gateway/src/repo/expiration-sweeps-sql.ts
@@ -204,7 +204,7 @@ export class SqlExpirationSweepsRepo implements ExpirationSweepsRepo {
              claimed_at = NULL
          WHERE claim_token = ?`,
       )
-      .bind(expectedRevision, completion.kind === 'partial', nextDueAt, nextDueAt, token)
+      .bind(expectedRevision, completion.kind === 'partial' ? 1 : 0, nextDueAt, nextDueAt, token)
       .run();
   }
 }

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -51,7 +51,7 @@ import { bucketForTtftMs, bucketForTpotUs } from '../shared/performance-histogra
 import { parseServerSecret } from '../shared/server-secret.ts';
 import { assertWebSearchProviderName, type WebSearchConfig } from '../shared/web-search-providers.ts';
 import { AgentSetupTokenCollisionError } from '@floway-dev/agent-setup';
-import type { SqlDatabase, SqlPreparedStatement } from '@floway-dev/platform';
+import type { SqlBindValue, SqlDatabase, SqlPreparedStatement } from '@floway-dev/platform';
 import { addDecimalStrings, canonicalPricingSelectorKey, parseBillingMetric, parseModelKind, parseNonNegativeDecimalString, parsePricingSelectorKey, type AliasSelection, type AliasTarget, type AnnouncedMetadata } from '@floway-dev/protocols/common';
 import type { ProviderModel, ProxyFallbackEntry, ModelPrefixConfig, UpstreamRecord } from '@floway-dev/provider';
 import { normalizeModelPrefix, parsePerformanceOperation } from '@floway-dev/provider';
@@ -203,12 +203,12 @@ class SqlApiKeyRepo implements ApiKeyRepo {
          RETURNING ${API_KEY_COLUMNS}`,
       )
       .bind(
-        hasName, patch.name ?? null,
-        hasKey, patch.key ?? null,
-        hasLastUsedAt, patch.lastUsedAt ?? null,
-        hasUpstreamIds, hasUpstreamIds ? serializeUpstreamIds(patch.upstreamIds!) : null,
-        hasDumpRetention, patch.dumpRetentionSeconds ?? null,
-        hasResponsesRetention, patch.responsesRetentionSeconds ?? null,
+        hasName ? 1 : 0, patch.name ?? null,
+        hasKey ? 1 : 0, patch.key ?? null,
+        hasLastUsedAt ? 1 : 0, patch.lastUsedAt ?? null,
+        hasUpstreamIds ? 1 : 0, hasUpstreamIds ? serializeUpstreamIds(patch.upstreamIds!) : null,
+        hasDumpRetention ? 1 : 0, patch.dumpRetentionSeconds ?? null,
+        hasResponsesRetention ? 1 : 0, patch.responsesRetentionSeconds ?? null,
         id,
       )
       .first<ApiKeyRow>();
@@ -545,7 +545,7 @@ class SqlWebSearchUsageRepo implements WebSearchUsageRepo {
 
   async query(opts: { provider?: WebSearchUsageRecord['provider']; keyId?: string; action?: WebSearchUsageRecord['action']; start: string; end: string }): Promise<WebSearchUsageRecord[]> {
     const filters = ['hour >= ?', 'hour < ?'];
-    const binds: unknown[] = [opts.start, opts.end];
+    const binds: SqlBindValue[] = [opts.start, opts.end];
     if (opts.provider) {
       const validProvider = assertWebSearchProviderName(opts.provider);
       filters.unshift('provider = ?');
@@ -622,7 +622,7 @@ const performanceDimensionsFromRow = (row: PerformanceDimensionRow): Performance
 const performanceRecordKey = (dims: PerformanceDimensions): string =>
   `${dims.hour}\0${dims.keyId}\0${dims.model}\0${dims.upstream}\0${dims.operation}\0${dims.runtimeLocation}`;
 
-const performanceDimensionBinds = (dims: PerformanceDimensions): unknown[] =>
+const performanceDimensionBinds = (dims: PerformanceDimensions): SqlBindValue[] =>
   [dims.hour, dims.keyId, dims.model, dims.upstream, dims.operation, dims.runtimeLocation];
 
 const PERFORMANCE_SUMMARY_COUNT_COLUMNS = ['requests', 'ttft_samples_ok', 'errors_with_output', 'errors_no_output', 'neutral', 'tpot_samples', 'ttft_ms_sum', 'tpot_us_sum'] as const;
@@ -740,7 +740,7 @@ class SqlPerformanceRepo implements PerformanceRepo {
 
   private async rowsFor(opts: { keyId?: string; start?: string; end?: string }): Promise<PerformanceTelemetryRecord[]> {
     const clauses: string[] = [];
-    const binds: unknown[] = [];
+    const binds: SqlBindValue[] = [];
     if (opts.start !== undefined) {
       clauses.push('hour >= ?');
       binds.push(opts.start);

--- a/packages/platform/src/sql-database.ts
+++ b/packages/platform/src/sql-database.ts
@@ -12,8 +12,20 @@ export interface SqlResultMeta {
   changes?: number;
 }
 
+// The value types every deployment target accepts as a bound parameter. The
+// two targets disagree at the edges, so the contract is their intersection and
+// callers normalize anything else themselves. D1 coerces a boolean to 1/0 and
+// rejects bigint; node:sqlite rejects booleans outright — deliberately, since
+// it could not read the original type back — and takes bigint for INTEGER
+// affinity. Neither accepts undefined.
+// https://developers.cloudflare.com/d1/worker-api/#type-conversion
+// https://github.com/cloudflare/workerd/blob/773b22265b07894b91d28c0d5358c7b1d503d79e/src/cloudflare/internal/d1-api.ts#L483-L518
+// https://nodejs.org/api/sqlite.html#type-conversion-between-javascript-and-sqlite
+// https://github.com/nodejs/node/blob/9de263aa8831941561f7e29aa1c13b03ceeba878/src/node_sqlite.cc#L2692-L2747
+export type SqlBindValue = null | number | string | Uint8Array;
+
 export interface SqlPreparedStatement {
-  bind(...values: unknown[]): SqlPreparedStatement;
+  bind(...values: SqlBindValue[]): SqlPreparedStatement;
   first<T = Record<string, unknown>>(): Promise<T | null>;
   all<T = Record<string, unknown>>(): Promise<SqlResult<T>>;
   run(): Promise<SqlResult>;


### PR DESCRIPTION
`PATCH /api/keys/:id`, key rotation, the `recordUsage` write that stamps `api_keys.last_used_at` on every data-plane request, and every partial expiration-sweep completion fail on the Node target with `TypeError: Provided value cannot be bound to SQLite parameter 1`.

Two statements select the column to update with `CASE WHEN ? THEN ? ELSE col END` and bind a JavaScript boolean for that flag: `SqlApiKeyRepo.update` (six flags, from #249) and `SqlExpirationSweepsRepo.complete`'s `completion.kind === 'partial'` (from #254).

D1's shim coerces a boolean to 1/0, so Cloudflare never saw it. `node:sqlite` refuses booleans deliberately — it could not read the original type back — and has never accepted them in any release.

- [workerd `d1-api.ts` bind validation](https://github.com/cloudflare/workerd/blob/773b22265b07894b91d28c0d5358c7b1d503d79e/src/cloudflare/internal/d1-api.ts#L483-L518)
- [`node_sqlite.cc` `BindValue`](https://github.com/nodejs/node/blob/9de263aa8831941561f7e29aa1c13b03ceeba878/src/node_sqlite.cc#L2692-L2747)

## Why nothing caught it

The bind surface was typed `unknown[]`, so neither runtime's rules were expressed anywhere. The `sql.js`-backed test double binds through JavaScript and accepts booleans too, and both call sites already had coverage — the suite stayed green while one of the two deployment targets was broken.

## The change

`SqlPreparedStatement.bind` now takes `SqlBindValue = null | number | string | Uint8Array`, the intersection of what the two targets accept, documented against both implementations. D1 additionally rejects `bigint`, `node:sqlite` additionally rejects a bare `ArrayBuffer`, and neither takes `undefined`, so anything outside the intersection is normalized by the caller. The flags take the `? 1 : 0` form the repo layer already uses at nine other binds.

Coverage closes from both sides: the test double rejects values outside the union, and the repo now also runs against the real `node:sqlite` driver over the real migrations, so a bind only one target refuses fails in the suite instead of in production.

Coercing inside the Node adapter instead would paper over a type the contract does not accept, leave the `bigint` / `ArrayBuffer` / `undefined` divergences unexpressed, make the nine existing coercions redundant, and keep the test double more permissive than production.

## Credit

The root-cause analysis, the bisect to #249, the intersection argument, and the real-driver test come from @moooyo, who diagnosed this in #262 and wrote moooyo/Floway#2 before this PR existed. The `node:sqlite` repo suite here is their test, ported into the workspace's `__tests__/` mirror.

Closes #286, closes #265

## Test Plan

- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Regression proof: reverting either bind to a boolean (casting past the type) fails both real-driver cases with `Provided value cannot be bound to SQLite parameter N`, and six `sql.js` cases with `SQL parameter N is a boolean, which no deployment target can bind`
- [x] Live Node instance on a fresh SQLite database, exercising every `SqlApiKeyRepo.update` caller over HTTP: name-only `PATCH`, upstream-whitelist `PATCH`, retention `PATCH`, and `POST /api/keys/:id/rotate` all return 200 with the stored row updated, where they previously answered 500
- [x] Same instance, the highest-frequency path from #286: a real `/v1/chat/completions` request against a stub upstream returns 200 and `api_keys.last_used_at` advances from NULL to a timestamp, with no `Failed to record usage` and no bind error in the log

