### PR TITLE
fix(web): avoid the Chromium checkbox animation hang

### DIFF
--- a/apps/web/__tests__/winui/controls/checkbox-motion_test.ts
+++ b/apps/web/__tests__/winui/controls/checkbox-motion_test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { choiceCss } from '../../../src/winui/controls/choice.css';
+
+const CHECK_ON_BEZIER = [0.55, 0, 0, 1] as const;
+
+const cubicCoordinate = (time: number, first: number, second: number) =>
+  3 * (1 - time) ** 2 * time * first + 3 * (1 - time) * time ** 2 * second + time ** 3;
+
+const cubicOutputAt = (progress: number) => {
+  const [x1, y1, x2, y2] = CHECK_ON_BEZIER;
+  let low = 0;
+  let high = 1;
+  for (let iteration = 0; iteration < 60; iteration += 1) {
+    const time = (low + high) / 2;
+    if (cubicCoordinate(time, x1, x2) < progress) low = time; else high = time;
+  }
+  return cubicCoordinate((low + high) / 2, y1, y2);
+};
+
+const linearStops = () => {
+  const supported = /@supports \(transition-timing-function: linear\(0, 1\)\)[\s\S]*?transition-timing-function: linear\(([^)]*)\)/.exec(choiceCss);
+  if (supported === null) throw new Error('the check-on motion has no linear() feature gate');
+  return supported[1]!.split(',').map(value => Number(value.trim()));
+};
+
+const linearOutputAt = (stops: number[], progress: number) => {
+  if (progress === 1) return stops.at(-1)!;
+  const position = progress * (stops.length - 1);
+  const index = Math.floor(position);
+  const offset = position - index;
+  return stops[index]! + (stops[index + 1]! - stops[index]!) * offset;
+};
+
+describe('WinUI checkbox motion', () => {
+  it('keeps the WinUI cubic fallback outside the linear() feature gate', () => {
+    const fallback = choiceCss.indexOf('transition-timing-function: cubic-bezier(0.55, 0, 0, 1)');
+    const gate = choiceCss.indexOf('@supports (transition-timing-function: linear(0, 1))');
+    expect(fallback).toBeGreaterThan(-1);
+    expect(gate).toBeGreaterThan(fallback);
+  });
+
+  it('keeps the linear() route within five thousandths of the WinUI curve', () => {
+    const stops = linearStops();
+    expect(stops).toHaveLength(41);
+    expect(stops[0]).toBe(0);
+    expect(stops.at(-1)).toBe(1);
+
+    let largestError = 0;
+    for (let sample = 0; sample <= 10_000; sample += 1) {
+      const progress = sample / 10_000;
+      largestError = Math.max(largestError, Math.abs(linearOutputAt(stops, progress) - cubicOutputAt(progress)));
+    }
+    expect(largestError).toBeLessThan(0.005);
+  });
+});

--- a/apps/web/src/winui/controls/choice.css.ts
+++ b/apps/web/src/winui/controls/choice.css.ts
@@ -96,8 +96,36 @@ const COMPOSITION_MS = 26666666 / 10000;
 const CHECK_ON_MS = `${exact((0.2128125 - 0.0940625) * COMPOSITION_MS)}ms`;
 const CHECK_OFF_MS = `${exact(0.0253125 * COMPOSITION_MS)}ms`;
 // https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/AnimatedIcon/AnimatedVisuals/AnimatedAcceptVisualSource.cpp#L1471-L1479
-const CHECK_ON_EASING = 'cubic-bezier(0.55, 0, 0, 1)';
+const CHECK_ON_BEZIER = [0.55, 0, 0, 1] as const;
+const CHECK_ON_EASING = `cubic-bezier(${CHECK_ON_BEZIER.join(', ')})`;
 const CHECK_OFF_EASING = 'cubic-bezier(0.167, 0.167, 0.833, 0.833)';
+
+const cubicCoordinate = (time: number, first: number, second: number) =>
+  3 * (1 - time) ** 2 * time * first + 3 * (1 - time) * time ** 2 * second + time ** 3;
+
+const cubicOutputAt = ([x1, y1, x2, y2]: readonly [number, number, number, number], progress: number) => {
+  let low = 0;
+  let high = 1;
+  for (let iteration = 0; iteration < 60; iteration += 1) {
+    const time = (low + high) / 2;
+    if (cubicCoordinate(time, x1, x2) < progress) low = time; else high = time;
+  }
+  return cubicCoordinate((low + high) / 2, y1, y2);
+};
+
+// Chromium 150-152 can loop forever while finding the range of this cubic
+// timing function for a composited clip-path transition. Forty straight
+// segments keep the largest progress error below 0.005 -- under 0.06px across
+// this mark -- while routing supporting browsers through LinearTimingFunction.
+// The cubic remains the fallback for engines that do not parse linear().
+// https://issues.chromium.org/issues/536936875
+// https://chromium-review.googlesource.com/c/chromium/src/+/8152879
+// https://drafts.csswg.org/css-easing-2/#the-linear-easing-function
+const CHECK_ON_LINEAR_SEGMENTS = 40;
+const CHECK_ON_LINEAR_EASING = `linear(${Array.from(
+  { length: CHECK_ON_LINEAR_SEGMENTS + 1 },
+  (_, index) => exact(cubicOutputAt(CHECK_ON_BEZIER, index / CHECK_ON_LINEAR_SEGMENTS)),
+).join(', ')})`;
 
 // The tri-state check box is named by the data-winui-checked stamp
 // ../appearance.ts applies, never by :indeterminate -- that module carries why
@@ -295,6 +323,12 @@ ${nested(checkboxSurfaceCss({
     clip-path: inset(0 0 0 0);
     transition-duration: ${CHECK_ON_MS};
     transition-timing-function: ${CHECK_ON_EASING};
+  }
+
+  @supports (transition-timing-function: linear(0, 1)) {
+    .fui-Checkbox__input:checked ~ .fui-Checkbox__indicator.fui-Checkbox__indicator::before {
+      transition-timing-function: ${CHECK_ON_LINEAR_EASING};
+    }
   }
 
   /* The indeterminate states name single frames rather than a transition pair,


### PR DESCRIPTION
## Summary

- preserve the WinUI cubic easing as the fallback for browsers without CSS `linear()`
- route supporting browsers through a 40-segment `linear()` approximation, avoiding Chromium 150–152's infinite `CubicBezierTimingFunction::Range()` loop for composited `clip-path`
- bound the generated curve to less than 0.005 progress error from the WinUI source curve

Chromium issue: https://issues.chromium.org/issues/536936875
Upstream fix: https://chromium-review.googlesource.com/c/chromium/src/+/8152879

## Test Plan

- [x] Toggle `/completions`, `/responses`, and `/messages` in the production build on Edge 151 without freezing
- [x] Pass workspace tests in CI
- [x] Pass workspace typecheck in CI
- [x] Pass workspace lint in CI
- [x] Pass Agent Setup installer verification in CI
- [x] Pass generated-asset drift verification in CI
- [x] Build the web application in CI