### PR TITLE
fix(web): treat a 204 as a success with no body

### DIFF
--- a/apps/web/__tests__/api/client_test.ts
+++ b/apps/web/__tests__/api/client_test.ts
@@ -1,16 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { callApi } from '../../src/api/client.ts';
+import { callApi, callApiNoContent } from '../../src/api/client.ts';
 
 const respond = (response: Response) => () => Promise.resolve(response);
 
 describe('callApi', () => {
-  it('reports a 204 as a success carrying no data', async () => {
-    const result = await callApi(respond(new Response(null, { status: 204 })));
-    expect(result.error).toBeUndefined();
-    expect(result.data).toBeUndefined();
-  });
-
   it('parses a JSON body on a 200', async () => {
     const result = await callApi<{ id: string }>(respond(Response.json({ id: 'alias_1' })));
     expect(result.error).toBeUndefined();
@@ -22,6 +16,12 @@ describe('callApi', () => {
     expect(result.error).toEqual({ status: 404, message: 'Alias not found', raw: { error: 'Alias not found' } });
   });
 
+  it('falls back to the status line when the failure carries no JSON body', async () => {
+    const result = await callApi(respond(new Response(null, { status: 502 })));
+    expect(result.error?.status).toBe(502);
+    expect(result.error?.message).toBe('HTTP 502');
+  });
+
   it('reports a malformed body on a status that promised one', async () => {
     const result = await callApi(respond(new Response('not json', { status: 200 })));
     expect(result.error?.status).toBe(200);
@@ -30,6 +30,26 @@ describe('callApi', () => {
 
   it('reports a transport failure as status 0', async () => {
     const result = await callApi(() => Promise.reject(new Error('network down')));
+    expect(result.error).toEqual({ status: 0, message: 'network down' });
+  });
+});
+
+describe('callApiNoContent', () => {
+  it('reports a 204 as a success', async () => {
+    const result = await callApiNoContent(respond(new Response(null, { status: 204 })));
+    expect(result.error).toBeUndefined();
+    expect(result.data).toBeUndefined();
+  });
+
+  it('surfaces a failure the same way callApi does', async () => {
+    const result = await callApiNoContent(respond(Response.json({ error: 'Proxy is referenced by upstreams' }, { status: 409 })));
+    expect(result.error?.status).toBe(409);
+    expect(result.error?.message).toBe('Proxy is referenced by upstreams');
+    expect(result.error?.raw).toEqual({ error: 'Proxy is referenced by upstreams' });
+  });
+
+  it('reports a transport failure as status 0', async () => {
+    const result = await callApiNoContent(() => Promise.reject(new Error('network down')));
     expect(result.error).toEqual({ status: 0, message: 'network down' });
   });
 });

--- a/apps/web/__tests__/api/client_test.ts
+++ b/apps/web/__tests__/api/client_test.ts
@@ -28,6 +28,12 @@ describe('callApi', () => {
     expect(result.data).toBeUndefined();
   });
 
+  it('reports a body-less 204 as an error, which is what callApiNoContent exists to avoid', async () => {
+    const result = await callApi(respond(new Response(null, { status: 204 })));
+    expect(result.data).toBeUndefined();
+    expect(result.error?.status).toBe(204);
+  });
+
   it('reports a transport failure as status 0', async () => {
     const result = await callApi(() => Promise.reject(new Error('network down')));
     expect(result.error).toEqual({ status: 0, message: 'network down' });

--- a/apps/web/__tests__/api/client_test.ts
+++ b/apps/web/__tests__/api/client_test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { callApi } from '../../src/api/client.ts';
+
+const respond = (response: Response) => () => Promise.resolve(response);
+
+describe('callApi', () => {
+  it('reports a 204 as a success carrying no data', async () => {
+    const result = await callApi(respond(new Response(null, { status: 204 })));
+    expect(result.error).toBeUndefined();
+    expect(result.data).toBeUndefined();
+  });
+
+  it('parses a JSON body on a 200', async () => {
+    const result = await callApi<{ id: string }>(respond(Response.json({ id: 'alias_1' })));
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({ id: 'alias_1' });
+  });
+
+  it('surfaces the gateway error message from a failed response', async () => {
+    const result = await callApi(respond(Response.json({ error: 'Alias not found' }, { status: 404 })));
+    expect(result.error).toEqual({ status: 404, message: 'Alias not found', raw: { error: 'Alias not found' } });
+  });
+
+  it('reports a malformed body on a status that promised one', async () => {
+    const result = await callApi(respond(new Response('not json', { status: 200 })));
+    expect(result.error?.status).toBe(200);
+    expect(result.data).toBeUndefined();
+  });
+
+  it('reports a transport failure as status 0', async () => {
+    const result = await callApi(() => Promise.reject(new Error('network down')));
+    expect(result.error).toEqual({ status: 0, message: 'network down' });
+  });
+});

--- a/apps/web/__tests__/components/settings/AliasesSettingsCard_test.ts
+++ b/apps/web/__tests__/components/settings/AliasesSettingsCard_test.ts
@@ -16,7 +16,10 @@ vi.mock('../../../src/composables/useModelAliases.ts', () => ({
 vi.mock('../../../src/composables/useModels.ts', () => ({
   useRawModelsStore: () => ({ models: modelsRef, loading: ref(false), error: ref<string | null>(null), load: async () => {} }),
 }));
-vi.mock('../../../src/api/client.ts', () => ({
+// Only the Hono client is stubbed; the real callApi* helpers run so the
+// delete path is exercised against an actual 204 response.
+vi.mock('../../../src/api/client.ts', async importOriginal => ({
+  ...await importOriginal<typeof import('../../../src/api/client.ts')>(),
   useApi: () => ({
     api: {
       aliases: {
@@ -24,11 +27,6 @@ vi.mock('../../../src/api/client.ts', () => ({
       },
     },
   }),
-  callApi: async <T>(fn: () => Promise<Response>) => {
-    const res = await fn();
-    if (!res.ok && res.status !== 204) return { error: { status: res.status, message: 'mock-error' } };
-    return { data: undefined as T };
-  },
   authFetch: vi.fn(),
 }));
 

--- a/apps/web/__tests__/components/settings/AliasesSettingsCard_test.ts
+++ b/apps/web/__tests__/components/settings/AliasesSettingsCard_test.ts
@@ -27,7 +27,6 @@ vi.mock('../../../src/api/client.ts', async importOriginal => ({
       },
     },
   }),
-  authFetch: vi.fn(),
 }));
 
 const { default: AliasesSettingsCard } = await import('../../../src/components/settings/AliasesSettingsCard.vue');

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -28,18 +28,11 @@ export interface GlobalError {
 
 export type ApiResult<T> = { data: T; error?: undefined } | { data?: undefined; error: GlobalError };
 
-// A 204 carries no body by definition (RFC 9110 §15.3.5), so there is nothing
-// to parse and no data to hand back. The gateway answers `DELETE /api/aliases/
-// :id` and `DELETE /api/proxies/:id` that way; parsing it as JSON turned a
-// successful delete into "Unexpected end of JSON input", which the dashboard
-// reported as a failed request while the row was already gone server-side.
-//
-// https://www.rfc-editor.org/rfc/rfc9110#section-15.3.5
-const NO_CONTENT = 204;
-
-export const callApi = async <T>(
+// Transport and failure handling, shared by both entry points: what differs
+// between them is only what a successful response is expected to carry.
+const runRequest = async (
   fn: () => Promise<Response>,
-): Promise<ApiResult<T>> => {
+): Promise<{ response: Response; error?: undefined } | { response?: undefined; error: GlobalError }> => {
   let response: Response;
   try {
     response = await fn();
@@ -47,31 +40,46 @@ export const callApi = async <T>(
     return { error: { status: 0, message: e instanceof Error ? e.message : String(e) } };
   }
 
-  if (!response.ok) {
-    let body: unknown;
-    try {
-      body = await response.json();
-    } catch { /* non-JSON body */ }
-    let message = `HTTP ${response.status}`;
-    if (body && typeof body === 'object') {
-      const obj = body as Record<string, unknown>;
-      if (typeof obj.error === 'string') message = obj.error;
-      else if (obj.error && typeof obj.error === 'object' && typeof (obj.error as Record<string, unknown>).message === 'string') {
-        message = (obj.error as { message: string }).message;
-      }
-    }
-    return { error: { status: response.status, message, raw: body } };
-  }
+  if (response.ok) return { response };
 
-  // Callers of a body-less route read `error` and ignore `data`; typing the
-  // absent body as `T` keeps the result shape uniform for everyone else.
-  if (response.status === NO_CONTENT) return { data: undefined as T };
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch { /* non-JSON body */ }
+  let message = `HTTP ${response.status}`;
+  if (body && typeof body === 'object') {
+    const obj = body as Record<string, unknown>;
+    if (typeof obj.error === 'string') message = obj.error;
+    else if (obj.error && typeof obj.error === 'object' && typeof (obj.error as Record<string, unknown>).message === 'string') {
+      message = (obj.error as { message: string }).message;
+    }
+  }
+  return { error: { status: response.status, message, raw: body } };
+};
+
+export const callApi = async <T>(
+  fn: () => Promise<Response>,
+): Promise<ApiResult<T>> => {
+  const result = await runRequest(fn);
+  if (result.error) return { error: result.error };
 
   let data: T;
   try {
-    data = (await response.json()) as T;
+    data = (await result.response.json()) as T;
   } catch (e: unknown) {
-    return { error: { status: response.status, message: e instanceof Error ? e.message : 'Invalid JSON response' } };
+    return { error: { status: result.response.status, message: e instanceof Error ? e.message : 'Invalid JSON response' } };
   }
   return { data };
+};
+
+// For a route that answers 204, which carries no body at all
+// (https://www.rfc-editor.org/rfc/rfc9110#section-15.3.5) — the gateway's
+// `DELETE /api/aliases/:id` and `DELETE /api/proxies/:id`. Success is the
+// absence of an error, so nothing is parsed and `data` is `void`; asking
+// `callApi<T>` for one of these would report a real success as a JSON error.
+export const callApiNoContent = async (
+  fn: () => Promise<Response>,
+): Promise<ApiResult<void>> => {
+  const { error } = await runRequest(fn);
+  return error ? { error } : { data: undefined };
 };

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -28,11 +28,7 @@ export interface GlobalError {
 
 export type ApiResult<T> = { data: T; error?: undefined } | { data?: undefined; error: GlobalError };
 
-// Transport and failure handling, shared by both entry points: what differs
-// between them is only what a successful response is expected to carry.
-const runRequest = async (
-  fn: () => Promise<Response>,
-): Promise<{ response: Response; error?: undefined } | { response?: undefined; error: GlobalError }> => {
+const runRequest = async (fn: () => Promise<Response>): Promise<ApiResult<Response>> => {
   let response: Response;
   try {
     response = await fn();
@@ -40,7 +36,7 @@ const runRequest = async (
     return { error: { status: 0, message: e instanceof Error ? e.message : String(e) } };
   }
 
-  if (response.ok) return { response };
+  if (response.ok) return { data: response };
 
   let body: unknown;
   try {
@@ -61,22 +57,20 @@ export const callApi = async <T>(
   fn: () => Promise<Response>,
 ): Promise<ApiResult<T>> => {
   const result = await runRequest(fn);
-  if (result.error) return { error: result.error };
+  if (result.error) return result;
 
   let data: T;
   try {
-    data = (await result.response.json()) as T;
+    data = (await result.data.json()) as T;
   } catch (e: unknown) {
-    return { error: { status: result.response.status, message: e instanceof Error ? e.message : 'Invalid JSON response' } };
+    return { error: { status: result.data.status, message: e instanceof Error ? e.message : 'Invalid JSON response' } };
   }
   return { data };
 };
 
 // For a route that answers 204, which carries no body at all
-// (https://www.rfc-editor.org/rfc/rfc9110#section-15.3.5) — the gateway's
-// `DELETE /api/aliases/:id` and `DELETE /api/proxies/:id`. Success is the
-// absence of an error, so nothing is parsed and `data` is `void`; asking
-// `callApi<T>` for one of these would report a real success as a JSON error.
+// (https://www.rfc-editor.org/rfc/rfc9110#section-15.3.5): success is the
+// absence of an error, and nothing is parsed.
 export const callApiNoContent = async (
   fn: () => Promise<Response>,
 ): Promise<ApiResult<void>> => {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -28,6 +28,15 @@ export interface GlobalError {
 
 export type ApiResult<T> = { data: T; error?: undefined } | { data?: undefined; error: GlobalError };
 
+// A 204 carries no body by definition (RFC 9110 §15.3.5), so there is nothing
+// to parse and no data to hand back. The gateway answers `DELETE /api/aliases/
+// :id` and `DELETE /api/proxies/:id` that way; parsing it as JSON turned a
+// successful delete into "Unexpected end of JSON input", which the dashboard
+// reported as a failed request while the row was already gone server-side.
+//
+// https://www.rfc-editor.org/rfc/rfc9110#section-15.3.5
+const NO_CONTENT = 204;
+
 export const callApi = async <T>(
   fn: () => Promise<Response>,
 ): Promise<ApiResult<T>> => {
@@ -53,6 +62,10 @@ export const callApi = async <T>(
     }
     return { error: { status: response.status, message, raw: body } };
   }
+
+  // Callers of a body-less route read `error` and ignore `data`; typing the
+  // absent body as `T` keeps the result shape uniform for everyone else.
+  if (response.status === NO_CONTENT) return { data: undefined as T };
 
   let data: T;
   try {

--- a/apps/web/src/components/proxy-edit/ProxyEditDialog.vue
+++ b/apps/web/src/components/proxy-edit/ProxyEditDialog.vue
@@ -12,7 +12,7 @@ import { RouterLink } from 'vue-router';
 
 import { defaultsFor } from './proxy-form-defaults.ts';
 import ProxyConfigForm from './ProxyConfigForm.vue';
-import { callApi, useApi } from '../../api/client.ts';
+import { callApi, callApiNoContent, useApi } from '../../api/client.ts';
 import type { BackoffRow, ProxyConflictBody, ProxyRecord } from '../../api/types.ts';
 import { useProxiesStore } from '../../composables/useProxies.ts';
 import { useUpstreamsStore } from '../../composables/useUpstreams.ts';
@@ -273,7 +273,7 @@ const remove = async () => {
   deleting.value = true;
   deleteError.value = null;
   try {
-    const { error } = await callApi(
+    const { error } = await callApiNoContent(
       () => api.api.proxies[':id'].$delete({ param: { id: props.record!.id } }),
     );
     if (error) {

--- a/apps/web/src/components/settings/AliasesSettingsCard.vue
+++ b/apps/web/src/components/settings/AliasesSettingsCard.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 
 import AliasRow from './AliasRow.vue';
-import { callApi, useApi } from '../../api/client.ts';
+import { callApiNoContent, useApi } from '../../api/client.ts';
 import type { ModelAlias } from '../../api/types.ts';
 import { useModelAliases } from '../../composables/useModelAliases.ts';
 import { useRawModelsStore } from '../../composables/useModels.ts';
@@ -22,7 +22,7 @@ const aliases = computed<ModelAlias[]>(() => aliasesStore.aliases.value ?? []);
 
 const deleteAlias = async (record: ModelAlias) => {
   if (!window.confirm(`Delete alias "${record.name}"?`)) return;
-  const { error } = await callApi(() => api.api.aliases[':id'].$delete({ param: { id: record.id } }));
+  const { error } = await callApiNoContent(() => api.api.aliases[':id'].$delete({ param: { id: record.id } }));
   if (error) {
     window.alert(`Delete failed: ${error.message}`);
     return;

--- a/apps/web/src/components/settings/ProxiesSettingsCard.vue
+++ b/apps/web/src/components/settings/ProxiesSettingsCard.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 
 import ProxyRow from './ProxyRow.vue';
-import { callApi, useApi } from '../../api/client.ts';
+import { callApiNoContent, useApi } from '../../api/client.ts';
 import type { ProxyConflictBody, ProxyRecord } from '../../api/types.ts';
 import { useProxiesStore } from '../../composables/useProxies.ts';
 import { useUpstreamsStore } from '../../composables/useUpstreams.ts';
@@ -28,7 +28,7 @@ const upstreamNames = computed<Map<string, string>>(() => {
 
 const deleteProxy = async (record: ProxyRecord) => {
   if (!window.confirm(`Delete proxy "${record.name}"?`)) return;
-  const { error } = await callApi(() => api.api.proxies[':id'].$delete({ param: { id: record.id } }));
+  const { error } = await callApiNoContent(() => api.api.proxies[':id'].$delete({ param: { id: record.id } }));
   if (error) {
     if (error.status === 409) {
       const refs = (error.raw as ProxyConflictBody | undefined)?.referencing_upstream_ids ?? [];


### PR DESCRIPTION
## Problem

The dashboard's delete buttons reported a failure on every successful delete.

`callApi` parsed every successful response as JSON, but `DELETE /api/aliases/:id` and `DELETE /api/proxies/:id` answer 204, which carries no body. The parse threw, the helper returned that as an error, and the caller popped `Delete failed: Failed to execute 'json' on 'Response': Unexpected end of JSON input` and skipped its list refresh — so the row stayed on screen until a manual reload, even though the server had already deleted it.

## Change

- `runRequest` holds the transport `try`/`catch` and the non-2xx error-body sniffing both entry points share, and hands back the raw `Response` on success.
- `callApi<T>` keeps parsing JSON. A 204 reaching it is still an error: those routes promise a body, so an empty one is a contract break worth surfacing.
- `callApiNoContent` is the entry point for a body-less route. It returns `ApiResult<void>` — success is the absence of an error — so nothing is parsed and no `undefined` is cast into a caller's `T`.
- The three call sites that delete an alias or a proxy use it: both settings cards and the proxy edit dialog.

## Test Plan

- [x] `pnpm run test` — 4949 passed, including a new `apps/web/__tests__/api/client_test.ts` that pins both helpers against 204, JSON, malformed-body, and transport-failure responses.
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Browser check against the Node target and the real dashboard (headless Chrome): delete an alias from its row, a proxy from its row, and a second proxy from inside its edit dialog. Every row leaves the list without a reload, no failure alert appears, and each deletion is confirmed against `GET /api/aliases` and `GET /api/proxies`.
