### PR TITLE
fix(gateway): record the synthesized stream-error frame in the dump

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/respond_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/respond_test.ts
@@ -1,0 +1,66 @@
+import { Hono } from 'hono';
+import { expect, test } from 'vitest';
+
+import { respondChatCompletions } from '../../../../src/data-plane/chat/chat-completions/respond.ts';
+import type { DumpAccumulator } from '../../../../src/dump/accumulator.ts';
+import { mockChatGatewayCtx } from '../../../test-utils/gateway-ctx.ts';
+import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
+import { doneFrame, eventFrame, type ProtocolFrame } from '@floway-dev/protocols/common';
+import { eventResult } from '@floway-dev/provider';
+import { assert, assertEquals, testTelemetryModelIdentity } from '@floway-dev/test-utils';
+
+const recordingDump = () => {
+  const frames: ProtocolFrame<ChatCompletionsStreamEvent>[] = [];
+  return {
+    frames,
+    dump: {
+      failed: () => {},
+      success: () => {},
+      frame: (frame: ProtocolFrame<ChatCompletionsStreamEvent>) => { frames.push(frame); },
+    } as unknown as DumpAccumulator,
+  };
+};
+
+const chunk = (text: string): ChatCompletionsStreamEvent => ({
+  id: 'x', object: 'chat.completion.chunk', created: 0, model: 'm',
+  choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+});
+
+const serve = async (dump: DumpAccumulator, frames: AsyncGenerator<ProtocolFrame<ChatCompletionsStreamEvent>>): Promise<string> => {
+  const ctx = mockChatGatewayCtx({ wantsStream: true, dump });
+  const app = new Hono().get('/', c =>
+    respondChatCompletions(c, eventResult(frames, testTelemetryModelIdentity), true, true, ctx));
+  return await (await app.request('/')).text();
+};
+
+test('the error frame the client is sent is recorded like every other frame', async () => {
+  const { dump, frames } = recordingDump();
+  const body = await serve(dump, (async function* () {
+    yield eventFrame(chunk('hi'));
+    throw new RangeError('cache token counts exceed inclusive input tokens: 479 - 13312 - 0');
+  })());
+
+  // What the client receives is unchanged by this.
+  expect(body).toContain('event: error');
+  expect(body).toContain('cache token counts exceed inclusive input tokens');
+  expect(body).not.toContain('data: [DONE]');
+
+  // And the recorded turn now ends on the same event rather than on the last
+  // good chunk.
+  assertEquals(frames.length, 2);
+  const last = frames[1];
+  assert(last.type === 'event', 'expected an event frame');
+  const payload = last.event as unknown as { error?: { message?: string } };
+  assertEquals(payload.error?.message, 'cache token counts exceed inclusive input tokens: 479 - 13312 - 0');
+});
+
+test('a stream that completes records only its own frames', async () => {
+  const { dump, frames } = recordingDump();
+  const body = await serve(dump, (async function* () {
+    yield eventFrame(chunk('hi'));
+    yield doneFrame();
+  })());
+
+  expect(body).toContain('data: [DONE]');
+  assertEquals(frames.length, 2);
+});

--- a/packages/gateway/src/data-plane/chat/chat-completions/respond.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/respond.ts
@@ -12,7 +12,7 @@ import { affinityEgressOptions } from '../shared/affinity/index.ts';
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
 import { chatCompletionsProtocolFrameToSSEFrame, CHAT_COMPLETIONS_MISSING_TERMINAL_MESSAGE, collectChatCompletionsProtocolEventsToResult, chatCompletionsErrorPayloadMessage } from '@floway-dev/protocols/chat-completions';
