### PR TITLE
fix: accept any image detail a client sends, including none

### DIFF
--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -600,8 +600,9 @@ Known losses:
 - `input_file` message/tool-output content and assistant-side files or images
   have no Chat counterpart and are rejected.
 - File-id-only images cannot be materialized by the pure translator and are
-  rejected. Chat image detail supports only `auto`, `low`, and `high`; other
-  Responses values such as `original` are rejected.
+  rejected. Image `detail` is forwarded verbatim and the target decides what it
+  accepts; an absent or null value becomes an omitted key, which both protocols
+  read as `auto`.
 - opaque Responses reasoning state is not requested, translated, or preserved on
   Chat fallback paths.
 

--- a/packages/protocols/src/chat-completions/index.ts
+++ b/packages/protocols/src/chat-completions/index.ts
@@ -75,7 +75,12 @@ interface ChatCompletionsTextPart {
 
 interface ChatCompletionsImagePart {
   type: 'image_url';
-  image_url: { url: string; detail?: 'low' | 'high' | 'auto' };
+  // OpenAI publishes `detail` as an optional `[auto, low, high]` string
+  // defaulting to `auto`, with no null member. The value is open here because
+  // the upstream owns the accept decision, and the absent case is the only one
+  // whose meaning the protocol itself fixes.
+  // https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L30795-L30803
+  image_url: { url: string; detail?: 'low' | 'high' | 'auto' | (string & {}) };
 }
 
 interface ChatCompletionsRefusalPart {

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -150,11 +150,23 @@ export interface ResponsesInputText {
 }
 
 export interface ResponsesInputImage {
-  // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L3947-L3979
+  // OpenAI splits this part in two: `ResponseInputImageContent` /
+  // `InputImageContentParamAutoParam` is the request-side shape and leaves
+  // `detail` optional and nullable, while `ResponseInputImage` /
+  // `InputImageContent` requires it and is the response-side echo. This
+  // interface types requests, so it follows the former. Omitting `detail`
+  // means `auto` on both Responses and Chat Completions.
+  // https://web.archive.org/web/20260730100926/https://developers.openai.com/api/docs/guides/images-vision.md
+  // Request side:
+  // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L4000-L4029
+  // https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L67923-L67961
+  // Response side:
+  // https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L3951-L3980
+  // https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L65928-L65961
   type: 'input_image';
   image_url?: string | null;
   file_id?: string | null;
-  detail: 'auto' | 'low' | 'high' | 'original' | (string & {});
+  detail?: 'auto' | 'low' | 'high' | 'original' | (string & {}) | null;
   prompt_cache_breakpoint?: ResponsesPromptCacheBreakpoint | null;
 }
 
@@ -391,7 +403,7 @@ export type ResponsesAgentMessageContent =
   | ResponsesInputFile
   | { type: 'text' | 'summary_text' | 'reasoning_text'; text: string }
   | { type: 'refusal'; refusal: string }
-  | { type: 'computer_screenshot'; image_url: string | null; file_id: string | null; detail: 'auto' | 'low' | 'high' | 'original' | (string & {}) }
+  | { type: 'computer_screenshot'; image_url: string | null; file_id: string | null; detail?: 'auto' | 'low' | 'high' | 'original' | (string & {}) | null }
   | { type: 'encrypted_content'; encrypted_content: string }
   | (Record<string, unknown> & { type: string });
 

--- a/packages/translate/__tests__/canonicalize-responses-payload_test.ts
+++ b/packages/translate/__tests__/canonicalize-responses-payload_test.ts
@@ -45,6 +45,16 @@ test('canonicalizes string and implicit-message wire inputs', () => {
   });
 });
 
