### PR TITLE
fix(gateway): validate an imported ollama upstream against its own config shape

### DIFF
--- a/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
@@ -158,6 +158,34 @@ const AZURE_UPSTREAM: UpstreamRecord = {
   state: null,
 };
 
+const OLLAMA_UPSTREAM: UpstreamRecord = {
+  id: 'up_ollama_a',
+  kind: 'ollama',
+  name: 'Ollama A',
+  enabled: true,
+  sortOrder: 25,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  flagOverrides: {},
+  disabledPublicModelIds: [],
+  proxyFallbackList: [],
+  modelPrefix: null,
+  modelsCache: null,
+  color: null,
+  config: {
+    baseUrl: 'https://ollama.com',
+    apiKey: 'ollama-key',
+    models: [
+      {
+        upstreamModelId: 'qwen3-coder:480b-cloud',
+        kind: 'chat',
+        endpoints: { chatCompletions: {} },
+      },
+    ],
+  },
+  state: null,
+};
+
 const CODEX_UPSTREAM: UpstreamRecord = {
   id: 'up_codex_a',
   kind: 'codex',
@@ -671,6 +699,28 @@ test('import rejects missing upstreams before clearing existing data', async () 
   assertEquals(await repo.apiKeys.list(), [KEY_A]);
   assertEquals(await repo.upstreams.list(), [CUSTOM_UPSTREAM]);
   assertEquals(await repo.usage.listAll(), [USAGE_1]);
+});
+
+test('ollama upstreams export and import round-trip', async () => {
+  const { app, repo } = setup();
+  await repo.upstreams.save(OLLAMA_UPSTREAM);
+  await repo.webSearchConfig.save(DEFAULT_WEB_SEARCH_CONFIG);
+
+  const result = await doExport(app);
+  const exportedOllama = result.data.upstreams.find((upstream: any) => upstream.id === 'up_ollama_a');
+  assertEquals(exportedOllama.config, OLLAMA_UPSTREAM.config);
+
+  const replaceResult = await doImport(app, 'replace', {
+    users: [SEED_ADMIN],
+    apiKeys: [],
+    upstreams: [exportedOllama],
+    usage: [],
+    searchUsage: [],
+    performanceIncluded: false,
+    searchConfig: DEFAULT_WEB_SEARCH_CONFIG,
+  });
+  assertEquals(replaceResult.status, 200);
+  assertEquals(await repo.upstreams.list(), [OLLAMA_UPSTREAM]);
 });
 
 test('codex upstreams export and import round-trip with state intact', async () => {

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -34,6 +34,7 @@ import { assertClaudeCodeUpstreamRecord, assertClaudeCodeUpstreamState } from '@
 import { assertCodexUpstreamRecord, assertCodexUpstreamState } from '@floway-dev/provider-codex';
 import { parseCopilotUpstreamConfig } from '@floway-dev/provider-copilot';
 import { assertCustomUpstreamRecord } from '@floway-dev/provider-custom';
+import { assertOllamaUpstreamRecord } from '@floway-dev/provider-ollama';
 import { parseProxyUri } from '@floway-dev/proxy';
 
 // Wire shape of a proxy entry in the export/import payload. The backoff rows
@@ -81,17 +82,22 @@ const importErrorBuilder = (field: string, expected: string) => new Error(`${fie
 const nonEmptyString = (value: unknown, field: string): string => nonEmptyStringField(value, field, importErrorBuilder);
 
 const normalizeUpstreamConfig = (record: UpstreamRecord): unknown => {
-  if (record.kind === 'custom') return assertCustomUpstreamRecord(record).config;
-  if (record.kind === 'azure') return assertAzureUpstreamRecord(record).config;
-  if (record.kind === 'codex') {
+  switch (record.kind) {
+  case 'custom':
+    return assertCustomUpstreamRecord(record).config;
+  case 'azure':
+    return assertAzureUpstreamRecord(record).config;
+  case 'ollama':
+    return assertOllamaUpstreamRecord(record).config;
+  case 'codex':
     assertCodexUpstreamRecord(record);
     return record.config;
-  }
-  if (record.kind === 'claude-code') {
+  case 'claude-code':
     assertClaudeCodeUpstreamRecord(record);
     return record.config;
+  case 'copilot':
+    return parseCopilotUpstreamConfig(record.config, importErrorBuilder);
   }
-  return parseCopilotUpstreamConfig(record.config, importErrorBuilder);
 };
 
 // Only Codex and Claude Code carry state across an import: their per-account


### PR DESCRIPTION
An export containing an ollama upstream could not be imported back.

`normalizeUpstreamConfig` in `packages/gateway/src/control-plane/data-transfer/routes.ts` dispatched through a chain of `if` checks covering `custom`, `azure`, `codex`, and `claude-code`, ending in an unconditional `parseCopilotUpstreamConfig` call. `ollama` is the only kind that reaches that trailing call without being copilot, so an ollama config was validated as a Copilot config and rejected for the missing `githubToken`:

```
400 invalid upstreams at index N: githubToken must be a non-empty string
```

The whole import fails, not just that record, and the error names a credential the payload never claimed to carry. Export is unaffected — `upstreams/serialize.ts` handles ollama correctly — so the symptom is an export that reads fine and an import that dies on an unrelated GitHub token.

The normalizer is now an exhaustive `switch` on `record.kind` with an `assertOllamaUpstreamRecord` branch. A future provider kind becomes a type error at the return position rather than a silent fallthrough onto copilot's parser.

A regression test covers the ollama export/import round trip; it returns 400 against the previous normalizer.

## Verification

- `pnpm --filter @floway-dev/gateway run typecheck`
- `pnpm --filter @floway-dev/gateway exec vitest run __tests__/control-plane/data-transfer/routes_test.ts` — 52 passed
- `pnpm run lint`