### PR TITLE
fix(web): fall back to Learn when the Azure China font mirror is unreachable

### DIFF
--- a/apps/web/src/global.css
+++ b/apps/web/src/global.css
@@ -18,15 +18,28 @@
    single network and a mainland resolver that answers SERVFAIL for it would
    otherwise cost the typeface. The two URLs are the same bytes -- both hosts
    return x-ms-blob-content-md5 0z9O1Vho99UFoTkPuyg75g== and the downloads
-   compare equal -- so the second entry buys reachability and nothing else, and a source list is walked lazily enough for
-   that to be free: measured in Chromium 151, Firefox 153 and WebKit 26.5, the
-   second URL is fetched when and only when the first face errors, whether the
-   host does not resolve, refuses the connection, answers 404 or 500, returns a
-   body that is not a font, or omits the CORS header. It is never touched when
-   the mirror answers. The one shape this does not cover is a mirror that
-   accepts the connection and then never replies: the face stays pending rather
-   than failing, so nothing advances the list and `font-display: swap` holds the
-   system stack for as long as the request does.
+   compare equal -- so the second entry buys reachability and nothing else. It
+   also costs nothing on the common path, because a source list is walked
+   lazily: the user agent takes "the first one it can successfully parse and
+   activate", and activation is defined to include downloading the file.
+   https://drafts.csswg.org/css-fonts-4/#src-desc
+   Measured in Chromium 151, Firefox 153 and WebKit 26.5, the second URL is
+   fetched when and only when the first face errors, whether the host does not
+   resolve, refuses the connection, answers 404 or 500, returns a body that is
+   not a font, or omits the CORS header. It is never touched when the mirror
+   answers.
+
+   Two constraints hold this together, and both are easy to break from a
+   distance. `font-display` must stay at a value that waits for the face:
+   under `fallback` or `optional` the display timer expires before a slow
+   failure does, the face is abandoned, and the second URL is never requested
+   at all -- measured in Chromium against an unroutable primary, where `swap`
+   moves on at 5.2 s and neither of the other two ever moves. And the failure
+   has to be one the network reports: a mirror that accepts the connection and
+   then goes silent leaves the face pending rather than errored, so nothing
+   advances the list and the system stack stands in for as long as the request
+   does. SERVFAIL, refusal and reset are all reported, so the case this exists
+   for is covered.
 
    TrueType is the only container upstream; there is no woff2 of the variable
    face on either host, and it costs less than it looks -- the CDN gzips it to

--- a/apps/web/src/global.css
+++ b/apps/web/src/global.css
@@ -10,12 +10,26 @@
    https://learn.microsoft.com/en-us/typography/font-list/segoe-ui-variable
 
    Microsoft mirrors Learn's static tree byte-for-byte on Azure China, and we
-   point at the mirror: learn.microsoft.com is fronted by Akamai, which maps
+   ask the mirror first: learn.microsoft.com is fronted by Akamai, which maps
    mainland clients onto European and US edges, while this host stays on
    Microsoft's own AS8075 -- 1.0 s against 3.4 s from China Telecom in Nanjing.
 
+   Learn follows as a second source, because the mirror is a single host on a
+   single network and a mainland resolver that answers SERVFAIL for it would
+   otherwise cost the typeface. The two URLs are the same bytes -- both hosts
+   return x-ms-blob-content-md5 0z9O1Vho99UFoTkPuyg75g== and the downloads
+   compare equal -- so the second entry buys reachability and nothing else, and a source list is walked lazily enough for
+   that to be free: measured in Chromium 151, Firefox 153 and WebKit 26.5, the
+   second URL is fetched when and only when the first face errors, whether the
+   host does not resolve, refuses the connection, answers 404 or 500, returns a
+   body that is not a font, or omits the CORS header. It is never touched when
+   the mirror answers. The one shape this does not cover is a mirror that
+   accepts the connection and then never replies: the face stays pending rather
+   than failing, so nothing advances the list and `font-display: swap` holds the
+   system stack for as long as the request does.
+
    TrueType is the only container upstream; there is no woff2 of the variable
-   face on this host, and it costs less than it looks -- the CDN gzips it to
+   face on either host, and it costs less than it looks -- the CDN gzips it to
    1.05 MB against the 949 KB woff2 on microsoft.design, which answers a large
    share of mainland requests with a Cloudflare challenge instead of the font.
    Declaring no font-variation-settings is deliberate: the face carries an
