### PR TITLE
fix(responses): send the spec's `status` key on WebSocket error frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Impact levels:
 
 Hard and minor entries may include recommended actions; those actions do not need a separate advisory entry.
 
+## 2026-07-30 · minor
+
+### Responses WebSocket error frames carry `status` instead of `status_code`
+
+The JSON error envelope sent on the Responses WebSocket transport renamed its HTTP-style status key from `status_code` to `status`, matching the OpenResponses 2026-04-24 `WebSocketErrorEvent` contract. The nested `error` object (`type`, `code`, `message`, `param`) is unchanged, so clients that only read `error.code` need no adaptation; clients that read the numeric status off the envelope must read `status`.
+
 ## 2026-07-24 · advisory
 
 ### Audit dump files created before payload-file tracking

--- a/packages/gateway/__tests__/data-plane/chat/responses/envelope_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/envelope_test.ts
@@ -1,0 +1,301 @@
+import { describe, it } from 'vitest';
+
+import { completeResponsesEnvelope, wrapResponsesEnvelopeCompletion } from '../../../../src/data-plane/chat/responses/envelope.ts';
+import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { assertEquals, assertExists } from '@floway-dev/test-utils';
+
+// Every key `ResponseResource.required` lists.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+const REQUIRED_ENVELOPE_KEYS = [
+  'id',
+  'object',
+  'created_at',
+  'completed_at',
+  'status',
+  'incomplete_details',
+  'model',
+  'previous_response_id',
+  'instructions',
+  'output',
+  'error',
+  'tools',
+  'tool_choice',
+  'truncation',
+  'parallel_tool_calls',
+  'text',
+  'top_p',
+  'presence_penalty',
+  'frequency_penalty',
+  'top_logprobs',
+  'temperature',
+  'reasoning',
+  'usage',
+  'max_output_tokens',
+  'max_tool_calls',
+  'store',
+  'background',
+  'service_tier',
+  'metadata',
+  'safety_identifier',
+  'prompt_cache_key',
+] as const;
+
+const request = (overrides: Partial<CanonicalResponsesPayload> = {}): CanonicalResponsesPayload => ({
+  model: 'gpt-5-mini',
+  input: [{ type: 'message', role: 'user', content: 'hi' }],
+  ...overrides,
+});
+
+const sources = (overrides: Partial<CanonicalResponsesPayload> = {}) => ({
+  request: request(overrides),
+  createdAt: 1_700_000_000,
+  stored: true,
+});
+
+// The shape a translated target hands to the client boundary: identity,
+// status, output and usage, and nothing else.
+const translatedEnvelope = (): ResponsesResult => ({
+  id: 'resp_1',
+  object: 'response',
+  model: 'gpt-4.1',
+  output: [],
+  status: 'completed',
+  error: null,
+  incomplete_details: null,
+  usage: { input_tokens: 8, output_tokens: 10, total_tokens: 18 },
+});
+
+const missingKeys = (envelope: Record<string, unknown>): string[] =>
+  REQUIRED_ENVELOPE_KEYS.filter(key => !(key in envelope));
+
+describe('Responses envelope completion', () => {
+  it('fills every required key a translated target left out', () => {
+    const completed = completeResponsesEnvelope(translatedEnvelope(), sources(), true);
+    assertEquals(missingKeys(completed), []);
+  });
+
+  it('prefers what the upstream reported over what the client asked for', () => {
+    const upstream: ResponsesResult = {
+      ...translatedEnvelope(),
+      temperature: 0.2,
+      top_p: 0.5,
+      parallel_tool_calls: false,
+      truncation: 'auto',
+      metadata: { trace: 'abc' },
+      created_at: 1_600_000_000,
+    };
+    const completed = completeResponsesEnvelope(upstream, sources({ temperature: 1, top_p: 1, truncation: 'disabled' }), true);
+    assertEquals(completed.temperature, 0.2);
+    assertEquals(completed.top_p, 0.5);
+    assertEquals(completed.parallel_tool_calls, false);
+    assertEquals(completed.truncation, 'auto');
+    assertEquals(completed.metadata, { trace: 'abc' });
+    // `created_at` is gateway state: only Floway knows when it received the
+    // request, so an upstream value never wins there.
+    assertEquals(completed.created_at, 1_700_000_000);
+  });
+
+  it('keeps an upstream null on a slot whose schema offers null', () => {
+    const upstream: ResponsesResult = { ...translatedEnvelope(), max_output_tokens: null, instructions: null };
+    const completed = completeResponsesEnvelope(upstream, sources({ max_output_tokens: 512, instructions: 'be terse' }), true);
+    assertEquals(completed.max_output_tokens, null);
+    assertEquals(completed.instructions, null);
+  });
+
+  it('resolves past an upstream null on a slot whose schema offers none', () => {
+    const upstream: ResponsesResult = {
+      ...translatedEnvelope(),
+      temperature: null,
+      top_p: null,
+      truncation: null,
+      service_tier: null,
+      metadata: null,
+    };
+    const completed = completeResponsesEnvelope(upstream, sources({ temperature: 0.4 }), true);
+    // The client's own value is the next candidate…
+    assertEquals(completed.temperature, 0.4);
+    // …and the stated default ends the chain when neither side said anything.
+    assertEquals(completed.top_p, 1);
+    assertEquals(completed.truncation, 'disabled');
+    assertEquals(completed.service_tier, 'default');
+    assertEquals(completed.metadata, {});
+  });
+
+  it('echoes what the client sent in preference to the stated default', () => {
+    const completed = completeResponsesEnvelope(translatedEnvelope(), sources({
+      temperature: 0.3,
+      top_p: 0.9,
+      truncation: 'auto',
+      background: true,
+      top_logprobs: 5,
+      presence_penalty: 1.5,
+      frequency_penalty: -0.5,
+      parallel_tool_calls: false,
+      service_tier: 'priority',
+      tool_choice: 'required',
+      metadata: { run: '7' },
+      instructions: 'be terse',
+      previous_response_id: 'resp_0',
+      prompt_cache_key: 'cache-1',
+      safety_identifier: 'user-1',
+      max_output_tokens: 512,
+      max_tool_calls: 3,
+    }), true);
+    assertEquals(completed.temperature, 0.3);
+    assertEquals(completed.top_p, 0.9);
+    assertEquals(completed.truncation, 'auto');
+    assertEquals(completed.background, true);
+    assertEquals(completed.top_logprobs, 5);
+    assertEquals(completed.presence_penalty, 1.5);
+    assertEquals(completed.frequency_penalty, -0.5);
+    assertEquals(completed.parallel_tool_calls, false);
+    assertEquals(completed.service_tier, 'priority');
+    assertEquals(completed.tool_choice, 'required');
+    assertEquals(completed.metadata, { run: '7' });
+    assertEquals(completed.instructions, 'be terse');
+    assertEquals(completed.previous_response_id, 'resp_0');
+    assertEquals(completed.prompt_cache_key, 'cache-1');
+    assertEquals(completed.safety_identifier, 'user-1');
+    assertEquals(completed.max_output_tokens, 512);
+    assertEquals(completed.max_tool_calls, 3);
+  });
+
+  it('states the schema default for a required key neither side supplied', () => {
+    const completed = completeResponsesEnvelope(translatedEnvelope(), sources(), true);
+    assertEquals(completed.temperature, 1);
+    assertEquals(completed.top_p, 1);
+    assertEquals(completed.presence_penalty, 0);
+    assertEquals(completed.frequency_penalty, 0);
+    assertEquals(completed.top_logprobs, 0);
+    assertEquals(completed.parallel_tool_calls, true);
+    assertEquals(completed.truncation, 'disabled');
+    assertEquals(completed.background, false);
+    assertEquals(completed.service_tier, 'default');
+    assertEquals(completed.tool_choice, 'auto');
+    assertEquals(completed.tools, []);
+    assertEquals(completed.metadata, {});
+    assertEquals(completed.text, { format: { type: 'text' } });
+  });
+
+  it('marks an unrequested nullable key absent rather than inventing a value', () => {
+    const completed = completeResponsesEnvelope(translatedEnvelope(), sources(), true);
+    assertEquals(completed.previous_response_id, null);
+    assertEquals(completed.instructions, null);
+    assertEquals(completed.reasoning, null);
+    assertEquals(completed.max_output_tokens, null);
+    assertEquals(completed.max_tool_calls, null);
+    assertEquals(completed.safety_identifier, null);
+    assertEquals(completed.prompt_cache_key, null);
+  });
+
+  it('reports gateway state for created_at and store', () => {
+    const completed = completeResponsesEnvelope(translatedEnvelope(), { ...sources({ store: true }), stored: false }, true);
+    assertEquals(completed.created_at, 1_700_000_000);
+    assertEquals(completed.store, false);
+  });
+
+  it('completes both usage breakdowns and reports a missing usage as null', () => {
+    const completed = completeResponsesEnvelope(translatedEnvelope(), sources(), true);
+    assertEquals(completed.usage, {
+      input_tokens: 8,
+      output_tokens: 10,
+      total_tokens: 18,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    });
+
+    const { usage: _usage, ...withoutUsage } = translatedEnvelope();
+    assertEquals(completeResponsesEnvelope(withoutUsage, sources(), true).usage, null);
+  });
+
+  it('keeps a usage breakdown the upstream actually reported', () => {
+    const upstream: ResponsesResult = {
+      ...translatedEnvelope(),
+      usage: { input_tokens: 8, output_tokens: 10, total_tokens: 18, output_tokens_details: { reasoning_tokens: 7 } },
+    };
+    assertEquals(completeResponsesEnvelope(upstream, sources(), true).usage?.output_tokens_details, { reasoning_tokens: 7 });
+  });
+
+  it('completes a reasoning block and a text block to their own required keys', () => {
+    const completed = completeResponsesEnvelope(
+      translatedEnvelope(),
+      sources({ reasoning: { effort: 'high' }, text: { verbosity: 'low' } }),
+      true,
+    );
+    assertEquals(completed.reasoning, { effort: 'high', summary: null });
+    assertEquals(completed.text, { verbosity: 'low', format: { type: 'text' } });
+  });
+
+  it('completes a minimal echoed function tool to every key the tool schema requires', () => {
+    const completed = completeResponsesEnvelope(
+      translatedEnvelope(),
+      sources({ tools: [{ type: 'function', name: 'lookup' }] }),
+      true,
+    );
+    assertEquals(completed.tools, [{ type: 'function', name: 'lookup', description: null, parameters: null, strict: null }]);
+  });
+
+  // The normalizers run on the resolved value, so a tool array the upstream
+  // echoed — or one the server-tool shim reconstructed — is completed like any
+  // other. Resolving first and normalizing after is what closes that path.
+  it('completes a minimal function tool the upstream echoed back', () => {
+    const upstream: ResponsesResult = {
+      ...translatedEnvelope(),
+      tools: [{ type: 'function', name: 'lookup', parameters: { type: 'object' } }],
+    };
+    const completed = completeResponsesEnvelope(
+      upstream,
+      sources({ tools: [{ type: 'function', name: 'lookup', parameters: { type: 'object' }, strict: true, description: 'ignored' }] }),
+      true,
+    );
+    assertEquals(completed.tools, [{
+      type: 'function',
+      name: 'lookup',
+      parameters: { type: 'object' },
+      description: null,
+      strict: null,
+    }]);
+  });
+
+  it('leaves a non-function tool untouched', () => {
+    const completed = completeResponsesEnvelope(
+      translatedEnvelope(),
+      sources({ tools: [{ type: 'web_search' }] }),
+      true,
+    );
+    assertEquals(completed.tools, [{ type: 'web_search' }]);
+  });
+
+  it('completes every envelope frame of a stream and reports completed_at only on the terminal one', async () => {
+    const source = async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+      yield eventFrame({ type: 'response.created', sequence_number: 0, response: { ...translatedEnvelope(), status: 'in_progress' } } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.output_text.delta', sequence_number: 1, item_id: 'msg_1', output_index: 0, content_index: 0, delta: 'hi' } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.completed', sequence_number: 2, response: translatedEnvelope() } as ResponsesStreamEvent);
+      yield doneFrame();
+    };
+
+    const seen: ResponsesStreamEvent[] = [];
+    for await (const frame of wrapResponsesEnvelopeCompletion(source(), sources())) {
+      if (frame.type === 'event') seen.push(frame.event);
+    }
+
+    assertEquals(seen.length, 3);
+    const created = seen[0];
+    const terminal = seen[2];
+    assertExists(created);
+    assertExists(terminal);
+    if (created.type !== 'response.created' || terminal.type !== 'response.completed') {
+      throw new Error('expected the envelope frames to survive completion unchanged in type');
+    }
+    assertEquals(missingKeys(created.response as unknown as Record<string, unknown>), []);
+    assertEquals(missingKeys(terminal.response as unknown as Record<string, unknown>), []);
+    assertEquals(created.response.completed_at, null);
+    assertEquals(typeof terminal.response.completed_at, 'number');
+    // One `created_at` per response, so a client reading any frame sees the
+    // same creation time.
+    assertEquals(created.response.created_at, terminal.response.created_at);
+    // A non-envelope event is forwarded untouched.
+    assertEquals(seen[1]?.type, 'response.output_text.delta');
+  });
+});

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -351,6 +351,32 @@ test('POST /v1/responses returns a single JSON body when stream is omitted', asy
   assertEquals(body.status, 'completed');
 });
 
