### PR TITLE
fix(responses): answer /responses/compact with the compaction resource

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { test, vi } from 'vitest';
 
 import { TEST_RESPONSES_RETENTION_SECONDS } from './test-policy.ts';
-import { missingRequiredResourceKeys } from './test-required-resource-keys.ts';
+import { missingRequiredCompactionKeys, missingRequiredResourceKeys, responseOnlyKeysAdded } from './test-required-resource-keys.ts';
 import type { AuthVars } from '../../../../src/middleware/auth.ts';
 import { initRepo } from '../../../../src/repo/index.ts';
 import type { ApiKey, User } from '../../../../src/repo/types.ts';
@@ -432,13 +432,19 @@ test('POST /v1/responses returns 502 when the response snapshot cannot be persis
   }
 });
 
-test('POST /v1/responses/compact returns a non-streaming compaction envelope', async () => {
-  const repo = installRepo();
+// One compact turn against a stubbed candidate. The upstream result is
+// returned so a test can compare the answered body against what the upstream
+// actually sent.
+const compactTurn = async (
+  upstream: Partial<ResponsesResult> = {},
+  requestFields: Record<string, unknown> = {},
+): Promise<{ upstream: ResponsesResult; response: Response }> => {
   const compactionItem = { type: 'compaction' as const, id: 'cmp_1', encrypted_content: 'ENC' };
   const compactionResult: ResponsesResult = {
     ...makeResponsesResult(),
     object: 'response.compaction',
     output: [compactionItem] as unknown as ResponsesResult['output'],
+    ...upstream,
   };
   const callResponses = vi.fn(async (_model: unknown, _body: unknown, action: ResponsesAction): Promise<ProviderResponsesResult> => {
     if (action !== 'compact') throw new Error(`expected compact, got ${action}`);
@@ -453,8 +459,15 @@ test('POST /v1/responses/compact returns a non-streaming compaction envelope', a
       model: 'test-model',
       input: [{ type: 'message', role: 'user', content: 'kept' }],
       store: false,
+      ...requestFields,
     }),
   });
+  return { upstream: compactionResult, response };
+};
+
+test('POST /v1/responses/compact returns a non-streaming compaction body', async () => {
+  const repo = installRepo();
+  const { response } = await compactTurn();
 
   assertEquals(response.status, 200);
   assertEquals(response.headers.get('content-type')?.split(';')[0], 'application/json');
@@ -463,6 +476,42 @@ test('POST /v1/responses/compact returns a non-streaming compaction envelope', a
   assert(body.id.length > 0 && body.id !== 'resp_test', 'expected the source boundary to replace the upstream response id');
   assertEquals(await repo.responsesSnapshots.lookup(API_KEY_ID, body.id, 0), null);
   assertEquals(await repo.responsesItems.lookupMany(API_KEY_ID, body.output.map(item => item.id), 0), []);
+});
+
+test('POST /v1/responses/compact answers the compaction resource, not the response resource', async () => {
+  installRepo();
+  const { upstream, response } = await compactTurn(
+    { usage: { input_tokens: 12, output_tokens: 3, total_tokens: 15 } },
+    { temperature: 0.3 },
+  );
+
+  assertEquals(response.status, 200);
+  const body = await response.json() as Record<string, unknown>;
+  assertEquals(missingRequiredCompactionKeys(body), []);
+  assertEquals(typeof body.created_at, 'number');
+  assertEquals(body.usage, {
+    input_tokens: 12,
+    output_tokens: 3,
+    total_tokens: 15,
+    input_tokens_details: { cached_tokens: 0 },
+    output_tokens_details: { reasoning_tokens: 0 },
+  });
+  assertEquals(responseOnlyKeysAdded(upstream, body), []);
+});
+
+test('POST /v1/responses/compact states zero tokens when the upstream reported no usage', async () => {
+  installRepo();
+  const { response } = await compactTurn();
+
+  assertEquals(response.status, 200);
+  const body = await response.json() as Record<string, unknown>;
+  assertEquals(body.usage, {
+    input_tokens: 0,
+    output_tokens: 0,
+    total_tokens: 0,
+    input_tokens_details: { cached_tokens: 0 },
+    output_tokens_details: { reasoning_tokens: 0 },
+  });
 });
 
 test('POST /v1/responses with an unresolvable previous_response_id renders the verbatim 400 envelope', async () => {

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -434,7 +434,9 @@ test('POST /v1/responses returns 502 when the response snapshot cannot be persis
 
 // One compact turn against a stubbed candidate. The upstream result is
 // returned so a test can compare the answered body against what the upstream
-// actually sent.
+// actually sent. Token counts are part of the default because every real
+// compaction is a turn a model ran; a test that wants the reported-nothing
+// case passes `usage: null`.
 const compactTurn = async (
   upstream: Partial<ResponsesResult> = {},
   requestFields: Record<string, unknown> = {},
@@ -444,6 +446,7 @@ const compactTurn = async (
     ...makeResponsesResult(),
     object: 'response.compaction',
     output: [compactionItem] as unknown as ResponsesResult['output'],
+    usage: { input_tokens: 12, output_tokens: 3, total_tokens: 15 },
     ...upstream,
   };
   const callResponses = vi.fn(async (_model: unknown, _body: unknown, action: ResponsesAction): Promise<ProviderResponsesResult> => {
@@ -499,19 +502,17 @@ test('POST /v1/responses/compact answers the compaction resource, not the respon
   assertEquals(responseOnlyKeysAdded(upstream, body), []);
 });
 
-test('POST /v1/responses/compact states zero tokens when the upstream reported no usage', async () => {
+test('POST /v1/responses/compact reports the failure when the upstream reported no usage', async () => {
   installRepo();
-  const { response } = await compactTurn();
+  const { response } = await compactTurn({ usage: null });
 
-  assertEquals(response.status, 200);
-  const body = await response.json() as Record<string, unknown>;
-  assertEquals(body.usage, {
-    input_tokens: 0,
-    output_tokens: 0,
-    total_tokens: 0,
-    input_tokens_details: { cached_tokens: 0 },
-    output_tokens_details: { reasoning_tokens: 0 },
-  });
+  assertEquals(response.status, 500);
+  const body = await response.json() as { error: { type: string; message: string } };
+  assertEquals(body.error.type, 'internal_error');
+  assert(
+    body.error.message.includes('reported no token usage'),
+    `expected the missing-usage condition to be named, got ${body.error.message}`,
+  );
 });
 
 test('POST /v1/responses with an unresolvable previous_response_id renders the verbatim 400 envelope', async () => {

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -506,7 +506,7 @@ test('POST /v1/responses/compact reports the failure when the upstream reported 
   installRepo();
   const { response } = await compactTurn({ usage: null });
 
-  assertEquals(response.status, 500);
+  assertEquals(response.status, 502);
   const body = await response.json() as { error: { type: string; message: string } };
   assertEquals(body.error.type, 'internal_error');
   assert(
@@ -586,6 +586,7 @@ test('POST /v1/responses/compact routes a codex-auto-review request through the 
     ...makeResponsesResult(),
     object: 'response.compaction',
     output: [compactionItem] as unknown as ResponsesResult['output'],
+    usage: { input_tokens: 12, output_tokens: 3, total_tokens: 15 },
   };
   queueCodexAutoReviewCandidate(async (_model, body, action): Promise<ProviderResponsesResult> => {
     if (action !== 'compact') throw new Error(`expected compact, got ${action}`);

--- a/packages/gateway/__tests__/data-plane/chat/responses/serve_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/serve_test.ts
@@ -189,6 +189,7 @@ test('compact returns a result envelope from the wrapped attempt', async () => {
     ...makeResponsesResult(),
     object: 'response.compaction',
     output: [compactionItem] as unknown as ResponsesResult['output'],
+    usage: { input_tokens: 12, output_tokens: 3, total_tokens: 15 },
   };
   const observedModelIds: string[] = [];
   const callResponses = vi.fn(async (model: unknown, _body: unknown, action: ResponsesAction): Promise<ProviderResponsesResult> => {

--- a/packages/gateway/__tests__/data-plane/chat/responses/test-required-resource-keys.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/test-required-resource-keys.ts
@@ -36,3 +36,20 @@ export const REQUIRED_RESOURCE_KEYS = [
 
 export const missingRequiredResourceKeys = (resource: Record<string, unknown>): string[] =>
   REQUIRED_RESOURCE_KEYS.filter(key => !(key in resource));
+
+// Every key `CompactResource.required` lists — the whole schema, which declares
+// nothing else.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L4008
+export const REQUIRED_COMPACTION_KEYS = ['id', 'object', 'output', 'created_at', 'usage'] as const;
+
+export const missingRequiredCompactionKeys = (resource: Record<string, unknown>): string[] =>
+  REQUIRED_COMPACTION_KEYS.filter(key => !(key in resource));
+
+// What a compaction body must not pick up from the response resource: any key
+// that resource requires, `CompactResource` does not declare, and the upstream
+// never sent. Keys the upstream did send ride through the completion's spread
+// and are not Floway's statement.
+export const responseOnlyKeysAdded = (upstream: object, body: Record<string, unknown>): string[] =>
+  REQUIRED_RESOURCE_KEYS.filter(key => !(REQUIRED_COMPACTION_KEYS as readonly string[]).includes(key)
+    && !(key in upstream)
+    && key in body);

--- a/packages/gateway/src/data-plane/chat/responses/client-output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/client-output.ts
@@ -8,26 +8,38 @@ import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { CanonicalResponsesPayload, ClientResponsesStreamEvent, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
-// Affinity wraps routing metadata first. The client-output boundary then stores
+// Unix seconds, from the gateway's own request-start instant, so both resources
+// date a turn the same way.
+export const responsesCreatedAt = (ctx: GatewayCtx): number => Math.floor(ctx.requestStartedAt / 1000);
+
+// Affinity wraps routing metadata first; the client-output boundary then stores
 // each complete emitted item under its exact ID and applies one generated
-// response ID to the downstream stream and snapshot. Resource completion runs
-// outermost, so it sees the ID the boundary applied and is the last thing that
-// touches a response resource before serialization.
-export const wrapNativeResponsesClientOutput = (
+// response ID to the downstream stream and snapshot. Every native Responses
+// turn goes through this half, whichever resource it answers with.
+export const wrapResponsesStatefulOutput = (
+  frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
+  ctx: ChatGatewayCtx,
+): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> => {
+  const withAffinity = wrapResponsesAffinityEgress(frames, affinityEgressOptions(ctx));
+  return wrapResponsesClientOutput(withAffinity, {
+    store: ctx.store,
+    responseId: createResponsesResponseId(),
+  });
+};
+
+// The generate path's egress: the stateful half plus the response resource's
+// completion. `/responses/compact` answers with `CompactResource`, so it stops
+// at the stateful half and completes that resource itself.
+export const wrapResponsesClientEgress = (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   ctx: GatewayCtx,
   request: CanonicalResponsesPayload,
 ): AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>> => {
-  if (!('affinity' in ctx) || !('store' in ctx)) throw new Error('Responses output reached the client-facing boundary without chat context');
+  if (!('affinity' in ctx) || !('store' in ctx)) throw new Error('Responses output requires chat context');
   const chatCtx = ctx as ChatGatewayCtx;
-  const withAffinity = wrapResponsesAffinityEgress(frames, affinityEgressOptions(ctx));
-  const stored = wrapResponsesClientOutput(withAffinity, {
-    store: chatCtx.store,
-    responseId: createResponsesResponseId(),
-  });
-  return wrapResponseResourceCompletion(stored, {
+  return wrapResponseResourceCompletion(wrapResponsesStatefulOutput(frames, chatCtx), {
     request,
-    createdAt: Math.floor(ctx.requestStartedAt / 1000),
+    createdAt: responsesCreatedAt(ctx),
     stored: chatCtx.store.writesState,
   });
 };

--- a/packages/gateway/src/data-plane/chat/responses/compaction-resource.ts
+++ b/packages/gateway/src/data-plane/chat/responses/compaction-resource.ts
@@ -1,0 +1,43 @@
+import { completeUsage } from './response-resource.ts';
+import type { ClientResponsesCompaction, ResponsesResult } from '@floway-dev/protocols/responses';
+
+// `Usage` requires the three totals as well as both breakdowns, and this
+// resource's slot has no `null` alternative, so an upstream that reported no
+// token counts — `usage` absent, or `null`, which this protocol treats as that
+// same report — has no spelling on this wire and the totals are stated as zero.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2384-L2429
+//
+// Zero here always means the upstream said nothing, never that Floway lost the
+// count. No stage between the provider and this line drops it: the compact
+// route's round trip through item persistence puts the whole result on the
+// terminal event and reassembles that object verbatim, rewriting only `id`, and
+// the shim's synthesized envelope spreads its summarization turn. Absence is
+// the upstream's own, on either of two routes: a native Responses upstream may
+// report no counts on a compaction, and `responses-via-chat-completions` emits
+// `usage` only from a usage chunk it actually received, so a chat upstream that
+// ignores the `stream_options.include_usage` the gateway forces on every call
+// leaves none. That second silence empties `billableUsage` too, which reads the
+// same chunk, so the wire and the bill agree on it.
+const NO_TOKENS_REPORTED = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+
+// Completing a compaction with `completeResponseResource` would decorate it
+// with `temperature`, `tools`, `truncation`, `service_tier`, `store` and the
+// twenty-one further keys `ResponseResource` requires and `CompactResource`
+// does not declare, so the compact route completes its own five instead.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L4008
+//
+// `id` carries the response id the stateful boundary minted; `output` is the
+// upstream's own compacted list. `object` is restated because `ResponsesResult`
+// types it as a bare `string`, and the literal is what satisfies the enum the
+// compaction resource pins. The spread keeps every other key the upstream sent:
+// dropping a field a client may already read is a user-visible removal with
+// nothing to gain.
+export const completeResponsesCompaction = (
+  upstream: ResponsesResult,
+  createdAt: number,
+): ClientResponsesCompaction => ({
+  ...upstream,
+  object: 'response.compaction',
+  created_at: createdAt,
+  usage: completeUsage(upstream.usage ?? NO_TOKENS_REPORTED),
+});

--- a/packages/gateway/src/data-plane/chat/responses/compaction-resource.ts
+++ b/packages/gateway/src/data-plane/chat/responses/compaction-resource.ts
@@ -1,24 +1,24 @@
 import { completeUsage } from './response-resource.ts';
 import type { ClientResponsesCompaction, ResponsesResult } from '@floway-dev/protocols/responses';
 
-// `Usage` requires the three totals as well as both breakdowns, and this
-// resource's slot has no `null` alternative, so an upstream that reported no
-// token counts — `usage` absent, or `null`, which this protocol treats as that
-// same report — has no spelling on this wire and the totals are stated as zero.
+// `Usage` requires the three totals, and this resource's slot has no `null`
+// alternative, so an upstream that reported no token counts — `usage` absent,
+// or `null`, which this protocol treats as that same report — has no spelling
+// on this wire.
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2384-L2429
 //
-// Zero here always means the upstream said nothing, never that Floway lost the
-// count. No stage between the provider and this line drops it: the compact
-// route's round trip through item persistence puts the whole result on the
-// terminal event and reassembles that object verbatim, rewriting only `id`, and
-// the shim's synthesized envelope spreads its summarization turn. Absence is
-// the upstream's own, on either of two routes: a native Responses upstream may
-// report no counts on a compaction, and `responses-via-chat-completions` emits
-// `usage` only from a usage chunk it actually received, so a chat upstream that
-// ignores the `stream_options.include_usage` the gateway forces on every call
-// leaves none. That second silence empties `billableUsage` too, which reads the
-// same chunk, so the wire and the bill agree on it.
-const NO_TOKENS_REPORTED = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+// Zeros are not that spelling. A compaction is a turn a model actually ran, so
+// zero totals are never a true statement about one, and a client reading them
+// as the turn's cost would be reading a number Floway invented. The absence is
+// also not ours to paper over: no stage between the provider and this line
+// drops a count — the compact route's round trip through item persistence puts
+// the whole result on the terminal event and reassembles that object verbatim,
+// rewriting only `id`, and the shim's synthesized envelope spreads its
+// summarization turn. So an upstream that states nothing here has left us
+// unable to answer, and that is what gets reported.
+const missingUsage = (): never => {
+  throw new TypeError('Responses compaction upstream reported no token usage; the compaction resource requires it');
+};
 
 // Completing a compaction with `completeResponseResource` would decorate it
 // with `temperature`, `tools`, `truncation`, `service_tier`, `store` and the
@@ -39,5 +39,5 @@ export const completeResponsesCompaction = (
   ...upstream,
   object: 'response.compaction',
   created_at: createdAt,
-  usage: completeUsage(upstream.usage ?? NO_TOKENS_REPORTED),
+  usage: completeUsage(upstream.usage ?? missingUsage()),
 });

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -94,12 +94,14 @@ export const responsesHttp = {
       ctx = createChatGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, (apiKey, requestStartedAt) => createResponsesHttpStore(apiKey, requestStartedAt, payload.store ?? undefined));
       const result = await responsesServe.compact({ payload, ctx, headers: inboundHeadersForUpstream(c) });
       if (result.type === 'result') {
-        // Compact drains the upstream stream into a single envelope with
-        // no per-token stamps; recordPerformance therefore lands in
-        // the neutral bucket (request counted, no TTFT/TPOT sample). The
-        // envelope's own `status` is authoritative for failure — a compact
-        // that surfaced as `response.failed` must be recorded as such so it
-        // shows up in the error column instead of masquerading as a success.
+        // Compact drains the upstream stream into a single compaction
+        // resource with no per-token stamps; recordPerformance therefore
+        // lands in the neutral bucket (request counted, no TTFT/TPOT sample).
+        // `status` is not a `CompactResource` key — it survives the spread
+        // from the upstream turn — and it is authoritative for failure: a
+        // compact that surfaced as `response.failed` must be recorded as such
+        // so it shows up in the error column instead of masquerading as a
+        // success.
         const failed = result.result.status === 'failed';
         if (failed) {
           ctx.dump?.failed('compact envelope status=failed');

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/types.ts
@@ -8,15 +8,19 @@ import type { EventResultMetadata, ExecuteResult, ResponsesInvocation, Telemetry
 export type { ResponsesInvocation };
 
 // The chain runner produces an event stream for both actions — the attempt
-// post-processes it into a single `response.compaction` envelope when the
-// caller's intent action was 'compact'. `modelIdentity`, `usage`, and
-// `performance` carry the per-turn attribution forward so the http layer
-// records the success path identically to streaming generate.
-export type ResponsesAttemptResult =
+// drains it into a single non-streaming result when the caller's intent action
+// was 'compact', and serve completes that result into the compaction resource.
+// `modelIdentity`, `usage`, and `performance` carry the per-turn attribution
+// forward so the http layer records the success path identically to streaming
+// generate.
+// The non-streaming result is parameterized because `/responses/compact`
+// answers with `CompactResource` rather than the response resource, and its
+// own completion narrows the type further.
+export type ResponsesAttemptResult<Result = ResponsesResult> =
   | ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>
   | {
     readonly type: 'result';
-    readonly result: ResponsesResult;
+    readonly result: Result;
     readonly modelIdentity: TelemetryModelIdentity;
     readonly usage: TokenUsage | null;
     readonly performance: EventResultMetadata['performance'];

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
 
-import { wrapNativeResponsesClientOutput } from './client-output.ts';
+import { wrapResponsesClientEgress } from './client-output.ts';
 import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import { type StreamCompletion, writeSSEFrames } from '../../shared/sse.ts';
 import { recordFailedRequest } from '../../shared/telemetry/performance.ts';
@@ -54,7 +54,7 @@ export const respondResponses = async (
 
   const state = new SourceStreamState();
   const observed = observeResponsesFrames(result.events, state, ctx);
-  const frames = wrapNativeResponsesClientOutput(observed, ctx, request);
+  const frames = wrapResponsesClientEgress(observed, ctx, request);
 
   if (!wantsStream) {
     try {

--- a/packages/gateway/src/data-plane/chat/responses/response-resource.ts
+++ b/packages/gateway/src/data-plane/chat/responses/response-resource.ts
@@ -34,9 +34,11 @@ import type {
 //   ordered ids, and awaits that before the terminal frame leaves it, so no
 //   response resource is ever stored. Affinity egress runs underneath too, and
 //   billing reads `billableUsage` off the `ExecuteResult` rather than the
-//   resource. The readers that do sit above this stage — the `settle` call and
-//   the compact path's failure check — read only `status`, which rides through
-//   from the upstream and is never stated here.
+//   resource. One reader sits above this stage, the non-streaming `settle`
+//   call, and it reads only `status`, which rides through from the upstream and
+//   is never stated here. The WebSocket transport buffers the terminal event
+//   and flushes it last, branching only on the event type; it reads nothing off
+//   the resource at all.
 //
 // #125's "no tools synthesized when upstream omits it" therefore still holds:
 // the interior resource carries no `tools`, and egress states `[]` on the way
@@ -96,16 +98,17 @@ const completeReasoning = (reasoning: NonNullable<ResponsesResult['reasoning']> 
 
 // Both breakdowns are required whenever `usage` itself is an object. An absent
 // breakdown means the upstream reported no cached input tokens and no reasoning
-// output tokens.
+// output tokens. Shared with the compaction resource, whose `usage` is the same
+// `Usage` schema.
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2384-L2429
-const completeUsage = (usage: NonNullable<ResponsesResult['usage']> | null): ClientResponsesUsage | null =>
-  usage === null
-    ? null
-    : {
-        ...usage,
-        input_tokens_details: usage.input_tokens_details ?? { cached_tokens: 0 },
-        output_tokens_details: usage.output_tokens_details ?? { reasoning_tokens: 0 },
-      };
+export const completeUsage = (usage: NonNullable<ResponsesResult['usage']>): ClientResponsesUsage => ({
+  ...usage,
+  input_tokens_details: usage.input_tokens_details ?? { cached_tokens: 0 },
+  output_tokens_details: usage.output_tokens_details ?? { reasoning_tokens: 0 },
+});
+
+const completeUsageOrNull = (usage: NonNullable<ResponsesResult['usage']> | null): ClientResponsesUsage | null =>
+  usage === null ? null : completeUsage(usage);
 
 export interface ResponseResourceSources {
   // The request these events answer. Every echoed value comes from here.
@@ -194,7 +197,7 @@ export const completeResponseResource = (
     prompt_cache_key: observed([upstream.prompt_cache_key, request.prompt_cache_key]),
     reasoning: completeReasoning(observed<NonNullable<ResponsesResult['reasoning']>>([upstream.reasoning, request.reasoning])),
     // The request has no counterpart: token counts are the upstream's alone.
-    usage: completeUsage(observed([upstream.usage])),
+    usage: completeUsageOrNull(observed([upstream.usage])),
   };
 };
 

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -1,12 +1,13 @@
 import { responsesAttempt } from './attempt.ts';
-import { wrapNativeResponsesClientOutput } from './client-output.ts';
+import { responsesCreatedAt, wrapResponsesStatefulOutput } from './client-output.ts';
+import { completeResponsesCompaction } from './compaction-resource.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
 import { syntheticEventsFromResult } from './items/output.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
 import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { collectResponsesProtocolEventsToResult, type CanonicalResponsesPayload, type ClientResponsesCompaction, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 
 interface ResponsesServeArgs {
@@ -48,7 +49,7 @@ export const responsesServe = {
     return result;
   },
 
-  compact: async (args: ResponsesServeArgs): Promise<ResponsesAttemptResult> => {
+  compact: async (args: ResponsesServeArgs): Promise<ResponsesAttemptResult<ClientResponsesCompaction>> => {
     const { payload, ctx, headers } = args;
     // Compact accepts `previous_response_id` (the official endpoint documents
     // it). When present serve-prep expands it the same way generate does so
@@ -82,12 +83,11 @@ export const responsesServe = {
     );
     if (result.type !== 'result') return result;
 
-    const stored = wrapNativeResponsesClientOutput(syntheticEventsFromResult(result.result), ctx, payload);
-    const clientResult = await collectResponsesProtocolEventsToResult(stored);
+    const stored = wrapResponsesStatefulOutput(syntheticEventsFromResult(result.result), ctx);
+    const persisted = await collectResponsesProtocolEventsToResult(stored);
     return {
       ...result,
-      result: clientResult,
-      usage: result.usage,
+      result: completeResponsesCompaction(persisted, responsesCreatedAt(ctx)),
     };
   },
 };

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono';
 
-import { wrapNativeResponsesClientOutput } from './client-output.ts';
+import { wrapResponsesClientEgress } from './client-output.ts';
 import { createResponsesWsSession } from './items/store.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
@@ -349,7 +349,7 @@ const respondResponsesWebSocket = async (input: {
   try {
     let terminalEvent: ClientResponsesStreamEvent | undefined;
     const observed = observeResponsesWebSocketFrames(result.events, state, ctx);
-    const output = wrapNativeResponsesClientOutput(observed, ctx, payload);
+    const output = wrapResponsesClientEgress(observed, ctx, payload);
     const iterator = output[Symbol.asyncIterator]();
     let pendingNext = pendingWsFrameResult(iterator.next());
     let completed = false;

--- a/packages/protocols/src/responses/client-resource.ts
+++ b/packages/protocols/src/responses/client-resource.ts
@@ -98,6 +98,19 @@ export type ClientResponseResource =
     usage: ClientResponsesUsage | null;
   };
 
+// `/responses/compact` answers with a resource of its own. `CompactResource`
+// requires `id`, `object`, `output`, `created_at` and `usage` — five keys, none
+// of them a request echo. `object` and `usage` are the two keys the two
+// resources spell differently: the enum value changes, and `ResponseResource`
+// gives `usage` a `null` alternative where this one does not, so a compaction
+// must state token counts. The schema forbids no extras, so keys the upstream
+// sent beyond these ride through.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L4008
+export type ClientResponsesCompaction =
+  Omit<ResponsesResult, 'object' | 'created_at' | 'usage'>
+  & Required<Pick<ResponsesResult, 'created_at'>>
+  & { object: 'response.compaction'; usage: ClientResponsesUsage };
+
 // Every resource-bearing member of the stream union, re-declared with the
 // completed resource. Distributive so each member keeps its `type` literal.
 // A `response.*` event added to `ResponsesStreamEvent` is narrowed

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -1369,6 +1369,7 @@ export { parseResponsesStream, type ParseResponsesStreamOptions } from './stream
 
 export type {
   ClientResponseResource,
+  ClientResponsesCompaction,
   ClientResponsesReasoning,
   ClientResponsesStreamEvent,
   ClientResponsesTextField,


### PR DESCRIPTION
The compact route sent its result through the same client-output pipeline as a generate turn, because it needs the item-persistence half of it. That also ran the **response** resource's completion over a `response.compaction` body, so a compaction left Floway decorated with `temperature: 1`, `tools: []`, `truncation`, `service_tier`, `store` and twenty-one other keys `CompactResource` does not declare — while still missing `created_at` and `usage.output_tokens_details`, which it does. Non-strict Zod strips the extras, so nothing caught it.

The pipeline is split at the seam the two resources actually share:

- `wrapResponsesStatefulOutput` carries affinity metadata, per-item persistence and the one generated response id. Every native Responses turn goes through it.
- `wrapResponsesClientEgress` composes the response resource's completion on top, for the generate path only.
- `/responses/compact` stops at the stateful half and applies `completeResponsesCompaction` — the compaction resource's own **five required keys** (`id`, `object`, `output`, `created_at`, `usage`), one usage normalizer, nothing else.

### `CompactResource.usage` is required *and* non-nullable

That is the one required key the two resources spell differently (`object` aside): `ResponseResource.usage` is `anyOf [Usage, null]`, `CompactResource.usage` is a bare `Usage`, and `Usage` itself requires the three totals plus both breakdowns. So a compaction must state token counts, and an upstream that reported none has no spelling on this wire.

Zeros are not that spelling. A compaction is a turn a model actually ran, so zero totals are never a true statement about one, and a client reading them as the turn's cost would be reading a number Floway invented. The absence is also not ours to paper over: every stage between the upstream and the completion carries `usage` on a spread — `provider-copilot`'s compaction envelope over the `/responses` turn it triggers, Azure's and Codex's verbatim pass-through of their compact bodies, the synthetic-event round trip that runs the result back through item persistence, and the shim's envelope over its summarization turn — and the terminal event carries the whole result, so the round trip copies it. An upstream that states nothing here has left the gateway unable to answer, and that is what gets reported: a `TypeError` naming the condition, which the Responses http entry shapes into a 502 carrying the stack.

Live probes confirm the reported-nothing case is not one real upstreams produce. Driven through Floway's own compact route against a proxied upstream, Codex's native `/codex/responses/compact` answered `input_tokens: 78, output_tokens: 69, total_tokens: 147`; Copilot's RemoteCompactionV2 replay on `gpt-5-mini` answered `144 / 1667 / 1811` with `reasoning_tokens: 576`; and the shim over a Messages upstream on `claude-haiku-4-5` answered `170 / 293 / 463`. Azure was not exercised — no credential was available.

Billing never reads this resource; it prices the attempt's own `billableUsage`.

`completeUsage` is shared between the two resources — both slots are the same `Usage` schema — and the response resource, the only side with a `null` to spell, keeps a private nullable adapter over it.

### Types

`ResponsesAttemptResult` is parameterized on its non-streaming result so the compact route's narrower resource reaches `http.ts` as a type rather than being widened back to `ResponsesResult`. `ClientResponsesCompaction` is derived from `ResponsesResult` in the same idiom as its sibling `ClientResponseResource`, so the two cannot drift.

Keys beyond the five ride through from the upstream compaction result — `model`, `status`, `error` and `incomplete_details` among them. `CompactResource` declares none of them and the spec forbids no extras, so they are kept: dropping a field a client may already read would be a user-visible removal with nothing to gain. `http.ts` reads exactly one of them, `status`, to record a failed compaction as a failure.

### Files

`packages/gateway/src/data-plane/chat/responses/{compaction-resource.ts (new),client-output.ts,response-resource.ts,serve.ts,respond.ts,websocket.ts,http.ts,interceptors/types.ts}`, `packages/protocols/src/responses/{client-resource.ts,index.ts}`, with `http_test.ts` and `test-required-resource-keys.ts`.


### Verification

Deferred to central verification. Earlier, on an integration branch containing the full OpenResponses fix set rather than this branch alone: 17/17 on all three Responses paths (`gpt-5-mini` native, `gpt-4.1` via Chat Completions, `claude-haiku-4-5` via Messages), twice, with typecheck and lint clean and 4935 unit tests passing. Baseline was 1/17 per path.

Supersedes #303, which was merged without authorization and cannot be reopened.




