### PR TITLE
fix(responses): reject a request without `model` at the wire boundary

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/errors_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/errors_test.ts
@@ -35,6 +35,21 @@ test('responsesInputErrorResult renders an OpenAI 400 invalid_request_error enve
   });
 });
 
+test('responsesInputErrorResult carries an explicit error code into the envelope', () => {
+  const result = responsesInputErrorResult(
+    new TranslatorInputError("Missing required parameter: 'model'.", { param: 'model', code: 'missing_required_parameter' }),
+  );
+
+  assertEquals(bodyOf(result), {
+    error: {
+      message: "Missing required parameter: 'model'.",
+      type: 'invalid_request_error',
+      param: 'model',
+      code: 'missing_required_parameter',
+    },
+  });
+});
+
 test('responsesInputErrorResult honors an explicit input param', () => {
   const result = responsesInputErrorResult(
     new TranslatorInputError('content block not supported', { param: 'input[1].content[0]' }),

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -471,6 +471,29 @@ test('POST /v1/responses with an unresolvable previous_response_id renders the v
   assertEquals(body.error.code, 'previous_response_not_found');
 });
 
+test('POST /v1/responses and /v1/responses/compact reject a body without `model` with the OpenAI missing-parameter 400', async () => {
+  installRepo();
+
+  // No candidates need to be queued — the wire boundary rejects before
+  // resolution binds the model id into the alias lookup.
+  for (const path of ['/v1/responses', '/v1/responses/compact']) {
+    const response = await makeApp().request(path, {
+      method: 'POST',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ input: 'hello' }),
+    });
+
+    assertEquals(response.status, 400);
+    const body = await response.json() as { error: { message: string; type: string; param: string; code: string } };
+    assertEquals(body.error, {
+      message: "Missing required parameter: 'model'.",
+      type: 'invalid_request_error',
+      param: 'model',
+      code: 'missing_required_parameter',
+    });
+  }
+});
+
 const queueCodexAutoReviewCandidate = (
   callResponses: (model: unknown, body: unknown, action: ResponsesAction, signal?: AbortSignal, opts?: UpstreamCallOptions) => Promise<ProviderResponsesResult>,
 ): void => {

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -537,8 +537,24 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
       status_code: 400,
       error: {
         type: 'invalid_request_error',
+        code: 'missing_required_parameter',
+        message: "Missing required parameter: 'model'.",
+        param: 'model',
+      },
+    }]);
+
+    const invalidInput = waitForMessages(client, messages => messages.length === 1);
+    client.send(JSON.stringify({ type: 'response.create', event_id: 'evt_input', response: { model: 'test-model' } }));
+
+    assertEquals(await invalidInput, [{
+      type: 'error',
+      event_id: 'evt_input',
+      status_code: 400,
+      error: {
+        type: 'invalid_request_error',
         code: 'invalid_request_error',
-        message: 'response.create requires response.model to be a non-empty string.',
+        message: 'Responses input must be a string or an array.',
+        param: 'input',
       },
     }]);
 

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -531,32 +531,30 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     const invalidResponse = waitForMessages(client, messages => messages.length === 1);
     client.send(JSON.stringify({ type: 'response.create', event_id: 'evt_response', response: {} }));
 
-    assertEquals(await invalidResponse, [{
-      type: 'error',
-      event_id: 'evt_response',
-      status_code: 400,
-      error: {
-        type: 'invalid_request_error',
-        code: 'missing_required_parameter',
-        message: "Missing required parameter: 'model'.",
-        param: 'model',
-      },
-    }]);
+    const [invalidResponseMessage] = await invalidResponse;
+    assertExists(invalidResponseMessage);
+    assertEquals(invalidResponseMessage.type, 'error');
+    assertEquals(invalidResponseMessage.event_id, 'evt_response');
+    assertEquals(invalidResponseMessage.error, {
+      type: 'invalid_request_error',
+      code: 'missing_required_parameter',
+      message: "Missing required parameter: 'model'.",
+      param: 'model',
+    });
 
     const invalidInput = waitForMessages(client, messages => messages.length === 1);
     client.send(JSON.stringify({ type: 'response.create', event_id: 'evt_input', response: { model: 'test-model' } }));
 
