### PR TITLE
fix(responses): keep an idle WebSocket turn alive with a spec extension event

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -384,11 +384,11 @@ test('Responses WebSocket keep-alive waits for the first event and takes a slot 
   // cannot yield to.
   const realSetTimeout = globalThis.setTimeout;
   const time = new FakeTime();
-  // Registered as a test hook rather than run from a `finally`: the body below
-  // drives a socket whose frames arrive on the fake clock, and an assertion
-  // that never gets its frame would leave the body suspended, so a `finally`
-  // would never run and every later test in the file would inherit the fake
-  // clock.
+  // Registered as a test hook rather than run from a `finally`: the
+  // `upstreamReadStarted` await below is unbounded, so a turn that never
+  // reaches the upstream body suspends the body forever, and a `finally` that
+  // never runs would leave the fake clock installed for every later test in
+  // the file.
   onTestFinished(() => time.restore());
   const encoder = new TextEncoder();
   const reasoning = {

--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -1,9 +1,10 @@
 import type { ExecutionContext } from 'hono';
-import { test, vi } from 'vitest';
+import { onTestFinished, test, vi } from 'vitest';
 
 import { app } from '../../../../src/app.ts';
 import { hashResponsesItem } from '../../../../src/data-plane/chat/responses/items/identity.ts';
 import { responsesServe } from '../../../../src/data-plane/chat/responses/serve.ts';
+import { KEEP_ALIVE_EVENT_TYPE } from '../../../../src/data-plane/chat/responses/websocket.ts';
 import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS } from '../../../../src/data-plane/shared/sse.ts';
 import { initDumpBroker, initDumpStore } from '../../../../src/dump/registry.ts';
 import { installDumpStubs } from '../../../dump/test-fixtures.ts';
@@ -376,10 +377,26 @@ test('Responses WebSocket reports a failed turn when an output item cannot be pe
   }
 });
 
