### PR TITLE
fix(responses): reject missing models before routing

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -416,6 +416,23 @@ test('POST /v1/responses returns 502 when the response snapshot cannot be persis
   }
 });
 
+test('POST /v1/responses/compact rejects a missing model before resolution', async () => {
+  installRepo();
+  lastSeenModel.value = null;
+
+  const response = await makeApp().request('/v1/responses/compact', {
+    method: 'POST',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ input: 'hello' }),
+  });
+
+  assertEquals(response.status, 400);
+  const body = await response.json() as { error: { message: string; param: string } };
+  assertEquals(body.error.message, 'Responses model must be a string.');
+  assertEquals(body.error.param, 'model');
+  assertEquals(lastSeenModel.value, null);
+});
+
 test('POST /v1/responses/compact returns a non-streaming compaction envelope', async () => {
   const repo = installRepo();
   const compactionItem = { type: 'compaction' as const, id: 'cmp_1', encrypted_content: 'ENC' };

--- a/packages/translate/__tests__/canonicalize-responses-payload_test.ts
+++ b/packages/translate/__tests__/canonicalize-responses-payload_test.ts
@@ -45,6 +45,21 @@ test('canonicalizes string and implicit-message wire inputs', () => {
   });
 });
 
+test('rejects a missing or non-string model at the canonical boundary', () => {
+  for (const payload of [
+    { input: 'hello' },
+    { model: null, input: 'hello' },
+    { model: 42, input: 'hello' },
+  ]) {
+    const error = assertThrows(
+      () => canonicalizeResponsesPayload(payload),
+      TranslatorInputError,
+      'model must be a string',
+    ) as TranslatorInputError;
+    assertEquals(error.param, 'model');
+  }
+});
+
 test('rejects malformed untyped input items at the canonical boundary', () => {
   for (const malformed of [
     null,

--- a/packages/translate/src/canonicalize-responses-payload.ts
+++ b/packages/translate/src/canonicalize-responses-payload.ts
@@ -48,6 +48,9 @@ export function canonicalizeResponsesPayload(value: unknown): CanonicalResponses
     throw new TranslatorInputError('Responses payload must be an object.');
   }
   const payload = value as ResponsesRequestPayload;
+  if (typeof payload.model !== 'string') {
+    throw new TranslatorInputError('Responses model must be a string.', { param: 'model' });
+  }
   const input: unknown = payload.input;
   if (typeof input !== 'string' && !Array.isArray(input)) {
     throw new TranslatorInputError('Responses input must be a string or an array.', { param: 'input' });


### PR DESCRIPTION
## Summary

- validate Responses request models at the canonical source boundary
- return a Responses-shaped 400 with `param: "model"` for missing or non-string values
- keep malformed compact requests out of alias lookup and model resolution

## Root cause

The wire payload was cast to `ResponsesRequestPayload` without validating `model`. A request that omitted it therefore carried `undefined` into `SqlModelAliasesRepo.getByName`; both node:sqlite and D1 reject that bind value and surfaced a 500.

Current OpenAI OpenAPI and SDK contracts require the compact `model` field, and Codex has always serialized its active model for this endpoint, so this is a client input error rather than a model-defaulting case.

## Verification

- `pnpm run test` — 422 files, 4907 tests passed
- `pnpm run lint`
- `pnpm run typecheck`
