### PR TITLE
refactor(proxy): encode IP literals with ipaddr.js

### DIFF
--- a/packages/proxy/__tests__/bytes_test.ts
+++ b/packages/proxy/__tests__/bytes_test.ts
@@ -23,7 +23,7 @@ describe('encodeAtypAddress — strict IP literal boundaries', () => {
     '0x7f.0.0.1',
     '127.00.0.1',
     '256.0.0.1',
-  ])('does not reinterpret non-canonical IPv4 %s as an address literal', (host) => {
+  ])('does not reinterpret non-canonical IPv4 %s as an address literal', host => {
     const encoded = encodeAtypAddress(host, SOCKS_ATYP);
     expect(encoded[0]).toBe(0x03);
     expect(encoded[1]).toBe(host.length);
@@ -45,7 +45,7 @@ describe('encodeAtypAddress — strict IP literal boundaries', () => {
     'fe80::1%25eth0',
     '::ffff:192.168.001.1',
     '::ffff:0xc0.168.1.1',
-  ])('keeps scoped or non-canonical IPv6 %s off the literal path', (host) => {
+  ])('keeps scoped or non-canonical IPv6 %s off the literal path', host => {
     const encoded = encodeAtypAddress(host, SOCKS_ATYP);
     expect(encoded[0]).toBe(0x03);
     expect(new TextDecoder().decode(encoded.subarray(2))).toBe(host);

--- a/packages/proxy/__tests__/bytes_test.ts
+++ b/packages/proxy/__tests__/bytes_test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { encodeAtypAddress } from '../src/bytes.ts';
+
+const SOCKS_ATYP = { v4: 0x01, domain: 0x03, v6: 0x04 };
+const VLESS_ATYP = { v4: 0x01, domain: 0x02, v6: 0x03 };
+
+const bytes = (value: Uint8Array): number[] => Array.from(value);
+
+describe('encodeAtypAddress — strict IP literal boundaries', () => {
+  it.each([
+    ['0.0.0.0', [0, 0, 0, 0]],
+    ['1.2.3.4', [1, 2, 3, 4]],
+    ['255.255.255.255', [255, 255, 255, 255]],
+  ] as const)('encodes four-part decimal IPv4 %s as raw octets', (host, octets) => {
+    expect(bytes(encodeAtypAddress(host, SOCKS_ATYP))).toEqual([0x01, ...octets]);
+  });
+
+  it.each([
+    '127.1',
+    '2130706433',
+    '0177.0.0.1',
+    '0x7f.0.0.1',
+    '127.00.0.1',
+    '256.0.0.1',
+  ])('does not reinterpret non-canonical IPv4 %s as an address literal', (host) => {
+    const encoded = encodeAtypAddress(host, SOCKS_ATYP);
+    expect(encoded[0]).toBe(0x03);
+    expect(encoded[1]).toBe(host.length);
+    expect(new TextDecoder().decode(encoded.subarray(2))).toBe(host);
+  });
+
+  it.each([
+    ['::', new Array<number>(16).fill(0)],
+    ['::1', [...new Array<number>(15).fill(0), 1]],
+    ['2001:db8:0:1:2:3:4:5', [0x20, 0x01, 0x0d, 0xb8, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5]],
+    ['ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', new Array<number>(16).fill(0xff)],
+    ['::ffff:192.0.2.128', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 0, 2, 128]],
+  ] as const)('encodes IPv6 %s as 16 network-order octets', (host, octets) => {
+    expect(bytes(encodeAtypAddress(host, SOCKS_ATYP))).toEqual([0x04, ...octets]);
+  });
+
+  it.each([
+    'fe80::1%eth0',
+    'fe80::1%25eth0',
+    '::ffff:192.168.001.1',
+    '::ffff:0xc0.168.1.1',
+  ])('keeps scoped or non-canonical IPv6 %s off the literal path', (host) => {
+    const encoded = encodeAtypAddress(host, SOCKS_ATYP);
+    expect(encoded[0]).toBe(0x03);
+    expect(new TextDecoder().decode(encoded.subarray(2))).toBe(host);
+  });
+});
+
+describe('encodeAtypAddress — protocol ATYP parity', () => {
+  it.each([
+    ['SOCKS5', SOCKS_ATYP],
+    ['Shadowsocks', SOCKS_ATYP],
+    ['Shadowsocks 2022', SOCKS_ATYP],
+    ['Trojan', SOCKS_ATYP],
+    ['VLESS', VLESS_ATYP],
+  ] as const)('preserves %s IPv4/domain/IPv6 discriminants', (_protocol, atyp) => {
+    expect(bytes(encodeAtypAddress('1.2.3.4', atyp))).toEqual([atyp.v4, 1, 2, 3, 4]);
+    expect(bytes(encodeAtypAddress('::1', atyp))).toEqual([
+      atyp.v6,
+      0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 1,
+    ]);
+
+    const domain = encodeAtypAddress('example.com', atyp);
+    expect(domain[0]).toBe(atyp.domain);
+    expect(domain[1]).toBe(11);
+    expect(new TextDecoder().decode(domain.subarray(2))).toBe('example.com');
+  });
+});

--- a/packages/proxy/__tests__/bytes_test.ts
+++ b/packages/proxy/__tests__/bytes_test.ts
@@ -35,9 +35,25 @@ describe('encodeAtypAddress — strict IP literal boundaries', () => {
     ['::1', [...new Array<number>(15).fill(0), 1]],
     ['2001:db8:0:1:2:3:4:5', [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5]],
     ['ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', new Array<number>(16).fill(0xff)],
-    ['::ffff:192.0.2.128', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 0, 2, 128]],
   ] as const)('encodes IPv6 %s as 16 network-order octets', (host, octets) => {
     expect(bytes(encodeAtypAddress(host, SOCKS_ATYP))).toEqual([0x04, ...octets]);
+  });
+
+  it('preserves the distinct wire bits of IPv4-compatible and IPv4-mapped IPv6', () => {
+    const compatible = bytes(encodeAtypAddress('::192.0.2.128', SOCKS_ATYP));
+    const mapped = bytes(encodeAtypAddress('::ffff:192.0.2.128', SOCKS_ATYP));
+
+    expect(compatible).toEqual([
+      0x04,
+      0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 192, 0, 2, 128,
+    ]);
+    expect(mapped).toEqual([
+      0x04,
+      0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0xff, 0xff, 192, 0, 2, 128,
+    ]);
+    expect(compatible).not.toEqual(mapped);
   });
 
   it.each([

--- a/packages/proxy/__tests__/bytes_test.ts
+++ b/packages/proxy/__tests__/bytes_test.ts
@@ -33,7 +33,7 @@ describe('encodeAtypAddress — strict IP literal boundaries', () => {
   it.each([
     ['::', new Array<number>(16).fill(0)],
     ['::1', [...new Array<number>(15).fill(0), 1]],
-    ['2001:db8:0:1:2:3:4:5', [0x20, 0x01, 0x0d, 0xb8, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5]],
+    ['2001:db8:0:1:2:3:4:5', [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5]],
     ['ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', new Array<number>(16).fill(0xff)],
     ['::ffff:192.0.2.128', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 0, 2, 128]],
   ] as const)('encodes IPv6 %s as 16 network-order octets', (host, octets) => {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -32,6 +32,7 @@
     "@floway-dev/http": "workspace:*",
     "@noble/ciphers": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@reclaimprotocol/tls": "0.1.2"
+    "@reclaimprotocol/tls": "0.1.2",
+    "ipaddr.js": "2.5.0"
   }
 }

--- a/packages/proxy/src/bytes.ts
+++ b/packages/proxy/src/bytes.ts
@@ -3,6 +3,8 @@
 // Buffers read from a transport-owned ReadableStream may be pooled or reused
 // by the runtime, so retained or downstream-enqueued bytes must own their memory.
 
+import ipaddr from 'ipaddr.js';
+
 /**
  * Allocate a fresh ArrayBuffer-backed Uint8Array detached from any
  * transport-owned backing storage so the consumer can hold or mutate it
@@ -124,69 +126,39 @@ export const base64DecodeBytes = (s: string): Uint8Array<ArrayBuffer> => {
   return out;
 };
 
-/**
- * Parse an IPv4 dotted-quad literal into 4 octets, or return null if `s`
- * isn't a literal IPv4. Strict: each component must be a decimal in
- * 0..255 with no leading zeros (the "no leading zeros" rule prevents
- * "0123" being read as 123 — some resolvers interpret leading zeros as
- * octal).
- */
-const parseIpv4Literal = (s: string): Uint8Array | null => {
-  if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(s)) return null;
-  const parts = s.split('.');
-  const out = new Uint8Array(4);
-  for (let i = 0; i < 4; i++) {
-    const p = parts[i]!;
-    if (p.length > 1 && p.startsWith('0')) return null;
-    const n = Number(p);
-    if (n > 255) return null;
-    out[i] = n;
-  }
-  return out;
-};
+type IpLiteral =
+  | { kind: 'ipv4'; bytes: Uint8Array<ArrayBuffer> }
+  | { kind: 'ipv6'; bytes: Uint8Array<ArrayBuffer> };
 
 /**
- * Parse an IPv6 literal into 16 octets, or return null if `s` isn't a
- * literal IPv6. Defers to the WHATWG `URL` parser, which has a fully
- * spec-compliant IPv6 grammar and handles `::`, IPv4-mapped suffixes
- * (`::ffff:1.2.3.4`), and the all-the-shapes cases that a regex couldn't
- * cover.
+ * Parse a canonical wire-safe IP literal. IPv4 remains restricted to four
+ * decimal components without leading zeroes: ipaddr.js intentionally accepts
+ * historical short, octal, and hexadecimal forms through its general parser,
+ * while proxy targets must not reinterpret those resolver-dependent strings.
+ * IPv6 zone IDs identify a local interface rather than an address that can be
+ * carried meaningfully to a remote proxy, so they stay on the domain path.
  */
-const parseIpv6Literal = (s: string): Uint8Array | null => {
-  // A plain IPv4 would parse as a `URL` hostname too but without colons —
-  // filter that out so this helper only ever returns IPv6 octets.
-  if (!s.includes(':')) return null;
-  let url: URL;
-  try {
-    url = new URL(`http://[${s}]/`);
-  } catch {
-    return null;
+const parseIpLiteral = (host: string): IpLiteral | null => {
+  if (ipaddr.IPv4.isValidFourPartDecimal(host)) {
+    return {
+      kind: 'ipv4',
+      bytes: Uint8Array.from(ipaddr.IPv4.parse(host).toByteArray()),
+    };
   }
-  // `url.hostname` is normalised — `[::1]` → `[::1]`. Strip the brackets,
-  // then expand to 16 octets via `ipv6StringToBytes` below.
-  const norm = url.hostname.slice(1, -1);
-  return ipv6StringToBytes(norm);
-};
 
-const ipv6StringToBytes = (s: string): Uint8Array => {
-  // Input always arrives via parseIpv6Literal → `new URL('http://[…]/').hostname`,
-  // and the WHATWG URL serializer collapses any IPv4-mapped tail into hex groups
-  // (`::ffff:1.2.3.4` → `[::ffff:102:304]`). The expansion below is therefore a
-  // pure hex-group parser.
-  const [left, right] = s.includes('::') ? s.split('::', 2) as [string, string] : [s, ''];
-  const leftParts = left === '' ? [] : left.split(':');
-  const rightParts = right === '' ? [] : right.split(':');
-  const groups: number[] = [];
-  for (const p of leftParts) groups.push(parseInt(p, 16));
-  const zerosNeeded = 8 - leftParts.length - rightParts.length;
-  for (let i = 0; i < zerosNeeded; i++) groups.push(0);
-  for (const p of rightParts) groups.push(parseInt(p, 16));
-  const out = new Uint8Array(16);
-  for (let i = 0; i < groups.length; i++) {
-    out[i * 2] = (groups[i]! >> 8) & 0xff;
-    out[i * 2 + 1] = groups[i]! & 0xff;
+  if (host.includes('%') || !ipaddr.IPv6.isValid(host)) return null;
+
+  // ipaddr.js accepts the same historical IPv4 spellings in an IPv6
+  // transitional tail. Keep the tail aligned with the strict IPv4 contract.
+  if (host.includes('.')) {
+    const ipv4Tail = host.slice(host.lastIndexOf(':') + 1);
+    if (!ipaddr.IPv4.isValidFourPartDecimal(ipv4Tail)) return null;
   }
-  return out;
+
+  return {
+    kind: 'ipv6',
+    bytes: Uint8Array.from(ipaddr.IPv6.parse(host).toByteArray()),
+  };
 };
 
 /**
@@ -216,18 +188,11 @@ export const encodeAtypAddress = (
   host: string,
   atyp: AtypBytes,
 ): Uint8Array<ArrayBuffer> => {
-  const v4 = parseIpv4Literal(host);
-  if (v4) {
-    const out = new Uint8Array(1 + 4);
-    out[0] = atyp.v4;
-    out.set(v4, 1);
-    return out;
-  }
-  const v6 = parseIpv6Literal(host);
-  if (v6) {
-    const out = new Uint8Array(1 + 16);
-    out[0] = atyp.v6;
-    out.set(v6, 1);
+  const literal = parseIpLiteral(host);
+  if (literal) {
+    const out = new Uint8Array(1 + literal.bytes.byteLength);
+    out[0] = literal.kind === 'ipv4' ? atyp.v4 : atyp.v6;
+    out.set(literal.bytes, 1);
     return out;
   }
   const dom = utf8Bytes(host);

--- a/packages/proxy/src/bytes.ts
+++ b/packages/proxy/src/bytes.ts
@@ -150,14 +150,23 @@ const parseIpLiteral = (host: string): IpLiteral | null => {
 
   // ipaddr.js accepts the same historical IPv4 spellings in an IPv6
   // transitional tail. Keep the tail aligned with the strict IPv4 contract.
+  let ipv6Host = host;
   if (host.includes('.')) {
     const ipv4Tail = host.slice(host.lastIndexOf(':') + 1);
     if (!ipaddr.IPv4.isValidFourPartDecimal(ipv4Tail)) return null;
+
+    // ipaddr.js treats bare IPv4-compatible `::192.0.2.128` as the
+    // IPv4-mapped `::ffff:192.0.2.128`. Turn an already-validated dotted tail
+    // into its two native IPv6 groups first so compatible and mapped forms
+    // retain their distinct wire bits.
+    const [a, b, c, d] = ipaddr.IPv4.parse(ipv4Tail).toByteArray();
+    const ipv6Prefix = host.slice(0, host.lastIndexOf(':') + 1);
+    ipv6Host = `${ipv6Prefix}${((a! << 8) | b!).toString(16)}:${((c! << 8) | d!).toString(16)}`;
   }
 
   return {
     kind: 'ipv6',
-    bytes: Uint8Array.from(ipaddr.IPv6.parse(host).toByteArray()),
+    bytes: Uint8Array.from(ipaddr.IPv6.parse(ipv6Host).toByteArray()),
   };
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
       '@reclaimprotocol/tls':
         specifier: 0.1.2
         version: 0.1.2(patch_hash=8ed07af54e914cbcc2cea19ce7109635092cbbe35b9d2ad1bf55e3dfef1b8fd6)
+      ipaddr.js:
+        specifier: 2.5.0
+        version: 2.5.0
 
   packages/test-utils:
     dependencies:
@@ -3672,6 +3675,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ipaddr.js@2.5.0:
+    resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
+    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -8854,6 +8861,8 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  ipaddr.js@2.5.0: {}
 
   is-alphabetical@2.0.1: {}
 


### PR DESCRIPTION
## Purpose

Proxy address framing maintained separate IPv4 and IPv6 parsers plus a network-order IPv6 encoder. Delegate generic literal mechanics to `ipaddr.js` while preserving Floway's stricter accepted language and exact ATYP wire bytes.

## Change

- Accept IPv4 only through the strict four-part decimal predicate.
- Reject IPv6 zone ids.
- Preserve distinct IPv4-compatible and IPv4-mapped IPv6 dotted-tail forms.
- Exercise identical bytes across SOCKS5, Shadowsocks, Shadowsocks 2022, Trojan, and VLESS.

## Test Plan

- [x] Proxy address and protocol suites
- [x] `pnpm --filter @floway-dev/proxy run typecheck`
- [x] Changed-file lint and diff checks
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
