### PR TITLE
fix(responses): terminate the SSE stream with the [DONE] sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Impact levels:
 
 Hard and minor entries may include recommended actions; those actions do not need a separate advisory entry.
 
+## 2026-07-30 · minor
+
+### Responses SSE streams now end with the `[DONE]` sentinel
+
+Streaming `POST /v1/responses` responses now terminate with the literal `data: [DONE]` event, matching the streaming contract already followed by Chat Completions and Completions. Standard OpenAI SDKs already recognize the sentinel and stop there. A hand-written client that feeds every `data:` payload on the Responses stream straight into a JSON parser will now hit a parse failure on the final event and must skip `[DONE]` instead.
+
 ## 2026-07-24 · advisory
 
 ### Audit dump files created before payload-file tracking

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -183,6 +183,8 @@ test('POST /v1/responses streams a successful SSE body', async () => {
   const completedMatch = body.match(/"id":"(resp_[A-Za-z0-9_-]+)"/);
   assert(completedMatch !== null, 'expected a source-owned response id in the SSE body');
   assert(completedMatch[1] !== 'resp_test', 'expected the source boundary to replace the upstream response id');
+  assertEquals(body.split('data: [DONE]').length - 1, 1);
+  assert(body.endsWith('data: [DONE]\n\n'), 'expected the SSE body to terminate on the [DONE] sentinel');
   assertEquals(callResponses.mock.calls.length, 1);
 });
 
@@ -391,6 +393,7 @@ test('POST /v1/responses terminates an SSE stream with error when an output item
     assert(body.includes('simulated item persistence failure'));
     assert(!body.includes('event: response.output_item.done'));
     assert(!body.includes('event: response.completed'));
+    assert(!body.includes('[DONE]'), 'expected a failed stream to end on the error frame, not the sentinel');
   } finally {
     persistence.mockRestore();
   }

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -171,6 +171,7 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
     },
     async () => await withWorkerWebSocketRuntime(async () => {
       const client = await connectResponsesWebSocket(apiKey.key);
+      const raw = recordRawMessages(client);
       const received = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
 
       client.send(JSON.stringify({
@@ -183,6 +184,8 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
       }));
 
       const messages = await received;
+      raw.stop();
+      assert(raw.messages.every(message => !message.includes('[DONE]')), 'expected the WebSocket transport to carry no SSE sentinel');
       assert(messages.every(message => message.event_id === 'evt_1'));
       const completed = messages.find(message => message.type === 'response.completed') as { response?: { id?: unknown } } | undefined;
       assertExists(completed);

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -9,7 +9,7 @@ import { settle } from '../../shared/telemetry/settle.ts';
 import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
 import { forwardUpstreamHeaders, mergeForwardedUpstreamHeaders } from '../../shared/upstream-response.ts';
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
-import { type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
+import { doneFrame, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { responsesProtocolFrameToSSEFrame, RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
 import { isResponsesTerminalEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, type PlainResult, type InternalDebugError, toInternalDebugError } from '@floway-dev/provider';
@@ -135,18 +135,18 @@ const observeResponsesFrames = async function* (frames: AsyncIterable<ProtocolFr
 const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>, state: SourceStreamState) {
   try {
     for await (const frame of frames) {
-      const sse = responsesProtocolFrameToSSEFrame(frame);
-      if (sse) yield sse;
+      yield responsesProtocolFrameToSSEFrame(frame);
     }
     // The SSE transport terminates on the literal `[DONE]` payload, per the
     // OpenResponses 2026-04-24 spec, "Streaming HTTP Responses":
     // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx?plain=1#L84
-    // The sentinel is transport-specific, so it is emitted here rather than
-    // in the frame serializer: the same Responses frame stream also feeds the
-    // WebSocket transport, which carries streaming event objects only and has
-    // no sentinel. Only the non-throwing path reaches this; a failed stream
-    // ends on the error frame below.
-    yield sseFrame('[DONE]');
+    // A Responses stream is defined to end on its terminal event, not on a
+    // `done` frame: both the client-output boundary and `observeResponsesFrames`
+    // return as soon as the terminal event passes, so a producer's `done` frame
+    // can never reach a serializer. This generator is therefore the only place
+    // that knows the stream ran to a clean terminal, and it appends the
+    // terminating frame itself. A failed stream ends on the error frame below.
+    yield responsesProtocolFrameToSSEFrame(doneFrame());
   } catch (error) {
     state.failed = true;
     yield internalResponsesStreamErrorFrame(error);

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -138,6 +138,15 @@ const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<
       const sse = responsesProtocolFrameToSSEFrame(frame);
       if (sse) yield sse;
     }
+    // The SSE transport terminates on the literal `[DONE]` payload, per the
+    // OpenResponses 2026-04-24 spec, "Streaming HTTP Responses":
+    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx?plain=1#L84
+    // The sentinel is transport-specific, so it is emitted here rather than
+    // in the frame serializer: the same Responses frame stream also feeds the
+    // WebSocket transport, which carries streaming event objects only and has
+    // no sentinel. Only the non-throwing path reaches this; a failed stream
+    // ends on the error frame below.
+    yield sseFrame('[DONE]');
   } catch (error) {
     state.failed = true;
     yield internalResponsesStreamErrorFrame(error);

--- a/packages/protocols/__tests__/responses/to-sse_test.ts
+++ b/packages/protocols/__tests__/responses/to-sse_test.ts
@@ -1,11 +1,11 @@
 import { test } from 'vitest';
 
-import { eventFrame } from '../../src/common/index.ts';
+import { doneFrame, eventFrame } from '../../src/common/index.ts';
 import type { ResponsesStreamEvent } from '../../src/responses/index.ts';
 import { responsesProtocolFrameToSSEFrame } from '../../src/responses/to-sse.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
-test('responsesProtocolFrameToSSEFrame serializes events without owning termination', () => {
+test('responsesProtocolFrameToSSEFrame names each event and renders the terminating frame as the sentinel', () => {
   const frames = [
     eventFrame({
       type: 'response.completed',
@@ -29,10 +29,12 @@ test('responsesProtocolFrameToSSEFrame serializes events without owning terminat
       content_index: 0,
       delta: 'still serialized',
     } satisfies ResponsesStreamEvent),
+    doneFrame(),
   ].map(responsesProtocolFrameToSSEFrame);
 
   assertEquals(
-    frames.map(frame => frame?.event),
-    ['response.completed', 'response.output_text.delta'],
+    frames.map(frame => frame.event),
+    ['response.completed', 'response.output_text.delta', undefined],
   );
+  assertEquals(frames[2]?.data, '[DONE]');
 });

--- a/packages/protocols/src/responses/to-sse.ts
+++ b/packages/protocols/src/responses/to-sse.ts
@@ -1,5 +1,5 @@
 import type { ResponsesStreamEvent } from './index.ts';
 import { type ProtocolFrame, type SseFrame, sseFrame } from '../common/index.ts';
 
-export const responsesProtocolFrameToSSEFrame = (frame: ProtocolFrame<ResponsesStreamEvent>): SseFrame | null =>
-  frame.type === 'event' ? sseFrame(JSON.stringify(frame.event), frame.event.type) : null;
+export const responsesProtocolFrameToSSEFrame = (frame: ProtocolFrame<ResponsesStreamEvent>): SseFrame =>
+  (frame.type === 'done' ? sseFrame('[DONE]') : sseFrame(JSON.stringify(frame.event), frame.event.type));


### PR DESCRIPTION
redacted