### PR TITLE
docs(provider-copilot): re-ground the inline-system threshold in a direct test

### DIFF
--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -28,10 +28,13 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
   'strip-prompt-cache-key': false,
 };
 
-// True when the model id names a Claude release whose Anthropic Messages
-// wire accepts inline `role:'system'` (i.e., a mid-conversation system
-// turn placed between assistant/user turns rather than in the top-level
-// `system` field).
+// True when the model id names a Claude release Copilot can serve an inline
+// `role:'system'` turn for — a mid-conversation system message carried in
+// `messages` rather than the top-level `system` field.
+//
+// Two independent things can reject such a turn, and this predicate has to
+// cover both: the model may not implement the feature at all, or the
+// deployment serving the request may run a validator that predates it.
 //
 // The id-family regex accepts any `claude-<family>-<major>[[.-]<minor>]`
 // shape — the version number is the sole gate, family names are opaque
@@ -44,62 +47,82 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
 //
 // # Empirical evidence
 //
-// Copilot's Claude model catalog is served through both AWS Bedrock and
-// Google Vertex, with the choice made per-request by Copilot's own load
-// balancer. Only Bedrock has shipped Anthropic's mid-conversation-system
-// feature; Vertex still validates against the pre-feature role enum
-// `user | assistant` and rejects `role:'system'` outright with:
+// ## Direct functional test
 //
-//     Unexpected role "system". The Messages API accepts a top-level
-//     `system` parameter, not "system" as an input message role.
+// The validator constrains an inline system turn from both sides: it must
+// FOLLOW a user turn and PRECEDE an assistant turn, so in a generation request
+// the only legal position is last, immediately before the turn being
+// generated. Probed in that position, with no `anthropic-beta` header (see
+// below), against every Claude model in the catalog:
 //
-// The `anthropic-beta: mid-conversation-system-2026-04-07` header does
-// NOT unlock this on Vertex — Vertex returns
-// `Unexpected value for the 'anthropic-beta' header` when it appears.
-// On Bedrock the header is a no-op (the feature is GA there for models
-// that have it).
+//     | model             | verdict                                   |
+//     | claude-opus-4.8   | 200                                       |
+//     | claude-opus-5     | 200                                       |
+//     | claude-sonnet-5   | 200                                       |
+//     | claude-opus-4.7   | role 'system' is not supported on this... |
+//     | claude-haiku-4.5  | role 'system' is not supported on this... |
+//     | claude-opus-4.6   | Unexpected role "system". The Messages...  |
+//     | claude-sonnet-4.6 | Unexpected role "system". The Messages...  |
 //
-// So the operative question is: given a public model id, does the
-// Copilot LB route to Bedrock deterministically enough that we can
-// leave inline system on, or is the model split across backends where
-// we must demote to avoid random Vertex-side 400s?
+// The two rejections are different failures. `role 'system' is not supported
+// on this model` comes back from a deployment that implements the feature and
+// is telling us the model does not — 4.7 and haiku-4.5 draw it while served by
+// Anthropic's own API. `Unexpected role "system"` is a validator that does not
+// know the role exists, which is what 4.6 and sonnet-4.6 are still served by.
+// The `>= 4.8` threshold happens to separate both at once.
 //
-// We ran a two-day cron-driven probe (Jun 26 → Jun 28 2026) that hit
-// the Copilot enterprise endpoint from two accounts (personal + GHE)
-// every 30
-// minutes with a Shape E payload
-// (`[user, assistant, system, user]` + the beta header) against every
-// Claude model then in the catalog. The classifier keyed on
-// `request_id`: `req_vrtx_*` = Vertex; bare `req_*` = Bedrock
-// (Copilot forwards AWS `InvokeModel` calls whose ids never carry the
-// `bdrk_` infix Anthropic's own SDK wrapper adds). Where Copilot
-// stripped the id, backend was recovered from validator wording —
-// `Unexpected role "system"` = Vertex legacy, `messages.N: role
-// 'system' must ...` = Bedrock mid-conv validator.
+// The `anthropic-beta: mid-conversation-system-2026-04-07` header does not
+// help and can hurt: Vertex answers `Unexpected value for the 'anthropic-beta'
+// header` when it appears, and elsewhere it is a no-op for models that have
+// the feature. The gateway's allow-list drops it anyway, so the probe above
+// measures what actually goes on the wire.
 //
