### PR TITLE
fix(translate): carry reasoning tokens into Responses usage

### DIFF
--- a/packages/protocols/src/messages/index.ts
+++ b/packages/protocols/src/messages/index.ts
@@ -370,6 +370,7 @@ export interface MessagesMessageDeltaEvent {
       ephemeral_5m_input_tokens?: number;
       ephemeral_1h_input_tokens?: number;
     };
+    output_tokens_details?: { thinking_tokens: number };
     service_tier?: 'standard' | 'priority' | 'batch' | (string & {});
     speed?: 'standard' | 'fast' | (string & {});
     server_tool_use?: MessagesUsageServerToolUse;

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -41,6 +41,12 @@ export interface MessagesUsage {
     ephemeral_5m_input_tokens?: number;
     ephemeral_1h_input_tokens?: number;
   };
+  // `thinking_tokens` is the reasoning subset of the inclusive `output_tokens`
+  // total, re-tokenized from the raw reasoning rather than from the possibly
+  // summarized thinking text that reaches the response body, so it can differ
+  // from the model's own generation count by a few tokens.
+  // https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/messages/messages.ts#L1292-L1304
+  output_tokens_details?: { thinking_tokens: number };
   // https://docs.claude.com/en/api/service-tiers
   service_tier?: 'standard' | 'priority' | 'batch' | (string & {});
   // https://docs.claude.com/en/build-with-claude/fast-mode
@@ -61,6 +67,7 @@ export interface MessagesUsageSnapshot extends MessagesCacheCreationUsage {
   input_tokens?: number;
   output_tokens: number;
   cache_read_input_tokens?: number;
+  output_tokens_details?: { thinking_tokens: number };
   service_tier?: string;
   speed?: string;
   iterations?: MessagesUsageIteration[] | null;
@@ -71,6 +78,7 @@ export const messagesUsageSnapshot = (usage?: MessagesUsageSnapshot): MessagesUs
   : {
       ...usage,
       ...(usage.cache_creation === undefined ? {} : { cache_creation: { ...usage.cache_creation } }),
+      ...(usage.output_tokens_details === undefined ? {} : { output_tokens_details: { ...usage.output_tokens_details } }),
       ...(usage.iterations === undefined ? {} : { iterations: cloneMessagesUsageIterations(usage.iterations) }),
     };
 
@@ -84,6 +92,7 @@ export const mergeMessagesUsageSnapshot = (
   ...(delta.cache_read_input_tokens === undefined ? {} : { cache_read_input_tokens: delta.cache_read_input_tokens }),
   ...(delta.cache_creation_input_tokens === undefined ? {} : { cache_creation_input_tokens: delta.cache_creation_input_tokens }),
   ...(delta.cache_creation === undefined ? {} : { cache_creation: { ...delta.cache_creation } }),
+  ...(delta.output_tokens_details === undefined ? {} : { output_tokens_details: { ...delta.output_tokens_details } }),
   ...(delta.iterations === undefined ? {} : { iterations: cloneMessagesUsageIterations(delta.iterations) }),
   ...(delta.speed === undefined && delta.service_tier === undefined
     ? {}

--- a/packages/translate/__tests__/responses-via-chat-completions/events_test.ts
+++ b/packages/translate/__tests__/responses-via-chat-completions/events_test.ts
@@ -196,6 +196,7 @@ test('translateChatCompletionsChunkToResponsesEvents maps usage on incomplete le
     output_tokens: 6,
     total_tokens: 10,
     input_tokens_details: { cached_tokens: 1, cache_write_tokens: 2 },
+    output_tokens_details: { reasoning_tokens: 2 },
   });
 });
 

--- a/packages/translate/__tests__/responses-via-messages/events_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/events_test.ts
@@ -25,6 +25,7 @@ const runToCompletion = (
     cache_read_input_tokens?: number;
     cache_creation_input_tokens?: number;
     cache_creation?: { ephemeral_5m_input_tokens?: number; ephemeral_1h_input_tokens?: number };
+    output_tokens_details?: { thinking_tokens: number };
     speed?: string;
     service_tier?: string;
   },