+test('canonicalizes an untyped message carrying an image without detail', () => {
+  assertEquals(canonicalizeResponsesPayload({
+    model: 'gpt-test',
+    input: [{ role: 'user', content: [{ type: 'input_image', image_url: 'data:image/png;base64,AQID' }] }],
+  }), {
+    model: 'gpt-test',
+    input: [{ type: 'message', role: 'user', content: [{ type: 'input_image', image_url: 'data:image/png;base64,AQID' }] }],
+  });
+});
+
 test('rejects malformed untyped input items at the canonical boundary', () => {
   for (const malformed of [
     null,

--- a/packages/translate/__tests__/gemini-via-responses/request_test.ts
+++ b/packages/translate/__tests__/gemini-via-responses/request_test.ts
@@ -45,7 +45,6 @@ test('buildTargetRequest maps instructions and multimodal user input without def
           {
             type: 'input_image',
             image_url: 'data:image/png;base64,aW1hZ2U=',
-            detail: 'auto',
           },
         ],
       },

--- a/packages/translate/__tests__/responses-via-chat-completions/request_test.ts
+++ b/packages/translate/__tests__/responses-via-chat-completions/request_test.ts
@@ -611,15 +611,62 @@ test('buildTargetRequest rejects file_id-only images', () => {
   );
 });
 
-test('buildTargetRequest rejects Responses-only original image detail', () => {
-  assertThrows(
-    () => buildTargetRequest({
-      model: 'gpt-test',
-      input: [{ type: 'message', role: 'user', content: [{ type: 'input_image', image_url: 'https://example.com/a.png', detail: 'original' }] }],
-    }),
-    Error,
-    "image detail 'original'",
-  );
+test('buildTargetRequest forwards image details Chat Completions does not publish', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    input: [{
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_image', image_url: 'https://example.com/a.png', detail: 'original' },
+        { type: 'input_image', image_url: 'https://example.com/b.png', detail: 'ultra' },
+      ],
+    }],
+  });
+
+  assertEquals(result.target.messages[0].content, [
+    { type: 'image_url', image_url: { url: 'https://example.com/a.png', detail: 'original' } },
+    { type: 'image_url', image_url: { url: 'https://example.com/b.png', detail: 'ultra' } },
+  ]);
+});
+
+test('buildTargetRequest omits image detail when the client sends none', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    input: [{ type: 'message', role: 'user', content: [{ type: 'input_image', image_url: 'data:image/png;base64,AQID' }] }],
+  });
+
+  assertEquals(result.target.messages, [
+    { role: 'user', content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AQID' } }] },
+  ]);
+});
+
+test('buildTargetRequest omits image detail when the client sends null', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    input: [{ type: 'message', role: 'user', content: [{ type: 'input_image', image_url: 'data:image/png;base64,AQID', detail: null }] }],
+  });
+
+  assertEquals(result.target.messages[0].content, [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AQID' } }]);
+});
+
+test('buildTargetRequest omits image detail on lifted tool-output images', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    input: [
+      { type: 'function_call', call_id: 'call_1', name: 'screenshot', arguments: '{}', status: 'completed' },
+      {
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: [{ type: 'input_image', image_url: 'data:image/png;base64,AQID' }],
+      },
+    ],
+  });
+
+  assertEquals(result.target.messages.at(-1)?.content, [
+    { type: 'text', text: 'Image output from tool call call_1:' },
+    { type: 'image_url', image_url: { url: 'data:image/png;base64,AQID' } },
+  ]);
 });
 
 test('buildTargetRequest throws on a stray web_search_call input item (shim owns the reverse path)', () => {

--- a/packages/translate/__tests__/shared/responses-via/agent-message_test.ts
+++ b/packages/translate/__tests__/shared/responses-via/agent-message_test.ts
@@ -47,6 +47,16 @@ test('agentMessageContent normalizes readable beta content into Responses input 
   ]);
 });
 
