### PR TITLE
refactor(proxy): reuse Noble byte comparison

### DIFF
--- a/packages/proxy/__tests__/protocols/reality_test.ts
+++ b/packages/proxy/__tests__/protocols/reality_test.ts
@@ -7,7 +7,6 @@ import { hexDecode } from '../../src/bytes.ts';
 import {
   buildRealityAad,
   buildRealitySessionId,
-  constantTimeEqual,
   dialReality,
   extractEd25519RawPubKey,
   parseShortId,
@@ -374,23 +373,6 @@ describe('extractEd25519RawPubKey', () => {
     spki.set(ED25519_SPKI_PREFIX, 0);
     spki[6] = 0xff;
     expect(() => extractEd25519RawPubKey(spki)).toThrow(/prefix mismatch/);
-  });
-});
-
-describe('constantTimeEqual', () => {
-  it('returns true for identical buffers', () => {
-    expect(constantTimeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(true);
-    expect(constantTimeEqual(new Uint8Array(0), new Uint8Array(0))).toBe(true);
-  });
-
-  it('returns false for buffers that differ in any byte', () => {
-    expect(constantTimeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 4]))).toBe(false);
-    expect(constantTimeEqual(new Uint8Array([0, 0, 0]), new Uint8Array([0, 0, 1]))).toBe(false);
-  });
-
-  it('returns false for buffers of different lengths', () => {
-    expect(constantTimeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3, 4]))).toBe(false);
-    expect(constantTimeEqual(new Uint8Array(0), new Uint8Array(1))).toBe(false);
   });
 });
 

--- a/packages/proxy/src/protocols/reality.ts
+++ b/packages/proxy/src/protocols/reality.ts
@@ -39,6 +39,7 @@
 // After REALITY auth completes, the inner protocol is VLESS by convention.
 
 import { gcm } from '@noble/ciphers/aes.js';
+import { equalBytes } from '@noble/ciphers/utils.js';
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { hmac } from '@noble/hashes/hmac.js';
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
@@ -408,7 +409,7 @@ export const verifyRealityLeaf = (authKey: Uint8Array, leafDer: Uint8Array, leaf
   }
   const certHmacWire = leafDer.subarray(leafDer.byteLength - 64);
   const tag = hmac(sha512, authKey, leafPub);
-  if (!constantTimeEqual(tag, certHmacWire)) {
+  if (!equalBytes(tag, certHmacWire)) {
     throw new ProxyDialError('REALITY: server HMAC-SHA512 over leaf pubkey did not match cert signatureValue', 'proxy-handshake');
   }
 };
@@ -526,20 +527,4 @@ export const extractEd25519RawPubKey = (spki: Uint8Array): Uint8Array => {
     }
   }
   return spki.slice(ED25519_SPKI_PREFIX.byteLength);
-};
-
-/**
- * Length-safe constant-time byte equality. Returns false immediately on
- * length mismatch — length is not secret here (the HMAC output length is
- * fixed at 64 bytes and the cert's signatureValue tail is wire-visible).
- * The per-byte loop never short-circuits, so a partial-match attack can't
- * read out which prefix matched.
- *
- * Exported for tests.
- */
-export const constantTimeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
-  if (a.byteLength !== b.byteLength) return false;
-  let diff = 0;
-  for (let i = 0; i < a.byteLength; i++) diff |= a[i]! ^ b[i]!;
-  return diff === 0;
 };


### PR DESCRIPTION
## Purpose

REALITY authentication maintained a local length-safe XOR loop even though `@noble/ciphers` is already a direct dependency and exposes the same constant-time byte comparison primitive.

## Change

- Use `equalBytes` from the documented `@noble/ciphers/utils.js` export.
- Remove the duplicate implementation and tests that only retested the dependency.
- Retain protocol-level success, mismatch, and boundary coverage.

## Test Plan

- [x] REALITY protocol suite — 40 passed
- [x] `pnpm --filter @floway-dev/proxy run typecheck`
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
