### PR TITLE
fix(responses): expand a native compaction into well-formed stream frames

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -634,3 +634,18 @@ test('POST /v1/responses renders the OpenAI-shaped model-unsupported 400 when no
   assertEquals(body.error.type, 'invalid_request_error');
   assert(body.error.message.includes('does not support'));
 });
+
+test('POST /v1/responses/compact answers a body that states no status, as a native compact upstream sends', async () => {
+  // `CompactResource` declares exactly `id`, `object`, `output`, `created_at`
+  // and `usage`, so a conformant compaction carries no `status` for the
+  // synthetic-event round trip to read. Azure's and Codex's native compact
+  // endpoints both answer those five keys and nothing else.
+  installRepo();
+  const { response } = await compactTurn({ status: undefined as unknown as ResponsesResult['status'] });
+
+  assertEquals(response.status, 200);
+  const body = await response.json() as Record<string, unknown>;
+  assertEquals(body.object, 'response.compaction');
+  assertEquals(missingRequiredCompactionKeys(body), []);
+  assertEquals((body.output as Array<{ type: string }>).map(item => item.type), ['compaction']);
+});

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -636,10 +636,6 @@ test('POST /v1/responses renders the OpenAI-shaped model-unsupported 400 when no
 });
 
 test('POST /v1/responses/compact answers a body that states no status, as a native compact upstream sends', async () => {
-  // `CompactResource` declares exactly `id`, `object`, `output`, `created_at`
-  // and `usage`, so a conformant compaction carries no `status` for the
-  // synthetic-event round trip to read. Azure's and Codex's native compact
-  // endpoints both answer those five keys and nothing else.
   installRepo();
   const { response } = await compactTurn({ status: undefined as unknown as ResponsesResult['status'] });
 

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -1,7 +1,7 @@
 import { responsesInterceptors } from './interceptors/index.ts';
 import type { ResponsesAttemptResult, ResponsesInvocation } from './interceptors/types.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
-import { syntheticEventsFromResult } from './items/output.ts';
+import { syntheticEventsFromCompaction } from './items/output.ts';
 import { billableUsageFromResponsesEvent } from './usage.ts';
 import { telemetryModelIdentity, upstreamPerformanceContext } from '../../shared/telemetry/attribution.ts';
 import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
@@ -228,7 +228,7 @@ const providerResponsesResultToExecuteResult = async (
     return { ...(await readUpstreamApiError(providerResult.response, candidate.provider.upstreamId)), performance: context };
   }
   return eventResult(
-    syntheticEventsFromResult(providerResult.result),
+    syntheticEventsFromCompaction(providerResult.result),
     telemetryModelIdentity(candidate, providerResult.modelKey),
     { performance: context },
   );

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -327,9 +327,8 @@ const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGate
   const cmpId = createRandomResponsesItemId('compaction');
   const synthesized = buildCompactionEnvelope(cmpId, summaryText, collected);
 
-  // The status-reading expansion, not the compaction one: this envelope
-  // spreads a real generate turn, so it does state a status, and a
-  // summarization turn that ended `incomplete` or `failed` must keep saying so.
+  // A real generate turn backs this envelope, so its own `incomplete` or
+  // `failed` status must reach the terminal event.
   return {
     ...upstreamResult,
     events: syntheticEventsFromResult(synthesized),

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -327,6 +327,9 @@ const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGate
   const cmpId = createRandomResponsesItemId('compaction');
   const synthesized = buildCompactionEnvelope(cmpId, summaryText, collected);
 
+  // The status-reading expansion, not the compaction one: this envelope
+  // spreads a real generate turn, so it does state a status, and a
+  // summarization turn that ended `incomplete` or `failed` must keep saying so.
   return {
     ...upstreamResult,
     events: syntheticEventsFromResult(synthesized),

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -110,3 +110,12 @@ export const syntheticEventsFromResult = async function* (result: ResponsesResul
   yield* responsesResultToEvents(result, { genericOutputItems: true });
   yield doneFrame();
 };
+
+// The same path for a body answered by a native `/responses/compact` upstream.
+// `CompactResource` declares no `status`, so the terminal is stated here rather
+// than read off the body: a compaction that got this far is one the upstream
+// answered 200, and the resource has no spelling for a failed compaction.
+export const syntheticEventsFromCompaction = async function* (result: ResponsesResult): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> {
+  yield* responsesResultToEvents(result, { genericOutputItems: true, terminal: 'response.completed' });
+  yield doneFrame();
+};

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -111,10 +111,10 @@ export const syntheticEventsFromResult = async function* (result: ResponsesResul
   yield doneFrame();
 };
 
-// The same path for a body answered by a native `/responses/compact` upstream.
-// `CompactResource` declares no `status`, so the terminal is stated here rather
-// than read off the body: a compaction that got this far is one the upstream
-// answered 200, and the resource has no spelling for a failed compaction.
+// `CompactResource` declares exactly `id`, `object`, `output`, `created_at` and
+// `usage`, so there is no `status` to read and no spelling for a failed
+// compaction — that arrives as an HTTP error instead of a 200 body.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L4008
 export const syntheticEventsFromCompaction = async function* (result: ResponsesResult): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> {
   yield* responsesResultToEvents(result, { genericOutputItems: true, terminal: 'response.completed' });
   yield doneFrame();

--- a/packages/gateway/src/data-plane/chat/responses/serve.ts
+++ b/packages/gateway/src/data-plane/chat/responses/serve.ts
@@ -2,7 +2,7 @@ import { responsesAttempt } from './attempt.ts';
 import { responsesCreatedAt, wrapResponsesStatefulOutput } from './client-output.ts';
 import { completeResponsesCompaction } from './compaction-resource.ts';
 import type { ResponsesAttemptResult } from './interceptors/types.ts';
-import { syntheticEventsFromResult } from './items/output.ts';
+import { syntheticEventsFromCompaction } from './items/output.ts';
 import { prepareResponsesServePlan } from './serve-prep.ts';
 import { iterateCandidates } from '../../shared/iterate-candidates.ts';
 import type { ChatGatewayCtx } from '../shared/gateway-ctx.ts';
@@ -83,7 +83,7 @@ export const responsesServe = {
     );
     if (result.type !== 'result') return result;
 
-    const stored = wrapResponsesStatefulOutput(syntheticEventsFromResult(result.result), ctx);
+    const stored = wrapResponsesStatefulOutput(syntheticEventsFromCompaction(result.result), ctx);
     const persisted = await collectResponsesProtocolEventsToResult(stored);
     return {
       ...result,

--- a/packages/protocols/src/responses/from-result.ts
+++ b/packages/protocols/src/responses/from-result.ts
@@ -13,6 +13,13 @@ const getTerminalEventName = (response: ResponsesResult): 'response.failed' | 'r
   case 'cancelled':
     throw new TypeError(`Cannot expand nonterminal Responses status '${response.status}' into terminal events`);
   }
+  // `status` is required on `ResponsesResult`, so the switch above is
+  // exhaustive to the compiler and this line is unreachable by the type. It is
+  // reachable by a value that was cast into the type without carrying the
+  // field, and returning `undefined` there produced a terminal frame typed
+  // `undefined` — a malformed event that no consumer recognizes as terminal,
+  // surfacing far downstream as a stream that never terminated.
+  throw new TypeError(`Responses result states no terminal status (got ${JSON.stringify(response.status)})`);
 };
 
 const responsesStartSnapshot = (response: ResponsesResult): ResponsesResult => {
@@ -317,7 +324,17 @@ const responsesOutputItemEvents = (item: ResponsesOutputItem, outputIndex: numbe
 // compaction blob is opaque; expanding them as assistant-message content
 // would mint mid-stream `output_text.delta` events that would not match the
 // item shape.
-export const responsesResultToEvents = (response: ResponsesResult, options?: { genericOutputItems?: boolean }): EventFrame<ResponsesStreamEvent>[] => {
+// `terminal` lets a caller state the terminal event rather than have it read
+// off `status`. `/responses/compact` needs that: `CompactResource` declares
+// exactly `id`, `object`, `output`, `created_at` and `usage`, so a conformant
+// compaction body carries no `status` to read, and a compaction that reached
+// this expansion is one the upstream answered 200 — the resource has no
+// spelling for a failed compaction, which arrives as an HTTP error instead.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L4008
+export const responsesResultToEvents = (
+  response: ResponsesResult,
+  options?: { genericOutputItems?: boolean; terminal?: 'response.completed' | 'response.incomplete' | 'response.failed' },
+): EventFrame<ResponsesStreamEvent>[] => {
   const started = responsesStartSnapshot(response);
   const outputEvents = options?.genericOutputItems
     ? response.output.flatMap(responsesGenericOutputItemEvents)
@@ -326,7 +343,7 @@ export const responsesResultToEvents = (response: ResponsesResult, options?: { g
     { type: 'response.created', response: started },
     { type: 'response.in_progress', response: started },
     ...outputEvents,
-    { type: getTerminalEventName(response), response },
+    { type: options?.terminal ?? getTerminalEventName(response), response },
   ];
 
   return events.map((event, sequenceNumber) => eventFrame({ ...event, sequence_number: sequenceNumber }));

--- a/packages/protocols/src/responses/from-result.ts
+++ b/packages/protocols/src/responses/from-result.ts
@@ -13,12 +13,9 @@ const getTerminalEventName = (response: ResponsesResult): 'response.failed' | 'r
   case 'cancelled':
     throw new TypeError(`Cannot expand nonterminal Responses status '${response.status}' into terminal events`);
   }
-  // `status` is required on `ResponsesResult`, so the switch above is
-  // exhaustive to the compiler and this line is unreachable by the type. It is
-  // reachable by a value that was cast into the type without carrying the
-  // field, and returning `undefined` there produced a terminal frame typed
-  // `undefined` — a malformed event that no consumer recognizes as terminal,
-  // surfacing far downstream as a stream that never terminated.
+  // Unreachable by the type, reachable by a value cast into it without a
+  // `status`: falling out of the switch instead minted a terminal frame typed
+  // `undefined`, which no consumer recognizes as terminal.
   throw new TypeError(`Responses result states no terminal status (got ${JSON.stringify(response.status)})`);
 };
 
@@ -324,13 +321,8 @@ const responsesOutputItemEvents = (item: ResponsesOutputItem, outputIndex: numbe
 // compaction blob is opaque; expanding them as assistant-message content
 // would mint mid-stream `output_text.delta` events that would not match the
 // item shape.
-// `terminal` lets a caller state the terminal event rather than have it read
-// off `status`. `/responses/compact` needs that: `CompactResource` declares
-// exactly `id`, `object`, `output`, `created_at` and `usage`, so a conformant
-// compaction body carries no `status` to read, and a compaction that reached
-// this expansion is one the upstream answered 200 — the resource has no
-// spelling for a failed compaction, which arrives as an HTTP error instead.
-// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L4008
+// `terminal` lets a caller state the terminal event instead of having it read
+// off `status`.
 export const responsesResultToEvents = (
   response: ResponsesResult,
   options?: { genericOutputItems?: boolean; terminal?: 'response.completed' | 'response.incomplete' | 'response.failed' },


### PR DESCRIPTION
Every native `/responses/compact` upstream — Azure and Codex — answered `502 Responses stream ended without a terminal event`. Verified live against both.

## What breaks

A compact result reaches the client through a synthetic event stream. The expansion exists so a non-streaming body traverses the same item persistence a live stream does, and the frames are reassembled straight back into a body; nothing about it is client-visible. It picked its terminal event by reading `status`:

```ts
const events: ResponsesStreamEvent[] = [
  { type: 'response.created', response: started },
  { type: 'response.in_progress', response: started },
  ...outputEvents,
  { type: getTerminalEventName(response), response },
];
```

`CompactResource` declares exactly `id`, `object`, `output`, `created_at` and `usage` ([openapi.json L3935-L4008](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/public/openapi/openapi.json#L3935-L4008)) — no `status`. So a conformant compaction body has nothing there to read. Both native upstreams answer exactly those five keys:

```json
{ "id": "resp_0bc8…", "object": "response.compaction", "created_at": 1785449590,
  "output": [ … ], "usage": { "input_tokens": 44, "output_tokens": 153, "total_tokens": 197 } }
```

`getTerminalEventName`'s `switch` matched no case and fell out returning `undefined`, so the expansion emitted a terminal frame typed `undefined`. No consumer recognizes that as terminal, so the reassembler ran the stream to exhaustion and threw. The failure surfaced two layers from its cause and named neither.

This is the left half of `upstream compact result → frames → downstream compact result`: the frames were never well-formed. Reassembly reported the malformation correctly.

## The fix

The compact seam states its terminal instead of reading a field the resource does not carry. A compaction that reached the expansion is one the upstream answered 200, and `CompactResource` has no spelling for a failed compaction — that arrives as an HTTP error.

The body is expanded **twice** on its way out — once turning the provider result into an `ExecuteResult`, once running it through item persistence — and both sites move.

`getTerminalEventName` now throws instead of returning `undefined`. `status` is required on `ResponsesResult`, so the switch is exhaustive to the compiler and the new line is unreachable by the type; it is reachable by a value cast into the type without carrying the field, which is exactly what the providers do. A cast that lies now fails where the field is read rather than manufacturing a malformed frame.

The compact shim keeps the status-reading expansion, with a comment saying why: its envelope spreads a real generate turn, so it does state a status, and a summarization turn that ended `incomplete` or `failed` must keep saying so.

## Why nobody hit this

Copilot has no native compact wire. It replays RemoteCompactionV2 over `/responses` and synthesizes the envelope by spreading that turn, which states a status. The Codex CLI also defaults to that client-side path rather than calling the compact endpoint. What reaches the broken path is a client that calls `/responses/compact` as the spec defines it — which is what the OpenResponses compliance suite does.

## Test Plan

- [x] `packages/gateway` and `packages/protocols` typecheck clean.
- [x] `packages/gateway` 178 files / 2128 tests passed; `packages/protocols` 33 files / 186 tests passed.
- [x] ESLint clean on all changed files.
- [x] New test proven load-bearing: reverting either expansion site fails exactly `POST /v1/responses/compact answers a body that states no status, as a native compact upstream sends`.
- [x] Live Azure Foundry `gpt-5.4` through `POST /v1/responses/compact`: was 502, now answers `object: response.compaction`, `output: ['reasoning','message','message','compaction']`, `usage 44/153/197`, integer `created_at`.
- [ ] Live Codex `/codex/responses/compact` re-run on the fix — the same defect and the same 502 were captured there before the change, but the after-state was only verified on Azure.

