### PR TITLE
fix(responses): stop synthesizing a `ping` event from the Messages path

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -5834,7 +5834,7 @@ test('consumeTurn keeps swallowing keepalive/ping-shape events that lack output_
     framesOf(
       mkResponseCreated(),
       eventFrame<ResponsesStreamEvent>({ type: 'keepalive' } as unknown as ResponsesStreamEvent),
-      eventFrame<ResponsesStreamEvent>({ type: 'ping' }),
+      eventFrame<ResponsesStreamEvent>({ type: 'ping' } as unknown as ResponsesStreamEvent),
       mkResponseCompleted(),
     ),
     state,

--- a/packages/protocols/__tests__/responses/stream_test.ts
+++ b/packages/protocols/__tests__/responses/stream_test.ts
@@ -370,7 +370,7 @@ test('parseResponsesStream fast-paths when ping interleaves the wrappers', async
     sseFrame('[DONE]'),
   ));
 
-  const eventTypes = frames.filter(frame => frame.type === 'event').map(frame => (frame.type === 'event' ? frame.event.type : ''));
+  const eventTypes: string[] = frames.filter(frame => frame.type === 'event').map(frame => (frame.type === 'event' ? frame.event.type : ''));
   assertEquals(eventTypes.includes('response.output_item.added'), true);
   assertEquals(eventTypes.at(-1), 'response.completed');
   assertEquals(eventTypes.includes('ping'), false);

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -1240,8 +1240,7 @@ type ResponsesStreamEventVariant =
     stack?: string;
     cause?: unknown;
     target_api?: string;
-  }
-  | { type: 'ping' };
+  };
 
 // Either side of the Responses reasoning round trip: input echoes a prior
 // turn's reasoning back in, output emits the current turn's reasoning. Shape

--- a/packages/protocols/src/responses/stream.ts
+++ b/packages/protocols/src/responses/stream.ts
@@ -8,17 +8,14 @@ export interface ParseResponsesStreamOptions {
 }
 
 // Deny-list: anything that is not a wrapper (`response.queued` /
-// `response.created` / `response.in_progress` / `ping`) and not terminal is treated as content-
-// bearing. `ping` is a transport-level keep-alive with no content semantics,
-// so its presence must not commit us out of the fast-path. Future Responses
-// event types fall through as structured by default, which is safer than
-// missing an allow-list entry and incorrectly triggering the fast-path
-// expansion below.
+// `response.created` / `response.in_progress`) and not terminal is treated as
+// content-bearing. Future Responses event types fall through as structured by
+// default, which is safer than missing an allow-list entry and incorrectly
+// triggering the fast-path expansion below.
 const isStructuredResponsesEvent = (event: { type: string }): boolean =>
   event.type !== 'response.queued'
   && event.type !== 'response.created'
   && event.type !== 'response.in_progress'
-  && event.type !== 'ping'
   && !isResponsesTerminalEvent(event as ResponsesStreamEvent);
 
 // Some Responses upstreams emit the event type only via the SSE `event:`
@@ -72,9 +69,15 @@ export const parseResponsesStream = (
       return;
     }
 
-    const event = projectSseJsonEvent(frame.data, frame.frame.event);
-    if (event.type === 'ping') continue;
+    // A keep-alive `ping` is neither a delta event nor a state-machine event,
+    // so the Responses event union admits no such member. Drop it off the raw
+    // body, before the body is projected into a typed event, so the union
+    // never has to name it; an upstream carries the name either in the JSON
+    // body or only in the SSE `event:` header.
+    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L459
+    if (((frame.data as { type?: string }).type ?? frame.frame.event) === 'ping') continue;
 
+    const event = projectSseJsonEvent(frame.data, frame.frame.event);
     const structured = isStructuredResponsesEvent(event);
     const terminal = isResponsesTerminalEvent(event);
 

--- a/packages/provider-copilot/src/interceptors/responses/item-id-membrane.ts
+++ b/packages/provider-copilot/src/interceptors/responses/item-id-membrane.ts
@@ -224,7 +224,7 @@ const normalizeStreamEvent = (event: ResponsesStreamEvent, state: StreamItemStat
     return { ...event, response: normalizeResponseOutput(event.response, state) };
   }
 
-  if (event.type === 'error' || event.type === 'ping') return event;
+  if (event.type === 'error') return event;
   const carrier = event as ResponsesStreamEvent & { item_id?: unknown; output_index?: unknown };
   const requiresItemId = ITEM_ID_EVENT_TYPES.has(event.type);
   const permitsMissingItemId = NO_ITEM_ID_EVENT_TYPES.has(event.type);

--- a/packages/translate/__tests__/responses-via-messages/events_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/events_test.ts
@@ -917,3 +917,31 @@ test('Messages fallback block changes the Responses serving model without becomi
   assertEquals(completed?.response.model, 'claude-opus-4-8');
   assertEquals(completed?.response.output, []);
 });
