### PR TITLE
fix(protocols): model a function tool as a client may actually send it

### DIFF
--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -567,8 +567,8 @@ Request mapping:
 - Responses `text.format` maps directly to Chat `response_format`; `text: {}`
   omits `response_format`, while `text: null` stays explicit `null`.
 - Responses function tools become Chat function tools, preserving explicit
-  `strict`, `parameters`, and `description`. Chat has no `null` spelling for an
-  unspecified one, so the key is omitted instead.
+  `strict`, `parameters`, and `description`. Chat has no `null` spelling, so an
+  unspecified one is omitted rather than forwarded.
   Freeform `custom` tools are wrapped as single-string function tools; see
   "Responses Custom Tool Wrapping".
 - Programmatic Tool Calling state handling is identical to Responses Via

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -334,7 +334,9 @@ Request mapping:
   open-string tier passes through as Messages `service_tier`.
 - `reasoning.effort: "none"` maps to disabled thinking; any other explicit
   effort maps to `output_config.effort`.
-- Responses function tools become Messages tools, preserving explicit `strict`.
+- Responses function tools become Messages tools, preserving explicit `strict`
+  and `description`. Messages requires `input_schema`, so a tool that specifies
+  no `parameters` gets the empty object schema.
   Freeform `custom` tools are wrapped as single-string function tools; see
   "Responses Custom Tool Wrapping".
 - Responses `tool_choice` maps to the corresponding Messages tool choice when
@@ -564,7 +566,9 @@ Request mapping:
   `service_tier`, and explicit `reasoning.effort` pass through when present.
 - Responses `text.format` maps directly to Chat `response_format`; `text: {}`
   omits `response_format`, while `text: null` stays explicit `null`.
-- Responses function tools become Chat function tools, preserving `strict`.
+- Responses function tools become Chat function tools, preserving explicit
+  `strict`, `parameters`, and `description`. Chat has no `null` spelling for an
+  unspecified one, so the key is omitted instead.
   Freeform `custom` tools are wrapped as single-string function tools; see
   "Responses Custom Tool Wrapping".
 - Programmatic Tool Calling state handling is identical to Responses Via

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -193,7 +193,7 @@ export const sumUsage = (a: MergeUsage, b: MergeUsage): MergeUsage => {
   return out;
 };
 