+// Every key `ResponseResource.required` lists.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+const REQUIRED_ENVELOPE_KEYS = [
+  'id', 'object', 'created_at', 'completed_at', 'status', 'incomplete_details', 'model',
+  'previous_response_id', 'instructions', 'output', 'error', 'tools', 'tool_choice',
+  'truncation', 'parallel_tool_calls', 'text', 'top_p', 'presence_penalty',
+  'frequency_penalty', 'top_logprobs', 'temperature', 'reasoning', 'usage',
+  'max_output_tokens', 'max_tool_calls', 'store', 'background', 'service_tier',
+  'metadata', 'safety_identifier', 'prompt_cache_key',
+];
+
+test('POST /v1/responses answers a translated-shape upstream with a complete response resource', async () => {
+  installRepo();
+  queueCompletedResponse('resp_complete');
+
+  const response = await makeApp().request('/v1/responses', {
+    method: 'POST',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ model: 'test-model', input: 'hello' }),
+  });
+
+  assertEquals(response.status, 200);
+  const body = await response.json() as Record<string, unknown>;
+  assertEquals(REQUIRED_ENVELOPE_KEYS.filter(key => !(key in body)), []);
+});
+
 test('POST /v1/responses returns 502 when a non-streaming output item cannot be persisted', async () => {
   const repo = installRepo();
   const persistence = vi.spyOn(repo.responsesItems, 'insertMany').mockRejectedValue(new Error('simulated item persistence failure'));

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -475,6 +475,52 @@ test('POST /v1/responses/compact returns a non-streaming compaction envelope', a
   assertEquals(await repo.responsesItems.lookupMany(API_KEY_ID, body.output.map(item => item.id), 0), []);
 });
 
+// `CompactResource.required` — `id`, `object`, `output`, `created_at`, `usage`,
+// with both usage breakdowns required whenever `usage` is an object. It defines
+// none of the response resource's request echoes.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json
+test('POST /v1/responses/compact answers the compaction resource, not the response resource', async () => {
+  installRepo();
+  const compactionItem = { type: 'compaction' as const, id: 'cmp_1', encrypted_content: 'ENC' };
+  const compactionResult: ResponsesResult = {
+    ...makeResponsesResult(),
+    object: 'response.compaction',
+    output: [compactionItem] as unknown as ResponsesResult['output'],
+    usage: { input_tokens: 12, output_tokens: 3, total_tokens: 15 },
+  };
+  const callResponses = vi.fn(async (_model: unknown, _body: unknown, action: ResponsesAction): Promise<ProviderResponsesResult> => {
+    if (action !== 'compact') throw new Error(`expected compact, got ${action}`);
+    return { action: 'compact', ok: true, result: compactionResult, modelKey: 'test-model-key' };
+  });
+  queueResolution([makeCandidate({ callResponses })]);
+
+  const response = await makeApp().request('/v1/responses/compact', {
+    method: 'POST',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    body: JSON.stringify({
+      model: 'test-model',
+      input: [{ type: 'message', role: 'user', content: 'kept' }],
+      store: false,
+      temperature: 0.3,
+    }),
+  });
+
+  assertEquals(response.status, 200);
+  const body = await response.json() as Record<string, unknown>;
+  assertEquals(['id', 'object', 'output', 'created_at', 'usage'].filter(key => !(key in body)), []);
+  assertEquals(typeof body.created_at, 'number');
+  assertEquals(body.usage, {
+    input_tokens: 12,
+    output_tokens: 3,
+    total_tokens: 15,
+    input_tokens_details: { cached_tokens: 0 },
+    output_tokens_details: { reasoning_tokens: 0 },
+  });
+  // The response resource's echoes belong to `/responses`; a compaction states
+  // nothing about tools, sampling or service tier.
+  assertEquals(['tools', 'tool_choice', 'temperature', 'top_p', 'truncation', 'service_tier', 'store', 'text', 'metadata'].filter(key => key in body), []);
+});
+
 test('POST /v1/responses with an unresolvable previous_response_id renders the verbatim 400 envelope', async () => {
   installRepo();
 

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -299,7 +299,7 @@ test('Responses WebSocket rejects the next turn after its API key is rotated', a
 
       assertEquals(await received, [{
         type: 'error',
-        status_code: 401,
+        status: 401,
         error: {
           type: 'authentication_error',
           code: 'invalid_api_key',
@@ -358,9 +358,9 @@ test('Responses WebSocket reports a failed turn when an output item cannot be pe
         }));
 
         const messages = await received;
-        const error = messages.find(message => message.type === 'error') as { status_code?: unknown; error?: { message?: unknown } } | undefined;
+        const error = messages.find(message => message.type === 'error') as { status?: unknown; error?: { message?: unknown } } | undefined;
         assertExists(error);
-        assertEquals(error.status_code, 500);
+        assertEquals(error.status, 500);
         assertEquals(error.error?.message, 'simulated item persistence failure');
         assert(!messages.some(message => message.type === 'response.output_item.done'));
         assert(!messages.some(message => message.type === 'response.completed'));
@@ -488,7 +488,7 @@ test('Responses WebSocket returns OpenAI-style error envelopes for unsupported c
     assertEquals(await received, [{
       type: 'error',
       event_id: 'evt_bad',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -509,7 +509,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     const [invalidJsonMessage] = await invalidJson;
     assertExists(invalidJsonMessage);
     assertEquals(invalidJsonMessage.type, 'error');
-    assertEquals(invalidJsonMessage.status_code, 400);
+    assertEquals(invalidJsonMessage.status, 400);
     assertEquals((invalidJsonMessage.error as { type?: unknown; code?: unknown }).type, 'invalid_request_error');
     assertEquals((invalidJsonMessage.error as { type?: unknown; code?: unknown }).code, 'invalid_request_error');
     assertStringIncludes((invalidJsonMessage.error as { message: string }).message, 'valid JSON');
@@ -520,7 +520,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     assertEquals(await invalidShape, [{
       type: 'error',
       event_id: 'evt_shape',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -534,7 +534,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     assertEquals(await invalidResponse, [{
       type: 'error',
       event_id: 'evt_response',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -552,7 +552,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     assertEquals(await invalidItem, [{
       type: 'error',
       event_id: 'evt_item',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -563,7 +563,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
   });
 });
 
-test('Responses WebSocket forwards HTTP failures with status_code, error.code, and event_id', async () => {
+test('Responses WebSocket forwards HTTP failures with status, error.code, and event_id', async () => {
   const { apiKey } = await setupAppTest();
   await withMockedFetch(
     async request => {
@@ -591,7 +591,7 @@ test('Responses WebSocket forwards HTTP failures with status_code, error.code, a
       assertEquals(await received, [{
         type: 'error',
         event_id: 'evt_missing',
-        status_code: 404,
+        status: 404,
         error: {
           type: 'invalid_request_error',
           code: 'invalid_request_error',
@@ -631,7 +631,7 @@ test('Responses WebSocket dump responseBytes counts an error envelope sent downs
           },
         }));
 
-        assertEquals((await received)[0]?.status_code, 404);
+        assertEquals((await received)[0]?.status, 404);
         await vi.waitFor(() => assertEquals(dumps.stored.length, 1));
         const expectedBytes = recorded.messages.reduce(
           (total, message) => total + new TextEncoder().encode(message).byteLength,
@@ -746,7 +746,7 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
       assertEquals(await missingDone, [{
         type: 'error',
         event_id: 'evt_cross_session',
-        status_code: 400,
+        status: 400,
         error: {
           message: `Previous response with id '${firstResponseId}' not found.`,
           type: 'invalid_request_error',
@@ -1025,7 +1025,7 @@ test('Responses WebSocket session-level store: second message resolves prior ite
       assertEquals(await missingDone, [{
         type: 'error',
         event_id: 'evt_b',
-        status_code: 400,
+        status: 400,
         error: {
           message: "Previous response with id 'resp_session_1' not found.",
           type: 'invalid_request_error',
@@ -1142,7 +1142,7 @@ test('Responses WebSocket outer catch records a failed perf sample attributed to
         const [errorMessage] = await received;
         assertExists(errorMessage);
         assertEquals(errorMessage.type, 'error');
-        assertEquals(errorMessage.status_code, 500);
+        assertEquals(errorMessage.status, 500);
         assertEquals(errorMessage.event_id, 'evt_throw');
       }),
     );

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -194,7 +194,15 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
         event_id: 'evt_1',
         response: {
           id: responseId,
-          usage: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
+          // The summary reads the terminal envelope, which the egress stage
+          // has already completed, so the usage breakdowns are present.
+          usage: {
+            input_tokens: 3,
+            output_tokens: 5,
+            total_tokens: 8,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
         },
       });
     }),

--- a/packages/gateway/src/data-plane/chat/responses/client-output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/client-output.ts
@@ -8,26 +8,40 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { CanonicalResponsesPayload, ClientResponsesStreamEvent, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
-// Affinity wraps routing metadata first. The client-output boundary then stores
+// Affinity wraps routing metadata first; the client-output boundary then stores
 // each complete emitted item under its exact ID and applies one generated
-// response ID to the downstream stream and snapshot. Envelope completion runs
-// outermost, so it sees the ID the boundary applied and is the last thing that
-// touches a response envelope before serialization.
-export const wrapNativeResponsesClientOutput = (
+// response ID to the downstream stream and snapshot. Every native Responses
+// turn goes through this, whichever resource it answers with.
+export const wrapResponsesStatefulOutput = (
+  frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
+  ctx: GatewayCtx,
+): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> => {
+  if (!('affinity' in ctx) || !('store' in ctx)) throw new Error('Responses output reached the client-facing boundary without chat context');
+  const chatCtx = ctx as ChatGatewayCtx;
+  const withAffinity = wrapResponsesAffinityEgress(frames, affinityEgressOptions(ctx));
+  return wrapResponsesClientOutput(withAffinity, {
+    store: chatCtx.store,
+    responseId: createResponsesResponseId(),
+  });
+};
+
+// The generate path's egress: response-resource completion runs outermost, so
+// it sees the ID the stateful boundary applied and is the last thing that
+// touches an envelope before serialization. `/responses/compact` answers with
+// `CompactResource` instead and completes its own five keys, so it stops at the
+// stateful half.
+export const wrapResponsesClientEgress = (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   ctx: GatewayCtx,
   request: CanonicalResponsesPayload,
 ): AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>> => {
-  if (!('affinity' in ctx) || !('store' in ctx)) throw new Error('Responses output reached the client-facing boundary without chat context');
-  const chatCtx = ctx as ChatGatewayCtx;
-  const withAffinity = wrapResponsesAffinityEgress(frames, affinityEgressOptions(ctx));
-  const stored = wrapResponsesClientOutput(withAffinity, {
-    store: chatCtx.store,
-    responseId: createResponsesResponseId(),
-  });
+  const stored = wrapResponsesStatefulOutput(frames, ctx);
   return wrapResponsesEnvelopeCompletion(stored, {
     request,
-    createdAt: Math.floor(ctx.requestStartedAt / 1000),
-    stored: chatCtx.store.writesState,
+    createdAt: responsesCreatedAt(ctx),
+    stored: (ctx as ChatGatewayCtx).store.writesState,
   });
 };
+
+// Unix seconds, from the gateway's own request-start instant.
+export const responsesCreatedAt = (ctx: GatewayCtx): number => Math.floor(ctx.requestStartedAt / 1000);

--- a/packages/gateway/src/data-plane/chat/responses/client-output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/client-output.ts
@@ -1,24 +1,33 @@
 import { wrapResponsesAffinityEgress } from './affinity/egress.ts';
+import { wrapResponsesEnvelopeCompletion } from './envelope.ts';
 import { wrapResponsesClientOutput } from './items/output.ts';
 import { createResponsesResponseId } from './response-id.ts';
 import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import { affinityEgressOptions } from '../shared/affinity/index.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ClientResponsesStreamEvent, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 // Affinity wraps routing metadata first. The client-output boundary then stores
 // each complete emitted item under its exact ID and applies one generated
-// response ID to the downstream stream and snapshot.
+// response ID to the downstream stream and snapshot. Envelope completion runs
+// outermost, so it sees the ID the boundary applied and is the last thing that
+// touches a response envelope before serialization.
 export const wrapNativeResponsesClientOutput = (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   ctx: GatewayCtx,
-): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> => {
+  request: CanonicalResponsesPayload,
+): AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>> => {
   if (!('affinity' in ctx) || !('store' in ctx)) throw new Error('Responses output reached the client-facing boundary without chat context');
   const chatCtx = ctx as ChatGatewayCtx;
   const withAffinity = wrapResponsesAffinityEgress(frames, affinityEgressOptions(ctx));
-  return wrapResponsesClientOutput(withAffinity, {
+  const stored = wrapResponsesClientOutput(withAffinity, {
     store: chatCtx.store,
     responseId: createResponsesResponseId(),
+  });
+  return wrapResponsesEnvelopeCompletion(stored, {
+    request,
+    createdAt: Math.floor(ctx.requestStartedAt / 1000),
+    stored: chatCtx.store.writesState,
   });
 };

--- a/packages/gateway/src/data-plane/chat/responses/envelope.ts
+++ b/packages/gateway/src/data-plane/chat/responses/envelope.ts
@@ -1,0 +1,217 @@
+import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import type {
+  CanonicalResponsesPayload,
+  ClientResponsesEnvelope,
+  ClientResponsesReasoning,
+  ClientResponsesStreamEvent,
+  ClientResponsesTextField,
+  ClientResponsesTool,
+  ClientResponsesUsage,
+  ResponsesResult,
+  ResponsesStreamEvent,
+  ResponsesTool,
+} from '@floway-dev/protocols/responses';
+
+// ── The policy boundary ──
+//
+// Interior stages never state a value they did not observe. The egress stage is
+// the only place Floway states one, and only where the wire schema forbids both
+// omission and `null`.
+//
+// The other half of that rule lives in the server-tool shim, where
+// `upstreamResponseSnapshot` throws rather than fabricate an envelope it never
+// captured — 44322150d (#125) reasoned that "the spec defaults observed via
+// Azure echo (all 'auto') signal 'backend decides' rather than canonical values
+// worth synthesizing", and shipped "absent-echo (no tools synthesized when
+// upstream omits it)". The two rules do not conflict on any key, because they
+// answer different questions:
+//
+// - The shim's snapshot is interior. Its output re-enters Floway: it becomes
+//   the prologue and terminal envelope of a stitched multi-call turn, later
+//   shim logic reads it, and its items are persisted. A value invented there is
+//   indistinguishable from an observed one for every later reader.
+// - This stage is terminal. Its output is serialized and never read again by
+//   Floway. `commitSnapshot` persists ordered item ids only and runs strictly
+//   before completion, so nothing invented here is ever stored; affinity egress
+//   and telemetry likewise run below it. Nothing downstream can mistake a
+//   stated default for an observation, because nothing downstream is Floway.
+//
+// #125's "no tools synthesized when upstream omits it" therefore still holds:
+// the interior envelope carries no `tools`, and egress states `[]` on the way
+// out. `ResponseResource` types `tools`, `tool_choice`, `truncation`,
+// `temperature`, `service_tier` and ten others required AND non-nullable, so
+// there is no spec-conformant way to say "the backend decided" — the choice is
+// between a stated default and a body that fails validation.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+
+// A required slot with no `null` alternative: `null` and `undefined` both mean
+// "absent", and the schema gives absence no spelling, so a stated default
+// terminates the chain.
+const stated = <T>(candidates: readonly (T | null | undefined)[], fallback: T): T =>
+  candidates.find(value => value !== undefined && value !== null) ?? fallback;
+
+// A required slot with a `null` alternative: `null` is an observation, so only
+// `undefined` continues the chain and the chain's own end is `null`.
+const observed = <T>(candidates: readonly (T | null | undefined)[]): T | null => {
+  const hit = candidates.find(value => value !== undefined);
+  return hit === undefined ? null : hit;
+};
+
+// The normalizers run on the RESOLVED value, so an upstream-echoed or
+// shim-reconstructed object is completed exactly like one built from the
+// request.
+
+// A function tool must declare `description`, `parameters` and `strict` even
+// when the client omitted them: all three are required-with-a-`null`-alternative
+// on the response tool schema while the request schema leaves them optional. An
+// absent key becomes `null` rather than an invented `{}` / `false`, because the
+// caller expressed no choice and the upstream owns the effective default.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2141-L2192
+const completeTool = (tool: ResponsesTool): ClientResponsesTool =>
+  tool.type !== 'function'
+    ? tool
+    : {
+        ...tool,
+        description: tool.description ?? null,
+        parameters: tool.parameters ?? null,
+        strict: tool.strict ?? null,
+      };
+
+// `TextField` requires `format`, whose own default is plain text.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2298-L2319
+const completeText = (text: NonNullable<ResponsesResult['text']>): ClientResponsesTextField =>
+  ({ ...text, format: text.format ?? { type: 'text' } });
+
+// `Reasoning` requires `effort` and `summary`, both of which are nullable, so
+// an unconfigured reasoning object says so rather than naming a level.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2320-L2359
+const completeReasoning = (reasoning: NonNullable<ResponsesResult['reasoning']> | null): ClientResponsesReasoning | null =>
+  reasoning === null ? null : { ...reasoning, effort: reasoning.effort ?? null, summary: reasoning.summary ?? null };
+
+// Both breakdowns are required whenever `usage` itself is an object. An absent
+// breakdown means the upstream reported no cached input tokens and no reasoning
+// output tokens.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2384-L2429
+const completeUsage = (usage: NonNullable<ResponsesResult['usage']> | null): ClientResponsesUsage | null =>
+  usage === null
+    ? null
+    : {
+        ...usage,
+        input_tokens_details: usage.input_tokens_details ?? { cached_tokens: 0 },
+        output_tokens_details: usage.output_tokens_details ?? { reasoning_tokens: 0 },
+      };
+
+export interface ResponsesEnvelopeSources {
+  // The request these events answer. Every echoed value comes from here.
+  readonly request: CanonicalResponsesPayload;
+  // Unix seconds. One value per response, so every envelope frame of a single
+  // response reports the same `created_at`.
+  readonly createdAt: number;
+  // Whether the response is actually retrievable afterwards, which is what the
+  // schema's `store` describes ("Whether this response was stored so it can be
+  // retrieved later"). Sourced from the item store rather than the request's
+  // `store` flag, because retention policy and the WebSocket session's
+  // connection-local history both override what the client asked for.
+  readonly stored: boolean;
+}
+
+// Every description the response resource attaches to these keys is past
+// tense — "The tools that were available to the model during response
+// generation", "The service tier that was used for this response", "How the
+// input was truncated by the service". The resource states what happened, not
+// what was asked, so an upstream that reports an effective value outranks the
+// request; where the upstream reports nothing, the request's own value is the
+// best available statement about the turn; where neither exists the schema
+// forces a stated default.
+//
+// The stated defaults are the values OpenAI's own reference response body
+// reports for a request that specified none of them.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2726-L2778
+// The request-side declarations of the same defaults:
+// temperature 1 and top_p 1 — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L44081-L44100
+// truncation "disabled" — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L35856-L35873
+// parallel_tool_calls true — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L35915-L35921
+// background false — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L59062-L59068
+// presence_penalty 0 — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L33561-L33565
+// frequency_penalty 0 — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L33484-L33488
+// tool_choice "auto" — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L62038-L62058
+// service_tier: the request-side default is "auto", but the response reports
+// the tier that was actually used, which for an account with no tier configured
+// is "default" — the value the reference body carries.
+// https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L61500-L61518
+export const completeResponsesEnvelope = (
+  upstream: ResponsesResult,
+  sources: ResponsesEnvelopeSources,
+  terminal: boolean,
+): ClientResponsesEnvelope => {
+  const { request } = sources;
+  return {
+    // The keys the upstream owns outright — `id`, `object`, `model`, `status`,
+    // `output`, `output_text` — plus any vendor extension it carried ride
+    // through. Every key the resource declares required is resolved explicitly
+    // below, so nothing in this spread is load-bearing for conformance.
+    ...upstream,
+
+    // Gateway state: no candidate chain, because no other source can know it.
+    created_at: sources.createdAt,
+    completed_at: terminal ? Math.floor(Date.now() / 1000) : null,
+    store: sources.stored,
+
+    tools: stated<ResponsesTool[]>([upstream.tools, request.tools], []).map(completeTool),
+    tool_choice: stated([upstream.tool_choice, request.tool_choice], 'auto'),
+    truncation: stated([upstream.truncation, request.truncation], 'disabled'),
+    parallel_tool_calls: stated([upstream.parallel_tool_calls, request.parallel_tool_calls], true),
+    text: completeText(stated<NonNullable<ResponsesResult['text']>>([upstream.text, request.text], {})),
+    top_p: stated([upstream.top_p, request.top_p], 1),
+    presence_penalty: stated([upstream.presence_penalty, request.presence_penalty], 0),
+    frequency_penalty: stated([upstream.frequency_penalty, request.frequency_penalty], 0),
+    top_logprobs: stated([upstream.top_logprobs, request.top_logprobs], 0),
+    temperature: stated([upstream.temperature, request.temperature], 1),
+    background: stated([upstream.background, request.background], false),
+    service_tier: stated([upstream.service_tier, request.service_tier], 'default'),
+    metadata: stated<Record<string, unknown>>([upstream.metadata, request.metadata], {}),
+
+    previous_response_id: observed([upstream.previous_response_id, request.previous_response_id]),
+    instructions: observed([upstream.instructions, request.instructions]),
+    max_output_tokens: observed([upstream.max_output_tokens, request.max_output_tokens]),
+    max_tool_calls: observed([upstream.max_tool_calls, request.max_tool_calls]),
+    safety_identifier: observed([upstream.safety_identifier, request.safety_identifier]),
+    prompt_cache_key: observed([upstream.prompt_cache_key, request.prompt_cache_key]),
+    reasoning: completeReasoning(observed<NonNullable<ResponsesResult['reasoning']>>([upstream.reasoning, request.reasoning])),
+    // The request has no counterpart: token counts are the upstream's alone.
+    usage: completeUsage(observed([upstream.usage])),
+  };
+};
+
+// The client-facing egress stage: every envelope-bearing event carries the
+// complete resource, so a streamed response validates frame by frame and the
+// non-streaming body — which is the terminal frame's envelope verbatim —
+// validates too. The narrowed yield type propagates the guarantee, so a stage
+// inserted between this one and a client-facing exit must preserve it or fail
+// to compile.
+export const wrapResponsesEnvelopeCompletion = async function* (
+  frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
+  sources: ResponsesEnvelopeSources,
+): AsyncGenerator<ProtocolFrame<ClientResponsesStreamEvent>> {
+  for await (const frame of frames) {
+    if (frame.type !== 'event') {
+      yield frame;
+      continue;
+    }
+    const event = frame.event;
+    switch (event.type) {
+    case 'response.queued':
+    case 'response.created':
+    case 'response.in_progress':
+      yield eventFrame({ ...event, response: completeResponsesEnvelope(event.response, sources, false) });
+      continue;
+    case 'response.completed':
+    case 'response.incomplete':
+    case 'response.failed':
+      yield eventFrame({ ...event, response: completeResponsesEnvelope(event.response, sources, true) });
+      continue;
+    default:
+      yield eventFrame(event);
+    }
+  }
+};

--- a/packages/gateway/src/data-plane/chat/responses/envelope.ts
+++ b/packages/gateway/src/data-plane/chat/responses/envelope.ts
@@ -1,6 +1,7 @@
 import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
 import type {
   CanonicalResponsesPayload,
+  ClientResponsesCompaction,
   ClientResponsesEnvelope,
   ClientResponsesReasoning,
   ClientResponsesStreamEvent,
@@ -215,3 +216,25 @@ export const wrapResponsesEnvelopeCompletion = async function* (
     }
   }
 };
+
+// `/responses/compact` answers with `CompactResource`, which requires `id`,
+// `object`, `output`, `created_at` and `usage` and declares none of the
+// response resource's request echoes. Running the response resource's
+// completion over it would decorate a compaction with `temperature`, `tools`
+// and twenty other keys its own resource does not define, so the compact route
+// gets its own short completion instead.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json  (components.schemas.CompactResource)
+//
+// `model`, `status`, `error` and `incomplete_details` ride through from the
+// trigger turn. `CompactResource` does not define them and the spec does not
+// forbid extras, so they are kept: dropping a field a client may already read
+// is a user-visible removal, and there is nothing to gain from it.
+export const completeResponsesCompaction = (
+  upstream: ResponsesResult,
+  createdAt: number,
+): ClientResponsesCompaction => ({
+  ...upstream,
+  object: 'response.compaction',
+  created_at: createdAt,
+  usage: completeUsage(observed([upstream.usage])),
+});

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -46,7 +46,7 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   if (verbatim !== null) return verbatim;
   const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   const result = internalErrorResult(502, toInternalDebugError(error), effectiveCtx.attempt.telemetry);
-  const response = await respondResponses(c, result, false, effectiveCtx);
+  const response = await respondResponses(c, result, false, effectiveCtx, undefined);
   return finalizeGatewayResponse(effectiveCtx, response);
 };
 
@@ -61,7 +61,7 @@ const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: Req
   }
   if (error instanceof TranslatorInputError) {
     const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
-    const response = await respondResponses(c, responsesInputErrorResult(error, effectiveCtx.attempt.telemetry), false, effectiveCtx);
+    const response = await respondResponses(c, responsesInputErrorResult(error, effectiveCtx.attempt.telemetry), false, effectiveCtx, undefined);
     return finalizeGatewayResponse(effectiveCtx, response);
   }
   return await respondWithInternalError(c, error, requestBody, ctx);
@@ -79,7 +79,7 @@ export const responsesHttp = {
       const wantsStream = payload.stream === true;
       ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, (apiKey, requestStartedAt) => createResponsesHttpStore(apiKey, requestStartedAt, payload.store ?? undefined));
       const result = await responsesServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
-      const response = await respondResponses(c, result, wantsStream, ctx);
+      const response = await respondResponses(c, result, wantsStream, ctx, payload);
       return finalizeGatewayResponse(ctx, response);
     } catch (error) {
       return await respondToThrow(c, error, requestBody, ctx);
@@ -116,7 +116,7 @@ export const responsesHttp = {
         const compactResponse = Response.json(result.result);
         return finalizeGatewayResponse(ctx, compactResponse);
       }
-      const response = await respondResponses(c, result, false, ctx);
+      const response = await respondResponses(c, result, false, ctx, payload);
       return finalizeGatewayResponse(ctx, response);
     } catch (error) {
       return await respondToThrow(c, error, requestBody, ctx);

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -214,7 +214,7 @@ const usageForWire = (state: MergeState): ResponsesResult['usage'] => {
 };
 
 const usageOf = (usage: ResponsesResult['usage']): MergeUsage => {
-  if (usage === undefined) return {};
+  if (usage === undefined || usage === null) return {};
   const out: MergeUsage = {};
   if (usage.input_tokens !== undefined) out.input_tokens = usage.input_tokens;
   if (usage.output_tokens !== undefined) out.output_tokens = usage.output_tokens;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
@@ -12,11 +12,14 @@ export type { ResponsesInvocation };
 // caller's intent action was 'compact'. `modelIdentity`, `usage`, and
 // `performance` carry the per-turn attribution forward so the http layer
 // records the success path identically to streaming generate.
-export type ResponsesAttemptResult =
+// The non-streaming branch is parameterized because `/responses/compact`
+// answers with a different resource than `/responses` does, and the compact
+// route's own egress narrows it further.
+export type ResponsesAttemptResult<Result = ResponsesResult> =
   | ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>
   | {
     readonly type: 'result';
-    readonly result: ResponsesResult;
+    readonly result: Result;
     readonly modelIdentity: TelemetryModelIdentity;
     readonly usage: TokenUsage | null;
     readonly performance: EventResultMetadata['performance'];

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -11,7 +11,7 @@ import { forwardUpstreamHeaders, mergeForwardedUpstreamHeaders } from '../../sha
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
 import { type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { responsesProtocolFrameToSSEFrame, RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
-import { isResponsesTerminalEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ClientResponsesStreamEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, type PlainResult, type InternalDebugError, toInternalDebugError } from '@floway-dev/provider';
 import { apiErrorToResponse } from '@floway-dev/provider';
 
@@ -19,11 +19,16 @@ import { apiErrorToResponse } from '@floway-dev/provider';
 // error-typed result is a pre-stream failure and always answers as HTTP; an
 // events result drains to one JSON body (non-streaming) or is proxied frame by
 // frame (streaming).
+//
+// `request` is the payload the events answer. It is absent only on the
+// error-only entries that render a pre-parse failure, which never reach the
+// events branch — the branch asserts that rather than inventing a stand-in.
 export const respondResponses = async (
   c: Context,
   result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> | PlainResult,
   wantsStream: boolean,
   ctx: GatewayCtx,
+  request: CanonicalResponsesPayload | undefined,
 ): Promise<Response> => {
   if (result.type === 'api-error') {
     recordFailedRequest(ctx, result.performance);
@@ -44,9 +49,11 @@ export const respondResponses = async (
     return plainResultToResponse(result);
   }
 
+  if (request === undefined) throw new Error('Responses events reached the client-facing boundary without the originating request payload');
+
   const state = new SourceStreamState();
   const observed = observeResponsesFrames(result.events, state, ctx);
-  const frames = wrapNativeResponsesClientOutput(observed, ctx);
+  const frames = wrapNativeResponsesClientOutput(observed, ctx, request);
 
   if (!wantsStream) {
     try {
@@ -132,7 +139,7 @@ const observeResponsesFrames = async function* (frames: AsyncIterable<ProtocolFr
   throw new Error(RESPONSES_MISSING_TERMINAL_MESSAGE);
 };
 
-const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>, state: SourceStreamState) {
+const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>>, state: SourceStreamState) {
   try {
     for await (const frame of frames) {
       const sse = responsesProtocolFrameToSSEFrame(frame);

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
 
-import { wrapNativeResponsesClientOutput } from './client-output.ts';
+import { wrapResponsesClientEgress } from './client-output.ts';
 import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import { type StreamCompletion, writeSSEFrames } from '../../shared/sse.ts';
 import { recordFailedRequest } from '../../shared/telemetry/performance.ts';
@@ -53,7 +53,7 @@ export const respondResponses = async (
 
   const state = new SourceStreamState();
   const observed = observeResponsesFrames(result.events, state, ctx);
-  const frames = wrapNativeResponsesClientOutput(observed, ctx, request);
+  const frames = wrapResponsesClientEgress(observed, ctx, request);
 
   if (!wantsStream) {
     try {

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,12 +1,13 @@
 import { responsesAttempt } from './attempt.ts';
-import { wrapNativeResponsesClientOutput } from './client-output.ts';
+import { responsesCreatedAt, wrapResponsesStatefulOutput } from './client-output.ts';
+import { completeResponsesCompaction } from './envelope.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { syntheticEventsFromResult } from './items/output.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
 import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ClientResponsesCompaction, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 
 interface ResponsesServeArgs {
@@ -48,7 +49,7 @@ export const responsesServe = {
     return result;
   },
 
-  compact: async (args: ResponsesServeArgs): Promise<ResponsesAttemptResult> => {
+  compact: async (args: ResponsesServeArgs): Promise<ResponsesAttemptResult<ClientResponsesCompaction>> => {
     const { payload, ctx, headers } = args;
     // Compact accepts `previous_response_id` (the official endpoint documents
     // it). When present serve-prep expands it the same way generate does so
@@ -82,11 +83,11 @@ export const responsesServe = {
     );
     if (result.type !== 'result') return result;
 
-    const stored = wrapNativeResponsesClientOutput(syntheticEventsFromResult(result.result), ctx, payload);
-    const clientResult = await collectResponsesProtocolEventsToResult(stored);
+    const stored = wrapResponsesStatefulOutput(syntheticEventsFromResult(result.result), ctx);
+    const persisted = await collectResponsesProtocolEventsToResult(stored);
     return {
       ...result,
-      result: clientResult,
+      result: completeResponsesCompaction(persisted, responsesCreatedAt(ctx)),
       usage: result.usage,
     };
   },

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -82,7 +82,7 @@ export const responsesServe = {
     );
     if (result.type !== 'result') return result;
 
-    const stored = wrapNativeResponsesClientOutput(syntheticEventsFromResult(result.result), ctx);
+    const stored = wrapNativeResponsesClientOutput(syntheticEventsFromResult(result.result), ctx, payload);
     const clientResult = await collectResponsesProtocolEventsToResult(stored);
     return {
       ...result,

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -18,7 +18,7 @@ import { SourceStreamState, eventResultMetadata } from '../shared/respond.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { RESPONSES_MISSING_TERMINAL_MESSAGE } from '@floway-dev/protocols/responses';
-import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ResponsesRequestPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ClientResponsesStreamEvent, type ResponsesRequestPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { toInternalDebugError } from '@floway-dev/provider';
 import { canonicalizeResponsesPayload, TranslatorInputError } from '@floway-dev/translate';
@@ -256,7 +256,7 @@ const handleClientMessage = async (
       throw error;
     }
 
-    await respondResponsesWebSocket({ socket, eventId, signal, isClosed, result, ctx });
+    await respondResponsesWebSocket({ socket, eventId, signal, isClosed, result, ctx, payload });
   } catch (error) {
     if (signal.aborted || isClosed()) return;
     if (error instanceof TranslatorInputError) {
@@ -325,8 +325,9 @@ const respondResponsesWebSocket = async (input: {
   readonly isClosed: () => boolean;
   readonly result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>;
   readonly ctx: ChatGatewayCtx;
+  readonly payload: CanonicalResponsesPayload;
 }): Promise<void> => {
-  const { socket, eventId, signal, isClosed, result, ctx } = input;
+  const { socket, eventId, signal, isClosed, result, ctx, payload } = input;
   if (result.type === 'api-error') {
     recordFailedRequest(ctx, result.performance);
     ctx.dump?.error(result.source, result.upstreamId);
@@ -346,9 +347,9 @@ const respondResponsesWebSocket = async (input: {
   const state = new SourceStreamState();
   let completion: StreamCompletion = 'error';
   try {
-    let terminalEvent: ResponsesStreamEvent | undefined;
+    let terminalEvent: ClientResponsesStreamEvent | undefined;
     const observed = observeResponsesWebSocketFrames(result.events, state, ctx);
-    const output = wrapNativeResponsesClientOutput(observed, ctx);
+    const output = wrapNativeResponsesClientOutput(observed, ctx, payload);
     const iterator = output[Symbol.asyncIterator]();
     let pendingNext = pendingWsFrameResult(iterator.next());
     let completed = false;
@@ -395,7 +396,7 @@ const respondResponsesWebSocket = async (input: {
         if (terminalEvent !== undefined) continue;
 
         if (isResponsesTerminalEvent(event)) {
-          if (!sendJson(socket, event, eventId, ctx.dump)) {
+          if (!sendResponsesEvent(socket, event, eventId, ctx.dump)) {
             completion = 'cancel';
             continue;
           }
@@ -403,7 +404,7 @@ const respondResponsesWebSocket = async (input: {
           continue;
         }
 
-        if (!sendJson(socket, event, eventId, ctx.dump)) {
+        if (!sendResponsesEvent(socket, event, eventId, ctx.dump)) {
           stopForDownstream();
           return;
         }
@@ -460,11 +461,11 @@ const observeResponsesWebSocketFrames = async function* (
 };
 
 type WsFrameRaceResult =
-  | { type: 'frame'; result: IteratorResult<ProtocolFrame<ResponsesStreamEvent>> }
+  | { type: 'frame'; result: IteratorResult<ProtocolFrame<ClientResponsesStreamEvent>> }
   | { type: 'next-error'; error: unknown }
   | { type: 'keep-alive' };
 
-const pendingWsFrameResult = (pendingNext: Promise<IteratorResult<ProtocolFrame<ResponsesStreamEvent>>>): Promise<WsFrameRaceResult> =>
+const pendingWsFrameResult = (pendingNext: Promise<IteratorResult<ProtocolFrame<ClientResponsesStreamEvent>>>): Promise<WsFrameRaceResult> =>
   pendingNext.then(
     (result): WsFrameRaceResult => ({ type: 'frame', result }),
     (error): WsFrameRaceResult => ({ type: 'next-error', error }),
@@ -542,6 +543,17 @@ const sendError = (
 ): void => {
   sendJson(socket, { type: 'error', status_code: statusCode, error }, eventId, dump);
 };
+
+// A turn's own frames go out through this entry, which accepts only a stream
+// event whose envelope has already passed the client-facing egress stage. The
+// WebSocket's own frames — the error envelope and the keep-alive — are not
+// stream events and keep the untyped `sendJson`.
+const sendResponsesEvent = (
+  socket: ResponsesWebSocketSocket,
+  event: ClientResponsesStreamEvent,
+  eventId?: string,
+  dump?: DumpAccumulator | null,
+): boolean => sendJson(socket, event, eventId, dump);
 
 const sendJson = (
   socket: ResponsesWebSocketSocket,

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -163,8 +163,8 @@ const createResponsesWebSocketEvents = (c: AuthedContext): ResponsesWebSocketHan
           }
         })
         // WS-specific top-level: Hono's onError never runs for callbacks fired off
-        // an open socket, so we serialize the error inline as a close-frame-shaped
-        // JSON envelope. (HTTP entries let onError handle the same case.)
+        // an open socket, so we serialize the error inline as the spec's
+        // WebSocket error envelope. (HTTP entries let onError handle the same case.)
         .catch(error => {
           if (!closed) sendError(socket, 500, serverErrorEnvelope(error));
         });
@@ -240,7 +240,7 @@ const handleClientMessage = async (
     } catch (error) {
       if (signal.aborted || isClosed()) return;
       // The HTTP entry renders this verbatim envelope as a 400; WS surfaces the
-      // same body wrapped in our standard close-frame error shape so clients
+      // same body nested under the spec's WebSocket error envelope so clients
       // can still compare error.message byte-for-byte against upstream.
       if (error instanceof PreviousResponseNotFoundError) {
         sendError(socket, 400, {
@@ -533,14 +533,18 @@ const normalizeErrorBody = (body: unknown, statusCode: number): Record<string, u
   };
 };
 
+// "WebSocket failures MUST be sent as a JSON `error` envelope with a `status`
+// code and an `error.code`." The OpenAPI `WebSocketErrorEvent` schema pins the
+// required keys to exactly `type`, `status`, and `error`.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L166
 const sendError = (
   socket: ResponsesWebSocketSocket,
-  statusCode: number,
+  status: number,
   error: Record<string, unknown>,
   eventId?: string,
   dump?: DumpAccumulator | null,
 ): void => {
-  sendJson(socket, { type: 'error', status_code: statusCode, error }, eventId, dump);
+  sendJson(socket, { type: 'error', status, error }, eventId, dump);
 };
 
 const sendJson = (

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono';
 
-import { wrapNativeResponsesClientOutput } from './client-output.ts';
+import { wrapResponsesClientEgress } from './client-output.ts';
 import { createResponsesWsSession } from './items/store.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
@@ -349,7 +349,7 @@ const respondResponsesWebSocket = async (input: {
   try {
     let terminalEvent: ClientResponsesStreamEvent | undefined;
     const observed = observeResponsesWebSocketFrames(result.events, state, ctx);
-    const output = wrapNativeResponsesClientOutput(observed, ctx, payload);
+    const output = wrapResponsesClientEgress(observed, ctx, payload);
     const iterator = output[Symbol.asyncIterator]();
     let pendingNext = pendingWsFrameResult(iterator.next());
     let completed = false;

--- a/packages/protocols/src/responses/client-envelope.ts
+++ b/packages/protocols/src/responses/client-envelope.ts
@@ -1,0 +1,106 @@
+import type { ResponsesFunctionTool, ResponsesResult, ResponsesStreamEvent, ResponsesTool } from './index.ts';
+
+// The shape a client-facing Responses body must have, derived from
+// `ResponsesResult` rather than restated beside it. `ResponsesResult` models
+// four things at once — what an arbitrary upstream sent, what a translator
+// assembles mid-stream, what reaches a client, and (under
+// `object: 'response.compaction'`) a different resource entirely — so its
+// envelope keys are optional. Only the client-facing role has to satisfy
+// `ResponseResource.required`, and only at the last stage before
+// serialization.
+//
+// Deriving means the two cannot drift: a field added to `ResponsesResult`
+// widens these types automatically. The only hand-maintained artefacts are the
+// two key unions below, which transcribe the schema and change when it does.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+//
+// `ResponseResource.required` lists 31 keys. Seven of them (`id`, `object`,
+// `model`, `output`, `status`, `error`, `incomplete_details`) are already
+// non-optional on `ResponsesResult`. The remaining 24 are split below by the
+// single bit that decides how an absent value may be spelled on the wire:
+// whether the slot carries a `null` alternative.
+
+// Required with no `null` alternative: absence has no spelling at all, so a
+// value must be stated.
+export type ResponsesEnvelopeStatedKey =
+  | 'created_at'
+  | 'tools'
+  | 'tool_choice'
+  | 'truncation'
+  | 'parallel_tool_calls'
+  | 'text'
+  | 'top_p'
+  | 'presence_penalty'
+  | 'frequency_penalty'
+  | 'top_logprobs'
+  | 'temperature'
+  | 'store'
+  | 'background'
+  | 'service_tier'
+  | 'metadata';
+
+// Required with a `null` alternative: `null` IS the schema's spelling for
+// absence, so nothing has to be invented — only present.
+export type ResponsesEnvelopeNullableKey =
+  | 'completed_at'
+  | 'previous_response_id'
+  | 'instructions'
+  | 'reasoning'
+  | 'usage'
+  | 'max_output_tokens'
+  | 'max_tool_calls'
+  | 'safety_identifier'
+  | 'prompt_cache_key';
+
+// `Usage` requires both breakdowns whenever it is an object.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2384-L2429
+type ResponsesUsage = NonNullable<ResponsesResult['usage']>;
+export type ClientResponsesUsage =
+  Omit<ResponsesUsage, 'input_tokens_details' | 'output_tokens_details'>
+  & Required<Pick<ResponsesUsage, 'input_tokens_details' | 'output_tokens_details'>>;
+
+// `TextField` requires `format`.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2298-L2319
+type ResponsesTextField = NonNullable<ResponsesResult['text']>;
+export type ClientResponsesTextField = ResponsesTextField & Required<Pick<ResponsesTextField, 'format'>>;
+
+// `Reasoning` requires `effort` and `summary`.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2320-L2359
+type ResponsesReasoning = NonNullable<ResponsesResult['reasoning']>;
+export type ClientResponsesReasoning = ResponsesReasoning & Required<Pick<ResponsesReasoning, 'effort' | 'summary'>>;
+
+// `FunctionTool` requires `description`, `parameters` and `strict` on the
+// response side while the request side leaves all three optional. Distributive
+// so every other member of the tool union passes through unchanged and the
+// union stays discriminable on `type`.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2141-L2192
+export type ClientResponsesTool =
+  ResponsesTool extends infer Tool
+    ? Tool extends { type: 'function' }
+      ? Tool & Required<Pick<ResponsesFunctionTool, 'description' | 'parameters' | 'strict'>>
+      : Tool
+    : never;
+
+// `-?` preserves declared nullability, which is exactly the distinction the two
+// key unions draw: a stated key wrapped in `NonNullable` becomes present and
+// non-null, a nullable key becomes present and possibly null.
+export type ClientResponsesEnvelope =
+  Omit<ResponsesResult, ResponsesEnvelopeStatedKey | ResponsesEnvelopeNullableKey>
+  & { [K in ResponsesEnvelopeStatedKey]-?: NonNullable<ResponsesResult[K]> }
+  & { [K in ResponsesEnvelopeNullableKey]-?: ResponsesResult[K] | null }
+  & {
+    tools: ClientResponsesTool[];
+    text: ClientResponsesTextField;
+    reasoning: ClientResponsesReasoning | null;
+    usage: ClientResponsesUsage | null;
+  };
+
+// Every envelope-bearing member of the stream union, re-declared with the
+// completed envelope. Distributive so each member keeps its `type` literal.
+// A `response.*` event added to `ResponsesStreamEvent` is narrowed
+// automatically.
+type WithClientEnvelope<Event> = Event extends { response: ResponsesResult }
+  ? Omit<Event, 'response'> & { response: ClientResponsesEnvelope }
+  : Event;
+
+export type ClientResponsesStreamEvent = WithClientEnvelope<ResponsesStreamEvent>;

--- a/packages/protocols/src/responses/client-envelope.ts
+++ b/packages/protocols/src/responses/client-envelope.ts
@@ -104,3 +104,12 @@ type WithClientEnvelope<Event> = Event extends { response: ResponsesResult }
   : Event;
 
 export type ClientResponsesStreamEvent = WithClientEnvelope<ResponsesStreamEvent>;
+
+// `CompactResource` requires `id`, `object`, `output`, `created_at` and
+// `usage`, and declares none of the response resource's request echoes — so a
+// compaction body states nothing about tools, sampling or service tier. `id`,
+// `object` and `output` already arrive populated.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json  (components.schemas.CompactResource)
+export type ClientResponsesCompaction =
+  Omit<ResponsesResult, 'object' | 'created_at' | 'usage'>
+  & { object: 'response.compaction'; created_at: number; usage: ClientResponsesUsage | null };

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -613,9 +613,17 @@ export type ResponsesToolAllowedCaller = 'direct' | 'programmatic';
 export interface ResponsesFunctionTool {
   type: 'function';
   name: string;
-  parameters: Record<string, unknown>;
-  strict: boolean;
-  description?: string;
+  // `description`, `parameters` and `strict` are asymmetric across the two
+  // sides of the wire: a request may omit any of them, while the response tool
+  // schema marks all three required with an explicit `null` alternative. This
+  // interface models what a client may actually send, so all three are
+  // optional-nullable here and the client-facing egress completes an absent one
+  // as `null`.
+  // Request: https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L808-L845
+  // Response: https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2141-L2192
+  description?: string | null;
+  parameters?: Record<string, unknown> | null;
+  strict?: boolean | null;
   allowed_callers?: ResponsesToolAllowedCaller[] | null;
   defer_loading?: boolean;
   output_schema?: Record<string, unknown> | null;
@@ -841,7 +849,12 @@ export interface ResponsesResult {
     // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L7259-L7269
     input_tokens_details?: { cached_tokens: number; cache_write_tokens?: number };
     output_tokens_details?: { reasoning_tokens: number };
-  };
+    // `usage` is required-with-a-`null`-alternative on the response resource,
+    // so `null` is a value an upstream legitimately sends for a response that
+    // reported no token counts — distinct from a mid-stream envelope that has
+    // not accounted for them yet, which omits the key.
+    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+  } | null;
 }
 
 // Stored/output additional-tools roles are wider than the input-only

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -58,6 +58,24 @@ export interface ResponsesPayload {
   prompt_cache_retention?: ResponsesPromptCacheRetention | null;
   safety_identifier?: string | null;
   service_tier?: 'default' | 'auto' | 'flex' | 'priority' | 'scale' | (string & {}) | null;
+  // Request knobs Floway itself never acts on: they ride to the upstream in
+  // the forwarded body and come back on the response envelope. Declaring them
+  // keeps the client-facing echo honest instead of hard-coding the spec
+  // default for a client that sent its own value.
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L35856-L35873
+  truncation?: 'auto' | 'disabled' | (string & {}) | null;
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L59062-L59068
+  background?: boolean | null;
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L44064-L44080
+  top_logprobs?: number | null;
+  // Chat Completions sampling penalties. OpenAI's Responses request schema
+  // does not carry them, but the OpenResponses request and response schemas
+  // both do, so a client may send them and expects them echoed.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L33561-L33565
+  presence_penalty?: number | null;
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L33484-L33488
+  frequency_penalty?: number | null;
 }
 
 export type ResponsesInputItem =
@@ -839,6 +857,11 @@ export interface ResponsesResult {
   // confirm they're populated with server-enriched defaults.
   tools?: ResponsesTool[];
   tool_choice?: ResponsesToolChoice | null;
+  // `usage` is required-with-a-`null`-alternative on the response resource, so
+  // `null` is a value an upstream legitimately sends for a response that
+  // reported no token counts — distinct from a mid-stream envelope that has not
+  // accounted for them yet, which omits the key.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
   usage?: {
     input_tokens: number;
     output_tokens: number;
@@ -849,12 +872,51 @@ export interface ResponsesResult {
     // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L7259-L7269
     input_tokens_details?: { cached_tokens: number; cache_write_tokens?: number };
     output_tokens_details?: { reasoning_tokens: number };
-    // `usage` is required-with-a-`null`-alternative on the response resource,
-    // so `null` is a value an upstream legitimately sends for a response that
-    // reported no token counts — distinct from a mid-stream envelope that has
-    // not accounted for them yet, which omits the key.
-    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
   } | null;
+  // ── Envelope fields the response resource declares required ──
+  //
+  // Every key below is listed in `ResponseResource.required`, so a
+  // spec-conforming client-facing body must carry all of them:
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+  // They stay optional here because this interface also models what an
+  // arbitrary upstream sends and what a translator assembles mid-stream.
+  // Presence on the client-facing body is carried by `ClientResponsesEnvelope`
+  // in `./client-envelope.ts`, which derives from this interface rather than
+  // restating it.
+  //
+  // Unix seconds, not milliseconds.
+  created_at?: number;
+  // Null until the response reaches a terminal status.
+  completed_at?: number | null;
+  previous_response_id?: string | null;
+  instructions?: string | null;
+  truncation?: 'auto' | 'disabled' | (string & {}) | null;
+  parallel_tool_calls?: boolean;
+  text?: { format?: Record<string, unknown> | null; verbosity?: string | null } | null;
+  top_p?: number | null;
+  presence_penalty?: number | null;
+  frequency_penalty?: number | null;
+  top_logprobs?: number | null;
+  temperature?: number | null;
+  // `effort` and `summary` are themselves required whenever `reasoning` is an
+  // object; other keys upstreams add (`context`, `mode`) ride along untouched.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2320-L2359
+  reasoning?: {
+    effort?: string | null;
+    summary?: 'detailed' | 'auto' | 'concise' | (string & {}) | null;
+    context?: 'auto' | 'current_turn' | 'all_turns' | (string & {}) | null;
+    [key: string]: unknown;
+  } | null;
+  max_output_tokens?: number | null;
+  max_tool_calls?: number | null;
+  // Whether the response was stored so it can be retrieved later — the wording
+  // of the schema's own description, which is why the gateway answers it from
+  // its store rather than from the request's `store` flag.
+  store?: boolean;
+  background?: boolean;
+  metadata?: Record<string, unknown> | null;
+  safety_identifier?: string | null;
+  prompt_cache_key?: string | null;
 }
 
 // Stored/output additional-tools roles are wider than the input-only
@@ -1281,6 +1343,16 @@ export { imageGenerationCallLifecycleEvents } from './image-generation-lifecycle
 export { webSearchCallLifecycleEvents } from './web-search-lifecycle.ts';
 export { parseResponsesStream, type ParseResponsesStreamOptions } from './stream.ts';
 
+export type {
+  ClientResponsesEnvelope,
+  ClientResponsesReasoning,
+  ClientResponsesStreamEvent,
+  ClientResponsesTextField,
+  ClientResponsesTool,
+  ClientResponsesUsage,
+  ResponsesEnvelopeNullableKey,
+  ResponsesEnvelopeStatedKey,
+} from './client-envelope.ts';
 export { RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from './to-result.ts';
 export { createRandomResponsesItemId, type GeneratedResponsesItemType } from './item-id.ts';
 export { reassembleResponsesEvents } from './reassemble.ts';

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -1344,6 +1344,7 @@ export { webSearchCallLifecycleEvents } from './web-search-lifecycle.ts';
 export { parseResponsesStream, type ParseResponsesStreamOptions } from './stream.ts';
 
 export type {
+  ClientResponsesCompaction,
   ClientResponsesEnvelope,
   ClientResponsesReasoning,
   ClientResponsesStreamEvent,

--- a/packages/protocols/src/responses/to-result.ts
+++ b/packages/protocols/src/responses/to-result.ts
@@ -1,10 +1,20 @@
+import type { ClientResponsesEnvelope, ClientResponsesStreamEvent } from './client-envelope.ts';
 import { isResponsesTerminalEvent, type ResponsesResult, type ResponsesStreamEvent } from './index.ts';
 import { reassembleResponsesEvents } from './reassemble.ts';
 import { type ProtocolFrame } from '../common/index.ts';
 
 export const RESPONSES_MISSING_TERMINAL_MESSAGE = 'Responses stream ended without a terminal event.';
 
-export const collectResponsesProtocolEventsToResult = async (frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesResult> => {
+// Reassembly copies each envelope through, so a stream whose frames already
+// carry the completed client envelope collects into a completed envelope. The
+// narrow signature comes first so overload resolution picks it exactly when the
+// argument is narrow. This is deliberately two signatures rather than one type
+// parameter: TypeScript cannot infer a type argument out of the distributive
+// conditional that builds `ClientResponsesStreamEvent`, so a generic version
+// would silently resolve to the wide default at every call site.
+export function collectResponsesProtocolEventsToResult(frames: AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>>): Promise<ClientResponsesEnvelope>;
+export function collectResponsesProtocolEventsToResult(frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesResult>;
+export async function collectResponsesProtocolEventsToResult(frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesResult> {
   const events = async function* (): AsyncGenerator<ResponsesStreamEvent> {
     for await (const frame of frames) {
       if (frame.type === 'done') continue;
@@ -17,4 +27,4 @@ export const collectResponsesProtocolEventsToResult = async (frames: AsyncIterab
   };
 
   return await reassembleResponsesEvents(events());
-};
+}

--- a/packages/translate/__tests__/responses-via-messages/request_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/request_test.ts
@@ -647,6 +647,23 @@ test('buildTargetRequest flattens namespace functions collision-safely and maps 
   assertEquals(result.target.tool_choice, { type: 'tool', name: 'web_run_2' });
 });
 
+test('buildTargetRequest gives a schema-less function tool the empty object schema', async () => {
+  const result = await buildTargetRequest({
+    ...minimalPayload,
+    tools: [{ type: 'function', name: 'ping' }],
+  });
+
+  // Forwarding an absent `parameters` verbatim put `input_schema: undefined` on
+  // the wire, which Anthropic rejects with a 400 for the whole request.
+  assertEquals(result.target.tools, [
+    {
+      name: 'ping',
+      input_schema: { type: 'object', properties: {} },
+      cache_control: { type: 'ephemeral' },
+    },
+  ]);
+});
+
 test('buildTargetRequest keeps plain-text function_call_output as string content', async () => {
   const result = await buildTargetRequest({
     model: 'claude-test',

--- a/packages/translate/src/responses-via-chat-completions/events.ts
+++ b/packages/translate/src/responses-via-chat-completions/events.ts
@@ -5,7 +5,7 @@ import type { ChatCompletionsStreamEvent, ChatCompletionsResult } from '@floway-
 import { eventFrame, splitInclusiveInputTokens, type ProtocolFrame } from '@floway-dev/protocols/common';
 import { createRandomResponsesItemId, type ResponsesOutputItem, type ResponsesOutputReasoning, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
-const mapChatCompletionsUsageToResponsesUsage = (usage: ChatCompletionsResult['usage'] | undefined): ResponsesResult['usage'] | undefined => {
+const mapChatCompletionsUsageToResponsesUsage = (usage: ChatCompletionsResult['usage'] | undefined): NonNullable<ResponsesResult['usage']> | undefined => {
   if (!usage) return undefined;
   const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
   const cacheWriteTokens = usage.prompt_tokens_details?.cache_creation_input_tokens
@@ -95,7 +95,7 @@ interface ChatCompletionsToResponsesStreamState {
   openFunctionCalls: Map<number, PendingFunctionCallItem>;
   deferredAfterReasoning: DeferredAfterReasoning[];
   reasoningItemsSeen: boolean;
-  usage?: ResponsesResult['usage'];
+  usage?: NonNullable<ResponsesResult['usage']>;
   serviceTier?: ResponsesResult['service_tier'];
   pendingFinishReason?: ChatCompletionsFinishReason;
   completed: boolean;

--- a/packages/translate/src/responses-via-chat-completions/request.ts
+++ b/packages/translate/src/responses-via-chat-completions/request.ts
@@ -100,8 +100,10 @@ const translateResponsesTools = (tools: ResponsesTool[] | null | undefined, cust
         type: 'function',
         function: {
           name: tool.name,
-          parameters: tool.parameters,
-          strict: tool.strict,
+          // Responses spells "unspecified" as an omitted key or an explicit
+          // `null`; Chat Completions has only the omitted-key spelling.
+          ...(tool.parameters === undefined || tool.parameters === null ? {} : { parameters: tool.parameters }),
+          ...(tool.strict === undefined || tool.strict === null ? {} : { strict: tool.strict }),
           ...(tool.description ? { description: tool.description } : {}),
         },
       });

--- a/packages/translate/src/responses-via-messages/request.ts
+++ b/packages/translate/src/responses-via-messages/request.ts
@@ -350,9 +350,16 @@ const translateTools = (
     if (tool.type === 'function') {
       out.push({
         name: tool.name,
-        description: tool.description,
-        input_schema: tool.parameters,
-        strict: tool.strict,
+        // Responses spells "this tool has no description" as an explicit
+        // `null`; Messages has no such spelling, so the key is dropped.
+        ...(tool.description === undefined || tool.description === null ? {} : { description: tool.description }),
+        // Messages has no spelling for "no schema" either: `input_schema` is
+        // required and must be a JSON Schema object, so an unspecified
+        // Responses `parameters` becomes the empty object schema. Forwarding
+        // `undefined` made Anthropic reject the whole request with a 400.
+        // https://docs.claude.com/en/api/messages
+        input_schema: tool.parameters ?? { type: 'object', properties: {} },
+        ...(tool.strict === undefined || tool.strict === null ? {} : { strict: tool.strict }),
       });
       continue;
     }


### PR DESCRIPTION
First of four PRs recreating the WebSocket conformance stack against the OpenResponses `2026-04-24` specification. The branches survived an unauthorized merge-and-revert cycle on `main`; the code is unchanged, this restores the review surface.

## Defect

The Responses WebSocket transport serialized its JSON error envelope as `{ type: 'error', status_code, error }`. The spec's `WebSocketErrorEvent` schema pins the required keys to exactly `type`, `status`, and `error`, so `status_code` was a Floway-private key with no other producer and no other consumer.

The practical consequence is narrower than it sounds, and worth stating precisely: Floway already emitted `previous_response_not_found` with the right code, at the right nesting depth, inside `error`. The compliance suite could read the code. The frame nonetheless failed schema validation on the envelope key name, and a failed frame validation fails the whole turn.

## Spec

> WebSocket failures MUST be sent as a JSON `error` envelope with a `status` code and an `error.code`.

`2026-04-24.mdx:166` — the OpenAPI `WebSocketErrorEvent` schema requires `["type", "status", "error"]`.
https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L166

## What changed

- `sendError` in `packages/gateway/src/data-plane/chat/responses/websocket.ts` emits `status` instead of `status_code`, and its parameter is renamed `statusCode` → `status` to match.
- The reference URL for the required key set now sits on `sendError` itself.
- Two doc comments described the frame as "close-frame-shaped". It is not a close frame — it is the spec's error envelope, sent over an open socket — so that wording is gone.
- `CHANGELOG.md` records the rename as `minor`: clients reading `error.code` need no adaptation; clients reading the numeric status off the envelope must read `status`.

## Verification

Observed on an integration branch containing the full OpenResponses fix set, **not** on this branch alone: the 17-test OpenResponses compliance suite passed 17/17 on all three Responses paths (`gpt-5-mini` native, `gpt-4.1` via Chat Completions, `claude-haiku-4-5` via Messages), twice, with typecheck and lint clean and 4935 unit tests passing. Baseline before the work was 1/17 per path.

For this WebSocket stack specifically, the six WebSocket tests went 0/6 → 1/6 per path, with `response.done`, `ping` and `error` frame-validation failures reaching zero and the eviction assertion passing. What still fails on those tests is the envelope gap alone, addressed elsewhere in the set.

## Classification

**Category 1 (clean).** A private key name is renamed to the one the spec requires. There is no competing prior decision — `status_code` was never justified in writing, had no second producer, and the error payload it wrapped was already correct.

## Note on this diff

This branch carries merges of `main` from a window in which `main` also held the envelope-completion, protocol-type-truth, and compaction-resource work that was subsequently reverted off `main`. Until those land again, this PR's diff against `main` shows their files too (`envelope.ts`, `client-envelope.ts`, `to-result.ts`, and their tests). The change owned by this PR is the `websocket.ts` envelope key and its `CHANGELOG.md` entry; the diff narrows on its own once the siblings are back on `main`.
