### PR TITLE
refactor(flags): name the role-compatibility flags after the rewrite they perform

### DIFF
--- a/apps/web/src/components/upstream-editor/feature-flags.tsx
+++ b/apps/web/src/components/upstream-editor/feature-flags.tsx
@@ -21,9 +21,9 @@ const flagGroupById = {
   'responses-image-generation-shim': 'shims',
   'responses-compact-shim': 'shims',
   'disable-reasoning-on-forced-tool-choice': 'apiCompatibility',
-  'demote-interleaved-system-to-user': 'apiCompatibility',
-  'demote-developer-to-system': 'apiCompatibility',
-  'promote-system-to-developer': 'apiCompatibility',
+  'rewrite-mid-conv-system-to-user': 'apiCompatibility',
+  'rewrite-developer-to-system': 'apiCompatibility',
+  'rewrite-system-to-developer': 'apiCompatibility',
   'strip-billing-attribution': 'sanitization',
   'strip-prompt-cache-key': 'sanitization',
 } as const satisfies Record<FlagId, FlagGroupId>;

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -617,17 +617,17 @@ const en = {
               description:
                   'Some upstreams do not support forced tool calls and reasoning mode at the same time, and reject such requests outright.\nWhen this option is enabled and the caller forces a specific tool through `tool_choice`, Floway **disables reasoning mode** before forwarding the request.',
             },