-const usageForWire = (state: MergeState): ResponsesResult['usage'] => {
+const usageForWire = (state: MergeState): NonNullable<ResponsesResult['usage']> | undefined => {
   const u = state.accumulatedUsage;
   if (
     u.input_tokens === undefined
@@ -214,7 +214,7 @@ const usageForWire = (state: MergeState): ResponsesResult['usage'] => {
 };
 
 const usageOf = (usage: ResponsesResult['usage']): MergeUsage => {
-  if (usage === undefined || usage === null) return {};
+  if (usage == null) return {};
   const out: MergeUsage = {};
   if (usage.input_tokens !== undefined) out.input_tokens = usage.input_tokens;
   if (usage.output_tokens !== undefined) out.output_tokens = usage.output_tokens;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -214,7 +214,7 @@ const usageForWire = (state: MergeState): ResponsesResult['usage'] => {
 };
 
 const usageOf = (usage: ResponsesResult['usage']): MergeUsage => {
-  if (usage === undefined) return {};
+  if (usage === undefined || usage === null) return {};
   const out: MergeUsage = {};
   if (usage.input_tokens !== undefined) out.input_tokens = usage.input_tokens;
   if (usage.output_tokens !== undefined) out.output_tokens = usage.output_tokens;

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -613,13 +613,12 @@ export type ResponsesToolAllowedCaller = 'direct' | 'programmatic';
 export interface ResponsesFunctionTool {
   type: 'function';
   name: string;
-  // `description`, `parameters` and `strict` are asymmetric across the two
-  // sides of the wire: a request may omit any of them, while the response tool
-  // schema marks all three required with an explicit `null` alternative. This
-  // interface models what a client may actually send, so all three are
-  // optional-nullable here and the client-facing egress completes an absent one
-  // as `null`.
-  // Request: https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L808-L845
+  // One interface serves both wire directions, and they disagree on
+  // `description`, `parameters` and `strict`: a request may omit all three,
+  // while the echoed response tool marks all three required with an explicit
+  // `null` alternative. The union of the two is optional-and-nullable, so a
+  // translator must handle absent and `null` alike.
+  // Request: https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L808-L847
   // Response: https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2141-L2192
   description?: string | null;
   parameters?: Record<string, unknown> | null;
@@ -839,6 +838,12 @@ export interface ResponsesResult {
   // confirm they're populated with server-enriched defaults.
   tools?: ResponsesTool[];
   tool_choice?: ResponsesToolChoice | null;
+  // The response resource requires `usage` and gives it an explicit `null`
+  // alternative, so `null` is what an upstream sends for a completed response
+  // that reported no token counts — distinct from a mid-stream envelope that
+  // has not accounted for them yet and omits the key entirely.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2613-L2629
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
   usage?: {
     input_tokens: number;
     output_tokens: number;
@@ -849,11 +854,6 @@ export interface ResponsesResult {
     // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L7259-L7269
     input_tokens_details?: { cached_tokens: number; cache_write_tokens?: number };
     output_tokens_details?: { reasoning_tokens: number };
-    // `usage` is required-with-a-`null`-alternative on the response resource,
-    // so `null` is a value an upstream legitimately sends for a response that
-    // reported no token counts — distinct from a mid-stream envelope that has
-    // not accounted for them yet, which omits the key.
-    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
   } | null;
 }
 

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -613,9 +613,17 @@ export type ResponsesToolAllowedCaller = 'direct' | 'programmatic';
 export interface ResponsesFunctionTool {
   type: 'function';
   name: string;
-  parameters: Record<string, unknown>;
-  strict: boolean;
-  description?: string;
+  // `description`, `parameters` and `strict` are asymmetric across the two
+  // sides of the wire: a request may omit any of them, while the response tool
+  // schema marks all three required with an explicit `null` alternative. This
+  // interface models what a client may actually send, so all three are
+  // optional-nullable here and the client-facing egress completes an absent one
+  // as `null`.
+  // Request: https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L808-L845
+  // Response: https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2141-L2192
+  description?: string | null;
+  parameters?: Record<string, unknown> | null;
+  strict?: boolean | null;
   allowed_callers?: ResponsesToolAllowedCaller[] | null;
   defer_loading?: boolean;
   output_schema?: Record<string, unknown> | null;
@@ -841,7 +849,12 @@ export interface ResponsesResult {
     // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L7259-L7269
     input_tokens_details?: { cached_tokens: number; cache_write_tokens?: number };
     output_tokens_details?: { reasoning_tokens: number };
-  };
+    // `usage` is required-with-a-`null`-alternative on the response resource,
+    // so `null` is a value an upstream legitimately sends for a response that
+    // reported no token counts — distinct from a mid-stream envelope that has
+    // not accounted for them yet, which omits the key.
+    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+  } | null;
 }
 
 // Stored/output additional-tools roles are wider than the input-only

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -839,9 +839,9 @@ export interface ResponsesResult {
   tools?: ResponsesTool[];
   tool_choice?: ResponsesToolChoice | null;
   // The response resource requires `usage` and gives it an explicit `null`
-  // alternative, so `null` is what an upstream sends for a completed response
-  // that reported no token counts — distinct from a mid-stream envelope that
-  // has not accounted for them yet and omits the key entirely.
+  // alternative, so `null` is what an upstream sends for a response that
+  // reported no token counts. The key stays optional because a partially built
+  // envelope carries no usage until the terminal event accounts for the turn.
   // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2613-L2629
   // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
   usage?: {

--- a/packages/translate/__tests__/responses-via-chat-completions/request_test.ts
+++ b/packages/translate/__tests__/responses-via-chat-completions/request_test.ts
@@ -333,6 +333,18 @@ test('buildTargetRequest filters out builtin tools that have no Chat Completions
   assertEquals(result.target.tools![1].function.description, undefined);
 });
 
+test('buildTargetRequest omits parameters and strict for a schema-less function tool', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    input: [{ type: 'message', role: 'user', content: 'Hi' }],
+    tools: [{ type: 'function', name: 'ping' }],
+  });
+
+  // `toEqual` treats an undefined-valued key as absent, so the keys are
+  // compared directly: emitting `parameters: undefined` is the regression.
+  assertEquals(Object.keys(result.target.tools![0].function), ['name']);
+});
+
 test('buildTargetRequest returns undefined tools when only builtin tools are present', () => {
   const result = buildTargetRequest({
     model: 'gpt-test',

--- a/packages/translate/__tests__/responses-via-messages/request_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/request_test.ts
@@ -653,8 +653,6 @@ test('buildTargetRequest gives a schema-less function tool the empty object sche
     tools: [{ type: 'function', name: 'ping' }],
   });
 
-  // Forwarding an absent `parameters` verbatim put `input_schema: undefined` on
-  // the wire, which Anthropic rejects with a 400 for the whole request.
   assertEquals(result.target.tools, [
     {
       name: 'ping',

--- a/packages/translate/__tests__/responses-via-messages/request_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/request_test.ts
@@ -647,6 +647,23 @@ test('buildTargetRequest flattens namespace functions collision-safely and maps 
   assertEquals(result.target.tool_choice, { type: 'tool', name: 'web_run_2' });
 });
 
+test('buildTargetRequest gives a schema-less function tool the empty object schema', async () => {
+  const result = await buildTargetRequest({
+    ...minimalPayload,
+    tools: [{ type: 'function', name: 'ping' }],
+  });
+
+  // Forwarding an absent `parameters` verbatim put `input_schema: undefined` on
+  // the wire, which Anthropic rejects with a 400 for the whole request.
+  assertEquals(result.target.tools, [
+    {
+      name: 'ping',
+      input_schema: { type: 'object', properties: {} },
+      cache_control: { type: 'ephemeral' },
+    },
+  ]);
+});
+
 test('buildTargetRequest keeps plain-text function_call_output as string content', async () => {
   const result = await buildTargetRequest({
     model: 'claude-test',

--- a/packages/translate/src/responses-via-chat-completions/events.ts
+++ b/packages/translate/src/responses-via-chat-completions/events.ts
@@ -5,7 +5,7 @@ import type { ChatCompletionsStreamEvent, ChatCompletionsResult } from '@floway-
 import { eventFrame, splitInclusiveInputTokens, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { createRandomResponsesItemId, type ResponsesOutputItem, type ResponsesOutputReasoning, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
-const mapChatCompletionsUsageToResponsesUsage = (usage: ChatCompletionsResult['usage'] | undefined): ResponsesResult['usage'] | undefined => {
+const mapChatCompletionsUsageToResponsesUsage = (usage: ChatCompletionsResult['usage'] | undefined): NonNullable<ResponsesResult['usage']> | undefined => {
   if (!usage) return undefined;
   const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
   const cacheWriteTokens = usage.prompt_tokens_details?.cache_creation_input_tokens
@@ -95,7 +95,7 @@ interface ChatCompletionsToResponsesStreamState {
   openFunctionCalls: Map<number, PendingFunctionCallItem>;
   deferredAfterReasoning: DeferredAfterReasoning[];
   reasoningItemsSeen: boolean;
-  usage?: ResponsesResult['usage'];
+  usage?: NonNullable<ResponsesResult['usage']>;
   serviceTier?: ResponsesResult['service_tier'];
   pendingFinishReason?: ChatCompletionsFinishReason;
   completed: boolean;

--- a/packages/translate/src/responses-via-chat-completions/request.ts
+++ b/packages/translate/src/responses-via-chat-completions/request.ts
@@ -100,8 +100,10 @@ const translateResponsesTools = (tools: ResponsesTool[] | null | undefined, cust
         type: 'function',
         function: {
           name: tool.name,
-          parameters: tool.parameters,
-          strict: tool.strict,
+          // Responses spells "unspecified" as an omitted key or an explicit
+          // `null`; Chat Completions has only the omitted-key spelling.
+          ...(tool.parameters === undefined || tool.parameters === null ? {} : { parameters: tool.parameters }),
+          ...(tool.strict === undefined || tool.strict === null ? {} : { strict: tool.strict }),
           ...(tool.description ? { description: tool.description } : {}),
         },
       });

--- a/packages/translate/src/responses-via-chat-completions/request.ts
+++ b/packages/translate/src/responses-via-chat-completions/request.ts
@@ -102,8 +102,8 @@ const translateResponsesTools = (tools: ResponsesTool[] | null | undefined, cust
           name: tool.name,
           // Responses spells "unspecified" as an omitted key or an explicit
           // `null`; Chat Completions has only the omitted-key spelling.
-          ...(tool.parameters === undefined || tool.parameters === null ? {} : { parameters: tool.parameters }),
-          ...(tool.strict === undefined || tool.strict === null ? {} : { strict: tool.strict }),
+          ...(tool.parameters == null ? {} : { parameters: tool.parameters }),
+          ...(tool.strict == null ? {} : { strict: tool.strict }),
           ...(tool.description ? { description: tool.description } : {}),
         },
       });

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -350,9 +350,16 @@ const translateTools = (
     if (tool.type === 'function') {
       out.push({
         name: tool.name,
-        description: tool.description,
-        input_schema: tool.parameters,
-        strict: tool.strict,
+        // Responses spells "this tool has no description" as an explicit
+        // `null`; Messages has no such spelling, so the key is dropped.
+        ...(tool.description === undefined || tool.description === null ? {} : { description: tool.description }),
+        // Messages has no spelling for "no schema" either: `input_schema` is
+        // required and must be a JSON Schema object, so an unspecified
+        // Responses `parameters` becomes the empty object schema. Forwarding
+        // `undefined` made Anthropic reject the whole request with a 400.
+        // https://docs.claude.com/en/api/messages
+        input_schema: tool.parameters ?? { type: 'object', properties: {} },
+        ...(tool.strict === undefined || tool.strict === null ? {} : { strict: tool.strict }),
       });
       continue;
     }

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -352,14 +352,15 @@ const translateTools = (
         name: tool.name,
         // Responses spells "this tool has no description" as an explicit
         // `null`; Messages has no such spelling, so the key is dropped.
-        ...(tool.description === undefined || tool.description === null ? {} : { description: tool.description }),
+        ...(tool.description == null ? {} : { description: tool.description }),
         // Messages has no spelling for "no schema" either: `input_schema` is
-        // required and must be a JSON Schema object, so an unspecified
-        // Responses `parameters` becomes the empty object schema. Forwarding
-        // `undefined` made Anthropic reject the whole request with a 400.
-        // https://docs.claude.com/en/api/messages
+        // required, and forwarding `undefined` makes Anthropic reject the whole
+        // request with a 400. The empty object schema is Anthropic's own
+        // spelling for a tool that takes no arguments.
+        // https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/messages/messages.ts#L1845-L1852
+        // https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/examples/managed-agents-self-hosted-sandbox-worker.ts#L34-L41
         input_schema: tool.parameters ?? { type: 'object', properties: {} },
-        ...(tool.strict === undefined || tool.strict === null ? {} : { strict: tool.strict }),
+        ...(tool.strict == null ? {} : { strict: tool.strict }),
       });
       continue;
     }


### PR DESCRIPTION
`ResponsesFunctionTool` declared `parameters` and `strict` required and `description` non-nullable. That is the inverse of the wire truth: the OpenResponses **request** schema marks all three optional, and only the **response** tool schema requires them present with an explicit `null` alternative. The interface asserted the response side's presence on the request side's shape, so every reader had to believe a value a client may legitimately omit. All three become optional-and-nullable — the union of the two directions — and the comment cites both schema ranges.

Widening them let the compiler surface a live bug that this change also fixes. `responses-via-messages/request.ts` forwarded `input_schema: tool.parameters` verbatim, so a schema-less function tool put `input_schema: undefined` on the wire and Anthropic rejected the whole request with a 400. Messages has no spelling for "no schema", so an unspecified `parameters` now becomes `{ type: 'object', properties: {} }`, the shape Anthropic's own first-party no-argument tool uses. `description` and `strict`, which Messages can simply omit, are dropped instead. Chat Completions has only the omitted-key spelling too, so its translator omits `parameters` and `strict` rather than emitting `undefined` values.

`ResponsesResult['usage']` gains `| null` on the same grounds: the response resource declares `usage` required with a `null` alternative, so `null` is a value an upstream actually sends — distinct from a partially built streaming envelope that carries no usage until the terminal event. The server-tool shim's `usageOf` guard widens to `== null`, and the Chat Completions translator's state and mapper annotations become `NonNullable<ResponsesResult['usage']>`.

`docs/TRANSLATION.md` records the resulting tool-mapping behavior on both Responses paths.

## Test Plan

- [x] `pnpm run typecheck` — passes.
- [x] `pnpm run lint` — passes.
- [x] `pnpm run test` — 422 files, 4907 tests passed, 0 failed. Includes the two new regression tests: the Messages path gives a schema-less tool the empty object schema, and the Chat Completions path emits only the `name` key for it.
