### PR TITLE
refactor(gateway): generate dump cursors with ulid

### DIFF
--- a/packages/gateway/__tests__/shared/ulid_test.ts
+++ b/packages/gateway/__tests__/shared/ulid_test.ts
@@ -10,12 +10,16 @@ const loadUlid = async () => {
   return (await import('../../src/shared/ulid.ts')).ulid;
 };
 
-test('ulid produces a canonical identifier for an explicit epoch timestamp', async () => {
+test('ulid produces canonical, increasing ids for an explicit epoch timestamp', async () => {
   const ulid = await loadUlid();
-  const id = ulid(0);
+  const a = ulid(0);
+  const b = ulid(0);
 
-  assertEquals(/^[0-9A-HJKMNP-TV-Z]{26}$/.test(id), true);
-  assertEquals(decodeTime(id), 0);
+  assertEquals(/^[0-9A-HJKMNP-TV-Z]{26}$/.test(a), true);
+  assertEquals(/^[0-9A-HJKMNP-TV-Z]{26}$/.test(b), true);
+  assertEquals(a < b, true);
+  assertEquals(decodeTime(a), 0);
+  assertEquals(decodeTime(b), 0);
 });
 
 test('ulid produces strictly increasing ids within the same millisecond', async () => {

--- a/packages/gateway/__tests__/shared/ulid_test.ts
+++ b/packages/gateway/__tests__/shared/ulid_test.ts
@@ -1,19 +1,25 @@
 import { decodeTime } from 'ulid';
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 
-import { ulid } from '../../src/shared/ulid.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 const TIMESTAMP = 2_000_000_000_000;
 
-test('ulid produces a canonical identifier for an explicit epoch timestamp', () => {
+const loadUlid = async () => {
+  vi.resetModules();
+  return (await import('../../src/shared/ulid.ts')).ulid;
+};
+
+test('ulid produces a canonical identifier for an explicit epoch timestamp', async () => {
+  const ulid = await loadUlid();
   const id = ulid(0);
 
   assertEquals(/^[0-9A-HJKMNP-TV-Z]{26}$/.test(id), true);
   assertEquals(decodeTime(id), 0);
 });
 
-test('ulid produces strictly increasing ids within the same millisecond', () => {
+test('ulid produces strictly increasing ids within the same millisecond', async () => {
+  const ulid = await loadUlid();
   const a = ulid(TIMESTAMP);
   const b = ulid(TIMESTAMP);
   const c = ulid(TIMESTAMP);
@@ -25,7 +31,8 @@ test('ulid produces strictly increasing ids within the same millisecond', () => 
   assertEquals(decodeTime(c), TIMESTAMP);
 });
 
-test('ulid encodes and orders consecutive milliseconds', () => {
+test('ulid encodes and orders consecutive milliseconds', async () => {
+  const ulid = await loadUlid();
   const a = ulid(TIMESTAMP + 1);
   const b = ulid(TIMESTAMP + 2);
 
@@ -34,7 +41,8 @@ test('ulid encodes and orders consecutive milliseconds', () => {
   assertEquals(decodeTime(b), TIMESTAMP + 2);
 });
 
-test('ulid produces strictly increasing ids when the clock rewinds', () => {
+test('ulid produces strictly increasing ids when the clock rewinds', async () => {
+  const ulid = await loadUlid();
   const a = ulid(TIMESTAMP + 3);
   const b = ulid(TIMESTAMP - 1_000);
   const c = ulid(TIMESTAMP - 2_000);

--- a/packages/gateway/__tests__/shared/ulid_test.ts
+++ b/packages/gateway/__tests__/shared/ulid_test.ts
@@ -1,23 +1,46 @@
+import { decodeTime } from 'ulid';
 import { test } from 'vitest';
 
 import { ulid } from '../../src/shared/ulid.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
+const TIMESTAMP = 2_000_000_000_000;
+
+test('ulid produces a canonical identifier for an explicit epoch timestamp', () => {
+  const id = ulid(0);
+
+  assertEquals(/^[0-9A-HJKMNP-TV-Z]{26}$/.test(id), true);
+  assertEquals(decodeTime(id), 0);
+});
+
 test('ulid produces strictly increasing ids within the same millisecond', () => {
-  const t = 1_700_000_000_000;
-  const a = ulid(t);
-  const b = ulid(t);
-  const c = ulid(t);
+  const a = ulid(TIMESTAMP);
+  const b = ulid(TIMESTAMP);
+  const c = ulid(TIMESTAMP);
+
   assertEquals(a < b, true);
   assertEquals(b < c, true);
+  assertEquals(decodeTime(a), TIMESTAMP);
+  assertEquals(decodeTime(b), TIMESTAMP);
+  assertEquals(decodeTime(c), TIMESTAMP);
+});
+
+test('ulid encodes and orders consecutive milliseconds', () => {
+  const a = ulid(TIMESTAMP + 1);
+  const b = ulid(TIMESTAMP + 2);
+
+  assertEquals(a < b, true);
+  assertEquals(decodeTime(a), TIMESTAMP + 1);
+  assertEquals(decodeTime(b), TIMESTAMP + 2);
 });
 
 test('ulid produces strictly increasing ids when the clock rewinds', () => {
-  // Step forward, then back: the cursor contract requires the rewound call
-  // to still sort AFTER the previous max so a paged list never loses rows.
-  const a = ulid(1_700_000_000_000);
-  const b = ulid(1_699_999_999_000);
-  const c = ulid(1_699_999_998_000);
+  const a = ulid(TIMESTAMP + 3);
+  const b = ulid(TIMESTAMP - 1_000);
+  const c = ulid(TIMESTAMP - 2_000);
+
   assertEquals(a < b, true);
   assertEquals(b < c, true);
+  assertEquals(decodeTime(b), TIMESTAMP + 3);
+  assertEquals(decodeTime(c), TIMESTAMP + 3);
 });

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -60,6 +60,7 @@
     "es-toolkit": "^1.49.0",
     "hono": "^4",
     "jsonrepair": "^3.14.0",
+    "ulid": "^3.0.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/gateway/src/shared/ulid.ts
+++ b/packages/gateway/src/shared/ulid.ts
@@ -1,70 +1,17 @@
-// 26-character Crockford Base32 ULID — 10 chars of millisecond timestamp
-// followed by 16 chars of randomness. Lexical order matches creation order
-// (within the same millisecond, randomness breaks ties), which lets us use
-// the id itself as a stable, monotonically-increasing cursor for record
-// pagination without a separate sequence number.
-//
-// Spec: https://github.com/ulid/spec
+import { encodeTime, monotonicFactory, TIME_LEN } from 'ulid';
 
-const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
-const ENCODING_LEN = ENCODING.length;
-const TIME_LEN = 10;
-const RANDOM_LEN = 16;
-
+const generateUlid = monotonicFactory();
 let lastTimestamp = -1;
-let lastRandom: number[] = [];
-
-const encodeTime = (now: number): string => {
-  let out = '';
-  for (let i = TIME_LEN - 1; i >= 0; i--) {
-    const mod = now % ENCODING_LEN;
-    out = ENCODING[mod]! + out;
-    now = (now - mod) / ENCODING_LEN;
-  }
-  return out;
-};
-
-const randomBytes = (n: number): number[] => {
-  const bytes = new Uint8Array(n);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, b => b % ENCODING_LEN);
-};
-
-const incrementRandom = (chars: number[]): number[] => {
-  // Carry-propagating +1 on the random tail. Used when two ULID calls land
-  // in the same millisecond — preserves the monotonic-within-ms invariant
-  // the cursor contract depends on without a separate counter. Overflow
-  // (>32^16 ≈ 10^24 ULIDs in the same ms) is physically unreachable, so we
-  // let the loop fall off the end and throw rather than papering over it.
-  for (let i = chars.length - 1; i >= 0; i--) {
-    if (chars[i]! < ENCODING_LEN - 1) {
-      chars[i]!++;
-      return chars;
-    }
-    chars[i] = 0;
-  }
-  throw new Error('ulid: random-tail overflow within a single millisecond');
-};
-
-const encodeChars = (chars: readonly number[]): string => {
-  let out = '';
-  for (const c of chars) out += ENCODING[c];
-  return out;
-};
 
 export const ulid = (now: number = Date.now()): string => {
-  // Treat any clock rewind (NTP step, container snapshot restore, etc.) as
-  // a same-ms collision: keep the previous timestamp and bump randomness.
-  // Without this guard a backwards-stepping clock produces ULIDs that sort
-  // BEFORE their predecessors, breaking the cursor contract.
-  const effective = now > lastTimestamp ? now : lastTimestamp;
-  let random: number[];
-  if (effective === lastTimestamp) {
-    random = incrementRandom([...lastRandom]);
-  } else {
-    random = randomBytes(RANDOM_LEN);
-  }
-  lastTimestamp = effective;
-  lastRandom = random;
-  return encodeTime(effective) + encodeChars(random);
+  const timestamp = Math.max(now, lastTimestamp);
+  lastTimestamp = timestamp;
+
+  // monotonicFactory treats zero as an omitted seed. Seed its state at one
+  // while retaining the explicit Unix-epoch timestamp supported by this API.
+  // https://github.com/ulid/javascript/blob/11c2067821ee19e4dc787ca4e0125a025485edc6/source/ulid.ts#L154-L165
+  const generated = generateUlid(timestamp === 0 ? 1 : timestamp);
+  return timestamp === 0
+    ? encodeTime(0) + generated.slice(TIME_LEN)
+    : generated;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
+      ulid:
+        specifier: ^3.0.2
+        version: 3.0.2
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4751,6 +4754,10 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
+    hasBin: true
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -10292,6 +10299,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
+
+  ulid@3.0.2: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
## Purpose

Dump cursors maintained a complete local ULID implementation. The maintained `ulid` package provides the same monotonic identifier contract.

## Change

- Generate cursor ids with one `monotonicFactory()` instance.
- Preserve canonical shape, decoded timestamps, same-millisecond order, and clock-rewind order.
- Preserve the helper's explicit Unix-epoch seed behavior.

## Test Plan

- [x] Dump cursor and expiration tests
- [x] Gateway typecheck
- [x] Changed-file lint and diff checks
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
