### PR TITLE
fix(responses): make the terminal event the last WebSocket frame of a turn

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -51,13 +51,16 @@ const waitForMicrotasks = async (): Promise<void> => {
   for (let i = 0; i < 10; i++) await Promise.resolve();
 };
 
-const responseDoneId = (messages: readonly Record<string, unknown>[]): string => {
-  const done = messages.find(message => message.type === 'response.done') as { response?: { id?: unknown } } | undefined;
-  assertExists(done);
-  const response = done.response;
+const isTerminalResponseEvent = (message: Record<string, unknown>): boolean =>
+  message.type === 'response.completed' || message.type === 'response.failed' || message.type === 'response.incomplete';
+
+const terminalResponseId = (messages: readonly Record<string, unknown>[]): string => {
+  const terminal = messages.find(isTerminalResponseEvent) as { response?: { id?: unknown } } | undefined;
+  assertExists(terminal);
+  const response = terminal.response;
   assertExists(response);
   const id = response.id;
-  if (typeof id !== 'string') throw new Error(`expected response.done id to be a string, got ${typeof id}`);
+  if (typeof id !== 'string') throw new Error(`expected the terminal response id to be a string, got ${typeof id}`);
   return id;
 };
 
@@ -131,7 +134,7 @@ const completeResponsesTurn = async (
   client: TestWorkerWebSocket,
   eventId: string,
 ): Promise<void> => {
-  const received = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+  const received = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
   client.send(JSON.stringify({
     type: 'response.create',
     event_id: eventId,
@@ -144,7 +147,7 @@ const completeResponsesTurn = async (
   await waitForMicrotasks();
 };
 
-test('Responses WebSocket forwards stream events, echoes event_id, and sends response.done', async () => {
+test('Responses WebSocket forwards stream events, echoes event_id, and ends the turn on the terminal event', async () => {
   const { apiKey } = await setupAppTest();
   await withMockedFetch(
     async request => {
@@ -171,7 +174,7 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
     },
     async () => await withWorkerWebSocketRuntime(async () => {
       const client = await connectResponsesWebSocket(apiKey.key);
-      const received = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      const received = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
 
       client.send(JSON.stringify({
         type: 'response.create',
@@ -184,19 +187,13 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
 
       const messages = await received;
       assert(messages.every(message => message.event_id === 'evt_1'));
-      const completed = messages.find(message => message.type === 'response.completed') as { response?: { id?: unknown } } | undefined;
+      const completed = messages.at(-1) as { type?: unknown; response?: { id?: unknown } } | undefined;
       assertExists(completed);
-      const responseId = (completed.response as { id?: unknown } | undefined)?.id;
+      const responseId = completed.response?.id;
       assertEquals(typeof responseId, 'string');
       assert(responseId !== 'resp_ws', 'expected the source boundary to replace the upstream response id');
-      assertEquals(messages.at(-1), {
-        type: 'response.done',
-        event_id: 'evt_1',
-        response: {
-          id: responseId,
-          usage: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
-        },
-      });
+      assertEquals(completed.type, 'response.completed');
+      assertEquals((completed.response as { usage?: unknown }).usage, { input_tokens: 3, output_tokens: 5, total_tokens: 8 });
     }),
   );
 });
@@ -363,8 +360,7 @@ test('Responses WebSocket reports a failed turn when an output item cannot be pe
         assertEquals(error.status, 500);
         assertEquals(error.error?.message, 'simulated item persistence failure');
         assert(!messages.some(message => message.type === 'response.output_item.done'));
-        assert(!messages.some(message => message.type === 'response.completed'));
-        assert(!messages.some(message => message.type === 'response.done'));
+        assert(!messages.some(isTerminalResponseEvent));
       }),
     );
   } finally {
@@ -444,7 +440,7 @@ test('Responses WebSocket keepalive during an in-flight request does not drop th
           }
 
           assert(hasMessageType(messages, 'ping'), 'expected a ping while the upstream response stream is idle');
-          const completed = waitForMessages(client, received => received.some(message => message.type === 'response.done'));
+          const completed = waitForMessages(client, received => received.some(isTerminalResponseEvent));
 
           const response = {
             id: 'resp_ws_keepalive',
@@ -465,8 +461,7 @@ test('Responses WebSocket keepalive during an in-flight request does not drop th
 
           const types = messages.map(message => message.type);
           assert(types.indexOf('ping') < types.indexOf('response.created'), 'expected the delayed upstream frame after the ping');
-          assert(types.includes('response.completed'), 'expected the terminal upstream frame after the ping');
-          assertEquals(types.at(-1), 'response.done');
+          assertEquals(types.at(-1), 'response.completed');
         } finally {
           client.removeEventListener('message', onMessage);
         }
@@ -682,7 +677,7 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
     },
     async () => await withWorkerWebSocketRuntime(async () => {
       const client = await connectResponsesWebSocket(apiKey.key);
-      const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      const firstTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
       client.send(JSON.stringify({
         type: 'response.create',
         response: {
@@ -691,8 +686,8 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
           store: false,
         },
       }));
-      const firstMessages = await firstDone;
-      const firstResponseId = responseDoneId(firstMessages);
+      const firstMessages = await firstTerminal;
+      const firstResponseId = terminalResponseId(firstMessages);
 
       assert(firstResponseId !== 'resp_ws_store_false_1', 'expected the source boundary to replace the upstream response id');
       assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, firstResponseId, 0), null);
@@ -707,7 +702,7 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
         [],
       );
 
-      const followupDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      const followupTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
       client.send(JSON.stringify({
         type: 'response.create',
         event_id: 'evt_followup',
@@ -718,8 +713,8 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
           store: false,
         },
       }));
-      const secondMessages = await followupDone;
-      const secondResponseId = responseDoneId(secondMessages);
+      const secondMessages = await followupTerminal;
+      const secondResponseId = terminalResponseId(secondMessages);
       assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, secondResponseId, 0), null);
 
       const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
@@ -731,7 +726,7 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
       ]);
 
       const sessionB = await connectResponsesWebSocket(apiKey.key);
-      const missingDone = waitForMessages(sessionB, messages => messages.length === 1);
+      const missingError = waitForMessages(sessionB, messages => messages.length === 1);
       sessionB.send(JSON.stringify({
         type: 'response.create',
         event_id: 'evt_cross_session',
@@ -743,7 +738,7 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
         },
       }));
 
-      assertEquals(await missingDone, [{
+      assertEquals(await missingError, [{
         type: 'error',
         event_id: 'evt_cross_session',
         status: 400,
@@ -795,16 +790,16 @@ test('Responses WebSocket store:true durable snapshots can chain through local s
     },
     async () => await withWorkerWebSocketRuntime(async () => {
       const client = await connectResponsesWebSocket(apiKey.key);
-      const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      const firstTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
       client.send(JSON.stringify({ type: 'response.create', response: { model: 'gpt-direct-responses', input: 'first' } }));
-      const firstMessages = await firstDone;
+      const firstMessages = await firstTerminal;
       const firstCompleted = firstMessages.find(message => message.type === 'response.completed') as { response?: { id?: string } } | undefined;
       firstResponseId = firstCompleted?.response?.id;
       assertExists(firstResponseId);
 
-      const secondDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      const secondTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
       client.send(JSON.stringify({ type: 'response.create', response: { model: 'gpt-direct-responses', previous_response_id: firstResponseId, input: 'second' } }));
-      const secondMessages = await secondDone;
+      const secondMessages = await secondTerminal;
       const secondCompleted = secondMessages.find(message => message.type === 'response.completed') as { response?: { id?: string } } | undefined;
       secondResponseId = secondCompleted?.response?.id;
       assertExists(secondResponseId);
@@ -885,13 +880,13 @@ test('Responses WebSocket makes a done reasoning item reusable from a fresh conn
     async () => await withWorkerWebSocketRuntime(async () => {
       try {
         firstClient = await connectResponsesWebSocket(apiKey.key);
-        const firstDone = waitForMessages(firstClient, messages =>
+        const firstTerminal = waitForMessages(firstClient, messages =>
           messages.some(message => message.type === 'response.output_item.done'));
         firstClient.send(JSON.stringify({
           type: 'response.create',
           response: { model: 'gpt-direct-responses', store: true, input: 'first' },
         }));
-        const messages = await firstDone;
+        const messages = await firstTerminal;
         const done = messages.find(message => message.type === 'response.output_item.done') as { item?: typeof originalReasoning } | undefined;
         assertExists(done?.item);
         assert(done.item.id !== originalReasoning.id, 'expected Copilot to replace the carried reasoning id');
@@ -962,12 +957,12 @@ test('Responses WebSocket session-level store: second message resolves prior ite
     },
     async () => await withWorkerWebSocketRuntime(async () => {
       const sessionA = await connectResponsesWebSocket(apiKey.key);
-      const firstDone = waitForMessages(sessionA, messages => messages.some(message => message.type === 'response.done'));
+      const firstTerminal = waitForMessages(sessionA, messages => messages.some(isTerminalResponseEvent));
       sessionA.send(JSON.stringify({
         type: 'response.create',
         response: { model: 'gpt-direct-responses', input: 'turn one input' },
       }));
-      const firstMessages = await firstDone;
+      const firstMessages = await firstTerminal;
       const firstCompleted = firstMessages.find(message => message.type === 'response.completed') as { response?: { id?: string } } | undefined;
       const firstResponseId = firstCompleted?.response?.id;
       assertExists(firstResponseId);
@@ -980,7 +975,7 @@ test('Responses WebSocket session-level store: second message resolves prior ite
       await repo.responsesItems.deleteAll();
       assertEquals(await repo.responsesSnapshots.lookup(apiKey.id, firstResponseId, 0), null);
 
-      const secondDone = waitForMessages(sessionA, messages => messages.some(message => message.type === 'response.done'));
+      const secondTerminal = waitForMessages(sessionA, messages => messages.some(isTerminalResponseEvent));
       sessionA.send(JSON.stringify({
         type: 'response.create',
         response: {
@@ -989,7 +984,7 @@ test('Responses WebSocket session-level store: second message resolves prior ite
           input: 'turn two input',
         },
       }));
-      await secondDone;
+      await secondTerminal;
 
       const secondBody = upstreamBodies[1] as { previous_response_id?: unknown; input: Array<{ type: string; role?: string; content?: unknown }> };
       assertEquals(secondBody.previous_response_id, undefined);
@@ -1011,7 +1006,7 @@ test('Responses WebSocket session-level store: second message resolves prior ite
       // A fresh WS session for the same api key has its own empty cache; with
       // the repo wiped, the snapshot is unreachable.
       const sessionB = await connectResponsesWebSocket(apiKey.key);
-      const missingDone = waitForMessages(sessionB, messages => messages.length === 1);
+      const missingError = waitForMessages(sessionB, messages => messages.length === 1);
       sessionB.send(JSON.stringify({
         type: 'response.create',
         event_id: 'evt_b',
@@ -1022,7 +1017,7 @@ test('Responses WebSocket session-level store: second message resolves prior ite
         },
       }));
 
-      assertEquals(await missingDone, [{
+      assertEquals(await missingError, [{
         type: 'error',
         event_id: 'evt_b',
         status: 400,

--- a/packages/gateway/__tests__/data-plane/codex/routes_websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/codex/routes_websocket_test.ts
@@ -60,10 +60,13 @@ const connectCodexResponsesWebSocket = async (
   return pair!.client;
 };
 
-const responseDoneId = (messages: readonly Record<string, unknown>[]): string => {
-  const done = messages.find(message => message.type === 'response.done') as { response?: { id?: unknown } } | undefined;
-  expect(done?.response?.id).toEqual(expect.any(String));
-  return done!.response!.id as string;
+const isTerminalResponseEvent = (message: Record<string, unknown>): boolean =>
+  message.type === 'response.completed' || message.type === 'response.failed' || message.type === 'response.incomplete';
+
+const terminalResponseId = (messages: readonly Record<string, unknown>[]): string => {
+  const terminal = messages.find(isTerminalResponseEvent) as { response?: { id?: unknown } } | undefined;
+  expect(terminal?.response?.id).toEqual(expect.any(String));
+  return terminal!.response!.id as string;
 };
 
 it('chains previous_response_id on the Codex Responses WebSocket', async () => {
@@ -103,15 +106,15 @@ it('chains previous_response_id on the Codex Responses WebSocket', async () => {
     },
     async () => await withWorkerWebSocketRuntime(async runtime => {
       const client = await connectCodexResponsesWebSocket(runtime, apiKey.key);
-      const firstDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      const firstTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
       client.send(JSON.stringify({
         type: 'response.create',
         response: { model: 'gpt-direct-responses', input: 'codex first', store: false },
       }));
-      const firstResponseId = responseDoneId(await firstDone);
+      const firstResponseId = terminalResponseId(await firstTerminal);
       expect(firstResponseId).not.toBe('resp_codex_ws_1');
 
-      const secondDone = waitForMessages(client, messages => messages.some(message => message.type === 'response.done'));
+      const secondTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
       client.send(JSON.stringify({
         type: 'response.create',
         response: {
@@ -121,7 +124,7 @@ it('chains previous_response_id on the Codex Responses WebSocket', async () => {
           store: false,
         },
       }));
-      const secondResponseId = responseDoneId(await secondDone);
+      const secondResponseId = terminalResponseId(await secondTerminal);
       expect(secondResponseId).not.toBe('resp_codex_ws_2');
       expect(secondResponseId).not.toBe(firstResponseId);
     }),

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -388,17 +388,23 @@ const respondResponsesWebSocket = async (input: {
         const event = frame.event;
 
         // The wrapped terminal event arrives only after its item and snapshot
-        // writes have committed. Flush it immediately, then drain the remainder
-        // of the generator before emitting the WS-only `response.done` envelope,
-        // so `response.done` remains the stable signal that a follow-up message
-        // can reference the stored response.
+        // writes have committed, but the generator still has work to drain
+        // behind it. Buffer it here and flush it once the loop has run to
+        // completion, so the terminal event is the last frame of the turn and
+        // is itself the signal that a follow-up turn may reference this
+        // response. WebSocket carries the same streaming event objects as
+        // streaming HTTP, and the specification defines no frame after the
+        // terminal event:
+        // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L117
+        // Live captures agree. Azure Foundry Responses-over-WebSocket, and the
+        // ChatGPT backend the Codex CLI talks to, both end a turn on
+        // `response.completed` and send nothing further while the socket stays
+        // open and idle. Codex's own reader breaks its loop on that event
+        // rather than waiting for any trailing envelope:
+        // https://github.com/openai/codex/blob/acd540f1581bf30f963fccbcce43ac494102242c/codex-rs/codex-api/src/endpoint/responses_websocket.rs#L792-L799
         if (terminalEvent !== undefined) continue;
 
         if (isResponsesTerminalEvent(event)) {
-          if (!sendJson(socket, event, eventId, ctx.dump)) {
-            completion = 'cancel';
-            continue;
-          }
           terminalEvent = event;
           continue;
         }
@@ -419,12 +425,11 @@ const respondResponsesWebSocket = async (input: {
     if (terminalEvent === undefined) {
       throw new Error(RESPONSES_MISSING_TERMINAL_MESSAGE);
     }
-    const done = responseDoneSummary(terminalEvent);
-    if (done !== null && !sendJson(socket, { type: 'response.done', response: done }, eventId, ctx.dump)) {
+    if (!sendJson(socket, terminalEvent, eventId, ctx.dump)) {
       completion = 'cancel';
       return;
     }
-    if (completion !== 'cancel') completion = 'eof';
+    completion = 'eof';
   } catch (error) {
     if (signal.aborted || isClosed()) {
       completion = 'cancel';
@@ -506,12 +511,6 @@ const serverErrorEnvelope = (error: unknown): Record<string, unknown> => ({
   ...toInternalDebugError(error),
   code: 'internal_error',
 });
-
-const responseDoneSummary = (event: ResponsesStreamEvent) => {
-  if (event.type !== 'response.completed' && event.type !== 'response.failed' && event.type !== 'response.incomplete') return null;
-  const { id, usage } = event.response;
-  return usage === undefined ? { id } : { id, usage };
-};
 
 const normalizeErrorBody = (body: unknown, status: number): Record<string, unknown> => {
   const source = body && typeof body === 'object' && 'error' in body && typeof (body as { error?: unknown }).error === 'object'


### PR DESCRIPTION
Part of the OpenResponses `2026-04-24` WebSocket conformance work. Targets `main` and stands alone.

## Defect

The WebSocket transport flushed the terminal response event (`response.completed` / `response.failed` / `response.incomplete`) the moment it arrived, drained the rest of the generator, and then appended a Floway-private `{ "type": "response.done", "response": { id, usage } }` envelope.

Two things are wrong with that. `response.done` is not a member of the spec's streaming-event union, so every turn ended on a frame no compliant client can validate. Worse, because it was sent **after** the terminal event, any client that reads frames in order and treats the terminal event as the turn boundary attributed the trailing frame to the **next** turn. That failed every multi-turn WebSocket conformance test, including ones whose own assertions were satisfied.

## Spec

- `2026-04-24.mdx:84` — the `[DONE]` sentinel is SSE-only and has no WebSocket counterpart.
- `2026-04-24.mdx:117` — WebSocket carries the same streaming event objects as streaming HTTP. `response.done` is not one of them, and the spec defines no frame after the terminal event.

https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L117

## No measured upstream sends the frame

If a real upstream emitted `response.done`, removing it would mean picking one protocol over another rather than deleting an invention. Two first-hand captures settle it, and they agree.

**Azure Foundry**, Responses over WebSocket, two turns on one socket, reading 8 s past the terminal each time. The sequence ends `response.output_item.done` → `response.completed`, and nothing follows — no `response.done`, no `[DONE]`. The terminal frame's top level is exactly `{response, sequence_number, type}`.

**The ChatGPT backend the Codex CLI talks to** (`chatgpt.com/backend-api/codex`, reached the way Codex reaches it — `wss://…/responses`, `originator: codex_cli_rs`, permessage-deflate, no `OpenAI-Beta` header). One full turn captured frame by frame, then 15 s of waiting past the terminal:

```
[   5.578s] <<< {"type":"response.output_item.done", ... ,"sequence_number":8}
[   5.578s] <<< {"type":"responsesapi.websocket_timing","timing_metrics":{...}}
[   5.578s] <<< {"type":"response.completed","response":{...},"sequence_number":9}
[  20.581s] *** 15s past terminal, nothing further. state=<State.OPEN: 1>
```

The socket stays open and idle. That matches `openai/codex`'s own client, which breaks its read loop on `ResponseEvent::Completed` and never looks for `response.done`:

https://github.com/openai/codex/blob/acd540f1581bf30f963fccbcce43ac494102242c/codex-rs/codex-api/src/endpoint/responses_websocket.rs#L792-L799

Scope of the claim: the second capture is the ChatGPT/Codex backend, not `api.openai.com`, which could not be reached from the capturing network at all. So: **no upstream that could be measured emits `response.done`.** The frame appears only in OpenAI's own mock server (`scripts/mock_responses_websocket_server.py`) and in an openai-python example comment calling it "the final event" — a mock and a comment, against two live captures.

## What changed

- The terminal event is buffered rather than sent inline, and flushed once the loop has run to completion — so it is the last frame of the turn.
- `response.done` and its `responseDoneSummary` helper are deleted.
- `completion` bookkeeping simplifies accordingly: the terminal flush is the single place that can downgrade a turn to `cancel`.
- Tests in `websocket_test.ts` and `codex/routes_websocket_test.ts` assert the terminal event as the final frame instead of `response.done`.
- The terminal flush goes through `sendResponsesEvent`, the narrowed entry `main` introduced for a turn's own frames. Its comment previously listed the `response.done` summary among the frames that keep the untyped `sendJson`; with that frame deleted the untyped path carries only the `error` envelope and the `ping` keep-alive, and the comment now says so.
- Clients that waited for `response.done` before sending the next `response.create` must wait for the terminal event; its `response.id` is the id to continue from.

## Why the guarantee survives

`response.done`'s code comment advertised a real property: it was the stable signal that the turn's item and snapshot writes had committed, so a follow-up message could reference the stored response. That property is not lost. The buffered terminal event is emitted only after the wrapped writes have committed **and** the generator is exhausted, so its arrival carries exactly the same guarantee. And a client cannot race it: the `onMessage` queue chain serialises turns on the socket, so a follow-up `response.create` cannot be processed before the previous turn's writes settle regardless of what the client does with the frame.

## Test Plan

Workspace-wide, at `e439fb432014115966116487256f225f3745eff2` (`main` merged in):

- [x] `pnpm run typecheck` — clean across all packages
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 422 test files passed (422), 4921 tests passed (4921)
- [ ] OpenResponses conformance runner — not runnable on this branch alone or in CI: it needs the full WebSocket fix set plus live upstream accounts for the three Responses paths

On an integration branch carrying the full OpenResponses fix set, the runner reached 17/17 on all three Responses paths (`gpt-5-mini` native, `gpt-4.1` via Chat Completions, `claude-haiku-4-5` via Messages), twice, against a baseline of 1/17 per path. Attributable to this change specifically: the six WebSocket tests went 0/6 → 1/6 per path, and `response.done` frame-validation failures reached zero.