-    assertEquals(await invalidInput, [{
-      type: 'error',
-      event_id: 'evt_input',
-      status_code: 400,
-      error: {
-        type: 'invalid_request_error',
-        code: 'invalid_request_error',
-        message: 'Responses input must be a string or an array.',
-        param: 'input',
-      },
-    }]);
+    const [invalidInputMessage] = await invalidInput;
+    assertExists(invalidInputMessage);
+    assertEquals(invalidInputMessage.type, 'error');
+    assertEquals(invalidInputMessage.event_id, 'evt_input');
+    assertEquals(invalidInputMessage.error, {
+      type: 'invalid_request_error',
+      code: 'invalid_request_error',
+      message: 'Responses input must be a string or an array.',
+      param: 'input',
+    });
 
     const invalidItem = waitForMessages(client, messages => messages.length === 1);
     client.send(JSON.stringify({

--- a/packages/gateway/src/data-plane/chat/responses/errors.ts
+++ b/packages/gateway/src/data-plane/chat/responses/errors.ts
@@ -10,10 +10,10 @@ export type ResponsesServeFailure = ChatServeFailure | { readonly kind: 'item-no
 // membrane share the Responses 400 envelope. `performance` retains candidate
 // attribution when validation fires after attempt dispatch.
 export const responsesInputErrorResult = (
-  error: { readonly message: string; readonly param?: string },
+  error: { readonly message: string; readonly param?: string; readonly code?: string },
   performance?: PerformanceTelemetryContext,
 ): ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> =>
-  openAiErrorResult(400, error.message, { param: error.param ?? 'input', code: null }, performance);
+  openAiErrorResult(400, error.message, { param: error.param ?? 'input', code: error.code ?? null }, performance);
 
 export const renderResponsesFailure = (
   failure: ResponsesServeFailure,

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -262,7 +262,7 @@ const handleClientMessage = async (
     if (error instanceof TranslatorInputError) {
       sendError(socket, 400, {
         type: 'invalid_request_error',
-        code: 'invalid_request_error',
+        code: error.code ?? 'invalid_request_error',
         message: error.message,
         param: error.param,
       }, eventId);
@@ -306,17 +306,9 @@ const validateClientMessage = (parsed: unknown): ResponsesWebSocketClientEvent =
   return parsed as ResponsesWebSocketClientEvent;
 };
 
-const responsesPayloadFromClientSource = (source: object): CanonicalResponsesPayload => {
-  const candidate = source as { model?: unknown; input?: unknown };
-  if (typeof candidate.model !== 'string' || candidate.model.length === 0) {
-    throw new WebSocketClientMessageError('response.create requires response.model to be a non-empty string.');
-  }
-  if (typeof candidate.input !== 'string' && !Array.isArray(candidate.input)) {
-    throw new WebSocketClientMessageError('response.create requires response.input to be a string or an array.');
-  }
+const responsesPayloadFromClientSource = (source: object): CanonicalResponsesPayload =>
   // stamp stream: true — the WS transport always streams.
-  return { ...canonicalizeResponsesPayload(source as ResponsesRequestPayload), stream: true };
-};
+  ({ ...canonicalizeResponsesPayload(source as ResponsesRequestPayload), stream: true });
 
 const respondResponsesWebSocket = async (input: {
   readonly socket: ResponsesWebSocketSocket;

--- a/packages/translate/__tests__/canonicalize-responses-payload_test.ts
+++ b/packages/translate/__tests__/canonicalize-responses-payload_test.ts
@@ -45,6 +45,23 @@ test('canonicalizes string and implicit-message wire inputs', () => {
   });
 });
 
+test('rejects a payload without a usable model at the canonical boundary', () => {
+  for (const payload of [
+    { input: 'hello' },
+    { model: '', input: 'hello' },
+    { model: 42, input: 'hello' },
+    { model: null, input: 'hello' },
+  ]) {
+    const error = assertThrows(
+      () => canonicalizeResponsesPayload(payload),
+      TranslatorInputError,
+      "Missing required parameter: 'model'.",
+    ) as TranslatorInputError;
+    assertEquals(error.param, 'model');
+    assertEquals(error.code, 'missing_required_parameter');
+  }
+});
+
 test('rejects malformed untyped input items at the canonical boundary', () => {
   for (const malformed of [
     null,

--- a/packages/translate/src/canonicalize-responses-payload.ts
+++ b/packages/translate/src/canonicalize-responses-payload.ts
@@ -48,6 +48,14 @@ export function canonicalizeResponsesPayload(value: unknown): CanonicalResponses
     throw new TranslatorInputError('Responses payload must be an object.');
   }
   const payload = value as ResponsesRequestPayload;
+  // `model` is required on both the create and the compact request bodies, and
+  // resolution binds it straight into a SQL lookup, so the wire boundary is the
+  // only place that can still turn a missing id into a caller-facing 400. The
+  // message and code reproduce OpenAI's own rejection verbatim.
+  // https://github.com/mattermost/mattermost-plugin-agents/issues/476
+  if (typeof payload.model !== 'string' || payload.model.length === 0) {
+    throw new TranslatorInputError("Missing required parameter: 'model'.", { param: 'model', code: 'missing_required_parameter' });
+  }
   const input: unknown = payload.input;
   if (typeof input !== 'string' && !Array.isArray(input)) {
     throw new TranslatorInputError('Responses input must be a string or an array.', { param: 'input' });

--- a/packages/translate/src/translator-input-error.ts
+++ b/packages/translate/src/translator-input-error.ts
@@ -4,14 +4,17 @@
 // the target requires, etc.). Distinct from a plain `Error` so the
 // data-plane http handlers can return a protocol-shaped 400 envelope
 // instead of routing the failure through the generic internal-error 502
-// path. The optional `param` follows the OpenAI / Anthropic error-body
-// convention for naming the offending caller-visible field.
+// path. The optional `param` and `code` follow the OpenAI / Anthropic
+// error-body convention for naming the offending caller-visible field and
+// the machine-readable reason it was rejected.
 export class TranslatorInputError extends Error {
   readonly param: string | undefined;
+  readonly code: string | undefined;
 
-  constructor(message: string, options?: { param?: string }) {
+  constructor(message: string, options?: { param?: string; code?: string }) {
     super(message);
     this.name = 'TranslatorInputError';
     this.param = options?.param;
+    this.code = options?.code;
   }
 }


### PR DESCRIPTION
redacted