### PR TITLE
fix(web): close a title-only toast under a title that wraps

### DIFF
--- a/apps/web/src/routes/dashboard-winui-gallery.tsx
+++ b/apps/web/src/routes/dashboard-winui-gallery.tsx
@@ -895,6 +895,10 @@ function ToastSection() {
         'warning',
       )}>Wrapping body</Button>
       <Button onClick={() => fire(
+        <Toast><ToastTitle>{wrappingTitle}</ToastTitle></Toast>,
+        'error',
+      )}>Wrapping title only</Button>
+      <Button onClick={() => fire(
         <Toast><ToastTitle>{wrappingTitle}</ToastTitle><ToastBody>Retrying in 30 seconds.</ToastBody></Toast>,
         'error',
       )}>Wrapping title</Button>

--- a/apps/web/src/winui/controls/toast.css.ts
+++ b/apps/web/src/winui/controls/toast.css.ts
@@ -74,12 +74,20 @@ ${severityCss({ card: '.fui-Toast', icon: '.fui-ToastTitle__media', ground: 'var
    panel spends on its first child either way.
 
    A title-only card is InfoBar's horizontal orientation, whose panel padding is
-   zero on every side: 14 + the 20px line + InfoBarMinHeight's remaining 14 is
-   the whole box. A card with a body below it is the vertical orientation, and
-   the trailing 18 of that padding closes it.
+   zero on every side: 14 + the 20px line + a trailing 14 is InfoBarMinHeight
+   exactly. The trailing step is stated rather than left to the min-height,
+   because a toast wraps where an InfoBar's single row does not: over two lines
+   the title alone outgrows the 48 and the height that supplied that step is
+   gone, closing the card on the text. The two agree on one line, so the rule
+   changes nothing there. A card with a body below it is the vertical
+   orientation, and the trailing 18 of that padding closes it instead.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/InfoBar/InfoBar_themeresources.xaml#L79-L82 */
 .fui-ToastTitle.fui-ToastTitle {
   padding-top: 14px;
+}
+
+.fui-Toast.fui-Toast:not(:has(.fui-ToastBody, .fui-ToastFooter)) .fui-ToastTitle {
+  padding-bottom: 14px;
 }
 
 .fui-Toast.fui-Toast:has(.fui-ToastBody, .fui-ToastFooter) {


### PR DESCRIPTION
A toast whose title is its only row is InfoBar's horizontal orientation, whose panel padding is zero on every side. The card's box was therefore 14 above the title, the 20px line, and whatever `InfoBarMinHeight` had left over — and that leftover *is* the trailing step. It only exists while the content fits in 48: a title over two lines is 54 on its own, so the card closed on the text with nothing below the second line. Every real pending toast (`components/ui/outcome-toast.tsx`) is this layout, so any message long enough to wrap hit it.

The fix states the trailing 14 on the title row where no body or footer follows it. The two agree on one line, so the single-line card is untouched; the vertical orientation keeps the trailing 18 it already had.

The gallery had every wrapping case except this one — the layout that breaks was the layout nobody could fire — so it gains a title-only wrapping toast beside the one that carries a body.

## Measured in a running browser

Chromium, dev build, light theme, `#toast` in the WinUI gallery. `ink` is the distance from the card edge to the first/last text line box.

| case | before | after |
| --- | --- | --- |
| title only, one line | 50px, ink 17 / 16 | 50px, ink 17 / 16 |
| title only, wrapped | 56px, ink 17 / **2** | 70px, ink 17 / **16** |
| title + body, wrapped title | 98px, ink 17 / 20 | 98px, ink 17 / 20 |
| title + body, one line each | 98px, ink 17 / 20 | 98px, ink 17 / 20 |

`min-height: 48px` resolves against this card's content box, so the step cannot move onto the card's own padding — that would stack on the floor rather than replace it, and it measured 78px for the single-line card.

## Verification

`pnpm run lint`, `pnpm --filter @floway-dev/web run typecheck`, `pnpm --filter @floway-dev/web run test` (81 files, 449 tests) all pass.