### PR TITLE
fix(gateway): reject arrays at JSON object boundaries

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import type { ChatCompletionsInvocation } from '../../../../../src/data-plane/chat/chat-completions/interceptors/types.ts';
 import { withVendorDeepSeekChatCompletionsNormalize } from '../../../../../src/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize.ts';
@@ -341,6 +341,19 @@ test('replaces array-shaped prompt_tokens_details without copying array indices'
   if (frame.type !== 'event') throw new Error('expected event frame');
   const usage = usageRecord(frame.event.usage!);
   assertEquals(usage.prompt_tokens_details, { cached_tokens: 70 });
+});
+
+test('propagates upstream stream errors unchanged', async () => {
+  const failure = new Error('upstream stream failed');
+  const result = await withVendorDeepSeekChatCompletionsNormalize(invocation(baseRequest()), stubCtx, () =>
+    Promise.resolve(eventResult(
+      (async function* () {
+        throw failure;
+      })(),
+      testTelemetryModelIdentity,
+    )));
+
+  await expect(collectFrames(result)).rejects.toBe(failure);
 });
 
 // ── Pass-through ──

--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
@@ -311,6 +311,37 @@ test('rewrites prompt_cache_hit_tokens/prompt_cache_miss_tokens into prompt_toke
   assertEquals('prompt_cache_miss_tokens' in usage, false);
 });
 
+test('replaces array-shaped prompt_tokens_details without copying array indices', async () => {
+  const ctx = invocation(baseRequest());
+  const result = await withVendorDeepSeekChatCompletionsNormalize(ctx, stubCtx, () =>
+    Promise.resolve(eventResult(
+      (async function* () {
+        yield eventFrame({
+          id: 'x',
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'deepseek-test',
+          choices: [],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            total_tokens: 120,
+            prompt_cache_hit_tokens: 70,
+            prompt_cache_miss_tokens: 30,
+            prompt_tokens_details: [{ cached_tokens: 1 }],
+          } as unknown as ChatCompletionsStreamEvent['usage'],
+        });
+      })(),
+      testTelemetryModelIdentity,
+    )));
+
+  const frames = await collectFrames(result);
+  const frame = frames[0];
+  if (frame.type !== 'event') throw new Error('expected event frame');
+  const usage = usageRecord(frame.event.usage!);
+  assertEquals(usage.prompt_tokens_details, { cached_tokens: 70 });
+});
+
 // ── Pass-through ──
 
 test('leaves protocol done frames untouched', async () => {

--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-deepseek-normalize_test.ts
@@ -294,6 +294,7 @@ test('rewrites prompt_cache_hit_tokens/prompt_cache_miss_tokens into prompt_toke
             total_tokens: 120,
             prompt_cache_hit_tokens: 70,
             prompt_cache_miss_tokens: 30,
+            prompt_tokens_details: { upstream_metric: 'preserved' },
           } as unknown as ChatCompletionsStreamEvent['usage'],
         });
       })(),
@@ -306,7 +307,7 @@ test('rewrites prompt_cache_hit_tokens/prompt_cache_miss_tokens into prompt_toke
   if (frame.type !== 'event') throw new Error('expected event frame');
   const usage = usageRecord(frame.event.usage!);
   assertEquals(usage.prompt_tokens, 100);
-  assertEquals(usage.prompt_tokens_details, { cached_tokens: 70 });
+  assertEquals(usage.prompt_tokens_details, { upstream_metric: 'preserved', cached_tokens: 70 });
   assertEquals('prompt_cache_hit_tokens' in usage, false);
   assertEquals('prompt_cache_miss_tokens' in usage, false);
 });

--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import type { ChatCompletionsInvocation } from '../../../../../src/data-plane/chat/chat-completions/interceptors/types.ts';
 import { withVendorKimiChatCompletionsNormalize } from '../../../../../src/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize.ts';
