### PR TITLE
test(responses): pin the snapshot against a terminal that omits a streamed item

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/items/output_test.ts
@@ -595,3 +595,36 @@ test('snapshot output IDs follow output_index rather than done arrival order', a
     terminal.output.map(item => item.id),
   );
 });
+
+test('snapshot retains completed streamed items omitted from the terminal output', async () => {
+  const { repo, store } = memoryOutputHarness();
+  const call = {
+    type: 'custom_tool_call' as const,
+    id: 'ctc_streamed_only',
+    call_id: 'call_streamed_only',
+    name: 'exec_command',
+    input: 'printf floway-repro',
+    status: 'completed',
+  };
+  const response: ResponsesResult = {
+    id: 'resp_upstream',
+    object: 'response',
+    model: 'model',
+    status: 'completed',
+    output: [],
+    error: null,
+    incomplete_details: null,
+  };
+  const input = async function* (): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> {
+    yield eventFrame({ type: 'response.output_item.done', output_index: 0, item: call });
+    yield eventFrame({ type: 'response.completed', response });
+  };
+
+  for await (const _frame of wrapResponsesClientOutput(input(), {
+    store,
+    responseId: 'resp_public',
+  })) { /* drain */ }
+
+  expect((await repo.responsesSnapshots.lookup('key-a', 'resp_public', 0))?.itemIds).toEqual([call.id]);
+  expect((await repo.responsesItems.lookupMany('key-a', [call.id], 0))[0].payload.item).toEqual(call);
+});


### PR DESCRIPTION
## The production fix in this branch is already on `main`

This branch's change to `wrapResponsesClientOutput` was: keep the terminal-envelope check as a validation, and build the snapshot from every finalized output index rather than from the terminal's own restatement.

`main` does exactly that today, landed through #328:

```ts
event.response.output.forEach((_item, outputIndex) => {
  if (!finalizedOutputIds.has(outputIndex)) {
    throw new TypeError(`Responses terminal output_index ${outputIndex} arrived before output_item.done`);
  }
});
const orderedOutputIds = [...finalizedOutputIds]
  .sort(([left], [right]) => left - right)
  .map(([, id]) => id);
```

Replaying this branch's commit onto `main` conflicts, and the conflict is purely textual — the same guard and the same sorted-map snapshot, written differently, down to the error message.

**The two were written independently, and this one came first.** #328 landed the same fix without crediting its author. Recording it here since the merged commit cannot be rewritten.

## What remains is the test, and it earns its place

#328's tests sit at the client-facing egress. This one sits a layer in, at the item-id membrane, and covers a case nothing else does: a `custom_tool_call` item closed by `output_item.done` while the terminal states `output: []`. It asserts both halves — that the snapshot names the item, and that the persisted item payload round-trips.

Applied to `main`'s production code unchanged it passes, so it pins behaviour that is already correct rather than describing a fix.

The branch is now that single commit, rebuilt on current `main` and keeping `Co-Authored-By: Kirikaze Chiyuki`. The fourteen other commits it carried were superseded versions of work that has since reached `main` by other routes, and are gone with the rewrite.

## Test Plan

- [x] `packages/gateway` typecheck clean.
- [x] ESLint clean on the changed file.
- [x] `packages/gateway` full Vitest suite: 178 files / 2137 tests passed — one more than `main`, which is this test.
