### PR TITLE
fix(responses): evict a failed continuation's previous_response_id from connection-local state

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -9,7 +9,7 @@ import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS } from '../../../../src/data-plane/sh
 import { initDumpBroker, initDumpStore } from '../../../../src/dump/registry.ts';
 import { installDumpStubs } from '../../../dump/test-fixtures.ts';
 import { FakeTime } from '../../../test-time.ts';
-import { copilotModels, flushAsyncWork, setupAppTest, sseResponsesResponse } from '../../../test-utils/app.ts';
+import { copilotModels, flushAsyncWork, setupAppTest, sseResponse, sseResponsesResponse } from '../../../test-utils/app.ts';
 import { installWorkerWebSocketRuntime, type TestWorkerWebSocket } from '../../../test-utils/worker-websocket.ts';
 import { assert, assertEquals, assertExists, assertStringIncludes, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
@@ -874,6 +874,111 @@ test('Responses WebSocket evicts a failed continuation target so the next attemp
           code: 'bad_request',
         },
       }]);
+
+      const evicted = waitForMessages(client, messages => messages.some(message => message.type === 'error'));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_evicted',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'retry from the same id',
+          store: false,
+        },
+      }));
+
+      assertEquals(await evicted, [{
+        type: 'error',
+        event_id: 'evt_evicted',
+        status: 400,
+        error: {
+          message: `Previous response with id '${firstResponseId}' not found.`,
+          type: 'invalid_request_error',
+          param: 'previous_response_id',
+          code: 'previous_response_not_found',
+        },
+      }]);
+      assertEquals(responseCalls, 2);
+    }),
+  );
+});
+
+// A turn that fails by streaming a `response.failed` terminal answers the
+// client with an event instead of an error envelope, so it leaves the handler
+// through a different exit than the rejected turn above — and the spec's
+// eviction rule applies to it just the same.
+test('Responses WebSocket evicts a continuation that failed through a streamed terminal event', async () => {
+  const { apiKey } = await setupAppTest();
+  let responseCalls = 0;
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        responseCalls += 1;
+        if (responseCalls === 2) {
+          const failing = {
+            id: 'resp_ws_evict_streamed_2',
+            object: 'response',
+            model: 'gpt-direct-responses',
+            status: 'failed',
+            output: [],
+            output_text: '',
+            error: { code: 'server_error', message: 'the upstream gave up mid-turn' },
+            incomplete_details: null,
+          };
+          return sseResponse([
+            { event: 'response.created', data: { type: 'response.created', response: { ...failing, status: 'in_progress', error: null }, sequence_number: 0 } },
+            { event: 'response.failed', data: { type: 'response.failed', response: failing, sequence_number: 1 } },
+            { data: '[DONE]' },
+          ]);
+        }
+        return sseResponsesResponse({
+          id: `resp_ws_evict_streamed_${responseCalls}`,
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output_text: 'answer',
+          output: [{
+            id: `assistant_ws_evict_streamed_${responseCalls}`,
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'answer' }],
+          }],
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const firstTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        response: { model: 'gpt-direct-responses', input: 'first question', store: false },
+      }));
+      const firstResponseId = terminalResponseId(await firstTerminal);
+
+      const failedTurn = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_streamed_failure',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'follow-up the upstream abandons',
+          store: false,
+        },
+      }));
+      const failedMessages = await failedTurn;
+      assertEquals(failedMessages.at(-1)?.type, 'response.failed');
 
       const evicted = waitForMessages(client, messages => messages.some(message => message.type === 'error'));
       client.send(JSON.stringify({

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -806,6 +806,103 @@ test('Responses WebSocket store:false keeps session snapshots without durable re
   );
 });
 
+test('Responses WebSocket evicts a failed continuation target so the next attempt reports previous_response_not_found', async () => {
+  const { apiKey } = await setupAppTest();
+  let responseCalls = 0;
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        responseCalls += 1;
+        if (responseCalls === 2) {
+          return jsonResponse({
+            error: { message: 'simulated upstream rejection', type: 'invalid_request_error', code: 'bad_request' },
+          }, 400);
+        }
+        return sseResponsesResponse({
+          id: `resp_ws_evict_${responseCalls}`,
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output_text: 'answer',
+          output: [{
+            id: `assistant_ws_evict_${responseCalls}`,
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'answer' }],
+          }],
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const firstTerminal = waitForMessages(client, messages => messages.some(isTerminalResponseEvent));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        response: { model: 'gpt-direct-responses', input: 'first question', store: false },
+      }));
+      const firstResponseId = terminalResponseId(await firstTerminal);
+
+      const rejected = waitForMessages(client, messages => messages.some(message => message.type === 'error'));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_rejected',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'follow-up the upstream rejects',
+          store: false,
+        },
+      }));
+      assertEquals(await rejected, [{
+        type: 'error',
+        event_id: 'evt_rejected',
+        status: 400,
+        error: {
+          message: 'simulated upstream rejection',
+          type: 'invalid_request_error',
+          code: 'bad_request',
+        },
+      }]);
+
+      const evicted = waitForMessages(client, messages => messages.some(message => message.type === 'error'));
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_evicted',
+        response: {
+          model: 'gpt-direct-responses',
+          previous_response_id: firstResponseId,
+          input: 'retry from the same id',
+          store: false,
+        },
+      }));
+
+      assertEquals(await evicted, [{
+        type: 'error',
+        event_id: 'evt_evicted',
+        status: 400,
+        error: {
+          message: `Previous response with id '${firstResponseId}' not found.`,
+          type: 'invalid_request_error',
+          param: 'previous_response_id',
+          code: 'previous_response_not_found',
+        },
+      }]);
+      assertEquals(responseCalls, 2);
+    }),
+  );
+});
+
 test('Responses WebSocket store:true durable snapshots can chain through local session cache', async () => {
   const { apiKey, repo } = await setupAppTest();
   let turn = 0;

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -351,6 +351,13 @@ export class MemoryStatefulResponsesBacking implements StatefulResponsesBacking 
     }
     return Promise.resolve();
   }