@@ -23,7 +37,9 @@
    from the used font size continuously rather than at two pinned stops. */
 @font-face {
   font-family: 'Segoe UI Variable Web';
-  src: url('https://docs.azure.cn/static/third-party/SegoeUIVariable/SegoeUI-VF.ttf?floway-vf=2.02') format('truetype');
+  src:
+    url('https://docs.azure.cn/static/third-party/SegoeUIVariable/SegoeUI-VF.ttf?floway-vf=2.02') format('truetype'),
+    url('https://learn.microsoft.com/static/third-party/SegoeUIVariable/SegoeUI-VF.ttf?floway-vf=2.02') format('truetype');
   font-style: normal;
   font-weight: 300 700;
   font-display: swap;

--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -35,11 +35,14 @@ const { Button, FluentProvider } = fluentComponents;
 // The version query isolates the cross-origin response from a bare-path Azure
 // CDN cache entry stored with docs.azure.cn as its sole allowed origin and no
 // `Vary: Origin`.
-const SEGOE_UI_VARIABLE_URL = 'https://docs.azure.cn/static/third-party/SegoeUIVariable/SegoeUI-VF.ttf?floway-vf=2.02';
+// Only the mirror is warmed. ./global.css names learn.microsoft.com behind it as
+// a second source, and preloading that too would spend a second megabyte on
+// every visit to save a fraction of the visits where the mirror is unreachable.
+const SEGOE_UI_VARIABLE_MIRROR_URL = 'https://docs.azure.cn/static/third-party/SegoeUIVariable/SegoeUI-VF.ttf?floway-vf=2.02';
 
 export const links: Route.LinksFunction = () => [
   { rel: 'preconnect', href: 'https://docs.azure.cn', crossOrigin: 'anonymous' },
-  { rel: 'preload', as: 'font', type: 'font/ttf', href: SEGOE_UI_VARIABLE_URL, crossOrigin: 'anonymous' },
+  { rel: 'preload', as: 'font', type: 'font/ttf', href: SEGOE_UI_VARIABLE_MIRROR_URL, crossOrigin: 'anonymous' },
 ];
 
 const useSystemTheme = () => useMediaQuery(DARK_SCHEME_QUERY) ? winuiDarkTheme : winuiLightTheme;


### PR DESCRIPTION
The dashboard loads Segoe UI Variable from `docs.azure.cn`. That host is the right first choice — it stays on Microsoft's own AS8075, while `learn.microsoft.com` is fronted by Akamai and maps mainland clients onto European and US edges — but it is one host on one network, and a mainland resolver that answers SERVFAIL for it costs the typeface outright.

`learn.microsoft.com` now follows as a second `src` entry on the same face. Both hosts serve the same blob (`x-ms-blob-content-md5: 0z9O1Vho99UFoTkPuyg75g==`, and the two downloads compare equal), so the entry buys reachability and nothing else.

## Why a second `src` rather than a second family

Both arrangements were measured and both behave identically. One face with two sources needs no change at any `font-family` call site, and it avoids a hazard the two-family form carries: two faces of the same file in one stack fall through per glyph, so a glyph missing from the mirror's copy would pull the whole second megabyte.

This is the behaviour CSS Fonts 4 §4.3 specifies — the user agent takes "the first one it can successfully **parse and activate**", and "activation of a font involves **downloading the file**". A failed download is therefore defined to advance the list, not merely an unsupported `format()` hint.

## What was measured

A probe page across Chromium 151, Google Chrome 150, Microsoft Edge 151, Firefox 153 and WebKit 26.5, reading three independent instruments per run: the request log, `document.fonts` face status, and rendered text width against reference elements each bound to a single face.

The second URL is fetched **when and only when** the first face errors — unresolvable host, refused connection, 404, 500, a 200 whose body is not a font, and a cross-origin response with no CORS header. It is never requested when the mirror answers; the second source stays untouched in every engine, including with the mirror's `<link rel=preload>` in place.

## Two constraints this depends on

Both are easy to break from a distance, so both are recorded at the rule.

**`font-display` must wait for the face.** Under `fallback` or `optional` the display timer expires before a slow failure does, the face is abandoned, and the second URL is never requested at all. Against an unroutable primary in Chromium, `swap` moves on at 5.2 s while neither of the other two ever moves.

**The failure has to be one the network reports.** Time to reach the second source, `font-display: swap`:

| primary's failure | Chromium | Firefox | WebKit |
| --- | --- | --- | --- |
| SERVFAIL / refused / 404 / 500 | 10–60 ms | 10–60 ms | 10–60 ms |
| unroutable (no TCP handshake) | 5.2 s | 51.4 s | 15.5 s |
| accepted, then silent | never within 95 s | never within 95 s | never within 95 s |

The case this change exists for — SERVFAIL — is in the top row. A blackholed mirror is not addressable by any `src` list; the system stack stands in until the request settles.

## Verified on the shipped artifact

The production build was served against a live Node-target gateway and loaded in Chromium, Chrome, Firefox and WebKit under three network conditions:

| condition | font requests | face loaded |
| --- | --- | --- |
| mirror reachable | `docs.azure.cn` | yes |
| mirror SERVFAIL | `docs.azure.cn`, then `learn.microsoft.com` | yes |
| both hosts down (control) | both attempted | no |

Rendered text geometry under "mirror reachable" and "mirror SERVFAIL" is pixel-identical — 0 differing subpixels against a 0 noise floor, measured by rasterising every text box's client rects. The both-hosts-down control differs (Chromium: different layout entirely; WebKit: 11511 subpixels), which is what establishes the comparison can tell the two apart. A whole-page screenshot hash is not usable here: the animated backdrop makes three captures of the identical page produce two distinct hashes.

Lightning CSS preserves both entries and their order through minification.

## Not changed

Only the mirror is preloaded and preconnected. Warming Learn as well would spend a second megabyte on every visit to save the fraction of visits where the mirror is unreachable.

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 477 files, 5129 tests
- [x] `pnpm --filter @floway-dev/web run build`, then confirm both `src` entries and their order survive minification
- [x] Production bundle against a live gateway in Chromium, Chrome, Firefox and WebKit: mirror reachable, mirror SERVFAIL, both hosts down
- [x] Text geometry under SERVFAIL is pixel-identical to the healthy render, with the both-down control differing
- [x] `font-display` interaction and failover timing measured per engine
- [ ] Confirmed from a mainland network against the real resolver behaviour — needs a China-based vantage point, unavailable here; the SERVFAIL path is simulated by aborting the request with `namenotresolved`