+
+test('an upstream ping is consumed without emitting a Responses event or advancing the sequence', () => {
+  const state = createMessagesToResponsesStreamState('resp_test', 'claude-test');
+
+  const before = translateMessagesEventToResponsesEvents(
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    } as MessagesStreamEvent,
+    state,
+  );
+  const lastBefore = before.at(-1)?.sequence_number;
+  if (typeof lastBefore !== 'number') throw new Error('expected the preceding event to carry a sequence_number');
+
+  assertEquals(translateMessagesEventToResponsesEvents({ type: 'ping' } as MessagesStreamEvent, state), []);
+
+  const after = translateMessagesEventToResponsesEvents(
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'hi' },
+    } as MessagesStreamEvent,
+    state,
+  );
+
+  assertEquals(after[0]?.sequence_number, lastBefore + 1);
+});

--- a/packages/translate/src/messages-via-responses/events.ts
+++ b/packages/translate/src/messages-via-responses/events.ts
@@ -503,8 +503,6 @@ const translateReadyResponsesEvent = (event: ResponsesStreamEvent, state: Respon
     return handleFailed((event as Extract<ResponsesStreamEvent, { type: 'response.failed' }>).response, state);
   case 'error':
     return handleError(event as Extract<ResponsesStreamEvent, { type: 'error' }>, state);
-  case 'ping':
-    return [{ type: 'ping' }];
   default:
     return [];
   }

--- a/packages/translate/src/responses-via-messages/events.ts
+++ b/packages/translate/src/responses-via-messages/events.ts
@@ -403,8 +403,18 @@ export const translateMessagesEventToResponsesEvents = (event: MessagesStreamEve
 
     return responses.terminal(state, response);
   }
+  // Anthropic's `ping` is a transport keep-alive with no Responses counterpart:
+  // every spec event is either a delta event or a state-machine event, and a
+  // `ping` is neither.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L459
+  // The rule belongs with the producer rather than at a gateway transport
+  // boundary, so that it holds for every consumer of this translation and not
+  // only for the transports the gateway happens to serve; the native path
+  // likewise drops an upstream `ping` inside `parseResponsesStream`. Consuming
+  // the event without emitting one also keeps the sequence numbering
+  // contiguous, which a boundary filter could not do.
   case 'ping':
-    return responses.seq(state, [{ type: 'ping' }]);
+    return [];
   case 'error':
     return responses.seq(state, [
       {


### PR DESCRIPTION
The Messages-to-Responses translator synthesized a Responses `{ type: 'ping' }` event whenever the upstream Anthropic stream sent a `ping` keep-alive. That type is not a member of the OpenResponses streaming-event union: the spec admits two kinds of streaming event, delta events and state-machine events, and a keep-alive is neither. So any Messages-backed turn in which the upstream pinged produced a frame that no conformant client can place, reaching SSE and WebSocket clients alike.

The `ping` is now consumed and nothing is emitted.

## Why the translator, not a transport boundary

The rule belongs with the producer, so it holds for every consumer of this translation rather than only for the transports the gateway happens to serve. Consuming the event without emitting one also keeps `sequence_number` contiguous — a filter placed at a boundary would drop an already-numbered frame and leave a hole. And the sibling `chat-completions-via-messages` and `gemini-via-messages` translations already behave this way, so this removes an inconsistency rather than adding a special case.

## The union member and its readers

With no producer left, the `{ type: 'ping' }` member of `ResponsesStreamEvent` goes too, and with it three readers that could only ever have matched it:

- `isStructuredResponsesEvent`'s `!== 'ping'` test in `parseResponsesStream`'s fast-path deny-list.
- `provider-copilot`'s item-id membrane branch. It was already unreachable: every provider that streams Responses parses through `parseResponsesStream`, which drops `ping` before any interceptor sees the stream.
- `messages-via-responses`'s ping-to-ping case.

The parse-side drop now runs on the raw frame, before the body is projected into the typed union: `(frame.data.type ?? frame.frame.event) === 'ping'`. Both sources are needed — upstreams send `event: ping` with an empty JSON body, so the type name lives in the SSE header rather than in the payload.

## Caveat

This code path is latent. Copilot's Messages upstream emitted no `ping` during any live run, so the branch's guard test — an upstream ping is consumed without emitting an event and without advancing the sequence — is the only real coverage.

## Test Plan

- [x] `pnpm run typecheck` — clean across all 20 projects.
- [x] `pnpm run lint` — clean across the workspace.
- [x] `pnpm run test` — 422 files, 4906 tests passed, 0 failed, matching the pre-change baseline exactly, which is the evidence that behavior is unchanged.
