### PR TITLE
fix(responses): make a streaming failure reach the client as a failure

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -634,3 +634,38 @@ test('POST /v1/responses renders the OpenAI-shaped model-unsupported 400 when no
   assertEquals(body.error.type, 'invalid_request_error');
   assert(body.error.message.includes('does not support'));
 });
+
+test('POST /v1/responses nests a mid-stream failure under `error` so an SDK stream reader throws on it', async () => {
+  // Both official SDKs key their mid-stream throw on a top-level `error` key.
+  // A frame stating `message`/`code` at the top level is yielded to them as an
+  // ordinary event, so the failure never surfaces to the client as one.
+  installRepo();
+  const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
+    action: 'generate', ok: true,
+    events: (async function* (): AsyncGenerator<ProtocolFrame<ResponsesStreamEvent>> {
+      yield eventFrame(completedEvents()[0]!);
+      throw new Error('upstream exploded mid-stream');
+    })(),
+    modelKey: 'test-model-key',
+    headers: new Headers(),
+  }));
+  queueResolution([makeCandidate({ callResponses })]);
+
+  const response = await makeApp().request('/v1/responses', {
+    method: 'POST',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ model: 'test-model', input: 'hello', stream: true }),
+  });
+
+  const body = await response.text();
+  const chunk = body.split('\n\n').find(part => part.startsWith('event: error'));
+  assert(chunk !== undefined, `expected an error frame in ${body}`);
+  const data = JSON.parse(chunk.slice(chunk.indexOf('data: ') + 'data: '.length)) as {
+    type: string;
+    error?: { message?: unknown };
+    message?: unknown;
+  };
+  assertEquals(data.type, 'error');
+  assertEquals(data.error?.message, 'upstream exploded mid-stream');
+  assert(data.message === undefined, 'expected the payload to sit under `error`, not at the top level');
+});

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -635,10 +635,7 @@ test('POST /v1/responses renders the OpenAI-shaped model-unsupported 400 when no
   assert(body.error.message.includes('does not support'));
 });
 
