### PR TITLE
refactor(responses): state the WebSocket client message in its spec shape

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -71,12 +71,21 @@ declare const WebSocketPair: {
   };
 };
 
-interface ResponsesWebSocketClientEvent {
+// The spec puts the creation body's fields at the top level of
+// `response.create` — "The remaining fields follow the standard response
+// creation request body" — so that is the shape this type states.
+// https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L99-L115
+//
+// `response` is an accepted extension rather than the declared form: clients
+// built against the Realtime-style nested envelope reach us with it, and it is
+// read in preference when present so such a client is not silently handed a
+// turn assembled from the wrong level.
+type ResponsesWebSocketClientEvent = Partial<ResponsesRequestPayload> & {
   type: string;
   event_id?: string;
   response?: Partial<ResponsesRequestPayload>;
   [key: string]: unknown;
-}
+};
 
 export const responsesWebSocket = async (c: AuthedContext): Promise<Response> => {
   if (c.req.header('upgrade')?.toLowerCase() !== 'websocket') {

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -72,14 +72,9 @@ declare const WebSocketPair: {
 };
 
 // The spec puts the creation body's fields at the top level of
-// `response.create` — "The remaining fields follow the standard response
-// creation request body" — so that is the shape this type states.
+// `response.create`; the nested `response` envelope of Realtime-style clients
+// is an extension we also accept, and prefer when present.
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L99-L115
-//
-// `response` is an accepted extension rather than the declared form: clients
-// built against the Realtime-style nested envelope reach us with it, and it is
-// read in preference when present so such a client is not silently handed a
-// turn assembled from the wrong level.
 type ResponsesWebSocketClientEvent = Partial<ResponsesRequestPayload> & {
   type: string;
   event_id?: string;


### PR DESCRIPTION
The WebSocket client-message type declared the payload slot as `response?: Partial<ResponsesRequestPayload>`, so a reader would take the nested envelope for the shape Floway expects. The spec's own shape is the other one:

> Clients MUST start each turn by sending a JSON object with `type: "response.create"`. **The remaining fields follow the standard response creation request body**

```json
{ "type": "response.create", "model": "gpt-openresponses-1", "store": false, "input": [ … ], "tools": [] }
```

([2026-04-24.mdx L99-L115](https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L99-L115))

The spec's fields reached the handler only through the type's index signature, which is what let the mismatch go unnoticed.

## No behaviour change

The handler already reads both forms and prefers `response` when present:

```ts
const source = message.response && typeof message.response === 'object'
  ? message.response
  : Object.fromEntries(Object.entries(message).filter(([key]) => key !== 'type' && key !== 'event_id'));
```

That preference is deliberate — a client built against the Realtime-style nested envelope would otherwise have its turn assembled from the wrong level — so it stays. Only the type changes, to state the declared form and name the nested envelope as the extension it is.

## Test Plan

- [x] `packages/gateway` typecheck clean — the change is a type restatement, so the compiler is the check that matters.
- [x] `packages/gateway` 178 files / 2127 tests passed, including the WebSocket suite that exercises both message forms.
- [x] ESLint clean on the changed file.
