### PR TITLE
refactor(protocols): delegate decimal arithmetic to big.js

### DIFF
--- a/packages/protocols/__tests__/common/decimal_test.ts
+++ b/packages/protocols/__tests__/common/decimal_test.ts
@@ -17,7 +17,7 @@ test('decimal strings canonicalize without floating-point conversion', () => {
   assertThrows(() => parseDecimalString('.1'), TypeError, 'must be a decimal string');
   assertThrows(() => parseDecimalString('1.'), TypeError, 'must be a decimal string');
   assertEquals(parseDecimalString(`1.${'0'.repeat(509)}`), '1');
-  assertThrows(() => parseDecimalString(`1.${'0'.repeat(510)}`), TypeError, 'at most 512 characters');
+  assertThrows(() => parseDecimalString(`1.${'0'.repeat(511)}`), TypeError, 'at most 512 characters');
   assertEquals(parseDecimalString('1e399'), `1${'0'.repeat(399)}`);
   assertThrows(() => parseDecimalString('1e400'), RangeError, '400-digit integer');
   assertEquals(parseDecimalString('1e-400'), `0.${'0'.repeat(399)}1`);

--- a/packages/protocols/__tests__/common/decimal_test.ts
+++ b/packages/protocols/__tests__/common/decimal_test.ts
@@ -1,10 +1,11 @@
 import { test } from 'vitest';
 
-import { addDecimalStrings, divideDecimalString, multiplyDecimalStrings, parseDecimalString, parseNonNegativeDecimalString } from '../../src/common/decimal.ts';
+import { addDecimalStrings, decimalStringIsZero, decimalStringToNumber, divideDecimalString, multiplyDecimalStrings, parseDecimalString, parseNonNegativeDecimalString } from '../../src/common/decimal.ts';
 import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 test('decimal strings canonicalize without floating-point conversion', () => {
   assertEquals(parseDecimalString('001.2300'), '1.23');
+  assertEquals(parseDecimalString('+001.2300'), '1.23');
   assertEquals(parseDecimalString('1e-7'), '0.0000001');
   assertEquals(parseDecimalString('-0'), '0');
   assertEquals(parseNonNegativeDecimalString('0.00000000000000000001'), '0.00000000000000000001');
@@ -13,6 +14,13 @@ test('decimal strings canonicalize without floating-point conversion', () => {
   assertEquals(parseDecimalString('1e-324'), `0.${'0'.repeat(323)}1`);
   assertThrows(() => parseDecimalString('1e401'), RangeError, 'exponent must be between');
   assertThrows(() => parseDecimalString('1'.repeat(101)), RangeError, 'significant digits');
+  assertThrows(() => parseDecimalString('.1'), TypeError, 'must be a decimal string');
+  assertThrows(() => parseDecimalString('1.'), TypeError, 'must be a decimal string');
+  assertEquals(parseDecimalString(`1.${'0'.repeat(509)}`), '1');
+  assertThrows(() => parseDecimalString(`1.${'0'.repeat(510)}`), TypeError, 'at most 512 characters');
+  assertEquals(parseDecimalString('1e399'), `1${'0'.repeat(399)}`);
+  assertThrows(() => parseDecimalString('1e400'), RangeError, '400-digit integer');
+  assertEquals(parseDecimalString('1e-400'), `0.${'0'.repeat(399)}1`);
 });
 
 test('decimal arithmetic preserves exact finite decimal results', () => {
@@ -26,4 +34,20 @@ test('decimal arithmetic preserves exact finite decimal results', () => {
   const subnormalProduct = multiplyDecimalStrings('1e-324', '1e-324');
   assertEquals(subnormalProduct, `0.${'0'.repeat(647)}1`);
   assertEquals(addDecimalStrings(subnormalProduct, subnormalProduct), `0.${'0'.repeat(647)}2`);
+  assertThrows(() => addDecimalStrings('1'.repeat(1_001), '0'), RangeError, 'significant digits');
+  assertThrows(() => divideDecimalString('1', '0'), RangeError, 'must not be zero');
+});
+
+test('decimal division rounds half-up to 100 fractional digits', () => {
+  const lastPlace = `0.${'0'.repeat(99)}1`;
+  assertEquals(divideDecimalString('4', '1e101'), '0');
+  assertEquals(divideDecimalString('1', '2e100'), lastPlace);
+  assertEquals(divideDecimalString('-1', '2e100'), `-${lastPlace}`);
+  assertEquals(divideDecimalString('6', '1e101'), lastPlace);
+});
+
+test('decimal predicates and numeric conversion consume the same canonical domain', () => {
+  assertEquals(decimalStringIsZero('-0e400'), true);
+  assertEquals(decimalStringIsZero('1e-400'), false);
+  assertEquals(decimalStringToNumber('9007199254740993'), 9_007_199_254_740_992);
 });

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -20,9 +20,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "big.js": "^7.0.1",
     "eventsource-parser": "^3.1.0"
   },
   "devDependencies": {
-    "@floway-dev/test-utils": "workspace:*"
+    "@floway-dev/test-utils": "workspace:*",
+    "@types/big.js": "^7.0.0"
   }
 }

--- a/packages/protocols/src/common/decimal.ts
+++ b/packages/protocols/src/common/decimal.ts
@@ -1,3 +1,5 @@
+import Big from 'big.js';
+
 export type DecimalString = string;
 
 interface DecimalLimits {
@@ -25,26 +27,11 @@ const ARITHMETIC_LIMITS: DecimalLimits = {
 const DIVISION_SCALE = 100;
 const DECIMAL_PATTERN = /^([+-]?)(\d+)(?:[.](\d+))?(?:[eE]([+-]?\d+))?$/;
 
-interface FixedDecimal {
-  coefficient: bigint;
-  scale: number;
-}
+const Decimal = Big();
+Decimal.DP = DIVISION_SCALE;
+Decimal.RM = Decimal.roundHalfUp;
 
-const pow10 = (exponent: number): bigint => 10n ** BigInt(exponent);
-
-const formatFixedDecimal = ({ coefficient, scale }: FixedDecimal): DecimalString => {
-  if (coefficient === 0n) return '0';
-  const negative = coefficient < 0n;
-  let digits = (negative ? -coefficient : coefficient).toString();
-  if (scale > 0) {
-    digits = digits.padStart(scale + 1, '0');
-    const split = digits.length - scale;
-    digits = `${digits.slice(0, split)}.${digits.slice(split)}`.replace(/[.]?0+$/, '');
-  }
-  return negative ? `-${digits}` : digits;
-};
-
-const parseFixedDecimal = (value: string, label: string, limits: DecimalLimits): FixedDecimal => {
+const validateDecimalString = (value: string, label: string, limits: DecimalLimits): string => {
   if (value.length === 0 || value.length > limits.inputLength) {
     throw new TypeError(`${label} must be a decimal string of at most ${limits.inputLength} characters: ${JSON.stringify(value)}`);
   }
@@ -58,7 +45,7 @@ const parseFixedDecimal = (value: string, label: string, limits: DecimalLimits):
 
   const integer = rawInteger.replace(/^0+(?=\d)/, '');
   let digits = `${integer}${rawFraction}`.replace(/^0+/, '');
-  if (digits === '') return { coefficient: 0n, scale: 0 };
+  if (digits === '') return value.startsWith('+') ? value.slice(1) : value;
   const significantDigits = digits.replace(/0+$/, '').length;
   if (significantDigits > limits.significantDigits) {
     throw new RangeError(`${label} must have at most ${limits.significantDigits} significant digits: ${JSON.stringify(value)}`);
@@ -77,56 +64,46 @@ const parseFixedDecimal = (value: string, label: string, limits: DecimalLimits):
   if (integerDigits > limits.integerDigits || scale > limits.scale) {
     throw new RangeError(`${label} exceeds the supported ${limits.integerDigits}-digit integer or ${limits.scale}-digit scale: ${JSON.stringify(value)}`);
   }
-  const coefficient = BigInt(digits) * (sign === '-' ? -1n : 1n);
-  return { coefficient, scale };
+  return sign === '+' ? value.slice(1) : value;
 };
 
+const parseDecimal = (value: string, label: string, limits: DecimalLimits) =>
+  new Decimal(validateDecimalString(value, label, limits));
+
 export const parseDecimalString = (value: string, label = 'decimal'): DecimalString =>
-  formatFixedDecimal(parseFixedDecimal(value, label, PUBLIC_LIMITS));
+  parseDecimal(value, label, PUBLIC_LIMITS).toFixed();
 
 export const parseNonNegativeDecimalString = (value: unknown, label = 'decimal'): DecimalString => {
   if (typeof value !== 'string') throw new TypeError(`${label} must be a decimal string: ${JSON.stringify(value)}`);
-  const parsed = parseFixedDecimal(value, label, PUBLIC_LIMITS);
-  if (parsed.coefficient < 0n) throw new RangeError(`${label} must be non-negative: ${JSON.stringify(value)}`);
-  return formatFixedDecimal(parsed);
+  const parsed = parseDecimal(value, label, PUBLIC_LIMITS);
+  if (parsed.lt(0)) throw new RangeError(`${label} must be non-negative: ${JSON.stringify(value)}`);
+  return parsed.toFixed();
 };
 
 export const addDecimalStrings = (left: DecimalString, right: DecimalString): DecimalString => {
-  const a = parseFixedDecimal(left, 'left decimal', ARITHMETIC_LIMITS);
-  const b = parseFixedDecimal(right, 'right decimal', ARITHMETIC_LIMITS);
-  const scale = Math.max(a.scale, b.scale);
-  return formatFixedDecimal({
-    coefficient: a.coefficient * pow10(scale - a.scale) + b.coefficient * pow10(scale - b.scale),
-    scale,
-  });
+  const a = parseDecimal(left, 'left decimal', ARITHMETIC_LIMITS);
+  const b = parseDecimal(right, 'right decimal', ARITHMETIC_LIMITS);
+  return a.plus(b).toFixed();
 };
 
 export const multiplyDecimalStrings = (left: DecimalString, right: DecimalString): DecimalString => {
-  const a = parseFixedDecimal(left, 'left decimal', ARITHMETIC_LIMITS);
-  const b = parseFixedDecimal(right, 'right decimal', ARITHMETIC_LIMITS);
-  return formatFixedDecimal({ coefficient: a.coefficient * b.coefficient, scale: a.scale + b.scale });
+  const a = parseDecimal(left, 'left decimal', ARITHMETIC_LIMITS);
+  const b = parseDecimal(right, 'right decimal', ARITHMETIC_LIMITS);
+  return a.times(b).toFixed();
 };
 
 // Division is the sole non-exact operation: repeating results are rounded
 // half-up to 100 fractional digits. Prices, quantities, sums, and products
 // remain exact finite decimals.
 export const divideDecimalString = (value: DecimalString, divisor: DecimalString): DecimalString => {
-  const numeratorValue = parseFixedDecimal(value, 'decimal dividend', ARITHMETIC_LIMITS);
-  const divisorValue = parseFixedDecimal(divisor, 'decimal divisor', ARITHMETIC_LIMITS);
-  if (divisorValue.coefficient === 0n) throw new RangeError('decimal divisor must not be zero');
-
-  const numerator = numeratorValue.coefficient * pow10(divisorValue.scale + DIVISION_SCALE);
-  const denominator = divisorValue.coefficient * pow10(numeratorValue.scale);
-  let quotient = numerator / denominator;
-  const remainder = numerator % denominator;
-  const absRemainder = remainder < 0n ? -remainder : remainder;
-  const absDenominator = denominator < 0n ? -denominator : denominator;
-  if (absRemainder * 2n >= absDenominator) quotient += numerator * denominator < 0n ? -1n : 1n;
-  return formatFixedDecimal({ coefficient: quotient, scale: DIVISION_SCALE });
+  const dividend = parseDecimal(value, 'decimal dividend', ARITHMETIC_LIMITS);
+  const denominator = parseDecimal(divisor, 'decimal divisor', ARITHMETIC_LIMITS);
+  if (denominator.eq(0)) throw new RangeError('decimal divisor must not be zero');
+  return dividend.div(denominator).toFixed();
 };
 
 export const decimalStringIsZero = (value: DecimalString): boolean =>
-  parseFixedDecimal(value, 'decimal', ARITHMETIC_LIMITS).coefficient === 0n;
+  parseDecimal(value, 'decimal', ARITHMETIC_LIMITS).eq(0);
 
 export const decimalStringToNumber = (value: DecimalString): number =>
-  Number(formatFixedDecimal(parseFixedDecimal(value, 'decimal', ARITHMETIC_LIMITS)));
+  Number(parseDecimal(value, 'decimal', ARITHMETIC_LIMITS).toFixed());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
 
   packages/protocols:
     dependencies:
+      big.js:
+        specifier: ^7.0.1
+        version: 7.0.1
       eventsource-parser:
         specifier: ^3.1.0
         version: 3.1.0
@@ -411,6 +414,9 @@ importers:
       '@floway-dev/test-utils':
         specifier: workspace:*
         version: link:../test-utils
+      '@types/big.js':
+        specifier: ^7.0.0
+        version: 7.0.0
 
   packages/provider:
     dependencies:
@@ -2485,6 +2491,9 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/big.js@7.0.0':
+    resolution: {integrity: sha512-WfAGp7IbJvyB8EmWK4tJD24rJRAL6uVbw3LV/hJntFNam+os9KWKj0PzXo8rRRpjupYK8U0M8FoBB8dBhWF2dg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2963,6 +2972,9 @@ packages:
     resolution: {integrity: sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  big.js@7.0.1:
+    resolution: {integrity: sha512-iFgV784tD8kq4ccF1xtNMZnXeZzVuXWWM+ERFzKQjv+A5G9HC8CY3DuV45vgzFFcW+u2tIvmF95+AzWgs6BjCg==}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
@@ -7434,6 +7446,8 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/big.js@7.0.0': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -8009,6 +8023,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.11.5: {}
+
+  big.js@7.0.1: {}
 
   blake3-wasm@2.1.5: {}
 


### PR DESCRIPTION
## Purpose

Floway maintains a second arbitrary-precision decimal engine in `packages/protocols`. Delegate generic exact arithmetic to `big.js` while retaining Floway's accepted grammar, resource limits, error classes, canonical fixed notation, and public string API.

## Change

- Use an isolated `big.js` constructor configured for 100 fractional digits and half-up division.
- Preserve exact finite addition and multiplication, explicit division-by-zero errors, nonnegative validation, fixed-notation output, and negative-zero normalization.
- Cover positive and negative rounding ties and every relevant resource boundary.

`big.js` adds about 6.5 KB raw / 2.8 KB gzip to the dashboard's shared protocol chunk. A 1,000-digit multiplication benchmark measured about 2.43 ms; public decimals remain limited to 100 significant digits.

## Test Plan

- [x] `pnpm --filter @floway-dev/protocols run test` — 190 passed
- [x] `pnpm --filter @floway-dev/protocols run typecheck`
- [x] `pnpm run build:web`
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