-test('POST /v1/responses nests a mid-stream failure under `error` so an SDK stream reader throws on it', async () => {
-  // Both official SDKs key their mid-stream throw on a top-level `error` key.
-  // A frame stating `message`/`code` at the top level is yielded to them as an
-  // ordinary event, so the failure never surfaces to the client as one.
+test('POST /v1/responses nests a mid-stream failure under `error` so an SDK stream reader throws on it, then follows it with response.failed', async () => {
   installRepo();
   const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
     action: 'generate', ok: true,
@@ -669,8 +666,6 @@ test('POST /v1/responses nests a mid-stream failure under `error` so an SDK stre
   assertEquals(data.error?.message, 'upstream exploded mid-stream');
   assert(data.message === undefined, 'expected the payload to sit under `error`, not at the top level');
 
-  // "Any error incurred while streaming will be followed by a `response.failed`
-  // event." Without it a client tracking response state is left in progress.
   const failedChunk = body.split('\n\n').find(part => part.startsWith('event: response.failed'));
   assert(failedChunk !== undefined, `expected a response.failed frame in ${body}`);
   const failed = JSON.parse(failedChunk.slice(failedChunk.indexOf('data: ') + 'data: '.length)) as {
@@ -678,7 +673,6 @@ test('POST /v1/responses nests a mid-stream failure under `error` so an SDK stre
   };
   assertEquals(failed.response.status, 'failed');
   assertEquals(failed.response.error.message, 'upstream exploded mid-stream');
-  // The failure states the response the client was already watching.
   const created = JSON.parse(
     body.split('\n\n').find(part => part.startsWith('event: response.created'))!.split('data: ')[1]!,
   ) as { response: { id: string } };

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -668,4 +668,19 @@ test('POST /v1/responses nests a mid-stream failure under `error` so an SDK stre
   assertEquals(data.type, 'error');
   assertEquals(data.error?.message, 'upstream exploded mid-stream');
   assert(data.message === undefined, 'expected the payload to sit under `error`, not at the top level');
+
+  // "Any error incurred while streaming will be followed by a `response.failed`
+  // event." Without it a client tracking response state is left in progress.
+  const failedChunk = body.split('\n\n').find(part => part.startsWith('event: response.failed'));
+  assert(failedChunk !== undefined, `expected a response.failed frame in ${body}`);
+  const failed = JSON.parse(failedChunk.slice(failedChunk.indexOf('data: ') + 'data: '.length)) as {
+    response: { status: string; id: string; error: { message: string } };
+  };
+  assertEquals(failed.response.status, 'failed');
+  assertEquals(failed.response.error.message, 'upstream exploded mid-stream');
+  // The failure states the response the client was already watching.
+  const created = JSON.parse(
+    body.split('\n\n').find(part => part.startsWith('event: response.created'))!.split('data: ')[1]!,
+  ) as { response: { id: string } };
+  assertEquals(failed.response.id, created.response.id);
 });

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -108,17 +108,32 @@ const internalResponsesErrorResponse = (status: number, error: InternalDebugErro
     },
   }, { status });
 
+// The spec's `error` event nests its payload under `error`, and both official
+// SDKs key their mid-stream throw on exactly that key — openai-node's
+// `Stream.fromSSEResponse` on `data.error`, openai-python's `_streaming` on
+// `data.get("error")`. A frame that states those fields at the top level is
+// yielded to both as an ordinary event, so a failure mid-stream reaches neither
+// client as a failure: the stream simply ends.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L170-L177
+// https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/core/streaming.ts#L69-L71
+// https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/_streaming.py#L87-L98
+//
+// The fields are the ones the frame already carried, moved rather than
+// reshaped, so a client reading Floway's debug detail finds all of it one level
+// in.
 const internalResponsesStreamErrorFrame = (error: unknown) => {
   const debug = toInternalDebugError(error);
   return sseFrame(
     JSON.stringify({
       type: 'error',
-      message: debug.message,
-      code: debug.type,
-      name: debug.name,
-      stack: debug.stack,
-      cause: debug.cause,
-      target_api: debug.target_api,
+      error: {
+        message: debug.message,
+        code: debug.type,
+        name: debug.name,
+        stack: debug.stack,
+        cause: debug.cause,
+        target_api: debug.target_api,
+      },
     }),
     'error',
   );

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -10,8 +10,8 @@ import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
 import { forwardUpstreamHeaders, mergeForwardedUpstreamHeaders } from '../../shared/upstream-response.ts';
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
 import { eventFrame, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
-import { responsesProtocolFrameToSSEFrame, RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult, type ClientResponseResource } from '@floway-dev/protocols/responses';
-import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ClientResponsesStreamEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
+import { responsesProtocolFrameToSSEFrame, RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
+import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ClientResponseResource, type ClientResponsesStreamEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, type PlainResult, type InternalDebugError, toInternalDebugError } from '@floway-dev/provider';
 import { apiErrorToResponse } from '@floway-dev/provider';
 

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -9,8 +9,8 @@ import { settle } from '../../shared/telemetry/settle.ts';
 import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
 import { forwardUpstreamHeaders, mergeForwardedUpstreamHeaders } from '../../shared/upstream-response.ts';
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
-import { type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
-import { responsesProtocolFrameToSSEFrame, RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult } from '@floway-dev/protocols/responses';
+import { eventFrame, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
+import { responsesProtocolFrameToSSEFrame, RESPONSES_MISSING_TERMINAL_MESSAGE, collectResponsesProtocolEventsToResult, type ClientResponseResource } from '@floway-dev/protocols/responses';
 import { isResponsesTerminalEvent, type CanonicalResponsesPayload, type ClientResponsesStreamEvent, type ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { type ExecuteResult, type PlainResult, type InternalDebugError, toInternalDebugError } from '@floway-dev/provider';
 import { apiErrorToResponse } from '@floway-dev/provider';
@@ -155,14 +155,38 @@ const observeResponsesFrames = async function* (frames: AsyncIterable<ProtocolFr
   throw new Error(RESPONSES_MISSING_TERMINAL_MESSAGE);
 };
 
+// "Any error incurred while streaming will be followed by a `response.failed`
+// event." A stream that ended on the error frame alone left a client that
+// tracks response state with a response stuck in progress forever.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L430
+//
+// The terminal is derived from the last resource-bearing frame that went out,
+// which already carries the completed client resource, so the failure states
+// the same response the client has been watching. A failure before any such
+// frame has no response to fail — nothing was announced — and emits the error
+// alone.
+const responsesFailedFrame = (resource: ClientResponseResource, error: unknown) => {
+  const debug = toInternalDebugError(error);
+  return responsesProtocolFrameToSSEFrame(eventFrame({
+    type: 'response.failed',
+    response: { ...resource, status: 'failed', error: { code: debug.type, message: debug.message } },
+  } as ClientResponsesStreamEvent));
+};
+
 const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>>, state: SourceStreamState) {
+  let announced: ClientResponseResource | undefined;
   try {
     for await (const frame of frames) {
+      if (frame.type === 'event' && 'response' in frame.event) announced = frame.event.response;
       const sse = responsesProtocolFrameToSSEFrame(frame);
       if (sse) yield sse;
     }
   } catch (error) {
     state.failed = true;
     yield internalResponsesStreamErrorFrame(error);
+    if (announced !== undefined) {
+      const failed = responsesFailedFrame(announced, error);
+      if (failed) yield failed;
+    }
   }
 };

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -108,19 +108,12 @@ const internalResponsesErrorResponse = (status: number, error: InternalDebugErro
     },
   }, { status });
 
-// The spec's `error` event nests its payload under `error`, and both official
-// SDKs key their mid-stream throw on exactly that key — openai-node's
-// `Stream.fromSSEResponse` on `data.error`, openai-python's `_streaming` on
-// `data.get("error")`. A frame that states those fields at the top level is
-// yielded to both as an ordinary event, so a failure mid-stream reaches neither
-// client as a failure: the stream simply ends.
+// The spec nests the `error` event's payload under `error`, and both official
+// SDKs key their mid-stream throw on exactly that key; the same fields at the
+// top level are yielded to them as an ordinary event instead.
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L170-L177
 // https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/core/streaming.ts#L69-L71
 // https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/_streaming.py#L87-L98
-//
-// The fields are the ones the frame already carried, moved rather than
-// reshaped, so a client reading Floway's debug detail finds all of it one level
-// in.
 const internalResponsesStreamErrorFrame = (error: unknown) => {
   const debug = toInternalDebugError(error);
   return sseFrame(
@@ -156,15 +149,8 @@ const observeResponsesFrames = async function* (frames: AsyncIterable<ProtocolFr
 };
 
 // "Any error incurred while streaming will be followed by a `response.failed`
-// event." A stream that ended on the error frame alone left a client that
-// tracks response state with a response stuck in progress forever.
+// event."
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L430
-//
-// The terminal is derived from the last resource-bearing frame that went out,
-// which already carries the completed client resource, so the failure states
-// the same response the client has been watching. A failure before any such
-// frame has no response to fail — nothing was announced — and emits the error
-// alone.
 const responsesFailedFrame = (resource: ClientResponseResource, error: unknown) => {
   const debug = toInternalDebugError(error);
   return responsesProtocolFrameToSSEFrame(eventFrame({


### PR DESCRIPTION
A failure part-way through a streamed Responses turn does not reach the client as a failure. Neither official SDK throws, and no terminal event says the response failed — the stream simply ends and the client is left with a truncated response that still looks in progress.

Two halves of one sentence in the spec, and Floway got both wrong.

## Why

Floway's SSE `error` frame stated its payload at the top level:

```json
{"type":"error","message":"…","code":"internal_error","name":"…","stack":"…"}
```

Both SDKs key their mid-stream throw on a top-level `error` **key**:

- openai-node — `if (data && data.error) { throw new APIError(...) }` ([core/streaming.ts L69-L71](https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/core/streaming.ts#L69-L71)). The `sse.event == 'error'` branch below it is unreachable for this frame: it sits inside the `sse.event.startsWith('thread.')` arm, and Floway sends `event: error`.
- openai-python — `if is_mapping(data) and data.get("error")` ([_streaming.py L87-L98](https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/_streaming.py#L87-L98)).

Neither key is present, so the frame is yielded as an ordinary stream event and dropped by every consumer that switches on known types.

The spec agrees with the SDKs — its error event nests:

```json
{ "type": "error", "status": 400, "error": { "code": "…", "message": "…", "param": "…" } }
```

([2026-04-24.mdx L170-L177](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L170-L177))

So the flat frame was both non-conformant and invisible.

## Half one — the frame must nest

The payload moves under `error`. The fields are the ones the frame already carried — moved, not reshaped — so a client reading Floway's debug detail finds all of it one level in.

Only the client-facing boundary frame changes. The interior `error` stream event keeps the shape upstreams send, which the server-tool shim reads (`e.message`, `e.code`) when it converts an upstream error into a synthesized terminal.

`status` is deliberately not added. The spec's example carries one because it is the WebSocket envelope, where there is no HTTP status to carry it; on SSE the response has already committed 200 by the time this frame is written.

## Half two — the error must be followed by `response.failed`

> Any error incurred while streaming will be followed by a `response.failed` event.

([2026-04-24.mdx L430](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L430))

The stream ended on the error frame alone, so a client tracking response state had nothing telling it the response was over. The terminal is now derived from the last resource-bearing frame that went out — which already carries the completed client resource — so the failure states the same response the client has been watching, with `status: 'failed'` and the error on it.

A failure before any resource-bearing frame has no response to fail: nothing was announced, and the error frame goes out alone.

## Test Plan

- [x] `packages/gateway` typecheck clean; ESLint clean on both changed files.
- [x] `packages/gateway` 178 files / 2128 tests passed.
- [x] The new test also pins the `response.failed` terminal and asserts it carries the same `response.id` the client saw on `response.created`.
- [x] Load-bearing: restoring a top-level `message` fails exactly the new test and nothing else (1 failed / 16 passed in that file).
- [x] Both SDK checks read at their pinned SHAs and quoted above, including the unreachable second branch in openai-node.
- [ ] Driving a real `openai` SDK client against a Floway stream that fails mid-turn — the SDK behaviour is established by reading the code, not by running it.
