### PR TITLE
fix(copilot): forward every compaction item the trigger turn returns

### DIFF
--- a/packages/provider-copilot/__tests__/compaction_test.ts
+++ b/packages/provider-copilot/__tests__/compaction_test.ts
@@ -27,8 +27,8 @@ test('keeps retained user/assistant/developer/system messages and appends the co
     { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'lookup', arguments: '{}', status: 'completed' },
     { type: 'message', role: 'system', content: 'be nice' },
   ];
-  // The trigger turn may also emit a stray assistant message; only the lone
-  // compaction item survives, regardless of the generated assistant output.
+  // The trigger turn may also emit a stray assistant message; only the
+  // compaction items survive, regardless of the generated assistant output.
   const result = compactionResponse(input, generatedResult([{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'stray' }] }, compaction]));
 
   expect(result.object).toBe('response.compaction');
@@ -66,9 +66,19 @@ test('assigns final random ids to retained messages instead of reusing input ids
   expect(id).not.toBe('msg_input');
 });
 
-test('throws when the trigger turn did not return exactly one compaction item', () => {
-  expect(() => compactionResponse([], generatedResult([]))).toThrow(/exactly one compaction/);
-  expect(() => compactionResponse([], generatedResult([compaction, { type: 'compaction', id: 'cmp_2', encrypted_content: 'X' }]))).toThrow(/exactly one compaction/);
+test('forwards every compaction item of a segmented trigger turn, in upstream order, after the retained messages', () => {
+  const second = { type: 'compaction', id: 'cmp_2', encrypted_content: 'X' };
+  const result = compactionResponse(
+    [{ type: 'message', role: 'user', content: 'hello' }],
+    generatedResult([compaction, second]),
+  );
+
+  expect(shape(result)).toEqual(['message:user', 'compaction', 'compaction']);
+  expect(result.output.slice(1)).toEqual([compaction, second]);
+});
+
+test('throws when the trigger turn returned no compaction item', () => {
+  expect(() => compactionResponse([], generatedResult([]))).toThrow(/at least one compaction/);
 });
 
 test('truncates retained messages newest-first to the 64k token budget', () => {

--- a/packages/provider-copilot/__tests__/compaction_test.ts
+++ b/packages/provider-copilot/__tests__/compaction_test.ts
@@ -78,7 +78,7 @@ test('forwards every compaction item of a segmented trigger turn, in upstream or
 });
 
 test('throws when the trigger turn returned no compaction item', () => {
-  expect(() => compactionResponse([], generatedResult([]))).toThrow(/at least one compaction/);
+  expect(() => compactionResponse([], generatedResult([]))).toThrow(/no compaction output item/);
 });
 
 test('truncates retained messages newest-first to the 64k token budget', () => {

--- a/packages/provider-copilot/src/compaction.ts
+++ b/packages/provider-copilot/src/compaction.ts
@@ -4,9 +4,9 @@
 // Providers whose upstream exposes native /responses/compact (Azure, Codex,
 // custom) call that endpoint directly and bypass this helper entirely.
 //
-// References (codex @ ebb79803697acee75baf24073ef49af87ad7e483):
-//   codex-rs/core/src/compact_remote_v2.rs#L409-L457
-//   codex-rs/utils/string/src/truncate.rs#L71-L74
+// References:
+//   https://github.com/openai/codex/blob/3d805abdf09093bfa806f359a5adc6514766c420/codex-rs/core/src/compact_remote_v2.rs#L439-L501
+//   https://github.com/openai/codex/blob/3d805abdf09093bfa806f359a5adc6514766c420/codex-rs/utils/string/src/truncate.rs#L71-L74
 
 import { createRandomResponsesItemId, type ResponsesCompactionTriggerItem, type ResponsesInputContent, type ResponsesInputItem, type ResponsesInputMessage, type ResponsesOutputItem, type ResponsesResult } from '@floway-dev/protocols/responses';
 
@@ -72,28 +72,31 @@ export const compactionResponse = (input: ResponsesInputItem[], generated: Respo
     });
   }
 
-  // The trigger turn may also emit a stray assistant message, and it may segment
-  // its state across several compaction items: `gpt-5-mini-2025-08-07` returns
-  // two deterministically — independent ciphertexts of 7800 and 8968 bytes, each
-  // individually replayable, the first recovering the early turns and the second
+  // The trigger turn may also emit a stray assistant message, and it may
+  // segment its state across several compaction items: `gpt-5-mini-2025-08-07`
+  // returns two deterministically, reproduced across six probe variations
+  // spanning input size, tool items in the input, streaming, and chained
+  // re-feed. The two are independent ciphertexts of 7800 and 8968 bytes, each
+  // individually replayable — the first recovers the early turns, the second
   // the full history. Every other Responses model on the same account returns
-  // one. The compaction resource declares `output` as an unbounded array, so a
-  // segmented reply is a conformant reply and the whole array is what the client
-  // resends as the next turn's `input`:
-  //   https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935
+  // one. `CompactResource` declares `output` as an array with no `minItems`,
+  // no `maxItems`, and no prose cardinality rule, and the client contract is to
+  // resend the whole array as the next turn's `input`, so a segmented reply is
+  // a conformant reply:
+  //   https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L3953
   //
-  // codex hard-fails a count other than one, but that is a consumer-side
-  // invariant guarding its own single-blob history model; its own gateway-shaped
-  // /responses/compact handler installs the entire `output` array untouched.
-  // Serving the client means forwarding every segment in upstream order and
-  // failing only when the trigger turn produced no compaction state at all.
-  //
-  // References (codex @ 3d805abdf09093bfa806f359a5adc6514766c420):
-  //   codex-rs/core/src/compact_remote_v2.rs#L380-L432
-  //   codex-api/src/endpoint/compact.rs#L39-L86
+  // codex hard-fails a compaction count other than one, but that is a
+  // consumer-side invariant guarding its own single-blob history model: its
+  // client for the native /responses/compact endpoint deserializes `output`
+  // whole and returns it with no per-item inspection. We serve the client
+  // instead, and keep only the invariant that the turn produced compaction
+  // state at all — a model that ignores `compaction_trigger` answers with an
+  // ordinary completion carrying no compaction item.
+  //   https://github.com/openai/codex/blob/3d805abdf09093bfa806f359a5adc6514766c420/codex-rs/core/src/compact_remote_v2.rs#L380-L428
+  //   https://github.com/openai/codex/blob/3d805abdf09093bfa806f359a5adc6514766c420/codex-rs/codex-api/src/endpoint/compact.rs#L39-L88
   const compactionItems = generated.output.filter(it => it.type === 'compaction');
   if (compactionItems.length === 0) {
-    throw new Error('Expected at least one compaction output item, got none');
+    throw new Error("Copilot's compaction trigger turn returned no compaction output item");
   }
 
   return {

--- a/packages/provider-copilot/src/compaction.ts
+++ b/packages/provider-copilot/src/compaction.ts
@@ -1,6 +1,5 @@
-// Synthesizes the `response.compaction` envelope from Copilot's trigger turn,
-// which returns one `compaction` output item. Copilot has no native
-// /responses/compact endpoint and replays the official
+// Synthesizes the `response.compaction` envelope from Copilot's trigger turn.
+// Copilot has no native /responses/compact endpoint and replays the official
 // `RemoteCompactionV2` protocol client-side over /responses with stream:false.
 // Providers whose upstream exposes native /responses/compact (Azure, Codex,
 // custom) call that endpoint directly and bypass this helper entirely.
@@ -73,16 +72,33 @@ export const compactionResponse = (input: ResponsesInputItem[], generated: Respo
     });
   }
 
-  // The trigger turn may also emit a stray assistant message; codex ignores
-  // everything but the lone compaction item and errors if it is not exactly one.
+  // The trigger turn may also emit a stray assistant message, and it may segment
+  // its state across several compaction items: `gpt-5-mini-2025-08-07` returns
+  // two deterministically — independent ciphertexts of 7800 and 8968 bytes, each
+  // individually replayable, the first recovering the early turns and the second
+  // the full history. Every other Responses model on the same account returns
+  // one. The compaction resource declares `output` as an unbounded array, so a
+  // segmented reply is a conformant reply and the whole array is what the client
+  // resends as the next turn's `input`:
+  //   https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935
+  //
+  // codex hard-fails a count other than one, but that is a consumer-side
+  // invariant guarding its own single-blob history model; its own gateway-shaped
+  // /responses/compact handler installs the entire `output` array untouched.
+  // Serving the client means forwarding every segment in upstream order and
+  // failing only when the trigger turn produced no compaction state at all.
+  //
+  // References (codex @ 3d805abdf09093bfa806f359a5adc6514766c420):
+  //   codex-rs/core/src/compact_remote_v2.rs#L380-L432
+  //   codex-api/src/endpoint/compact.rs#L39-L86
   const compactionItems = generated.output.filter(it => it.type === 'compaction');
-  if (compactionItems.length !== 1) {
-    throw new Error(`Expected exactly one compaction output item, got ${compactionItems.length}`);
+  if (compactionItems.length === 0) {
+    throw new Error('Expected at least one compaction output item, got none');
   }
 
   return {
     ...generated,
     object: 'response.compaction',
-    output: [...kept.reverse(), compactionItems[0]] as unknown as ResponsesOutputItem[],
+    output: [...kept.reverse(), ...compactionItems] as unknown as ResponsesOutputItem[],
   };
 };


### PR DESCRIPTION
## Defect

`POST /responses/compact` answered `502 Expected exactly one compaction output item, got 2` on `gpt-5-mini`. Copilot exposes no native `/responses/compact`, so `packages/provider-copilot/src/compaction.ts` replays the `RemoteCompactionV2` protocol client-side over `/responses` and synthesizes the `response.compaction` envelope itself. That synthesizer asserted the trigger turn returns exactly one `compaction` output item and threw on any other count.

## Evidence

Probed against Copilot directly, with no gateway in the path. A compaction-trigger turn on `gpt-5-mini-2025-08-07` returns **two** `compaction` items, **deterministically** — reproduced across six variations: 1-message input, 24-message input, input carrying tool items, streaming, and chained re-feed.

The two blobs are not a duplicate:

- Independent ciphertexts, no shared prefix, 7800 and 8968 bytes.
- Each is individually valid replay state: item[0] recovers the early turns, item[1] the full history.

It is a **segmented compaction**. Every other Responses model on the same account returns exactly one compaction item and had been served by this endpoint without incident; `gpt-5-mini` is the only observed segmenting model.

## Spec position

`CompactResource.output` is `array<ItemField>` with no `minItems`, no `maxItems`, and no prose cardinality statement anywhere in the specification. The client contract is to resend the whole `output` array as the next turn's `input`, so a segmented reply is a conformant reply.

https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L3953

The compliance assertion the spec supports is "at least one", not "exactly one".

## Prior art — the crux

The `!= 1` rule came from openai/codex, which hard-fails a compaction count other than one in [`codex-rs/core/src/compact_remote_v2.rs#L380-L428`](https://github.com/openai/codex/blob/3d805abdf09093bfa806f359a5adc6514766c420/codex-rs/core/src/compact_remote_v2.rs#L380-L428).

But codex's own client for the native `/responses/compact` endpoint — [`codex-rs/codex-api/src/endpoint/compact.rs#L39-L88`](https://github.com/openai/codex/blob/3d805abdf09093bfa806f359a5adc6514766c420/codex-rs/codex-api/src/endpoint/compact.rs#L39-L88), same revision — deserializes the whole `output` array and returns it with no per-item inspection. codex enforces the arity where it *consumes* compaction state, not where it *carries* it.

Every other gateway surveyed passes compaction items through: caozhiyuan/copilot-api, bifrost, and new-api.

OpenAI's SDK docstring describing "a single compaction item" documents OpenAI's own server behavior, not a normative constraint — and Copilot's `gpt-5-mini` snapshot violates it while remaining spec-conformant.

That is the point of this PR: **codex's rule is a consumer-side invariant protecting its own single-blob history model. A gateway that adopts it turns a servable upstream response into a 502.**

## What changed

`compactionResponse` filters the trigger turn's `compaction` items as before, then requires at least one and forwards all of them, in upstream order, after the retained messages:

```ts
const compactionItems = generated.output.filter(it => it.type === 'compaction');
if (compactionItems.length === 0) {
  throw new Error("Copilot's compaction trigger turn returned no compaction output item");
}

return {
  ...generated,
  object: 'response.compaction',
  output: [...kept.reverse(), ...compactionItems] as unknown as ResponsesOutputItem[],
};
```

The surviving invariant is real: a model that ignores `compaction_trigger` answers with an ordinary completion carrying no compaction state, and that is an error. The retained-message truncation and the stray-assistant-message filter are unchanged. The module comment now carries the segmentation evidence, the spec permalink, and both codex references, so the next reader sees why the consumer-side rule was not adopted.

## Test Plan

- [x] `pnpm run test` — 422 files, 4906 tests passed, 0 failed
- [x] `packages/provider-copilot` suite — 42 files, 306 tests passed
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `packages/provider-copilot/__tests__/compaction_test.ts` — a segmented trigger turn yields `['message:user', 'compaction', 'compaction']` with `output.slice(1)` equal to the upstream items in upstream order; a trigger turn with no compaction item still throws
- [ ] End-to-end `POST /responses/compact` against live Copilot `gpt-5-mini` — requires an active GitHub Copilot subscription credential