@@ -88,6 +88,19 @@ test('replaces array-shaped prompt_tokens_details without copying array indices'
   if (frame.type !== 'event') throw new Error('expected event frame');
   const usage = usageRecord(frame.event.usage!);
   assertEquals(usage.prompt_tokens_details, { cached_tokens: 50 });
+});
+
+test('propagates upstream stream errors unchanged', async () => {
+  const failure = new Error('upstream stream failed');
+  const result = await withVendorKimiChatCompletionsNormalize(invocation(baseRequest()), stubCtx, () =>
+    Promise.resolve(eventResult(
+      (async function* () {
+        throw failure;
+      })(),
+      testTelemetryModelIdentity,
+    )));
+
+  await expect(collectFrames(result)).rejects.toBe(failure);
 });
 
 test('early-returns when its flag is not set on the candidate', async () => {

--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
@@ -59,6 +59,36 @@ test('rewrites flat cached_tokens into prompt_tokens_details.cached_tokens', asy
   assertEquals('cached_tokens' in usage, false);
 });
 
+test('replaces array-shaped prompt_tokens_details without copying array indices', async () => {
+  const ctx = invocation(baseRequest());
+  const result = await withVendorKimiChatCompletionsNormalize(ctx, stubCtx, () =>
+    Promise.resolve(eventResult(
+      (async function* () {
+        yield eventFrame({
+          id: 'x',
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'kimi-test',
+          choices: [],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            total_tokens: 120,
+            cached_tokens: 50,
+            prompt_tokens_details: [{ cached_tokens: 1 }],
+          } as unknown as ChatCompletionsStreamEvent['usage'],
+        });
+      })(),
+      testTelemetryModelIdentity,
+    )));
+
+  const frames = await collectFrames(result);
+  const frame = frames[0];
+  if (frame.type !== 'event') throw new Error('expected event frame');
+  const usage = usageRecord(frame.event.usage!);
+  assertEquals(usage.prompt_tokens_details, { cached_tokens: 50 });
+});
+
 test('early-returns when its flag is not set on the candidate', async () => {
   const ctx = invocation(baseRequest(), new Set());
   const result = await withVendorKimiChatCompletionsNormalize(ctx, stubCtx, () =>

--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/interceptors/vendor-kimi-normalize_test.ts
@@ -44,6 +44,7 @@ test('rewrites flat cached_tokens into prompt_tokens_details.cached_tokens', asy
             completion_tokens: 20,
             total_tokens: 120,
             cached_tokens: 50,
+            prompt_tokens_details: { upstream_metric: 'preserved' },
           } as unknown as ChatCompletionsStreamEvent['usage'],
         });
       })(),
@@ -55,7 +56,7 @@ test('rewrites flat cached_tokens into prompt_tokens_details.cached_tokens', asy
   const frame = frames[0];
   if (frame.type !== 'event') throw new Error('expected event frame');
   const usage = usageRecord(frame.event.usage!);
-  assertEquals(usage.prompt_tokens_details, { cached_tokens: 50 });
+  assertEquals(usage.prompt_tokens_details, { upstream_metric: 'preserved', cached_tokens: 50 });
   assertEquals('cached_tokens' in usage, false);
 });
 

--- a/packages/gateway/src/shared/json-helpers.ts
+++ b/packages/gateway/src/shared/json-helpers.ts
@@ -1,5 +1,7 @@
-export { isJsonObject, type JsonObject } from '@floway-dev/protocols/common';
+import { isJsonObject, type JsonObject } from '@floway-dev/protocols/common';
 
-export const asJsonObject = (value: unknown): Record<string, unknown> | null => (value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null);
+export { isJsonObject, type JsonObject };
+
+export const asJsonObject = (value: unknown): JsonObject | null => (isJsonObject(value) ? value : null);
 
 export const readJsonNumber = (value: unknown): number | null => (typeof value === 'number' ? value : null);


### PR DESCRIPTION
## Problem

The gateway's duplicate JSON object guard accepted arrays. Vendor usage normalization could then spread an array into numeric object keys while adding canonical token-detail fields.

## Change

- Delegate to the shared strict `isJsonObject` helper.
- Reject arrays while preserving ordinary unknown object fields.
- Preserve original stream-error identity.
- Cover array-shaped Kimi and DeepSeek detail payloads.

## Test Plan

- [x] Targeted vendor normalization suites — 18 passed
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