-// After 40h / 1150 samples the distribution was:
+// ## Backend attribution
 //
-//     | model              | Bedrock | Vertex | Bedrock% |
-//     | claude-opus-4.8    |     163 |      0 |     100% |
-//     | claude-opus-4.7    |      82 |     82 |      50% |
-//     | claude-sonnet-4.6  |      46 |    117 |      28% |
-//     | claude-opus-4.6    |      14 |    150 |       9% |
-//     | claude-haiku-4.5   |      18 |    146 |      11% |
-//     | claude-opus-4.5    |       0 |    164 |       0% |
-//     | claude-sonnet-4.5  |       0 |    163 |       0% |
+// Copilot serves this catalog from three Anthropic deployments, not two: AWS
+// Bedrock, Google Vertex, and Anthropic's own API, chosen per request by
+// Copilot's load balancer. The Anthropic message id names the one that served
+// a response — `msg_vrtx_*`, `msg_bdrk_*`, or a bare `msg_01*` for
+// Anthropic-direct. The infix is applied by the platform, not by a client
+// library: both Anthropic SDKs contain zero occurrences of `bdrk` or `vrtx` in
+// their sources, so a proxied response carries it exactly as a direct one
+// does. Copilot strips Anthropic's `request-id` response header, which leaves
+// the message id as the only backend signal on a success; a 400 carries no
+// message id and is attributable only when its wording names a deployment.
 //
-// A follow-up 80-sample probe (Jul 3 2026) covered the newly-released
-// `claude-sonnet-5`; 80/80 = 100% Bedrock across both accounts. The
-// version-threshold hypothesis — Anthropic released mid-conv system on
-// Bedrock alongside the 4.8 line and every subsequent release ships
-// Bedrock-only routing — held; the equivalent check for older models
-// showed no Bedrock-favoring drift versus the earlier probe. The
-// backend selection is also account-independent (both accounts agreed
-// within ±5% on every non-4.8 model, and 100% on 4.8 / sonnet-5).
+// ## Routing distribution
 //
