### PR TITLE
refactor(gateway): use uniqWith for candidate resolution

### DIFF
--- a/packages/gateway/__tests__/data-plane/providers/resolution_test.ts
+++ b/packages/gateway/__tests__/data-plane/providers/resolution_test.ts
@@ -556,6 +556,38 @@ describe('enumerateModelCandidates alias walk (flat + dedup)', () => {
     );
   });
 
+  test('keeps the first representative in its original position when duplicate bindings are interleaved', async () => {
+    clearInFlightForTesting();
+    const { repo } = await setupAppTest();
+    await seedUpstreams(repo);
+    await repo.modelAliases.insert({
+      id: 'alias_interleaved-duplicates',
+      name: 'interleaved-duplicates', kind: 'chat', selection: 'first-available',
+      targets: [
+        { target_model_id: 'gpt-5', rules: { reasoning: { effort: 'low' } } },
+        { target_model_id: 'claude', rules: { reasoning: { effort: 'high' } } },
+        { target_model_id: 'gpt-5', rules: { reasoning: { effort: 'low' } } },
+      ],
+      ...aliasCommon,
+    });
+
+    await withMockedFetch(
+      buildCatalogFetch({ up_a: ['gpt-5'], up_b: ['claude'] }),
+      async () => {
+        const resolved = await enumerateModelCandidates({
+          upstreamIds: null, model: 'interleaved-duplicates', kind: 'chat', scheduler: testScheduler, runtimeLocation: 'TEST',
+        });
+        expect(resolved.candidates.map(candidate => ({
+          binding: `${candidate.model.id}@${candidate.provider.upstreamId}`,
+          effort: candidate.rules?.reasoning?.effort,
+        }))).toEqual([
+          { binding: 'gpt-5@up_a', effort: 'low' },
+          { binding: 'claude@up_b', effort: 'high' },
+        ]);
+      },
+    );
+  });
+
   test('keeps two entries for the same (model, upstream) with distinct rules', async () => {
     clearInFlightForTesting();
     const { repo } = await setupAppTest();

--- a/packages/gateway/src/data-plane/providers/resolution.ts
+++ b/packages/gateway/src/data-plane/providers/resolution.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'es-toolkit';
+import { isEqual, uniqWith } from 'es-toolkit';
 
 import { internalModelFromProviderModel } from './catalog.ts';
 import { fetchUpstreamModelsCached } from './models-cache.ts';
@@ -229,14 +229,10 @@ export const enumerateModelCandidates = async ({
       flat.push({ ...candidate, rules: target.rules });
     }
   }
-  const deduped: ModelCandidate[] = [];
-  for (const candidate of flat) {
-    const duplicate = deduped.some(existing =>
-      existing.model.id === candidate.model.id
-      && existing.provider.upstreamId === candidate.provider.upstreamId
-      && isEqual(existing.rules, candidate.rules));
-    if (!duplicate) deduped.push(candidate);
-  }
+  const deduped = uniqWith(flat, (candidate, existing) =>
+    candidate.model.id === existing.model.id
+    && candidate.provider.upstreamId === existing.provider.upstreamId
+    && isEqual(candidate.rules, existing.rules));
   return {
     candidates: deduped,
     sawModel: sawAny,


### PR DESCRIPTION
## Purpose

Candidate resolution implemented a local `uniqWith` loop even though the gateway already directly depends on `es-toolkit` and uses its `isEqual` in the same comparator.

## Change

- Use `es-toolkit`'s `uniqWith` for generic first-representative deduplication.
- Preserve the comparator over model id, upstream id, and rule equality.
- Pin original ordering with interleaved duplicates.

## Test Plan

- [x] Candidate resolution suite — 16 passed
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
