### PR TITLE
fix(husky): pin the main worktree on where HEAD landed, not on whether it moved

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -5,16 +5,12 @@
 # the main worktree off `main` is reverted immediately and reported as an
 # error.
 
-prev_head="$1"
 new_head="$2"
 branch_flag="$3"
 
 # Skip file checkouts (`git checkout -- path`); only branch/ref checkouts
 # pass branch_flag=1.
 [ "$branch_flag" = "1" ] || exit 0
-
-# Nothing actually moved (e.g. `git checkout` of the current branch).
-[ "$prev_head" = "$new_head" ] && exit 0
 
 # A linked worktree's per-worktree git dir sits under the main repo's
 # .git/worktrees/<name>/, so --absolute-git-dir and --git-common-dir
@@ -29,9 +25,14 @@ case "$common_dir" in
 esac
 [ "$git_dir" = "$common_dir" ] || exit 0
 
-# In the main worktree. `main` is the only acceptable HEAD. Husky runs us
-# under `sh -e`, so detached-HEAD failures from `git symbolic-ref` must be
-# swallowed explicitly — otherwise set -e kills the hook before we can react.
+# In the main worktree. Decide on where HEAD ended up, never on whether the
+# checkout moved it: post-checkout is handed two commit ids and no ref names,
+# so a `prev == new` test reads "same commit", not "same branch". Branch
+# creation at HEAD (`git checkout -b`) and a switch between two refs pointing
+# at one commit both leave the ids equal while moving the worktree off `main`.
+# `main` is the only acceptable HEAD, whatever the ids say. Husky runs us under
+# `sh -e`, so detached-HEAD failures from `git symbolic-ref` must be swallowed
+# explicitly — otherwise set -e kills the hook before we can react.
 current_branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 [ "$current_branch" = "main" ] && exit 0
 


### PR DESCRIPTION
`.husky/post-checkout` skipped its branch check whenever the two commit ids git passed it were equal:

```sh
# Nothing actually moved (e.g. `git checkout` of the current branch).
[ "$prev_head" = "$new_head" ] && exit 0
```

Those arguments are commit ids, and the post-checkout protocol carries no ref names, so the test reads "same commit" while the comment claims "same branch". Any checkout that changes the ref without changing the commit satisfied it and walked past the guard.

Observed on this repo: `git checkout -b <name>` from the main worktree creates the branch at HEAD, so the ids match, and the worktree was left off `main` with no error and no restore.

The fix drops the id comparison and lets the ref test that follows decide alone — `main` is the only acceptable HEAD, whatever the ids say. That test is ref-based, so the genuine no-op stays silent.

## Verification

Each case run from the main worktree:

| Case | Before | After |
| --- | --- | --- |
| `git checkout -b probe` | passed silently | error + restore to `main`, exit 1 |
| `git switch -c probe` | passed silently | error + restore, exit 1 |
| checkout of an existing branch at `main`'s commit | passed silently | error + restore, exit 1 |
| `git checkout --detach HEAD` | passed silently | error + restore, exit 1 |
| `git checkout main` while on `main` | silent, exit 0 | silent, exit 0 |
| `git checkout -- <path>` | silent, exit 0 | silent, exit 0 (leaves early on `branch_flag`) |

The hook's own `git checkout --quiet main` re-enters post-checkout once and terminates on the `main` test, so the restore does not recurse.