### PR TITLE
fix(web): give the proxy dial timeout placeholder a number format

### DIFF
--- a/apps/web/__tests__/components/proxy/timeout-placeholder_test.tsx
+++ b/apps/web/__tests__/components/proxy/timeout-placeholder_test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_DIAL_TIMEOUT_SECONDS, defaultsFor } from '../../../src/components/proxy/config';
+import { ProxyForm } from '../../../src/components/proxy/form';
+import { formatNumber } from '../../../src/lib/format-number';
+import { renderInApp } from '../../render';
+
+const renderForm = () => renderInApp(
+  <ProxyForm
+    config={defaultsFor('http', { host: '', port: 0, name: '' })}
+    dialTimeoutInput=""
+    errors={{}}
+    formName=""
+    onConfigChange={vi.fn()}
+    onDialTimeoutChange={vi.fn()}
+    onKindChange={vi.fn()}
+    onNameChange={vi.fn()}
+    onPortChange={vi.fn()}
+    onUrlChange={vi.fn()}
+    urlInput=""
+  />,
+);
+
+describe('proxy dial timeout placeholder', () => {
+  // The dial timeout is the one field of this form whose placeholder carries a
+  // number, and i18n/number-format.ts throws on a number that reaches a
+  // placeholder naming no format. That throw is a render error: it took the
+  // whole page down to the error boundary rather than showing a bad label.
+  it('names the default the field falls back to', () => {
+    const view = renderForm();
+
+    expect(view.container.innerHTML).toContain(formatNumber(DEFAULT_DIAL_TIMEOUT_SECONDS, 'en'));
+  });
+});

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1155,7 +1155,7 @@ const en = {
           shortId: 'Short ID (optional)',
           shortIdPlaceholder: 'hex, up to 16 chars',
           timeout: 'Dial timeout',
-          timeoutPlaceholder: '{{seconds}} (default)',
+          timeoutPlaceholder: '{{seconds, number}} (default)',
           timeoutHint: 'Seconds. Leave empty for default 10s timeout.',
         },
         validation: {

--- a/apps/web/src/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/i18n/locales/zh-Hans.ts
@@ -1089,7 +1089,7 @@ const zhHansCN = {
           shortId: 'Short ID（可选）',
           shortIdPlaceholder: '十六进制，最多 16 位',
           timeout: '拨号超时',
-          timeoutPlaceholder: '{{seconds}}（默认）',
+          timeoutPlaceholder: '{{seconds, number}}（默认）',
           timeoutHint: '单位为秒。留空使用默认 10 秒超时。',
         },
         validation: {


### PR DESCRIPTION
Opening the proxy editor at `/dashboard/providers/proxy` replaced the page with the error boundary, showing a minified stack whose top frame is `i18n/number-format.ts`:

> Interpolation `{{seconds}}` carries a number but names no format; write `{{seconds, number}}`.

`dashboard.proxy.form.timeoutPlaceholder` was written as `'{{seconds}} (default)'`, and the dial timeout field passes `DEFAULT_DIAL_TIMEOUT_SECONDS` — a number. i18n runs with `alwaysFormat: true`, so the formatter module sees every interpolation and, by design, throws on a number that names no format rather than letting it render ungrouped beside values that went through `lib/format-number`. Because that throw happens during render, it takes the whole route down instead of producing one label that disagrees with its neighbours.

Both locales now write `{{seconds, number}}`. A suite renders `ProxyForm` and asserts the formatted default reaches the placeholder; without the fix it reproduces the reported stack frame for frame.

Every other bare `{{…}}` placeholder in the locale files was checked against its call site, and all of them are string-valued, so this is the only occurrence. Nothing statically prevents the next one — that guard is a separate change.

## Test Plan

- [x] `pnpm exec vitest run --project @floway-dev/web` — 85 files, 465 tests passing
- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] `eslint` over the changed files
- [x] The new suite fails with the reported `TypeError` when the locale strings are reverted