+test('agentMessageContent carries images that omit detail', () => {
+  assertEquals(agentMessageContent(agentMessage([
+    { type: 'input_image', image_url: 'https://example.com/image.png', file_id: null },
+    { type: 'computer_screenshot', image_url: null, file_id: 'file_screen' },
+  ])).filter(part => part.type === 'input_image'), [
+    { type: 'input_image', image_url: 'https://example.com/image.png', file_id: null, detail: undefined },
+    { type: 'input_image', image_url: null, file_id: 'file_screen', detail: undefined },
+  ]);
+});
+
 test('agentMessageContent reports the exact path for unknown beta content', () => {
   const error = assertThrows(
     () => agentMessageContent(agentMessage([{ type: 'future_agent_part', value: 1 }])),

--- a/packages/translate/src/canonicalize-responses-payload.ts
+++ b/packages/translate/src/canonicalize-responses-payload.ts
@@ -34,7 +34,6 @@ export function canonicalizeResponsesPayload(value: unknown): CanonicalResponses
           return typeof content.text === 'string' && hasValidPromptCacheBreakpoint(content);
         case 'input_image':
           return (typeof content.image_url === 'string' || typeof content.file_id === 'string')
-            && typeof content.detail === 'string'
             && hasValidPromptCacheBreakpoint(content);
         case 'input_file':
           return hasValidPromptCacheBreakpoint(content);

--- a/packages/translate/src/gemini-via-responses/request.ts
+++ b/packages/translate/src/gemini-via-responses/request.ts
@@ -31,7 +31,6 @@ const inlineDataToInputImage = (part: GeminiPart): ResponsesInputContent | null 
   return {
     type: 'input_image',
     image_url: imageUrl,
-    detail: 'auto',
   };
 };
 

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -38,7 +38,6 @@ const translateUserContentBlock = (
     return {
       type: 'input_image',
       image_url: `data:${block.source.media_type};base64,${block.source.data}`,
-      detail: 'auto',
     };
   }
 

--- a/packages/translate/src/shared/chat-completions-and-responses/content.ts
+++ b/packages/translate/src/shared/chat-completions-and-responses/content.ts
@@ -29,7 +29,7 @@ export const chatCompletionsContentToResponsesInputContent = (content: string | 
         return {
           type: 'input_image',
           image_url: part.image_url.url,
-          detail: part.image_url.detail ?? 'auto',
+          ...(part.image_url.detail === undefined ? {} : { detail: part.image_url.detail }),
         };
       }
     },
@@ -51,19 +51,17 @@ export const responsesContentToChatCompletionsContent = (content: string | Respo
             if (typeof part.image_url !== 'string') {
               throw new TranslatorInputError('Cannot translate file_id-only image content to Chat Completions.');
             }
-            let detail: 'auto' | 'low' | 'high';
-            switch (part.detail) {
-            case 'auto': detail = 'auto'; break;
-            case 'low': detail = 'low'; break;
-            case 'high': detail = 'high'; break;
-            default:
-              throw new TranslatorInputError(`Cannot translate image detail '${part.detail}' to Chat Completions.`);
-            }
             return {
               type: 'image_url',
               image_url: {
                 url: part.image_url,
-                detail,
+                // Both protocols read an absent `detail` as `auto`, and Chat
+                // Completions has no null member, so an absent or null value
+                // becomes an omitted key. Anything else is the upstream's to
+                // accept or reject.
+                // https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L30795-L30803
+                // https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L67946-L67951
+                ...(part.detail == null ? {} : { detail: part.detail }),
               },
             };
           }

--- a/packages/translate/src/shared/responses-via/agent-message.ts
+++ b/packages/translate/src/shared/responses-via/agent-message.ts
@@ -24,13 +24,6 @@ const nullableString = (value: unknown, path: string): string | null | undefined
   return value;
 };
 
-const imageDetail = (value: unknown, path: string): ResponsesInputImage['detail'] => {
-  if (typeof value !== 'string') {
-    throw new TranslatorInputError(`Invalid type for '${path}': expected a string.`, { param: path });
-  }
-  return value as ResponsesInputImage['detail'];
-};
-
 const escapeXmlText = (value: string): string =>
   value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 
@@ -99,7 +92,7 @@ export const agentMessageContent = (
         type: 'input_image',
         image_url: nullableString((part as AgentContentFields).image_url, `${path}.image_url`),
         file_id: nullableString((part as AgentContentFields).file_id, `${path}.file_id`),
-        detail: imageDetail((part as AgentContentFields).detail, `${path}.detail`),
+        detail: nullableString((part as AgentContentFields).detail, `${path}.detail`),
       });
       break;
     case 'input_file':
@@ -110,7 +103,7 @@ export const agentMessageContent = (
         type: 'input_image',
         image_url: nullableString((part as AgentContentFields).image_url, `${path}.image_url`),
         file_id: nullableString((part as AgentContentFields).file_id, `${path}.file_id`),
-        detail: imageDetail((part as AgentContentFields).detail, `${path}.detail`),
+        detail: nullableString((part as AgentContentFields).detail, `${path}.detail`),
       });
       break;
     default:


