### PR TITLE
fix(translate): omit a tool_choice the source never expressed

### DIFF
--- a/packages/translate/__tests__/chat-completions-via-responses/request_test.ts
+++ b/packages/translate/__tests__/chat-completions-via-responses/request_test.ts
@@ -151,6 +151,29 @@ test('buildTargetRequest omits store when Chat omits store', () => {
   assertFalse('store' in result);
 });
 
+test('buildTargetRequest omits tool_choice when Chat omits it', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    messages: [{ role: 'user', content: 'hello' }],
+    tools: [{ type: 'function', function: { name: 'lookup' } }],
+  });
+
+  assertFalse('tool_choice' in result);
+});
+
+test('buildTargetRequest omits tool_choice when Chat carries no tools to apply it to', () => {
+  for (const tools of [undefined, null, []]) {
+    const result = buildTargetRequest({
+      model: 'gpt-test',
+      messages: [{ role: 'user', content: 'hello' }],
+      tool_choice: 'required',
+      tools,
+    });
+
+    assertFalse('tool_choice' in result);
+  }
+});
+
 test('buildTargetRequest preserves explicit null prompt cache and safety fields', () => {
   const result = buildTargetRequest({
     model: 'gpt-test',

--- a/packages/translate/__tests__/messages-via-responses/request_test.ts
+++ b/packages/translate/__tests__/messages-via-responses/request_test.ts
@@ -78,6 +78,28 @@ test('buildTargetRequest recovers an empty-front packed signature as id-only rea
   });
 });
 
+test('buildTargetRequest omits tool_choice when Messages omits it', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    max_tokens: 256,
+    messages: [{ role: 'user', content: 'hello' }],
+    tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+  });
+
+  assertFalse('tool_choice' in result);
+});
+
+test('buildTargetRequest omits tool_choice when Messages carries no client tools to apply it to', () => {
+  const result = buildTargetRequest({
+    model: 'gpt-test',
+    max_tokens: 256,
+    messages: [{ role: 'user', content: 'hello' }],
+    tool_choice: { type: 'any' },
+  });
+
+  assertFalse('tool_choice' in result);
+});
+
 test('buildTargetRequest drops filtered-native tool_choice and rewrites assistant native web-search history as function-call history', () => {
   const result = buildTargetRequest({
     model: 'gpt-test',
@@ -112,7 +134,7 @@ test('buildTargetRequest drops filtered-native tool_choice and rewrites assistan
   });
 
   assertEquals(result.tools, null);
-  assertEquals(result.tool_choice, 'auto');
+  assertEquals(result.tool_choice, undefined);
   assertEquals(result.input, [
     {
       type: 'function_call',

--- a/packages/translate/src/chat-completions-via-responses/request.ts
+++ b/packages/translate/src/chat-completions-via-responses/request.ts
@@ -17,8 +17,8 @@ const translateChatTools = (tools?: ChatCompletionsTool[] | null): ResponsesTool
       }))
     : null;
 
-const translateChatToolChoice = (choice?: ChatCompletionsPayload['tool_choice']): ResponsesToolChoice =>
-  choice == null ? 'auto' : typeof choice === 'string' ? choice : { type: 'function', name: choice.function.name };
+const translateChatToolChoice = (choice: NonNullable<ChatCompletionsPayload['tool_choice']>): ResponsesToolChoice =>
+  typeof choice === 'string' ? choice : { type: 'function', name: choice.function.name };
 
 const translateAssistantContent = (message: ChatCompletionsMessage): ResponsesInputContent[] => {
   const content: ResponsesInputContent[] = [];
@@ -149,7 +149,14 @@ export const buildTargetRequest = (payload: ChatCompletionsPayload): CanonicalRe
     ...(payload.top_p !== undefined ? { top_p: payload.top_p } : {}),
     ...(payload.max_tokens !== undefined ? { max_output_tokens: payload.max_tokens } : {}),
     ...(payload.tools !== undefined ? { tools: translateChatTools(payload.tools) } : {}),
-    tool_choice: translateChatToolChoice(payload.tool_choice),
+    // Responses upstreams disagree on an orphaned `tool_choice` — one sent
+    // without tools: OpenAI-backed models ignore it, while xAI-backed ones
+    // reject the request with `invalid-argument: A tool_choice was set on the
+    // request but no tools were specified`. Other gateways hit the same wall on
+    // both the native Responses path and the Responses → Chat Completions path:
+    // https://github.com/Wei-Shaw/sub2api/issues/4819
+    // https://github.com/jlcodes99/cockpit-tools/issues/1727
+    ...(payload.tool_choice != null && payload.tools?.length ? { tool_choice: translateChatToolChoice(payload.tool_choice) } : {}),
     // Same-purpose OpenAI fields are normal Chat/Responses adapter surface;
     // provider-specific policy filtering belongs at the target boundary, not in
     // pairwise translation.

--- a/packages/translate/src/messages-via-responses/request.ts
+++ b/packages/translate/src/messages-via-responses/request.ts
@@ -192,8 +192,15 @@ const translateTools = (tools: MessagesClientTool[] | undefined): ResponsesTool[
   }));
 };
 
-const translateToolChoice = (toolChoice: MessagesPayload['tool_choice'], tools?: MessagesClientTool[]): ResponsesToolChoice => {
-  if (!toolChoice || !tools || tools.length === 0) return 'auto';
+// Responses upstreams disagree on an orphaned `tool_choice` — one sent without
+// tools: OpenAI-backed models ignore it, while xAI-backed ones reject the
+// request with `invalid-argument: A tool_choice was set on the request but no
+// tools were specified`. Other gateways hit the same wall on both the native
+// Responses path and the Responses → Chat Completions path:
+// https://github.com/Wei-Shaw/sub2api/issues/4819
+// https://github.com/jlcodes99/cockpit-tools/issues/1727
+const translateToolChoice = (toolChoice: MessagesPayload['tool_choice'], tools?: MessagesClientTool[]): ResponsesToolChoice | undefined => {
+  if (!toolChoice || !tools || tools.length === 0) return undefined;
 
   const toolNames = new Set(tools.map(tool => tool.name));
 
@@ -203,11 +210,9 @@ const translateToolChoice = (toolChoice: MessagesPayload['tool_choice'], tools?:
   case 'any':
     return 'required';
   case 'tool':
-    return toolChoice.name && toolNames.has(toolChoice.name) ? { type: 'function', name: toolChoice.name } : 'auto';
+    return toolChoice.name && toolNames.has(toolChoice.name) ? { type: 'function', name: toolChoice.name } : undefined;
   case 'none':
     return 'none';
-  default:
-    return 'auto';
   }
 };
 
@@ -223,6 +228,7 @@ export const buildTargetRequest = (payload: MessagesPayload): CanonicalResponses
   const text = jsonSchema ? { format: { type: 'json_schema' as const, ...jsonSchema } } : undefined;
 
   const serviceTier = openAIServiceTierFromMessages(payload);
+  const toolChoice = translateToolChoice(payload.tool_choice, clientTools);
 
   // Keep fallback semantics strict: do not synthesize `temperature: 1`,
   // `store: false`, `parallel_tool_calls: true`, `reasoning.summary`, or
@@ -237,7 +243,7 @@ export const buildTargetRequest = (payload: MessagesPayload): CanonicalResponses
     ...(payload.top_p !== undefined ? { top_p: payload.top_p } : {}),
     max_output_tokens: payload.max_tokens,
     ...(payload.tools !== undefined ? { tools: translateTools(clientTools) } : {}),
-    tool_choice: translateToolChoice(payload.tool_choice, clientTools),
+    ...(toolChoice !== undefined ? { tool_choice: toolChoice } : {}),
     ...(payload.metadata ? { metadata: { ...payload.metadata } } : {}),
     stream: true,
     ...(reasoning ? { reasoning } : {}),


### PR DESCRIPTION
## Problem

Any Messages or Chat Completions request that carries no tools fails on a Responses-only upstream backed by xAI. Claude Code's `/model grok-4.5` trips it immediately:

```
{"error":{"message":"{\"code\":\"invalid-argument\",\"error\":\"Invalid request content: A tool_choice was set on the request but no tools were specified.\"}","code":"invalid_request_body"}}
```

Copilot advertises `grok-4.5` as `supported_endpoints: ["/responses"]`, so a Messages-source request reaches it through `messages-via-responses`. That builder — and its `chat-completions-via-responses` sibling — resolved an absent or unsatisfiable `tool_choice` to `"auto"` and then wrote the field unconditionally, so a tool-less request arrived at the upstream carrying `tool_choice` with no `tools`.

The synthesis dates to the first Responses translator, where the payload type declared `tool_choice` non-optional and forced a value. The type is optional today, but both builders kept the habit — contradicting the no-synthesis rule their own neighbouring fields document and follow for `store`, `temperature`, `parallel_tool_calls`, and `reasoning.*`.

## Why it stayed latent

OpenAI-backed Responses upstreams ignore an orphaned `tool_choice`; xAI-backed ones reject it. Probed directly against Copilot:

| request | result |
| --- | --- |
| `tool_choice:"auto"`, no tools — `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol` | 200 |
| `tool_choice:"auto"`, no tools — `grok-4.5` | 400 |
| `tool_choice:"none"`, no tools — `grok-4.5` | 400 |
| `tools:null` / `tools:[]` with no `tool_choice` — `grok-4.5` | 200 |

The synthesized `tools: null` is harmless; only the synthesized `tool_choice` breaks. Other gateways have hit the same wall on both the native Responses path ([Wei-Shaw/sub2api#4819](https://github.com/Wei-Shaw/sub2api/issues/4819)) and the Responses → Chat Completions path ([jlcodes99/cockpit-tools#1727](https://github.com/jlcodes99/cockpit-tools/issues/1727)).

## Change

Both builders emit `tool_choice` only when the source expressed a choice that has tools to apply to.

`messages-via-responses` guards inside `translateToolChoice`, which already needs the filtered client-tool name set to resolve a named choice; a choice naming a tool that did not survive translation is dropped rather than downgraded. Its `default:` arm is gone — `MessagesPayload['tool_choice'].type` is a closed union with every member cased, so once the return type admitted `undefined` the arm was identical to fall-through.

`chat-completions-via-responses` guards at the call site next to the `tools:` emission it depends on, leaving `translateChatToolChoice` a pure shape mapping over `NonNullable<...>`. Passing `tools` into the translator would add a parameter its body never reads.

The other five pairs already preserve absence: `responses-via-messages` and `responses-via-chat-completions` return `undefined`, and the three `gemini-via-*` pairs only assign `tool_choice` inside their `if (tools)` branch.

## Test Plan

- [x] `pnpm run test` — 4953 passed
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] New unit coverage in both `*-via-responses` request suites: choice omitted by the source, `tools` absent/`null`/`[]`, and a named choice whose tool did not survive translation
- [x] End-to-end against live `grok-4.5` through a scratch Node instance with a Copilot upstream: `POST /v1/messages` with no tools, with `tools: []`, and `POST /v1/chat/completions` with no tools all return 200; `tool_choice: {type:"any"}` with a real tool still returns `stop_reason: tool_use` naming that tool
- [x] Same no-tools request on the pre-fix source reproduces the 400, confirming the diff is what changed the outcome