### PR TITLE
fix(repo): retry the upstream state write instead of reporting a lost race

### DIFF
--- a/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
@@ -2201,8 +2201,7 @@ test('GET /api/upstreams/:id returns the full record with fresh Codex quota for 
   state.accounts[0].quotaSnapshot = {
     premium: { fetchedAt: Date.now(), data: quota },
   };
-  const saved = await repo.upstreams.saveState(created.id, state, { expectedState: stored.state });
-  assertEquals(saved.updated, true);
+  await repo.upstreams.saveState(created.id, () => state);
 
   const resp = await requestApp(`/api/upstreams/${created.id}`, { headers: { 'x-floway-session': adminSession } });
   assertEquals(resp.status, 200);
@@ -2298,8 +2297,7 @@ test('POST /api/upstreams/copilot/quota leaves the stored snapshot alone when th
   };
   await repo.upstreams.saveState(
     copilotUpstream.id,
-    { ...(stored.state as Record<string, unknown>), quotaSnapshot: harvested },
-    { expectedState: stored.state },
+    current => ({ ...(current as Record<string, unknown>), quotaSnapshot: harvested }),
   );
 
   const envelope = envelopeFromRecord(await getRecord(repo, copilotUpstream.id));

--- a/packages/gateway/__tests__/data-plane/chat/responses/affinity/copilot-roundtrip_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/affinity/copilot-roundtrip_test.ts
@@ -63,7 +63,7 @@ test('Copilot item-id and generic affinity trailers compose and unwrap in bounda
   initProviderRepo(() => ({
     upstreams: {
       getById: async () => upstream,
-      saveState: async () => ({ updated: true }),
+      saveState: async () => {},
     },
   }));
   clearInProcessCopilotTokenCache();

--- a/packages/gateway/__tests__/repo/memory.ts
+++ b/packages/gateway/__tests__/repo/memory.ts
@@ -60,7 +60,7 @@ import { bucketForTtftMs, bucketForTpotUs } from '../../src/shared/performance-h
 import { assertWebSearchProviderName, type WebSearchConfig } from '../../src/shared/web-search-providers.ts';
 import { AgentSetupTokenCollisionError } from '@floway-dev/agent-setup';
 import { addDecimalStrings, canonicalPricingSelectorKey, canonicalizePricingSelector, type BillingMetric, type DecimalString, type PricingSelector } from '@floway-dev/protocols/common';
-import type { ProviderModel, UpstreamRecord } from '@floway-dev/provider';
+import { UpstreamGoneError, type ProviderModel, type UpstreamRecord } from '@floway-dev/provider';
 
 const SEED_ADMIN_USER: User = {
   id: SEED_ADMIN_USER_ID,
@@ -617,7 +617,7 @@ class MemoryUpstreamRepo implements UpstreamRepo {
   // unchanged is a no-op here too.
   saveState(id: string, mutate: (current: unknown) => unknown): Promise<void> {
     const existing = this.store.get(id);
-    if (!existing) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+    if (!existing) throw new UpstreamGoneError(id);
     const next = mutate(existing.state);
     const serialized = serializeStoredState(next);
     existing.state = serialized === null ? null : (JSON.parse(serialized) as unknown);

--- a/packages/gateway/__tests__/repo/memory.ts
+++ b/packages/gateway/__tests__/repo/memory.ts
@@ -611,14 +611,17 @@ class MemoryUpstreamRepo implements UpstreamRepo {
     return Promise.resolve();
   }
 
-  saveState(id: string, newState: unknown, options: { expectedState: unknown }): Promise<{ updated: boolean }> {
+  // No retry loop: this store is single-threaded, so the mutator always sees
+  // the current state and the write always lands. Serialization still round-
+  // trips through the canonical encoder so a mutator that returns its argument
+  // unchanged is a no-op here too.
+  saveState(id: string, mutate: (current: unknown) => unknown): Promise<void> {
     const existing = this.store.get(id);
-    if (!existing) return Promise.resolve({ updated: false });
-    if (serializeStoredState(existing.state) !== serializeStoredState(options.expectedState)) {
-      return Promise.resolve({ updated: false });
-    }
-    existing.state = newState === undefined ? null : structuredClone(newState);
-    return Promise.resolve({ updated: true });
+    if (!existing) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+    const next = mutate(existing.state);
+    const serialized = serializeStoredState(next);
+    existing.state = serialized === null ? null : (JSON.parse(serialized) as unknown);
+    return Promise.resolve();
   }
 }
 

--- a/packages/gateway/__tests__/repo/sql_test.ts
+++ b/packages/gateway/__tests__/repo/sql_test.ts
@@ -2,8 +2,9 @@ import { test } from 'vitest';
 
 import { createSqliteTestDb } from './test-sqlite.ts';
 import { SqlRepo } from '../../src/repo/sql.ts';
+import type { SqlDatabase, SqlPreparedStatement } from '@floway-dev/platform';
 import type { UpstreamRecord } from '@floway-dev/provider';
-import { assertEquals, stubProviderModel } from '@floway-dev/test-utils';
+import { assertEquals, assertRejects, stubProviderModel } from '@floway-dev/test-utils';
 
 const goodAccount = { chatgptAccountId: 'aid', refresh_token: 'rt_v1', state: 'active' as const, state_updated_at: '2026-01-01T00:00:00Z' };
 const baseRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => ({
@@ -46,53 +47,80 @@ test('SQL upstream repo round-trips state_json on save/list/getById', async () =
   assertEquals((await repo.list())[0].state, { accounts: [goodAccount] });
 });
 
-test('SQL upstream repo saveState writes when expectedState matches', async () => {
+test('SQL upstream repo saveState applies the mutator to the stored state', async () => {
   const repo = new SqlRepo(await createSqliteTestDb()).upstreams;
   await repo.save(baseRecord());
-  const nextAccount = { ...goodAccount, refresh_token: 'rt_v2' };
-  const result = await repo.saveState(
-    'up_test',
-    { accounts: [nextAccount] },
-    { expectedState: { accounts: [goodAccount] } },
-  );
-  assertEquals(result.updated, true);
-  assertEquals((await repo.getById('up_test'))?.state, { accounts: [nextAccount] });
+  await repo.saveState('up_test', current => {
+    assertEquals(current, { accounts: [goodAccount] });
+    return { accounts: [{ ...goodAccount, refresh_token: 'rt_v2' }] };
+  });
+  assertEquals((await repo.getById('up_test'))?.state, { accounts: [{ ...goodAccount, refresh_token: 'rt_v2' }] });
 });
 
-test('SQL upstream repo saveState refuses when expectedState diverges (operator re-import race)', async () => {
-  const repo = new SqlRepo(await createSqliteTestDb()).upstreams;
+// Deterministic stand-in for a concurrent writer: the first read of
+// `state_json` lands an out-of-band write before returning, so the CAS that
+// follows it is guaranteed to lose. Without this the retry path is unreachable
+// from a single-threaded test.
+const withWriterRacingTheFirstRead = (db: SqlDatabase, race: () => void): SqlDatabase => {
+  let raced = false;
+  const wrapStatement = (statement: SqlPreparedStatement, racing: boolean): SqlPreparedStatement => ({
+    bind: (...values) => wrapStatement(statement.bind(...values), racing),
+    all: <T>() => statement.all<T>(),
+    run: () => statement.run(),
+    first: async <T>() => {
+      const row = await statement.first<T>();
+      if (racing && !raced) {
+        raced = true;
+        race();
+      }
+      return row;
+    },
+  });
+  return {
+    prepare: query => wrapStatement(db.prepare(query), query.startsWith('SELECT state_json')),
+    exec: sql => db.exec(sql),
+  };
+};
+
+// The reason the change is a function rather than a document: the writer whose
+// read was invalidated re-derives its change from the state that won, so both
+// survive. A caller that had computed its document up front would instead
+// reinstate the value the winner replaced.
+test('SQL upstream repo saveState re-applies the mutator against the write that won', async () => {
+  const db = await createSqliteTestDb();
+  const repo = new SqlRepo(db).upstreams;
   await repo.save(baseRecord());
-  const operatorAccount = { ...goodAccount, refresh_token: 'rt_operator_new' };
-  // Simulate operator re-import that replaced the credential out-of-band.
-  await repo.save(baseRecord({ state: { accounts: [operatorAccount] } }));
-  const result = await repo.saveState(
-    'up_test',
-    { accounts: [{ ...goodAccount, refresh_token: 'rt_v2' }] },
-    { expectedState: { accounts: [goodAccount] } },
-  );
-  assertEquals(result.updated, false);
-  assertEquals((await repo.getById('up_test'))?.state, { accounts: [operatorAccount] });
+  const racing = new SqlRepo(withWriterRacingTheFirstRead(db, () => {
+    db.prepare('UPDATE upstreams SET state_json = ? WHERE id = ?')
+      .bind(JSON.stringify({ accounts: [{ ...goodAccount, state_message: 'written by a sibling' }] }), 'up_test')
+      .run();
+  })).upstreams;
+
+  const seen: string[] = [];
+  await racing.saveState('up_test', current => {
+    const [account] = (current as { accounts: { state_message?: string }[] }).accounts;
+    seen.push(account.state_message ?? '(none)');
+    return { accounts: [{ ...account, refresh_token: 'rt_v2' }] };
+  });
+
+  // First attempt read the pre-race state, the retry read the sibling's.
+  assertEquals(seen, ['(none)', 'written by a sibling']);
+  const stored = (await repo.getById('up_test'))?.state as { accounts: { refresh_token: string; state_message?: string }[] };
+  assertEquals(stored.accounts[0].refresh_token, 'rt_v2');
+  assertEquals(stored.accounts[0].state_message, 'written by a sibling');
 });
 
-test('SQL upstream repo saveState round-trip uses canonical JSON form (back-to-back CAS works)', async () => {
+test('SQL upstream repo saveState throws when the row is gone', async () => {
+  const repo = new SqlRepo(await createSqliteTestDb()).upstreams;
+  await assertRejects(() => repo.saveState('up_missing', current => current), Error, 'disappeared');
+});
+
+// A mutator that decided there is nothing to do hands back what it was given.
+test('SQL upstream repo saveState skips the write when the mutator changes nothing', async () => {
   const repo = new SqlRepo(await createSqliteTestDb()).upstreams;
   await repo.save(baseRecord());
-  const v2Account = { state: 'active' as const, refresh_token: 'rt_v2', chatgptAccountId: 'aid', state_updated_at: '2026-01-02T00:00:00Z' }; // intentionally re-ordered keys
-  // First CAS: prior state shape from save() must match.
-  const first = await repo.saveState(
-    'up_test',
-    { accounts: [v2Account] },
-    { expectedState: { accounts: [goodAccount] } },
-  );
-  assertEquals(first.updated, true);
-  // Second CAS: the previously-written shape must serialize identically when
-  // passed back as expectedState (regardless of input key order).
-  const second = await repo.saveState(
-    'up_test',
-    { accounts: [{ ...v2Account, refresh_token: 'rt_v3' }] },
-    { expectedState: { accounts: [v2Account] } },
-  );
-  assertEquals(second.updated, true);
+  await repo.saveState('up_test', current => current);
+  assertEquals((await repo.getById('up_test'))?.state, { accounts: [goodAccount] });
 });
 
 // sql.js gives us real SQLite semantics in-process (including `IS NULL`

--- a/packages/gateway/__tests__/repo/sql_test.ts
+++ b/packages/gateway/__tests__/repo/sql_test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 
 import { createSqliteTestDb } from './test-sqlite.ts';
-import { SqlRepo } from '../../src/repo/sql.ts';
+import { SqlRepo, UPSTREAM_STATE_WRITE_ATTEMPTS } from '../../src/repo/sql.ts';
 import type { SqlDatabase, SqlPreparedStatement } from '@floway-dev/platform';
 import type { UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals, assertRejects, stubProviderModel } from '@floway-dev/test-utils';
@@ -57,20 +57,20 @@ test('SQL upstream repo saveState applies the mutator to the stored state', asyn
   assertEquals((await repo.getById('up_test'))?.state, { accounts: [{ ...goodAccount, refresh_token: 'rt_v2' }] });
 });
 
-// Deterministic stand-in for a concurrent writer: the first read of
-// `state_json` lands an out-of-band write before returning, so the CAS that
-// follows it is guaranteed to lose. Without this the retry path is unreachable
-// from a single-threaded test.
-const withWriterRacingTheFirstRead = (db: SqlDatabase, race: () => Promise<unknown>): SqlDatabase => {
-  let raced = false;
+// Deterministic stand-in for a concurrent writer: each of the first `times`
+// reads of `state_json` lands an out-of-band write before returning, so that
+// many CAS attempts are guaranteed to lose. Without this neither the retry nor
+// the exhaustion path is reachable from a single-threaded test.
+const withWriterRacingReads = (db: SqlDatabase, race: () => Promise<unknown>, times: number): SqlDatabase => {
+  let raced = 0;
   const wrapStatement = (statement: SqlPreparedStatement, racing: boolean): SqlPreparedStatement => ({
     bind: (...values) => wrapStatement(statement.bind(...values), racing),
     all: <T>() => statement.all<T>(),
     run: () => statement.run(),
     first: async <T>() => {
       const row = await statement.first<T>();
-      if (racing && !raced) {
-        raced = true;
+      if (racing && raced < times) {
+        raced += 1;
         await race();
       }
       return row;
@@ -90,10 +90,10 @@ test('SQL upstream repo saveState re-applies the mutator against the write that 
   const db = await createSqliteTestDb();
   const repo = new SqlRepo(db).upstreams;
   await repo.save(baseRecord());
-  const racing = new SqlRepo(withWriterRacingTheFirstRead(db, () =>
+  const racing = new SqlRepo(withWriterRacingReads(db, () =>
     db.prepare('UPDATE upstreams SET state_json = ? WHERE id = ?')
       .bind(JSON.stringify({ accounts: [{ ...goodAccount, state_message: 'written by a sibling' }] }), 'up_test')
-      .run())).upstreams;
+      .run(), 1)).upstreams;
 
   const seen: string[] = [];
   await racing.saveState('up_test', current => {
@@ -107,6 +107,36 @@ test('SQL upstream repo saveState re-applies the mutator against the write that 
   const stored = (await repo.getById('up_test'))?.state as { accounts: { refresh_token: string; state_message?: string }[] };
   assertEquals(stored.accounts[0].refresh_token, 'rt_v2');
   assertEquals(stored.accounts[0].state_message, 'written by a sibling');
+});
+
+// A writer that never wins gives up rather than looping, and says so instead
+// of reporting a flag a caller could drop.
+test('SQL upstream repo saveState gives up after a bounded number of lost races', async () => {
+  const db = await createSqliteTestDb();
+  const repo = new SqlRepo(db).upstreams;
+  await repo.save(baseRecord());
+  let siblingWrites = 0;
+  const racing = new SqlRepo(withWriterRacingReads(db, () => {
+    siblingWrites += 1;
+    return db.prepare('UPDATE upstreams SET state_json = ? WHERE id = ?')
+      .bind(JSON.stringify({ accounts: [{ ...goodAccount, state_message: `sibling ${siblingWrites}` }] }), 'up_test')
+      .run();
+  }, Number.MAX_SAFE_INTEGER)).upstreams;
+
+  let attempts = 0;
+  await assertRejects(
+    () => racing.saveState('up_test', current => {
+      attempts += 1;
+      const [account] = (current as { accounts: Record<string, unknown>[] }).accounts;
+      return { accounts: [{ ...account, refresh_token: 'rt_v2' }] };
+    }),
+    Error,
+    'consecutive races',
+  );
+  // Every attempt ran the mutator, and none of them landed.
+  assertEquals(attempts, UPSTREAM_STATE_WRITE_ATTEMPTS);
+  const stored = (await repo.getById('up_test'))?.state as { accounts: { refresh_token: string }[] };
+  assertEquals(stored.accounts[0].refresh_token, goodAccount.refresh_token);
 });
 
 test('SQL upstream repo saveState throws when the row is gone', async () => {

--- a/packages/gateway/__tests__/repo/sql_test.ts
+++ b/packages/gateway/__tests__/repo/sql_test.ts
@@ -61,7 +61,7 @@ test('SQL upstream repo saveState applies the mutator to the stored state', asyn
 // `state_json` lands an out-of-band write before returning, so the CAS that
 // follows it is guaranteed to lose. Without this the retry path is unreachable
 // from a single-threaded test.
-const withWriterRacingTheFirstRead = (db: SqlDatabase, race: () => void): SqlDatabase => {
+const withWriterRacingTheFirstRead = (db: SqlDatabase, race: () => Promise<unknown>): SqlDatabase => {
   let raced = false;
   const wrapStatement = (statement: SqlPreparedStatement, racing: boolean): SqlPreparedStatement => ({
     bind: (...values) => wrapStatement(statement.bind(...values), racing),
@@ -71,7 +71,7 @@ const withWriterRacingTheFirstRead = (db: SqlDatabase, race: () => void): SqlDat
       const row = await statement.first<T>();
       if (racing && !raced) {
         raced = true;
-        race();
+        await race();
       }
       return row;
     },
@@ -90,11 +90,10 @@ test('SQL upstream repo saveState re-applies the mutator against the write that 
   const db = await createSqliteTestDb();
   const repo = new SqlRepo(db).upstreams;
   await repo.save(baseRecord());
-  const racing = new SqlRepo(withWriterRacingTheFirstRead(db, () => {
+  const racing = new SqlRepo(withWriterRacingTheFirstRead(db, () =>
     db.prepare('UPDATE upstreams SET state_json = ? WHERE id = ?')
       .bind(JSON.stringify({ accounts: [{ ...goodAccount, state_message: 'written by a sibling' }] }), 'up_test')
-      .run();
-  })).upstreams;
+      .run())).upstreams;
 
   const seen: string[] = [];
   await racing.saveState('up_test', current => {

--- a/packages/gateway/migrations/0031_cache_storage_rework.sql
+++ b/packages/gateway/migrations/0031_cache_storage_rework.sql
@@ -31,13 +31,13 @@ CREATE TABLE image_cache (
 -- The pre-rework `models_store:<id>` rows in `config` cannot be lifted into
 -- `upstreams.state_json` from SQL: serializeStoredState canonicalizes by
 -- recursively sorting object keys, but SQLite's JSON1 (`json_object`,
--- `json()`) only minify and preserve input order. Any in-SQL lift would
--- write a non-canonical blob that the runtime saveState CAS could never
--- match (`UPDATE ... WHERE state_json IS ?` binds the canonicalized form),
--- so token mints and 24h known-models updates would silently drop until
--- something else rewrote the row. The runtime re-derives the ledger from
--- `/models` on first request after deploy, so dropping the legacy data is
--- a one-fetch cost with no correctness loss.
+-- `json()`) only minify and preserve input order. Under the CAS as it stood
+-- at this migration, which bound the canonicalized form, any in-SQL lift
+-- would have written a blob the runtime could never match again, so token
+-- mints and 24h known-models updates would silently drop until something
+-- else rewrote the row. The runtime re-derives the ledger from `/models` on
+-- first request after deploy, so dropping the legacy data is a one-fetch
+-- cost with no correctness loss.
 
 -- Lift search-config singleton -------------------------------------------
 

--- a/packages/gateway/src/control-plane/upstreams/claude-code.ts
+++ b/packages/gateway/src/control-plane/upstreams/claude-code.ts
@@ -247,16 +247,12 @@ export const claudeCodeProbe = async (c: CtxWithJson<typeof claudeCodeProbeBody>
   // instead of asking the client to hand-merge into accounts[0].
   const merged = mergeSnapshotInto(readClaudeCodeUpstreamState(record.state));
 
+  // The snapshot rides on top of whatever state is current at write time, so a
+  // concurrent rotation neither loses its own write nor is overwritten by this
+  // one. A draft that has never been saved has no row to write to.
   if (record.id !== '') {
-    // Best-effort CAS persist against the currently-stored state — a losing
-    // race means a concurrent rotation wrote newer state that supersedes
-    // ours, which is fine (the snapshot rides on top of that new state on
-    // the next probe).
-    const fresh = await getRepo().upstreams.getById(record.id);
-    if (fresh) {
-      const freshMerged = mergeSnapshotInto(readClaudeCodeUpstreamState(fresh.state));
-      await getRepo().upstreams.saveState(record.id, freshMerged, { expectedState: fresh.state });
-    }
+    await getRepo().upstreams.saveState(record.id, current =>
+      mergeSnapshotInto(readClaudeCodeUpstreamState(current)));
   }
 
   logInfo('claude_code_admin_action', { upstream_id: record.id, action: 'quota_probe', actor, outcome: 'ok' });

--- a/packages/gateway/src/control-plane/upstreams/codex.ts
+++ b/packages/gateway/src/control-plane/upstreams/codex.ts
@@ -106,22 +106,22 @@ export const codexOAuthRefresh = async (c: CtxWithJson<typeof codexOAuthRefreshB
     return c.json({ error: errorMessage(err) }, 400);
   }
 
-  // Persist callback shape matches `createCodexProvider` — a rotated
-  // refresh_token CAS-writes back into the account slot with the just-read
-  // state as the expected value. A losing CAS is not an error here: the
-  // sibling that won the race already persisted a newer refresh_token, and
-  // `ensureCodexAccessToken`'s `recoverFromRefreshRace` picks up the
-  // sibling's fresh access token when our mint gets `invalid_grant`.
+  // Persist callback shape matches `createCodexProvider`. The rotated
+  // refresh_token must reach storage: the upstream invalidated the previous one
+  // when it issued this one, so a write that does not land leaves the row
+  // holding a dead credential that no later request can distinguish from a
+  // revoked one. The repo re-applies this against whichever concurrent write
+  // won and throws if it cannot.
   const persistRefreshTokenRotation = async (newRefreshToken: string): Promise<void> => {
-    const fresh = await getRepo().upstreams.getById(record.id);
-    if (!fresh) return;
-    assertCodexUpstreamState(fresh.state);
-    const next: CodexUpstreamState = {
-      accounts: fresh.state.accounts.map(a => a.chatgptAccountId === account.chatgptAccountId
-        ? { ...a, refresh_token: newRefreshToken, state_updated_at: new Date().toISOString() }
-        : a),
-    };
-    await getRepo().upstreams.saveState(record.id, next, { expectedState: fresh.state });
+    const rotatedAt = new Date().toISOString();
+    await getRepo().upstreams.saveState(record.id, current => {
+      assertCodexUpstreamState(current);
+      return {
+        accounts: current.accounts.map(a => a.chatgptAccountId === account.chatgptAccountId
+          ? { ...a, refresh_token: newRefreshToken, state_updated_at: rotatedAt }
+          : a),
+      } satisfies CodexUpstreamState;
+    });
   };
 
   try {
@@ -133,18 +133,15 @@ export const codexOAuthRefresh = async (c: CtxWithJson<typeof codexOAuthRefreshB
       // Terminal flip mirrors `createCodexProvider.persistTerminalState`:
       // clear the cached access token, mark the account refresh_failed so
       // the dashboard renders the red badge and prompts a re-import.
-      // Best-effort — a losing CAS means a concurrent rotation already
-      // wrote newer state that supersedes ours.
-      const fresh = await getRepo().upstreams.getById(record.id);
-      if (fresh) {
-        assertCodexUpstreamState(fresh.state);
-        const next: CodexUpstreamState = {
-          accounts: fresh.state.accounts.map(a => a.chatgptAccountId === account.chatgptAccountId
-            ? { ...a, state: 'refresh_failed' as const, state_message: err.upstreamMessage, state_updated_at: new Date().toISOString(), accessToken: null }
+      const failedAt = new Date().toISOString();
+      await getRepo().upstreams.saveState(record.id, current => {
+        assertCodexUpstreamState(current);
+        return {
+          accounts: current.accounts.map(a => a.chatgptAccountId === account.chatgptAccountId
+            ? { ...a, state: 'refresh_failed' as const, state_message: err.upstreamMessage, state_updated_at: failedAt, accessToken: null }
             : a),
-        };
-        await getRepo().upstreams.saveState(record.id, next, { expectedState: fresh.state });
-      }
+        } satisfies CodexUpstreamState;
+      });
       return c.json({ error: `Codex refresh failed: ${err.upstreamMessage}. Re-run OAuth exchange to recover.` }, 400);
     }
     return c.json({ error: errorMessage(err) }, 502);

--- a/packages/gateway/src/control-plane/upstreams/copilot.ts
+++ b/packages/gateway/src/control-plane/upstreams/copilot.ts
@@ -145,10 +145,9 @@ export const copilotQuota = async (c: CtxWithJson<typeof copilotQuotaBody>) => {
     const snapshot = projectCopilotUsageResponse((await resp.json()) as CopilotUsageResponse, new Date());
     // A body that reports no buckets is "nothing observed", so it neither
     // persists nor replaces what the dashboard is already showing — the
-    // caller falls back to the stored snapshot. Persistence is otherwise
-    // best-effort and deliberately outside the caller's result: the operator
-    // asked for a reading, and a CAS loss to concurrent data-plane traffic
-    // means a fresher snapshot already won the slot.
+    // caller falls back to the stored snapshot. The reading otherwise merges
+    // into whatever state wins the row, and the catch is here only so a
+    // storage failure does not fail the operator's request.
     if (snapshot !== null && record.id !== '') {
       await putCopilotQuota(record.id, snapshot).catch((err: unknown) => {
         console.warn(`Failed to persist Copilot quota snapshot for ${record.id}:`, err);

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -903,6 +903,11 @@ class SqlWebSearchConfigRepo implements WebSearchConfigRepo {
   }
 }
 
+// Four attempts against a measured per-attempt loss rate of a few percent puts
+// the residual failure below one write in ten thousand, and a failure is
+// visible rather than silent.
+const UPSTREAM_STATE_WRITE_ATTEMPTS = 4;
+
 class SqlUpstreamRepo implements UpstreamRepo {
   constructor(private db: SqlDatabase) {}
 
@@ -969,16 +974,45 @@ class SqlUpstreamRepo implements UpstreamRepo {
     await this.db.prepare('DELETE FROM upstreams').run();
   }
 
-  // `IS` (not `=`) so NULL on either side compares correctly — a row whose
-  // state_json is SQL NULL still matches when the caller passes
-  // expectedState: null. The serialized form here must equal what save()
-  // wrote for the predicate to hold on the back-to-back write path.
-  async saveState(id: string, newState: unknown, options: { expectedState: unknown }): Promise<{ updated: boolean }> {
-    const result = await this.db
-      .prepare('UPDATE upstreams SET state_json = ? WHERE id = ? AND state_json IS ?')
-      .bind(serializeStoredState(newState), id, serializeStoredState(options.expectedState))
-      .run();
-    return { updated: (result.meta.changes ?? 0) > 0 };
+  // Read-modify-write under optimistic concurrency, retried against the winner
+  // on a loss. `IS` (not `=`) so a row whose state_json is SQL NULL still
+  // matches. The predicate binds the exact text this method read rather than a
+  // re-serialized form, so the CAS holds against a row written by anything —
+  // including a migration, which has no way to reproduce the canonical
+  // encoder's output.
+  //
+  // Losing is expected, not exceptional: the same row carries values written on
+  // every data-plane response, so a rotation's read-to-write window overlaps
+  // them routinely. Retrying is what makes the loss harmless; exhausting the
+  // retries is not, because the caller's change — a rotated refresh token the
+  // vendor has already invalidated — cannot be reconstructed later, so it
+  // throws rather than returning a flag a caller can drop.
+  async saveState(id: string, mutate: (current: unknown) => unknown): Promise<void> {
+    for (let attempt = 0; attempt < UPSTREAM_STATE_WRITE_ATTEMPTS; attempt++) {
+      const row = await this.db
+        .prepare('SELECT state_json FROM upstreams WHERE id = ?')
+        .bind(id)
+        .first<{ state_json: string | null }>();
+      if (!row) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+      let current: unknown = null;
+      if (row.state_json !== null) {
+        try {
+          current = JSON.parse(row.state_json) as unknown;
+        } catch (cause) {
+          throw new Error(`Malformed upstream state JSON for ${id}`, { cause });
+        }
+      }
+      const next = serializeStoredState(mutate(current));
+      // A mutator that decided there is nothing to do returns what it was
+      // given, which serializes back to the stored text.
+      if (next === row.state_json) return;
+      const result = await this.db
+        .prepare('UPDATE upstreams SET state_json = ? WHERE id = ? AND state_json IS ?')
+        .bind(next, id, row.state_json)
+        .run();
+      if ((result.meta.changes ?? 0) > 0) return;
+    }
+    throw new Error(`Upstream ${id} state write lost ${UPSTREAM_STATE_WRITE_ATTEMPTS} consecutive races`);
   }
 }
 

--- a/packages/gateway/src/repo/sql.ts
+++ b/packages/gateway/src/repo/sql.ts
@@ -54,7 +54,7 @@ import { AgentSetupTokenCollisionError } from '@floway-dev/agent-setup';
 import type { SqlBindValue, SqlDatabase, SqlPreparedStatement } from '@floway-dev/platform';
 import { addDecimalStrings, canonicalPricingSelectorKey, parseBillingMetric, parseModelKind, parseNonNegativeDecimalString, parsePricingSelectorKey, type AliasSelection, type AliasTarget, type AnnouncedMetadata } from '@floway-dev/protocols/common';
 import type { ProviderModel, ProxyFallbackEntry, ModelPrefixConfig, UpstreamRecord } from '@floway-dev/provider';
-import { normalizeModelPrefix, parsePerformanceOperation } from '@floway-dev/provider';
+import { normalizeModelPrefix, parsePerformanceOperation, UpstreamGoneError } from '@floway-dev/provider';
 
 interface ApiKeyRow {
   id: string;
@@ -903,10 +903,12 @@ class SqlWebSearchConfigRepo implements WebSearchConfigRepo {
   }
 }
 
-// Four attempts against a measured per-attempt loss rate of a few percent puts
-// the residual failure below one write in ten thousand, and a failure is
-// visible rather than silent.
-const UPSTREAM_STATE_WRITE_ATTEMPTS = 4;
+// Losing once is ordinary on a row this contended, losing four times in a row
+// is not — and the attempts run back-to-back with no delay, so they observe
+// much the same contention rather than independent draws. The bound is a
+// judgement call about how much immediate re-reading is worth doing before
+// declaring the row unwritable, not a derived figure.
+export const UPSTREAM_STATE_WRITE_ATTEMPTS = 4;
 
 class SqlUpstreamRepo implements UpstreamRepo {
   constructor(private db: SqlDatabase) {}
@@ -993,7 +995,7 @@ class SqlUpstreamRepo implements UpstreamRepo {
         .prepare('SELECT state_json FROM upstreams WHERE id = ?')
         .bind(id)
         .first<{ state_json: string | null }>();
-      if (!row) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+      if (!row) throw new UpstreamGoneError(id);
       let current: unknown = null;
       if (row.state_json !== null) {
         try {

--- a/packages/gateway/src/repo/types.ts
+++ b/packages/gateway/src/repo/types.ts
@@ -270,11 +270,11 @@ export interface UpstreamRepo {
   deleteAll(): Promise<void>;
   // Upstream state write with optimistic concurrency, used both by the
   // gateway's own token-rotation work and by the operator-triggered OAuth
-  // refresh / probe routes. Returns updated:true only if the row's
-  // state_json equals the serialized form of options.expectedState at write
-  // time. On updated:false the caller re-reads and decides whether to retry
-  // or drop the update.
-  saveState(id: string, newState: unknown, options: { expectedState: unknown }): Promise<{ updated: boolean }>;
+  // refresh / probe routes. The repo reads, applies `mutate`, and writes under
+  // a CAS, retrying against the winner when it loses; exhausting the retries
+  // throws. See UpstreamsRepoSlim in @floway-dev/provider for why the change
+  // is a function.
+  saveState(id: string, mutate: (current: unknown) => unknown): Promise<void>;
 }
 
 export interface ProxyRecord {

--- a/packages/gateway/src/repo/upstream-json.ts
+++ b/packages/gateway/src/repo/upstream-json.ts
@@ -1,7 +1,8 @@
-// Canonical JSON encoding for upstream rows. saveState's optimistic-concurrency
-// CAS (UPDATE ... WHERE state_json IS ?) and the in-memory repo's CAS fallback
-// compare serialized forms, so key order must be stable. config_json shares
-// the encoder for symmetry.
+// Canonical JSON encoding for upstream rows. Key order is sorted recursively so
+// a row's stored text is a function of its data alone: two writes of the same
+// object produce the same bytes, which is what lets `saveState` recognize a
+// mutator that changed nothing and skip the write. config_json shares the
+// encoder for symmetry.
 
 const canonicalize = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(canonicalize);

--- a/packages/provider-claude-code/__tests__/access-token_test.ts
+++ b/packages/provider-claude-code/__tests__/access-token_test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/access-token.ts';
 import { ClaudeCodeOAuthSessionTerminatedError } from '../src/auth/oauth.ts';
 import type { ClaudeCodeUpstreamConfig } from '../src/config.ts';
-import type { ClaudeCodeUpstreamState } from '../src/state.ts';
+import type { ClaudeCodeQuotaSnapshotEntry, ClaudeCodeUpstreamState } from '../src/state.ts';
 import { directFetcher, type UpstreamRecord, type UpstreamsRepoSlim } from '@floway-dev/provider';
 
 const accountUuid = 'acc-uuid-1';
@@ -112,6 +112,41 @@ describe('ensureClaudeCodeAccessToken', () => {
     expect(account.refreshToken).toBe('rt_v2');
     expect(account.accessToken?.token).toBe('at_new');
     expect(account.state).toBe('active');
+  });
+
+  test('rotation lands on the state a concurrent quota write left behind', async () => {
+    // The row also carries values written on every data-plane response, so a
+    // quota snapshot routinely lands between our read and our write. The
+    // rotation is derived from whatever the repo hands the mutator, so both
+    // changes survive.
+    const siblingQuota: ClaudeCodeQuotaSnapshotEntry = {
+      fetchedAt: 1781805000000,
+      data: {
+        status: 'allowed',
+        reset: null,
+        fallbackAvailable: null,
+        fallbackPercentage: null,
+        representativeClaim: null,
+        overage: null,
+        fiveHour: null,
+        sevenDay: null,
+        raw: { 'anthropic-ratelimit-unified-status': 'allowed' },
+      },
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: siblingQuota }] });
+      return new Response(JSON.stringify({
+        access_token: 'at_new', token_type: 'Bearer', expires_in: 3600, refresh_token: 'rt_v2', scope: 'user:inference',
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+
+    await ensureClaudeCodeAccessToken({ upstreamId, repo, fetcher: directFetcher });
+
+    expect(writes).toHaveLength(1);
+    const account = writes[0].accounts[0];
+    expect(account.refreshToken).toBe('rt_v2');
+    expect(account.accessToken?.token).toBe('at_new');
+    expect(account.quotaSnapshot).toEqual(siblingQuota);
   });
 
   test('refreshes when the cached token is within the 5-minute skew window', async () => {
@@ -331,8 +366,8 @@ describe('ensureClaudeCodeAccessToken (setup-token kind)', () => {
     // No upstream call — there's nothing to refresh against.
     expect(fetchSpy).not.toHaveBeenCalled();
 
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    const persisted = saveStateSpy.mock.calls[0][1] as ClaudeCodeUpstreamState;
+    expect(writes).toHaveLength(1);
+    const persisted = writes[0];
     expect(persisted.accounts[0].state).toBe('refresh_failed');
     expect(persisted.accounts[0].stateMessage).toMatch(/re-import/);
     expect(persisted.accounts[0].accessToken).toBeNull();

--- a/packages/provider-claude-code/__tests__/access-token_test.ts
+++ b/packages/provider-claude-code/__tests__/access-token_test.ts
@@ -53,21 +53,32 @@ const baseAccount: ClaudeCodeUpstreamState['accounts'][number] = {
 
 const farFutureMs = Date.now() + 24 * 60 * 60 * 1000;
 
-type SaveStateSpy = ReturnType<typeof vi.fn<(id: string, newState: unknown, opts: { expectedState: unknown }) => Promise<{ updated: boolean }>>>;
+type SaveStateSpy = ReturnType<typeof vi.fn<(id: string, mutate: (current: unknown) => unknown) => Promise<void>>>;
 type GetByIdSpy = ReturnType<typeof vi.fn<(id: string) => Promise<UpstreamRecord | null>>>;
 
 let current: UpstreamRecord | null;
+// The states the stub repo actually committed, in order. A mutator that
+// returns its argument unchanged serializes back to the stored text, which the
+// live repo turns into a no-op, so this records intent-to-write rather than
+// call count.
+let writes: ClaudeCodeUpstreamState[];
 let saveStateSpy: SaveStateSpy;
 let getByIdSpy: GetByIdSpy;
 let repo: UpstreamsRepoSlim;
 
 beforeEach(() => {
   current = makeRecord({ accounts: [{ ...baseAccount }] });
-  // Mirror the live D1-backed repo's read-after-write behavior so the cache
-  // tests can rely on getById observing the just-persisted state.
-  saveStateSpy = vi.fn(async (_id, newState, _opts) => {
-    if (current) current = { ...current, state: newState as ClaudeCodeUpstreamState };
-    return { updated: true };
+  writes = [];
+  // Mirror the live D1-backed repo: read the stored state, hand it to the
+  // mutator, skip the write when the result serializes identically, and fail a
+  // write against a row that is gone. Read-after-write matters for the cache
+  // tests, which rely on getById observing the just-persisted state.
+  saveStateSpy = vi.fn(async (id, mutate) => {
+    if (!current) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+    const next = mutate(current.state) as ClaudeCodeUpstreamState;
+    if (JSON.stringify(next) === JSON.stringify(current.state)) return;
+    current = { ...current, state: next };
+    writes.push(next);
   });
   getByIdSpy = vi.fn(async () => current);
   repo = { getById: getByIdSpy, saveState: saveStateSpy };
@@ -86,7 +97,7 @@ describe('ensureClaudeCodeAccessToken', () => {
     expect(saveStateSpy).not.toHaveBeenCalled();
   });
 
-  test('refreshes when no token is cached, rotates refresh_token via CAS, persists fresh access token', async () => {
+  test('refreshes when no token is cached, rotates refresh_token, persists fresh access token', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
       access_token: 'at_new', token_type: 'Bearer', expires_in: 3600, refresh_token: 'rt_v2', scope: 'user:inference',
     }), { status: 200, headers: { 'content-type': 'application/json' } }));
@@ -96,9 +107,8 @@ describe('ensureClaudeCodeAccessToken', () => {
     expect(out.entry.token).toBe('at_new');
     expect(out.entry.expiresAt).toBeGreaterThan(Date.now());
 
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    const [, nextState] = saveStateSpy.mock.calls[0];
-    const account = (nextState as ClaudeCodeUpstreamState).accounts[0];
+    expect(writes).toHaveLength(1);
+    const account = writes[0].accounts[0];
     expect(account.refreshToken).toBe('rt_v2');
     expect(account.accessToken?.token).toBe('at_new');
     expect(account.state).toBe('active');
@@ -123,8 +133,8 @@ describe('ensureClaudeCodeAccessToken', () => {
     await expect(ensureClaudeCodeAccessToken({ upstreamId, repo, fetcher: directFetcher }))
       .rejects.toBeInstanceOf(ClaudeCodeOAuthSessionTerminatedError);
 
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    const persisted = saveStateSpy.mock.calls[0][1] as ClaudeCodeUpstreamState;
+    expect(writes).toHaveLength(1);
+    const persisted = writes[0];
     expect(persisted.accounts[0].state).toBe('refresh_failed');
     expect(persisted.accounts[0].stateMessage).toContain('Refresh token revoked');
     expect(persisted.accounts[0].accessToken).toBeNull();
@@ -166,19 +176,10 @@ describe('ensureClaudeCodeAccessToken', () => {
       .rejects.toBeInstanceOf(ClaudeCodeOAuthSessionTerminatedError);
 
     expect(getByIdSpy).toHaveBeenCalledTimes(1);
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    const persisted = saveStateSpy.mock.calls[0][1] as ClaudeCodeUpstreamState;
+    expect(writes).toHaveLength(1);
+    const persisted = writes[0];
     expect(persisted.accounts[0].state).toBe('refresh_failed');
     expect(persisted.accounts[0].stateMessage).toBe('Session ended by Anthropic');
-  });
-
-  test('CAS loss on refresh-token rotation surfaces as an error (sibling rotation already won)', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
-      access_token: 'at_new', token_type: 'Bearer', expires_in: 3600, refresh_token: 'rt_v2', scope: 'user:inference',
-    }), { status: 200, headers: { 'content-type': 'application/json' } }));
-    saveStateSpy.mockResolvedValueOnce({ updated: false });
-    await expect(ensureClaudeCodeAccessToken({ upstreamId, repo, fetcher: directFetcher }))
-      .rejects.toThrow(/CAS/);
   });
 
   test('saveState storage failure propagates without rotating', async () => {
@@ -188,6 +189,7 @@ describe('ensureClaudeCodeAccessToken', () => {
     saveStateSpy.mockRejectedValueOnce(new Error('D1 boom'));
     await expect(ensureClaudeCodeAccessToken({ upstreamId, repo, fetcher: directFetcher }))
       .rejects.toThrow(/D1 boom/);
+    expect(writes).toHaveLength(0);
   });
 
   test('throws when the upstream row is missing', async () => {
@@ -210,21 +212,20 @@ describe('invalidateClaudeCodeAccessToken', () => {
     const entry: ClaudeCodeAccessTokenEntry = { token: 'at_x', expiresAt: farFutureMs, refreshedAt: 'now' };
     current = makeRecord({ accounts: [{ ...baseAccount, accessToken: entry }] });
     await invalidateClaudeCodeAccessToken({ upstreamId, repo });
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    const persisted = saveStateSpy.mock.calls[0][1] as ClaudeCodeUpstreamState;
-    expect(persisted.accounts[0].accessToken).toBeNull();
-    expect(persisted.accounts[0].refreshToken).toBe('rt_v1');
+    expect(writes).toHaveLength(1);
+    expect(writes[0].accounts[0].accessToken).toBeNull();
+    expect(writes[0].accounts[0].refreshToken).toBe('rt_v1');
   });
 
   test('no-ops when the slot is already null', async () => {
     await invalidateClaudeCodeAccessToken({ upstreamId, repo });
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(writes).toHaveLength(0);
   });
 
   test('throws when the upstream disappeared', async () => {
     current = null;
     await expect(invalidateClaudeCodeAccessToken({ upstreamId, repo })).rejects.toThrow(/disappeared/);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(writes).toHaveLength(0);
   });
 });
 

--- a/packages/provider-claude-code/__tests__/access-token_test.ts
+++ b/packages/provider-claude-code/__tests__/access-token_test.ts
@@ -8,7 +8,7 @@ import {
 import { ClaudeCodeOAuthSessionTerminatedError } from '../src/auth/oauth.ts';
 import type { ClaudeCodeUpstreamConfig } from '../src/config.ts';
 import type { ClaudeCodeQuotaSnapshotEntry, ClaudeCodeUpstreamState } from '../src/state.ts';
-import { directFetcher, type UpstreamRecord, type UpstreamsRepoSlim } from '@floway-dev/provider';
+import { directFetcher, UpstreamGoneError, type UpstreamRecord, type UpstreamsRepoSlim } from '@floway-dev/provider';
 
 const accountUuid = 'acc-uuid-1';
 const upstreamId = 'up-claude-1';
@@ -74,7 +74,7 @@ beforeEach(() => {
   // write against a row that is gone. Read-after-write matters for the cache
   // tests, which rely on getById observing the just-persisted state.
   saveStateSpy = vi.fn(async (id, mutate) => {
-    if (!current) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+    if (!current) throw new UpstreamGoneError(id);
     const next = mutate(current.state) as ClaudeCodeUpstreamState;
     if (JSON.stringify(next) === JSON.stringify(current.state)) return;
     current = { ...current, state: next };

--- a/packages/provider-claude-code/__tests__/fetch_test.ts
+++ b/packages/provider-claude-code/__tests__/fetch_test.ts
@@ -92,9 +92,8 @@ beforeEach(() => {
   initProviderRepo(() => ({
     upstreams: {
       getById: async () => currentRecord,
-      saveState: async (_id, newState) => {
-        currentRecord = { ...currentRecord, state: newState as ClaudeCodeUpstreamState };
-        return { updated: true };
+      saveState: async (_id, mutate) => {
+        currentRecord = { ...currentRecord, state: mutate(currentRecord.state) };
       },
     },
   }));

--- a/packages/provider-claude-code/__tests__/provider_test.ts
+++ b/packages/provider-claude-code/__tests__/provider_test.ts
@@ -64,9 +64,8 @@ beforeEach(() => {
   initProviderRepo(() => ({
     upstreams: {
       getById: async () => currentRecord,
-      saveState: async (_id, newState) => {
-        currentRecord = { ...currentRecord, state: newState as ClaudeCodeUpstreamState };
-        return { updated: true };
+      saveState: async (_id, mutate) => {
+        currentRecord = { ...currentRecord, state: mutate(currentRecord.state) };
       },
     },
   }));

--- a/packages/provider-claude-code/src/access-token.ts
+++ b/packages/provider-claude-code/src/access-token.ts
@@ -7,7 +7,7 @@ import {
   readClaudeCodeUpstreamState,
   replaceSoleAccount,
   type ClaudeCodeAccessTokenEntry,
-  type ClaudeCodeUpstreamState,
+  type ClaudeCodeAccountCredential,
 } from './state.ts';
 import type { Fetcher, UpstreamsRepoSlim } from '@floway-dev/provider';
 
@@ -86,12 +86,9 @@ export const ensureClaudeCodeAccessToken = async (
 };
 
 // Reads, refreshes, and persists. The rotated refresh token and the new
-// cached access token are committed together in a single CAS write. CAS
-// loss on that write is fatal: the upstream rotates on every refresh call,
-// so a sibling rotation already burned the refresh token we hold, and
-// reusing our response would be rejected as `invalid_grant`. We throw so
-// the next request re-reads state and refreshes from the live tail of the
-// rotation chain.
+// cached access token are committed together in a single state write; the
+// repo applies our change to whatever state it finds, so a quota write or a
+// sibling rotation landing in between costs us nothing.
 //
 // Refresh-race recovery: when the upstream returns `invalid_grant`, it
 // might mean either (a) the refresh token is genuinely revoked, or (b) a
@@ -133,7 +130,7 @@ const ensureClaudeCodeAccessTokenInner = async (
       return { entry: account.accessToken, freshlyMinted: false };
     }
     const message = 'Setup token expired or absent; re-import to recover';
-    await persistTerminalState(args.repo, args.upstreamId, fresh.state, state, {
+    await persistTerminalState(args.repo, args.upstreamId, account, {
       reason: 'setup_token_expired',
       message,
       oauthCode: null,
@@ -154,7 +151,7 @@ const ensureClaudeCodeAccessTokenInner = async (
         const recovered = await recoverFromRefreshRace(args, account.refreshToken);
         if (recovered) return recovered;
       }
-      await persistTerminalState(args.repo, args.upstreamId, fresh.state, state, {
+      await persistTerminalState(args.repo, args.upstreamId, account, {
         reason: 'oauth_refresh_failed',
         message: error.upstreamMessage,
         oauthCode: error.code,
@@ -170,26 +167,28 @@ const ensureClaudeCodeAccessTokenInner = async (
     refreshedAt: now,
   };
 
-  // Refresh-token rotation: CAS-write the new refresh token alongside the
-  // fresh access-token entry in a single state transition. `state` /
-  // `stateUpdatedAt` stay untouched on a successful refresh — 'active' is
-  // already what we want, and bumping the timestamp on every refresh would
-  // muddy the dashboard's "credential health changed" signal.
+  // Refresh-token rotation: the new refresh token and the fresh access-token
+  // entry land in one state transition. `state` / `stateUpdatedAt` stay
+  // untouched on a successful refresh — 'active' is already what we want, and
+  // bumping the timestamp on every refresh would muddy the dashboard's
+  // "credential health changed" signal.
+  //
+  // The two fields are set on whatever account the repo hands us rather than
+  // on the account we read before the round-trip: the upstream has already
+  // invalidated the token we rotated out, so this write must survive a
+  // concurrent quota write. A re-import that swapped the credential class in
+  // the meantime leaves nothing to rotate — the account is returned untouched,
+  // which the repo reads as "nothing to do".
   const rotatedRefreshToken = refreshed.refresh_token;
   if (typeof rotatedRefreshToken !== 'string' || rotatedRefreshToken === '') {
     throw new Error('Claude Code refresh response missing refresh_token');
   }
-  const rotated = replaceSoleAccount(state, () => ({
-    ...account,
-    refreshToken: rotatedRefreshToken,
-    accessToken: newAccessTokenEntry,
-  }));
-  const result = await args.repo.saveState(args.upstreamId, rotated, { expectedState: fresh.state });
-  if (!result.updated) {
-    throw new Error(
-      `Claude Code refresh-token rotation lost CAS for upstream ${args.upstreamId}; another rotation won`,
-    );
-  }
+  await args.repo.saveState(args.upstreamId, current =>
+    replaceSoleAccount(readClaudeCodeUpstreamState(current), stored => (
+      stored.tokenKind === 'oauth'
+        ? { ...stored, refreshToken: rotatedRefreshToken, accessToken: newAccessTokenEntry }
+        : stored
+    )));
   logInfo('claude_code_refresh_token_rotated', {
     upstream_id: args.upstreamId,
     account_uuid: account.accountUuid,
@@ -200,16 +199,14 @@ const ensureClaudeCodeAccessTokenInner = async (
 };
 
 // Terminal flip from the oauth-error path. Distinct from fetch.ts's
-// `persistTerminalAccountState`: caller already holds a fresh state read
-// (so we take it as a param rather than re-reading), the trigger is an
-// oauth-protocol code (logged as `oauth_code`, possibly null for
-// code-internal flips), and the caller has already established the
-// account is active.
+// `persistTerminalAccountState`: the caller has already read the account and
+// established that it is active, so the log's identity and `from_state` come
+// from that read instead of a second one, and the trigger is an oauth-protocol
+// code (logged as `oauth_code`, possibly null for code-internal flips).
 const persistTerminalState = async (
   repo: UpstreamsRepoSlim,
   upstreamId: string,
-  expectedState: unknown,
-  current: ClaudeCodeUpstreamState,
+  previousAccount: ClaudeCodeAccountCredential,
   fields: {
     reason: string;
     message: string;
@@ -220,15 +217,14 @@ const persistTerminalState = async (
     oauthCode: string | null;
   },
 ): Promise<void> => {
-  const previousAccount = current.accounts[0];
-  const flipped = replaceSoleAccount(current, account => ({
-    ...account,
-    state: 'refresh_failed',
-    stateMessage: fields.message,
-    stateUpdatedAt: new Date().toISOString(),
-    accessToken: null,
-  }));
-  await repo.saveState(upstreamId, flipped, { expectedState });
+  await repo.saveState(upstreamId, current =>
+    replaceSoleAccount(readClaudeCodeUpstreamState(current), account => ({
+      ...account,
+      state: 'refresh_failed',
+      stateMessage: fields.message,
+      stateUpdatedAt: new Date().toISOString(),
+      accessToken: null,
+    })));
   logWarn('claude_code_account_state_flip', {
     upstream_id: upstreamId,
     account_uuid: previousAccount.accountUuid,
@@ -283,16 +279,15 @@ const recoverFromRefreshRace = async (
 };
 
 // Used in 401-retry: clear the cached access token without touching the
-// refresh token, so the next call mints a fresh one.
+// refresh token, so the next call mints a fresh one. An account whose slot is
+// already empty is returned untouched, which the repo reads as "nothing to do".
 export const invalidateClaudeCodeAccessToken = async (args: {
   upstreamId: string;
   repo: UpstreamsRepoSlim;
 }): Promise<void> => {
-  const fresh = await args.repo.getById(args.upstreamId);
-  if (!fresh) throw new Error(`Claude Code upstream ${args.upstreamId} disappeared mid-request`);
-  const state = readClaudeCodeUpstreamState(fresh.state);
-  const account = state.accounts[0];
-  if (account.accessToken === null) return;
-  const cleared = replaceSoleAccount(state, account => ({ ...account, accessToken: null }));
-  await args.repo.saveState(args.upstreamId, cleared, { expectedState: fresh.state });
+  await args.repo.saveState(args.upstreamId, current => {
+    const state = readClaudeCodeUpstreamState(current);
+    if (state.accounts[0].accessToken === null) return state;
+    return replaceSoleAccount(state, account => ({ ...account, accessToken: null }));
+  });
 };

--- a/packages/provider-claude-code/src/access-token.ts
+++ b/packages/provider-claude-code/src/access-token.ts
@@ -217,12 +217,15 @@ const persistTerminalState = async (
     oauthCode: string | null;
   },
 ): Promise<void> => {
+  // Stamped before the write: the mutator is replayed on a lost race and must
+  // return the same document each time.
+  const flippedAt = new Date().toISOString();
   await repo.saveState(upstreamId, current =>
     replaceSoleAccount(readClaudeCodeUpstreamState(current), account => ({
       ...account,
       state: 'refresh_failed',
       stateMessage: fields.message,
-      stateUpdatedAt: new Date().toISOString(),
+      stateUpdatedAt: flippedAt,
       accessToken: null,
     })));
   logWarn('claude_code_account_state_flip', {

--- a/packages/provider-claude-code/src/fetch.ts
+++ b/packages/provider-claude-code/src/fetch.ts
@@ -7,6 +7,7 @@ import { parseClaudeCodeQuotaHeaders, type ClaudeCodeQuotaSnapshot } from './quo
 import {
   readClaudeCodeUpstreamState,
   replaceSoleAccount,
+  type ClaudeCodeAccountCredential,
 } from './state.ts';
 import type { MessagesPayload, MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
@@ -122,16 +123,19 @@ const isRateLimitedNow = (
 };
 
 const persistQuotaSnapshot = async (upstreamId: string, snapshot: ClaudeCodeQuotaSnapshot): Promise<void> => {
-  const fresh = await getProviderRepo().upstreams.getById(upstreamId);
-  if (!fresh) throw new Error(`Claude Code upstream ${upstreamId} disappeared mid-request`);
-  const state = readClaudeCodeUpstreamState(fresh.state);
-  const account = state.accounts[0];
-  const priorStatus = account.quotaSnapshot === null ? null : account.quotaSnapshot.data.status;
-  const next = replaceSoleAccount(state, account => ({
-    ...account,
-    quotaSnapshot: { fetchedAt: Date.now(), data: snapshot },
-  }));
-  await getProviderRepo().upstreams.saveState(upstreamId, next, { expectedState: fresh.state });
+  // The prior status comes from the state the mutator was handed: the write is
+  // retried against whoever won the row, so only that view describes the
+  // snapshot this write actually replaced.
+  let previousAccount!: ClaudeCodeAccountCredential;
+  await getProviderRepo().upstreams.saveState(upstreamId, current => {
+    const state = readClaudeCodeUpstreamState(current);
+    previousAccount = state.accounts[0];
+    return replaceSoleAccount(state, account => ({
+      ...account,
+      quotaSnapshot: { fetchedAt: Date.now(), data: snapshot },
+    }));
+  });
+  const priorStatus = previousAccount.quotaSnapshot === null ? null : previousAccount.quotaSnapshot.data.status;
   // Emit only on transition. Persisting every response would flood the log
   // with one event per request; the dashboard already reads the snapshot
   // verbatim. Operators care about the moment the upstream flipped from
@@ -139,7 +143,7 @@ const persistQuotaSnapshot = async (upstreamId: string, snapshot: ClaudeCodeQuot
   if (priorStatus !== snapshot.status) {
     logInfo('claude_code_quota_state_transition', {
       upstream_id: upstreamId,
-      account_uuid: account.accountUuid,
+      account_uuid: previousAccount.accountUuid,
       from_status: priorStatus,
       to_status: snapshot.status,
       reset_at_iso: snapshot.reset,
@@ -148,12 +152,10 @@ const persistQuotaSnapshot = async (upstreamId: string, snapshot: ClaudeCodeQuot
   }
 };
 
-// Best-effort persist: a CAS loss to a concurrent rotation or quota write is
-// fine because the live state already carries a snapshot at least as fresh
-// as the one we'd write. The hot path must not block on the write completing
-// or surface its failures to the caller. Skip writing when the response
-// carries no rate-limit signal at all — that would erase the prior snapshot
-// for no upside.
+// Best-effort persist: the hot path must not block on the write completing or
+// surface its failures to the caller. Skip writing when the response carries
+// no rate-limit signal at all — that would erase the prior snapshot for no
+// upside.
 //
 // On Cloudflare Workers the runtime cancels orphan promises the moment the
 // response is sent to the client, so a bare fire-and-forget would lose the
@@ -228,38 +230,38 @@ const detectTerminalSentinel = (status: number, bodyText: string): string | null
 
 // Terminal flip from the data-plane sentinel detector. Distinct from
 // access-token.ts's `persistTerminalState`: this path runs in a
-// fire-and-forget context with no caller-side state, so we re-read; the
-// flip is body-sentinel-triggered (org disabled/banned), not oauth-error-
-// triggered, so the log carries `upstream_status` instead of `oauth_code`;
-// and a sibling oauth-side flip may have already happened, so we skip the
-// write when the account isn't `active` anymore. Merging the two helpers
-// would force conditional dispatch on every one of these axes.
+// fire-and-forget context with no caller-side state, so the account it logs
+// comes from the mutator's own view; the flip is body-sentinel-triggered (org
+// disabled/banned), not oauth-error-triggered, so the log carries
+// `upstream_status` instead of `oauth_code`; and a sibling oauth-side flip may
+// have already happened, so an account that is no longer `active` is returned
+// untouched — the repo reads that as "nothing to do" and the dashboard keeps
+// the first signal. Merging the two helpers would force conditional dispatch
+// on every one of these axes.
 const persistTerminalAccountState = async (
   upstreamId: string,
   terminalMessage: string,
   reason: string,
   upstreamStatus: number,
 ): Promise<void> => {
-  const fresh = await getProviderRepo().upstreams.getById(upstreamId);
-  if (!fresh) return;
-  const state = readClaudeCodeUpstreamState(fresh.state);
-  const account = state.accounts[0];
-  // Already terminal — a sibling write (e.g. an OAuth refresh death) won;
-  // skip overwriting the prior message so the dashboard keeps the first
-  // signal.
-  if (account.state !== 'active') return;
-  const flipped = replaceSoleAccount(state, account => ({
-    ...account,
-    state: 'refresh_failed',
-    stateMessage: terminalMessage,
-    stateUpdatedAt: new Date().toISOString(),
-    accessToken: null,
-  }));
-  await getProviderRepo().upstreams.saveState(upstreamId, flipped, { expectedState: fresh.state });
+  let previousAccount!: ClaudeCodeAccountCredential;
+  await getProviderRepo().upstreams.saveState(upstreamId, current => {
+    const state = readClaudeCodeUpstreamState(current);
+    previousAccount = state.accounts[0];
+    if (previousAccount.state !== 'active') return state;
+    return replaceSoleAccount(state, account => ({
+      ...account,
+      state: 'refresh_failed',
+      stateMessage: terminalMessage,
+      stateUpdatedAt: new Date().toISOString(),
+      accessToken: null,
+    }));
+  });
+  if (previousAccount.state !== 'active') return;
   logWarn('claude_code_account_state_flip', {
     upstream_id: upstreamId,
-    account_uuid: account.accountUuid,
-    from_state: account.state,
+    account_uuid: previousAccount.accountUuid,
+    from_state: previousAccount.state,
     to_state: 'refresh_failed',
     reason,
     upstream_status: upstreamStatus,
@@ -269,10 +271,7 @@ const persistTerminalAccountState = async (
 
 // Fire-and-forget: clones the response so the original body still streams
 // to the caller intact (we surface upstream verbatim — the terminal flip
-// is purely additional dashboard signal). CAS loss to a concurrent
-// rotation is fine: either the sibling already flipped to terminal (no
-// regression) or the sibling rotated state and the next request
-// re-detects the sentinel.
+// is purely additional dashboard signal).
 //
 // Same lifecycle dance as `persistQuotaFromHeadersFireAndForget`: under
 // Workers the runtime cancels orphan promises the moment the response is

--- a/packages/provider-claude-code/src/fetch.ts
+++ b/packages/provider-claude-code/src/fetch.ts
@@ -123,6 +123,10 @@ const isRateLimitedNow = (
 };
 
 const persistQuotaSnapshot = async (upstreamId: string, snapshot: ClaudeCodeQuotaSnapshot): Promise<void> => {
+  // Stamped before the write: the mutator is replayed on a lost race and must
+  // return the same document each time, and this records when the snapshot was
+  // observed rather than which attempt landed it.
+  const fetchedAt = Date.now();
   // The prior status comes from the state the mutator was handed: the write is
   // retried against whoever won the row, so only that view describes the
   // snapshot this write actually replaced.
@@ -132,7 +136,7 @@ const persistQuotaSnapshot = async (upstreamId: string, snapshot: ClaudeCodeQuot
     previousAccount = state.accounts[0];
     return replaceSoleAccount(state, account => ({
       ...account,
-      quotaSnapshot: { fetchedAt: Date.now(), data: snapshot },
+      quotaSnapshot: { fetchedAt, data: snapshot },
     }));
   });
   const priorStatus = previousAccount.quotaSnapshot === null ? null : previousAccount.quotaSnapshot.data.status;
@@ -244,6 +248,9 @@ const persistTerminalAccountState = async (
   reason: string,
   upstreamStatus: number,
 ): Promise<void> => {
+  // Stamped before the write for the same reason as the quota snapshot: a
+  // replay must produce the same document.
+  const flippedAt = new Date().toISOString();
   let previousAccount!: ClaudeCodeAccountCredential;
   await getProviderRepo().upstreams.saveState(upstreamId, current => {
     const state = readClaudeCodeUpstreamState(current);
@@ -253,7 +260,7 @@ const persistTerminalAccountState = async (
       ...account,
       state: 'refresh_failed',
       stateMessage: terminalMessage,
-      stateUpdatedAt: new Date().toISOString(),
+      stateUpdatedAt: flippedAt,
       accessToken: null,
     }));
   });

--- a/packages/provider-claude-code/src/state.ts
+++ b/packages/provider-claude-code/src/state.ts
@@ -1,6 +1,7 @@
 // Gateway-managed Claude Code credential state, persisted in
-// upstreams.state_json. Writes happen via UpstreamRepo.saveState with
-// optimistic concurrency keyed on the prior state JSON.
+// upstreams.state_json. Writes happen via UpstreamRepo.saveState, which applies
+// the caller's mutator to the stored document and retries it against the winner
+// of a concurrent write.
 //
 // The shape carries the long-lived refresh token (rotated on every refresh
 // call) plus a cached short-lived access token and the most recent
@@ -12,7 +13,7 @@
 //
 // - `oauth`: a short-lived access token plus a rotating refresh token.
 //   Every refresh call mints a new access token AND rotates the refresh
-//   token; the access-token module CASes both together.
+//   token; the access-token module commits both together.
 // - `setup-token`: a long-lived (~1 year) inference-only bearer with NO
 //   refresh token. The `accessToken` entry IS the credential — when it
 //   expires the operator must re-import. `refreshToken` is null. The

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -74,10 +74,15 @@ describe('putCodexAccessToken', () => {
     await expect(putCodexAccessToken(upstreamId, accountId, entry)).rejects.toThrow('D1 boom');
   });
 
-  test('surfaces an upstream that disappeared mid-flight', async () => {
+  // A minted access token is bookkeeping the next request re-derives, so an
+  // operator deleting the upstream mid-request is tolerated. The storage
+  // failure above is not — that distinction is the whole point of the typed
+  // error.
+  test('tolerates an upstream that disappeared mid-flight', async () => {
     current = null;
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'now' };
-    await expect(putCodexAccessToken(upstreamId, accountId, entry)).rejects.toThrow(/disappeared/);
+    await putCodexAccessToken(upstreamId, accountId, entry);
+    expect(repo.writes).toEqual([]);
   });
 
   test('warns and writes nothing when the requested account is not in the pool', async () => {

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/access-token.ts';
 import { CodexOAuthSessionTerminatedError } from '../src/auth/oauth.ts';
 import type { CodexUpstreamState } from '../src/state.ts';
+import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 
 const accountId = 'acc_1';
@@ -43,52 +44,46 @@ const baseAccount = {
 const farFutureMs = Date.now() + 24 * 60 * 60 * 1000;
 
 let current: UpstreamRecord | null;
-let saveStateSpy: ReturnType<typeof vi.fn<(id: string, newState: unknown, opts: { expectedState: unknown }) => Promise<{ updated: boolean }>>>;
-let getByIdSpy: ReturnType<typeof vi.fn<(id: string) => Promise<UpstreamRecord | null>>>;
+let repo: UpstreamStateRepoStub;
 
 beforeEach(() => {
   current = makeRecord({ accounts: [{ ...baseAccount }] });
-  // Mirror the live D1-backed CAS: write-through so subsequent getById sees the update.
-  saveStateSpy = vi.fn(async (_id, newState, _opts) => {
-    if (current) current = { ...current, state: newState as CodexUpstreamState };
-    return { updated: true };
+  // Write-through, so a subsequent read observes what the last write landed.
+  repo = createUpstreamStateRepoStub(() => current, state => {
+    current = { ...current!, state: state as CodexUpstreamState };
   });
-  getByIdSpy = vi.fn(async () => current);
-  initProviderRepo(() => ({
-    upstreams: { getById: getByIdSpy, saveState: saveStateSpy },
-  }));
+  initProviderRepo(() => ({ upstreams: repo }));
 });
 
 afterEach(() => vi.restoreAllMocks());
 
+const storedState = (): CodexUpstreamState => current!.state as CodexUpstreamState;
+
 describe('putCodexAccessToken', () => {
-  test('persists the entry into the account slot via saveState', async () => {
+  test('persists the entry into the account slot, leaving the rest of the credential alone', async () => {
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: '2026-06-01T00:00:00.000Z' };
     await putCodexAccessToken(upstreamId, accountId, entry);
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    const [id, nextState, opts] = saveStateSpy.mock.calls[0];
-    expect(id).toBe(upstreamId);
-    expect((nextState as CodexUpstreamState).accounts[0].accessToken).toEqual(entry);
-    expect(opts.expectedState).toEqual({ accounts: [{ ...baseAccount }] });
+    expect(repo.saveState).toHaveBeenCalledTimes(1);
+    expect(repo.saveState.mock.calls[0][0]).toBe(upstreamId);
+    expect(storedState()).toEqual({ accounts: [{ ...baseAccount, accessToken: entry }] });
   });
 
-  test('propagates saveState failures so the request path surfaces them', async () => {
-    saveStateSpy.mockRejectedValueOnce(new Error('CAS lost'));
+  test('propagates storage failures so the request path surfaces them', async () => {
+    repo.saveState.mockRejectedValueOnce(new Error('D1 boom'));
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'now' };
-    await expect(putCodexAccessToken(upstreamId, accountId, entry)).rejects.toThrow('CAS lost');
+    await expect(putCodexAccessToken(upstreamId, accountId, entry)).rejects.toThrow('D1 boom');
   });
 
-  test('warns and exits when the upstream disappeared mid-flight', async () => {
+  test('surfaces an upstream that disappeared mid-flight', async () => {
     current = null;
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'now' };
-    await putCodexAccessToken(upstreamId, accountId, entry);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    await expect(putCodexAccessToken(upstreamId, accountId, entry)).rejects.toThrow(/disappeared/);
   });
 
-  test('warns and exits when the requested account is not in the pool', async () => {
+  test('warns and writes nothing when the requested account is not in the pool', async () => {
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'now' };
     await putCodexAccessToken(upstreamId, 'acc_other', entry);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(repo.writes).toEqual([]);
   });
 });
 
@@ -97,13 +92,12 @@ describe('invalidateCodexAccessToken', () => {
     const entry: CodexAccessTokenEntry = { token: 'at_x', expiresAt: farFutureMs, refreshedAt: 'now' };
     current = makeRecord({ accounts: [{ ...baseAccount, accessToken: entry }] });
     await invalidateCodexAccessToken(upstreamId, accountId);
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    expect((saveStateSpy.mock.calls[0][1] as CodexUpstreamState).accounts[0].accessToken).toBeNull();
+    expect(storedState().accounts[0].accessToken).toBeNull();
   });
 
-  test('no-ops when the slot is already null', async () => {
+  test('writes nothing when the slot is already null', async () => {
     await invalidateCodexAccessToken(upstreamId, accountId);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(repo.writes).toEqual([]);
   });
 });
 
@@ -123,8 +117,7 @@ describe('ensureCodexAccessToken', () => {
     const out = await ensureCodexAccessToken(upstreamId, accountId, mint);
     expect(out).toEqual(minted);
     expect(mint).toHaveBeenCalledWith('rt_v1');
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    expect((saveStateSpy.mock.calls[0][1] as CodexUpstreamState).accounts[0].accessToken).toEqual(minted);
+    expect(storedState().accounts[0].accessToken).toEqual(minted);
   });
 
   test('mints when the cached token is within the refresh skew window', async () => {
@@ -153,17 +146,17 @@ describe('ensureCodexAccessToken', () => {
   test('propagates mint errors without persisting', async () => {
     const mint = vi.fn().mockRejectedValue(new Error('oauth boom'));
     await expect(ensureCodexAccessToken(upstreamId, accountId, mint)).rejects.toThrow(/oauth boom/);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(repo.writes).toEqual([]);
   });
 
   test('invalid_grant with a sibling rotation in flight → returns the sibling-minted access token, no persist', async () => {
-    // Simulate the race: between our pre-mint getById and the upstream
-    // rejecting our refresh_token, a sibling worker won the rotation and
-    // CAS-wrote rt_v2 + at_sibling. Re-read on recovery observes the new
-    // pair scoped to the same accountId; we should return it instead of
-    // destroying a working credential.
+    // Simulate the race: between our pre-mint read and the upstream rejecting
+    // our refresh_token, a sibling worker won the rotation and wrote rt_v2 +
+    // at_sibling. Re-read on recovery observes the new pair scoped to the same
+    // accountId; we should return it instead of destroying a working
+    // credential.
     const siblingEntry: CodexAccessTokenEntry = { token: 'at_sibling', expiresAt: farFutureMs, refreshedAt: 'sibling' };
-    getByIdSpy.mockImplementationOnce(async () => current).mockImplementationOnce(async () => {
+    repo.getById.mockImplementationOnce(async () => current).mockImplementationOnce(async () => {
       current = makeRecord({ accounts: [{ ...baseAccount, refresh_token: 'rt_v2', accessToken: siblingEntry }] });
       return current;
     });
@@ -173,7 +166,7 @@ describe('ensureCodexAccessToken', () => {
     expect(out).toEqual(siblingEntry);
     expect(mint).toHaveBeenCalledTimes(1);
     // Recovery returns the sibling's cached token; no fresh persist from us.
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(repo.writes).toEqual([]);
   });
 
   test('invalid_grant with stored RT unchanged → rethrows for the caller to flip to terminal', async () => {
@@ -183,7 +176,7 @@ describe('ensureCodexAccessToken', () => {
     const mint = vi.fn().mockRejectedValue(new CodexOAuthSessionTerminatedError({ code: 'invalid_grant', message: 'revoked' }));
     await expect(ensureCodexAccessToken(upstreamId, accountId, mint)).rejects.toBeInstanceOf(CodexOAuthSessionTerminatedError);
     expect(mint).toHaveBeenCalledTimes(1);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(repo.writes).toEqual([]);
   });
 
   test('app_session_terminated never attempts race recovery — single getById, original error rethrown', async () => {
@@ -192,7 +185,7 @@ describe('ensureCodexAccessToken', () => {
     // them. Assert via the absence of a second getById call.
     const mint = vi.fn().mockRejectedValue(new CodexOAuthSessionTerminatedError({ code: 'app_session_terminated', message: 'gone' }));
     await expect(ensureCodexAccessToken(upstreamId, accountId, mint)).rejects.toBeInstanceOf(CodexOAuthSessionTerminatedError);
-    expect(getByIdSpy).toHaveBeenCalledTimes(1);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(repo.getById).toHaveBeenCalledTimes(1);
+    expect(repo.writes).toEqual([]);
   });
 });

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import {
   ensureCodexAccessToken,
   invalidateCodexAccessToken,
@@ -8,7 +9,6 @@ import {
 } from '../src/access-token.ts';
 import { CodexOAuthSessionTerminatedError } from '../src/auth/oauth.ts';
 import type { CodexUpstreamState } from '../src/state.ts';
-import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 
 const accountId = 'acc_1';

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from '../src/constants.ts';
 import { callCodexAlphaSearch, callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from '../src/fetch.ts';
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotEntryMap, CodexUpstreamState } from '../src/state.ts';
+import { createUpstreamStateRepoStub } from './upstream-state-repo.ts';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
@@ -63,13 +64,9 @@ beforeEach(() => {
   vi.useRealTimers();
   currentRecord = makeRecord({ accounts: [{ ...activeAccount }] });
   initProviderRepo(() => ({
-    upstreams: {
-      getById: async () => currentRecord,
-      saveState: async (_id, newState) => {
-        currentRecord = { ...currentRecord, state: newState as CodexUpstreamState };
-        return { updated: true };
-      },
-    },
+    upstreams: createUpstreamStateRepoStub(() => currentRecord, state => {
+      currentRecord = { ...currentRecord, state: state as CodexUpstreamState };
+    }),
   }));
 });
 

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { createUpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from '../src/constants.ts';
 import { callCodexAlphaSearch, callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from '../src/fetch.ts';
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotEntryMap, CodexUpstreamState } from '../src/state.ts';
-import { createUpstreamStateRepoStub } from './upstream-state-repo.ts';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';

--- a/packages/provider-codex/__tests__/interceptors/responses/action-pivot_test.ts
+++ b/packages/provider-codex/__tests__/interceptors/responses/action-pivot_test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, test, vi } from 'vitest';
 
 import type { ResponsesBoundaryCtx } from '../../../src/interceptors/responses/types.ts';
+import { createUpstreamStateRepoStub } from '../../upstream-state-repo.ts';
 import type { Interceptor } from '@floway-dev/interceptor';
 import { initProviderRepo, type ProviderResponsesResult, type UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
@@ -53,10 +54,7 @@ const baseRecord: UpstreamRecord = {
 
 beforeEach(() => {
   initProviderRepo(() => ({
-    upstreams: {
-      getById: async () => baseRecord,
-      saveState: async () => ({ updated: true }),
-    },
+    upstreams: createUpstreamStateRepoStub(() => baseRecord, () => {}),
   }));
 });
 

--- a/packages/provider-codex/__tests__/provider_test.ts
+++ b/packages/provider-codex/__tests__/provider_test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { createCodexProvider } from '../src/provider.ts';
 import type { CodexAccessTokenEntry, CodexUpstreamState } from '../src/state.ts';
-import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { directFetcher, initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
 

--- a/packages/provider-codex/__tests__/provider_test.ts
+++ b/packages/provider-codex/__tests__/provider_test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { createCodexProvider } from '../src/provider.ts';
 import type { CodexAccessTokenEntry, CodexUpstreamState } from '../src/state.ts';
+import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { directFetcher, initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
 
@@ -31,15 +32,15 @@ const recordWithAccessToken = (entry: CodexAccessTokenEntry = freshAccessToken):
   state: { accounts: [{ chatgptAccountId: 'acc', refresh_token: 'rt_v1', state: 'active', state_updated_at: '2026-01-01T00:00:00Z', openaiDeviceId: '11111111-2222-4333-8444-555555555555', accessToken: entry, quotaSnapshot: null }] },
 });
 
-let saveStateSpy: ReturnType<typeof vi.fn<(id: string, newState: unknown, options: { expectedState: unknown }) => Promise<{ updated: boolean }>>>;
-let getByIdSpy: ReturnType<typeof vi.fn<(id: string) => Promise<UpstreamRecord | null>>>;
+let current: UpstreamRecord | null;
+let repo: UpstreamStateRepoStub;
 
 beforeEach(() => {
-  saveStateSpy = vi.fn<(id: string, newState: unknown, options: { expectedState: unknown }) => Promise<{ updated: boolean }>>(async () => ({ updated: true }));
-  getByIdSpy = vi.fn<(id: string) => Promise<UpstreamRecord | null>>(async () => recordWithAccessToken());
-  initProviderRepo(() => ({
-    upstreams: { getById: getByIdSpy, saveState: saveStateSpy },
-  }));
+  current = recordWithAccessToken();
+  repo = createUpstreamStateRepoStub(() => current, state => {
+    current = { ...current!, state: state as CodexUpstreamState };
+  });
+  initProviderRepo(() => ({ upstreams: repo }));
 });
 
 afterEach(() => vi.restoreAllMocks());
@@ -90,7 +91,7 @@ describe('createCodexProvider', () => {
   });
 
   test('getProvidedModels mints an access token when none is cached, then fetches the catalog', async () => {
-    getByIdSpy.mockImplementation(async () => baseRecord);
+    current = baseRecord;
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
       const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : (input as Request).url);
       if (url.includes('/oauth/token')) return oauthTokenResponse();
@@ -103,13 +104,14 @@ describe('createCodexProvider', () => {
     const urls = fetchSpy.mock.calls.map(c => typeof c[0] === 'string' ? c[0] : (c[0] as URL | Request).toString());
     expect(urls.some(u => u.includes('/oauth/token'))).toBe(true);
     expect(urls.some(u => u.includes('/codex/models'))).toBe(true);
-    // Mint persists twice via CAS: once for the rotated refresh_token from the
-    // OAuth response, once for the freshly minted access token in the same
-    // account slot. Both writes must land for the next caller to see a usable
-    // credential pair.
-    const persistedStates = saveStateSpy.mock.calls.map(c => c[1] as CodexUpstreamState);
-    expect(persistedStates.some(s => s.accounts[0].refresh_token === 'rt_v2')).toBe(true);
-    expect(persistedStates.some(s => s.accounts[0].accessToken?.token === 'at_minted')).toBe(true);
+    // A mint writes twice into the same account slot: the rotated
+    // refresh_token from the OAuth response, then the freshly minted access
+    // token. Both changes must survive for the next caller to see a usable
+    // credential pair, which is what the second write applying on top of the
+    // first proves.
+    const account = (current!.state as CodexUpstreamState).accounts[0];
+    expect(account.refresh_token).toBe('rt_v2');
+    expect(account.accessToken?.token).toBe('at_minted');
   });
 
   test('getProvidedModels propagates catalog fetch failures', async () => {
@@ -119,7 +121,7 @@ describe('createCodexProvider', () => {
   });
 
   test('getProvidedModels propagates OAuth refresh failures', async () => {
-    getByIdSpy.mockImplementation(async () => baseRecord);
+    current = baseRecord;
     vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
       const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : (input as Request).url);
       if (url.includes('/oauth/token')) return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400, headers: new Headers({ 'content-type': 'application/json' }) });
@@ -178,7 +180,7 @@ describe('createCodexProvider', () => {
   });
 
   test('callResponses re-reads state per request (operator re-import takes effect)', async () => {
-    getByIdSpy.mockResolvedValueOnce({ ...baseRecord, state: { accounts: [{ chatgptAccountId: 'acc', refresh_token: 'rt_v1', state: 'session_terminated', state_updated_at: '2026-01-02T00:00:00Z', openaiDeviceId: '11111111-2222-4333-8444-555555555555', accessToken: null, quotaSnapshot: null }] } as CodexUpstreamState });
+    repo.getById.mockResolvedValueOnce({ ...baseRecord, state: { accounts: [{ chatgptAccountId: 'acc', refresh_token: 'rt_v1', state: 'session_terminated', state_updated_at: '2026-01-02T00:00:00Z', openaiDeviceId: '11111111-2222-4333-8444-555555555555', accessToken: null, quotaSnapshot: null }] } as CodexUpstreamState });
     const instance = createCodexProvider(baseRecord);
     const result = await instance.instance.callResponses(
       stubProviderModel({ id: 'gpt-5.4', display_name: 'gpt-5.4', endpoints: { responses: {} } }),

--- a/packages/provider-codex/__tests__/quota_test.ts
+++ b/packages/provider-codex/__tests__/quota_test.ts
@@ -10,6 +10,7 @@ import {
   type CodexQuotaSnapshot,
 } from '../src/quota.ts';
 import type { CodexQuotaSnapshotEntryMap, CodexUpstreamState } from '../src/state.ts';
+import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 
 const accountId = 'acc_1';
@@ -199,13 +200,13 @@ describe('putCodexQuota', () => {
 
   test('throws when the upstream disappeared mid-flight', async () => {
     current = null;
-    await expect(putCodexQuota(upstreamId, accountId, { observed_at: 'now' })).rejects.toThrow(/disappeared mid-request/);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    await expect(putCodexQuota(upstreamId, accountId, { observed_at: 'now' })).rejects.toThrow(/disappeared/);
+    expect(repo.writes).toEqual([]);
   });
 
   test('throws when the requested account is not in the pool', async () => {
     await expect(putCodexQuota(upstreamId, 'acc_other', { observed_at: 'now' })).rejects.toThrow(/not found in upstream/);
-    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(repo.writes).toEqual([]);
   });
 });
 

--- a/packages/provider-codex/__tests__/quota_test.ts
+++ b/packages/provider-codex/__tests__/quota_test.ts
@@ -43,19 +43,14 @@ const baseAccount = {
 };
 
 let current: UpstreamRecord | null;
-let saveStateSpy: ReturnType<typeof vi.fn<(id: string, newState: unknown, opts: { expectedState: unknown }) => Promise<{ updated: boolean }>>>;
-let getByIdSpy: ReturnType<typeof vi.fn<(id: string) => Promise<UpstreamRecord | null>>>;
+let repo: UpstreamStateRepoStub;
 
 beforeEach(() => {
   current = makeRecord({ accounts: [{ ...baseAccount }] });
-  saveStateSpy = vi.fn(async (_id, newState, _opts) => {
-    if (current) current = { ...current, state: newState as CodexUpstreamState };
-    return { updated: true };
+  repo = createUpstreamStateRepoStub(() => current, state => {
+    current = { ...current!, state: state as CodexUpstreamState };
   });
-  getByIdSpy = vi.fn(async () => current);
-  initProviderRepo(() => ({
-    upstreams: { getById: getByIdSpy, saveState: saveStateSpy },
-  }));
+  initProviderRepo(() => ({ upstreams: repo }));
 });
 
 afterEach(() => vi.restoreAllMocks());
@@ -167,16 +162,15 @@ describe('getCodexQuota', () => {
 });
 
 describe('putCodexQuota', () => {
-  test('persists the snapshot under its active limit via saveState', async () => {
+  test('persists the snapshot under its active limit, leaving the rest of the credential alone', async () => {
     const snap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'premium', primary_used_percent: 42 };
     await putCodexQuota(upstreamId, accountId, snap);
-    expect(saveStateSpy).toHaveBeenCalledTimes(1);
-    const [id, nextState, opts] = saveStateSpy.mock.calls[0];
-    expect(id).toBe(upstreamId);
-    const written = (nextState as CodexUpstreamState).accounts[0].quotaSnapshot;
+    expect(repo.saveState).toHaveBeenCalledTimes(1);
+    expect(repo.saveState.mock.calls[0][0]).toBe(upstreamId);
+    const written = (current!.state as CodexUpstreamState).accounts[0].quotaSnapshot;
     expect(written?.premium?.data).toEqual(snap);
     expect(typeof written?.premium?.fetchedAt).toBe('number');
-    expect(opts.expectedState).toEqual({ accounts: [{ ...baseAccount }] });
+    expect({ ...(current!.state as CodexUpstreamState).accounts[0], quotaSnapshot: null }).toEqual({ ...baseAccount });
   });
 
   test('preserves other active-limit buckets and replaces the matching bucket', async () => {

--- a/packages/provider-codex/__tests__/quota_test.ts
+++ b/packages/provider-codex/__tests__/quota_test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import {
   CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT,
   codexQuotaActiveLimitKey,
@@ -10,7 +11,6 @@ import {
   type CodexQuotaSnapshot,
 } from '../src/quota.ts';
 import type { CodexQuotaSnapshotEntryMap, CodexUpstreamState } from '../src/state.ts';
-import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 
 const accountId = 'acc_1';

--- a/packages/provider-codex/__tests__/upstream-state-repo.ts
+++ b/packages/provider-codex/__tests__/upstream-state-repo.ts
@@ -1,0 +1,34 @@
+import { vi } from 'vitest';
+
+import type { UpstreamRecord } from '@floway-dev/provider';
+
+export interface UpstreamStateRepoStub {
+  getById: ReturnType<typeof vi.fn<(id: string) => Promise<UpstreamRecord | null>>>;
+  saveState: ReturnType<typeof vi.fn<(id: string, mutate: (current: unknown) => unknown) => Promise<void>>>;
+  // Documents actually written, in order. A mutator that hands back the state
+  // it was given leaves this empty, which is how a suite asserts that a write
+  // path decided there was nothing to do.
+  writes: unknown[];
+}
+
+// Stand-in for the SQL upstream repo, faithful to the parts the Codex state
+// writers depend on: the mutator sees the stored document, a result that
+// serializes identically to it is not written, and a missing row throws.
+export const createUpstreamStateRepoStub = (
+  read: () => UpstreamRecord | null,
+  commit: (state: unknown) => void,
+): UpstreamStateRepoStub => {
+  const writes: unknown[] = [];
+  return {
+    getById: vi.fn(async () => read()),
+    saveState: vi.fn(async (id, mutate) => {
+      const row = read();
+      if (!row) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+      const next = mutate(row.state);
+      if (JSON.stringify(next) === JSON.stringify(row.state)) return;
+      writes.push(next);
+      commit(next);
+    }),
+    writes,
+  };
+};

--- a/packages/provider-codex/__tests__/upstream-state-repo.ts
+++ b/packages/provider-codex/__tests__/upstream-state-repo.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-import type { UpstreamRecord } from '@floway-dev/provider';
+import { UpstreamGoneError, type UpstreamRecord } from '@floway-dev/provider';
 
 export interface UpstreamStateRepoStub {
   getById: ReturnType<typeof vi.fn<(id: string) => Promise<UpstreamRecord | null>>>;
@@ -23,7 +23,7 @@ export const createUpstreamStateRepoStub = (
     getById: vi.fn(async () => read()),
     saveState: vi.fn(async (id, mutate) => {
       const row = read();
-      if (!row) throw new Error(`Upstream ${id} disappeared before its state could be written`);
+      if (!row) throw new UpstreamGoneError(id);
       const next = mutate(row.state);
       if (JSON.stringify(next) === JSON.stringify(row.state)) return;
       writes.push(next);

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -1,6 +1,6 @@
 import { CodexOAuthSessionTerminatedError, refreshCodexAccessToken } from './auth/oauth.ts';
 import { findCodexAccountIndex, readCodexUpstreamState, replaceCodexAccount, type CodexAccessTokenEntry } from './state.ts';
-import { getProviderRepo, type Fetcher } from '@floway-dev/provider';
+import { getProviderRepo, UpstreamGoneError, type Fetcher } from '@floway-dev/provider';
 
 export type { CodexAccessTokenEntry };
 
@@ -22,18 +22,34 @@ const persistAccessToken = async (
   entry: CodexAccessTokenEntry | null,
   where: string,
 ): Promise<void> => {
-  await getProviderRepo().upstreams.saveState(upstreamId, current => {
-    const state = readCodexUpstreamState(current);
-    const idx = findCodexAccountIndex(state, accountId);
-    if (idx < 0) {
-      console.warn(`${where}: Codex account ${accountId} not found in upstream ${upstreamId}`);
-      return current;
-    }
-    // Invalidating an already-null slot has nothing to write — the case where
-    // a 401 retry races a concurrent refresh that already cleared the token.
-    if (entry === null && state.accounts[idx].accessToken === null) return current;
-    return replaceCodexAccount(state, idx, account => ({ ...account, accessToken: entry }));
-  });
+  // The mutator is replayed on a lost race, so the diagnostic is recorded and
+  // emitted once afterwards rather than logged from inside it.
+  let accountMissing = false;
+  try {
+    await getProviderRepo().upstreams.saveState(upstreamId, current => {
+      const state = readCodexUpstreamState(current);
+      const idx = findCodexAccountIndex(state, accountId);
+      if (idx < 0) {
+        accountMissing = true;
+        return current;
+      }
+      accountMissing = false;
+      // Invalidating an already-null slot has nothing to write — the case where
+      // a 401 retry races a concurrent refresh that already cleared the token.
+      if (entry === null && state.accounts[idx].accessToken === null) return current;
+      return replaceCodexAccount(state, idx, account => ({ ...account, accessToken: entry }));
+    });
+  } catch (err) {
+    // A minted access token is bookkeeping the next request re-derives, so an
+    // operator deleting the upstream mid-request is not worth failing that
+    // request over. Every other storage failure still propagates.
+    if (!(err instanceof UpstreamGoneError)) throw err;
+    console.warn(`${where}: Codex upstream ${upstreamId} disappeared mid-request`);
+    return;
+  }
+  if (accountMissing) {
+    console.warn(`${where}: Codex account ${accountId} not found in upstream ${upstreamId}`);
+  }
 };
 
 export const putCodexAccessToken = async (

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -12,32 +12,28 @@ const REFRESH_SKEW_MS = 5 * 60 * 1000;
 const isAccessTokenFresh = (entry: CodexAccessTokenEntry): boolean =>
   entry.expiresAt > Date.now() + REFRESH_SKEW_MS;
 
-// A losing CAS is not an error — saveState reports it via `updated: false`,
-// and the next call re-reads state and refreshes if needed. Genuine storage
-// failures propagate so the request path surfaces them rather than silently
-// running on a stale cached token.
+// The whole change is expressed against the state the repo hands us, so a
+// write that loses its race is simply replayed against the winner's document
+// and both changes survive. Storage failures propagate so the request path
+// surfaces them rather than silently running on a stale cached token.
 const persistAccessToken = async (
   upstreamId: string,
   accountId: string,
   entry: CodexAccessTokenEntry | null,
   where: string,
 ): Promise<void> => {
-  const fresh = await getProviderRepo().upstreams.getById(upstreamId);
-  if (!fresh) {
-    console.warn(`${where}: Codex upstream ${upstreamId} disappeared mid-request`);
-    return;
-  }
-  const state = readCodexUpstreamState(fresh.state);
-  const idx = findCodexAccountIndex(state, accountId);
-  if (idx < 0) {
-    console.warn(`${where}: Codex account ${accountId} not found in upstream ${upstreamId}`);
-    return;
-  }
-  // No-op when invalidating an already-null slot — avoids a spurious CAS write
-  // when a 401 retry races a concurrent refresh that already cleared the token.
-  if (entry === null && state.accounts[idx].accessToken === null) return;
-  const next = replaceCodexAccount(state, idx, account => ({ ...account, accessToken: entry }));
-  await getProviderRepo().upstreams.saveState(upstreamId, next, { expectedState: fresh.state });
+  await getProviderRepo().upstreams.saveState(upstreamId, current => {
+    const state = readCodexUpstreamState(current);
+    const idx = findCodexAccountIndex(state, accountId);
+    if (idx < 0) {
+      console.warn(`${where}: Codex account ${accountId} not found in upstream ${upstreamId}`);
+      return current;
+    }
+    // Invalidating an already-null slot has nothing to write — the case where
+    // a 401 retry races a concurrent refresh that already cleared the token.
+    if (entry === null && state.accounts[idx].accessToken === null) return current;
+    return replaceCodexAccount(state, idx, account => ({ ...account, accessToken: entry }));
+  });
 };
 
 export const putCodexAccessToken = async (
@@ -52,7 +48,7 @@ export const invalidateCodexAccessToken = async (
 ): Promise<void> => { await persistAccessToken(upstreamId, accountId, null, 'invalidateCodexAccessToken'); };
 
 // Reads, mints, and persists. The mint callback is responsible for routing
-// the rotated refresh_token through the upstream's CAS hook;
+// the rotated refresh_token through the upstream's persistence hook;
 // `mintCodexAccessToken` below is the standard implementation.
 //
 // Refresh-race recovery: when the mint throws `invalid_grant`, it might mean
@@ -171,14 +167,11 @@ const recoverFromRefreshRace = async (
 };
 
 // Mints a fresh access token via /oauth/token and routes the rotated
-// refresh_token through the caller's CAS hook. Awaiting the rotation
+// refresh_token through the caller's persistence hook. Awaiting the rotation
 // persistence (rather than fire-and-forget) is deliberate: under concurrent
 // rotations each call's new refresh_token must reach the hook before the
 // next attempt reads state, otherwise an unhandled rejection can swallow the
 // rotated token and the upstream eventually returns app_session_terminated.
-// A losing CAS inside the hook is fine — `expectedState` mismatched a
-// concurrent operator re-import or sibling rotation, and the already-
-// persisted newer state supersedes ours.
 export const mintCodexAccessToken = async (
   refreshToken: string,
   fetcher: Fetcher,

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -22,10 +22,10 @@ export type ProviderCompactionResult =
   | { ok: true; result: ResponsesCompactionResult; modelKey: string }
   | { ok: false; response: Response; modelKey: string };
 
-// Hooks for repo-side state transitions, applied with optimistic concurrency.
-// Refresh-token rotations and terminal-state transitions go through the repo;
-// access-token and quota persistence are handled inside their own helpers
-// (also state_json writes via the same CAS hook).
+// Hooks for repo-side state transitions. Refresh-token rotations and
+// terminal-state transitions go through the repo; access-token and quota
+// persistence are handled inside their own helpers, which write the same
+// state_json row the same way.
 export interface CodexCallEffects {
   persistRefreshTokenRotation(newRefreshToken: string): Promise<void>;
   persistTerminalState(state: 'session_terminated' | 'refresh_failed', message: string): Promise<void>;
@@ -370,15 +370,14 @@ const dispatchCodexHttpCall = async (
 };
 
 // Force-mint a fresh access token after a 401, persisting it best-effort.
-// `ensureCodexAccessToken`'s read-then-maybe-mint is bypassed: if the
-// invalidate's CAS lost to a sibling write (a concurrent quota putCodexQuota,
-// refresh-token rotation, or operator re-import all touch the same state_json
-// row), the broken token still sits in the slot and a re-read would hand it
-// back as fresh — Codex tokens carry multi-day expiresAt — sending us into
-// an immediate second 401 with `alreadyRetried` already flipped. Minting
-// unconditionally and persisting best-effort sidesteps that window; a CAS
-// loss on persist is fine because the next request will re-mint if its read
-// still sees the dead token.
+// `ensureCodexAccessToken`'s read-then-maybe-mint is bypassed because a
+// re-read can still observe the token we just invalidated: a sibling that
+// minted before our 401 lands its `putCodexAccessToken` after our
+// invalidation, restoring the broken token, and Codex tokens carry multi-day
+// expiresAt so the freshness gate hands it straight back — sending us into an
+// immediate second 401 with `alreadyRetried` already flipped. Minting
+// unconditionally sidesteps that window, and persisting best-effort is enough
+// because the next request re-mints if its read still sees the dead token.
 const refreshAccessTokenForRetry = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: string } | { ok: false; response: Response }> => {
   await invalidateCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId);
   try {
@@ -523,8 +522,8 @@ const ensureSseContentType = (response: Response): Response => {
 
 // Hand best-effort writes to waitUntil so workerd does not cancel them when
 // the streaming response returns; the swallow guards against recoverable
-// noise (CAS losses on access-token / quota state_json rows, transient
-// storage errors) tripping the request.
+// noise (transient storage errors, a state_json write that lost every one of
+// its retries) tripping the request.
 const registerBackgroundWrite = (opts: CodexBackendCallBase, write: Promise<void>): void => {
   opts.call.waitUntil(write.catch(() => {}));
 };

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -26,40 +26,45 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
   // without re-resolving.
   const enabledFlags = resolveEffectiveFlags([CODEX_DEFAULT_FLAGS, record.flagOverrides]);
 
-  // Re-read upstream state on every request rather than capturing the record's
-  // state at construction. Refresh-token rotation, terminal-state transitions,
-  // and operator re-imports must all be visible to the next in-flight call.
-  // Throw rather than guess when the active credential is missing — a row that
-  // has lost its credential by id has been hand-edited, and silently using the
-  // wrong refresh_token would be worse than failing loudly.
-  const readActiveAccount = async () => {
-    const fresh = await getProviderRepo().upstreams.getById(record.id);
-    if (!fresh) throw new Error(`Codex upstream ${record.id} disappeared mid-request`);
-    assertCodexUpstreamState(fresh.state);
-    const state = fresh.state;
-    const accountIndex = findCodexAccountIndex(state, accountIdentity.chatgptAccountId);
+  // Locate the pool's active credential inside a state document. Throw rather
+  // than guess when it is missing — a row that has lost its credential by id
+  // has been hand-edited, and silently using the wrong refresh_token would be
+  // worse than failing loudly.
+  const locateActiveAccount = (raw: unknown) => {
+    assertCodexUpstreamState(raw);
+    const accountIndex = findCodexAccountIndex(raw, accountIdentity.chatgptAccountId);
     if (accountIndex < 0) {
       throw new Error(`Codex upstream ${record.id} state has no credential for account ${accountIdentity.chatgptAccountId}`);
     }
-    return { state, accountIndex, account: state.accounts[accountIndex]! };
+    return { state: raw, accountIndex, account: raw.accounts[accountIndex]! };
+  };
+
+  // Re-read upstream state on every request rather than capturing the record's
+  // state at construction. Refresh-token rotation, terminal-state transitions,
+  // and operator re-imports must all be visible to the next in-flight call.
+  const readActiveAccount = async () => {
+    const fresh = await getProviderRepo().upstreams.getById(record.id);
+    if (!fresh) throw new Error(`Codex upstream ${record.id} disappeared mid-request`);
+    return locateActiveAccount(fresh.state);
   };
 
   const persistRefreshTokenRotation = async (newRefreshToken: string): Promise<void> => {
-    const { state, accountIndex } = await readActiveAccount();
-    const next = replaceCodexAccount(state, accountIndex, account => ({ ...account, refresh_token: newRefreshToken, state_updated_at: new Date().toISOString() }));
-    // CAS write keyed on the just-read state. A losing CAS means a concurrent
-    // operator re-import (or another isolate's rotation) already advanced the
-    // row; their write supersedes ours and no retry is needed.
-    await getProviderRepo().upstreams.saveState(record.id, next, { expectedState: state });
+    const rotatedAt = new Date().toISOString();
+    await getProviderRepo().upstreams.saveState(record.id, current => {
+      const { state, accountIndex } = locateActiveAccount(current);
+      return replaceCodexAccount(state, accountIndex, account => ({ ...account, refresh_token: newRefreshToken, state_updated_at: rotatedAt }));
+    });
   };
 
   const persistTerminalState = async (newState: 'session_terminated' | 'refresh_failed', message: string): Promise<void> => {
-    const { state, accountIndex } = await readActiveAccount();
-    // Clear any cached access token on the terminal flip — once the credential
-    // is dead the cached token is dead too, and leaving it would confuse the
-    // dashboard's status panel.
-    const next = replaceCodexAccount(state, accountIndex, account => ({ ...account, state: newState, state_message: message, state_updated_at: new Date().toISOString(), accessToken: null }));
-    await getProviderRepo().upstreams.saveState(record.id, next, { expectedState: state });
+    const flippedAt = new Date().toISOString();
+    await getProviderRepo().upstreams.saveState(record.id, current => {
+      const { state, accountIndex } = locateActiveAccount(current);
+      // Clear any cached access token on the terminal flip — once the credential
+      // is dead the cached token is dead too, and leaving it would confuse the
+      // dashboard's status panel.
+      return replaceCodexAccount(state, accountIndex, account => ({ ...account, state: newState, state_message: message, state_updated_at: flippedAt, accessToken: null }));
+    });
   };
 
   const effects: CodexCallEffects = { persistRefreshTokenRotation, persistTerminalState };

--- a/packages/provider-codex/src/quota.ts
+++ b/packages/provider-codex/src/quota.ts
@@ -130,13 +130,16 @@ export const putCodexQuota = async (
   accountId: string,
   snapshot: CodexQuotaSnapshot,
 ): Promise<void> => {
-  const fresh = await getProviderRepo().upstreams.getById(upstreamId);
-  if (!fresh) throw new Error(`putCodexQuota: Codex upstream ${upstreamId} disappeared mid-request`);
-  const state = readCodexUpstreamState(fresh.state);
-  const idx = findCodexAccountIndex(state, accountId);
-  if (idx < 0) throw new Error(`putCodexQuota: Codex account ${accountId} not found in upstream ${upstreamId}`);
-  const currentQuota = state.accounts[idx].quotaSnapshot ?? {};
-  const nextQuota = { ...currentQuota, [codexQuotaActiveLimitKey(snapshot)]: { fetchedAt: Date.now(), data: snapshot } };
-  const next = replaceCodexAccount(state, idx, account => ({ ...account, quotaSnapshot: nextQuota }));
-  await getProviderRepo().upstreams.saveState(upstreamId, next, { expectedState: fresh.state });
+  // Stamped before the write so a replay against a winning sibling produces
+  // the same document rather than a later `fetchedAt`.
+  const fetchedAt = Date.now();
+  await getProviderRepo().upstreams.saveState(upstreamId, current => {
+    const state = readCodexUpstreamState(current);
+    const idx = findCodexAccountIndex(state, accountId);
+    if (idx < 0) throw new Error(`putCodexQuota: Codex account ${accountId} not found in upstream ${upstreamId}`);
+    return replaceCodexAccount(state, idx, account => ({
+      ...account,
+      quotaSnapshot: { ...account.quotaSnapshot ?? {}, [codexQuotaActiveLimitKey(snapshot)]: { fetchedAt, data: snapshot } },
+    }));
+  });
 };

--- a/packages/provider-codex/src/state.ts
+++ b/packages/provider-codex/src/state.ts
@@ -1,6 +1,6 @@
 // Gateway-managed Codex credential state, persisted in upstreams.state_json.
-// Writes happen via UpstreamRepo.saveState with optimistic concurrency keyed
-// on the prior state JSON.
+// Writes happen via UpstreamRepo.saveState, which read-modify-writes the row
+// and replays the mutator whenever a concurrent writer wins.
 
 import type { CodexQuotaSnapshot } from './quota.ts';
 
@@ -46,11 +46,9 @@ export interface CodexAccountCredential {
   // older rows so the contract is closed end-to-end.
   openaiDeviceId: string;
   // accessToken / quotaSnapshot were added after the initial schema; absent on
-  // pre-existing rows. The asserter accepts that absent-key case unchanged so
-  // we never mutate the input (which would poison CAS via the caller's
-  // `fresh.state` reference); `readCodexUpstreamState` is the boundary that
-  // normalizes absent → `null` on a shallow copy, so consumers can rely on
-  // the typed `null` slot here.
+  // pre-existing rows. The asserter accepts that absent-key case unchanged;
+  // `readCodexUpstreamState` is the boundary that normalizes absent → `null`
+  // on a shallow copy, so consumers can rely on the typed `null` slot here.
   accessToken: CodexAccessTokenEntry | null;
   quotaSnapshot: CodexQuotaSnapshotEntryMap | null;
 }
@@ -187,10 +185,8 @@ const assertCodexAccountCredential = (value: unknown, where: string): void => {
   }
   // accessToken / quotaSnapshot were added after the initial schema; absent on
   // pre-existing rows. Accept the absent-key case verbatim and only validate
-  // the shape when the key is present and non-null. Mutating the input here
-  // (e.g. defaulting to null in place) would propagate through the caller's
-  // `fresh.state` reference and poison the CAS `expectedState` — the absent →
-  // `null` normalization to satisfy the typed contract happens in
+  // the shape when the key is present and non-null; the absent → `null`
+  // normalization that satisfies the typed contract happens in
   // `readCodexUpstreamState` on a shallow copy instead.
   if (obj.accessToken !== undefined && obj.accessToken !== null) {
     assertCodexAccessTokenEntry(obj.accessToken, `${where}.accessToken`);
@@ -227,9 +223,9 @@ export function assertCodexUpstreamState(value: unknown): asserts value is Codex
 // `quotaSnapshot` key; the typed contract on `CodexAccountCredential`
 // promises `null` rather than `undefined`. Build a shallow copy of the
 // state with absent → `null` so consumers can rely on `=== null` checks
-// without seeing legacy rows escape unfilled. The original `raw` is left
-// untouched so callers (e.g. the access-token and quota modules) can still pass it
-// straight through as the CAS `expectedState`.
+// without seeing legacy rows escape unfilled. `raw` is left untouched, which
+// keeps the state-write helpers free to hand it straight back to the repo to
+// say there is nothing to write.
 export const readCodexUpstreamState = (raw: unknown): CodexUpstreamState => {
   assertCodexUpstreamState(raw);
   return {

--- a/packages/provider-copilot/__tests__/auth_test.ts
+++ b/packages/provider-copilot/__tests__/auth_test.ts
@@ -30,9 +30,8 @@ const installRepoAndClearCache = async () => {
   initProviderRepo(() => ({
     upstreams: {
       getById: async () => ({ ...stub, state }),
-      saveState: async (_id, newState) => {
-        state = newState;
-        return { updated: true };
+      saveState: async (_id, mutate) => {
+        state = mutate(state);
       },
     },
   }));
@@ -198,15 +197,14 @@ test('copilotAuthedFetch reads a still-valid Copilot token from state_json inste
   assertEquals(authHeader, 'Bearer tok-persisted');
 });
 
-// Regression: the token persist used to key its CAS on the row read BEFORE
-// the token exchange, so any write that landed during that round trip — and
-// the quota harvest writes this row on every data-plane response — cost the
-// upstream its freshly minted token, sending every isolate back to the token
-// endpoint on its own. The persist now re-reads immediately before saving.
+// Regression: the token persist used to build its document from the row read
+// BEFORE the token exchange, so any write that landed during that round trip —
+// and the quota harvest writes this row on every data-plane response — was
+// either overwritten or cost the upstream its freshly minted token. The persist
+// is now a mutator over the state the repo hands it at write time.
 test('copilotAuthedFetch persists a minted token even when the row changed during the exchange', async () => {
   let state: unknown = { knownModels: null, copilotToken: null, quotaSnapshot: null };
   let exchanged = false;
-  const casLosses: number[] = [];
   const stub: UpstreamRecord = {
     id: UPSTREAM_ID,
     kind: 'copilot',
@@ -226,16 +224,8 @@ test('copilotAuthedFetch persists a minted token even when the row changed durin
   initProviderRepo(() => ({
     upstreams: {
       getById: async () => ({ ...stub, state }),
-      saveState: async (_id, newState, options) => {
-        // Real CAS semantics: the mock persists inline, so JSON equality on
-        // the state we read vs. the row's current value is what D1's
-        // state_json round-trip would compare.
-        if (JSON.stringify(options.expectedState) !== JSON.stringify(state)) {
-          casLosses.push(1);
-          return { updated: false };
-        }
-        state = newState;
-        return { updated: true };
+      saveState: async (_id, mutate) => {
+        state = mutate(state);
       },
     },
   }));
@@ -272,10 +262,9 @@ test('copilotAuthedFetch persists a minted token even when the row changed durin
   );
 
   assertEquals(exchanged, true);
-  assertEquals(casLosses.length, 0);
   const persisted = state as CopilotUpstreamState;
   assertEquals(persisted.copilotToken?.token, 'tok-test');
-  // The sibling write that landed mid-exchange survives — the persist carries
+  // The sibling write that landed mid-exchange survives — the persist spreads
   // the row as it stands now, not the snapshot taken before the round trip.
   assertEquals(persisted.quotaSnapshot?.fetchedAt, 1);
 });

--- a/packages/provider-copilot/__tests__/fetch-models_test.ts
+++ b/packages/provider-copilot/__tests__/fetch-models_test.ts
@@ -27,7 +27,7 @@ const installRepoAndConfig = async () => {
   initProviderRepo(() => ({
     upstreams: {
       getById: async () => stub,
-      saveState: async () => ({ updated: true }),
+      saveState: async () => {},
     },
   }));
   clearInProcessCopilotTokenCache();

--- a/packages/provider-copilot/__tests__/interceptors/responses/action-pivot_test.ts
+++ b/packages/provider-copilot/__tests__/interceptors/responses/action-pivot_test.ts
@@ -59,7 +59,7 @@ test('Copilot provider terminal dispatches on post-chain ctx.action (interceptor
   initProviderRepo(() => ({
     upstreams: {
       getById: async () => upstream,
-      saveState: async () => ({ updated: true }),
+      saveState: async () => {},
     },
   }));
   initImageProcessor(createInMemoryImageProcessor());

--- a/packages/provider-copilot/__tests__/provider_test.ts
+++ b/packages/provider-copilot/__tests__/provider_test.ts
@@ -48,58 +48,38 @@ const buildCopilotUpstream = (overrides: Partial<UpstreamRecord> = {}): Upstream
   };
 };
 
-interface SaveStateCall {
-  newState: unknown;
-  expectedState: unknown;
-}
-
 interface CopilotTestRepo {
   copilotUpstream: UpstreamRecord;
-  saveStateCalls: SaveStateCall[];
+  savedStates: unknown[];
   setUpstreamState: (state: unknown) => void;
   getCurrentState: () => unknown;
-  setSaveStateResult: (result: { updated: boolean }) => void;
   overrideGetById: (impl: () => Promise<UpstreamRecord | null>) => void;
-  overrideSaveState: (impl: (id: string, newState: unknown, options: { expectedState: unknown }) => Promise<{ updated: boolean }>) => void;
+  overrideSaveState: (impl: (id: string, mutate: (current: unknown) => unknown) => Promise<void>) => void;
 }
 
-interface SetupOptions extends Partial<UpstreamRecord> {
-  enforceCas?: boolean;
-}
-
-const setupCopilotTest = async (initial: SetupOptions = {}): Promise<CopilotTestRepo> => {
-  const { enforceCas = false, ...recordOverrides } = initial;
+const setupCopilotTest = async (recordOverrides: Partial<UpstreamRecord> = {}): Promise<CopilotTestRepo> => {
   let upstream = buildCopilotUpstream(recordOverrides);
-  const saveStateCalls: SaveStateCall[] = [];
-  let saveResult: { updated: boolean } = { updated: true };
+  const savedStates: unknown[] = [];
   let getByIdImpl: () => Promise<UpstreamRecord | null> = async () => upstream;
-  // Real CAS would compare row-version columns, but the mock persists state
-  // inline, so JSON-shape equality on expectedState vs the row's current state
-  // matches what D1's state_json round-trip would observe.
-  const stateMatches = (expected: unknown, current: unknown): boolean =>
-    JSON.stringify(expected) === JSON.stringify(current);
-  let saveStateImpl: (id: string, newState: unknown, options: { expectedState: unknown }) => Promise<{ updated: boolean }> = async (_id, newState, options) => {
-    saveStateCalls.push({ newState, expectedState: options.expectedState });
-    if (enforceCas && !stateMatches(options.expectedState, upstream.state)) {
-      return { updated: false };
-    }
-    upstream = { ...upstream, state: newState };
-    return saveResult;
+  // Applies the mutator to the row as it stands, the way the repo does.
+  let saveStateImpl: (id: string, mutate: (current: unknown) => unknown) => Promise<void> = async (_id, mutate) => {
+    const next = mutate(upstream.state);
+    savedStates.push(next);
+    upstream = { ...upstream, state: next };
   };
   initProviderRepo(() => ({
     upstreams: {
       getById: () => getByIdImpl(),
-      saveState: (id, newState, options) => saveStateImpl(id, newState, options),
+      saveState: (id, mutate) => saveStateImpl(id, mutate),
     },
   }));
   initImageProcessor(createInMemoryImageProcessor());
   clearInProcessCopilotTokenCache();
   return {
     copilotUpstream: upstream,
-    saveStateCalls,
+    savedStates,
     setUpstreamState: state => { upstream = { ...upstream, state }; },
     getCurrentState: () => upstream.state,
-    setSaveStateResult: result => { saveResult = result; },
     overrideGetById: impl => { getByIdImpl = impl; },
     overrideSaveState: impl => { saveStateImpl = impl; },
   };
@@ -751,9 +731,9 @@ test('Copilot provider rejects a merged public model without a raw variant group
   }
 });
 
-test('Copilot provider persists merged known-models view via saveState CAS keyed on the read state', async () => {
+test('Copilot provider persists the minted token and the merged known-models view as two writes to distinct slots', async () => {
   const harness = await setupCopilotTest();
-  const { copilotUpstream, saveStateCalls } = harness;
+  const { copilotUpstream, savedStates } = harness;
 
   await withMockedFetch(
     request => {
@@ -772,31 +752,20 @@ test('Copilot provider persists merged known-models view via saveState CAS keyed
     },
   );
 
-  assertEquals(saveStateCalls.length, 2);
-  const tokenWrite = saveStateCalls.find(c => (c.newState as CopilotUpstreamState).copilotToken !== null);
-  const modelsWrite = saveStateCalls.find(c => (c.newState as CopilotUpstreamState).knownModels !== null);
-  if (!tokenWrite || !modelsWrite) throw new Error('expected one token write and one models write');
-  // Both writes ran against the same seeded row (state=null) on the first
-  // call; the token write happens first and lands a non-null state, so the
-  // models write's expectedState is whatever the token write produced.
-  assertEquals(tokenWrite.expectedState, null);
-  const tokenPersisted = tokenWrite.newState as CopilotUpstreamState;
-  assertEquals(tokenPersisted.knownModels, null);
-  assertEquals(typeof tokenPersisted.copilotToken?.token, 'string');
-  const modelsPersisted = modelsWrite.newState as CopilotUpstreamState;
-  if (!modelsPersisted.knownModels) throw new Error('expected knownModels persisted');
-  assertEquals(Object.keys(modelsPersisted.knownModels.models), ['m1']);
+  assertEquals(savedStates.length, 2);
+  const [tokenWrite, modelsWrite] = savedStates as [CopilotUpstreamState, CopilotUpstreamState];
+  // The token mint runs inside the models fetch, so it writes first and only
+  // fills its own slot.
+  assertEquals(tokenWrite.knownModels, null);
+  assertEquals(typeof tokenWrite.copilotToken?.token, 'string');
+  if (!modelsWrite.knownModels) throw new Error('expected knownModels persisted');
+  assertEquals(Object.keys(modelsWrite.knownModels.models), ['m1']);
+  // Spreading the state it was handed is what carries the token through.
+  assertEquals(modelsWrite.copilotToken?.token, tokenWrite.copilotToken?.token);
 });
 
-test('Copilot provider persists known-models even when the token-mint write advanced the row mid-call', async () => {
-  // CAS-enforcing harness: a saveState whose expectedState != the row's
-  // current state returns {updated:false} without mutating. The token-mint
-  // path inside fetchCopilotModels persists copilotToken under its own CAS
-  // before the known-models save runs, so the known-models save MUST key on
-  // the post-mint state, not the pre-fetch snapshot — otherwise its CAS
-  // deterministically loses on every token expiry and knownModels never
-  // grows.
-  const harness = await setupCopilotTest({ enforceCas: true });
+test('Copilot provider merges known-models into the row as it stands after the fetch, not into the pre-fetch snapshot', async () => {
+  const harness = await setupCopilotTest();
   const { copilotUpstream } = harness;
 
   await withMockedFetch(
@@ -805,6 +774,13 @@ test('Copilot provider persists known-models even when the token-mint write adva
       if (pre) return pre;
       const url = new URL(request.url);
       if (url.pathname === '/models') {
+        // A concurrent quota harvest lands while the catalog fetch is in
+        // flight, on top of the token the mint just persisted.
+        const current = readCopilotUpstreamState(harness.getCurrentState());
+        harness.setUpstreamState({
+          ...current,
+          quotaSnapshot: { fetchedAt: 1, data: { observed_at: '2026-08-01T00:00:00.000Z', reset_at: null, quotas: {} } },
+        } satisfies CopilotUpstreamState);
         return jsonResponse({ object: 'list', data: [{ id: 'm1', supported_endpoints: ['/v1/messages'] }] });
       }
       throw new Error(`Unhandled fetch ${request.url}`);
@@ -815,12 +791,11 @@ test('Copilot provider persists known-models even when the token-mint write adva
     },
   );
 
-  // Inspect the persisted state directly — the token-mint write lands first
-  // and a correctly-keyed known-models write must observe it AND extend it.
   const final = readCopilotUpstreamState(harness.getCurrentState());
-  if (!final.copilotToken) throw new Error('expected copilotToken to be persisted by the token-mint write');
-  if (!final.knownModels) throw new Error('expected knownModels to be persisted after the token-mint CAS advanced the row');
+  if (!final.knownModels) throw new Error('expected knownModels to be persisted');
   assertEquals(Object.keys(final.knownModels.models), ['m1']);
+  if (!final.copilotToken) throw new Error('expected the minted token to survive the known-models write');
+  assertEquals(final.quotaSnapshot?.fetchedAt, 1);
 });
 
 test('Copilot provider accumulates known-models across calls so a model dropped from the fetch still surfaces', async () => {
@@ -891,31 +866,9 @@ test('Copilot provider throws "disappeared mid-request" when the upstream row va
   );
 });
 
-test('Copilot provider accepts a losing CAS write and still returns the freshly fetched models', async () => {
-  const harness = await setupCopilotTest();
-  harness.setSaveStateResult({ updated: false });
-
-  await withMockedFetch(
-    request => {
-      const pre = copilotPreflight(request);
-      if (pre) return pre;
-      const url = new URL(request.url);
-      if (url.pathname === '/models') {
-        return jsonResponse({ object: 'list', data: [{ id: 'm1', supported_endpoints: ['/v1/messages'] }] });
-      }
-      throw new Error(`Unhandled fetch ${request.url}`);
-    },
-    async () => {
-      const instance = createCopilotProvider(harness.copilotUpstream);
-      const result = await instance.instance.getProvidedModels(directFetcher);
-      assertEquals(result.map(m => m.id), ['m1']);
-    },
-  );
-});
-
 test('Copilot provider swallows a saveState throw so a transient persistence hiccup does not invalidate the fetched models', async () => {
   // Persistence is best-effort: the fetched models are the user-facing
-  // payload, and a DB-level error on the CAS write must not propagate out of
+  // payload, and a storage-level error on the write must not propagate out of
   // getProvidedModels. Mirrors the gateway SWR layer's persistence policy.
   const harness = await setupCopilotTest();
   harness.overrideSaveState(() => Promise.reject(new Error('D1 hiccup')));

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -141,26 +141,15 @@ async function getCopilotToken(upstreamId: string, githubToken: string, fetcher:
   return await withRetry(async () => {
     const entry = await exchangeCopilotToken(githubToken, fetcher, signal);
     inProcessTokenCache.set(upstreamId, { entry, cachedAt: Date.now() });
-    // Re-read the row after the exchange instead of keying the CAS on the
-    // snapshot taken before it. The exchange is a full api.github.com round
-    // trip, and the quota harvest writes this same state_json row on every
-    // data-plane response, so a pre-fetch `expectedState` loses on any busy
-    // upstream — leaving the persisted slot holding the expired token and
-    // sending every isolate back to the token endpoint on its own. Same
-    // rationale as the known-models save in provider.ts.
-    //
-    // Best-effort throughout: a losing CAS or transient DB error must not
-    // invalidate the freshly fetched token, which the caller is about to use
-    // to satisfy a live request.
+    // Best-effort: the caller is about to satisfy a live request with this
+    // token, so a storage failure costs the next cold isolate one extra mint
+    // rather than the request. Swallowing here also keeps such a failure out
+    // of withRetry, which would otherwise answer it by minting again.
     try {
-      const latest = await getRepo().upstreams.getById(upstreamId);
-      if (latest) {
-        await getRepo().upstreams.saveState(
-          upstreamId,
-          { ...readCopilotUpstreamState(latest.state), copilotToken: entry } satisfies CopilotUpstreamState,
-          { expectedState: latest.state },
-        );
-      }
+      await getRepo().upstreams.saveState(upstreamId, current => ({
+        ...readCopilotUpstreamState(current),
+        copilotToken: entry,
+      } satisfies CopilotUpstreamState));
     } catch (err) {
       console.warn(`Failed to persist Copilot token for ${upstreamId}:`, err);
     }

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -291,30 +291,26 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
     getProvidedModels: async fetcher => {
       const fresh = await getProviderRepo().upstreams.getById(copilot.id);
       if (!fresh) throw new Error(`Copilot upstream ${copilot.id} disappeared mid-request`);
-      const initialState = readCopilotUpstreamState(fresh.state);
-      const known = initialState.knownModels ?? emptyKnownModels();
+      const known = readCopilotUpstreamState(fresh.state).knownModels ?? emptyKnownModels();
       const response = await fetchCopilotModels(upstreamConfig, fetcher);
       const now = Date.now();
       const merged = mergeKnownModels(known, response, now);
-      // Re-read after the upstream fetch — fetchCopilotModels may have minted a
-      // new Copilot token via the auth path, which persists copilotToken under
-      // its own CAS and advances state_json. Keying this save on the pre-fetch
-      // snapshot would lose deterministically on every token mint (~each
-      // expiry), so the known-models accumulator would never grow. Persistence
-      // is best-effort either way: a losing CAS or thrown error must not
-      // invalidate the response, which the caller is about to use.
-      const latest = await getProviderRepo().upstreams.getById(copilot.id);
-      if (latest) {
-        const latestState = readCopilotUpstreamState(latest.state);
-        try {
-          await getProviderRepo().upstreams.saveState(
-            copilot.id,
-            { ...latestState, knownModels: merged } satisfies CopilotUpstreamState,
-            { expectedState: latest.state },
-          );
-        } catch (err) {
-          console.warn(`Failed to persist Copilot known-models for ${copilot.id}:`, err);
-        }
+      // The accumulator merges into whatever is stored at write time, not into
+      // the snapshot read before the fetch — fetchCopilotModels may have minted
+      // a token and written this same row on the way through. Persistence stays
+      // best-effort: the fetched catalog is what the caller is about to serve,
+      // and a storage failure only costs the next call the entries this one
+      // would have added.
+      try {
+        await getProviderRepo().upstreams.saveState(copilot.id, current => {
+          const state = readCopilotUpstreamState(current);
+          return {
+            ...state,
+            knownModels: mergeKnownModels(state.knownModels ?? emptyKnownModels(), response, now),
+          } satisfies CopilotUpstreamState;
+        });
+      } catch (err) {
+        console.warn(`Failed to persist Copilot known-models for ${copilot.id}:`, err);
       }
       return finalizeCopilotModels(projectKnownModels(merged, now), copilot.flagOverrides);
     },

--- a/packages/provider-copilot/src/quota.ts
+++ b/packages/provider-copilot/src/quota.ts
@@ -225,16 +225,13 @@ export const fetchCopilotUsage = (githubToken: string, fetcher: Fetcher): Promis
   fetcher('https://api.github.com/copilot_internal/user', { headers: githubHeaders(githubToken) });
 
 // Both sources land in the same slot, so whichever observed the seat most
-// recently is what the dashboard shows. The CAS is keyed on the state we just
-// read: losing it to a concurrent token mint or known-models save is expected
-// under load, and the loser's snapshot is worth no more than the winner's.
+// recently is what the dashboard shows. `fetchedAt` is stamped outside the
+// mutator: the mutator is re-run on a lost race and must return the same
+// snapshot each time.
 export const putCopilotQuota = async (upstreamId: string, snapshot: CopilotQuotaSnapshot): Promise<void> => {
-  const fresh = await getProviderRepo().upstreams.getById(upstreamId);
-  if (!fresh) throw new Error(`putCopilotQuota: Copilot upstream ${upstreamId} disappeared mid-request`);
-  const state = readCopilotUpstreamState(fresh.state);
-  await getProviderRepo().upstreams.saveState(
-    upstreamId,
-    { ...state, quotaSnapshot: { fetchedAt: Date.now(), data: snapshot } } satisfies CopilotUpstreamState,
-    { expectedState: fresh.state },
-  );
+  const fetchedAt = Date.now();
+  await getProviderRepo().upstreams.saveState(upstreamId, current => ({
+    ...readCopilotUpstreamState(current),
+    quotaSnapshot: { fetchedAt, data: snapshot },
+  } satisfies CopilotUpstreamState));
 };

--- a/packages/provider-copilot/src/state.ts
+++ b/packages/provider-copilot/src/state.ts
@@ -1,6 +1,8 @@
 // Gateway-managed Copilot upstream state, persisted in upstreams.state_json.
-// Writes happen via UpstreamRepo.saveState with optimistic concurrency keyed
-// on the prior state JSON.
+// The three slots below are written by three independent paths, so each write
+// goes through UpstreamRepo.saveState as a mutator that spreads the state it
+// is handed and replaces its own slot — that is what keeps a sibling path's
+// concurrent write intact.
 
 import type { CopilotKnownModels } from './known-models.ts';
 import type { CopilotQuotaSnapshot } from './quota.ts';

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -64,7 +64,7 @@ export type { ProviderStreamParser } from './streaming.ts';
 export { streamingProviderCall } from './streaming.ts';
 
 export type { ProviderRepo, UpstreamsRepoSlim } from './repo.ts';
-export { getProviderRepo, initProviderRepo } from './repo.ts';
+export { getProviderRepo, initProviderRepo, UpstreamGoneError } from './repo.ts';
 
 export {
   ProviderModelsUnavailableError,

--- a/packages/provider/src/repo.ts
+++ b/packages/provider/src/repo.ts
@@ -5,9 +5,16 @@ import type { UpstreamRecord } from './model.ts';
 // from operator-triggered control-plane actions alike, so every write goes
 // through the same read-modify-CAS. Structurally compatible with the full
 // UpstreamRepo in packages/gateway, so the wiring stays a single accessor.
+//
+// `saveState` takes the change as a function rather than a finished document
+// because the write is retried: a caller that computed its document from an
+// earlier read would, on losing the race, either overwrite the winner's fields
+// or have to re-derive the change itself. The mutator is re-run against
+// whatever state won, so both writers' changes survive. It must therefore be
+// pure, and returning the state unchanged skips the write.
 export interface UpstreamsRepoSlim {
   getById(id: string): Promise<UpstreamRecord | null>;
-  saveState(id: string, newState: unknown, options: { expectedState: unknown }): Promise<{ updated: boolean }>;
+  saveState(id: string, mutate: (current: unknown) => unknown): Promise<void>;
 }
 
 export interface ProviderRepo {

--- a/packages/provider/src/repo.ts
+++ b/packages/provider/src/repo.ts
@@ -17,6 +17,17 @@ export interface UpstreamsRepoSlim {
   saveState(id: string, mutate: (current: unknown) => unknown): Promise<void>;
 }
 
+// Thrown when the row a write targets no longer exists. Distinct from a
+// storage failure so a best-effort writer can tolerate the operator having
+// deleted the upstream mid-request, while a write that must not be lost — a
+// rotated refresh token — still propagates.
+export class UpstreamGoneError extends Error {
+  constructor(readonly upstreamId: string) {
+    super(`Upstream ${upstreamId} disappeared before its state could be written`);
+    this.name = 'UpstreamGoneError';
+  }
+}
+
 export interface ProviderRepo {
   upstreams: UpstreamsRepoSlim;
 }


### PR DESCRIPTION
Fixes #340.

## The bug

`upstreams.state_json` holds an OAuth provider's rotating refresh token, and it also holds values the gateway writes on **every data-plane response** — the minted access token, the quota snapshot parsed off the response headers. Every writer read-modify-wrote that one cell under a compare-and-swap on its serialized text.

A rotation's read-to-write window spans a full round trip to the vendor's token endpoint, so it routinely overlapped those per-response writes and lost the CAS. The write reported the loss as `{ updated: false }`, and the call sites dropped it — Codex silently, Claude Code by throwing a message blaming "another rotation". Either way the row kept a refresh token the vendor had already invalidated when it issued the new one, and `recoverFromRefreshRace` cannot tell that apart from a real revocation: in both cases the stored token equals the one just used. The account flips to a terminal state and the operator has to re-import.

Production traffic over seven days: 12,394 state writes against 5.1 requests/second — rare enough to look like bad luck, frequent enough to burn credentials.

## The change

The write takes the change as a function instead of a finished document:

```ts
saveState(id: string, mutate: (current: unknown) => unknown): Promise<void>
```

The repo reads, applies the mutator, and CASes; on a loss it re-reads and re-applies against whichever write won, bounded, and throws if it cannot land. There is no boolean left to drop.

Two properties follow from taking a function rather than a document:

- **Both changes survive a race.** A caller that computed its document from an earlier read would, on retry, reinstate the values the winner had replaced. The mutator derives its result from the state it is handed, so a rotation landing on top of a concurrent quota write keeps both.
- **The CAS binds the exact text the repo read**, not a re-serialized form, so it no longer depends on callers reproducing the canonical encoder. That coupling is why migration 0031 could not lift data into this column from SQL at all.

Returning the argument unchanged is how a caller says "nothing to do"; the repo skips the write. That replaces the hand-rolled no-op guards at several call sites.

A vanished row throws a typed `UpstreamGoneError`. The distinction is load-bearing: a minted access token is bookkeeping the next request re-derives, so an operator deleting an upstream mid-request should not fail that request, while a real storage failure must still propagate.

No schema change, no migration, and no provider state contract changes.

## Fallout worth noting

Machinery that existed only to dodge a lost CAS is gone: the Copilot token mint and the known-models save each re-read the row after their network round trip for exactly that reason, and both collapse into a plain mutator. Several comments asserting that a lost CAS meant "a concurrent rotation superseded us" were describing a race that was usually lost to a quota write instead; they are corrected rather than carried over.

Because the mutator is replayed, anything that varies per attempt has to sit outside it — timestamps are stamped before the write, and a diagnostic is recorded inside and emitted once after.

## Test plan

- [x] `pnpm run test` — 422 files green
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] Repo suite covers the retry and its exhaustion with a deterministic racing writer that lands an out-of-band write between the read and the CAS; the exhaustion case pins that the mutator runs exactly the bound, the write throws, and the row keeps the winner's value
- [x] Verified by inversion: the retry case fails when the bound is dropped to one, and the vanished-row case fails when the tolerance branch is removed
- [x] Per-provider suites assert the state a write left behind rather than the document argument, including a Claude Code case pinning that a rotation lands on top of a concurrent quota snapshot