@@ -132,6 +133,19 @@ test('handles no cache fields (backward compat)', () => {
   assertEquals(result.usage!.input_tokens, 100);
   assertEquals(result.usage!.total_tokens, 150);
   assertEquals(result.usage!.input_tokens_details, undefined);
+  assertEquals(result.usage!.output_tokens_details, undefined);
+});
+
+// ── output_tokens_details ──
+
+test('maps Messages thinking_tokens onto Responses reasoning_tokens', () => {
+  const result = runToCompletion(
+    { input_tokens: 10, output_tokens: 60 },
+    { output_tokens_details: { thinking_tokens: 45 } },
+  );
+
+  assertEquals(result.usage!.output_tokens, 60);
+  assertEquals(result.usage!.output_tokens_details, { reasoning_tokens: 45 });
 });
 
 test('redacted_thinking stream block round-trips its opaque data as encrypted_content', () => {

--- a/packages/translate/src/responses-via-chat-completions/events.ts
+++ b/packages/translate/src/responses-via-chat-completions/events.ts
@@ -10,6 +10,7 @@ const mapChatCompletionsUsageToResponsesUsage = (usage: ChatCompletionsResult['u
   const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
   const cacheWriteTokens = usage.prompt_tokens_details?.cache_creation_input_tokens
     ?? usage.prompt_tokens_details?.cache_write_tokens;
+  const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens;
   splitInclusiveInputTokens(usage.prompt_tokens, cachedTokens, cacheWriteTokens);
   return {
     input_tokens: usage.prompt_tokens,
@@ -23,6 +24,14 @@ const mapChatCompletionsUsageToResponsesUsage = (usage: ChatCompletionsResult['u
           },
         }
       : {}),
+    // Chat Completions' `reasoning_tokens` and Responses' `reasoning_tokens`
+    // are the same quantity, so an upstream that reports one is translated
+    // rather than dropped. OpenAI's schema makes the breakdown mandatory, but
+    // a translator's output is interior — a zero synthesized here would be
+    // indistinguishable from a zero an upstream measured — so absence stays
+    // absence, exactly as for the input breakdown above.
+    // https://github.com/openai/openai-python/blob/f16fbbd2bd25dc1ff150b5f78dbd15ff6bab6d91/src/openai/types/responses/response_usage.py#L21-L47
+    ...(reasoningTokens === undefined ? {} : { output_tokens_details: { reasoning_tokens: reasoningTokens } }),
   };
 };
 

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -98,6 +98,7 @@ const buildResult = (state: MessagesToResponsesStreamState, status: ResponsesRes
   const hasCacheCreation = state.usage.cache_creation_input_tokens !== undefined
     || state.usage.cache_creation?.ephemeral_5m_input_tokens !== undefined
     || state.usage.cache_creation?.ephemeral_1h_input_tokens !== undefined;
+  const thinkingTokens = state.usage.output_tokens_details?.thinking_tokens;
   const serviceTier = openAIServiceTierFromMessagesUsage(state.usage);
 
   return responses.result({
@@ -123,6 +124,12 @@ const buildResult = (state: MessagesToResponsesStreamState, status: ResponsesRes
             },
           }
         : {}),
+      // Anthropic's `thinking_tokens` and Responses' `reasoning_tokens` are the
+      // same quantity: the reasoning share of the inclusive output-token total.
+      // As with the input breakdown above, an upstream that reports none is
+      // translated to absence rather than to a synthesized zero.
+      // https://github.com/openai/openai-python/blob/f16fbbd2bd25dc1ff150b5f78dbd15ff6bab6d91/src/openai/types/responses/response_usage.py#L21-L47
+      ...(thinkingTokens === undefined ? {} : { output_tokens_details: { reasoning_tokens: thinkingTokens } }),
     },
     ...(serviceTier !== undefined ? { serviceTier } : {}),
     ...(status === 'failed' ? { error: messagesRefusalResponsesError(state.stopDetails) } : {}),


### PR DESCRIPTION
Both translated Responses paths dropped a reasoning-token breakdown that the upstream actually reported. This carries it through.

## Chat Completions path

`mapChatCompletionsUsageToResponsesUsage` in `packages/translate/src/responses-via-chat-completions/events.ts` never read `usage.completion_tokens_details.reasoning_tokens`. Chat Completions' `reasoning_tokens` and Responses' `output_tokens_details.reasoning_tokens` are the same quantity — the reasoning share of the inclusive output-token total — so this was real upstream data discarded at the translation seam. It now maps across.

Responses' target field: https://github.com/openai/openai-python/blob/f16fbbd2bd25dc1ff150b5f78dbd15ff6bab6d91/src/openai/types/responses/response_usage.py#L21-L47

## Messages path

Anthropic's Messages usage carries `output_tokens_details.thinking_tokens`, and Floway's protocol type did not model it at all — the same dropped-data defect on the second path.

https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/messages/messages.ts#L1292-L1304

`MessagesUsage` and `MessagesUsageSnapshot` gain the field, and both `messagesUsageSnapshot` (clone) and `mergeMessagesUsageSnapshot` carry it. Anthropic reports the final counts on `message_delta`, so `MessagesMessageDeltaEvent`'s inline usage shape needed the field too — otherwise it only reached the merge by structural accident. The stream translator then maps `thinking_tokens` onto Responses' `reasoning_tokens`.

## Observation-only

An upstream that reports no reasoning tokens states nothing here, exactly as an upstream that reports no cache activity states no input breakdown. A translator's output is interior — it feeds the server-tool shim, affinity, and the item store — so a zero synthesized here would be indistinguishable from a zero an upstream measured. The schema does require the breakdown on a client-facing body, but where that requirement gets satisfied for the client is not this change's business.

## Deliberately out of scope

Worth recording because it is billing-visible: Copilot's Chat Completions never populates `completion_tokens_details.reasoning_tokens`. It reports a top-level `usage.reasoning_tokens`, and containment differs by model family:

- `gpt-5-mini` counts reasoning **inside** `completion_tokens` — 63 + 624 = 687 = total.
- `gemini-3.1-pro-preview` counts it **outside** — 66 + 465 + 637 = 1168, with `completion_tokens` 465.

Honoring that means deciding per family whether `output_tokens` absorbs the reasoning share so `reasoning_tokens ⊆ output_tokens` holds. That is provider knowledge and belongs in `provider-copilot`, not in a protocol-neutral translator.

## Test Plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` — 422 files, 4906 tests passed, 0 failed
- [ ] End-to-end Responses usage check against live Copilot and Anthropic upstreams — requires provider credentials and billable calls, so it is not run as part of this PR's verification.

