### PR TITLE
test(responses): pin the snapshot against a terminal that omits a streamed item

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/items/output_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/items/output_test.ts
@@ -529,13 +529,11 @@ test('later done and terminal views may omit id after first-done durability', as
   const first = {
     type: 'message' as const,
     id: 'msg_first_done',
-    status: 'completed' as const,
     role: 'assistant' as const,
     content: [{ type: 'output_text' as const, text: 'first', annotations: [] }],
   };
   const later = {
     type: 'message' as const,
-    status: 'completed' as const,
     role: 'assistant' as const,
     content: [{ type: 'output_text' as const, text: 'later', annotations: [] }],
   };
@@ -594,4 +592,37 @@ test('snapshot output IDs follow output_index rather than done arrival order', a
   expect((await repo.responsesSnapshots.lookup('key-a', 'resp_public', 0))?.itemIds).toEqual(
     terminal.output.map(item => item.id),
   );
+});
+
+test('snapshot retains completed streamed items omitted from the terminal output', async () => {
+  const { repo, store } = memoryOutputHarness();
+  const call = {
+    type: 'custom_tool_call' as const,
+    id: 'ctc_streamed_only',
+    call_id: 'call_streamed_only',
+    name: 'exec_command',
+    input: 'printf floway-repro',
+    status: 'completed',
+  };
+  const response: ResponsesResult = {
+    id: 'resp_upstream',
+    object: 'response',
+    model: 'model',
+    status: 'completed',
+    output: [],
+    error: null,
+    incomplete_details: null,
+  };
+  const input = async function* (): AsyncIterable<ProtocolFrame<ResponsesStreamEvent>> {
+    yield eventFrame({ type: 'response.output_item.done', output_index: 0, item: call });
+    yield eventFrame({ type: 'response.completed', response });
+  };
+
+  for await (const _frame of wrapResponsesClientOutput(input(), {
+    store,
+    responseId: 'resp_public',
+  })) { /* drain */ }
+
+  expect((await repo.responsesSnapshots.lookup('key-a', 'resp_public', 0))?.itemIds).toEqual([call.id]);
+  expect((await repo.responsesItems.lookupMany('key-a', [call.id], 0))[0].payload.item).toEqual(call);
 });


### PR DESCRIPTION
This carries what remains of #304. That PR's head branch was deleted during the branch-history rewrite, and GitHub detached it: recreating the branch does not re-point it, so it still reports its old head and fifteen commits, fourteen of which are superseded versions of work that has since landed on `main` by other routes.

## Its production fix is already on `main`

#304's change to `wrapResponsesClientOutput` was: keep the terminal-envelope check as a validation, and build the snapshot from every finalized output index instead of from the terminal's own restatement.

`main` does exactly that today, landed through #328:

```ts
event.response.output.forEach((_item, outputIndex) => {
  if (!finalizedOutputIds.has(outputIndex)) {
    throw new TypeError(`Responses terminal output_index ${outputIndex} arrived before output_item.done`);
  }
});
const orderedOutputIds = [...finalizedOutputIds]
  .sort(([left], [right]) => left - right)
  .map(([, id]) => id);
```

Replaying #304's commit onto `main` conflicts, and the conflict is purely textual — the same guard and the same sorted-map snapshot, written differently. Same error message, same behaviour.

**The two were written independently, and #304's came first** (2026-07-30). #328 landed the same fix without crediting its author. That is worth recording even though the code is identical.

## Its test does not exist on `main`, and still earns its place

#328's tests sit at the client-facing egress. #304's sits one layer in, at the item-id membrane, and covers a case nothing else does: a `custom_tool_call` item closed by `output_item.done` while the terminal states `output: []`. It asserts both halves — that the snapshot names the item, and that the persisted item payload round-trips.

Applied unchanged to `main`'s production code it passes, so it pins behaviour that is already correct rather than describing a fix.

The commit keeps `Co-Authored-By: Kirikaze Chiyuki`.

## Test Plan

- [x] `packages/gateway` — `output_test.ts` 20 tests passed against `main`'s production code with only the test applied.
- [x] Confirmed by replay that #304's production hunk and `main`'s current code are the same change.
