### PR TITLE
fix(copilot): read a quota bucket the seat does not have as absent, not exhausted

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -98,9 +98,10 @@ export interface CopilotUpstreamConfig {
 
 // One entitlement bucket, keyed in `CopilotQuotaSnapshot.quotas` by Copilot's
 // open-string `quota_id` (`premium_interactions`, `chat`, `completions`, and
-// `premium_models` in the wild). `unlimited` is the only reliable way to tell
-// an uncapped bucket: the two quota sources express it with different
-// `entitlement` / `quota_remaining` values, so neither number infers a cap.
+// `premium_models` in the wild). A bucket is uncapped when `unlimited` is set —
+// the two quota sources spell that with different `entitlement` values, so no
+// number infers it — and does not apply to the seat at all when `entitlement`
+// is not positive, which is how a free seat reports `premium_interactions`.
 export interface CopilotQuotaDetail {
   entitlement: number;
   overage_count: number;

--- a/apps/web/src/components/upstream-edit/CopilotInfo.vue
+++ b/apps/web/src/components/upstream-edit/CopilotInfo.vue
@@ -48,27 +48,34 @@ const refresh = async () => {
   refreshed.value = data ?? null;
 };
 
-// Every bucket the seat reports, in the upstream's own naming. A paid seat
-// meters `premium_interactions` (or `premium_models`) against a real
-// entitlement and reports `chat` / `completions` as unlimited; a free seat
-// meters the latter two instead. Rendering whatever comes back keeps the card
-// honest on both without pinning a known set of quota ids.
+// Every bucket the seat reports, in the upstream's own naming, sorted into the
+// three kinds a seat actually reports. A paid seat meters
+// `premium_interactions` (or `premium_models`) and reports `chat` /
+// `completions` as unlimited; a free seat meters the latter two and reports
+// `premium_interactions` as unavailable — `entitlement: 0`, which the upstream
+// pairs with `percent_remaining: 0`, so treating it as a metered bucket would
+// render a full bar on a seat that simply has no premium allotment.
+//
+// `usedPercent` is reported as the upstream computed it, including past 100
+// when an overage-permitted bucket runs negative. Only the bar is clamped,
+// because a bar cannot be wider than itself.
 const allBuckets = computed(() => Object.entries(quota.value?.quotas ?? {}).map(([id, detail]) => ({
   id,
   label: id.replace(/_/g, ' '),
   detail,
-  usedPercent: Math.min(100, Math.max(0, Math.round(100 - detail.percent_remaining))),
+  kind: detail.unlimited ? 'unlimited' : detail.entitlement > 0 ? 'metered' : 'unavailable',
+  usedPercent: Math.round(100 - detail.percent_remaining),
+  barPercent: Math.min(100, Math.max(0, Math.round(100 - detail.percent_remaining))),
   used: Math.round(detail.entitlement - detail.quota_remaining),
 })));
 
-// An unlimited bucket has nothing to report, so the card shows only what is
-// actually metered. A seat with no metered bucket at all still gets one row —
-// otherwise the card would read as "no quota observed" when the truth is
-// "nothing is capped". The premium bucket is the one an operator looks for, so
-// it is the preferred stand-in; falling back to the first reported bucket
-// keeps that working if GitHub renames it.
+// Only metered buckets carry information, so they are the card. A seat with
+// nothing metered still gets one row — otherwise the card would read as "no
+// quota observed" when the truth is "nothing is capped". The premium bucket is
+// the one an operator looks for, so it is the preferred stand-in; falling back
+// to the first reported bucket keeps that working if GitHub renames it.
 const buckets = computed(() => {
-  const metered = allBuckets.value.filter(bucket => !bucket.detail.unlimited);
+  const metered = allBuckets.value.filter(bucket => bucket.kind === 'metered');
   if (metered.length > 0) return metered;
   const premium = allBuckets.value.find(bucket => bucket.id.startsWith('premium'));
   const standIn = premium ?? allBuckets.value[0];
@@ -120,16 +127,17 @@ const resetsOn = computed(() => {
         <div v-for="bucket in buckets" :key="bucket.id" class="space-y-1.5">
           <div class="flex items-baseline justify-between text-sm">
             <span class="capitalize text-gray-300">{{ bucket.label }}</span>
-            <span v-if="bucket.detail.unlimited" class="text-xs text-gray-400">Unlimited</span>
+            <span v-if="bucket.kind === 'unlimited'" class="text-xs text-gray-400">Unlimited</span>
+            <span v-else-if="bucket.kind === 'unavailable'" class="text-xs text-gray-400">Not included in this plan</span>
             <span v-else class="text-white">
               {{ bucket.used.toLocaleString() }} / {{ bucket.detail.entitlement.toLocaleString() }}
               <span class="text-xs text-gray-400">· {{ bucket.usedPercent }}% used</span>
             </span>
           </div>
-          <div v-if="!bucket.detail.unlimited" class="h-1.5 overflow-hidden rounded-full bg-surface-700">
+          <div v-if="bucket.kind === 'metered'" class="h-1.5 overflow-hidden rounded-full bg-surface-700">
             <div
               class="h-full bg-accent-cyan transition-[width]"
-              :style="{ width: `${bucket.usedPercent}%` }"
+              :style="{ width: `${bucket.barPercent}%` }"
             />
           </div>
         </div>

--- a/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
@@ -2282,8 +2282,8 @@ test('POST /api/upstreams/copilot/quota projects the GitHub body and persists it
 
 // The passive header path refuses to write an empty snapshot so a good
 // reading survives; the operator refresh has to honour the same contract, or
-// pressing Refresh on a free seat — whose usage body carries no quota_snapshots
-// at all — would erase what the headers harvested.
+// pressing Refresh against a body on the pre-2026-06 shape — which carries no
+// `quota_snapshots` — would erase what the headers harvested.
 test('POST /api/upstreams/copilot/quota leaves the stored snapshot alone when the body reports no buckets', async () => {
   const { repo, adminSession, copilotUpstream } = await setupAppTest();
   const stored = await repo.upstreams.getById(copilotUpstream.id);
@@ -2306,7 +2306,7 @@ test('POST /api/upstreams/copilot/quota leaves the stored snapshot alone when th
   await withMockedFetch(
     async (request: Request) => {
       if (request.url === 'https://api.github.com/copilot_internal/user') {
-        return jsonResponse({ access_type_sku: 'free_limited_copilot', copilot_plan: 'free', limited_user_quotas: { chat: 10 } });
+        return jsonResponse({ access_type_sku: 'free_limited_copilot', copilot_plan: 'individual', limited_user_quotas: { chat: 500, completions: 3876 }, monthly_quotas: { chat: 500, completions: 4000 } });
       }
       throw new Error(`Unhandled fetch ${request.url}`);
     },

--- a/packages/provider-copilot/__tests__/quota_test.ts
+++ b/packages/provider-copilot/__tests__/quota_test.ts
@@ -76,8 +76,6 @@ test('parseCopilotQuotaHeaders ignores a prototype-polluting quota id', () => {
 
 test('projectCopilotUsageResponse lands on the same shape the headers produce', () => {
   const body: CopilotUsageResponse = {
-    access_type_sku: 'copilot_pro',
-    copilot_plan: 'individual',
     quota_reset_date_utc: '2026-09-01T00:00:00.000Z',
     quota_snapshots: {
       premium_interactions: {
@@ -104,8 +102,6 @@ test('projectCopilotUsageResponse lands on the same shape the headers produce', 
 // inventing one.
 test('projectCopilotUsageResponse reports a missing reset instant as null', () => {
   const projected = projectCopilotUsageResponse({
-    access_type_sku: 'copilot_pro',
-    copilot_plan: 'individual',
     quota_snapshots: {
       premium_interactions: {
         entitlement: 300,
@@ -127,13 +123,70 @@ test('projectCopilotUsageResponse reports a missing reset instant as null', () =
 // buckets is "nothing observed", so an operator's refresh on such a seat
 // neither fails nor overwrites what the headers already harvested.
 test('projectCopilotUsageResponse reports a body with no quota buckets as no observation', () => {
-  assertEquals(projectCopilotUsageResponse({
-    access_type_sku: 'free_limited_copilot',
-    copilot_plan: 'free',
-  }, NOW), null);
-  assertEquals(projectCopilotUsageResponse({
-    access_type_sku: 'copilot_pro',
-    copilot_plan: 'individual',
-    quota_snapshots: {},
-  }, NOW), null);
+  assertEquals(projectCopilotUsageResponse({}, NOW), null);
+  assertEquals(projectCopilotUsageResponse({ quota_snapshots: {} }, NOW), null);
+});
+
+// Captured from a live `free_limited_copilot` seat on 2026-07-08
+// (https://github.com/TopiCsarno/yapcap/blob/152ea67c3abd44776268627d58533003099da951/fixtures/copilot/copilot_user_response.json).
+// The seat meters chat and completions and reports `premium_interactions` as
+// `entitlement: 0` — an allotment it does not have, not one it has exhausted.
+test('projectCopilotUsageResponse keeps a free seat’s metered buckets and its zero-entitlement one apart', () => {
+  const projected = projectCopilotUsageResponse({
+    quota_reset_date_utc: '2026-08-01T00:00:00.000Z',
+    quota_snapshots: {
+      chat: { entitlement: 200, unlimited: false, quota_remaining: 200, percent_remaining: 100, overage_count: 0, overage_permitted: false },
+      completions: { entitlement: 2000, unlimited: false, quota_remaining: 2000, percent_remaining: 100, overage_count: 0, overage_permitted: false },
+      premium_interactions: { entitlement: 0, unlimited: false, quota_remaining: 0, percent_remaining: 0, overage_count: 0, overage_permitted: false },
+    },
+  }, NOW);
+
+  assertEquals(projected?.quotas.chat.entitlement, 200);
+  assertEquals(projected?.quotas.completions.entitlement, 2000);
+  // Projected verbatim; the dashboard reads `entitlement > 0` to tell a bucket
+  // the seat does not have from one it has burned through.
+  assertEquals(projected?.quotas.premium_interactions.entitlement, 0);
+  assertEquals(projected?.quotas.premium_interactions.unlimited, false);
+});
+
+// Every field on this endpoint is optional per GitHub's own SDK schema. A
+// bucket without a cap or a remainder cannot be rendered honestly, so it is
+// dropped the way the header path drops a half-parsed one.
+test('projectCopilotUsageResponse drops a bucket whose cap or remainder is missing', () => {
+  const projected = projectCopilotUsageResponse({
+    quota_snapshots: {
+      chat: { percent_remaining: 50 },
+      completions: { entitlement: 2000, quota_remaining: 1500 },
+    },
+  }, NOW);
+
+  assertEquals(Object.keys(projected?.quotas ?? {}), ['completions']);
+});
+
+// `percent_remaining` is optional; deriving it from the two fields we do
+// require is arithmetic, not a default standing in for an unknown.
+test('projectCopilotUsageResponse derives percent_remaining when the body omits it', () => {
+  const projected = projectCopilotUsageResponse({
+    quota_snapshots: {
+      completions: { entitlement: 2000, quota_remaining: 1500 },
+    },
+  }, NOW);
+
+  assertEquals(projected?.quotas.completions.percent_remaining, 75);
+});
+
+// Both sources can report an empty reset instant — `rst=` with no value, or
+// `quota_reset_date_utc: ""`. Rendering either produces "Invalid Date".
+test('both quota sources report an unparseable reset instant as none', () => {
+  const fromBody = projectCopilotUsageResponse({
+    quota_reset_date_utc: '',
+    quota_snapshots: { chat: { entitlement: 200, quota_remaining: 200, percent_remaining: 100 } },
+  }, NOW);
+  assertEquals(fromBody?.reset_at, null);
+
+  const fromHeaders = parseCopilotQuotaHeaders(
+    new Headers({ 'x-quota-snapshot-chat': 'ent=200&ov=0.0&ovPerm=false&rem=100.0&rst=&totRem=200' }),
+    NOW,
+  );
+  assertEquals(fromHeaders?.reset_at, null);
 });

--- a/packages/provider-copilot/__tests__/quota_test.ts
+++ b/packages/provider-copilot/__tests__/quota_test.ts
@@ -118,10 +118,11 @@ test('projectCopilotUsageResponse reports a missing reset instant as null', () =
   assertEquals(projected?.quotas.premium_interactions.quota_remaining, 270);
 });
 
-// A free / limited seat omits `quota_snapshots` entirely and reports through
-// `limited_user_quotas` instead. Same null contract as the header path: no
-// buckets is "nothing observed", so an operator's refresh on such a seat
-// neither fails nor overwrites what the headers already harvested.
+// A body on the pre-2026-06 shape leaves `quota_snapshots` empty or absent and
+// reports through `limited_user_quotas`, which we do not read. Same null
+// contract as the header path: no buckets is "nothing observed", so an
+// operator's refresh against such a body neither fails nor overwrites what the
+// headers already harvested.
 test('projectCopilotUsageResponse reports a body with no quota buckets as no observation', () => {
   assertEquals(projectCopilotUsageResponse({}, NOW), null);
   assertEquals(projectCopilotUsageResponse({ quota_snapshots: {} }, NOW), null);

--- a/packages/provider-copilot/src/quota.ts
+++ b/packages/provider-copilot/src/quota.ts
@@ -159,9 +159,9 @@ export const parseCopilotQuotaHeaders = (headers: Headers, now: Date): CopilotQu
 // `limited_user_quotas` (remaining) + `monthly_quotas` (entitlement) and leaves
 // `quota_snapshots` empty or absent — we do not read those, so such a body
 // projects to "nothing observed" and the header path is what fills the slot.
-// Captured legacy and current bodies for the same free SKU:
+// Captured current and legacy bodies for the same free SKU, in that order:
 // https://github.com/TopiCsarno/yapcap/blob/152ea67c3abd44776268627d58533003099da951/fixtures/copilot/copilot_user_response.json
-// https://github.com/bugwz/AIMeter/blob/main/docs/providers/copliot/demo.free.json
+// https://github.com/bugwz/AIMeter/blob/b93c15558863c3eb3fe1a0e71197c233343c9400/docs/providers/copliot/demo.free.json
 export interface CopilotUsageResponse {
   quota_reset_date_utc?: string;
   quota_snapshots?: Record<string, {

--- a/packages/provider-copilot/src/quota.ts
+++ b/packages/provider-copilot/src/quota.ts
@@ -70,6 +70,10 @@ export interface CopilotQuotaSnapshot {
 
 const QUOTA_SNAPSHOT_HEADER_PREFIX = 'x-quota-snapshot-';
 
+// `-1` denotes an unlimited entitlement, per GitHub's own SDK declaration of
+// this field — `@github/copilot-sdk@1.0.8`, `dist/generated/rpc.d.ts`:
+// "Number of requests/units included in the entitlement for this period; `-1`
+// denotes an unlimited entitlement."
 const UNLIMITED_SENTINEL = -1;
 
 const isUnsafeQuotaId = (id: string): boolean =>
@@ -137,11 +141,15 @@ export const parseCopilotQuotaHeaders = (headers: Headers, now: Date): CopilotQu
   return { observed_at: now.toISOString(), reset_at: resetAt, quotas };
 };
 
-// `GET /copilot_internal/user`. Every field is optional: that is how GitHub's own
-// Copilot CLI SDK types this endpoint (a zod schema in `@github/copilot`'s
-// typings, `strip` mode so unknown keys pass through), and the captures agree.
-// We declare only what we project — a field we do not read has no business
-// being here.
+// `GET /copilot_internal/user`. Every field is optional, including every field
+// inside a bucket — that is how GitHub's own SDK declares this endpoint, in
+// `@github/copilot-sdk@1.0.8`, `dist/generated/rpc.d.ts` (`quota_snapshots?` on
+// `CopilotUserResponse`, and `entitlement?` / `percent_remaining?` /
+// `quota_remaining?` / `unlimited?` on `CopilotUserResponseQuotaSnapshotsChat`).
+// The captures we have carry every field, so the SDK is the only source for the
+// optionality; it is a generated declaration file rather than a runtime schema,
+// and the interfaces are marked `@experimental`. We declare only what we
+// project — a field we do not read has no business being here.
 //
 // Two body shapes are live at once, split by GitHub's 2026-06-01 AI-Credits
 // change. A seat on the current shape reports `quota_snapshots` whatever its

--- a/packages/provider-copilot/src/quota.ts
+++ b/packages/provider-copilot/src/quota.ts
@@ -30,11 +30,21 @@ import { githubHeaders } from './auth.ts';
 import { readCopilotUpstreamState, type CopilotUpstreamState } from './state.ts';
 import { getProviderRepo, type Fetcher } from '@floway-dev/provider';
 
-// One quota bucket. `unlimited` is the authoritative flag on both sources, and
-// it is the only one: the headers spell an uncapped bucket `ent=-1&totRem=-1`
-// (from which we derive the flag), while the REST body reports the same bucket
-// as `unlimited: true` with `entitlement: 0` and `quota_remaining: 0`. Reading
-// either number to infer a cap is wrong on one source or the other.
+// One quota bucket. A seat reports three kinds of bucket and both sources spell
+// them differently, so nothing but the pair below is safe to read:
+//
+//   metered      real cap, real consumption.
+//   uncapped     `unlimited`. Headers spell it `ent=-1&totRem=-1`; the REST body
+//                sets the flag with `entitlement: 0`, so neither number infers it.
+//   unavailable  the bucket does not apply to this seat — a free seat's
+//                `premium_interactions` comes back `entitlement: 0` with
+//                `has_quota: false` and `percent_remaining: 0`. Reading that as
+//                consumption renders "0 / 0 · 100% used" on a seat that simply
+//                has no premium allotment.
+//
+// `entitlement > 0` separates metered from unavailable on both sources, which is
+// why `has_quota` is not projected: the headers have no counterpart for it, so a
+// consumer keying off it would work on one source and not the other.
 export interface CopilotQuotaDetail {
   entitlement: number;
   overage_count: number;
@@ -69,6 +79,18 @@ const parseNumber = (raw: string | null): number | null => {
   if (raw === null) return null;
   const value = Number(raw);
   return Number.isFinite(value) ? value : null;
+};
+
+const finiteOrNull = (value: number | undefined): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+// Both sources hand us a reset instant as a string, and both can hand us an
+// empty one — `rst=` with no value, or `quota_reset_date_utc: ""`. Rendering
+// that produces "Invalid Date", so anything unparseable reads as "no reset
+// instant reported".
+const resetInstantOrNull = (raw: string | null | undefined): string | null => {
+  if (raw === null || raw === undefined || raw.trim() === '') return null;
+  return Number.isNaN(new Date(raw).getTime()) ? null : raw;
 };
 
 // `ent=-1&ov=0.0&ovPerm=false&rem=100.0&rst=...&totRem=-1`. A bucket is only
@@ -108,66 +130,85 @@ export const parseCopilotQuotaHeaders = (headers: Headers, now: Date): CopilotQu
     const detail = parseQuotaDetail(fields);
     if (detail === null) return;
     quotas[quotaId] = detail;
-    resetAt ??= fields.get('rst');
+    resetAt ??= resetInstantOrNull(fields.get('rst'));
   });
 
   if (Object.keys(quotas).length === 0) return null;
   return { observed_at: now.toISOString(), reset_at: resetAt, quotas };
 };
 
-// `GET /copilot_internal/user`. Beyond the fields projected below, the body also
-// carries `credits_used`, `overage_entitlement`, `has_quota`,
-// `token_based_billing` (the AI-Credits vs. premium-interactions
-// discriminator), a per-bucket `timestamp_utc`, and the seat's plan and org
-// metadata. None of it has a consumer yet, and the header path cannot supply
-// any of it — surfacing one would mean a field that silently blanks out
-// whenever the passive path wins the race. Widen this interface and
-// `projectCopilotUsageResponse` together when something needs them.
+// `GET /copilot_internal/user`. Every field is optional: that is how GitHub's own
+// Copilot CLI SDK types this endpoint (a zod schema in `@github/copilot`'s
+// typings, `strip` mode so unknown keys pass through), and the captures agree.
+// We declare only what we project — a field we do not read has no business
+// being here.
 //
-// `quota_snapshots` is optional because a free / limited seat reports its
-// entitlement through `limited_user_quotas` + `monthly_quotas` instead and
-// omits the map entirely. We do not read those: the header path covers those
-// seats from their first request, and a body we cannot project reads as "no
-// buckets" rather than as a gateway error.
-// Prior art on the optionality:
-// https://github.com/raycast/extensions/blob/main/extensions/agent-usage/src/copilot/fetcher.ts
-// https://github.com/onllm-dev/onWatch/blob/main/internal/api/copilot_types.go
+// Two body shapes are live at once, split by GitHub's 2026-06-01 AI-Credits
+// change. A seat on the current shape reports `quota_snapshots` whatever its
+// plan, including free (captured 2026-07-08 on a `free_limited_copilot` seat:
+// `chat` 200, `completions` 2000, `premium_interactions` entitlement 0 with
+// `has_quota: false`). A seat on the legacy shape reports through
+// `limited_user_quotas` (remaining) + `monthly_quotas` (entitlement) and leaves
+// `quota_snapshots` empty or absent — we do not read those, so such a body
+// projects to "nothing observed" and the header path is what fills the slot.
+// Captured legacy and current bodies for the same free SKU:
+// https://github.com/TopiCsarno/yapcap/blob/152ea67c3abd44776268627d58533003099da951/fixtures/copilot/copilot_user_response.json
+// https://github.com/bugwz/AIMeter/blob/main/docs/providers/copliot/demo.free.json
 export interface CopilotUsageResponse {
-  access_type_sku: string;
-  copilot_plan: string;
   quota_reset_date_utc?: string;
   quota_snapshots?: Record<string, {
-    entitlement: number;
-    overage_count: number;
-    overage_permitted: boolean;
-    percent_remaining: number;
-    quota_remaining: number;
-    unlimited: boolean;
+    entitlement?: number;
+    overage_count?: number;
+    overage_permitted?: boolean;
+    percent_remaining?: number;
+    quota_remaining?: number;
+    unlimited?: boolean;
   }>;
 }
+
+// The REST body holds the same three numbers the headers do, so it gets the same
+// treatment: a bucket whose cap or remainder is missing or non-finite is dropped
+// rather than rendered as a confident zero. `percent_remaining` is derived when
+// the body omits it, because that is arithmetic on the two fields we require —
+// not a default standing in for an unknown.
+const projectQuotaDetail = (detail: {
+  entitlement?: number;
+  overage_count?: number;
+  overage_permitted?: boolean;
+  percent_remaining?: number;
+  quota_remaining?: number;
+  unlimited?: boolean;
+}): CopilotQuotaDetail | null => {
+  const entitlement = finiteOrNull(detail.entitlement);
+  const quotaRemaining = finiteOrNull(detail.quota_remaining);
+  if (entitlement === null || quotaRemaining === null) return null;
+  const percentRemaining = finiteOrNull(detail.percent_remaining)
+    ?? (entitlement > 0 ? (quotaRemaining / entitlement) * 100 : 0);
+  return {
+    entitlement,
+    overage_count: finiteOrNull(detail.overage_count) ?? 0,
+    overage_permitted: detail.overage_permitted === true,
+    percent_remaining: percentRemaining,
+    quota_remaining: quotaRemaining,
+    unlimited: detail.unlimited === true || entitlement === UNLIMITED_SENTINEL,
+  };
+};
 
 // Same null contract as `parseCopilotQuotaHeaders`: a body that reports no
 // buckets is "nothing observed", not "everything is zero". Returning a
 // well-formed empty snapshot here would let an operator's refresh overwrite a
-// good reading the header path had already harvested — which is exactly the
-// seat class that reaches this branch.
+// good reading the header path had already harvested.
 export const projectCopilotUsageResponse = (body: CopilotUsageResponse, now: Date): CopilotQuotaSnapshot | null => {
   const quotas: Record<string, CopilotQuotaDetail> = {};
   for (const [quotaId, detail] of Object.entries(body.quota_snapshots ?? {})) {
     if (isUnsafeQuotaId(quotaId)) continue;
-    quotas[quotaId] = {
-      entitlement: detail.entitlement,
-      overage_count: detail.overage_count,
-      overage_permitted: detail.overage_permitted,
-      percent_remaining: detail.percent_remaining,
-      quota_remaining: detail.quota_remaining,
-      unlimited: detail.unlimited,
-    };
+    const projected = projectQuotaDetail(detail);
+    if (projected !== null) quotas[quotaId] = projected;
   }
   if (Object.keys(quotas).length === 0) return null;
   return {
     observed_at: now.toISOString(),
-    reset_at: body.quota_reset_date_utc ?? null,
+    reset_at: resetInstantOrNull(body.quota_reset_date_utc),
     quotas,
   };
 };


### PR DESCRIPTION
Follow-up to #339. Captured `/copilot_internal/user` bodies for a real `free_limited_copilot` seat, plus GitHub's own declaration of that endpoint, showed the card reporting a quota the seat does not have as one it had exhausted.

## The bug

A free seat reports three buckets, and the third is not a quota it has spent ([captured 2026-07-08](https://github.com/TopiCsarno/yapcap/blob/152ea67c3abd44776268627d58533003099da951/fixtures/copilot/copilot_user_response.json)):

```json
"chat":                 { "entitlement": 200,  "quota_remaining": 200,  "percent_remaining": 100, "has_quota": true },
"completions":          { "entitlement": 2000, "quota_remaining": 2000, "percent_remaining": 100, "has_quota": true },
"premium_interactions": { "entitlement": 0,    "quota_remaining": 0,    "percent_remaining": 0,   "has_quota": false }
```

`unlimited` is false on all three, so the card treated the last one as metered and rendered `0 / 0 · 100% used` with a full bar — telling a free user they had burned through a premium allotment they never had.

Buckets are now sorted into **metered / unlimited / unavailable**, keyed on `entitlement > 0`. `has_quota` states the same thing more directly, but only the REST body carries it; the headers have no counterpart, so a consumer keying off it would work on one quota source and not the other.

## Also on the REST projection

Every field on that endpoint is optional — that is how GitHub declares it in `@github/copilot-sdk@1.0.8`, `dist/generated/rpc.d.ts` (`quota_snapshots?`, and `entitlement?` / `percent_remaining?` / `quota_remaining?` / `unlimited?` inside a bucket). The projection was copying fields verbatim into a shape that declared them required:

- A bucket missing its cap or remainder is dropped, the way the header path already drops a half-parsed one, instead of reaching the dashboard as `NaN% used`.
- `percent_remaining` is derived from the two fields we do require when the body omits it. That is arithmetic on known values, not a default standing in for an unknown.
- An unparseable reset instant — `quota_reset_date_utc: ""` from the body, `rst=` with no value from a header — reads as "none reported" rather than rendering `Resets on Invalid Date`.
- `access_type_sku` and `copilot_plan` are dropped from the interface. Nothing read them, and `copilot_plan` is actively misleading: it reads `"individual"` on a free seat, identical to paid Pro. `access_type_sku` is the only real discriminator, and we need none.

The same SDK declaration documents `-1` as the unlimited entitlement sentinel, which the header parser had been treating as one on captured evidence alone.

An overage-permitted bucket that runs negative now shows its real percentage; only the bar is clamped, because a bar cannot be wider than itself.

## Not in scope

A seat on the pre-2026-06 shape reports through `limited_user_quotas` (remaining) + `monthly_quotas` (entitlement) and leaves `quota_snapshots` empty. Reading that shape is a capability rather than a fix, and verifying it needs a seat still on it, so it is left for its own change. Such a body already projects to "nothing observed" and cannot erase a good reading.

## Test plan

- [x] `pnpm run test` — 422 files green
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Unit tests over the captured free-seat body, a bucket missing its cap, a derived `percent_remaining`, and an empty reset instant on both quota sources
- [x] Cited artifacts verified by fetching them: `@github/copilot-sdk@1.0.8`'s declaration file, and both captured bodies at their pinned commits
- [ ] Live free / limited Copilot seat — no such credential is available here; the captured body is the substitute
