### PR TITLE
fix(responses): price a native compaction from the counts it reported

### DIFF
--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -2,7 +2,7 @@ import { responsesInterceptors } from './interceptors/index.ts';
 import type { ResponsesAttemptResult, ResponsesInvocation } from './interceptors/types.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
 import { syntheticEventsFromResult } from './items/output.ts';
-import { billableUsageFromResponsesEvent } from './usage.ts';
+import { billableUsageFromResponsesEvent, billableUsageFromResponsesResult } from './usage.ts';
 import { telemetryModelIdentity, upstreamPerformanceContext } from '../../shared/telemetry/attribution.ts';
 import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
 import { buildUpstreamCallOptions } from '../../shared/upstream-call-options.ts';
@@ -227,9 +227,18 @@ const providerResponsesResultToExecuteResult = async (
   if (!providerResult.ok) {
     return { ...(await readUpstreamApiError(providerResult.response, candidate.provider.upstreamId)), performance: context };
   }
+  // A native compaction is a turn the model actually ran and the upstream
+  // charged for, and its body states the counts. Without `finalMetadata` the
+  // attempt priced it at nothing: the client was shown the upstream's real
+  // usage while the request recorded zero tokens against the key.
+  const modelIdentity = telemetryModelIdentity(candidate, providerResult.modelKey);
+  const billableUsage = billableUsageFromResponsesResult(providerResult.result);
   return eventResult(
     syntheticEventsFromResult(providerResult.result),
-    telemetryModelIdentity(candidate, providerResult.modelKey),
-    { performance: context },
+    modelIdentity,
+    {
+      performance: context,
+      ...(billableUsage === null ? {} : { finalMetadata: Promise.resolve({ modelIdentity, billableUsage }) }),
+    },
   );
 };

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -227,10 +227,8 @@ const providerResponsesResultToExecuteResult = async (
   if (!providerResult.ok) {
     return { ...(await readUpstreamApiError(providerResult.response, candidate.provider.upstreamId)), performance: context };
   }
-  // A native compaction is a turn the model actually ran and the upstream
-  // charged for, and its body states the counts. Without `finalMetadata` the
-  // attempt priced it at nothing: the client was shown the upstream's real
-  // usage while the request recorded zero tokens against the key.
+  // A native compaction is a turn the upstream ran and charged for, and its
+  // body states the counts.
   const modelIdentity = telemetryModelIdentity(candidate, providerResult.modelKey);
   const billableUsage = billableUsageFromResponsesResult(providerResult.result);
   return eventResult(

--- a/packages/gateway/src/data-plane/chat/responses/usage.ts
+++ b/packages/gateway/src/data-plane/chat/responses/usage.ts
@@ -4,10 +4,11 @@ import { responsesResultFromStreamEvent, type ResponsesResult, type ResponsesStr
 // service_tier reports the tier actually served and therefore selects the
 // matching pricing entry rather than the tier originally requested.
 // https://developers.openai.com/api/docs/guides/priority-processing
-// Takes what it reads rather than a whole result, so a compaction body --
-// which states `usage` and none of the response-only fields -- can be priced
-// through the same helper.
-export const billableUsageFromResponsesResult = (response: { readonly usage?: ResponsesResult['usage'] }): BillableUsage | null => {
+// Takes the two fields it reads rather than a whole result, so a compaction
+// body can be priced through the same helper.
+export const billableUsageFromResponsesResult = (
+  response: { readonly usage?: ResponsesResult['usage']; readonly service_tier?: ResponsesResult['service_tier'] },
+): BillableUsage | null => {
   const usage = response.usage;
   if (!usage) return null;
   const cacheWrite = usage.input_tokens_details?.cache_write_tokens ?? 0;


### PR DESCRIPTION
A native compaction is a turn the model actually ran and the upstream charged for. Floway recorded it as one request and **zero tokens** — while answering the client with the upstream's real counts on that same turn.

## Where it went

`providerResponsesResultToExecuteResult`'s compact branch built its `ExecuteResult` with `performance` and no `finalMetadata`:

```ts
return eventResult(
  syntheticEventsFromResult(providerResult.result),
  telemetryModelIdentity(candidate, providerResult.modelKey),
  { performance: context },
);
```

so `tokenUsageFromBillableUsage((await chainResult.finalMetadata)?.billableUsage)` upstream of it resolved to `null`.

The counts were never missing. They are on the compaction body, and `billableUsageFromResponsesResult` already reads that shape. Measured live through Floway's own compact route:

| upstream | compaction usage |
| --- | --- |
| Azure Foundry `gpt-5.4` | 44 / 153 / 197 |
| Codex `gpt-5.4` | 78 / 69 / 147 |

The shim path was never affected — it forwards the summarization turn's own result, `finalMetadata` included.

## This changes what is billed

Compactions that previously recorded zero tokens will start recording their real usage. That is the point of the change, and it is stated here rather than folded in quietly: on a deployment where compaction traffic is significant, per-key token totals will step up after this ships, with no change in what upstreams were actually charging.

An upstream body that reports no counts still states nothing — `billableUsageFromResponsesResult` returns `null` and no `finalMetadata` is attached, so a price is not invented for an upstream that charged without saying so.

## Test Plan

- [x] `packages/gateway` typecheck clean; ESLint clean on the changed file.
- [x] `packages/gateway` 178 files / 2127 tests passed.
- [x] The usage values above were captured live through `POST /v1/responses/compact` against both upstreams.
- [ ] A recorded telemetry row for a native compaction before and after — the wire-side counts are measured, the recorded-usage side is reasoned from the code path.
