### PR TITLE
fix(responses): send the spec's status key on WebSocket error frames

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -299,7 +299,7 @@ test('Responses WebSocket rejects the next turn after its API key is rotated', a
 
       assertEquals(await received, [{
         type: 'error',
-        status_code: 401,
+        status: 401,
         error: {
           type: 'authentication_error',
           code: 'invalid_api_key',
@@ -358,9 +358,9 @@ test('Responses WebSocket reports a failed turn when an output item cannot be pe
         }));
 
         const messages = await received;
-        const error = messages.find(message => message.type === 'error') as { status_code?: unknown; error?: { message?: unknown } } | undefined;
+        const error = messages.find(message => message.type === 'error') as { status?: unknown; error?: { message?: unknown } } | undefined;
         assertExists(error);
-        assertEquals(error.status_code, 500);
+        assertEquals(error.status, 500);
         assertEquals(error.error?.message, 'simulated item persistence failure');
         assert(!messages.some(message => message.type === 'response.output_item.done'));
         assert(!messages.some(message => message.type === 'response.completed'));
@@ -488,7 +488,7 @@ test('Responses WebSocket returns OpenAI-style error envelopes for unsupported c
     assertEquals(await received, [{
       type: 'error',
       event_id: 'evt_bad',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -509,7 +509,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     const [invalidJsonMessage] = await invalidJson;
     assertExists(invalidJsonMessage);
     assertEquals(invalidJsonMessage.type, 'error');
-    assertEquals(invalidJsonMessage.status_code, 400);
+    assertEquals(invalidJsonMessage.status, 400);
     assertEquals((invalidJsonMessage.error as { type?: unknown; code?: unknown }).type, 'invalid_request_error');
     assertEquals((invalidJsonMessage.error as { type?: unknown; code?: unknown }).code, 'invalid_request_error');
     assertStringIncludes((invalidJsonMessage.error as { message: string }).message, 'valid JSON');
@@ -520,7 +520,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     assertEquals(await invalidShape, [{
       type: 'error',
       event_id: 'evt_shape',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -534,7 +534,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     assertEquals(await invalidResponse, [{
       type: 'error',
       event_id: 'evt_response',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -552,7 +552,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
     assertEquals(await invalidItem, [{
       type: 'error',
       event_id: 'evt_item',
-      status_code: 400,
+      status: 400,
       error: {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
@@ -563,7 +563,7 @@ test('Responses WebSocket returns invalid_request_error for malformed client mes
   });
 });
 
-test('Responses WebSocket forwards HTTP failures with status_code, error.code, and event_id', async () => {
+test('Responses WebSocket forwards HTTP failures with status, error.code, and event_id', async () => {
   const { apiKey } = await setupAppTest();
   await withMockedFetch(
     async request => {
@@ -591,7 +591,7 @@ test('Responses WebSocket forwards HTTP failures with status_code, error.code, a
       assertEquals(await received, [{
         type: 'error',
         event_id: 'evt_missing',
-        status_code: 404,
+        status: 404,
         error: {
           type: 'invalid_request_error',
           code: 'invalid_request_error',
@@ -631,7 +631,7 @@ test('Responses WebSocket dump responseBytes counts an error envelope sent downs
           },
         }));
 
-        assertEquals((await received)[0]?.status_code, 404);
+        assertEquals((await received)[0]?.status, 404);
         await vi.waitFor(() => assertEquals(dumps.stored.length, 1));
         const expectedBytes = recorded.messages.reduce(
           (total, message) => total + new TextEncoder().encode(message).byteLength,
@@ -746,7 +746,7 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
       assertEquals(await missingDone, [{
         type: 'error',
         event_id: 'evt_cross_session',
-        status_code: 400,
+        status: 400,
         error: {
           message: `Previous response with id '${firstResponseId}' not found.`,
           type: 'invalid_request_error',
@@ -1025,7 +1025,7 @@ test('Responses WebSocket session-level store: second message resolves prior ite
       assertEquals(await missingDone, [{
         type: 'error',
         event_id: 'evt_b',
-        status_code: 400,
+        status: 400,
         error: {
           message: "Previous response with id 'resp_session_1' not found.",
           type: 'invalid_request_error',
@@ -1142,7 +1142,7 @@ test('Responses WebSocket outer catch records a failed perf sample attributed to
         const [errorMessage] = await received;
         assertExists(errorMessage);
         assertEquals(errorMessage.type, 'error');
-        assertEquals(errorMessage.status_code, 500);
+        assertEquals(errorMessage.status, 500);
         assertEquals(errorMessage.event_id, 'evt_throw');
       }),
     );

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -163,8 +163,8 @@ const createResponsesWebSocketEvents = (c: AuthedContext): ResponsesWebSocketHan
           }
         })
         // WS-specific top-level: Hono's onError never runs for callbacks fired off
-        // an open socket, so we serialize the error inline as a close-frame-shaped
-        // JSON envelope. (HTTP entries let onError handle the same case.)
+        // an open socket, so we serialize the error inline as the spec's
+        // WebSocket error envelope. (HTTP entries let onError handle the same case.)
         .catch(error => {
           if (!closed) sendError(socket, 500, serverErrorEnvelope(error));
         });
@@ -240,7 +240,7 @@ const handleClientMessage = async (
     } catch (error) {
       if (signal.aborted || isClosed()) return;
       // The HTTP entry renders this verbatim envelope as a 400; WS surfaces the
-      // same body wrapped in our standard close-frame error shape so clients
+      // same body nested under the spec's WebSocket error envelope so clients
       // can still compare error.message byte-for-byte against upstream.
       if (error instanceof PreviousResponseNotFoundError) {
         sendError(socket, 400, {
@@ -513,7 +513,7 @@ const responseDoneSummary = (event: ResponsesStreamEvent) => {
   return usage === undefined ? { id } : { id, usage };
 };
 
-const normalizeErrorBody = (body: unknown, statusCode: number): Record<string, unknown> => {
+const normalizeErrorBody = (body: unknown, status: number): Record<string, unknown> => {
   const source = body && typeof body === 'object' && 'error' in body && typeof (body as { error?: unknown }).error === 'object'
     ? (body as { error: Record<string, unknown> }).error
     : body && typeof body === 'object'
@@ -521,10 +521,10 @@ const normalizeErrorBody = (body: unknown, statusCode: number): Record<string, u
       : {};
   const type = typeof source.type === 'string'
     ? source.type
-    : statusCode >= 500 ? 'server_error' : 'invalid_request_error';
+    : status >= 500 ? 'server_error' : 'invalid_request_error';
   const message = typeof source.message === 'string'
     ? source.message
-    : `Responses request failed with status ${statusCode}.`;
+    : `Responses request failed with status ${status}.`;
   return {
     ...source,
     type,
@@ -533,14 +533,20 @@ const normalizeErrorBody = (body: unknown, statusCode: number): Record<string, u
   };
 };
 
+// "WebSocket failures MUST be sent as a JSON `error` envelope with a `status`
+// code and an `error.code`."
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L166
+// The `WebSocketErrorEvent` schema requires `type`, `status`, and `error` and
+// leaves the top level open, so `sendJson` may add `event_id` beside them.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/schema/components/schemas/WebSocketErrorEvent.json#L47
 const sendError = (
   socket: ResponsesWebSocketSocket,
-  statusCode: number,
+  status: number,
   error: Record<string, unknown>,
   eventId?: string,
   dump?: DumpAccumulator | null,
 ): void => {
-  sendJson(socket, { type: 'error', status_code: statusCode, error }, eventId, dump);
+  sendJson(socket, { type: 'error', status, error }, eventId, dump);
 };
 
 const sendJson = (


### PR DESCRIPTION
The Responses WebSocket transport serialized its JSON error envelope as `{ type: 'error', status_code, error }`. The OpenResponses `WebSocketErrorEvent` schema requires `type`, `status`, and `error`, so the frame failed schema validation on the envelope key name alone — and a failed frame validation fails the whole turn.

The practical consequence is narrower than it sounds, and worth stating precisely: the nested `error` object was already correct (`type`, `code`, `message`, `param`), so a client reading `error.code` always got the right value. What was wrong was the HTTP-style status key beside it. `status_code` was Floway-private, justified nowhere, and had no other producer anywhere in the workspace.

## Spec

> WebSocket failures MUST be sent as a JSON `error` envelope with a `status` code and an `error.code`.

`2026-04-24.mdx:166`:
https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L166

The `WebSocketErrorEvent` schema is the machine-readable form of the same requirement — `"required": ["type", "status", "error"]`:
https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/schema/components/schemas/WebSocketErrorEvent.json#L47

Both URLs sit on `sendError` in the code.

## What changed

- `sendError` in `packages/gateway/src/data-plane/chat/responses/websocket.ts` emits `status` instead of `status_code`.
- `sendError`'s parameter, and the matching parameter of the sibling `normalizeErrorBody`, are named `status`, so the one HTTP status expression at the call site no longer travels under two names into a single call.
- Two doc comments called the frame "close-frame-shaped". It is not a close frame — it is the spec's error envelope, sent over an open socket — so they now name it as such.

The schema does not close the top level to `additionalProperties`, and `sendJson` splices `event_id` into the very object `sendError` builds, so a conformant frame carries more than the three required keys by design.

Clients reading `error.code` need no adaptation; a client reading the numeric status off the envelope must read `status`.

## Not in scope

The `code` values this file emits elsewhere conflate OpenAI's *type* vocabulary with its *code* vocabulary — `invalid_request_error` is a type, and `code` should carry something like `invalid_event`. Correcting that touches several call sites and is a separate change; folding it in here would make this rename harder to review.

## Test Plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes — 422 files, 4905 tests, 0 failed
- [x] `packages/gateway` suite green (178 files, 2118 tests), including all 17 tests in `data-plane/chat/responses/websocket_test.ts`, which assert `status` on every error envelope they observe