### PR DESCRIPTION
Floway rejected Responses `input_image` parts that omit `detail` with `400 Cannot translate image detail 'undefined' to Chat Completions` — **a gate the upstream never had**.

## Root cause

One layer below the throw. Floway's single request-side type, `ResponsesInputImage`, was pointed at OpenAI's **response-side** schema (`ResponseInputImage` / `InputImageContent`, where `detail` is required) instead of the **request-side** variant (`ResponseInputImageContent` / `InputImageContentParamAutoParam`, where it is optional and nullable). Because the type said `detail` was always there, the translator's exhaustive `switch` looked total and its `default:` arm looked unreachable; it was not.

Schema references: [openai-node request side](https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/resources/responses/responses.ts#L4000-L4029), [openai-openapi request side](https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L67923-L67961).

## Behavioural authority

OpenAI's vision guide:

> If you skip the parameter, the model will use `auto`. This behavior is the same in both the Responses API and the Chat Completions API.

https://web.archive.org/web/20260730100926/https://developers.openai.com/api/docs/guides/images-vision.md — Wayback because the live host serves `x-vercel-mitigated: deny`.

So `required: [type, detail]` on the response-side schema is a generation artifact of the published spec, not enforced request semantics. Both protocols default an absent `detail` to `auto`.

## Blast radius, stated precisely

Every `input_image` on the Chat Completions path that omits `detail` or sends `null` — regardless of format (PNG/JPEG), size (307 B through 3.3 MB), or reference kind. The throw happened before any byte was inspected, so the accurate sentence is "images without an explicit `detail` are rejected", not "data URIs are rejected".

## What changed

- `ResponsesInputImage.detail` is now optional, nullable, and open-string, with the request-vs-response distinction recorded on the type. `ResponsesAgentMessageContent`'s `computer_screenshot` member gets the same treatment.
- `ChatCompletionsImagePart`'s `image_url.detail` carries `(string & {})` as well. The published enum is `[auto, low, high]` with `default: auto` ([spec](https://github.com/openai/openai-openapi/blob/db3e53198a66732cfe161339ea63bf36fc0137ad/openapi.yaml#L30795-L30803)), but the accept decision belongs to whatever upstream is behind the endpoint, so the type states that the slot is open. Every reader of that field was swept: only this translator and `provider-copilot`'s `compress-images` interceptor, which merely spreads the object. No zod schema or control-plane validator constrains it.
- `packages/translate/src/shared/chat-completions-and-responses/content.ts` forwards `detail` verbatim in both directions.
- The one mapping that survives is the one the wire forces: an absent or `null` Responses `detail` becomes an **omitted key**, never a forwarded `null`, because Chat Completions carries no null member and both protocols read absence as `auto`.
- Three synthesized `'auto'` defaults are gone — Chat→Responses, Messages→Responses, Gemini→Responses. Floway no longer states a value the client did not send.
- The untyped message recognizer in `canonicalizeResponsesPayload` no longer requires a string `detail`, and `agent_message` content accepts a missing one.

`original` now reaches a Chat Completions upstream unmodified, as does any value nobody has catalogued yet. Whether a given upstream honours it is that upstream's answer to give, not Floway's to pre-empt.

## Not over-promising

With `detail: "auto"` an `https://` image URL still returns `400 validating image item: external image URLs are not supported`. That is Copilot's own error passed through, which is correct gateway behaviour — this PR does not change it.

## Coverage

The added tests cover user-message images, tool-output lifted images, the untyped message recognizer, `agent_message` content, and detail values Chat Completions does not publish. That last one sends both `original` and an invented `ultra` and asserts both arrive verbatim, so what is pinned is the open-string path rather than one known literal.

## Test Plan

- [x] `pnpm run typecheck` — clean across all packages, including `apps/web`'s `vue-tsc` (run at `1ca09dc87`)
- [x] `pnpm run lint` — exit 0 across the workspace (run at `1ca09dc87`)
- [x] `pnpm run test` — 422 files / 4910 tests passed, 0 failed (run at `1ca09dc87`)
