### PR TITLE
fix(protocols): deeply isolate Messages usage iterations

### DIFF
--- a/packages/protocols/__tests__/messages/usage_test.ts
+++ b/packages/protocols/__tests__/messages/usage_test.ts
@@ -45,21 +45,46 @@ test('Messages usage snapshots merge late counters and atomically replace the ti
   });
 });
 
-test('Messages usage snapshots preserve nullable iterations and isolate nested cache data', () => {
+test('Messages usage snapshots preserve nullable iterations and isolate all nested iteration data', () => {
   expect(messagesUsageSnapshot({ output_tokens: 0, iterations: null })).toEqual({ output_tokens: 0, iterations: null });
 
   const source = [{
     type: 'compaction',
     input_tokens: 7,
     cache_creation: { ephemeral_5m_input_tokens: 3 },
+    provider_metadata: {
+      attempts: [{ regions: ['us-east', 'us-west'] }],
+    },
   }];
   const snapshot = messagesUsageSnapshot({ output_tokens: 0, iterations: source });
   source[0].cache_creation.ephemeral_5m_input_tokens = 9;
+  source[0].provider_metadata.attempts[0].regions.push('eu-west');
 
   expect(snapshot.iterations).toEqual([{
     type: 'compaction',
     input_tokens: 7,
     cache_creation: { ephemeral_5m_input_tokens: 3 },
+    provider_metadata: {
+      attempts: [{ regions: ['us-east', 'us-west'] }],
+    },
   }]);
   expect(mergeMessagesUsageSnapshot(snapshot, { output_tokens: 1, iterations: null }).iterations).toBeNull();
+});
+
+test('Messages usage snapshot merges isolate opaque nested iteration data from the delta', () => {
+  const iterations = [{
+    type: 'model',
+    provider_metadata: {
+      attempts: [{ warnings: ['slow'] }],
+    },
+  }];
+  const merged = mergeMessagesUsageSnapshot({ output_tokens: 0 }, { output_tokens: 1, iterations });
+  iterations[0].provider_metadata.attempts[0].warnings[0] = 'mutated';
+
+  expect(merged.iterations).toEqual([{
+    type: 'model',
+    provider_metadata: {
+      attempts: [{ warnings: ['slow'] }],
+    },
+  }]);
 });

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -21,12 +21,7 @@ export interface MessagesUsageIteration {
 // isolated opaque snapshot, not a closed projection of those variants.
 // https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/beta/messages/messages.ts#L1724-L1829
 export const cloneMessagesUsageIterations = (iterations: MessagesUsageIteration[] | null): MessagesUsageIteration[] | null =>
-  iterations?.map(iteration => ({
-    ...iteration,
-    ...(iteration.cache_creation === undefined || iteration.cache_creation === null
-      ? {}
-      : { cache_creation: { ...iteration.cache_creation } }),
-  })) ?? null;
+  iterations === null ? null : structuredClone(iterations);
 
 export interface MessagesUsage {
   input_tokens: number;


### PR DESCRIPTION
## Problem

Messages usage `iterations` is an open upstream-owned structure. The snapshot helper copied only known nesting, leaving unknown objects and arrays shared with the source event.

## Change

- Use `structuredClone` for non-null iteration arrays.
- Preserve the explicit `null` contract and whole-array replacement during usage merges.
- Cover nested unknown object and array metadata in initial snapshots and merge deltas.

## Test Plan

- [x] `pnpm --filter @floway-dev/protocols run test` — 189 passed
- [x] `pnpm --filter @floway-dev/protocols run typecheck`
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