-test('Responses WebSocket keepalive during an in-flight request does not drop the pending upstream frame', async () => {
+test('Responses WebSocket keep-alive waits for the first event and takes a slot in the stream sequence', async () => {
   const { apiKey } = await setupAppTest();
+  // Captured before the clock is faked: the turn's frames cross real event-loop
+  // turns (upstream body reads, item persistence), which a faked `setTimeout`
+  // cannot yield to.
+  const realSetTimeout = globalThis.setTimeout;
   const time = new FakeTime();
+  // Registered as a test hook rather than run from a `finally`: the body below
+  // drives a socket whose frames arrive on the fake clock, and an assertion
+  // that never gets its frame would leave the body suspended, so a `finally`
+  // would never run and every later test in the file would inherit the fake
+  // clock.
+  onTestFinished(() => time.restore());
   const encoder = new TextEncoder();
+  const reasoning = {
+    type: 'reasoning' as const,
+    id: 'rs_keepalive',
+    summary: [],
+    encrypted_content: 'opaque',
+  };
   let upstreamController!: ReadableStreamDefaultController<Uint8Array>;
   let resolveUpstreamReadStarted!: () => void;
   const upstreamReadStarted = new Promise<void>(resolve => {
@@ -395,89 +412,117 @@ test('Responses WebSocket keepalive during an in-flight request does not drop th
   const enqueueSseEvent = (event: string, data: unknown): void => {
     upstreamController.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
   };
-  const hasMessageType = (messages: readonly Record<string, unknown>[], type: string): boolean =>
-    messages.some(message => message.type === type);
+  // Every wait below is bounded by a turn count, not by a clock: a frame that
+  // never comes fails an assertion instead of suspending the test body, which
+  // under a fake clock would hang until the runner's timeout and leave the
+  // fake clock installed for every test after it.
+  const drainFramesUntil = async (settled: () => boolean): Promise<boolean> => {
+    for (let i = 0; i < 200 && !settled(); i++) {
+      await new Promise<void>(resolve => { realSetTimeout(resolve, 0); });
+      await time.tickAsync(0);
+    }
+    return settled();
+  };
+  const tickKeepAliveIntervals = async (count: number): Promise<void> => {
+    for (let i = 0; i < count; i++) {
+      await waitForMicrotasks();
+      await time.tickAsync(DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS);
+    }
+  };
 
-  try {
-    await withMockedFetch(
-      async request => {
-        const url = new URL(request.url);
-        if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
-        if (url.pathname === '/copilot_internal/v2/token') {
-          return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
-        }
-        if (url.pathname === '/models') {
-          return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
-        }
-        if (url.pathname === '/responses') {
-          return new Response(new ReadableStream<Uint8Array>({
-            start(controller) {
-              upstreamController = controller;
-            },
-            pull() {
-              resolveReadStartedOnce();
-            },
-          }), {
-            headers: { 'content-type': 'text/event-stream' },
-          });
-        }
-        throw new Error(`Unhandled fetch ${request.url}`);
-      },
-      async () => await withWorkerWebSocketRuntime(async () => {
-        const client = await connectResponsesWebSocket(apiKey.key);
-        const messages: Record<string, unknown>[] = [];
-        const onMessage = (event: Event): void => {
-          messages.push(JSON.parse((event as MessageEvent<string>).data) as Record<string, unknown>);
-        };
-        client.addEventListener('message', onMessage);
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        return new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            upstreamController = controller;
+          },
+          pull() {
+            resolveReadStartedOnce();
+          },
+        }), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const client = await connectResponsesWebSocket(apiKey.key);
+      const messages: Record<string, unknown>[] = [];
+      const onMessage = (event: Event): void => {
+        messages.push(JSON.parse((event as MessageEvent<string>).data) as Record<string, unknown>);
+      };
+      client.addEventListener('message', onMessage);
 
-        try {
-          client.send(JSON.stringify({
-            type: 'response.create',
-            event_id: 'evt_keepalive',
-            response: {
-              model: 'gpt-direct-responses',
-              input: 'hello',
-            },
-          }));
-
-          await upstreamReadStarted;
-          for (let i = 0; i < 4 && !hasMessageType(messages, 'ping'); i++) {
-            await waitForMicrotasks();
-            await time.tickAsync(DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS);
-          }
-
-          assert(hasMessageType(messages, 'ping'), 'expected a ping while the upstream response stream is idle');
-          const completed = waitForMessages(client, received => received.some(isTerminalResponseEvent));
-
-          const response = {
-            id: 'resp_ws_keepalive',
-            object: 'response',
+      try {
+        client.send(JSON.stringify({
+          type: 'response.create',
+          event_id: 'evt_keepalive',
+          response: {
             model: 'gpt-direct-responses',
-            status: 'completed',
-            output: [],
-            output_text: 'done',
-          };
-          const inProgress = { ...response, status: 'in_progress', output: [], output_text: '' };
-          enqueueSseEvent('response.created', { type: 'response.created', response: inProgress, sequence_number: 0 });
-          enqueueSseEvent('response.in_progress', { type: 'response.in_progress', response: inProgress, sequence_number: 1 });
-          enqueueSseEvent('response.completed', { type: 'response.completed', response, sequence_number: 2 });
-          upstreamController.enqueue(encoder.encode('data: [DONE]\n\n'));
-          upstreamController.close();
+            input: 'hello',
+          },
+        }));
 
-          await completed;
+        await upstreamReadStarted;
 
-          const types = messages.map(message => message.type);
-          assert(types.indexOf('ping') < types.indexOf('response.created'), 'expected the delayed upstream frame after the ping');
-          assertEquals(types.at(-1), 'response.completed');
-        } finally {
-          client.removeEventListener('message', onMessage);
-        }
-      }),
-    );
-  } finally {
-    time.restore();
-  }
+        await tickKeepAliveIntervals(4);
+        assertEquals(messages, [], 'expected no keep-alive before the turn sent its first event');
+
+        const response = {
+          id: 'resp_ws_keepalive',
+          object: 'response',
+          model: 'gpt-direct-responses',
+          status: 'completed',
+          output: [reasoning],
+          output_text: 'done',
+        };
+        const inProgress = { ...response, status: 'in_progress', output: [], output_text: '' };
+        enqueueSseEvent('response.created', { type: 'response.created', response: inProgress, sequence_number: 0 });
+        assert(
+          await drainFramesUntil(() => messages.length >= 1),
+          `expected the turn to open, got ${JSON.stringify(messages)}`,
+        );
+        assertEquals(
+          messages.map(message => message.type),
+          ['response.created'],
+          'expected the turn to open before any keep-alive',
+        );
+
+        await tickKeepAliveIntervals(1);
+
+        enqueueSseEvent('response.output_item.done', { type: 'response.output_item.done', output_index: 0, item: reasoning, sequence_number: 1 });
+        enqueueSseEvent('response.completed', { type: 'response.completed', response, sequence_number: 2 });
+        upstreamController.enqueue(encoder.encode('data: [DONE]\n\n'));
+        upstreamController.close();
+        assert(
+          await drainFramesUntil(() => messages.some(isTerminalResponseEvent)),
+          `expected the turn to reach its terminal event, got ${JSON.stringify(messages)}`,
+        );
+
+        assertEquals(
+          messages.map(message => [message.type, message.sequence_number]),
+          [
+            ['response.created', 0],
+            [KEEP_ALIVE_EVENT_TYPE, 1],
+            ['response.output_item.done', 2],
+            ['response.completed', 3],
+          ],
+          'expected the keep-alive to take a slot and shift every later event past it',
+        );
+      } finally {
+        client.removeEventListener('message', onMessage);
+      }
+    }),
+  );
 });
 
 test('Responses WebSocket returns OpenAI-style error envelopes for unsupported client events', async () => {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -382,17 +382,34 @@ const respondResponsesWebSocket = async (input: {
         if (next.type === 'keep-alive') {
           // Extended reasoning turns go completely silent: upstream sends SSE
           // `ping` events, `parseResponsesStream` drops them, and no frame at
-          // all reaches this socket for minutes. A silent Workers WebSocket is
-          // torn down — a raw probe against a Cloudflare-proxied endpoint died
-          // at TCP level around 125 s with no close frame and no
-          // edge-originated ping, and a Worker cannot answer with one of its
-          // own: workerd's `WebSocket` exposes only
-          // accept/send/close/(de)serializeAttachment, and the kj layer beneath
-          // states the omission as a design decision ("Ping/Pong … are not
-          // exposed through this interface"). RFC 6455 §5.5.2 is the right
-          // mechanism and it is unreachable here; it would also not help the
-          // client that needs it most, since Codex's frame pump swallows
-          // control frames and only a text frame rearms its 300 s idle timeout.
+          // all reaches this socket for minutes. A silent Workers WebSocket
+          // does not reliably survive that. Cloudflare states the
+          // teardown without naming a duration — "when no data is transmitted
+          // in either direction for a period of time" — and probing a
+          // `workers.dev` endpoint built on this handler's own `WebSocketPair`
+          // shape found no constant to design against: from one vantage point
+          // an idle socket lived a full hour, 4/4, while from another 13 of 16
+          // idle sockets died between 215.8 s and 1788.2 s, median around
+          // 660 s. Teardown is path-dependent and stochastic, and it is always
+          // a silent EOF — across roughly 40 observed teardowns, not one CLOSE
+          // frame and not one RST, so the failure carries no protocol-level
+          // signal.
+          // https://developers.cloudflare.com/network/websockets/#idle-timeout
+          //
+          // Cloudflare's stated remedy, a client-side ping/pong heartbeat,
+          // does not cover it: on the path that drops, 6 of 9 sockets pinging
+          // every 30 s died anyway, one of them after 61.5 s. A
+          // server-originated text frame did cover it — 12/12 survived on that
+          // same path, with ≤400 s intervals holding and ≥500 s failing. Why a
+          // data frame outlives a protocol ping there was not established.
+          // Sending a ping is not open to us regardless: workerd's `WebSocket`
+          // exposes only accept/send/close/(de)serializeAttachment, and the kj
+          // layer beneath states the omission as a design decision ("Ping/Pong
+          // … are not exposed through this interface"). RFC 6455 §5.5.2 is the
+          // right mechanism, it is unreachable here, and it would not help the
+          // client that needs it most either, since Codex's frame pump
+          // swallows control frames and only a text frame rearms its 300 s
+          // idle timeout.
           // https://github.com/cloudflare/workerd/blob/26b5461b7dcc640bb16072f1ba6f2c6df82572ba/src/workerd/api/web-socket.h#L346-L394
           // https://github.com/capnproto/capnproto/blob/e9fa5c7dc98192fc0dc0098ec770db68f997a938/c%2B%2B/src/kj/compat/http.h#L622-L631
           //
@@ -524,6 +541,12 @@ const pendingWsFrameResult = (pendingNext: Promise<IteratorResult<ProtocolFrame<
     (error): WsFrameRaceResult => ({ type: 'next-error', error }),
   );
 
+// The interval is the one already shared with SSE rather than a WebSocket
+// constant of its own. Probing showed intervals up to 400 s still holding a
+// dropping path open, so 15 s is far more frequent than the mechanism needs;
+// it is kept because there is nothing to buy by widening it. A keep-alive is
+// ~70 bytes, and the observed teardowns had a low tail at 61.5 s, against
+// which any interval chosen for economy would have no margin left.
 const nextFrameOrKeepAlive = async (pendingFrame: Promise<WsFrameRaceResult>): Promise<WsFrameRaceResult> => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const keepAlive = new Promise<WsFrameRaceResult>(resolve => {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -35,11 +35,14 @@ interface ResponsesWebSocketSocket {
 const UTF8_ENCODER = new TextEncoder();
 
 // Our implementor slug prefixes the keep-alive's wire type; the spec reserves
-// every unprefixed type for itself. The frame carries nothing beyond `type`
-// and `sequence_number`: a top-level `error` key in particular would be fatal,
-// since openai-node raises an `APIError` on any frame carrying one whatever
-// its type.
-// https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/core/streaming.ts#L69-L70
+// every unprefixed type for itself, gives `acme:trace_event` as the form, and
+// makes `type` and `sequence_number` the only mandatory fields — which is all
+// this frame carries.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L758-L765
+// A slug type is inert in openai-node's WebSocket reader: the frame is emitted
+// under its own literal type name, nothing is listening on that name, and only
+// a frame typed `error` is routed into the socket's error path.
+// https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/resources/responses/ws-base.ts#L346-L371
 export const KEEP_ALIVE_EVENT_TYPE = 'floway:keep_alive';
 
 interface ResponsesWebSocketHandlers {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -415,6 +415,9 @@ const respondResponsesWebSocket = async (input: {
           // idle timeout.
           // https://github.com/cloudflare/workerd/blob/26b5461b7dcc640bb16072f1ba6f2c6df82572ba/src/workerd/api/web-socket.h#L346-L394
           // https://github.com/capnproto/capnproto/blob/e9fa5c7dc98192fc0dc0098ec770db68f997a938/c%2B%2B/src/kj/compat/http.h#L622-L631
+          // https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/codex-api/src/endpoint/responses_websocket.rs#L91-L101
+          // https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/codex-api/src/endpoint/responses_websocket.rs#L695-L699
+          // https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/model-provider-info/src/lib.rs#L26
           //
           // So the keep-alive is a text frame whose `type` no client
           // recognizes. The spec's extension section governs its shape: an
@@ -422,17 +425,27 @@ const respondResponsesWebSocket = async (input: {
           // neither a delta nor a state-machine event, so it cannot be spelled
           // as a `response.*` event; the slug form is what makes it ignorable
           // without loss. openai-node's SSE `responses.stream()` helper is the
-          // one client that treats a prefixed type as fatal, and it is out of
-          // reach here — Floway's SSE keep-alive is a comment line and this
-          // frame exists only on the WebSocket transport.
+          // one client that treats a prefixed type as fatal — its accumulator
+          // closes its `switch` on `assertNever` — and it is out of reach here:
+          // Floway's SSE keep-alive is a comment line, and this frame exists
+          // only on the WebSocket transport.
           // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L758
+          // https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/lib/responses/ResponseAccumulator.ts#L387-L389
           //
-          // Held back until the turn's first event has gone out. Both SDK
-          // stream helpers require `response.created` to be the very first
-          // event they see and raise on anything before it, so the window
-          // before it stays unprotected by design.
+          // Held back until the turn's first event has gone out. That gate is
+          // parity with the stricter transport, not a demand of this one: both
+          // SDKs' SSE stream helpers refuse anything before `response.created`
+          // — openai-node rejects even its own `keepalive` type there — while
+          // every WebSocket reader we can inspect tolerates an unknown type at
+          // any position, openai-node emitting it under a name nothing listens
+          // on, openai-python constructing it unchecked, and Codex tracing and
+          // discarding it. The window before the first event therefore stays
+          // unprotected, and closing it is a behavior question rather than a
+          // client-compatibility one.
           // https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/lib/responses/ResponseAccumulator.ts#L25-L31
           // https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/lib/streaming/responses/_responses.py#L369-L370
+          // https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/resources/responses/responses.py#L4493-L4502
+          // https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/codex-api/src/sse/responses.rs#L466-L472
           if (!streamed) continue;
           if (!sendJson(socket, { type: KEEP_ALIVE_EVENT_TYPE, sequence_number: sequence.take() }, eventId, ctx.dump)) {
             stopForDownstream();

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -542,11 +542,13 @@ const pendingWsFrameResult = (pendingNext: Promise<IteratorResult<ProtocolFrame<
   );
 
 // The interval is the one already shared with SSE rather than a WebSocket
-// constant of its own. Probing showed intervals up to 400 s still holding a
-// dropping path open, so 15 s is far more frequent than the mechanism needs;
-// it is kept because there is nothing to buy by widening it. A keep-alive is
-// ~70 bytes, and the observed teardowns had a low tail at 61.5 s, against
-// which any interval chosen for economy would have no margin left.
+// constant of its own. Widening the gap between server data frames on a
+// dropping path put the boundary between 400 s, which still held the socket
+// open, and 500 s, which did not, so 15 s is far more frequent than the
+// mechanism needs. It is kept because widening it buys nothing: a keep-alive
+// is ~70 bytes, and the earliest unprotected idle teardown seen on that same
+// path was 215.8 s, so an interval chosen for economy would spend a real
+// margin against a stochastic teardown to save nothing.
 const nextFrameOrKeepAlive = async (pendingFrame: Promise<WsFrameRaceResult>): Promise<WsFrameRaceResult> => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const keepAlive = new Promise<WsFrameRaceResult>(resolve => {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -34,6 +34,14 @@ interface ResponsesWebSocketSocket {
 
 const UTF8_ENCODER = new TextEncoder();
 
+// Our implementor slug prefixes the keep-alive's wire type; the spec reserves
+// every unprefixed type for itself. The frame carries nothing beyond `type`
+// and `sequence_number`: a top-level `error` key in particular would be fatal,
+// since openai-node raises an `APIError` on any frame carrying one whatever
+// its type.
+// https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/core/streaming.ts#L69-L70
+export const KEEP_ALIVE_EVENT_TYPE = 'floway:keep_alive';
+
 interface ResponsesWebSocketHandlers {
   onMessage(event: { readonly data: unknown }, socket: ResponsesWebSocketSocket): void;
   onClose(event: unknown, socket: ResponsesWebSocketSocket): void;
@@ -354,6 +362,8 @@ const respondResponsesWebSocket = async (input: {
     let pendingNext = pendingWsFrameResult(iterator.next());
     let completed = false;
     let stoppedByDownstream = false;
+    let streamed = false;
+    const sequence = createDownstreamSequence();
 
     const stopForDownstream = (): void => {
       stoppedByDownstream = true;
@@ -370,7 +380,41 @@ const respondResponsesWebSocket = async (input: {
         const next = await nextFrameOrKeepAlive(pendingNext);
 
         if (next.type === 'keep-alive') {
-          if (!sendJson(socket, { type: 'ping' }, eventId, ctx.dump)) {
+          // Extended reasoning turns go completely silent: upstream sends SSE
+          // `ping` events, `parseResponsesStream` drops them, and no frame at
+          // all reaches this socket for minutes. A silent Workers WebSocket is
+          // torn down — a raw probe against a Cloudflare-proxied endpoint died
+          // at TCP level around 125 s with no close frame and no
+          // edge-originated ping, and a Worker cannot answer with one of its
+          // own: workerd's `WebSocket` exposes only
+          // accept/send/close/(de)serializeAttachment, and the kj layer beneath
+          // states the omission as a design decision ("Ping/Pong … are not
+          // exposed through this interface"). RFC 6455 §5.5.2 is the right
+          // mechanism and it is unreachable here; it would also not help the
+          // client that needs it most, since Codex's frame pump swallows
+          // control frames and only a text frame rearms its 300 s idle timeout.
+          // https://github.com/cloudflare/workerd/blob/26b5461b7dcc640bb16072f1ba6f2c6df82572ba/src/workerd/api/web-socket.h#L346-L394
+          // https://github.com/capnproto/capnproto/blob/e9fa5c7dc98192fc0dc0098ec770db68f997a938/c%2B%2B/src/kj/compat/http.h#L622-L631
+          //
+          // So the keep-alive is a text frame whose `type` no client
+          // recognizes. The spec's extension section governs its shape: an
+          // implementor slug prefix plus a `sequence_number`. A keep-alive is
+          // neither a delta nor a state-machine event, so it cannot be spelled
+          // as a `response.*` event; the slug form is what makes it ignorable
+          // without loss. openai-node's SSE `responses.stream()` helper is the
+          // one client that treats a prefixed type as fatal, and it is out of
+          // reach here — Floway's SSE keep-alive is a comment line and this
+          // frame exists only on the WebSocket transport.
+          // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L758
+          //
+          // Held back until the turn's first event has gone out. Both SDK
+          // stream helpers require `response.created` to be the very first
+          // event they see and raise on anything before it, so the window
+          // before it stays unprotected by design.
+          // https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/lib/responses/ResponseAccumulator.ts#L25-L31
+          // https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/lib/streaming/responses/_responses.py#L369-L370
+          if (!streamed) continue;
+          if (!sendJson(socket, { type: KEEP_ALIVE_EVENT_TYPE, sequence_number: sequence.take() }, eventId, ctx.dump)) {
             stopForDownstream();
             return;
           }
@@ -410,10 +454,11 @@ const respondResponsesWebSocket = async (input: {
           continue;
         }
 
-        if (!sendResponsesEvent(socket, event, eventId, ctx.dump)) {
+        if (!sendResponsesEvent(socket, sequence.renumber(event), eventId, ctx.dump)) {
           stopForDownstream();
           return;
         }
+        streamed = true;
       }
     } finally {
       if (!completed) {
@@ -426,7 +471,10 @@ const respondResponsesWebSocket = async (input: {
     if (terminalEvent === undefined) {
       throw new Error(RESPONSES_MISSING_TERMINAL_MESSAGE);
     }
-    if (!sendResponsesEvent(socket, terminalEvent, eventId, ctx.dump)) {
+    // Renumbered here rather than where it was buffered: keep-alives can still
+    // fire while the generator drains behind the terminal event, and each of
+    // those takes a slot that has to land before the terminal event's own.
+    if (!sendResponsesEvent(socket, sequence.renumber(terminalEvent), eventId, ctx.dump)) {
       completion = 'cancel';
       return;
     }
@@ -486,6 +534,41 @@ const nextFrameOrKeepAlive = async (pendingFrame: Promise<WsFrameRaceResult>): P
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId);
   }
+};
+
+interface DownstreamSequence {
+  renumber(event: ClientResponsesStreamEvent): ClientResponsesStreamEvent;
+  take(): number;
+}
+
+// A WebSocket turn shares one sequence space with the streaming-HTTP events it
+// carries, so a keep-alive cannot sit outside that numbering: it takes a real
+// slot and every later event is shifted past it. The number is always present
+// and always numeric, because a resuming openai-python client compares it with
+// `>` against its `starting_after` cursor and `None` there raises a TypeError.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L117
+// https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/lib/streaming/responses/_responses.py#L59
+//
+// Upstream numbering is left untouched until the first keep-alive, and a
+// keep-alive can only follow an event that already went out, so the slot it
+// takes is always known.
+const createDownstreamSequence = (): DownstreamSequence => {
+  let shift = 0;
+  let next = 0;
+  return {
+    renumber: event => {
+      if (event.sequence_number === undefined) return event;
+      const sequenceNumber = event.sequence_number + shift;
+      next = sequenceNumber + 1;
+      return { ...event, sequence_number: sequenceNumber };
+    },
+    take: () => {
+      shift += 1;
+      const taken = next;
+      next += 1;
+      return taken;
+    },
+  };
 };
 
 const parseMaybeJson = (body: Uint8Array, headers: Headers): unknown => {
@@ -552,8 +635,11 @@ const sendError = (
 // A turn's own frames go out through this entry, which accepts only a stream
 // event whose response resource has already passed the client-facing egress
 // stage. The two frames Floway synthesizes for the transport itself — the
-// `error` envelope and the `ping` keep-alive — carry no response resource at
-// all and are not protocol stream events, so they keep the untyped `sendJson`.
+// `error` envelope and the `floway:keep_alive` keep-alive — carry no response
+// resource at all, and neither belongs to the stream-event union: the error
+// envelope is not a streaming event, and the keep-alive is a slug-prefixed
+// extension the union deliberately does not model. Both keep the untyped
+// `sendJson`.
 const sendResponsesEvent = (
   socket: ResponsesWebSocketSocket,
   event: ClientResponsesStreamEvent,


### PR DESCRIPTION
While a Responses turn reasons, the upstream emits SSE `ping` events, `parseResponsesStream` filters them out, and the WebSocket carries nothing at all — for minutes. This PR keeps that silence from killing the connection, with a frame whose shape a validating client can accept.

## What the edge actually does to a silent socket

Cloudflare documents the teardown without a duration — "Cloudflare will close a WebSocket connection when no data is transmitted in either direction for a period of time" ([Idle timeout](https://developers.cloudflare.com/network/websockets/#idle-timeout)) — and a probe Worker using this handler's own `WebSocketPair` shape on `*.workers.dev`, driven from three vantage points with every trial repeated at least three times, found no constant behind that sentence:

- From one vantage point (IPv6, NRT colo) a fully idle connection survived 3600 s, 4/4 — no teardown at all.
- From another (IPv4, SJC colo) teardown was stochastic: 13 of 16 idle connections died, spread between 215.8 s and 1788.2 s with a median around 660 s. That is a wide, non-repeatable distribution, not a timer.
- A third vantage point died around 990 s, but that one is local rather than Cloudflare: a non-Cloudflare control server on the same runs died at 991.4 s, so something on that machine's path drops idle flows regardless of destination.

Two further results decide the design:

- **A client-originated protocol ping does not reliably protect the connection.** On the path that actually drops, 6 of 9 ping trials still died — one at 61.5 s while pinging every 30 s. Cloudflare's own stated remedy, "implement a client-side heartbeat (ping/pong) mechanism", is insufficient there.
- **A server-originated data frame does.** 12/12 survived on that same path, and the largest interval that still worked was ≤400 s (≥500 s did not). The mechanism behind that asymmetry was not established.

Every teardown observed was a silent EOF: across roughly 40 of them, zero WebSocket CLOSE frames and zero RSTs. The failure carries no protocol-level signal at all, so nothing downstream can react to it.

These numbers come from three vantage points against one probe Worker. They establish that there is no fixed idle constant to design against and that on a dropping path data frames beat pings; they are not a universal Cloudflare rule.

## Why not a protocol ping

RFC 6455 §5.5.2 is the right mechanism and it is unreachable here. workerd's `WebSocket` exposes only `accept`/`send`/`close`/`serializeAttachment`/`deserializeAttachment` ([web-socket.h L346-L394](https://github.com/cloudflare/workerd/blob/26b5461b7dcc640bb16072f1ba6f2c6df82572ba/src/workerd/api/web-socket.h#L346-L394)), and kj states the omission as a design decision ([http.h L622-L631](https://github.com/capnproto/capnproto/blob/e9fa5c7dc98192fc0dc0098ec770db68f997a938/c%2B%2B/src/kj/compat/http.h#L622-L631)).

Nor would delegating the heartbeat to the client work. Pinging is what was measured to fail on the dropping path, and it would not rearm the client that needs it most: Codex's frame pump answers `Message::Ping` inside the pump and drops `Message::Pong`, so neither ever reaches the channel its `tokio::time::timeout` races ([responses_websocket.rs L91-L101](https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/codex-api/src/endpoint/responses_websocket.rs#L91-L101)). Only a text frame rearms its 300 s `DEFAULT_STREAM_IDLE_TIMEOUT_MS` ([model-provider-info L26](https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/model-provider-info/src/lib.rs#L26)).

Codex also does not degrade quietly when the socket dies. `force_http_fallback` is session-wide and sticky, but it is armed only by an HTTP 426 or by exhausting `DEFAULT_STREAM_MAX_RETRIES = 5` ([client.rs L521-L540](https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/core/src/client.rs#L521-L540)). A killed socket therefore produces a retry storm ending in a failed turn, not a quiet downgrade to HTTP.

## The frame

`{"type":"ping"}` belongs to no Responses streaming-event union, so any client that validates its stream cannot accept it. The spec's answer is its extension section: a non-standard streaming event MUST be slug-prefixed, and `type` and `sequence_number` are the only mandatory fields ([2026-04-24.mdx L758-L765](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L758-L765)). A keep-alive is neither a delta event nor a state-machine event (L459), which is exactly why it cannot be spelled as a `response.*` event.

The frame is therefore `{"type":"floway:keep_alive","sequence_number":N}`, sent as text — which is what both ends need:

- **Cloudflare** needs bytes on the wire from the server, and text `send` is all a Worker has.
- **Codex** tolerates the unknown type completely: `ResponsesStreamEvent`'s `type` is an open `String` and dispatch is `match kind.as_str()` with `_ => trace!(…)` → `Ok(None)` ([sse/responses.rs L466-L472](https://github.com/openai/codex/blob/e6cfd40c3f444aadd6017c9eeab01db70f48961a/codex-rs/codex-api/src/sse/responses.rs#L466-L472)). There is no prefix parsing, so `floway:keep_alive` is as harmless as `foo`, and the forwarded text frame rebuilds the timeout, which is the point.
- **openai-node's WebSocket reader** emits a valid-JSON frame under its own literal type name and drops it when nothing is listening; only a frame typed `error` is routed into the socket's error path ([ws-base.ts L346-L371](https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/resources/responses/ws-base.ts#L346-L371)). **openai-python** parses with `construct_type_unchecked`, so an unknown type constructs fine ([responses.py L4493-L4502](https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/resources/responses/responses.py#L4493-L4502)).
- **Binary is disqualified.** Codex hard-errors: `Message::Binary(_) => return Err(ApiError::Stream("unexpected binary websocket event"))` aborts the turn. openai-python raises an uncaught `JSONDecodeError` unless the payload happens to be valid JSON, at which point binary buys nothing over text.

On WebSocket clients a slug-prefixed type and a bare `keepalive` are indistinguishable — every WS client tolerates arbitrary types. They diverge only on openai-node's **SSE** `responses.stream()` helper, whose accumulator closes its `switch` on `assertNever` ([ResponseAccumulator.ts L387-L389](https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/lib/responses/ResponseAccumulator.ts#L387-L389)). That divergence does not reach us: Floway's SSE keep-alive is an SSE comment line, invisible to the event stream, and this frame exists only on the WebSocket transport. The comment in the code says so, so that nobody later "simplifies" the two paths together.

## `sequence_number`

The spec gives WebSocket frames the same sequence space as streaming HTTP — "Event ordering, `sequence_number`, output item lifecycle … have the same meaning on both transports" ([L117](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L117)). A keep-alive on that wire therefore cannot sit outside the numbering, and it cannot reuse a neighbour's number either: openai-python's resume path evaluates `event.sequence_number > self._starting_after`, so the value must be numeric and ordered ([_responses.py L59](https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/lib/streaming/responses/_responses.py#L59)); `None` there is a `TypeError`.

The decision: **a keep-alive takes a real slot, and every later event is shifted past it.** The transport keeps a shift that starts at zero and grows by one per keep-alive, so a turn with no keep-alive is numbered exactly as upstream numbered it, and a turn with keep-alives stays gapless and strictly increasing. This is the same technique `affinity/egress.ts` already uses when it injects a synthetic item into a stream — but not the same layer: that machinery is the per-source-protocol affinity membrane and is shared with SSE, while the keep-alive exists only on this transport, so the shift lives in the WebSocket forwarder.

The buffered terminal event is renumbered where it is sent rather than where it was buffered, because keep-alives can still fire while the generator drains behind it and each of those takes a slot that must land first.

## The gate before the first event

The keep-alive is held back until the turn's first event has gone out, so the slot it takes is always known.

That gate is parity with the stricter transport rather than a demand of this one. Both SDKs' SSE stream helpers refuse anything before `response.created` — openai-node's accumulator throws ([ResponseAccumulator.ts L25-L31](https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/lib/responses/ResponseAccumulator.ts#L25-L31)), openai-python raises `RuntimeError(f"Expected to have received 'response.created' before '{event.type}'")` ([_responses.py L369-L370](https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/lib/streaming/responses/_responses.py#L369-L370)), and openai-node rejects even its own blessed `keepalive` type there. Every WebSocket reader inspected above tolerates an unknown type at any position.

**Residual exposure, stated plainly:** the window before the turn's first event is unprotected. Measured first-frame latency on `gpt-5-mini` at high effort was 5-32 s, comfortably inside even the earliest death the probe recorded (61.5 s), so the exposure is small. Widening the gate is a behavior decision, not a client-compatibility one, and is deliberately not taken here.

## Interval

Left at the shared `DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS` (15 s). Against the measured mechanism that is very conservative — intervals up to 400 s held the dropping path open — so the honest justification is not that 15 s is required but that widening it buys nothing. The frame is ~70 bytes; the constant already exists and is shared with SSE, so keeping it avoids a second keep-alive cadence in the codebase; and the unprotected idle distribution has a low tail at 215.8 s, against which an interval chosen for economy would spend a real margin to save nothing. Against Codex's 300 s idle timeout, 15 s is twenty times the required rate, so several consecutive misses still leave the socket alive.

## Wire capture

Node target on a scratch instance, `gpt-5-mini` at `reasoning.effort: high` with no reasoning summary requested, so the turn goes genuinely silent after `response.output_item.added`. Raw frames as received by a Bun WebSocket client:

```text
  0.0s  OPEN
 31.9s  response.created seq=0
 31.9s  response.in_progress seq=1
 31.9s  response.output_item.added seq=2
 46.9s  {"type":"floway:keep_alive","sequence_number":3,"event_id":"evt_capture"}
 61.9s  {"type":"floway:keep_alive","sequence_number":4,"event_id":"evt_capture"}
 76.9s  {"type":"floway:keep_alive","sequence_number":5,"event_id":"evt_capture"}
 91.9s  {"type":"floway:keep_alive","sequence_number":6,"event_id":"evt_capture"}
106.9s  {"type":"floway:keep_alive","sequence_number":7,"event_id":"evt_capture"}
121.9s  {"type":"floway:keep_alive","sequence_number":8,"event_id":"evt_capture"}
131.8s  response.output_item.done seq=13
131.8s  response.output_item.added seq=14
132.0s  response.content_part.added seq=15
132.0s  response.output_text.delta seq=16
132.0s  response.output_text.done seq=17
132.0s  response.content_part.done seq=18
132.0s  response.output_item.done seq=19
132.2s  response.completed seq=20
132.4s  CLOSE code=1000
```

Six keep-alives take slots 3-8 during a 100 s silence. The upstream event that broke the silence carried `sequence_number` 7 and went out as 13; the terminal event carried 14 and went out as 20 — every later event shifted by exactly the six slots taken, leaving the stream gapless and strictly increasing, with the terminal event last. A parallel capture on a harder prompt ran 15 minutes of unbroken silence and stayed alive through 59 keep-alives.

The ~32 s of initial silence in that capture is an artifact of the cyber-policy retry interceptor, which buffered the wrapper prologue and has since been removed from `main`; that is also why the first keep-alive lands in slot 3. On the current tree `response.created` itself opens the protected window. The test asserts exactly that, ticking four intervals before any upstream frame and seeing nothing, then sending `response.created` alone and seeing a keep-alive one tick later:

```text
[["response.created",0],["floway:keep_alive",1],["response.output_item.done",2],["response.completed",3]]
```

## Test Plan

- [x] `packages/gateway` typecheck clean (`tsc --noEmit`, exit 0).
- [x] `packages/gateway` full Vitest suite: 178 files / 2123 tests passed; `websocket_test.ts` alone 17 passed in 153 ms, with no 30 s fixture timeouts.
- [x] ESLint clean on both changed files.
- [x] Live wire capture against a Copilot upstream on the Node target, `gpt-5-mini` at high effort — keep-alives fill the silence, numbering stays gapless and strictly increasing, terminal event last, socket closes 1000.
- [x] Probe Worker on `*.workers.dev` from three vantage points establishing the idle-teardown behaviour and the ping-versus-data-frame asymmetry the design rests on. Probe Worker and its deployment were removed afterwards.
- [ ] Behaviour under a Cloudflare production deployment rather than the Node target — not exercised, since the probe measured the transport in isolation and the handler itself is runtime-agnostic.