-import { type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
+import { eventFrame, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { type ExecuteResult, type PlainResult, type InternalDebugError, toInternalDebugError } from '@floway-dev/provider';
 import { apiErrorToResponse } from '@floway-dev/provider';
 
@@ -65,7 +65,7 @@ export const respondChatCompletions = async (
   return streamSSE(c, async stream => {
     let completion: StreamCompletion = 'error';
     try {
-      completion = await writeSSEFrames(stream, chatCompletionsSseFrames(frames, includeUsageChunk, state), {
+      completion = await writeSSEFrames(stream, chatCompletionsSseFrames(frames, includeUsageChunk, state, ctx), {
         keepAlive: { frame: sseCommentFrame('keepalive') },
         ...(ctx.downstreamAbortController !== undefined ? { downstreamAbortController: ctx.downstreamAbortController } : {}),
       });
@@ -115,7 +115,7 @@ const observeChatCompletionsFrames = async function* (frames: AsyncIterable<Prot
   throw new Error(CHAT_COMPLETIONS_MISSING_TERMINAL_MESSAGE);
 };
 
-const chatCompletionsSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ChatCompletionsStreamEvent>>, includeUsageChunk: boolean, state: SourceStreamState) {
+const chatCompletionsSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ChatCompletionsStreamEvent>>, includeUsageChunk: boolean, state: SourceStreamState, ctx: GatewayCtx) {
   try {
     for await (const frame of frames) {
       const sse = chatCompletionsProtocolFrameToSSEFrame(frame, { includeUsageChunk });
@@ -123,6 +123,8 @@ const chatCompletionsSseFrames = async function* (frames: AsyncIterable<Protocol
     }
   } catch (error) {
     state.failed = true;
-    yield sseFrame(JSON.stringify(internalChatCompletionsErrorPayload(toInternalDebugError(error))), 'error');
+    const event = internalChatCompletionsErrorPayload(toInternalDebugError(error)) as unknown as ChatCompletionsStreamEvent;
+    ctx.dump?.frame(eventFrame(event));
+    yield sseFrame(JSON.stringify(event), 'error');
   }
 };

--- a/packages/gateway/src/data-plane/chat/gemini/respond.ts
+++ b/packages/gateway/src/data-plane/chat/gemini/respond.ts
@@ -11,7 +11,7 @@ import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
 import { forwardUpstreamHeaders, mergeForwardedUpstreamHeaders } from '../../shared/upstream-response.ts';
 import { affinityEgressOptions } from '../shared/affinity/index.ts';
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
-import { type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
+import { eventFrame, type ProtocolFrame, sseCommentFrame, sseFrame } from '@floway-dev/protocols/common';
 import { geminiProtocolFrameToSSEFrame, GEMINI_MISSING_TERMINAL_MESSAGE, isGeminiErrorEvent, isGeminiTerminalEvent, collectGeminiProtocolEventsToResult } from '@floway-dev/protocols/gemini';
 import type { GeminiErrorResponse, GeminiStreamEvent } from '@floway-dev/protocols/gemini';
 import { type ExecuteResult, type PlainResult, type ApiErrorResult, type InternalDebugError, toInternalDebugError, decodeApiErrorBody } from '@floway-dev/provider';
@@ -68,7 +68,7 @@ export const respondGemini = async (
   return streamSSE(c, async stream => {
     let completion: StreamCompletion = 'error';
     try {
-      completion = await writeSSEFrames(stream, geminiSseFrames(frames, state), {
+      completion = await writeSSEFrames(stream, geminiSseFrames(frames, state, ctx), {
         keepAlive: { frame: sseCommentFrame('keepalive') },
         ...(ctx.downstreamAbortController !== undefined ? { downstreamAbortController: ctx.downstreamAbortController } : {}),
       });
@@ -179,7 +179,8 @@ const caughtGeminiErrorEvent = (error: unknown): GeminiErrorResponse | null => {
   return isGeminiErrorResponse(error.cause) ? error.cause : null;
 };
 
-const geminiStreamErrorFrame = (error: unknown) => sseFrame(JSON.stringify(caughtGeminiErrorEvent(error) ?? geminiInternalRpcErrorPayload(500, error)));
+const geminiStreamErrorEvent = (error: unknown): GeminiStreamEvent =>
+  (caughtGeminiErrorEvent(error) ?? geminiInternalRpcErrorPayload(500, error)) as unknown as GeminiStreamEvent;
 
 // --- frame observation ---
 
@@ -197,7 +198,7 @@ const observeGeminiFrames = async function* (frames: AsyncIterable<ProtocolFrame
   throw new Error(GEMINI_MISSING_TERMINAL_MESSAGE);
 };
 
-const geminiSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<GeminiStreamEvent>>, state: SourceStreamState) {
+const geminiSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<GeminiStreamEvent>>, state: SourceStreamState, ctx: GatewayCtx) {
   try {
     for await (const frame of frames) {
       const sse = geminiProtocolFrameToSSEFrame(frame);
@@ -205,6 +206,8 @@ const geminiSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<Gem
     }
   } catch (error) {
     state.failed = true;
-    yield geminiStreamErrorFrame(error);
+    const event = geminiStreamErrorEvent(error);
+    ctx.dump?.frame(eventFrame(event));
+    yield sseFrame(JSON.stringify(event));
   }
 };

--- a/packages/gateway/src/data-plane/chat/messages/respond.ts
+++ b/packages/gateway/src/data-plane/chat/messages/respond.ts
@@ -10,7 +10,7 @@ import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
 import { forwardUpstreamHeaders, mergeForwardedUpstreamHeaders } from '../../shared/upstream-response.ts';
 import { affinityEgressOptions } from '../shared/affinity/index.ts';
 import { SourceStreamState, eventResultMetadata, plainResultToResponse } from '../shared/respond.ts';
-import { type ProtocolFrame, sseFrame } from '@floway-dev/protocols/common';
+import { eventFrame, type ProtocolFrame, sseFrame } from '@floway-dev/protocols/common';
 import { messagesProtocolFrameToSSEFrame, MESSAGES_MISSING_TERMINAL_MESSAGE, collectMessagesProtocolEventsToResult } from '@floway-dev/protocols/messages';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { type ExecuteResult, type PlainResult, type InternalDebugError, toInternalDebugError } from '@floway-dev/provider';
@@ -68,7 +68,7 @@ export const respondMessages = async (
   return streamSSE(c, async stream => {
     let completion: StreamCompletion = 'error';
     try {
-      completion = await writeSSEFrames(stream, messagesSseFrames(frames, state), {
+      completion = await writeSSEFrames(stream, messagesSseFrames(frames, state, ctx), {
         keepAlive: { frame: sseFrame(JSON.stringify({ type: 'ping' }), 'ping') },
         ...(ctx.downstreamAbortController !== undefined ? { downstreamAbortController: ctx.downstreamAbortController } : {}),
       });
@@ -117,7 +117,7 @@ const observeMessagesFrames = async function* (
   throw new Error(MESSAGES_MISSING_TERMINAL_MESSAGE);
 };
 
-const messagesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<MessagesStreamEvent>>, state: SourceStreamState) {
+const messagesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<MessagesStreamEvent>>, state: SourceStreamState, ctx: GatewayCtx) {
   try {
     for await (const frame of frames) {
       const sse = messagesProtocolFrameToSSEFrame(frame);
@@ -125,6 +125,8 @@ const messagesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<M
     }
   } catch (error) {
     state.failed = true;
-    yield sseFrame(JSON.stringify(internalMessagesErrorPayload(toInternalDebugError(error))), 'error');
+    const event = internalMessagesErrorPayload(toInternalDebugError(error)) as unknown as MessagesStreamEvent;
+    ctx.dump?.frame(eventFrame(event));
+    yield sseFrame(JSON.stringify(event), 'error');
   }
 };

--- a/packages/gateway/src/data-plane/chat/responses/respond.ts
+++ b/packages/gateway/src/data-plane/chat/responses/respond.ts
@@ -75,7 +75,7 @@ export const respondResponses = async (
   const response = streamSSE(c, async stream => {
     let completion: StreamCompletion = 'error';
     try {
-      completion = await writeSSEFrames(stream, responsesSseFrames(frames, state), {
+      completion = await writeSSEFrames(stream, responsesSseFrames(frames, state, ctx), {
         keepAlive: { frame: sseCommentFrame('keepalive') },
         ...(ctx.downstreamAbortController !== undefined ? { downstreamAbortController: ctx.downstreamAbortController } : {}),
       });
@@ -114,22 +114,19 @@ const internalResponsesErrorResponse = (status: number, error: InternalDebugErro
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L170-L177
 // https://github.com/openai/openai-node/blob/d77cf24d9f3885739c6cba76bc009abf0ab97428/src/core/streaming.ts#L69-L71
 // https://github.com/openai/openai-python/blob/3844843c277f42b0b18beaa58152cfda61df524a/src/openai/_streaming.py#L87-L98
-const internalResponsesStreamErrorFrame = (error: unknown) => {
+const internalResponsesStreamErrorEvent = (error: unknown): ClientResponsesStreamEvent => {
   const debug = toInternalDebugError(error);
-  return sseFrame(
-    JSON.stringify({
-      type: 'error',
-      error: {
-        message: debug.message,
-        code: debug.type,
-        name: debug.name,
-        stack: debug.stack,
-        cause: debug.cause,
-        target_api: debug.target_api,
-      },
-    }),
-    'error',
-  );
+  return {
+    type: 'error',
+    error: {
+      message: debug.message,
+      code: debug.type,
+      name: debug.name,
+      stack: debug.stack,
+      cause: debug.cause,
+      target_api: debug.target_api,
+    },
+  } as unknown as ClientResponsesStreamEvent;
 };
 
 // --- frame observation ---
@@ -151,15 +148,15 @@ const observeResponsesFrames = async function* (frames: AsyncIterable<ProtocolFr
 // "Any error incurred while streaming will be followed by a `response.failed`
 // event."
 // https://github.com/openresponses/openresponses/blob/92c12d96d7b61d6d15e2214daa5e9c6000ab6e1c/src/specifications/2026-04-24.mdx#L430
-const responsesFailedFrame = (resource: ClientResponseResource, error: unknown) => {
+const responsesFailedEvent = (resource: ClientResponseResource, error: unknown): ClientResponsesStreamEvent => {
   const debug = toInternalDebugError(error);
-  return responsesProtocolFrameToSSEFrame(eventFrame({
+  return {
     type: 'response.failed',
     response: { ...resource, status: 'failed', error: { code: debug.type, message: debug.message } },
-  } as ClientResponsesStreamEvent));
+  } as ClientResponsesStreamEvent;
 };
 
-const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>>, state: SourceStreamState) {
+const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<ClientResponsesStreamEvent>>, state: SourceStreamState, ctx: GatewayCtx) {
   let announced: ClientResponseResource | undefined;
   try {
     for await (const frame of frames) {
@@ -171,7 +168,13 @@ const responsesSseFrames = async function* (frames: AsyncIterable<ProtocolFrame<
     yield responsesProtocolFrameToSSEFrame(doneFrame());
   } catch (error) {
     state.failed = true;
-    yield internalResponsesStreamErrorFrame(error);
-    if (announced !== undefined) yield responsesFailedFrame(announced, error);
+    const errorEvent = internalResponsesStreamErrorEvent(error);
+    ctx.dump?.frame(eventFrame(errorEvent));
+    yield sseFrame(JSON.stringify(errorEvent), 'error');
+    if (announced !== undefined) {
+      const failedFrame = eventFrame(responsesFailedEvent(announced, error));
+      ctx.dump?.frame(failedFrame);
+      yield responsesProtocolFrameToSSEFrame(failedFrame);
+    }
   }
 };


### PR DESCRIPTION
## Summary

- dump the error frame each source's SSE encoder synthesizes, so a recorded turn ends on the same event the client was sent
- do the same for the Responses `response.failed` frame appended when the response resource was already announced

## Why

When a frame iterator throws mid-stream, the response is already committed, so the encoder catches the error and renders it into an `event: error` frame carrying the internal-debug envelope. That encoder runs downstream of `observe*Frames`, which is what calls `ctx.dump?.frame(...)` — so the synthesized frame never entered the dump. The client was told exactly what went wrong; an operator opening the same turn in the dashboard saw a stream that stopped after the last good chunk, plus a `failed` reason that only restated the stream state.

Observed on a real turn: one `event: error` reached the client with `"message":"cache token counts exceed inclusive input tokens: 2527 - 11264 - 0"` and a full stack, and none of that was in the record.

## Shape

The error is a frame, so it is recorded as one rather than carried out of band on the stream state. Each encoder now builds the error *event*, dumps it, and renders that same object — one event reaching both sinks instead of two descriptions of it. `internalResponsesStreamErrorFrame` and `responsesFailedFrame` become `…Event` builders for the same reason; the SSE rendering moves to the call site that already had it.

Nothing on the wire changes: the same JSON, under the same `event: error` name, in the same order.

## Known gap this does not close

The dashboard derives a dump's SSE view through the per-protocol frame encoder, and `chatCompletionsProtocolFrameToSSEFrame` renders every event as a bare `data:` line. So the recorded error frame replays as `data: {"error":…}` while the client received it under `event: error`. That naming lives only in the catch path today; teaching the encoder to name it would also change how an *upstream* error payload renders on the wire, which is a client-visible change and not this fix's call.

## Verification

- `pnpm run test` — 468 files, 5,070 tests passed
- `pnpm run typecheck`
- `pnpm run lint` — clean on this change; the one `prefer-nullish-coalescing` error in `apps/web/src/routes/dashboard-services-api-keys.tsx:176` is pre-existing on `main`
