### PR TITLE
fix(responses): summarize from the items the compaction turn closed

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -563,9 +563,6 @@ test('round-trip: outbound synthesis then inbound expansion recovers the summary
   assertEquals(items[0].content[0].text, `${SUMMARY_PREFIX}\nSUMMARY TEXT`);
 });
 
-// A Codex upstream closes a `message` item and then states an `output` that
-// omits it. Reading the terminal would pack an empty summary into the blob and
-// answer 200 with it.
 const upstreamRunStatingNoOutput = (summaryText: string): () => Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
   const message = {
     type: 'message' as const,

--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/compact-shim_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/compact-shim_test.ts
@@ -562,3 +562,53 @@ test('round-trip: outbound synthesis then inbound expansion recovers the summary
   assertEquals(items[0].role, 'user');
   assertEquals(items[0].content[0].text, `${SUMMARY_PREFIX}\nSUMMARY TEXT`);
 });
+
+// A Codex upstream closes a `message` item and then states an `output` that
+// omits it. Reading the terminal would pack an empty summary into the blob and
+// answer 200 with it.
+const upstreamRunStatingNoOutput = (summaryText: string): () => Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>> => {
+  const message = {
+    type: 'message' as const,
+    id: 'msg_1',
+    role: 'assistant' as const,
+    status: 'completed' as const,
+    content: [{ type: 'output_text' as const, text: summaryText, annotations: [] }],
+  };
+  const response: ResponsesResult = {
+    id: 'resp_fake_upstream',
+    object: 'response',
+    model: 'test-upstream-model',
+    status: 'completed',
+    output: [],
+    error: null,
+    incomplete_details: null,
+    usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+  };
+  return () => Promise.resolve(eventResult(
+    (async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+      yield eventFrame({ type: 'response.output_item.added', sequence_number: 0, output_index: 0, item: message });
+      yield eventFrame({ type: 'response.output_item.done', sequence_number: 1, output_index: 0, item: message });
+      yield eventFrame({ type: 'response.completed', sequence_number: 2, response });
+      yield doneFrame();
+    })(),
+    testTelemetryModelIdentity,
+  ));
+};
+
+test('compact + flag on: the summary is the item the turn closed, not the output its terminal stated', async () => {
+  const inv = makeInvocation(
+    { input: [{ type: 'message', role: 'user', content: 'long conversation history' }] },
+    { action: 'compact' },
+  );
+
+  const result = await withResponsesCompactShim(inv, stubCtx, upstreamRunStatingNoOutput('CONDENSED SUMMARY'));
+  if (result.type !== 'events') throw new Error(`expected events branch, got ${result.type}`);
+
+  const collected = await collectResponsesProtocolEventsToResult(result.events);
+  const compaction = collected.output[0] as unknown as { type: string; encrypted_content: string };
+  assertEquals(compaction.type, 'compaction');
+  const decoded = JSON.parse(new TextDecoder().decode(
+    Uint8Array.from(atob(compaction.encrypted_content.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0)),
+  )) as Array<{ content: Array<{ text: string }> }>;
+  assertEquals(decoded[0]?.content[0]?.text, `${SUMMARY_PREFIX}\nCONDENSED SUMMARY`);
+});

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -58,7 +58,7 @@ import { isJsonObject } from '../../../../shared/json-helpers.ts';
 import type { ChatGatewayCtx } from '../../shared/gateway-ctx.ts';
 import { syntheticEventsFromResult } from '../items/output.ts';
 import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import { collectResponsesProtocolEventsToResult, createRandomResponsesItemId, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { collectResponsesProtocolEventsToResult, createRandomResponsesItemId, type CanonicalResponsesPayload, type ResponsesInputItem, type ResponsesOutputItem, type ResponsesResult, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { providerModelOf, type ExecuteResult } from '@floway-dev/provider';
 
 // The two vendored constants below (SUMMARIZATION_PROMPT and SUMMARY_PREFIX)
@@ -184,11 +184,16 @@ export const expandShimCompactionItems = (payload: CanonicalResponsesPayload): C
 
 type ChainRun = () => Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>>;
 
-// Extracts the summary text from the upstream's response to the
-// SUMMARIZATION_PROMPT.
-const extractTextFromResult = (result: ResponsesResult): string => {
+// The summarization turn's answer, read from the items it closed rather than
+// from the terminal envelope it stated. The spec makes the item lifecycle the
+// authority and requires nothing of the terminal's `output`, and a Codex
+// upstream states an `output` that omits the assistant's own message — which
+// here would mean packing an empty summary into the compaction blob and
+// answering 200 with it.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L237
+const summaryTextFromClosedItems = (closed: Map<number, ResponsesOutputItem>): string => {
   const parts: string[] = [];
-  for (const item of result.output) {
+  for (const [, item] of [...closed].sort(([left], [right]) => left - right)) {
     if (item.type !== 'message') continue;
     for (const block of item.content) {
       if (block.type === 'output_text') parts.push(block.text);
@@ -322,8 +327,25 @@ const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGate
     return upstreamResult;
   }
 
-  const collected = await collectResponsesProtocolEventsToResult(upstreamResult.events);
-  const summaryText = extractTextFromResult(collected);
+  const closedItems = new Map<number, ResponsesOutputItem>();
+  const observed = (async function* (): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> {
+    for await (const frame of upstreamResult.events) {
+      if (frame.type === 'event' && frame.event.type === 'response.output_item.done') {
+        closedItems.set(frame.event.output_index, frame.event.item);
+      }
+      yield frame;
+    }
+  })();
+
+  const collected = await collectResponsesProtocolEventsToResult(observed);
+  const summaryText = summaryTextFromClosedItems(closedItems);
+  // A compaction blob is the whole of what the next turn inherits, so an empty
+  // one silently discards the conversation. The turn answered without saying
+  // anything the summary could be built from, and that is reported rather than
+  // sealed into an envelope that looks successful.
+  if (summaryText.length === 0) {
+    throw new Error('Responses compact shim: the summarization turn closed no assistant text to summarize');
+  }
   const cmpId = createRandomResponsesItemId('compaction');
   const synthesized = buildCompactionEnvelope(cmpId, summaryText, collected);
 

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -184,13 +184,10 @@ export const expandShimCompactionItems = (payload: CanonicalResponsesPayload): C
 
 type ChainRun = () => Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>>;
 
-// The summarization turn's answer, read from the items it closed rather than
-// from the terminal envelope it stated. The spec makes the item lifecycle the
-// authority and requires nothing of the terminal's `output`, and a Codex
-// upstream states an `output` that omits the assistant's own message — which
-// here would mean packing an empty summary into the compaction blob and
-// answering 200 with it. A turn that closed no item at all is read from what
-// its terminal stated, the same rule the client-facing egress applies.
+// The spec makes the item lifecycle the authority and requires nothing of the
+// terminal's `output`; a Codex upstream states an `output` that omits the
+// assistant message it just closed. A turn that closed nothing falls back to
+// the terminal, as the client-facing egress does.
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L237
 const summaryTextFrom = (closed: Map<number, ResponsesOutputItem>, stated: readonly ResponsesOutputItem[]): string => {
   const items = closed.size === 0
@@ -344,9 +341,7 @@ const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGate
   const collected = await collectResponsesProtocolEventsToResult(observed);
   const summaryText = summaryTextFrom(closedItems, collected.output);
   // A compaction blob is the whole of what the next turn inherits, so an empty
-  // one silently discards the conversation. The turn answered without saying
-  // anything the summary could be built from, and that is reported rather than
-  // sealed into an envelope that looks successful.
+  // one silently discards the conversation.
   if (summaryText.length === 0) {
     throw new Error('Responses compact shim: the summarization turn closed no assistant text to summarize');
   }

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/compact-shim.ts
@@ -189,11 +189,15 @@ type ChainRun = () => Promise<ExecuteResult<ProtocolFrame<ResponsesStreamEvent>>
 // authority and requires nothing of the terminal's `output`, and a Codex
 // upstream states an `output` that omits the assistant's own message — which
 // here would mean packing an empty summary into the compaction blob and
-// answering 200 with it.
+// answering 200 with it. A turn that closed no item at all is read from what
+// its terminal stated, the same rule the client-facing egress applies.
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L237
-const summaryTextFromClosedItems = (closed: Map<number, ResponsesOutputItem>): string => {
+const summaryTextFrom = (closed: Map<number, ResponsesOutputItem>, stated: readonly ResponsesOutputItem[]): string => {
+  const items = closed.size === 0
+    ? stated
+    : [...closed].sort(([left], [right]) => left - right).map(([, item]) => item);
   const parts: string[] = [];
-  for (const [, item] of [...closed].sort(([left], [right]) => left - right)) {
+  for (const item of items) {
     if (item.type !== 'message') continue;
     for (const block of item.content) {
       if (block.type === 'output_text') parts.push(block.text);
@@ -338,7 +342,7 @@ const simulateCompaction = async (ctx: ResponsesInvocation, gatewayCtx: ChatGate
   })();
 
   const collected = await collectResponsesProtocolEventsToResult(observed);
-  const summaryText = summaryTextFromClosedItems(closedItems);
+  const summaryText = summaryTextFrom(closedItems, collected.output);
   // A compaction blob is the whole of what the next turn inherits, so an empty
   // one silently discards the conversation. The turn answered without saying
   // anything the summary could be built from, and that is reported rather than


### PR DESCRIPTION
The compact shim builds its summary from the reassembled result's `output` — the terminal envelope verbatim. Against an upstream whose terminal omits the items it closed, the shim packs an **empty summary** into the compaction blob and answers 200 with it. The conversation is silently discarded and nothing reports it.

## Why the terminal is the wrong source

The spec makes the item lifecycle the authority on what a response produced: `response.output_item.added` MUST be an item's first event ([L237](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L237)), the item is closed with `response.output_item.done` ([L313](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L313)). Nothing requires the terminal's `output` to restate them.

A live Codex `/responses` turn does exactly that — closes `reasoning` and `message`, then states `output: ['reasoning']`, reproduced 3/3. Its compaction turn states `output: []`. Both are conformant.

## The change

The summary is read from the items the turn closed, observed as the frames pass through on their way to reassembly. A stream that closed no item at all is still read from what its terminal stated — the same rule the client-facing egress applies, so a terminal-only stream is summarized rather than rejected.

An empty summary is no longer sealed into a successful-looking envelope. The blob is the whole of what the next turn inherits, so an empty one silently discards the conversation; a turn that closed no assistant text is reported instead.

## Relationship to the other terminal-authority PRs

Same defect, different stage. This one is an interceptor and sits upstream of the client-facing egress, so it reads the raw terminal and is not covered by fixing that egress. The stages move independently and each needs the statement made where it reads.

## Test Plan

- [x] `packages/gateway` typecheck clean; ESLint clean on both changed files.
- [x] `packages/gateway` 178 files / 2128 tests passed.
- [x] Load-bearing: forcing the terminal-stated path fails exactly the new test and nothing else (1 failed / 18 passed in that file).
- [x] The existing shim suite, whose fixtures emit a terminal and no item events, still passes on the fallback.
- [ ] Live re-run through a Codex upstream with the shim flag on — the upstream shape that motivates this is measured, this particular composition is covered by unit tests only.
