### PR TITLE
fix(responses): stop the server-tool shim dropping an event it has no opinion about

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -6259,3 +6259,25 @@ test('the shim carries the upstream turn cost onto the metadata pricing reads', 
   await collectFrames(result.events);
   assertEquals((await result.finalMetadata!).billableUsage, billableUsage);
 });
+
+test('consumeTurn forwards an event carrying no output_index instead of dropping it', async () => {
+  // The stream parser classifies by deny-list so an event type it does not
+  // recognize survives as structured. This stage rewrites item positions, so
+  // a positionless event has nothing to rewrite and must reach the client
+  // unchanged rather than disappear.
+  const unrecognized = eventFrame({
+    type: 'response.some_future_event',
+    detail: 'carried through',
+  } as unknown as ResponsesStreamEvent);
+
+  const result = await consumeTurn(
+    framesOf(mkResponseCreated(), unrecognized, mkResponseCompleted()),
+    createMergeState(),
+    true,
+  );
+
+  assertEquals(eventTypesOf(result.downstreamFrames), ['response.created', 'response.some_future_event']);
+  const forwarded = result.downstreamFrames[1];
+  assert(forwarded.type === 'event');
+  assertEquals((forwarded.event as unknown as { detail: string }).detail, 'carried through');
+});

--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -6261,10 +6261,6 @@ test('the shim carries the upstream turn cost onto the metadata pricing reads', 
 });
 
 test('consumeTurn forwards an event carrying no output_index instead of dropping it', async () => {
-  // The stream parser classifies by deny-list so an event type it does not
-  // recognize survives as structured. This stage rewrites item positions, so
-  // a positionless event has nothing to rewrite and must reach the client
-  // unchanged rather than disappear.
   const unrecognized = eventFrame({
     type: 'response.some_future_event',
     detail: 'carried through',

--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/server-tool-shim_test.ts
@@ -5830,7 +5830,7 @@ test('consumeTurn live-forwards indexed progress events without hardcoded event-
   assertEquals(new Set(indices).size, 1);
 });
 
-test('consumeTurn keeps swallowing keepalive/ping-shape events that lack output_index', async () => {
+test('consumeTurn swallows keepalive/ping filler frames', async () => {
   const state = createMergeState();
   const result = await consumeTurn(
     framesOf(

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -653,6 +653,14 @@ export const consumeTurnStreaming = async function* (
       continue;
     }
 
+    // Filler a transport injects to hold a connection open, named rather than
+    // recognized by its lack of a position. `parseResponsesStream` already
+    // drops `ping` before a parsed stream reaches this stage, so this catches
+    // the frames handed to us directly, plus `keepalive` — the type openai-node
+    // models for the same purpose — which nothing upstream of here drops.
+    // https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/lib/responses/ResponseAccumulator.ts#L382-L386
+    if ((event.type as string) === 'ping' || (event.type as string) === 'keepalive') continue;
+
     const rewriteResult = rewriteOutputIndex(event, openItems, openItemIds, merge);
     if (rewriteResult !== null) {
       const maybeItemEvent = rewriteResult as ResponsesStreamEvent & { output_index?: number; item?: unknown };
@@ -665,12 +673,12 @@ export const consumeTurnStreaming = async function* (
 
     // What this stage rewrites is an item's position, so an event that states
     // no position has nothing here to rewrite and is forwarded as it arrived.
-    // Every event type that lacks `output_index` today is a wrapper, a
+    // Every remaining event type without `output_index` today is a wrapper, a
     // terminal, or `error`, and each is answered by a branch above, so nothing
-    // in the current protocol reaches this line. What does reach it is
-    // whatever the protocol grows: `parseResponsesStream` classifies by
-    // deny-list precisely so an unrecognized type survives parsing as
-    // structured, and a stage that dropped it would spend that guarantee.
+    // in the current protocol reaches this line. What does reach it is whatever
+    // the protocol grows: `parseResponsesStream` classifies by deny-list
+    // precisely so an unrecognized type survives parsing as structured, and a
+    // stage that dropped it would spend that guarantee.
     yield stamp(event);
   }
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -662,6 +662,16 @@ export const consumeTurnStreaming = async function* (
       yield stamp(rewriteResult);
       continue;
     }
+
+    // What this stage rewrites is an item's position, so an event that states
+    // no position has nothing here to rewrite and is forwarded as it arrived.
+    // Every event type that lacks `output_index` today is a wrapper, a
+    // terminal, or `error`, and each is answered by a branch above, so nothing
+    // in the current protocol reaches this line. What does reach it is
+    // whatever the protocol grows: `parseResponsesStream` classifies by
+    // deny-list precisely so an unrecognized type survives parsing as
+    // structured, and a stage that dropped it would spend that guarantee.
+    yield stamp(event);
   }
 
   if (terminalStatus === undefined) {

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/server-tool-shim.ts
@@ -653,11 +653,9 @@ export const consumeTurnStreaming = async function* (
       continue;
     }
 
-    // Filler a transport injects to hold a connection open, named rather than
-    // recognized by its lack of a position. `parseResponsesStream` already
-    // drops `ping` before a parsed stream reaches this stage, so this catches
-    // the frames handed to us directly, plus `keepalive` — the type openai-node
-    // models for the same purpose — which nothing upstream of here drops.
+    // Filler a transport injects to hold a connection open. It has to be named
+    // here, because the positionless fall-through below forwards whatever it
+    // does not recognize. `keepalive` is openai-node's name for the same frame.
     // https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/lib/responses/ResponseAccumulator.ts#L382-L386
     if ((event.type as string) === 'ping' || (event.type as string) === 'keepalive') continue;
 
@@ -671,14 +669,10 @@ export const consumeTurnStreaming = async function* (
       continue;
     }
 
-    // What this stage rewrites is an item's position, so an event that states
-    // no position has nothing here to rewrite and is forwarded as it arrived.
-    // Every remaining event type without `output_index` today is a wrapper, a
-    // terminal, or `error`, and each is answered by a branch above, so nothing
-    // in the current protocol reaches this line. What does reach it is whatever
-    // the protocol grows: `parseResponsesStream` classifies by deny-list
-    // precisely so an unrecognized type survives parsing as structured, and a
-    // stage that dropped it would spend that guarantee.
+    // No event of the current protocol reaches here; every positionless type is
+    // answered above. This line is for what the protocol grows:
+    // `parseResponsesStream` classifies by deny-list so an unrecognized type
+    // survives as structured, and dropping it here would spend that guarantee.
     yield stamp(event);
   }
 


### PR DESCRIPTION
The server-tool shim's merge loop rewrites each upstream event's `output_index` into the shim's own contiguous space. Its last branch did that and forwarded the result — and fell off the end of the loop body when there was no index to rewrite, so the event was silently discarded.

That drop was load-bearing: it is how the stage swallowed `ping` and `keepalive` filler frames, pinned by a test. But it was implemented as a side effect of "carries no `output_index`" rather than by naming what it drops, so it took every unrecognized event type with it.

## Why that matters even though nothing hits it today

Every event type in the union that lacks `output_index` is a wrapper (`response.queued` / `response.created` / `response.in_progress`), a terminal, or `error` — and each is answered by an earlier branch. So no event in the current protocol reaches that line, and this change moves no traffic.

What reaches it is whatever the protocol grows. `parseResponsesStream` classifies content-bearing events by **deny-list**, and says so:

> Future Responses event types fall through as structured by default, which is safer than missing an allow-list entry and incorrectly triggering the fast-path expansion below.

So an event type Floway does not model survives parsing intact — and then, on any request routed through a shimmed upstream, disappears here without a trace. A stage that drops what it does not recognize spends the guarantee the parser was written to provide.

## The change

Two statements, in order:

- Filler frames are named: `ping` and `keepalive` are dropped by type. `parseResponsesStream` already drops `ping` ahead of this stage, so what this catches is frames handed to `consumeTurnStreaming` directly, plus `keepalive` — openai-node's name for the same frame, which nothing upstream of here drops.
- The positionless fall-through forwards instead of dropping. What this stage rewrites is an item's position; an event that states no position has nothing here to rewrite.

## Considered and not taken

Moving the filler filter into `parseResponsesStream`, next to the `ping` drop it already performs, would put it at the boundary where frames are parsed rather than in one interceptor that happens to sit in some paths. It is the better home. It is not this change because the shim also consumes streams that never went through that parser — translated `responses-via-*` output and synthetic events — and those would lose the filter. Deciding whether they can carry filler at all is a separate question from stopping the silent sink.

## Test Plan

- [x] `packages/gateway` typecheck clean; ESLint clean on both changed files.
- [x] `packages/gateway` full Vitest suite: 178 files / 2124 tests passed.
- [x] New test proven load-bearing: deleting the forwarding `yield` fails exactly `consumeTurn forwards an event carrying no output_index instead of dropping it` and nothing else.
- [x] The pinned filler-swallow test still passes with the drop reimplemented by name.