-// Threshold conclusion: `>= 4.8`. This includes `claude-opus-4.8` and
-// every 5.x release (which trivially exceeds `[4, 8]`); everything at
-// 4.7 or below stays demoted.
+// A two-day probe (Jun 26 → Jun 28 2026) hit the Copilot enterprise endpoint
+// from two accounts every 30 minutes with an inline-system payload. It
+// predates the message-id classifier and read the backend from validator
+// wording, which separates deployments that carry the feature from those that
+// do not rather than naming the platform — so its non-Vertex column merges
+// Bedrock with Anthropic-direct. The Vertex column is the load-bearing one and
+// is sound, `Unexpected role "system"` being the pre-feature validator.
+//
+//     | model              | non-Vertex | Vertex | non-Vertex% |
+//     | claude-opus-4.8    |        163 |      0 |        100% |
+//     | claude-opus-4.7    |         82 |     82 |         50% |
+//     | claude-sonnet-4.6  |         46 |    117 |         28% |
+//     | claude-opus-4.6    |         14 |    150 |          9% |
+//     | claude-haiku-4.5   |         18 |    146 |         11% |
+//     | claude-opus-4.5    |          0 |    164 |          0% |
+//     | claude-sonnet-4.5  |          0 |    163 |          0% |
+//
+// A follow-up 80-sample probe (Jul 3 2026) covered the then-new
+// `claude-sonnet-5`: 80/80 non-Vertex across both accounts. Backend selection
+// is account-independent, and a later 4500-sample run (Jul 27 → Aug 1 2026)
+// from two network egresses reproduced the same split with the message-id
+// classifier and found the client's source address irrelevant to it. Vertex
+// appeared only on models below 4.8 in every run.
+//
+// References:
+// - https://github.com/anthropics/anthropic-sdk-typescript/tree/f298e9ad78cea4c047940a33d944f20e3f3b60f2/src (no `bdrk` / `vrtx` anywhere; the infix is the platform's)
+// - https://github.com/anthropics/anthropic-sdk-python/tree/main/src/anthropic (same)
+//
+// Threshold conclusion: `>= 4.8`. This includes `claude-opus-4.8` and every
+// 5.x release (which trivially exceeds `[4, 8]`); everything at 4.7 or below
+// stays demoted.
 const supportsInlineSystem = (id: string): boolean => {
   const m = /^claude-[a-z]+-(\d+)(?:[.-](\d+))?$/.exec(id);
   if (!m) return false;


### PR DESCRIPTION
Comment-only change to `packages/provider-copilot/src/defaults.ts`. The predicate and the flag it feeds are untouched.

## The falsified claim

The evidence block behind `supportsInlineSystem` explained how it classified a probe sample's serving backend:

> The classifier keyed on `request_id`: `req_vrtx_*` = Vertex; bare `req_*` = Bedrock (Copilot forwards AWS `InvokeModel` calls whose ids never carry the `bdrk_` infix Anthropic's own SDK wrapper adds).

Live probing of the Copilot Messages upstream contradicts both halves:

- `msg_bdrk_*` **does** appear on Copilot's wire.
- The infix is applied by the serving platform, not by a client library. Neither Anthropic SDK contains `bdrk` or `vrtx` anywhere in its source, so a proxied response carries it exactly as a direct one does.
- A bare id is therefore not Bedrock but a **third** deployment — Anthropic's own API. Copilot serves this catalog from three, not two.

Consequence: the probe's `Bedrock` column merged Bedrock with Anthropic-direct. It is relabelled `non-Vertex`. Its `Vertex` column never depended on the mistake and stands unchanged, `Unexpected role "system"` being the pre-feature validator either way.

## The threshold no longer needs to be inferred

The old reasoning reached `>= 4.8` indirectly, by arguing that those models route to a backend that carries the feature. A direct test is now available.

The validator constrains an inline system turn from both sides — it must FOLLOW a user turn and PRECEDE an assistant turn — so in a generation request the only legal position is last, immediately before the turn being generated. Earlier probes placed it after an assistant turn or between two user turns and were rejected on placement alone, which is why the capability was never measured directly. Probed in the legal position:

| model | verdict |
|---|---|
| claude-opus-4.8 | 200 |
| claude-opus-5 | 200 |
| claude-sonnet-5 | 200 |
| claude-opus-4.7 | `role 'system' is not supported on this model` |
| claude-haiku-4.5 | `role 'system' is not supported on this model` |
| claude-opus-4.6 | `Unexpected role "system"` |
| claude-sonnet-4.6 | `Unexpected role "system"` |

The two rejections are independent failures, and the comment now says so. `role 'system' is not supported on this model` comes from a deployment that implements the feature reporting that the *model* does not — 4.7 and haiku-4.5 draw it while served by Anthropic-direct. `Unexpected role "system"` is a validator that does not know the role exists. `>= 4.8` separates both at once, which is why one predicate covers them.

## Also recorded

The message-id classifier (`msg_vrtx_*` / `msg_bdrk_*` / bare `msg_01*`) that made per-sample attribution possible, the fact that Copilot strips Anthropic's `request-id` response header so the message id is the only backend signal on a success, and a later 4500-sample run across two network egresses that reproduced the same split and found the client's source address irrelevant to it.

## Test Plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 4947 passed / 421 files