+
+  // Beyond the backing contract: only the connection-local layer forgets a
+  // snapshot, so the delete path deliberately stops here rather than reaching
+  // the interface every backing implements.
+  evictSnapshot(apiKeyId: string, id: string): void {
+    this.snapshots.delete(scopedResponsesKey(apiKeyId, id));
+  }
 }
 
 type ResponsesStatePolicy = Pick<ApiKey, 'id' | 'responsesRetentionSeconds'>;
@@ -380,7 +387,14 @@ export const createNonResponsesSourceStore = (apiKeyId: string): StatefulRespons
 
 export const createResponsesWsSession = (): {
   createStore(apiKey: ResponsesStatePolicy, requestStartedAt: number, store: boolean | undefined): StatefulResponsesStore;
+  evictSnapshot(apiKeyId: string, id: string): void;
 } => {
+  // "Servers SHOULD keep the most recent previous-response state in
+  // connection-local memory for the active WebSocket. […] With `store=false`,
+  // there is no persisted fallback; if the referenced response is not
+  // available from connection-local state, the server MUST fail the turn with
+  // an error whose code is `previous_response_not_found`."
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L125
   const local = new MemoryStatefulResponsesBacking();
   return {
     createStore(apiKey: ResponsesStatePolicy, requestStartedAt: number, store: boolean | undefined): StatefulResponsesStore {
@@ -393,6 +407,13 @@ export const createResponsesWsSession = (): {
         reads: durable === null ? [local] : [local, durable],
         writes,
       });
+    },
+    // "If a continuation turn fails with a `4xx` or `5xx` error, the server
+    // MUST evict the referenced `previous_response_id` from the
+    // connection-local cache."
+    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L127
+    evictSnapshot(apiKeyId: string, id: string): void {
+      local.evictSnapshot(apiKeyId, id);
     },
   };
 };

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -352,9 +352,11 @@ export class MemoryStatefulResponsesBacking implements StatefulResponsesBacking 
     return Promise.resolve();
   }
 
-  // Beyond the backing contract: only the connection-local layer forgets a
-  // snapshot, so the delete path deliberately stops here rather than reaching
-  // the interface every backing implements.
+  // Beyond `StatefulResponsesBacking`: the spec scopes eviction to the
+  // connection-local cache, so the delete path deliberately stops at this
+  // in-memory backing rather than becoming a contract every backing — the
+  // durable one included — has to answer for.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L127
   evictSnapshot(apiKeyId: string, id: string): void {
     this.snapshots.delete(scopedResponsesKey(apiKeyId, id));
   }

