### PR TITLE
fix(responses): complete the client-facing response resource

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/errors_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/errors_test.ts
@@ -6,9 +6,8 @@ import type { ApiErrorResult } from '@floway-dev/provider';
 import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 import { TranslatorInputError } from '@floway-dev/translate';
 
-const apiErrorOf = (result: ReturnType<typeof responsesInputErrorResult>): ApiErrorResult => result as ApiErrorResult;
-const bodyOf = (result: ReturnType<typeof responsesInputErrorResult>): unknown =>
-  JSON.parse(new TextDecoder().decode(apiErrorOf(result).body));
+const bodyOf = (result: ApiErrorResult): unknown =>
+  JSON.parse(new TextDecoder().decode(result.body));
 
 test('round-trips the Responses-only item-not-found failure through throw/catch', () => {
   const failure: ResponsesServeFailure = { kind: 'item-not-found', itemId: 'msg_abc' };
@@ -20,11 +19,9 @@ test('responsesInputErrorResult renders an OpenAI 400 invalid_request_error enve
   const result = responsesInputErrorResult(
     new TranslatorInputError("Invalid input item type 'image_generation_call'."),
   );
-  const apiError = apiErrorOf(result);
-
-  assertEquals(apiError.type, 'api-error');
-  assertEquals(apiError.source, 'gateway');
-  assertEquals(apiError.status, 400);
+  assertEquals(result.type, 'api-error');
+  assertEquals(result.source, 'gateway');
+  assertEquals(result.status, 400);
   assertEquals(bodyOf(result), {
     error: {
       message: "Invalid input item type 'image_generation_call'.",

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { test, vi } from 'vitest';
 
 import { TEST_RESPONSES_RETENTION_SECONDS } from './test-policy.ts';
+import { missingRequiredResourceKeys } from './test-required-resource-keys.ts';
 import type { AuthVars } from '../../../../src/middleware/auth.ts';
 import { initRepo } from '../../../../src/repo/index.ts';
 import type { ApiKey, User } from '../../../../src/repo/types.ts';
@@ -349,6 +350,21 @@ test('POST /v1/responses returns a single JSON body when stream is omitted', asy
   const body = await response.json() as ResponsesResult;
   assert(body.id.length > 0 && body.id !== 'resp_nonstream', 'expected the source boundary to replace the upstream response id');
   assertEquals(body.status, 'completed');
+});
+
+test('POST /v1/responses answers a translated-shape upstream with a complete response resource', async () => {
+  installRepo();
+  queueCompletedResponse('resp_complete');
+
+  const response = await makeApp().request('/v1/responses', {
+    method: 'POST',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ model: 'test-model', input: 'hello' }),
+  });
+
+  assertEquals(response.status, 200);
+  const body = await response.json() as Record<string, unknown>;
+  assertEquals(missingRequiredResourceKeys(body), []);
 });
 
 test('POST /v1/responses returns 502 when a non-streaming output item cannot be persisted', async () => {

--- a/packages/gateway/__tests__/data-plane/chat/responses/response-resource_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/response-resource_test.ts
@@ -1,0 +1,263 @@
+import { describe, it } from 'vitest';
+
+import { missingRequiredResourceKeys } from './test-required-resource-keys.ts';
+import { completeResponseResource, wrapResponseResourceCompletion } from '../../../../src/data-plane/chat/responses/response-resource.ts';
+import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import type { CanonicalResponsesPayload, ResponsesResult, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { assertEquals, assertExists } from '@floway-dev/test-utils';
+
+const request = (overrides: Partial<CanonicalResponsesPayload> = {}): CanonicalResponsesPayload => ({
+  model: 'gpt-5-mini',
+  input: [{ type: 'message', role: 'user', content: 'hi' }],
+  ...overrides,
+});
+
+const sources = (overrides: Partial<CanonicalResponsesPayload> = {}) => ({
+  request: request(overrides),
+  createdAt: 1_700_000_000,
+  stored: true,
+});
+
+// The shape a translated target hands to the client boundary: identity,
+// status, output and usage, and nothing else.
+const translatedResource = (): ResponsesResult => ({
+  id: 'resp_1',
+  object: 'response',
+  model: 'gpt-4.1',
+  output: [],
+  status: 'completed',
+  error: null,
+  incomplete_details: null,
+  usage: { input_tokens: 8, output_tokens: 10, total_tokens: 18 },
+});
+
+describe('Responses resource completion', () => {
+  it('fills every required key a translated target left out', () => {
+    const completed = completeResponseResource(translatedResource(), sources(), true);
+    assertEquals(missingRequiredResourceKeys(completed), []);
+  });
+
+  it('prefers what the upstream reported over what the client asked for', () => {
+    const upstream: ResponsesResult = {
+      ...translatedResource(),
+      temperature: 0.2,
+      top_p: 0.5,
+      parallel_tool_calls: false,
+      truncation: 'auto',
+      metadata: { trace: 'abc' },
+      created_at: 1_600_000_000,
+    };
+    const completed = completeResponseResource(upstream, sources({ temperature: 1, top_p: 1, truncation: 'disabled' }), true);
+    assertEquals(completed.temperature, 0.2);
+    assertEquals(completed.top_p, 0.5);
+    assertEquals(completed.parallel_tool_calls, false);
+    assertEquals(completed.truncation, 'auto');
+    assertEquals(completed.metadata, { trace: 'abc' });
+    // `created_at` is gateway state: only Floway knows when it received the
+    // request, so an upstream value never wins there.
+    assertEquals(completed.created_at, 1_700_000_000);
+  });
+
+  it('keeps an upstream null on a slot whose schema offers null', () => {
+    const upstream: ResponsesResult = { ...translatedResource(), max_output_tokens: null, instructions: null };
+    const completed = completeResponseResource(upstream, sources({ max_output_tokens: 512, instructions: 'be terse' }), true);
+    assertEquals(completed.max_output_tokens, null);
+    assertEquals(completed.instructions, null);
+  });
+
+  it('resolves past an upstream null on a slot whose schema offers none', () => {
+    const upstream: ResponsesResult = {
+      ...translatedResource(),
+      temperature: null,
+      top_p: null,
+      truncation: null,
+      service_tier: null,
+      metadata: null,
+    };
+    const completed = completeResponseResource(upstream, sources({ temperature: 0.4 }), true);
+    // The client's own value is the next candidate…
+    assertEquals(completed.temperature, 0.4);
+    // …and the stated default ends the chain when neither side said anything.
+    assertEquals(completed.top_p, 1);
+    assertEquals(completed.truncation, 'disabled');
+    assertEquals(completed.service_tier, 'default');
+    assertEquals(completed.metadata, {});
+  });
+
+  it('echoes what the client sent in preference to the stated default', () => {
+    const completed = completeResponseResource(translatedResource(), sources({
+      temperature: 0.3,
+      top_p: 0.9,
+      truncation: 'auto',
+      background: true,
+      top_logprobs: 5,
+      presence_penalty: 1.5,
+      frequency_penalty: -0.5,
+      parallel_tool_calls: false,
+      service_tier: 'priority',
+      tool_choice: 'required',
+      metadata: { run: '7' },
+      instructions: 'be terse',
+      previous_response_id: 'resp_0',
+      prompt_cache_key: 'cache-1',
+      safety_identifier: 'user-1',
+      max_output_tokens: 512,
+      max_tool_calls: 3,
+    }), true);
+    assertEquals(completed.temperature, 0.3);
+    assertEquals(completed.top_p, 0.9);
+    assertEquals(completed.truncation, 'auto');
+    assertEquals(completed.background, true);
+    assertEquals(completed.top_logprobs, 5);
+    assertEquals(completed.presence_penalty, 1.5);
+    assertEquals(completed.frequency_penalty, -0.5);
+    assertEquals(completed.parallel_tool_calls, false);
+    assertEquals(completed.service_tier, 'priority');
+    assertEquals(completed.tool_choice, 'required');
+    assertEquals(completed.metadata, { run: '7' });
+    assertEquals(completed.instructions, 'be terse');
+    assertEquals(completed.previous_response_id, 'resp_0');
+    assertEquals(completed.prompt_cache_key, 'cache-1');
+    assertEquals(completed.safety_identifier, 'user-1');
+    assertEquals(completed.max_output_tokens, 512);
+    assertEquals(completed.max_tool_calls, 3);
+  });
+
+  it('states the schema default for a required key neither side supplied', () => {
+    const completed = completeResponseResource(translatedResource(), sources(), true);
+    assertEquals(completed.temperature, 1);
+    assertEquals(completed.top_p, 1);
+    assertEquals(completed.presence_penalty, 0);
+    assertEquals(completed.frequency_penalty, 0);
+    assertEquals(completed.top_logprobs, 0);
+    assertEquals(completed.parallel_tool_calls, true);
+    assertEquals(completed.truncation, 'disabled');
+    assertEquals(completed.background, false);
+    assertEquals(completed.service_tier, 'default');
+    assertEquals(completed.tool_choice, 'auto');
+    assertEquals(completed.tools, []);
+    assertEquals(completed.metadata, {});
+    assertEquals(completed.text, { format: { type: 'text' } });
+  });
+
+  it('marks an unrequested nullable key absent rather than inventing a value', () => {
+    const completed = completeResponseResource(translatedResource(), sources(), true);
+    assertEquals(completed.previous_response_id, null);
+    assertEquals(completed.instructions, null);
+    assertEquals(completed.reasoning, null);
+    assertEquals(completed.max_output_tokens, null);
+    assertEquals(completed.max_tool_calls, null);
+    assertEquals(completed.safety_identifier, null);
+    assertEquals(completed.prompt_cache_key, null);
+  });
+
+  it('reports gateway state for created_at and store', () => {
+    const completed = completeResponseResource(translatedResource(), { ...sources({ store: true }), stored: false }, true);
+    assertEquals(completed.created_at, 1_700_000_000);
+    assertEquals(completed.store, false);
+  });
+
+  it('completes both usage breakdowns and reports a missing usage as null', () => {
+    const completed = completeResponseResource(translatedResource(), sources(), true);
+    assertEquals(completed.usage, {
+      input_tokens: 8,
+      output_tokens: 10,
+      total_tokens: 18,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    });
+
+    const { usage: _usage, ...withoutUsage } = translatedResource();
+    assertEquals(completeResponseResource(withoutUsage, sources(), true).usage, null);
+  });
+
+  it('keeps a usage breakdown the upstream actually reported', () => {
+    const upstream: ResponsesResult = {
+      ...translatedResource(),
+      usage: { input_tokens: 8, output_tokens: 10, total_tokens: 18, output_tokens_details: { reasoning_tokens: 7 } },
+    };
+    assertEquals(completeResponseResource(upstream, sources(), true).usage?.output_tokens_details, { reasoning_tokens: 7 });
+  });
+
+  it('completes a reasoning block and a text block to their own required keys', () => {
+    const completed = completeResponseResource(
+      translatedResource(),
+      sources({ reasoning: { effort: 'high' }, text: { verbosity: 'low' } }),
+      true,
+    );
+    assertEquals(completed.reasoning, { effort: 'high', summary: null });
+    assertEquals(completed.text, { verbosity: 'low', format: { type: 'text' } });
+  });
+
+  it('completes a minimal echoed function tool to every key the tool schema requires', () => {
+    const completed = completeResponseResource(
+      translatedResource(),
+      sources({ tools: [{ type: 'function', name: 'lookup' }] }),
+      true,
+    );
+    assertEquals(completed.tools, [{ type: 'function', name: 'lookup', description: null, parameters: null, strict: null }]);
+  });
+
+  // The normalizers run on the resolved value, so a tool array the upstream
+  // echoed — or one the server-tool shim reconstructed — is completed like any
+  // other. Resolving first and normalizing after is what closes that path.
+  it('completes a minimal function tool the upstream echoed back', () => {
+    const upstream: ResponsesResult = {
+      ...translatedResource(),
+      tools: [{ type: 'function', name: 'lookup', parameters: { type: 'object' } }],
+    };
+    const completed = completeResponseResource(
+      upstream,
+      sources({ tools: [{ type: 'function', name: 'lookup', parameters: { type: 'object' }, strict: true, description: 'ignored' }] }),
+      true,
+    );
+    assertEquals(completed.tools, [{
+      type: 'function',
+      name: 'lookup',
+      parameters: { type: 'object' },
+      description: null,
+      strict: null,
+    }]);
+  });
+
+  it('leaves a non-function tool untouched', () => {
+    const completed = completeResponseResource(
+      translatedResource(),
+      sources({ tools: [{ type: 'web_search' }] }),
+      true,
+    );
+    assertEquals(completed.tools, [{ type: 'web_search' }]);
+  });
+
+  it('completes every resource-bearing frame of a stream and reports completed_at only on the terminal one', async () => {
+    const source = async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+      yield eventFrame({ type: 'response.created', sequence_number: 0, response: { ...translatedResource(), status: 'in_progress' } } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.output_text.delta', sequence_number: 1, item_id: 'msg_1', output_index: 0, content_index: 0, delta: 'hi' } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.completed', sequence_number: 2, response: translatedResource() } as ResponsesStreamEvent);
+      yield doneFrame();
+    };
+
+    const seen: ResponsesStreamEvent[] = [];
+    for await (const frame of wrapResponseResourceCompletion(source(), sources())) {
+      if (frame.type === 'event') seen.push(frame.event);
+    }
+
+    assertEquals(seen.length, 3);
+    const created = seen[0];
+    const terminal = seen[2];
+    assertExists(created);
+    assertExists(terminal);
+    if (created.type !== 'response.created' || terminal.type !== 'response.completed') {
+      throw new Error('expected the resource-bearing frames to survive completion unchanged in type');
+    }
+    assertEquals(missingRequiredResourceKeys(created.response as unknown as Record<string, unknown>), []);
+    assertEquals(missingRequiredResourceKeys(terminal.response as unknown as Record<string, unknown>), []);
+    assertEquals(created.response.completed_at, null);
+    assertEquals(typeof terminal.response.completed_at, 'number');
+    // One `created_at` per response, so a client reading any frame sees the
+    // same creation time.
+    assertEquals(created.response.created_at, terminal.response.created_at);
+    // An event that carries no response resource is forwarded untouched.
+    assertEquals(seen[1]?.type, 'response.output_text.delta');
+  });
+});

--- a/packages/gateway/__tests__/data-plane/chat/responses/test-required-resource-keys.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/test-required-resource-keys.ts
@@ -1,0 +1,38 @@
+// Every key `ResponseResource.required` lists.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+export const REQUIRED_RESOURCE_KEYS = [
+  'id',
+  'object',
+  'created_at',
+  'completed_at',
+  'status',
+  'incomplete_details',
+  'model',
+  'previous_response_id',
+  'instructions',
+  'output',
+  'error',
+  'tools',
+  'tool_choice',
+  'truncation',
+  'parallel_tool_calls',
+  'text',
+  'top_p',
+  'presence_penalty',
+  'frequency_penalty',
+  'top_logprobs',
+  'temperature',
+  'reasoning',
+  'usage',
+  'max_output_tokens',
+  'max_tool_calls',
+  'store',
+  'background',
+  'service_tier',
+  'metadata',
+  'safety_identifier',
+  'prompt_cache_key',
+] as const;
+
+export const missingRequiredResourceKeys = (resource: Record<string, unknown>): string[] =>
+  REQUIRED_RESOURCE_KEYS.filter(key => !(key in resource));

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -194,7 +194,15 @@ test('Responses WebSocket forwards stream events, echoes event_id, and sends res
         event_id: 'evt_1',
         response: {
           id: responseId,
-          usage: { input_tokens: 3, output_tokens: 5, total_tokens: 8 },
+          // The summary reads the terminal response resource, which the egress
+          // stage has already completed, so the usage breakdowns are present.
+          usage: {
+            input_tokens: 3,
+            output_tokens: 5,
+            total_tokens: 8,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
         },
       });
     }),

--- a/packages/gateway/src/data-plane/chat/responses/client-output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/client-output.ts
@@ -1,24 +1,33 @@
 import { wrapResponsesAffinityEgress } from './affinity/egress.ts';
 import { wrapResponsesClientOutput } from './items/output.ts';
 import { createResponsesResponseId } from './response-id.ts';
+import { wrapResponseResourceCompletion } from './response-resource.ts';
 import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import { affinityEgressOptions } from '../shared/affinity/index.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import type { CanonicalResponsesPayload, ClientResponsesStreamEvent, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 
 // Affinity wraps routing metadata first. The client-output boundary then stores
 // each complete emitted item under its exact ID and applies one generated
-// response ID to the downstream stream and snapshot.
+// response ID to the downstream stream and snapshot. Resource completion runs
+// outermost, so it sees the ID the boundary applied and is the last thing that
+// touches a response resource before serialization.
 export const wrapNativeResponsesClientOutput = (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   ctx: GatewayCtx,
-): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> => {
+  request: CanonicalResponsesPayload,
+): AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>> => {
   if (!('affinity' in ctx) || !('store' in ctx)) throw new Error('Responses output reached the client-facing boundary without chat context');
   const chatCtx = ctx as ChatGatewayCtx;
   const withAffinity = wrapResponsesAffinityEgress(frames, affinityEgressOptions(ctx));
-  return wrapResponsesClientOutput(withAffinity, {
+  const stored = wrapResponsesClientOutput(withAffinity, {
     store: chatCtx.store,
     responseId: createResponsesResponseId(),
+  });
+  return wrapResponseResourceCompletion(stored, {
+    request,
+    createdAt: Math.floor(ctx.requestStartedAt / 1000),
+    stored: chatCtx.store.writesState,
   });
 };

--- a/packages/gateway/src/data-plane/chat/responses/errors.ts
+++ b/packages/gateway/src/data-plane/chat/responses/errors.ts
@@ -2,7 +2,7 @@ import { appendFailedUpstreams } from '../../shared/failed-upstreams.ts';
 import { openAiErrorResult, type ChatServeFailure } from '../shared/errors.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import type { ResponsesStreamEvent } from '@floway-dev/protocols/responses';
-import type { ExecuteResult, PerformanceTelemetryContext } from '@floway-dev/provider';
+import type { ApiErrorResult, ExecuteResult, PerformanceTelemetryContext } from '@floway-dev/provider';
 
 export type ResponsesServeFailure = ChatServeFailure | { readonly kind: 'item-not-found'; readonly itemId: string };
 
@@ -12,7 +12,7 @@ export type ResponsesServeFailure = ChatServeFailure | { readonly kind: 'item-no
 export const responsesInputErrorResult = (
   error: { readonly message: string; readonly param?: string },
   performance?: PerformanceTelemetryContext,
-): ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> =>
+): ApiErrorResult =>
   openAiErrorResult(400, error.message, { param: error.param ?? 'input', code: null }, performance);
 
 export const renderResponsesFailure = (

--- a/packages/gateway/src/data-plane/chat/responses/http.ts
+++ b/packages/gateway/src/data-plane/chat/responses/http.ts
@@ -1,6 +1,6 @@
 import { responsesInputErrorResult } from './errors.ts';
 import { createResponsesHttpStore } from './items/store.ts';
-import { respondResponses } from './respond.ts';
+import { respondResponses, respondResponsesFailure } from './respond.ts';
 import { PreviousResponseNotFoundError } from './serve-prep.ts';
 import { responsesServe } from './serve.ts';
 import type { AuthedContext } from '../../../middleware/auth.ts';
@@ -46,7 +46,7 @@ const respondWithInternalError = async (c: AuthedContext, error: unknown, reques
   if (verbatim !== null) return verbatim;
   const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
   const result = internalErrorResult(502, toInternalDebugError(error), effectiveCtx.attempt.telemetry);
-  const response = await respondResponses(c, result, false, effectiveCtx);
+  const response = respondResponsesFailure(result, effectiveCtx);
   return finalizeGatewayResponse(effectiveCtx, response);
 };
 
@@ -61,7 +61,7 @@ const respondToThrow = async (c: AuthedContext, error: unknown, requestBody: Req
   }
   if (error instanceof TranslatorInputError) {
     const effectiveCtx = ctx ?? createGatewayCtxFromHono(c, { wantsStream: false, requestBody: takeRequestBody(requestBody), backgroundScheduler: backgroundSchedulerFromContext(c) });
-    const response = await respondResponses(c, responsesInputErrorResult(error, effectiveCtx.attempt.telemetry), false, effectiveCtx);
+    const response = respondResponsesFailure(responsesInputErrorResult(error, effectiveCtx.attempt.telemetry), effectiveCtx);
     return finalizeGatewayResponse(effectiveCtx, response);
   }
   return await respondWithInternalError(c, error, requestBody, ctx);
@@ -79,7 +79,7 @@ export const responsesHttp = {
       const wantsStream = payload.stream === true;
       ctx = createChatGatewayCtxFromHono(c, { wantsStream, requestBody: takeRequestBody(requestBody), model: payload.model, backgroundScheduler: backgroundSchedulerFromContext(c) }, (apiKey, requestStartedAt) => createResponsesHttpStore(apiKey, requestStartedAt, payload.store ?? undefined));
       const result = await responsesServe.generate({ payload, ctx, headers: inboundHeadersForUpstream(c) });
-      const response = await respondResponses(c, result, wantsStream, ctx);
+      const response = await respondResponses(c, result, wantsStream, ctx, payload);
       return finalizeGatewayResponse(ctx, response);
     } catch (error) {
       return await respondToThrow(c, error, requestBody, ctx);
@@ -116,7 +116,7 @@ export const responsesHttp = {
         const compactResponse = Response.json(result.result);
         return finalizeGatewayResponse(ctx, compactResponse);
       }
-      const response = await respondResponses(c, result, false, ctx);
+      const response = await respondResponses(c, result, false, ctx, payload);
       return finalizeGatewayResponse(ctx, response);
     } catch (error) {
       return await respondToThrow(c, error, requestBody, ctx);

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -11,20 +11,17 @@ import { forwardUpstreamHeaders, mergeForwardedUpstreamHeaders } from '../../sha
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
 import { type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { responsesProtocolFrameToSSEFrame, RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
-import { isResponsesTerminalEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ClientResponsesStreamEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, type PlainResult, type InternalDebugError, toInternalDebugError } from '@floway-dev/provider';
 import { apiErrorToResponse } from '@floway-dev/provider';
 
-// Renders an upstream Responses result into the client HTTP/SSE response. An
-// error-typed result is a pre-stream failure and always answers as HTTP; an
-// events result drains to one JSON body (non-streaming) or is proxied frame by
-// frame (streaming).
-export const respondResponses = async (
-  c: Context,
-  result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> | PlainResult,
-  wantsStream: boolean,
+// Renders a Responses failure that never opened a stream. Separate entry
+// because a request that fails before its payload parses has no payload to
+// answer with, and the events path below requires one.
+export const respondResponsesFailure = (
+  result: Exclude<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>, { type: 'events' }> | PlainResult,
   ctx: GatewayCtx,
-): Promise<Response> => {
+): Response => {
   if (result.type === 'api-error') {
     recordFailedRequest(ctx, result.performance);
     ctx.dump?.error(result.source, result.upstreamId);
@@ -37,16 +34,27 @@ export const respondResponses = async (
     return internalResponsesErrorResponse(result.status, result.error);
   }
 
-  if (result.type === 'plain') {
-    if (result.status >= 400) {
-      ctx.dump?.error(result.upstreamId !== undefined ? 'upstream' : 'gateway', result.upstreamId);
-    }
-    return plainResultToResponse(result);
+  if (result.status >= 400) {
+    ctx.dump?.error(result.upstreamId !== undefined ? 'upstream' : 'gateway', result.upstreamId);
   }
+  return plainResultToResponse(result);
+};
+
+// Renders an upstream Responses result into the client HTTP/SSE response. An
+// events result drains to one JSON body (non-streaming) or is proxied frame by
+// frame (streaming); anything else is a pre-stream failure.
+export const respondResponses = async (
+  c: Context,
+  result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>> | PlainResult,
+  wantsStream: boolean,
+  ctx: GatewayCtx,
+  request: CanonicalResponsesPayload,
+): Promise<Response> => {
+  if (result.type !== 'events') return respondResponsesFailure(result, ctx);
 
   const state = new SourceStreamState();
   const observed = observeResponsesFrames(result.events, state, ctx);
-  const frames = wrapNativeResponsesClientOutput(observed, ctx);
+  const frames = wrapNativeResponsesClientOutput(observed, ctx, request);
 
   if (!wantsStream) {
     try {
@@ -132,7 +140,7 @@ const observeResponsesFrames = async function* (frames: AsyncIterable<ProtocolFr
   throw new Error(RESPONSES_MISSING_TERMINAL_MESSAGE);
 };
 
-const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>, state: SourceStreamState) {
+const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>>, state: SourceStreamState) {
   try {
     for await (const frame of frames) {
       const sse = responsesProtocolFrameToSSEFrame(frame);

--- a/packages/gateway/src/data-plane/chat/responses/response-resource.ts
+++ b/packages/gateway/src/data-plane/chat/responses/response-resource.ts
@@ -1,0 +1,232 @@
+import { eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import type {
+  CanonicalResponsesPayload,
+  ClientResponseResource,
+  ClientResponsesReasoning,
+  ClientResponsesStreamEvent,
+  ClientResponsesTextField,
+  ClientResponsesTool,
+  ClientResponsesUsage,
+  ResponsesResult,
+  ResponsesStreamEvent,
+  ResponsesTool,
+} from '@floway-dev/protocols/responses';
+
+// ── The policy boundary ──
+//
+// Interior stages never state a value they did not observe. The egress stage is
+// the only place Floway states one, and only where the wire schema forbids both
+// omission and `null`.
+//
+// The other half of that rule lives in the server-tool shim, which shipped
+// "absent-echo (no tools synthesized when upstream omits it)" in 44322150d
+// (#125) and whose synthesis paths throw on an absent `upstreamResponseSnapshot`
+// rather than fabricate a resource never captured. The two rules do not conflict
+// on any key, because they answer different questions:
+//
+// - The shim's snapshot is interior. Its output re-enters Floway: it becomes
+//   the prologue and terminal resource of a stitched multi-call turn, later
+//   shim logic reads it, and its items are persisted. A value invented there is
+//   indistinguishable from an observed one for every later reader.
+// - This stage is terminal. Nothing below it consumes a value stated here.
+//   Item persistence runs underneath: `wrapResponsesClientOutput` commits the
+//   rows carried by `response.output_item.done` and a snapshot record of their
+//   ordered ids, and awaits that before the terminal frame leaves it, so no
+//   response resource is ever stored. Affinity egress runs underneath too, and
+//   billing reads `billableUsage` off the `ExecuteResult` rather than the
+//   resource. The readers that do sit above this stage — the `settle` call and
+//   the compact path's failure check — read only `status`, which rides through
+//   from the upstream and is never stated here.
+//
+// #125's "no tools synthesized when upstream omits it" therefore still holds:
+// the interior resource carries no `tools`, and egress states `[]` on the way
+// out. `ResponseResource` declares twenty of its thirty-one required keys
+// non-nullable. Thirteen of those — `tools`, `tool_choice`, `truncation`,
+// `temperature`, `service_tier` among them — are ones no interior stage is
+// guaranteed to have observed, and the schema offers no way to say "the backend
+// decided", so the choice is between a stated default and a body that fails
+// validation. Two more, `created_at` and `store`, are answered from gateway
+// state below rather than from any default; the remaining five ride through
+// from the upstream.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+
+// A required slot with no `null` alternative: `null` and `undefined` both mean
+// "absent", and the schema gives absence no spelling, so a stated default
+// terminates the chain.
+const stated = <T>(candidates: readonly (T | null | undefined)[], fallback: T): T =>
+  candidates.find(value => value !== undefined && value !== null) ?? fallback;
+
+// A required slot with a `null` alternative: `null` is an observation, so only
+// `undefined` continues the chain and the chain's own end is `null`.
+const observed = <T>(candidates: readonly (T | null | undefined)[]): T | null => {
+  const hit = candidates.find(value => value !== undefined);
+  return hit === undefined ? null : hit;
+};
+
+// The normalizers run on the resolved value, so an upstream-echoed or
+// shim-reconstructed object is completed exactly like one built from the
+// request.
+
+// A function tool must declare `description`, `parameters` and `strict` even
+// when the client omitted them: all three are required-with-a-`null`-alternative
+// on the response tool schema while the request schema leaves them optional. An
+// absent key becomes `null` rather than an invented `{}` / `false`, because the
+// caller expressed no choice and the upstream owns the effective default.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2141-L2192
+const completeTool = (tool: ResponsesTool): ClientResponsesTool =>
+  tool.type !== 'function'
+    ? tool
+    : {
+        ...tool,
+        description: tool.description ?? null,
+        parameters: tool.parameters ?? null,
+        strict: tool.strict ?? null,
+      };
+
+// `TextField` requires `format`, whose own default is plain text.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2298-L2319
+const completeText = (text: NonNullable<ResponsesResult['text']>): ClientResponsesTextField =>
+  ({ ...text, format: text.format ?? { type: 'text' } });
+
+// `Reasoning` requires `effort` and `summary`, both of which are nullable, so
+// an unconfigured reasoning object says so rather than naming a level.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2320-L2359
+const completeReasoning = (reasoning: NonNullable<ResponsesResult['reasoning']> | null): ClientResponsesReasoning | null =>
+  reasoning === null ? null : { ...reasoning, effort: reasoning.effort ?? null, summary: reasoning.summary ?? null };
+
+// Both breakdowns are required whenever `usage` itself is an object. An absent
+// breakdown means the upstream reported no cached input tokens and no reasoning
+// output tokens.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2384-L2429
+const completeUsage = (usage: NonNullable<ResponsesResult['usage']> | null): ClientResponsesUsage | null =>
+  usage === null
+    ? null
+    : {
+        ...usage,
+        input_tokens_details: usage.input_tokens_details ?? { cached_tokens: 0 },
+        output_tokens_details: usage.output_tokens_details ?? { reasoning_tokens: 0 },
+      };
+
+export interface ResponseResourceSources {
+  // The request these events answer. Every echoed value comes from here.
+  readonly request: CanonicalResponsesPayload;
+  // Unix seconds. One value per response, so every resource-bearing frame of a
+  // single response reports the same `created_at`.
+  readonly createdAt: number;
+  // Whether the response is actually retrievable afterwards, which is what the
+  // schema's `store` describes ("Whether this response was stored so it can be
+  // retrieved later"). Sourced from the item store rather than the request's
+  // `store` flag, because retention policy and the WebSocket session's
+  // connection-local history both override what the client asked for.
+  readonly stored: boolean;
+}
+
+// Every description the response resource attaches to these keys is past
+// tense — "The tools that were available to the model during response
+// generation", "The service tier that was used for this response", "How the
+// input was truncated by the service". The resource states what happened, not
+// what was asked, so an upstream that reports an effective value outranks the
+// request; where the upstream reports nothing, the request's own value is the
+// best available statement about the turn; where neither exists the schema
+// forces a stated default.
+//
+// The stated defaults are the values OpenAI's own reference response body
+// reports for a request that specified none of them.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2726-L2778
+// The request-side declarations of the same defaults:
+// temperature 1 and top_p 1 — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L44081-L44100
+// truncation "disabled" — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L35856-L35873
+// parallel_tool_calls true — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L35915-L35921
+// background false — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L59062-L59068
+// presence_penalty 0 — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L32766-L32771
+// frequency_penalty 0 — https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L32752-L32757
+// `tool_choice` has no request-side `default:` anywhere in the spec; "auto" is
+// what the reference response body above reports.
+// service_tier is the one key whose stated default is not its request-side
+// default: the request declares "auto", but the response slot reports the tier
+// that was actually used, and an account with no tier configured resolves
+// "auto" to "default" — the value the reference body carries. The request value
+// still outranks that default, because a client that named a concrete tier
+// ("priority", "flex") described the routing this turn was submitted under, and
+// no other source survives to contradict it.
+// https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L61500-L61518
+export const completeResponseResource = (
+  upstream: ResponsesResult,
+  sources: ResponseResourceSources,
+  terminal: boolean,
+): ClientResponseResource => {
+  const { request } = sources;
+  return {
+    // The keys the upstream owns outright — `id`, `object`, `model`, `status`,
+    // `output`, `output_text` — plus any vendor extension it carried ride
+    // through. Every key the resource declares required is resolved explicitly
+    // below, so nothing in this spread is load-bearing for conformance.
+    ...upstream,
+
+    // Gateway state. `created_at` and `store` have no candidate chain because no
+    // other source can know them. `completed_at` overrides any upstream value
+    // because one client turn can span several upstream calls behind the
+    // server-tool runtime, so no single upstream's completion instant describes
+    // it.
+    created_at: sources.createdAt,
+    completed_at: terminal ? Math.floor(Date.now() / 1000) : null,
+    store: sources.stored,
+
+    tools: stated<ResponsesTool[]>([upstream.tools, request.tools], []).map(completeTool),
+    tool_choice: stated([upstream.tool_choice, request.tool_choice], 'auto'),
+    truncation: stated([upstream.truncation, request.truncation], 'disabled'),
+    parallel_tool_calls: stated([upstream.parallel_tool_calls, request.parallel_tool_calls], true),
+    text: completeText(stated<NonNullable<ResponsesResult['text']>>([upstream.text, request.text], {})),
+    top_p: stated([upstream.top_p, request.top_p], 1),
+    presence_penalty: stated([upstream.presence_penalty, request.presence_penalty], 0),
+    frequency_penalty: stated([upstream.frequency_penalty, request.frequency_penalty], 0),
+    top_logprobs: stated([upstream.top_logprobs, request.top_logprobs], 0),
+    temperature: stated([upstream.temperature, request.temperature], 1),
+    background: stated([upstream.background, request.background], false),
+    service_tier: stated([upstream.service_tier, request.service_tier], 'default'),
+    metadata: stated<Record<string, unknown>>([upstream.metadata, request.metadata], {}),
+
+    previous_response_id: observed([upstream.previous_response_id, request.previous_response_id]),
+    instructions: observed([upstream.instructions, request.instructions]),
+    max_output_tokens: observed([upstream.max_output_tokens, request.max_output_tokens]),
+    max_tool_calls: observed([upstream.max_tool_calls, request.max_tool_calls]),
+    safety_identifier: observed([upstream.safety_identifier, request.safety_identifier]),
+    prompt_cache_key: observed([upstream.prompt_cache_key, request.prompt_cache_key]),
+    reasoning: completeReasoning(observed<NonNullable<ResponsesResult['reasoning']>>([upstream.reasoning, request.reasoning])),
+    // The request has no counterpart: token counts are the upstream's alone.
+    usage: completeUsage(observed([upstream.usage])),
+  };
+};
+
+// The client-facing egress stage: every resource-bearing event carries the
+// complete resource, so a streamed response validates frame by frame and the
+// non-streaming body — which is the terminal frame's resource verbatim —
+// validates too. The narrowed yield type propagates the guarantee, so a stage
+// inserted between this one and a client-facing exit must preserve it or fail
+// to compile.
+export const wrapResponseResourceCompletion = async function* (
+  frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
+  sources: ResponseResourceSources,
+): AsyncGenerator<ProtocolFrame<ClientResponsesStreamEvent>> {
+  for await (const frame of frames) {
+    if (frame.type !== 'event') {
+      yield frame;
+      continue;
+    }
+    const event = frame.event;
+    switch (event.type) {
+    case 'response.queued':
+    case 'response.created':
+    case 'response.in_progress':
+      yield eventFrame({ ...event, response: completeResponseResource(event.response, sources, false) });
+      continue;
+    case 'response.completed':
+    case 'response.incomplete':
+    case 'response.failed':
+      yield eventFrame({ ...event, response: completeResponseResource(event.response, sources, true) });
+      continue;
+    default:
+      yield eventFrame(event);
+    }
+  }
+};

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -82,7 +82,7 @@ export const responsesServe = {
     );
     if (result.type !== 'result') return result;
 
-    const stored = wrapNativeResponsesClientOutput(syntheticEventsFromResult(result.result), ctx);
+    const stored = wrapNativeResponsesClientOutput(syntheticEventsFromResult(result.result), ctx, payload);
     const clientResult = await collectResponsesProtocolEventsToResult(stored);
     return {
       ...result,

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -18,7 +18,7 @@ import { SourceStreamState, eventResultMetadata } from '../shared/respond.ts';
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
 import { RESPONSES_MISSING_TERMINAL_MESSAGE } from '@floway-dev/protocols/responses';
-import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ResponsesRequestPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ClientResponsesStreamEvent, type ResponsesRequestPayload, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import type { ExecuteResult } from '@floway-dev/provider';
 import { toInternalDebugError } from '@floway-dev/provider';
 import { canonicalizeResponsesPayload, TranslatorInputError } from '@floway-dev/translate';
@@ -256,7 +256,7 @@ const handleClientMessage = async (
       throw error;
     }
 
-    await respondResponsesWebSocket({ socket, eventId, signal, isClosed, result, ctx });
+    await respondResponsesWebSocket({ socket, eventId, signal, isClosed, result, ctx, payload });
   } catch (error) {
     if (signal.aborted || isClosed()) return;
     if (error instanceof TranslatorInputError) {
@@ -325,8 +325,9 @@ const respondResponsesWebSocket = async (input: {
   readonly isClosed: () => boolean;
   readonly result: ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>;
   readonly ctx: ChatGatewayCtx;
+  readonly payload: CanonicalResponsesPayload;
 }): Promise<void> => {
-  const { socket, eventId, signal, isClosed, result, ctx } = input;
+  const { socket, eventId, signal, isClosed, result, ctx, payload } = input;
   if (result.type === 'api-error') {
     recordFailedRequest(ctx, result.performance);
     ctx.dump?.error(result.source, result.upstreamId);
@@ -346,9 +347,9 @@ const respondResponsesWebSocket = async (input: {
   const state = new SourceStreamState();
   let completion: StreamCompletion = 'error';
   try {
-    let terminalEvent: ResponsesStreamEvent | undefined;
+    let terminalEvent: ClientResponsesStreamEvent | undefined;
     const observed = observeResponsesWebSocketFrames(result.events, state, ctx);
-    const output = wrapNativeResponsesClientOutput(observed, ctx);
+    const output = wrapNativeResponsesClientOutput(observed, ctx, payload);
     const iterator = output[Symbol.asyncIterator]();
     let pendingNext = pendingWsFrameResult(iterator.next());
     let completed = false;
@@ -395,7 +396,7 @@ const respondResponsesWebSocket = async (input: {
         if (terminalEvent !== undefined) continue;
 
         if (isResponsesTerminalEvent(event)) {
-          if (!sendJson(socket, event, eventId, ctx.dump)) {
+          if (!sendResponsesEvent(socket, event, eventId, ctx.dump)) {
             completion = 'cancel';
             continue;
           }
@@ -403,7 +404,7 @@ const respondResponsesWebSocket = async (input: {
           continue;
         }
 
-        if (!sendJson(socket, event, eventId, ctx.dump)) {
+        if (!sendResponsesEvent(socket, event, eventId, ctx.dump)) {
           stopForDownstream();
           return;
         }
@@ -460,11 +461,11 @@ const observeResponsesWebSocketFrames = async function* (
 };
 
 type WsFrameRaceResult =
-  | { type: 'frame'; result: IteratorResult<ProtocolFrame<ResponsesStreamEvent>> }
+  | { type: 'frame'; result: IteratorResult<ProtocolFrame<ClientResponsesStreamEvent>> }
   | { type: 'next-error'; error: unknown }
   | { type: 'keep-alive' };
 
-const pendingWsFrameResult = (pendingNext: Promise<IteratorResult<ProtocolFrame<ResponsesStreamEvent>>>): Promise<WsFrameRaceResult> =>
+const pendingWsFrameResult = (pendingNext: Promise<IteratorResult<ProtocolFrame<ClientResponsesStreamEvent>>>): Promise<WsFrameRaceResult> =>
   pendingNext.then(
     (result): WsFrameRaceResult => ({ type: 'frame', result }),
     (error): WsFrameRaceResult => ({ type: 'next-error', error }),
@@ -548,6 +549,19 @@ const sendError = (
 ): void => {
   sendJson(socket, { type: 'error', status, error }, eventId, dump);
 };
+
+// A turn's own frames go out through this entry, which accepts only a stream
+// event whose response resource has already passed the client-facing egress
+// stage. The frames Floway synthesizes for the transport itself — the error
+// envelope, the keep-alive, and the `response.done` summary, which projects a
+// couple of fields off the completed resource rather than carrying it — are not
+// protocol stream events and keep the untyped `sendJson`.
+const sendResponsesEvent = (
+  socket: ResponsesWebSocketSocket,
+  event: ClientResponsesStreamEvent,
+  eventId?: string,
+  dump?: DumpAccumulator | null,
+): boolean => sendJson(socket, event, eventId, dump);
 
 const sendJson = (
   socket: ResponsesWebSocketSocket,

--- a/packages/protocols/src/responses/client-resource.ts
+++ b/packages/protocols/src/responses/client-resource.ts
@@ -1,0 +1,109 @@
+import type { ResponsesFunctionTool, ResponsesResult, ResponsesStreamEvent, ResponsesTool } from './index.ts';
+
+// The shape a client-facing Responses body must have, derived from
+// `ResponsesResult` rather than restated beside it. `ResponsesResult` models
+// four things at once — what an arbitrary upstream sent, what a translator
+// assembles mid-stream, what reaches a client, and (under
+// `object: 'response.compaction'`) a different resource entirely — so its
+// resource keys are optional. Only the client-facing role has to satisfy
+// `ResponseResource.required`, and only at the last stage before
+// serialization.
+//
+// Deriving means the two cannot drift: a field added to `ResponsesResult`
+// widens these types automatically. The only hand-maintained artefacts are the
+// two key unions below, which transcribe the schema and change when it does.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+//
+// `ResponseResource.required` lists 31 keys. Seven of them (`id`, `object`,
+// `model`, `output`, `status`, `error`, `incomplete_details`) are already
+// non-optional on `ResponsesResult`. The remaining 24 are split below by the
+// single bit that decides how an absent value may be spelled on the wire:
+// whether the slot carries a `null` alternative.
+
+// Required with no `null` alternative: absence has no spelling at all, so a
+// value must be stated.
+type ResponseResourceStatedKey =
+  | 'created_at'
+  | 'tools'
+  | 'tool_choice'
+  | 'truncation'
+  | 'parallel_tool_calls'
+  | 'text'
+  | 'top_p'
+  | 'presence_penalty'
+  | 'frequency_penalty'
+  | 'top_logprobs'
+  | 'temperature'
+  | 'store'
+  | 'background'
+  | 'service_tier'
+  | 'metadata';
+
+// Required with a `null` alternative: `null` IS the schema's spelling for
+// absence, so nothing has to be invented — only present.
+type ResponseResourceNullableKey =
+  | 'completed_at'
+  | 'previous_response_id'
+  | 'instructions'
+  | 'reasoning'
+  | 'usage'
+  | 'max_output_tokens'
+  | 'max_tool_calls'
+  | 'safety_identifier'
+  | 'prompt_cache_key';
+
+// `Usage` requires both breakdowns whenever it is an object.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2384-L2429
+type ResponsesUsage = NonNullable<ResponsesResult['usage']>;
+export type ClientResponsesUsage =
+  Omit<ResponsesUsage, 'input_tokens_details' | 'output_tokens_details'>
+  & Required<Pick<ResponsesUsage, 'input_tokens_details' | 'output_tokens_details'>>;
+
+// `TextField` requires `format`.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2298-L2319
+type ResponsesTextField = NonNullable<ResponsesResult['text']>;
+export type ClientResponsesTextField = ResponsesTextField & Required<Pick<ResponsesTextField, 'format'>>;
+
+// `Reasoning` requires `effort` and `summary`.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2320-L2359
+type ResponsesReasoning = NonNullable<ResponsesResult['reasoning']>;
+export type ClientResponsesReasoning = ResponsesReasoning & Required<Pick<ResponsesReasoning, 'effort' | 'summary'>>;
+
+// `FunctionTool` requires `description`, `parameters` and `strict` on the
+// response side while the request side leaves all three optional. Distributive
+// so every other member of the tool union passes through unchanged and the
+// union stays discriminable on `type`.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2141-L2192
+export type ClientResponsesTool =
+  ResponsesTool extends infer Tool
+    ? Tool extends { type: 'function' }
+      ? Tool & Required<Pick<ResponsesFunctionTool, 'description' | 'parameters' | 'strict'>>
+      : Tool
+    : never;
+
+// Named for the schema's own `ResponseResource`, hence the singular `Response`
+// where the protocol-shaped siblings above carry `Responses`.
+//
+// `-?` preserves declared nullability, which is exactly the distinction the two
+// key unions draw: a stated key wrapped in `NonNullable` becomes present and
+// non-null, a nullable key becomes present and possibly null.
+export type ClientResponseResource =
+  Omit<ResponsesResult, ResponseResourceStatedKey | ResponseResourceNullableKey>
+  & { [K in ResponseResourceStatedKey]-?: NonNullable<ResponsesResult[K]> }
+  & { [K in ResponseResourceNullableKey]-?: ResponsesResult[K] | null }
+  & {
+    tools: ClientResponsesTool[];
+    text: ClientResponsesTextField;
+    reasoning: ClientResponsesReasoning | null;
+    usage: ClientResponsesUsage | null;
+  };
+
+// Every resource-bearing member of the stream union, re-declared with the
+// completed resource. Distributive so each member keeps its `type` literal.
+// A `response.*` event added to `ResponsesStreamEvent` is narrowed
+// automatically.
+type WithClientResource<Event> = Event extends { response: ResponsesResult }
+  ? Omit<Event, 'response'> & { response: ClientResponseResource }
+  : Event;
+
+export type ClientResponsesStreamEvent = WithClientResource<ResponsesStreamEvent>;

--- a/packages/protocols/src/responses/index.ts
+++ b/packages/protocols/src/responses/index.ts
@@ -58,6 +58,26 @@ export interface ResponsesPayload {
   prompt_cache_retention?: ResponsesPromptCacheRetention | null;
   safety_identifier?: string | null;
   service_tier?: 'default' | 'auto' | 'flex' | 'priority' | 'scale' | (string & {}) | null;
+  // Request knobs Floway itself never acts on. On a Responses-native target
+  // they ride to the upstream in the forwarded body and come back echoed; no
+  // translate pair carries them, so on a translated target the client-facing
+  // echo can only come from the request. Declaring them keeps that echo honest
+  // instead of hard-coding the spec default for a client that sent its own
+  // value.
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L35856-L35873
+  truncation?: 'auto' | 'disabled' | (string & {}) | null;
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L59062-L59068
+  background?: boolean | null;
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L44064-L44080
+  top_logprobs?: number | null;
+  // Chat Completions sampling penalties. OpenAI's Responses request schema
+  // does not carry them, but the OpenResponses request and response schemas
+  // both do, so a client may send them and expects them echoed.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L32766-L32771
+  presence_penalty?: number | null;
+  // https://github.com/openai/openai-openapi/blob/db14b6e1712aaf5265cf5a6871adff7a9c61d31c/openapi.yaml#L32752-L32757
+  frequency_penalty?: number | null;
 }
 
 export type ResponsesInputItem =
@@ -867,6 +887,51 @@ export interface ResponsesResult {
     input_tokens_details?: { cached_tokens: number; cache_write_tokens?: number };
     output_tokens_details?: { reasoning_tokens: number };
   } | null;
+  // ── Further fields the response resource declares required ──
+  //
+  // Every key below is listed in `ResponseResource.required` — as are `tools`,
+  // `tool_choice`, `usage` and `service_tier` above — so a spec-conforming
+  // client-facing body must carry all of them:
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2691-L2723
+  // They stay optional here because this interface also models what an
+  // arbitrary upstream sends and what a translator assembles mid-stream.
+  // Presence on the client-facing body is carried by `ClientResponseResource`
+  // in `./client-resource.ts`, which derives from this interface rather than
+  // restating it.
+  //
+  // Unix seconds, not milliseconds.
+  created_at?: number;
+  // Null until the response reaches a terminal status.
+  completed_at?: number | null;
+  previous_response_id?: string | null;
+  instructions?: string | null;
+  truncation?: 'auto' | 'disabled' | (string & {}) | null;
+  parallel_tool_calls?: boolean;
+  text?: { format?: Record<string, unknown> | null; verbosity?: string | null } | null;
+  top_p?: number | null;
+  presence_penalty?: number | null;
+  frequency_penalty?: number | null;
+  top_logprobs?: number | null;
+  temperature?: number | null;
+  // `effort` and `summary` are themselves required whenever `reasoning` is an
+  // object; other keys upstreams add (`context`, `mode`) ride along untouched.
+  // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L2320-L2359
+  reasoning?: {
+    effort?: string | null;
+    summary?: 'detailed' | 'auto' | 'concise' | (string & {}) | null;
+    context?: 'auto' | 'current_turn' | 'all_turns' | (string & {}) | null;
+    [key: string]: unknown;
+  } | null;
+  max_output_tokens?: number | null;
+  max_tool_calls?: number | null;
+  // Whether the response was stored so it can be retrieved later — the wording
+  // of the schema's own description, which is why the gateway answers it from
+  // its store rather than from the request's `store` flag.
+  store?: boolean;
+  background?: boolean;
+  metadata?: Record<string, unknown> | null;
+  safety_identifier?: string | null;
+  prompt_cache_key?: string | null;
 }
 
 // Stored/output additional-tools roles are wider than the input-only
@@ -1302,6 +1367,14 @@ export { imageGenerationCallLifecycleEvents } from './image-generation-lifecycle
 export { webSearchCallLifecycleEvents } from './web-search-lifecycle.ts';
 export { parseResponsesStream, type ParseResponsesStreamOptions } from './stream.ts';
 
+export type {
+  ClientResponseResource,
+  ClientResponsesReasoning,
+  ClientResponsesStreamEvent,
+  ClientResponsesTextField,
+  ClientResponsesTool,
+  ClientResponsesUsage,
+} from './client-resource.ts';
 export { RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from './to-result.ts';
 export { createRandomResponsesItemId, type GeneratedResponsesItemType } from './item-id.ts';
 export { reassembleResponsesEvents } from './reassemble.ts';

--- a/packages/protocols/src/responses/to-result.ts
+++ b/packages/protocols/src/responses/to-result.ts
@@ -1,10 +1,19 @@
+import type { ClientResponseResource, ClientResponsesStreamEvent } from './client-resource.ts';
 import { isResponsesTerminalEvent, type ResponsesResult, type ResponsesStreamEvent } from './index.ts';
 import { reassembleResponsesEvents } from './reassemble.ts';
 import { type ProtocolFrame } from '../common/index.ts';
 
 export const RESPONSES_MISSING_TERMINAL_MESSAGE = 'Responses stream ended without a terminal event.';
 
-export const collectResponsesProtocolEventsToResult = async (frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesResult> => {
+// Reassembly copies each response object through, so a stream whose frames
+// already carry the completed client resource collects into a completed
+// resource. The narrow signature comes first so overload resolution picks it
+// exactly when the argument is narrow — `ClientResponsesStreamEvent` is
+// assignable to `ResponsesStreamEvent`, so the wide signature would otherwise
+// swallow both calls and widen the completed result back to `ResponsesResult`.
+export function collectResponsesProtocolEventsToResult(frames: AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>>): Promise<ClientResponseResource>;
+export function collectResponsesProtocolEventsToResult(frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesResult>;
+export async function collectResponsesProtocolEventsToResult(frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>): Promise<ResponsesResult> {
   const events = async function* (): AsyncGenerator<ResponsesStreamEvent> {
     for await (const frame of frames) {
       if (frame.type === 'done') continue;
@@ -17,4 +26,4 @@ export const collectResponsesProtocolEventsToResult = async (frames: AsyncIterab
   };
 
   return await reassembleResponsesEvents(events());
-};
+}


### PR DESCRIPTION
## The defect

`POST /responses` did not return a spec-conformant response resource on any path. On the two translated paths the body carried only `id`, `object`, `model`, `output`, `output_text`, `status`, `error`, `incomplete_details` and `usage` — `ResponseResource.required` lists **31 keys**, so twenty-two were missing, plus `usage.output_tokens_details`. The native path was otherwise complete but never carried `prompt_cache_key`. The same gap appeared inside the resource carried by **every streaming `response.*` event**, not only the non-streaming body. A client validating against the schema therefore rejected bodies Floway had just produced.

## The seam

Completion happens at the one seam all three paths already converge on: `wrapNativeResponsesClientOutput`, the client-facing egress wrapper, called from the HTTP, WebSocket and non-streaming entries. It runs immediately before serialization, outermost of affinity egress and item persistence.

It cannot live in the translators. A translator has no access to the request, no `created_at` (which must be the gateway's request-start instant, not `Date.now()` inside a codec), and no knowledge of whether the response is actually retrievable. More fundamentally its output is *interior*: it feeds the server-tool shim, affinity egress and the item store, and it re-enters `responses.result()` on a stitched multi-call turn, so a value invented there would be indistinguishable from an observed one for every later reader.

`response-resource.ts` opens with the policy boundary it observes:

> Interior stages never state a value they did not observe. The egress stage is the only place Floway states one, and only where the wire schema forbids both omission and `null`.

That boundary is what reconciles this change with the absent-echo rule the server-tool shim shipped in `44322150d` (#125), and with `upstreamResponseSnapshot` throwing rather than fabricating. The two rules answer different questions: the shim's snapshot re-enters Floway, while this stage's output is serialized and never read again. Item persistence, affinity egress and billing all run underneath it; the only readers above it read `status`, which rides through from the upstream and is never stated here.

## One semantic, selected by one schema bit

The merge has a single semantic, chosen per key by whether the required slot admits `null`:

- `stated(candidates, fallback)` — no `null` alternative, so `null` and `undefined` both mean absent and a stated default terminates the chain.
- `observed(candidates)` — `null` *is* the schema's spelling for absence, so `null` is an observation and only `undefined` continues.

The upstream is first in every candidate chain, so any value an upstream reports — including one no schema publishes — survives untouched. The request answers only what the upstream did not; a stated default applies only when neither said anything. That order follows the resource's own authority: every description on these keys is past tense ("the tools that **were available** to the model during response generation", "the service tier that **was used**"). Each stated default carries a reference URL to the spec declaration it comes from.

Total normalizers (`completeTool`, `completeText`, `completeReasoning`, `completeUsage`) run on the **resolved** value rather than on one branch, which is what keeps an upstream-echoed or shim-reconstructed `tools` array completed identically to one built from the request.

`created_at`, `store` and `completed_at` come from gateway state, because no other source can know them: `store` reports whether the response is genuinely retrievable (the item store's `writesState`, not the request's `store` flag), and `completed_at` is the gateway's own completion instant, since one client turn can span several upstream calls behind the server-tool runtime.

## The type carries the guarantee

`ClientResponseResource` and `ClientResponsesStreamEvent` are **derived** from `ResponsesResult` and `ResponsesStreamEvent` — a mapped type with `-?` plus a distributive conditional — rather than hand-written twins, so they cannot drift, and every existing consumer of the wide types compiles untouched. The narrowed yield type then propagates: a stage inserted between this one and a client-facing exit either preserves completeness or fails to compile.

Three signature consequences:

1. `collectResponsesProtocolEventsToResult` gains a **narrow-first overload**, because `ClientResponsesStreamEvent` is assignable to `ResponsesStreamEvent` and a lone wide signature would widen the completed result back at the narrow call sites.
2. `respondResponses` takes the originating request payload; the pre-stream failure branches move to `respondResponsesFailure`, which the error-only entries call directly.
3. The WebSocket turn's frames go out through `sendResponsesEvent`, which accepts only a completed event; the transport's own `error`, keep-alive and `response.done` frames stay on the untyped `sendJson`.

## Files

`packages/protocols/src/responses/client-resource.ts` (new), `responses/index.ts`, `responses/to-result.ts`; `packages/gateway/src/data-plane/chat/responses/{response-resource.ts (new),client-output.ts,errors.ts,http.ts,respond.ts,serve.ts,websocket.ts}`, with `response-resource_test.ts`, the shared `test-required-resource-keys.ts` key list, and additions to `errors_test.ts`, `http_test.ts` and `websocket_test.ts`.

## Test Plan

- [x] `pnpm run typecheck` — exit 0 (at `c1ca779a6`)
- [x] `pnpm run lint` — exit 0 (at `c1ca779a6`)
- [x] `pnpm run test` — exit 0, 422 test files passed, no failures (at `c1ca779a6`)
- [ ] Live conformance sweep against real upstreams on all three Responses paths (native, via Chat Completions, via Messages) — requires provider credentials and billable upstream calls, so not rerun at this tip
