### PR TITLE
fix(responses): build the terminal output from the items the turn closed

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/response-resource_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/response-resource_test.ts
@@ -284,9 +284,8 @@ describe('terminal output authority', () => {
   };
 
   it('states the items the turn closed, not the output the envelope stated', async () => {
-    // Measured against a live Codex upstream: an ordinary turn closes
-    // `reasoning` and `message` and then states `output: ['reasoning']`, so the
-    // assistant's answer reaches the client only if the items are believed.
+    // Shape measured against a live Codex upstream: the turn closes `reasoning`
+    // and `message`, then states `output: ['reasoning']`.
     const source = async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
       yield eventFrame({ type: 'response.output_item.added', sequence_number: 0, output_index: 0, item: reasoningItem } as ResponsesStreamEvent);
       yield eventFrame({ type: 'response.output_item.done', sequence_number: 1, output_index: 0, item: reasoningItem } as ResponsesStreamEvent);

--- a/packages/gateway/__tests__/data-plane/chat/responses/response-resource_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/response-resource_test.ts
@@ -261,3 +261,61 @@ describe('Responses resource completion', () => {
     assertEquals(seen[1]?.type, 'response.output_text.delta');
   });
 });
+
+describe('terminal output authority', () => {
+  const reasoningItem = { type: 'reasoning', id: 'rs_1', summary: [] };
+  const messageItem = {
+    type: 'message',
+    id: 'msg_1',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ type: 'output_text', text: 'hi', annotations: [] }],
+  };
+
+  const terminalOutputOf = async (source: AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>>): Promise<string[]> => {
+    const seen: ResponsesStreamEvent[] = [];
+    for await (const frame of wrapResponseResourceCompletion(source, sources())) {
+      if (frame.type === 'event') seen.push(frame.event);
+    }
+    const terminal = seen.at(-1);
+    assertExists(terminal);
+    if (terminal.type !== 'response.completed') throw new Error('expected a completed terminal');
+    return terminal.response.output.map(item => item.type);
+  };
+
+  it('states the items the turn closed, not the output the envelope stated', async () => {
+    // Measured against a live Codex upstream: an ordinary turn closes
+    // `reasoning` and `message` and then states `output: ['reasoning']`, so the
+    // assistant's answer reaches the client only if the items are believed.
+    const source = async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+      yield eventFrame({ type: 'response.output_item.added', sequence_number: 0, output_index: 0, item: reasoningItem } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.output_item.done', sequence_number: 1, output_index: 0, item: reasoningItem } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.output_item.added', sequence_number: 2, output_index: 1, item: messageItem } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.output_item.done', sequence_number: 3, output_index: 1, item: messageItem } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.completed', sequence_number: 4, response: { ...translatedResource(), output: [reasoningItem] } } as ResponsesStreamEvent);
+      yield doneFrame();
+    };
+
+    assertEquals(await terminalOutputOf(source()), ['reasoning', 'message']);
+  });
+
+  it('orders the stated items by output_index, not by the order they closed', async () => {
+    const source = async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+      yield eventFrame({ type: 'response.output_item.done', sequence_number: 0, output_index: 1, item: messageItem } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.output_item.done', sequence_number: 1, output_index: 0, item: reasoningItem } as ResponsesStreamEvent);
+      yield eventFrame({ type: 'response.completed', sequence_number: 2, response: { ...translatedResource(), output: [] } } as ResponsesStreamEvent);
+      yield doneFrame();
+    };
+
+    assertEquals(await terminalOutputOf(source()), ['reasoning', 'message']);
+  });
+
+  it('leaves a terminal reached without a closed item exactly as it arrived', async () => {
+    const source = async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+      yield eventFrame({ type: 'response.completed', sequence_number: 0, response: { ...translatedResource(), output: [messageItem] } } as ResponsesStreamEvent);
+      yield doneFrame();
+    };
+
+    assertEquals(await terminalOutputOf(source()), ['message']);
+  });
+});

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -77,20 +77,18 @@ export const wrapResponsesClientOutput = async function* (
 
     if (event.type === 'response.completed' || event.type === 'response.incomplete') {
       if (store.writesState) {
-        // A terminal may state fewer items than the turn closed — a Codex turn
-        // closes `reasoning` and `message` and states only `reasoning` — but it
-        // may not state one that never closed, which would mean an item reached
-        // the client without the lifecycle the spec requires of it.
+        // A terminal may restate fewer items than the turn closed, but never
+        // one that never closed: that item reached the client without the
+        // lifecycle the spec requires of it.
         event.response.output.forEach((_item, outputIndex) => {
           if (!finalizedOutputIds.has(outputIndex)) {
             throw new TypeError(`Responses terminal output_index ${outputIndex} arrived before output_item.done`);
           }
         });
         // The snapshot a `previous_response_id` continuation replays is the
-        // items this turn closed, in `output_index` order. Committing what the
-        // terminal restated instead would drop the assistant's own message on
-        // that same Codex turn, so the next turn would continue from a
-        // conversation in which the assistant never spoke.
+        // items this turn closed, in `output_index` order; taking the terminal's
+        // own restatement would drop the assistant's message from the history
+        // the next turn continues from.
         const orderedOutputIds = [...finalizedOutputIds]
           .sort(([left], [right]) => left - right)
           .map(([, id]) => id);

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -77,13 +77,15 @@ export const wrapResponsesClientOutput = async function* (
 
     if (event.type === 'response.completed' || event.type === 'response.incomplete') {
       if (store.writesState) {
-        const orderedOutputIds = event.response.output.map((_item, outputIndex) => {
-          const id = finalizedOutputIds.get(outputIndex);
-          if (id === undefined) {
-            throw new TypeError(`Responses terminal output_index ${outputIndex} arrived before output_item.done`);
-          }
-          return id;
-        });
+        // The snapshot a `previous_response_id` continuation replays is the
+        // items this turn closed, in `output_index` order. Reading the terminal
+        // envelope's `output` instead would commit whatever it happened to
+        // restate: a Codex turn closes `reasoning` and `message` and then
+        // states only `reasoning`, so the next turn would continue from a
+        // conversation in which the assistant never spoke.
+        const orderedOutputIds = [...finalizedOutputIds]
+          .sort(([left], [right]) => left - right)
+          .map(([, id]) => id);
         await store.commitSnapshot(responseId, sawCompactionItem ? 'replace' : 'append', orderedOutputIds);
       }
       yield eventFrame({ ...event, response: clientEnvelope(event.response) });

--- a/packages/gateway/src/data-plane/chat/responses/items/output.ts
+++ b/packages/gateway/src/data-plane/chat/responses/items/output.ts
@@ -77,11 +77,19 @@ export const wrapResponsesClientOutput = async function* (
 
     if (event.type === 'response.completed' || event.type === 'response.incomplete') {
       if (store.writesState) {
+        // A terminal may state fewer items than the turn closed — a Codex turn
+        // closes `reasoning` and `message` and states only `reasoning` — but it
+        // may not state one that never closed, which would mean an item reached
+        // the client without the lifecycle the spec requires of it.
+        event.response.output.forEach((_item, outputIndex) => {
+          if (!finalizedOutputIds.has(outputIndex)) {
+            throw new TypeError(`Responses terminal output_index ${outputIndex} arrived before output_item.done`);
+          }
+        });
         // The snapshot a `previous_response_id` continuation replays is the
-        // items this turn closed, in `output_index` order. Reading the terminal
-        // envelope's `output` instead would commit whatever it happened to
-        // restate: a Codex turn closes `reasoning` and `message` and then
-        // states only `reasoning`, so the next turn would continue from a
+        // items this turn closed, in `output_index` order. Committing what the
+        // terminal restated instead would drop the assistant's own message on
+        // that same Codex turn, so the next turn would continue from a
         // conversation in which the assistant never spoke.
         const orderedOutputIds = [...finalizedOutputIds]
           .sort(([left], [right]) => left - right)

--- a/packages/gateway/src/data-plane/chat/responses/response-resource.ts
+++ b/packages/gateway/src/data-plane/chat/responses/response-resource.ts
@@ -7,6 +7,7 @@ import type {
   ClientResponsesTextField,
   ClientResponsesTool,
   ClientResponsesUsage,
+  ResponsesOutputItem,
   ResponsesResult,
   ResponsesStreamEvent,
   ResponsesTool,
@@ -207,10 +208,36 @@ export const completeResponseResource = (
 // validates too. The narrowed yield type propagates the guarantee, so a stage
 // inserted between this one and a client-facing exit must preserve it or fail
 // to compile.
+// The spec makes the item lifecycle the authority on what a response produced:
+// `response.output_item.added` MUST be an item's first event, the item is closed
+// with `response.output_item.done`, and an extension event MUST NOT change that
+// lifecycle. Nothing requires the terminal envelope's `output` to restate it.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L237
+//
+// Upstreams take that literally. A Codex `/responses` turn closes a `message`
+// item and then answers `output: ['reasoning']`, and its compaction turn closes
+// a `compaction` item and answers `output: []` — so a non-streaming client got
+// a response with the assistant's answer missing and no error to go with it.
+// The items are what the response produced; the terminal restates them.
+//
+// A stream that closed no item at all leaves the terminal alone. Only two
+// stages upstream of here reconstruct `output` themselves, both optional, and
+// neither can be relied on for the mandatory path — but a stream reaching this
+// stage without item events would otherwise be emptied, which is a worse
+// failure than the one this fixes.
+const withObservedOutput = (
+  response: ResponsesResult,
+  observed: Map<number, ResponsesOutputItem>,
+): ResponsesResult =>
+  observed.size === 0
+    ? response
+    : { ...response, output: [...observed].sort(([left], [right]) => left - right).map(([, item]) => item) };
+
 export const wrapResponseResourceCompletion = async function* (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   sources: ResponseResourceSources,
 ): AsyncGenerator<ProtocolFrame<ClientResponsesStreamEvent>> {
+  const observed = new Map<number, ResponsesOutputItem>();
   for await (const frame of frames) {
     if (frame.type !== 'event') {
       yield frame;
@@ -223,10 +250,14 @@ export const wrapResponseResourceCompletion = async function* (
     case 'response.in_progress':
       yield eventFrame({ ...event, response: completeResponseResource(event.response, sources, false) });
       continue;
+    case 'response.output_item.done':
+      observed.set(event.output_index, event.item);
+      yield eventFrame(event);
+      continue;
     case 'response.completed':
     case 'response.incomplete':
     case 'response.failed':
-      yield eventFrame({ ...event, response: completeResponseResource(event.response, sources, true) });
+      yield eventFrame({ ...event, response: completeResponseResource(withObservedOutput(event.response, observed), sources, true) });
       continue;
     default:
       yield eventFrame(event);

--- a/packages/gateway/src/data-plane/chat/responses/response-resource.ts
+++ b/packages/gateway/src/data-plane/chat/responses/response-resource.ts
@@ -202,29 +202,12 @@ export const completeResponseResource = (
   };
 };
 
-// The client-facing egress stage: every resource-bearing event carries the
-// complete resource, so a streamed response validates frame by frame and the
-// non-streaming body — which is the terminal frame's resource verbatim —
-// validates too. The narrowed yield type propagates the guarantee, so a stage
-// inserted between this one and a client-facing exit must preserve it or fail
-// to compile.
-// The spec makes the item lifecycle the authority on what a response produced:
-// `response.output_item.added` MUST be an item's first event, the item is closed
-// with `response.output_item.done`, and an extension event MUST NOT change that
-// lifecycle. Nothing requires the terminal envelope's `output` to restate it.
+// The item lifecycle — not the terminal envelope's `output` — is the spec's
+// authority on what a response produced, and upstreams take that literally: a
+// Codex turn that closed `reasoning` and `message` states `output:
+// ['reasoning']`, and its compaction turn states `output: []`. A terminal
+// reached without a closed item is left as it arrived.
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L237
-//
-// Upstreams take that literally. A Codex `/responses` turn closes a `message`
-// item and then answers `output: ['reasoning']`, and its compaction turn closes
-// a `compaction` item and answers `output: []` — so a non-streaming client got
-// a response with the assistant's answer missing and no error to go with it.
-// The items are what the response produced; the terminal restates them.
-//
-// A stream that closed no item at all leaves the terminal alone. Only two
-// stages upstream of here reconstruct `output` themselves, both optional, and
-// neither can be relied on for the mandatory path — but a stream reaching this
-// stage without item events would otherwise be emptied, which is a worse
-// failure than the one this fixes.
 const withObservedOutput = (
   response: ResponsesResult,
   observed: Map<number, ResponsesOutputItem>,
@@ -233,6 +216,12 @@ const withObservedOutput = (
     ? response
     : { ...response, output: [...observed].sort(([left], [right]) => left - right).map(([, item]) => item) };
 
+// The client-facing egress stage: every resource-bearing event carries the
+// complete resource, so a streamed response validates frame by frame and the
+// non-streaming body — which is the terminal frame's resource verbatim —
+// validates too. The narrowed yield type propagates the guarantee, so a stage
+// inserted between this one and a client-facing exit must preserve it or fail
+// to compile.
 export const wrapResponseResourceCompletion = async function* (
   frames: AsyncIterable<ProtocolFrame<ResponsesStreamEvent>>,
   sources: ResponseResourceSources,


### PR DESCRIPTION
A non-streaming Codex turn answers a response with the assistant's message missing, and no error to go with it. Reproduced 3/3 against the live upstream through Floway's own `/v1/responses`:

```
streamed output_item.done -> ['reasoning', 'message']
terminal                  -> ('response.completed', ['reasoning'])
```

```
status completed | output ['reasoning'] | output_text None
```

Its compaction turn is the same defect at full strength — `output_item.done` closes a `compaction` item, the terminal states `output: []`.

## Who is wrong

Not the upstream. The spec makes the **item lifecycle** the authority on what a response produced — `response.output_item.added` MUST be an item's first event ([L237](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L237)), the item is closed with `response.output_item.done` ([L313](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L313)), and an extension event MUST NOT change that lifecycle ([L756](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L756)). Nothing requires the terminal envelope's `output` to restate it.

So accumulating from `output_item.done` rests on a MUST; trusting the terminal rests on a habit. Codex declines the habit and is conformant in doing so.

## Why it went unseen

Only the **non-streaming native Responses body** is exposed. A streaming client sees the items go by and is unaffected. The translated paths build their result from item events already. And of the upstreams available to test, only Codex declines to restate:

| upstream | request | items closed | terminal `output` |
| --- | --- | --- | --- |
| Codex | generate | `reasoning`, `message` | `reasoning` |
| Codex | compaction | `compaction` | `[]` |
| Copilot | generate | `reasoning`, `message` | `reasoning`, `message` |
| Copilot | compaction | `compaction` ×2 | `compaction` ×2 |
| Azure | generate | `reasoning`, `message` | `reasoning`, `message` |

## The change

`wrapResponseResourceCompletion` — the client-facing egress every terminal frame passes through — collects each `response.output_item.done` and states them as the terminal's `output`, ordered by `output_index`. It sits downstream of the item-id membrane, so the items it collects already carry client-facing ids.

A stream that closed no item at all leaves the terminal exactly as it arrived. Two stages upstream reconstruct `output` themselves (the Copilot item-id membrane and the server-tool shim), but both are optional and neither covers the mandatory path; emptying a terminal that arrived without item events would be a worse failure than the one being fixed.

## The snapshot, one layer in

The continuation snapshot had the same defect and needed the same statement. `items/output.ts` built it by mapping the terminal envelope's `output` back onto the ids minted as items were finalized, so it inherited whatever the terminal restated — on that Codex turn, a snapshot holding `reasoning` and not the assistant's `message`. A `previous_response_id` follow-up would continue from a conversation in which the assistant never spoke. It is now ordered from the finalized-item map directly.

Fixing only the client body would have left the two disagreeing, so both move here.

The mapping that produced the snapshot also validated the terminal, and dropping it would have made a terminal item that never closed silently vanish — the mirror of the bug being fixed. That check stays as its own statement: a terminal may state **fewer** items than the turn closed, which is what Codex does and is conformant, but not one that never closed, which would mean an item reached the client without the lifecycle the spec requires of it.

## Test Plan

- [x] `packages/gateway` typecheck clean; ESLint clean on all changed files.
- [x] `packages/gateway` 178 files / 2130 tests passed.
- [x] Load-bearing: reverting the accumulation fails exactly the two new authority tests and nothing else (2 failed / 16 passed in that file).
- [x] Live Codex `/v1/responses` capture that motivated it, 3/3 reproducible, with Copilot and Azure controls on the same instance.
- [ ] Live re-run against Codex on the fix — the before-state is measured, the after-state is covered by unit tests only.