--- a/packages/gateway/src/data-plane/chat/responses/items/store.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/store.ts
@@ -410,10 +410,6 @@ export const createResponsesWsSession = (): {
         writes,
       });
     },
-    // "If a continuation turn fails with a `4xx` or `5xx` error, the server
-    // MUST evict the referenced `previous_response_id` from the
-    // connection-local cache."
-    // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L127
     evictSnapshot(apiKeyId: string, id: string): void {
       local.evictSnapshot(apiKeyId, id);
     },

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -210,13 +210,13 @@ const handleClientMessage = async (
   // `previous_response_not_found`."
   // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L127
   //
-  // A turn fails in one of two shapes and neither subsumes the other: it
-  // answers with an error envelope, or it streams a failing terminal event.
-  // `fail` carries the eviction for the first — including the `api-error` and
-  // `internal-error` results, which return before the streaming loop's
-  // `finally` is ever entered — and that `finally` carries it for the second.
-  // A throw inside the streaming loop is the one path that takes both routes,
-  // so it evicts twice; the delete is idempotent.
+  // Eviction is wired at two points because a failing turn can leave through
+  // two exits that do not share a path. `fail` covers the turn that answers
+  // the client with an error envelope, including the `api-error` and
+  // `internal-error` results, which return before the streaming loop is
+  // entered; the loop's `finally` covers the turn that ends failed without
+  // one. A throw inside the loop is the single path that takes both, and
+  // `Map.delete` makes the second call inert.
   const turnFailure: ResponsesWsTurnFailure = {
     evict: () => {
       if (ctx === undefined || previousResponseId === undefined) return;
@@ -557,9 +557,12 @@ const respondResponsesWebSocket = async (input: {
     const metadata = await eventResultMetadata(result);
     const failed = state.failedAfter(completion);
     if (failed) {
-      // A turn that streamed an `error` or `response.failed` event answered the
-      // client with a streaming event rather than an error envelope, so its
-      // eviction cannot come from `turnFailure.fail`.
+      // `fail` cannot carry the eviction for every failed turn: one that
+      // streamed an `error` or `response.failed` terminal answered the client
+      // with an event rather than an error envelope, and one the client
+      // abandoned before the terminal event answered with nothing at all.
+      // Both settle here. For the abandoned turn the eviction is inert — the
+      // connection-local cache dies with the socket.
       turnFailure.evict();
       ctx.dump?.failed(`responses ws turn failed (completion=${completion}, source-failed=${state.failed})`);
     } else ctx.dump?.success(metadata.modelIdentity, tokenUsageFromBillableUsage(metadata.billableUsage));

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -196,6 +196,30 @@ const handleClientMessage = async (
   const signal = downstreamAbortController.signal;
   let eventId: string | undefined;
   let ctx: ChatGatewayCtx | undefined;
+  let previousResponseId: string | null | undefined;
+
+  // "If a continuation turn fails with a `4xx` or `5xx` error, the server MUST
+  // evict the referenced `previous_response_id` from the connection-local
+  // cache. A later attempt to continue from that evicted `store=false`
+  // response ID on the same connection MUST fail with
+  // `previous_response_not_found`."
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L127
+  //
+  // Every failing exit of the turn routes through this one helper, so the
+  // eviction cannot drift away from the error it belongs to. `fail` covers the
+  // exits that answer with an error envelope; `evict` alone covers the turn
+  // that reported its failure through a `response.failed` terminal event.
+  const turnFailure: ResponsesWsTurnFailure = {
+    evict: () => {
+      if (ctx === undefined || previousResponseId === undefined || previousResponseId === null) return;
+      session.evictSnapshot(ctx.store.apiKeyId, previousResponseId);
+    },
+    fail: (status, error) => {
+      turnFailure.evict();
+      sendError(socket, status, error, eventId, ctx?.dump);
+    },
+  };
+
   try {
     // Capture raw frame bytes up front so they're available as the dump's
     // request body when `ctx` is constructed below. Payloads that fail to
@@ -203,7 +227,7 @@ const handleClientMessage = async (
     // them — there is no api-key-scoped turn to attribute them to.
     const requestBody = { bytes: wsDataToBytes(data), streamError: null };
     if (!(await authenticateApiKey(c, authenticatedRawKey))) {
-      sendError(socket, 401, {
+      turnFailure.fail(401, {
         type: 'authentication_error',
         code: 'invalid_api_key',
         message: 'Invalid API key.',
@@ -221,11 +245,11 @@ const handleClientMessage = async (
       : undefined;
     const message = validateClientMessage(parsed);
     if (message.type !== 'response.create') {
-      sendError(socket, 400, {
+      turnFailure.fail(400, {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
         message: `Unsupported WebSocket event type '${message.type}'.`,
-      }, eventId);
+      });
       return;
     }
 
@@ -233,6 +257,10 @@ const handleClientMessage = async (
       ? message.response
       : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
     const payload = responsesPayloadFromClientSource(source);
+    // Remember the continuation target before `expandPreviousResponseId`
+    // strips the field off the payload: a failing turn must evict exactly the
+    // id this turn referenced.
+    previousResponseId = payload.previous_response_id;
     ctx = createChatGatewayCtxFromHono(c, {
       wantsStream: true,
       downstreamAbortController,
@@ -254,12 +282,12 @@ const handleClientMessage = async (
       // same body nested under the spec's WebSocket error envelope so clients
       // can still compare error.message byte-for-byte against upstream.
       if (error instanceof PreviousResponseNotFoundError) {
-        sendError(socket, 400, {
+        turnFailure.fail(400, {
           message: error.message,
           type: 'invalid_request_error',
           param: 'previous_response_id',
           code: 'previous_response_not_found',
-        }, eventId, ctx.dump);
+        });
         ctx.dump?.failed(error);
         ctx.dump?.finalize(400, []);
         return;
@@ -267,27 +295,27 @@ const handleClientMessage = async (
       throw error;
     }
 
-    await respondResponsesWebSocket({ socket, eventId, signal, isClosed, result, ctx, payload });
+    await respondResponsesWebSocket({ socket, eventId, signal, isClosed, result, ctx, payload, turnFailure });
   } catch (error) {
     if (signal.aborted || isClosed()) return;
     if (error instanceof TranslatorInputError) {
-      sendError(socket, 400, {
+      turnFailure.fail(400, {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
         message: error.message,
         param: error.param,
-      }, eventId);
+      });
       return;
     }
     if (error instanceof WebSocketClientMessageError) {
-      sendError(socket, 400, {
+      turnFailure.fail(400, {
         type: 'invalid_request_error',
         code: 'invalid_request_error',
         message: error.message,
-      }, eventId);
+      });
       return;
     }
-    sendError(socket, 500, serverErrorEnvelope(error), eventId, ctx?.dump);
+    turnFailure.fail(500, serverErrorEnvelope(error));
     if (ctx !== undefined) {
       // Mid-attempt throws (interceptor bug, translation error, provider-layer JS
       // exception not represented as a ChatServeFailure) never reach the
@@ -300,6 +328,11 @@ const handleClientMessage = async (
     }
   }
 };
+
+interface ResponsesWsTurnFailure {
+  evict(): void;
+  fail(status: number, error: Record<string, unknown>): void;
+}
 
 class WebSocketClientMessageError extends Error {}
 
@@ -337,12 +370,13 @@ const respondResponsesWebSocket = async (input: {
   readonly result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>;
   readonly ctx: ChatGatewayCtx;
   readonly payload: CanonicalResponsesPayload;
+  readonly turnFailure: ResponsesWsTurnFailure;
 }): Promise<void> => {
-  const { socket, eventId, signal, isClosed, result, ctx, payload } = input;
+  const { socket, eventId, signal, isClosed, result, ctx, payload, turnFailure } = input;
   if (result.type === 'api-error') {
     recordFailedRequest(ctx, result.performance);
     ctx.dump?.error(result.source, result.upstreamId);
-    sendError(socket, result.status, normalizeErrorBody(parseMaybeJson(result.body, result.headers), result.status), eventId, ctx.dump);
+    turnFailure.fail(result.status, normalizeErrorBody(parseMaybeJson(result.body, result.headers), result.status));
     ctx.dump?.finalize(result.status, []);
     return;
   }
@@ -350,7 +384,7 @@ const respondResponsesWebSocket = async (input: {
   if (result.type === 'internal-error') {
     recordFailedRequest(ctx, result.performance);
     ctx.dump?.failed(result.error.message);
-    sendError(socket, result.status, internalErrorEnvelope(result.error), eventId, ctx.dump);
+    turnFailure.fail(result.status, internalErrorEnvelope(result.error));
     ctx.dump?.finalize(result.status, []);
     return;
   }
@@ -518,12 +552,18 @@ const respondResponsesWebSocket = async (input: {
       return;
     }
     state.failed = true;
-    sendError(socket, 500, serverErrorEnvelope(error), eventId, ctx.dump);
+    turnFailure.fail(500, serverErrorEnvelope(error));
   } finally {
     const metadata = await eventResultMetadata(result);
     const failed = state.failedAfter(completion);
-    if (failed) ctx.dump?.failed(`responses ws turn failed (completion=${completion}, source-failed=${state.failed})`);
-    else ctx.dump?.success(metadata.modelIdentity, tokenUsageFromBillableUsage(metadata.billableUsage));
+    if (failed) {
+      // A turn that ends on a `response.failed` terminal event answered the
+      // client with a streaming event rather than an error envelope, so the
+      // eviction the spec attaches to a failed continuation has to happen here
+      // instead of inside `turnFailure.fail`.
+      turnFailure.evict();
+      ctx.dump?.failed(`responses ws turn failed (completion=${completion}, source-failed=${state.failed})`);
+    } else ctx.dump?.success(metadata.modelIdentity, tokenUsageFromBillableUsage(metadata.billableUsage));
     ctx.dump?.finalize(failed ? 500 : 200, []);
     settle(ctx, metadata.performance, metadata.modelIdentity, tokenUsageFromBillableUsage(metadata.billableUsage), failed);
   }

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -183,6 +183,11 @@ const createResponsesWebSocketEvents = (c: AuthedContext): ResponsesWebSocketHan
   };
 };
 
+interface ResponsesWsTurnFailure {
+  evict(): void;
+  fail(status: number, error: Record<string, unknown>): void;
+}
+
 const handleClientMessage = async (
   c: AuthedContext,
   socket: ResponsesWebSocketSocket,
@@ -196,7 +201,7 @@ const handleClientMessage = async (
   const signal = downstreamAbortController.signal;
   let eventId: string | undefined;
   let ctx: ChatGatewayCtx | undefined;
-  let previousResponseId: string | null | undefined;
+  let previousResponseId: string | undefined;
 
   // "If a continuation turn fails with a `4xx` or `5xx` error, the server MUST
   // evict the referenced `previous_response_id` from the connection-local
@@ -205,13 +210,16 @@ const handleClientMessage = async (
   // `previous_response_not_found`."
   // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L127
   //
-  // Every failing exit of the turn routes through this one helper, so the
-  // eviction cannot drift away from the error it belongs to. `fail` covers the
-  // exits that answer with an error envelope; `evict` alone covers the turn
-  // that reported its failure through a `response.failed` terminal event.
+  // A turn fails in one of two shapes and neither subsumes the other: it
+  // answers with an error envelope, or it streams a failing terminal event.
+  // `fail` carries the eviction for the first — including the `api-error` and
+  // `internal-error` results, which return before the streaming loop's
+  // `finally` is ever entered — and that `finally` carries it for the second.
+  // A throw inside the streaming loop is the one path that takes both routes,
+  // so it evicts twice; the delete is idempotent.
   const turnFailure: ResponsesWsTurnFailure = {
     evict: () => {
-      if (ctx === undefined || previousResponseId === undefined || previousResponseId === null) return;
+      if (ctx === undefined || previousResponseId === undefined) return;
       session.evictSnapshot(ctx.store.apiKeyId, previousResponseId);
     },
     fail: (status, error) => {
@@ -257,10 +265,7 @@ const handleClientMessage = async (
       ? message.response
       : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
     const payload = responsesPayloadFromClientSource(source);
-    // Remember the continuation target before `expandPreviousResponseId`
-    // strips the field off the payload: a failing turn must evict exactly the
-    // id this turn referenced.
-    previousResponseId = payload.previous_response_id;
+    previousResponseId = payload.previous_response_id ?? undefined;
     ctx = createChatGatewayCtxFromHono(c, {
       wantsStream: true,
       downstreamAbortController,
@@ -328,11 +333,6 @@ const handleClientMessage = async (
     }
   }
 };
-
-interface ResponsesWsTurnFailure {
-  evict(): void;
-  fail(status: number, error: Record<string, unknown>): void;
-}
 
 class WebSocketClientMessageError extends Error {}
 
@@ -557,10 +557,9 @@ const respondResponsesWebSocket = async (input: {
     const metadata = await eventResultMetadata(result);
     const failed = state.failedAfter(completion);
     if (failed) {
-      // A turn that ends on a `response.failed` terminal event answered the
-      // client with a streaming event rather than an error envelope, so the
-      // eviction the spec attaches to a failed continuation has to happen here
-      // instead of inside `turnFailure.fail`.
+      // A turn that streamed an `error` or `response.failed` event answered the
+      // client with a streaming event rather than an error envelope, so its
+      // eviction cannot come from `turnFailure.fail`.
       turnFailure.evict();
       ctx.dump?.failed(`responses ws turn failed (completion=${completion}, source-failed=${state.failed})`);
     } else ctx.dump?.success(metadata.modelIdentity, tokenUsageFromBillableUsage(metadata.billableUsage));


### PR DESCRIPTION
A continuation turn that fails must not leave its `previous_response_id` usable on the same connection.

## Defect

The spec makes eviction mandatory: a continuation turn that fails with a 4xx or 5xx error must drop the referenced `previous_response_id` from connection-local state, so a later attempt to continue from that id on the same socket fails with `previous_response_not_found`. Floway kept the snapshot, so a `store:false` chain silently survived a failed turn.

## Spec

> If a continuation turn fails with a `4xx` or `5xx` error, the server MUST evict the referenced `previous_response_id` from the connection-local cache. A later attempt to continue from that evicted `store=false` response ID on the same connection MUST fail with `previous_response_not_found`.

`2026-04-24.mdx:127`
https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L127

The surrounding rule at `:125` — connection-local state is the only fallback when `store=false` — is what scopes the eviction.

## What changed

- `MemoryStatefulResponsesBacking` gains `evictSnapshot`, and `createResponsesWsSession` exposes it on the session handle. This is deliberately **beyond** the backing contract: the `StatefulResponsesBacking` interface and the durable backing gain no delete path, because the spec scopes eviction to connection-local state and persisted state stays addressable by id. That reasoning sits on `evictSnapshot` in `items/store.ts`, alongside the `:125` quote that grounds the session's own in-memory backing.
- `handleClientMessage` grows one turn-scoped `ResponsesWsTurnFailure` helper with `evict()` and `fail(status, error)`. All nine places a turn answers with an error envelope — auth rejection, unsupported message type, `PreviousResponseNotFoundError`, `TranslatorInputError`, `WebSocketClientMessageError`, the handler's catch-all 500, the `api-error` and `internal-error` result branches, and the streaming loop's catch-all 500 — go through `fail`, so the eviction cannot drift away from the error it belongs to. `sendError`'s `eventId` and `dump` arguments are now supplied by the helper rather than repeated at each call site.
- The streaming loop's `finally` evicts as well, for the failing turns that never answer with an envelope: one that streamed an `error` or `response.failed` terminal answered with an event instead, and one the client abandoned before the terminal event answered with nothing at all. Eviction after an abandoned turn is inert, since the connection-local cache dies with the socket.
- `websocket_test.ts` covers both routes: a chain that previously survived an upstream 4xx now fails the retry with `previous_response_not_found`, and so does a chain whose failing turn ended on a streamed `response.failed`. Clients recover by starting a new response without `previous_response_id`; `store:true` chains with a non-zero retention window are unaffected.

## The double trigger

Eviction fires from two places — the failure helper and the loop's `finally` — and they are disjoint by construction rather than duplicated. `api-error` and `internal-error` return before the streaming loop is entered, so only the helper can evict for them; a streamed failing terminal never reaches the helper, so only the `finally` can evict for it. A throw inside the loop is the single path that takes both, and `Map.delete` on an absent key makes the second call inert. Both comments state this at the code.

## Verification

`@floway-dev/gateway` at `b257e436f`: typecheck clean, 178 test files / 2125 tests passing, ESLint clean on the three changed files. Removing the `finally`'s `evict()` fails the streamed-terminal test, so both routes are pinned independently.

Behavior on live upstreams was observed on an integration branch containing the full OpenResponses fix set, **not** on this branch alone: 17/17 on all three Responses paths (`gpt-5-mini` native, `gpt-4.1` via Chat Completions, `claude-haiku-4-5` via Messages), twice, against a baseline of 1/17 per path. For this stack the six WebSocket tests went 0/6 → 1/6 per path, `response.done` / `ping` / `error` frame-validation failures reached zero, and this PR's eviction assertion passes on all three paths.