-            'demote-interleaved-system-to-user': {
+            'rewrite-mid-conv-system-to-user': {
               label: 'Rewrite Inline system Roles to user',
               description:
                   'Some upstreams only allow the `system` role at the beginning of a conversation and reject inline `system` messages interleaved between `user` or `assistant` messages (for example, DeepSeek-R1).\nWhen this option is enabled, consecutive `system` messages at the beginning of the conversation are preserved, while later interleaved `system` roles are rewritten to `user`. Message content remains unchanged.\nFor Messages API upstreams, this option is treated as enabled because system prompts can only appear in the top-level `system` field.',
             },
-            'demote-developer-to-system': {
+            'rewrite-developer-to-system': {
               label: 'Rewrite developer Roles to system',
               description:
                   'The latest OpenAI API specification includes the `developer` role (`role`), but some upstreams do not support it.\nEnable this option to rewrite `developer` as `system` before sending requests to the upstream.\nFor example, Codex system prompts use the `developer` role, while DeepSeek does not support it; enable this option in that case.',
             },
-            'promote-system-to-developer': {
+            'rewrite-system-to-developer': {
               label: 'Rewrite system Roles to developer',
               description:
                   'Rewrite messages with the `system` role to `developer` for upstreams that reject system-role input while accepting the developer role.',

--- a/apps/web/src/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/i18n/locales/zh-Hans.ts
@@ -589,17 +589,17 @@ const zhHansCN = {
               description:
                   '部分上游不支持同时开启“强制工具调用”和思考模式，会直接拒绝此类请求。\n开启此开关后，当调用方通过 `tool_choice` 强制指定某个工具时，Floway 会在转发请求时**关闭思考模式**。',
             },
-            'demote-interleaved-system-to-user': {
+            'rewrite-mid-conv-system-to-user': {
               label: '改写行内 system 角色为 user',
               description:
                   '部分上游只允许在对话开头使用 `system` 角色，不接受穿插在 `user` 或 `assistant` 消息之间的行内 `system` 消息（如 DeepSeek-R1）。\n开启此开关后，对话开头连续的 `system` 消息会保留，而后续穿插的 `system` 角色会被改写为 `user`。消息内容保持不变。\n对于 Messages API 上游，由于系统提示词只能放在顶层 `system` 字段中，此开关被视为开启。',
             },
-            'demote-developer-to-system': {
+            'rewrite-developer-to-system': {
               label: '改写 developer 角色为 system',
               description:
                   'OpenAI 的新版 API 规范中包含了 `developer` 这一角色（`role`），但部分上游并不支持。\n开启此开关，以在请求上游时，把 `developer` 改写为 `system`。\n例如，Codex 的系统提示词会使用 `developer` 角色，但 DeepSeek 不支持，此时就应开启。',
             },
-            'promote-system-to-developer': {
+            'rewrite-system-to-developer': {
               label: '改写 system 角色为 developer',
               description:
                   '对拒绝 system 角色但接受 developer 角色的上游，将 `system` 角色消息改写为 `developer`。',

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -51,8 +51,8 @@ than in pairwise translators.
 - Role compatibility is target-side within those lists, so pair sections below
   describe the translator's intermediate target shape, not an unconditional
   final wire role. Chat Completions and Responses apply enabled role rewrites
-  system-to-developer, developer-to-system, then interleaved system-to-user.
-  Messages can demote inline system messages because its only dedicated system
+  system-to-developer, developer-to-system, then mid-conversation system-to-user.
+  Messages can rewrite inline system messages because its only dedicated system
   slot is top-level `system`.
 - A provider may run another typed interceptor envelope inside `call*`, after
   the gateway protocol envelope and immediately before its wire call. Provider

--- a/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/upstreams/routes_test.ts
@@ -2202,7 +2202,7 @@ test('GET /api/upstreams/blueprint serves the record a new upstream starts as wi
   // Anthropic verbatim.
   const copilotPreview = (await (await requestApp('/api/upstreams/blueprint?kind=copilot', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
   assertEquals(copilotPreview.flag_defaults['strip-billing-attribution'], true);
-  assertEquals(copilotPreview.flag_defaults['demote-interleaved-system-to-user'], false);
+  assertEquals(copilotPreview.flag_defaults['rewrite-mid-conv-system-to-user'], false);
   const ccPreview = (await (await requestApp('/api/upstreams/blueprint?kind=claude-code', { headers: { 'x-floway-session': adminSession } })).json()) as JsonObject;
   assertEquals(ccPreview.flag_defaults['strip-billing-attribution'], false);
 });

--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/attempt_test.ts
@@ -146,9 +146,9 @@ test('generate native target applies role compatibility flags in target-chain or
       callChatCompletions,
       endpoints: { chatCompletions: {} },
       enabledFlags: new Set([
-        'demote-developer-to-system',
-        'demote-interleaved-system-to-user',
-        'promote-system-to-developer',
+        'rewrite-developer-to-system',
+        'rewrite-mid-conv-system-to-user',
+        'rewrite-system-to-developer',
       ]),
     }),
     headers: new Headers(),
@@ -244,7 +244,7 @@ test('generate translates through the Responses target when only that endpoint i
   assertEquals(callResponses.mock.calls.length, 1);
 });
 
-test('generate preserves translated instructions before promoting inline system messages', async () => {
+test('generate preserves translated instructions before rewriting inline system messages', async () => {
   installRepo();
   const observedBodies: Omit<ResponsesPayload, 'model'>[] = [];
   const callResponses = vi.fn(async (_model, body): Promise<ProviderResponsesResult> => {
@@ -275,7 +275,7 @@ test('generate preserves translated instructions before promoting inline system 
     candidate: makeCandidate({
       callResponses,
       endpoints: { responses: {} },
-      enabledFlags: new Set<FlagId>(['promote-system-to-developer']),
+      enabledFlags: new Set<FlagId>(['rewrite-system-to-developer']),
     }),
     headers: new Headers(),
   });

--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/apply-role-compatibility_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/apply-role-compatibility_test.ts
@@ -34,29 +34,29 @@ test('leaves roles unchanged without flags or at a translated target', async () 
 
   assertEquals(await applyRoles(messages, new Set()), messages);
   assertEquals(
-    await applyRoles(messages, new Set(['promote-system-to-developer']), 'responses'),
+    await applyRoles(messages, new Set(['rewrite-system-to-developer']), 'responses'),
     messages,
   );
 });
 
-test('applies promotion and developer demotion independently', async () => {
+test('applies the system and developer rewrites independently', async () => {
   assertEquals(
     await applyRoles(
       [{ role: 'system', content: 'rules' }, { role: 'user', content: 'hello' }],
-      new Set(['promote-system-to-developer']),
+      new Set(['rewrite-system-to-developer']),
     ),
     [{ role: 'developer', content: 'rules' }, { role: 'user', content: 'hello' }],
   );
   assertEquals(
     await applyRoles(
       [{ role: 'developer', content: 'rules' }, { role: 'user', content: 'hello' }],
-      new Set(['demote-developer-to-system']),
+      new Set(['rewrite-developer-to-system']),
     ),
     [{ role: 'system', content: 'rules' }, { role: 'user', content: 'hello' }],
   );
 });
 
-test('preserves the leading system run and demotes later system messages', async () => {
+test('preserves the leading system run and rewrites later system messages', async () => {
   assertEquals(
     await applyRoles(
       [
@@ -65,7 +65,7 @@ test('preserves the leading system run and demotes later system messages', async
         { role: 'user', content: 'hello' },
         { role: 'system', content: 'inline rules' },
       ],
-      new Set(['demote-interleaved-system-to-user']),
+      new Set(['rewrite-mid-conv-system-to-user']),
     ),
     [
       { role: 'system', content: 'base A' },
@@ -81,24 +81,24 @@ test('keeps a leading-only system run and an empty input unchanged', async () =>
     { role: 'system', content: 'base A' },
     { role: 'system', content: 'base B' },
   ];
-  assertEquals(await applyRoles(leading, new Set(['demote-interleaved-system-to-user'])), leading);
-  assertEquals(await applyRoles([], new Set(['demote-interleaved-system-to-user'])), []);
+  assertEquals(await applyRoles(leading, new Set(['rewrite-mid-conv-system-to-user'])), leading);
+  assertEquals(await applyRoles([], new Set(['rewrite-mid-conv-system-to-user'])), []);
 });
 
-test('preserves multipart content identity when demoting an interleaved system message', async () => {
+test('preserves multipart content identity when rewriting a mid-conversation system message', async () => {
   const content = [
     { type: 'text' as const, text: 'one' },
     { type: 'text' as const, text: 'two' },
   ];
   const result = await applyRoles(
     [{ role: 'user', content: 'hello' }, { role: 'system', content }],
-    new Set(['demote-interleaved-system-to-user']),
+    new Set(['rewrite-mid-conv-system-to-user']),
   );
   assertEquals(result, [{ role: 'user', content: 'hello' }, { role: 'user', content }]);
   assert(result[1]?.content === content);
 });
 
-test('applies overlapping flags in promotion then demotion order', async () => {
+test('applies overlapping flags in system-to-developer then developer-to-system order', async () => {
   assertEquals(
     await applyRoles(
       [
@@ -107,9 +107,9 @@ test('applies overlapping flags in promotion then demotion order', async () => {
         { role: 'system', content: 'inline rules' },
       ],
       new Set([
-        'promote-system-to-developer',
-        'demote-developer-to-system',
-        'demote-interleaved-system-to-user',
+        'rewrite-system-to-developer',
+        'rewrite-developer-to-system',
+        'rewrite-mid-conv-system-to-user',
       ]),
     ),
     [

--- a/packages/gateway/__tests__/data-plane/chat/messages/attempt_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/messages/attempt_test.ts
@@ -142,7 +142,7 @@ test('generate translate-to-responses branch routes through responsesAttempt', a
   assertEquals(callResponses.mock.calls.length, 1);
 });
 
-test('generate lets target promotion take precedence over source demotion', async () => {
+test('generate lets the target system-to-developer rewrite take precedence over the source system-to-user rewrite', async () => {
   installRepo();
   const observedBodies: Omit<ResponsesPayload, 'model'>[] = [];
   const callResponses = vi.fn(async (_model, body): Promise<ProviderResponsesResult> => {
@@ -181,8 +181,8 @@ test('generate lets target promotion take precedence over source demotion', asyn
       callResponses,
       endpoints: { responses: {} },
       enabledFlags: new Set<FlagId>([
-        'demote-interleaved-system-to-user',
-        'promote-system-to-developer',
+        'rewrite-mid-conv-system-to-user',
+        'rewrite-system-to-developer',
       ]),
     }),
     headers: new Headers(),
@@ -200,7 +200,7 @@ test('generate lets target promotion take precedence over source demotion', asyn
   assertEquals(input[1], { type: 'message', role: 'developer', content: 'inline instructions' });
 });
 
-test('generate translate-to-responses branch promotes multi-block system prefix', async () => {
+test('generate translate-to-responses branch rewrites a multi-block system prefix to developer', async () => {
   installRepo();
   const observedBodies: Omit<ResponsesPayload, 'model'>[] = [];
   const callResponses = vi.fn(async (_model, body): Promise<ProviderResponsesResult> => {
@@ -239,7 +239,7 @@ test('generate translate-to-responses branch promotes multi-block system prefix'
     candidate: makeCandidate({
       callResponses,
       endpoints: { responses: {} },
-      enabledFlags: new Set<FlagId>(['promote-system-to-developer']),
+      enabledFlags: new Set<FlagId>(['rewrite-system-to-developer']),
     }),
     headers: new Headers(),
   });
@@ -308,7 +308,7 @@ test('countTokens applies generation request transforms before provider dispatch
       enabledFlags: new Set<FlagId>([
         'strip-billing-attribution',
         'disable-reasoning-on-forced-tool-choice',
-        'demote-interleaved-system-to-user',
+        'rewrite-mid-conv-system-to-user',
       ]),
     }),
     headers: new Headers(),

--- a/packages/gateway/__tests__/data-plane/chat/messages/interceptors/apply-role-compatibility_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/messages/interceptors/apply-role-compatibility_test.ts
@@ -32,12 +32,12 @@ test('leaves roles unchanged without the flag or at a translated target', async 
   const messages: MessagesMessage[] = [{ role: 'system', content: 'inline rules' }];
   assertEquals(await applyRoles(messages, new Set()), messages);
   assertEquals(
-    await applyRoles(messages, new Set(['demote-interleaved-system-to-user']), 'responses'),
+    await applyRoles(messages, new Set(['rewrite-mid-conv-system-to-user']), 'responses'),
     messages,
   );
 });
 
-test('demotes every inline system message and preserves content', async () => {
+test('rewrites every inline system message and preserves content', async () => {
   const content = [{ type: 'text' as const, text: 'inline rules' }];
   assertEquals(
     await applyRoles(
@@ -46,7 +46,7 @@ test('demotes every inline system message and preserves content', async () => {
         { role: 'user', content: 'hello' },
         { role: 'system', content },
       ],
-      new Set(['demote-interleaved-system-to-user']),
+      new Set(['rewrite-mid-conv-system-to-user']),
     ),
     [
       { role: 'user', content: 'first rules' },
@@ -56,16 +56,16 @@ test('demotes every inline system message and preserves content', async () => {
   );
   const result = await applyRoles(
     [{ role: 'system', content }],
-    new Set(['demote-interleaved-system-to-user']),
+    new Set(['rewrite-mid-conv-system-to-user']),
   );
   assert(result[0]?.content === content);
 });
 
 test('handles empty input and leaves non-system messages unchanged', async () => {
-  assertEquals(await applyRoles([], new Set(['demote-interleaved-system-to-user'])), []);
+  assertEquals(await applyRoles([], new Set(['rewrite-mid-conv-system-to-user'])), []);
   const messages: MessagesMessage[] = [
     { role: 'user', content: 'hello' },
     { role: 'assistant', content: 'hi' },
   ];
-  assertEquals(await applyRoles(messages, new Set(['demote-interleaved-system-to-user'])), messages);
+  assertEquals(await applyRoles(messages, new Set(['rewrite-mid-conv-system-to-user'])), messages);
 });

--- a/packages/gateway/__tests__/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/attempt_test.ts
@@ -216,9 +216,9 @@ test('generate applies role compatibility flags in target-chain order', async ()
     };
   });
   const candidate = makeCandidate(callResponses, new Set([
-    'demote-developer-to-system',
-    'demote-interleaved-system-to-user',
-    'promote-system-to-developer',
+    'rewrite-developer-to-system',
+    'rewrite-mid-conv-system-to-user',
+    'rewrite-system-to-developer',
   ]));
 
   const result = await responsesAttempt.generate({
@@ -244,7 +244,7 @@ test('generate applies role compatibility flags in target-chain order', async ()
   ]);
 });
 
-test('generate defers role promotion until after translation to Chat Completions', async () => {
+test('generate defers the role rewrite until after translation to Chat Completions', async () => {
   installRepo();
   let observedBody: Omit<ChatCompletionsPayload, 'model'> | undefined;
   const callChatCompletions = vi.fn(async (
@@ -299,7 +299,7 @@ test('generate defers role promotion until after translation to Chat Completions
       providerModels: {
         [upstream]: stubProviderModel({
           endpoints,
-          enabledFlags: new Set(['promote-system-to-developer']),
+          enabledFlags: new Set(['rewrite-system-to-developer']),
         }),
       },
     }, upstream),

--- a/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/http_test.ts
@@ -281,7 +281,7 @@ test('POST /v1/responses makes a done reasoning item reusable before terminal', 
   }
 });
 
-test('POST /v1/responses canonicalizes and promotes an implicit system message', async () => {
+test('POST /v1/responses canonicalizes an implicit system message and rewrites it to developer', async () => {
   installRepo();
   let observedBody: Omit<CanonicalResponsesPayload, 'model'> | undefined;
   const callResponses = vi.fn(async (_model, body): Promise<ProviderResponsesResult> => {
@@ -296,7 +296,7 @@ test('POST /v1/responses canonicalizes and promotes an implicit system message',
   });
   queueResolution([makeCandidate({
     callResponses,
-    enabledFlags: new Set(['promote-system-to-developer']),
+    enabledFlags: new Set(['rewrite-system-to-developer']),
   })]);
 
   const response = await makeApp().request('/v1/responses', {

--- a/packages/gateway/__tests__/data-plane/chat/responses/interceptors/apply-role-compatibility_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/interceptors/apply-role-compatibility_test.ts
@@ -34,27 +34,27 @@ test('leaves roles unchanged without flags or at a translated target', async () 
   ];
 
   assertEquals(await applyRoles(input, new Set()), input);
-  assertEquals(await applyRoles(input, new Set(['promote-system-to-developer']), 'chat-completions'), input);
+  assertEquals(await applyRoles(input, new Set(['rewrite-system-to-developer']), 'chat-completions'), input);
 });
 
-test('applies promotion and developer demotion independently', async () => {
+test('applies the system and developer rewrites independently', async () => {
   assertEquals(
     await applyRoles(
       [{ type: 'message', role: 'system', content: 'rules' }],
-      new Set(['promote-system-to-developer']),
+      new Set(['rewrite-system-to-developer']),
     ),
     [{ type: 'message', role: 'developer', content: 'rules' }],
   );
   assertEquals(
     await applyRoles(
       [{ type: 'message', role: 'developer', content: 'rules' }],
-      new Set(['demote-developer-to-system']),
+      new Set(['rewrite-developer-to-system']),
     ),
     [{ type: 'message', role: 'system', content: 'rules' }],
   );
 });
 
-test('uses non-message items as the boundary before demoting later system', async () => {
+test('uses non-message items as the boundary before rewriting later system', async () => {
   assertEquals(
     await applyRoles(
       [
@@ -62,7 +62,7 @@ test('uses non-message items as the boundary before demoting later system', asyn
         { type: 'reasoning', id: 'rs_1', summary: [] },
         { type: 'message', role: 'system', content: 'inline rules' },
       ],
-      new Set(['demote-interleaved-system-to-user']),
+      new Set(['rewrite-mid-conv-system-to-user']),
     ),
     [
       { type: 'message', role: 'system', content: 'base rules' },
@@ -77,11 +77,11 @@ test('keeps a leading-only system run and an empty input unchanged', async () =>
     { type: 'message', role: 'system', content: 'base A' },
     { type: 'message', role: 'system', content: 'base B' },
   ];
-  assertEquals(await applyRoles(leading, new Set(['demote-interleaved-system-to-user'])), leading);
-  assertEquals(await applyRoles([], new Set(['demote-interleaved-system-to-user'])), []);
+  assertEquals(await applyRoles(leading, new Set(['rewrite-mid-conv-system-to-user'])), leading);
+  assertEquals(await applyRoles([], new Set(['rewrite-mid-conv-system-to-user'])), []);
 });
 
-test('preserves multipart content identity when demoting an interleaved system message', async () => {
+test('preserves multipart content identity when rewriting a mid-conversation system message', async () => {
   const content = [
     { type: 'input_text' as const, text: 'one' },
     { type: 'input_text' as const, text: 'two' },
@@ -91,17 +91,17 @@ test('preserves multipart content identity when demoting an interleaved system m
       { type: 'message', role: 'user', content: 'hello' },
       { type: 'message', role: 'system', content },
     ],
-    new Set(['demote-interleaved-system-to-user']),
+    new Set(['rewrite-mid-conv-system-to-user']),
   );
   assertEquals(result, [
     { type: 'message', role: 'user', content: 'hello' },
     { type: 'message', role: 'user', content },
   ]);
-  const demoted = result[1];
-  assert(demoted?.type === 'message' && demoted.content === content);
+  const rewritten = result[1];
+  assert(rewritten?.type === 'message' && rewritten.content === content);
 });
 
-test('applies overlapping flags in promotion then demotion order', async () => {
+test('applies overlapping flags in system-to-developer then developer-to-system order', async () => {
   assertEquals(
     await applyRoles(
       [
@@ -110,9 +110,9 @@ test('applies overlapping flags in promotion then demotion order', async () => {
         { type: 'message', role: 'system', content: 'inline rules' },
       ],
       new Set([
-        'promote-system-to-developer',
-        'demote-developer-to-system',
-        'demote-interleaved-system-to-user',
+        'rewrite-system-to-developer',
+        'rewrite-developer-to-system',
+        'rewrite-mid-conv-system-to-user',
       ]),
     ),
     [

--- a/packages/gateway/__tests__/repo/upstreams_test.ts
+++ b/packages/gateway/__tests__/repo/upstreams_test.ts
@@ -111,7 +111,7 @@ test('memory upstream repo deeply clones configs and flag overrides at the repo 
         headers: ['authorization'],
       },
     },
-    flagOverrides: { 'vendor-deepseek': true, 'demote-developer-to-system': true },
+    flagOverrides: { 'vendor-deepseek': true, 'rewrite-developer-to-system': true },
     disabledPublicModelIds: [],
   });
 
@@ -120,7 +120,7 @@ test('memory upstream repo deeply clones configs and flag overrides at the repo 
   (original.config as { nested: { headers: string[] } }).nested.headers.push('mutated-after-save');
 
   const saved = await repo.getById('up_custom_clone');
-  assertEquals(saved?.flagOverrides, { 'demote-developer-to-system': true, 'vendor-deepseek': true });
+  assertEquals(saved?.flagOverrides, { 'rewrite-developer-to-system': true, 'vendor-deepseek': true });
   assertEquals(saved?.config, {
     nested: {
       baseUrl: 'https://example.test/v1',
@@ -132,7 +132,7 @@ test('memory upstream repo deeply clones configs and flag overrides at the repo 
   listed[0].flagOverrides['responses-web-search-shim'] = true;
   (listed[0].config as { nested: { headers: string[] } }).nested.headers.push('mutated-after-list');
 
-  assertEquals((await repo.getById('up_custom_clone'))?.flagOverrides, { 'demote-developer-to-system': true, 'vendor-deepseek': true });
+  assertEquals((await repo.getById('up_custom_clone'))?.flagOverrides, { 'rewrite-developer-to-system': true, 'vendor-deepseek': true });
   assertEquals((await repo.getById('up_custom_clone'))?.config, {
     nested: {
       baseUrl: 'https://example.test/v1',
@@ -150,12 +150,12 @@ test('memory upstream repo sorts flag overrides by key when saving rows', async 
       kind: 'copilot',
       sortOrder: 0,
       createdAt: '2026-05-21T10:00:00.000Z',
-      flagOverrides: { 'vendor-deepseek': true, 'demote-developer-to-system': false, 'messages-web-search-shim': true },
+      flagOverrides: { 'vendor-deepseek': true, 'rewrite-developer-to-system': false, 'messages-web-search-shim': true },
       disabledPublicModelIds: [],
     }),
   );
 
-  assertEquals((await repo.getById('up_copilot_fixes'))?.flagOverrides, { 'demote-developer-to-system': false, 'messages-web-search-shim': true, 'vendor-deepseek': true });
+  assertEquals((await repo.getById('up_copilot_fixes'))?.flagOverrides, { 'rewrite-developer-to-system': false, 'messages-web-search-shim': true, 'vendor-deepseek': true });
 });
 
 const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
@@ -167,7 +167,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     createdAt: '2026-05-21T10:00:02.000Z',
     updatedAt: '2026-05-21T10:00:02.000Z',
     config: { baseUrl: 'https://custom.example/v1', authStyle: 'bearer', apiKey: 'sk-custom', endpoints: { chatCompletions: {} } },
-    flagOverrides: { 'vendor-deepseek': true, 'demote-developer-to-system': true },
+    flagOverrides: { 'vendor-deepseek': true, 'rewrite-developer-to-system': true },
     disabledPublicModelIds: [],
   });
   const copilot = upstream({
@@ -197,7 +197,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     (await repo.list()).map(row => row.id),
     ['up_azure_sql', 'up_copilot_sql', 'up_custom_sql'],
   );
-  assertEquals((await repo.getById('up_custom_sql'))?.flagOverrides, { 'demote-developer-to-system': true, 'vendor-deepseek': true });
+  assertEquals((await repo.getById('up_custom_sql'))?.flagOverrides, { 'rewrite-developer-to-system': true, 'vendor-deepseek': true });
   assertEquals(await repo.getById('missing'), null);
 
   await repo.save({
@@ -208,7 +208,7 @@ const exerciseSqlUpstreamRepo = async (repo: UpstreamRepo) => {
     createdAt: '2099-01-01T00:00:00.000Z',
     updatedAt: '2026-05-21T10:00:04.000Z',
     config: { baseUrl: 'https://updated.example/v1', authStyle: 'bearer', apiKey: 'sk-updated', endpoints: { responses: {} } },
-    flagOverrides: { 'messages-web-search-shim': true, 'demote-developer-to-system': true },
+    flagOverrides: { 'messages-web-search-shim': true, 'rewrite-developer-to-system': true },
     disabledPublicModelIds: [],
   });
   assertEquals(

--- a/packages/gateway/migrations/0073_rewrite_role_flags.sql
+++ b/packages/gateway/migrations/0073_rewrite_role_flags.sql
@@ -1,0 +1,174 @@
+-- Rename the three role-compatibility flags onto neutral `rewrite-` ids:
+--
+--   demote-interleaved-system-to-user -> rewrite-mid-conv-system-to-user
+--   demote-developer-to-system        -> rewrite-developer-to-system
+--   promote-system-to-developer       -> rewrite-system-to-developer
+--
+-- The old ids are gone from the catalog (packages/provider/src/flags.ts), so a
+-- saved row that still carries one would be rejected at write time by
+-- parseFlagOverridesWire's "Unknown flag_overrides ids" guard and at read time
+-- by the per-model flagOverridesField validator. Each rename is a pure
+-- relabel: the stored boolean carries over verbatim, so an operator's
+-- force-on and force-off decisions survive.
+--
+-- Three passes, mirroring the three places a flag id can be stored:
+--   1. upstreams.flag_overrides (every provider kind)
+--   2. upstreams.config_json.models[*].flagOverrides (manual model rows)
+--   3. upstreams.models_cache_json (resolved catalog snapshot)
+
+-- Pass 1: upstream-level flag_overrides. `json_extract` on a JSON boolean
+-- yields SQLite's 0/1 integer, so the value is re-encoded through a literal
+-- `json('true')` / `json('false')` to keep the column a map of JSON booleans.
+UPDATE upstreams
+SET flag_overrides = json_set(
+  json_remove(flag_overrides, '$."demote-interleaved-system-to-user"'),
+  '$."rewrite-mid-conv-system-to-user"',
+  json(CASE WHEN json_extract(flag_overrides, '$."demote-interleaved-system-to-user"') = 1 THEN 'true' ELSE 'false' END)
+)
+WHERE json_valid(flag_overrides)
+  AND json_type(flag_overrides, '$."demote-interleaved-system-to-user"') IS NOT NULL;
+
+UPDATE upstreams
+SET flag_overrides = json_set(
+  json_remove(flag_overrides, '$."demote-developer-to-system"'),
+  '$."rewrite-developer-to-system"',
+  json(CASE WHEN json_extract(flag_overrides, '$."demote-developer-to-system"') = 1 THEN 'true' ELSE 'false' END)
+)
+WHERE json_valid(flag_overrides)
+  AND json_type(flag_overrides, '$."demote-developer-to-system"') IS NOT NULL;
+
+UPDATE upstreams
+SET flag_overrides = json_set(
+  json_remove(flag_overrides, '$."promote-system-to-developer"'),
+  '$."rewrite-system-to-developer"',
+  json(CASE WHEN json_extract(flag_overrides, '$."promote-system-to-developer"') = 1 THEN 'true' ELSE 'false' END)
+)
+WHERE json_valid(flag_overrides)
+  AND json_type(flag_overrides, '$."promote-system-to-developer"') IS NOT NULL;
+
+-- Pass 2: per-model overrides (config_json.models[*].flagOverrides). Rebuild
+-- the models array via json_group_array(CASE …) so entries without the flag
+-- fall through the ELSE branch byte-for-byte unchanged. The outer EXISTS gate
+-- keeps the rewrite off rows that hold no affected entry, which also makes a
+-- re-run a no-op. One statement per flag; a row carrying several of them is
+-- visited once per flag it carries.
+UPDATE upstreams
+SET config_json = json_set(
+  config_json,
+  '$.models',
+  (
+    SELECT json_group_array(
+      CASE
+        WHEN json_type(model.value, '$.flagOverrides."demote-interleaved-system-to-user"') IS NOT NULL
+        THEN json_set(
+          model.value,
+          '$.flagOverrides',
+          json_set(
+            json_remove(
+              json_extract(model.value, '$.flagOverrides'),
+              '$."demote-interleaved-system-to-user"'
+            ),
+            '$."rewrite-mid-conv-system-to-user"',
+            json(CASE WHEN json_extract(model.value, '$.flagOverrides."demote-interleaved-system-to-user"') = 1 THEN 'true' ELSE 'false' END)
+          )
+        )
+        ELSE model.value
+      END
+    )
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+  )
+)
+WHERE json_valid(config_json)
+  AND json_type(config_json, '$.models') = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+    WHERE json_type(model.value, '$.flagOverrides."demote-interleaved-system-to-user"') IS NOT NULL
+  );
+
+UPDATE upstreams
+SET config_json = json_set(
+  config_json,
+  '$.models',
+  (
+    SELECT json_group_array(
+      CASE
+        WHEN json_type(model.value, '$.flagOverrides."demote-developer-to-system"') IS NOT NULL
+        THEN json_set(
+          model.value,
+          '$.flagOverrides',
+          json_set(
+            json_remove(
+              json_extract(model.value, '$.flagOverrides'),
+              '$."demote-developer-to-system"'
+            ),
+            '$."rewrite-developer-to-system"',
+            json(CASE WHEN json_extract(model.value, '$.flagOverrides."demote-developer-to-system"') = 1 THEN 'true' ELSE 'false' END)
+          )
+        )
+        ELSE model.value
+      END
+    )
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+  )
+)
+WHERE json_valid(config_json)
+  AND json_type(config_json, '$.models') = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+    WHERE json_type(model.value, '$.flagOverrides."demote-developer-to-system"') IS NOT NULL
+  );
+
+UPDATE upstreams
+SET config_json = json_set(
+  config_json,
+  '$.models',
+  (
+    SELECT json_group_array(
+      CASE
+        WHEN json_type(model.value, '$.flagOverrides."promote-system-to-developer"') IS NOT NULL
+        THEN json_set(
+          model.value,
+          '$.flagOverrides',
+          json_set(
+            json_remove(
+              json_extract(model.value, '$.flagOverrides'),
+              '$."promote-system-to-developer"'
+            ),
+            '$."rewrite-system-to-developer"',
+            json(CASE WHEN json_extract(model.value, '$.flagOverrides."promote-system-to-developer"') = 1 THEN 'true' ELSE 'false' END)
+          )
+        )
+        ELSE model.value
+      END
+    )
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+  )
+)
+WHERE json_valid(config_json)
+  AND json_type(config_json, '$.models') = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM json_each(json_extract(upstreams.config_json, '$.models')) AS model
+    WHERE json_type(model.value, '$.flagOverrides."promote-system-to-developer"') IS NOT NULL
+  );
+
+-- Pass 3: the resolved catalog snapshot. Every cached model carries the
+-- already-resolved `enabledFlags` plus the provider's per-model `flagOverrides`
+-- overlay, both keyed on flag id, and a snapshot written before this migration
+-- names the old ids. Nothing rejects those at read time — the data plane simply
+-- asks the Set for the new id and gets `false` — so an untouched snapshot would
+-- silently drop the rewrite until the entry ages out, and Copilot's Claude < 4.8
+-- rows would start sending inline `role:'system'` to a Vertex backend that
+-- rejects it. The entry is a cache, so the snapshot is discarded rather than
+-- edited: the affected upstreams re-fetch their catalog on the first request
+-- after deploy, which is the same work an expiry would have caused.
+UPDATE upstreams
+SET models_cache_json = NULL
+WHERE models_cache_json IS NOT NULL
+  AND (
+    models_cache_json LIKE '%demote-interleaved-system-to-user%'
+    OR models_cache_json LIKE '%demote-developer-to-system%'
+    OR models_cache_json LIKE '%promote-system-to-developer%'
+  );

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/apply-role-compatibility.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/apply-role-compatibility.ts
@@ -6,20 +6,20 @@ export const withRoleCompatibilityApplied: ChatCompletionsInterceptor = (ctx, _g
   if (ctx.targetApi !== 'chat-completions') return run();
 
   const flags = providerModelOf(ctx.candidate).enabledFlags;
-  const promoteSystem = flags.has('promote-system-to-developer');
-  const demoteDeveloper = flags.has('demote-developer-to-system');
-  const demoteInterleavedSystem = flags.has('demote-interleaved-system-to-user');
-  if (!promoteSystem && !demoteDeveloper && !demoteInterleavedSystem) return run();
+  const rewriteSystemToDeveloper = flags.has('rewrite-system-to-developer');
+  const rewriteDeveloperToSystem = flags.has('rewrite-developer-to-system');
+  const rewriteMidConvSystemToUser = flags.has('rewrite-mid-conv-system-to-user');
+  if (!rewriteSystemToDeveloper && !rewriteDeveloperToSystem && !rewriteMidConvSystemToUser) return run();
 
   let crossedLeadingSystemRun = false;
   ctx.payload = {
     ...ctx.payload,
     messages: ctx.payload.messages.map(message => {
       let mapped: ChatCompletionsMessage = message;
-      if (promoteSystem && mapped.role === 'system') mapped = { ...mapped, role: 'developer' };
-      if (demoteDeveloper && mapped.role === 'developer') mapped = { ...mapped, role: 'system' };
+      if (rewriteSystemToDeveloper && mapped.role === 'system') mapped = { ...mapped, role: 'developer' };
+      if (rewriteDeveloperToSystem && mapped.role === 'developer') mapped = { ...mapped, role: 'system' };
       if (!crossedLeadingSystemRun && mapped.role !== 'system') crossedLeadingSystemRun = true;
-      if (demoteInterleavedSystem && crossedLeadingSystemRun && mapped.role === 'system') {
+      if (rewriteMidConvSystemToUser && crossedLeadingSystemRun && mapped.role === 'system') {
         mapped = { ...mapped, role: 'user' };
       }
       return mapped;

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
@@ -23,8 +23,8 @@ import { withVendorQwenChatCompletionsNormalize } from './vendor-qwen-normalize.
 //     `disable-reasoning-on-forced-tool-choice`. Emits the gateway's canonical
 //     "no reasoning" sentinel only; vendor wire form is the vendor's job.
 //   - withRoleCompatibilityApplied: applies role flags in the fixed order
-//     `system → developer → system → user`; later demotions are authoritative
-//     when flags overlap, and the final step affects only interleaved system.
+//     `system → developer → system → user`; later rewrites are authoritative
+//     when flags overlap, and the final step affects only mid-conversation system.
 //   - withPromptCacheKeyStripped: gated by `strip-prompt-cache-key`. Drops
 //     the top-level `prompt_cache_key` field for upstreams that reject it as
 //     an unknown argument (e.g. Azure DeepSeek). Runs before vendor

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/apply-role-compatibility.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/apply-role-compatibility.ts
@@ -3,7 +3,7 @@ import { providerModelOf } from '@floway-dev/provider';
 
 export const withRoleCompatibilityApplied: MessagesPayloadInterceptor = (ctx, _gatewayCtx, run) => {
   if (ctx.targetApi !== 'messages') return run();
-  if (!providerModelOf(ctx.candidate).enabledFlags.has('demote-interleaved-system-to-user')) return run();
+  if (!providerModelOf(ctx.candidate).enabledFlags.has('rewrite-mid-conv-system-to-user')) return run();
 
   ctx.payload = {
     ...ctx.payload,

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
@@ -26,7 +26,7 @@ import { withMessagesWebSearchRequestPrepared, withMessagesWebSearchShim } from 
 //   - withReasoningDisabledOnForcedToolChoice: gated by
 //     `disable-reasoning-on-forced-tool-choice`.
 //   - withRoleCompatibilityApplied: Anthropic's top-level `payload.system` is
-//     the only first-position system slot, so the interleaved-system flag
+//     the only first-position system slot, so the mid-conversation-system flag
 //     rewrites every inline system message to user after Messages is selected
 //     as the final target.
 //

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/apply-role-compatibility.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/apply-role-compatibility.ts
@@ -6,25 +6,25 @@ export const withRoleCompatibilityApplied: ResponsesInterceptor = (ctx, _gateway
   if (ctx.targetApi !== 'responses') return run();
 
   const flags = providerModelOf(ctx.candidate).enabledFlags;
-  const promoteSystem = flags.has('promote-system-to-developer');
-  const demoteDeveloper = flags.has('demote-developer-to-system');
-  const demoteInterleavedSystem = flags.has('demote-interleaved-system-to-user');
-  if (!promoteSystem && !demoteDeveloper && !demoteInterleavedSystem) return run();
+  const rewriteSystemToDeveloper = flags.has('rewrite-system-to-developer');
+  const rewriteDeveloperToSystem = flags.has('rewrite-developer-to-system');
+  const rewriteMidConvSystemToUser = flags.has('rewrite-mid-conv-system-to-user');
+  if (!rewriteSystemToDeveloper && !rewriteDeveloperToSystem && !rewriteMidConvSystemToUser) return run();
 
   let crossedLeadingSystemRun = false;
   ctx.payload = {
     ...ctx.payload,
     input: ctx.payload.input.map(item => {
       let mapped: ResponsesInputItem = item;
-      if (mapped.type === 'message' && promoteSystem && mapped.role === 'system') {
+      if (mapped.type === 'message' && rewriteSystemToDeveloper && mapped.role === 'system') {
         mapped = { ...mapped, role: 'developer' };
       }
-      if (mapped.type === 'message' && demoteDeveloper && mapped.role === 'developer') {
+      if (mapped.type === 'message' && rewriteDeveloperToSystem && mapped.role === 'developer') {
         mapped = { ...mapped, role: 'system' };
       }
       const isSystemMessage = mapped.type === 'message' && mapped.role === 'system';
       if (!crossedLeadingSystemRun && !isSystemMessage) crossedLeadingSystemRun = true;
-      if (demoteInterleavedSystem && crossedLeadingSystemRun && mapped.type === 'message' && mapped.role === 'system') {
+      if (rewriteMidConvSystemToUser && crossedLeadingSystemRun && mapped.type === 'message' && mapped.role === 'system') {
         mapped = { ...mapped, role: 'user' };
       }
       return mapped;

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
@@ -28,8 +28,8 @@ import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 //   - withReasoningDisabledOnForcedToolChoice: gated by
 //     `disable-reasoning-on-forced-tool-choice`.
 //   - withRoleCompatibilityApplied: applies role flags in the fixed order
-//     `system → developer → system → user`; later demotions are authoritative
-//     when flags overlap, and the final step affects only interleaved system.
+//     `system → developer → system → user`; later rewrites are authoritative
+//     when flags overlap, and the final step affects only mid-conversation system.
 //   - withPromptCacheKeyStripped: gated by `strip-prompt-cache-key`. Drops
 //     the top-level `prompt_cache_key` field for upstreams that reject it
 //     as an unknown argument (e.g. Azure DeepSeek). Runs before vendor

--- a/packages/provider-azure/src/defaults.ts
+++ b/packages/provider-azure/src/defaults.ts
@@ -10,9 +10,9 @@ export const AZURE_DEFAULT_FLAGS: FlagDefaults = {
   // Azure exposes native /responses/compact.
   'responses-compact-shim': false,
   'disable-reasoning-on-forced-tool-choice': false,
-  'demote-interleaved-system-to-user': false,
-  'demote-developer-to-system': false,
-  'promote-system-to-developer': false,
+  'rewrite-mid-conv-system-to-user': false,
+  'rewrite-developer-to-system': false,
+  'rewrite-system-to-developer': false,
   'strip-billing-attribution': true,
   'strip-prompt-cache-key': false,
 };

--- a/packages/provider-claude-code/__tests__/models_test.ts
+++ b/packages/provider-claude-code/__tests__/models_test.ts
@@ -202,7 +202,7 @@ describe('buildClaudeCodeCatalog', () => {
   });
 
   test('forwards the supplied enabledFlags set onto every model', () => {
-    const flags: ReadonlySet<FlagId> = new Set(['demote-developer-to-system', 'promote-system-to-developer']);
+    const flags: ReadonlySet<FlagId> = new Set(['rewrite-developer-to-system', 'rewrite-system-to-developer']);
     const built = buildClaudeCodeCatalog(SAMPLE_API_MODELS, flags);
     for (const m of built) {
       expect(m.enabledFlags).toBe(flags);

--- a/packages/provider-claude-code/src/defaults.ts
+++ b/packages/provider-claude-code/src/defaults.ts
@@ -22,9 +22,9 @@ export const CLAUDE_CODE_DEFAULT_FLAGS: FlagDefaults = {
   'responses-image-generation-shim': false,
   'responses-compact-shim': true,
   'disable-reasoning-on-forced-tool-choice': false,
-  'demote-interleaved-system-to-user': false,
-  'demote-developer-to-system': false,
-  'promote-system-to-developer': false,
+  'rewrite-mid-conv-system-to-user': false,
+  'rewrite-developer-to-system': false,
+  'rewrite-system-to-developer': false,
   'strip-billing-attribution': false,
   'strip-prompt-cache-key': false,
 };

--- a/packages/provider-codex/__tests__/provider_test.ts
+++ b/packages/provider-codex/__tests__/provider_test.ts
@@ -145,7 +145,7 @@ describe('createCodexProvider', () => {
     const instance = createCodexProvider(recordWithOverride);
     const models = await instance.instance.getProvidedModels(directFetcher);
     for (const m of models) {
-      expect(m.enabledFlags.has('promote-system-to-developer')).toBe(true);
+      expect(m.enabledFlags.has('rewrite-system-to-developer')).toBe(true);
       expect(m.enabledFlags.has('responses-web-search-shim')).toBe(true);
     }
   });

--- a/packages/provider-codex/src/defaults.ts
+++ b/packages/provider-codex/src/defaults.ts
@@ -9,12 +9,12 @@ export const CODEX_DEFAULT_FLAGS: FlagDefaults = {
   'responses-image-generation-shim': false,
   'responses-compact-shim': false,
   'disable-reasoning-on-forced-tool-choice': false,
-  'demote-interleaved-system-to-user': false,
-  'demote-developer-to-system': false,
+  'rewrite-mid-conv-system-to-user': false,
+  'rewrite-developer-to-system': false,
   // Codex's Responses Lite wire carries base instructions as leading developer
   // messages. Use the same representation for system-role input.
   // https://github.com/openai/codex/blob/1f17e7512f0e47625f2cad416f14870688a99814/codex-rs/core/src/client.rs#L829-L849
-  'promote-system-to-developer': true,
+  'rewrite-system-to-developer': true,
   'strip-billing-attribution': true,
   'strip-prompt-cache-key': false,
 };

--- a/packages/provider-copilot/__tests__/defaults_test.ts
+++ b/packages/provider-copilot/__tests__/defaults_test.ts
@@ -13,7 +13,7 @@ const model = (id: string): Omit<ProviderModel, 'enabledFlags'> => ({
   limits: {},
 });
 
-const OVERLAY_ON = { 'demote-interleaved-system-to-user': true } as const;
+const OVERLAY_ON = { 'rewrite-mid-conv-system-to-user': true } as const;
 const OVERLAY_OFF = {} as const;
 
 // Copilot's public model ids arrive here in dash-separated minor form
@@ -23,7 +23,7 @@ const OVERLAY_OFF = {} as const;
 // `[N, 0]`. Sub-family names are treated as opaque — the version tuple
 // is the sole gate, so a future `claude-<newfamily>-<N.M>` routes the
 // same way as opus/sonnet/haiku.
-test('defaultFlagsForCopilotModel forces demote on Claude < 4.8', () => {
+test('defaultFlagsForCopilotModel forces the system rewrite on Claude < 4.8', () => {
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus-4-7')), OVERLAY_ON);
   assertEquals(defaultFlagsForCopilotModel(model('claude-sonnet-4-6')), OVERLAY_ON);
   assertEquals(defaultFlagsForCopilotModel(model('claude-haiku-4-5')), OVERLAY_ON);
@@ -31,7 +31,7 @@ test('defaultFlagsForCopilotModel forces demote on Claude < 4.8', () => {
   assertEquals(defaultFlagsForCopilotModel(model('claude-newfamily-4-7')), OVERLAY_ON);
 });
 
-test('defaultFlagsForCopilotModel leaves demote inherited for Claude >= 4.8', () => {
+test('defaultFlagsForCopilotModel leaves the system rewrite inherited for Claude >= 4.8', () => {
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus-4-8')), OVERLAY_OFF);
   assertEquals(defaultFlagsForCopilotModel(model('claude-opus-5-0')), OVERLAY_OFF);
   assertEquals(defaultFlagsForCopilotModel(model('claude-sonnet-5')), OVERLAY_OFF);
@@ -50,7 +50,7 @@ test('defaultFlagsForCopilotModel returns empty for non-Claude ids', () => {
   assertEquals(defaultFlagsForCopilotModel(model('o1-mini')), OVERLAY_OFF);
 });
 
-test('defaultFlagsForCopilotModel falls back to demote-on when a Claude id carries no version', () => {
+test('defaultFlagsForCopilotModel falls back to rewrite-on when a Claude id carries no version', () => {
   // Safer than defaulting off — a Claude id we cannot version-parse
   // might route through Vertex, which still rejects inline system turns.
   // Only a positive supportsInlineSystem match (regex + `>= 4.8` version

--- a/packages/provider-copilot/__tests__/provider_test.ts
+++ b/packages/provider-copilot/__tests__/provider_test.ts
@@ -437,15 +437,15 @@ test('Copilot provider exposes its default flag set via ProviderModel.enabledFla
   );
 });
 
-test('per-model provider default beats operator upstream override — Claude < 4.8 stays demoted even when the upstream flag is off', async () => {
+test('per-model provider default beats operator upstream override — Claude < 4.8 keeps the system rewrite even when the upstream flag is off', async () => {
   const { copilotUpstream } = await setupCopilotTest({
     // Operator flipped the upstream-wide flag off. Provider says
-    // Claude < 4.8 must stay demoted (its Vertex backend rejects
+    // Claude < 4.8 must keep the system rewrite (its Vertex backend rejects
     // inline `role:'system'`), and the per-model layer sits after the
     // upstream override in the resolve chain, so the provider judgment
     // wins for the affected model while every other model honors the
     // operator setting.
-    flagOverrides: { 'demote-interleaved-system-to-user': false },
+    flagOverrides: { 'rewrite-mid-conv-system-to-user': false },
   });
   const instance = createCopilotProvider(copilotUpstream);
 
@@ -478,15 +478,15 @@ test('per-model provider default beats operator upstream override — Claude < 4
       const claude48 = models.find(m => m.id === 'claude-opus-4-8');
       const gpt = models.find(m => m.id === 'gpt-test');
       if (!claude46 || !claude48 || !gpt) throw new Error('expected all three models in the emitted catalog');
-      // Per-model layer forces demote on for Claude < 4.8, even though
+      // Per-model layer forces the rewrite on for Claude < 4.8, even though
       // the operator upstream override said off.
-      assertEquals(claude46.enabledFlags.has('demote-interleaved-system-to-user'), true);
+      assertEquals(claude46.enabledFlags.has('rewrite-mid-conv-system-to-user'), true);
       // No per-model rule for Claude >= 4.8; the operator upstream
       // override wins on this row.
-      assertEquals(claude48.enabledFlags.has('demote-interleaved-system-to-user'), false);
+      assertEquals(claude48.enabledFlags.has('rewrite-mid-conv-system-to-user'), false);
       // Non-Claude ids never get a per-model rule; operator setting
       // stands.
-      assertEquals(gpt.enabledFlags.has('demote-interleaved-system-to-user'), false);
+      assertEquals(gpt.enabledFlags.has('rewrite-mid-conv-system-to-user'), false);
     },
   );
 });

--- a/packages/provider-copilot/src/defaults.ts
+++ b/packages/provider-copilot/src/defaults.ts
@@ -21,9 +21,9 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
   // Upstream default is off; Claude models below 4.8 flip it on via the
   // per-model default. See `defaultFlagsForCopilotModel` for the empirical
   // basis.
-  'demote-interleaved-system-to-user': false,
-  'demote-developer-to-system': false,
-  'promote-system-to-developer': false,
+  'rewrite-mid-conv-system-to-user': false,
+  'rewrite-developer-to-system': false,
+  'rewrite-system-to-developer': false,
   'strip-billing-attribution': true,
   'strip-prompt-cache-key': false,
 };
@@ -122,7 +122,7 @@ export const COPILOT_DEFAULT_FLAGS: FlagDefaults = {
 //
 // Threshold conclusion: `>= 4.8`. This includes `claude-opus-4.8` and every
 // 5.x release (which trivially exceeds `[4, 8]`); everything at 4.7 or below
-// stays demoted.
+// keeps the rewrite.
 const supportsInlineSystem = (id: string): boolean => {
   const m = /^claude-[a-z]+-(\d+)(?:[.-](\d+))?$/.exec(id);
   if (!m) return false;
@@ -132,12 +132,12 @@ const supportsInlineSystem = (id: string): boolean => {
 };
 
 // Per-model default flag deltas for Copilot. Only Claude models below
-// 4.8 opt into `demote-interleaved-system-to-user`; every other flag
+// 4.8 opt into `rewrite-mid-conv-system-to-user`; every other flag
 // inherits from `COPILOT_DEFAULT_FLAGS`. Upstream-wide operator overrides
 // are applied before this provider-enforced per-model delta, so the technical
 // requirement for affected Claude models remains authoritative.
 export const defaultFlagsForCopilotModel = (model: Omit<ProviderModel, 'enabledFlags'>): FlagOverrides => {
   if (!model.id.startsWith('claude-')) return {};
   if (supportsInlineSystem(model.id)) return {};
-  return { 'demote-interleaved-system-to-user': true };
+  return { 'rewrite-mid-conv-system-to-user': true };
 };

--- a/packages/provider-custom/src/defaults.ts
+++ b/packages/provider-custom/src/defaults.ts
@@ -14,9 +14,9 @@ export const CUSTOM_DEFAULT_FLAGS: FlagDefaults = {
   // upstream that lacks native compact.
   'responses-compact-shim': false,
   'disable-reasoning-on-forced-tool-choice': false,
-  'demote-interleaved-system-to-user': false,
-  'demote-developer-to-system': false,
-  'promote-system-to-developer': false,
+  'rewrite-mid-conv-system-to-user': false,
+  'rewrite-developer-to-system': false,
+  'rewrite-system-to-developer': false,
   // `x-anthropic-billing-header:` from Claude Code clients is meaningful
   // only to the Anthropic subscription endpoint; strip it here so it
   // does not pollute the upstream's prompt-cache key.

--- a/packages/provider-ollama/src/defaults.ts
+++ b/packages/provider-ollama/src/defaults.ts
@@ -9,9 +9,9 @@ export const OLLAMA_DEFAULT_FLAGS: FlagDefaults = {
   'responses-image-generation-shim': true,
   'responses-compact-shim': true,
   'disable-reasoning-on-forced-tool-choice': false,
-  'demote-interleaved-system-to-user': false,
-  'demote-developer-to-system': false,
-  'promote-system-to-developer': false,
+  'rewrite-mid-conv-system-to-user': false,
+  'rewrite-developer-to-system': false,
+  'rewrite-system-to-developer': false,
   'strip-billing-attribution': true,
   'strip-prompt-cache-key': false,
 };

--- a/packages/provider/src/flags.ts
+++ b/packages/provider/src/flags.ts
@@ -28,9 +28,9 @@ export const OPTIONAL_FLAG_IDS = [
   'responses-image-generation-shim',
   'responses-compact-shim',
   'disable-reasoning-on-forced-tool-choice',
-  'demote-interleaved-system-to-user',
-  'demote-developer-to-system',
-  'promote-system-to-developer',
+  'rewrite-mid-conv-system-to-user',
+  'rewrite-developer-to-system',
+  'rewrite-system-to-developer',
   'strip-billing-attribution',
   'strip-prompt-cache-key',
 ] as const;
@@ -115,7 +115,7 @@ export const parseFlagOverridesWire = (value: unknown): FlagOverrides =>
 //      Never both, since an auto/manual row cannot be the other.
 //
 // Placing per-model last lets provider-declared technical necessities
-// (e.g. Copilot forcing demote-interleaved-system-to-user on for
+// (e.g. Copilot forcing rewrite-mid-conv-system-to-user on for
 // Claude < 4.8, whose Vertex backend rejects inline `role:'system'`)
 // survive an upstream-wide operator override. Operators who genuinely
 // want to opt out of a provider's per-model call switch the row to

--- a/packages/provider/src/model.ts
+++ b/packages/provider/src/model.ts
@@ -208,7 +208,7 @@ export interface ProviderModel extends ModelMetadata {
   // model. Absent when the provider has no per-model call on this
   // model; when present, the map is non-empty (producers elide empty
   // overlays before emission). Populated only for providers with a
-  // per-model rule (e.g., Copilot's Claude < 4.8 demote clause); other
+  // per-model rule (e.g., Copilot's Claude < 4.8 system-rewrite clause); other
   // providers leave it undefined.
   //
   // The data plane consumes the already-resolved `enabledFlags` and

--- a/packages/translate/src/chat-completions-via-messages/request.ts
+++ b/packages/translate/src/chat-completions-via-messages/request.ts
@@ -150,7 +150,7 @@ const buildMessagesInput = async (messages: ChatCompletionsMessage[], loadRemote
       // was hoisted earlier). Anthropic upstreams diverge on inline
       // role:'system' here (Bedrock accepts it under placement rules;
       // Vertex rejects it outright), so the gateway's
-      // `demote-interleaved-system-to-user` interceptor flag is the safety
+      // `rewrite-mid-conv-system-to-user` interceptor flag is the safety
       // net for any inline system that would otherwise reach an upstream
       // that does not accept it.
       const blocks = convertSystemContent(message.content);


### PR DESCRIPTION
## Summary

Rename the three role-compatibility flags after the rewrite they perform, dropping the `promote-`/`demote-` framing. Those prefixes imply `system`, `developer`, and `user` are ranked, when each is only a slot a given upstream does or does not accept.

| old | new |
| --- | --- |
| `demote-interleaved-system-to-user` | `rewrite-mid-conv-system-to-user` |
| `demote-developer-to-system` | `rewrite-developer-to-system` |
| `promote-system-to-developer` | `rewrite-system-to-developer` |

`mid-conv` replaces `interleaved` in the first id: the flag fires on a system message that arrives after the conversation has started, which is exactly the leading-run boundary the interceptor tests.

The ids are followed through interceptor locals, chain-order comments, `docs/TRANSLATION.md`, provider defaults, dashboard flag grouping, both locale bundles, and test names. The dashboard labels already read "Rewrite … to …" and are unchanged.

Migration `0073` relabels stored operator overrides in `upstreams.flag_overrides` and in `config_json.models[*].flagOverrides`, carrying each boolean over verbatim so force-on and force-off decisions survive. It also discards `models_cache_json` on affected rows: that snapshot carries already-resolved `enabledFlags`, nothing rejects a stale id at read time, and an untouched snapshot would silently drop the rewrite until the entry ages out — including Copilot's Claude < 4.8 rows, whose Vertex backend rejects inline `role: 'system'`.

## Test Plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` — 467 files, 5,068 tests passed
- [x] `pnpm run test:agent-setup-installers` — 105 passed, 4 skipped
- [x] migration `0073` applied to a SQLite database seeded with old ids at every storage site: upstream-level and per-model overrides keep their booleans, rows carrying none of the three flags stay byte-identical, `models_cache_json` is dropped only where a stale id appears, and a second application is a no-op