### PR TITLE
refactor(copilot): delegate token retries to p-retry

### DIFF
--- a/packages/provider-copilot/__tests__/auth_test.ts
+++ b/packages/provider-copilot/__tests__/auth_test.ts
@@ -1,13 +1,20 @@
-import { test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { copilotAuthedFetch } from '../src/auth.ts';
 import { clearInProcessCopilotTokenCache } from '../src/index.ts';
 import type { CopilotUpstreamState } from '../src/state.ts';
-import { initProviderRepo, directFetcher, type UpstreamRecord, identityWrapUpstreamCall } from '@floway-dev/provider';
+import { initProviderRepo, directFetcher, type Fetcher, type UpstreamRecord, identityWrapUpstreamCall } from '@floway-dev/provider';
 import { assertEquals, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
 const UPSTREAM_ID = 'up_copilot_test';
 const TOKEN_BASE_URL = 'https://api.individual.githubcopilot.com';
+
+const tokenResponse = (): Response => jsonResponse({
+  token: 'tok-test',
+  expires_at: 4_102_444_800,
+  refresh_in: 1800,
+  endpoints: { api: TOKEN_BASE_URL },
+});
 
 const installRepoAndClearCache = async () => {
   let state: unknown = null;
@@ -76,6 +83,122 @@ const mockTokenAndCapture = async (
   if (!captured) throw new Error('upstream call never observed');
   assert(captured);
 };
+
+const runAuthedFetch = async (fetcher: Fetcher, signal?: AbortSignal): Promise<Response> => {
+  await installRepoAndClearCache();
+  return copilotAuthedFetch(
+    '/v1/messages',
+    { method: 'POST', body: '{}', signal },
+    { id: UPSTREAM_ID, githubToken: 'ghu_test' },
+    { fetcher, wrapUpstreamCall: identityWrapUpstreamCall },
+  );
+};
+
+describe('Copilot token exchange retries', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('makes four attempts after exact 1s, 2s, and 4s delays', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let tokenAttempts = 0;
+    const fetcher: Fetcher = async url => {
+      if (new URL(url).pathname !== '/copilot_internal/v2/token') return jsonResponse({});
+      tokenAttempts++;
+      if (tokenAttempts < 4) throw new Error(`transient ${tokenAttempts}`);
+      return tokenResponse();
+    };
+
+    const result = runAuthedFetch(fetcher);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tokenAttempts).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(tokenAttempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(tokenAttempts).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(tokenAttempts).toBe(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(tokenAttempts).toBe(3);
+
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(tokenAttempts).toBe(3);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toMatchObject({ status: 200 });
+    expect(tokenAttempts).toBe(4);
+    expect(warn.mock.calls).toEqual([
+      ['Retry 1/3 after 1000ms: transient 1'],
+      ['Retry 2/3 after 2000ms: transient 2'],
+      ['Retry 3/3 after 4000ms: transient 3'],
+    ]);
+  });
+
+  test.each([403, 429])('treats HTTP %i as terminal on the first attempt', async status => {
+    let tokenAttempts = 0;
+    const fetcher: Fetcher = async () => {
+      tokenAttempts++;
+      return new Response(`status ${status}`, { status });
+    };
+
+    await expect(runAuthedFetch(fetcher)).rejects.toMatchObject({
+      name: 'CopilotTokenFetchError',
+      status,
+      body: `status ${status}`,
+    });
+    expect(tokenAttempts).toBe(1);
+  });
+
+  test('preserves an AbortError thrown by the token fetcher without retrying', async () => {
+    const reason = new DOMException('fetch cancelled', 'AbortError');
+    let tokenAttempts = 0;
+    const fetcher: Fetcher = async () => {
+      tokenAttempts++;
+      throw reason;
+    };
+
+    await expect(runAuthedFetch(fetcher)).rejects.toBe(reason);
+    expect(tokenAttempts).toBe(1);
+  });
+
+  test('preserves an already-aborted signal reason without starting an attempt', async () => {
+    const controller = new AbortController();
+    const reason = new DOMException('already cancelled', 'AbortError');
+    controller.abort(reason);
+    let tokenAttempts = 0;
+    const fetcher: Fetcher = async () => {
+      tokenAttempts++;
+      return tokenResponse();
+    };
+
+    await expect(runAuthedFetch(fetcher, controller.signal)).rejects.toBe(reason);
+    expect(tokenAttempts).toBe(0);
+  });
+
+  test('preserves a signal reason when cancelled during backoff', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const controller = new AbortController();
+    const reason = new DOMException('cancelled during backoff', 'AbortError');
+    let tokenAttempts = 0;
+    const fetcher: Fetcher = async () => {
+      tokenAttempts++;
+      throw new Error('transient');
+    };
+
+    const result = runAuthedFetch(fetcher, controller.signal);
+    const rejection = expect(result).rejects.toBe(reason);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tokenAttempts).toBe(1);
+    controller.abort(reason);
+    await rejection;
+    expect(tokenAttempts).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
 
 test('copilotAuthedFetch overlays interceptor headers on the pinned base set', async () => {
   await mockTokenAndCapture(new Headers({ 'x-initiator': 'agent', 'copilot-vision-request': 'true' }), headers => {

--- a/packages/provider-copilot/__tests__/auth_test.ts
+++ b/packages/provider-copilot/__tests__/auth_test.ts
@@ -137,6 +137,45 @@ describe('Copilot token exchange retries', () => {
     ]);
   });
 
+  test.each([
+    { label: 'string', reason: 'proxy rejected', message: 'proxy rejected' },
+    { label: 'object', reason: { kind: 'proxy rejected' }, message: '[object Object]' },
+  ])('retries a non-Error $label rejection and finally preserves the original value', async ({ reason, message }) => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let tokenAttempts = 0;
+    const fetcher: Fetcher = async () => {
+      tokenAttempts++;
+      throw reason;
+    };
+
+    const result = runAuthedFetch(fetcher);
+    const rejection = expect(result).rejects.toBe(reason);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tokenAttempts).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(tokenAttempts).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(tokenAttempts).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(tokenAttempts).toBe(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(tokenAttempts).toBe(3);
+
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(tokenAttempts).toBe(3);
+    await vi.advanceTimersByTimeAsync(1);
+    await rejection;
+    expect(tokenAttempts).toBe(4);
+    expect(warn.mock.calls).toEqual([
+      [`Retry 1/3 after 1000ms: ${message}`],
+      [`Retry 2/3 after 2000ms: ${message}`],
+      [`Retry 3/3 after 4000ms: ${message}`],
+    ]);
+  });
+
   test.each([403, 429])('treats HTTP %i as terminal on the first attempt', async status => {
     let tokenAttempts = 0;
     const fetcher: Fetcher = async () => {

--- a/packages/provider-copilot/__tests__/auth_test.ts
+++ b/packages/provider-copilot/__tests__/auth_test.ts
@@ -86,7 +86,7 @@ const mockTokenAndCapture = async (
 
 const runAuthedFetch = async (fetcher: Fetcher, signal?: AbortSignal): Promise<Response> => {
   await installRepoAndClearCache();
-  return copilotAuthedFetch(
+  return await copilotAuthedFetch(
     '/v1/messages',
     { method: 'POST', body: '{}', signal },
     { id: UPSTREAM_ID, githubToken: 'ghu_test' },

--- a/packages/provider-copilot/__tests__/auth_test.ts
+++ b/packages/provider-copilot/__tests__/auth_test.ts
@@ -203,6 +203,18 @@ describe('Copilot token exchange retries', () => {
     expect(tokenAttempts).toBe(1);
   });
 
+  test('preserves a non-Error wrapper whose cause is an AbortError without retrying', async () => {
+    const reason = { cause: new DOMException('fetch cancelled', 'AbortError') };
+    let tokenAttempts = 0;
+    const fetcher: Fetcher = async () => {
+      tokenAttempts++;
+      throw reason;
+    };
+
+    await expect(runAuthedFetch(fetcher)).rejects.toBe(reason);
+    expect(tokenAttempts).toBe(1);
+  });
+
   test('preserves an already-aborted signal reason without starting an attempt', async () => {
     const controller = new AbortController();
     const reason = new DOMException('already cancelled', 'AbortError');

--- a/packages/provider-copilot/package.json
+++ b/packages/provider-copilot/package.json
@@ -4,7 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    ".": { "import": "./src/index.ts", "types": "./src/index.ts" }
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
@@ -13,7 +16,8 @@
     "@floway-dev/interceptor": "workspace:*",
     "@floway-dev/platform": "workspace:*",
     "@floway-dev/protocols": "workspace:*",
-    "@floway-dev/provider": "workspace:*"
+    "@floway-dev/provider": "workspace:*",
+    "p-retry": "^8.0.0"
   },
   "devDependencies": {
     "@floway-dev/test-utils": "workspace:*"

--- a/packages/provider-copilot/package.json
+++ b/packages/provider-copilot/package.json
@@ -4,10 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
-    }
+    ".": { "import": "./src/index.ts", "types": "./src/index.ts" }
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -78,14 +78,20 @@ class RetryableError extends Error {
   }
 }
 
+class NonErrorAbort extends Error {
+  constructor(readonly originalError: unknown) {
+    super(String(originalError), { cause: originalError });
+  }
+}
+
 const retryCopilotTokenFetch = async <T>(fn: () => Promise<T>, signal: AbortSignal | undefined): Promise<T> => {
   try {
     return await pRetry(async () => {
       try {
         return await fn();
       } catch (error) {
-        if (error instanceof Error && (isAbortError(error) || (isCopilotTokenFetchError(error) && isCopilotTokenFetchTerminalStatus(error.status)))) {
-          throw new RetryAbortError(error);
+        if (isAbortError(error) || (isCopilotTokenFetchError(error) && isCopilotTokenFetchTerminalStatus(error.status))) {
+          throw new RetryAbortError(error instanceof Error ? error : new NonErrorAbort(error));
         }
 
         // p-retry rejects non-network TypeErrors immediately and normalizes
@@ -108,6 +114,7 @@ const retryCopilotTokenFetch = async <T>(fn: () => Promise<T>, signal: AbortSign
     });
   } catch (error) {
     if (error instanceof RetryableError) throw error.originalError;
+    if (error instanceof NonErrorAbort) throw error.originalError;
     throw error;
   }
 }

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -72,9 +72,9 @@ export function clearInProcessCopilotTokenCache(): void {
   inProcessTokenCache.clear();
 }
 
-class RetryableTypeError extends Error {
-  constructor(readonly originalError: TypeError) {
-    super(originalError.message, { cause: originalError });
+class RetryableError extends Error {
+  constructor(readonly originalError: unknown) {
+    super(originalError instanceof Error ? originalError.message : String(originalError), { cause: originalError });
   }
 }
 
@@ -88,11 +88,11 @@ const retryCopilotTokenFetch = async <T>(fn: () => Promise<T>, signal: AbortSign
           throw new RetryAbortError(error);
         }
 
-        // p-retry deliberately rejects non-network TypeErrors immediately.
-        // The token exchange previously retried every non-terminal failure,
-        // and proxy fetchers can use TypeError for failures that the library's
-        // browser-message heuristic does not recognize.
-        if (error instanceof TypeError) throw new RetryableTypeError(error);
+        // p-retry rejects non-network TypeErrors immediately and normalizes
+        // non-Error rejections into terminal TypeErrors. The token exchange
+        // previously retried every non-terminal value, so both shapes travel
+        // through a retryable Error and are restored at the boundary.
+        if (!(error instanceof Error) || error instanceof TypeError) throw new RetryableError(error);
         throw error;
       }
     }, {
@@ -102,12 +102,12 @@ const retryCopilotTokenFetch = async <T>(fn: () => Promise<T>, signal: AbortSign
       signal,
       onFailedAttempt: ({ error, attemptNumber, retryDelay }) => {
         if (retryDelay === 0) return;
-        const cause = error instanceof RetryableTypeError ? error.originalError : error;
-        console.warn(`Retry ${attemptNumber}/3 after ${retryDelay}ms: ${cause.message}`);
+        const cause = error instanceof RetryableError ? error.originalError : error;
+        console.warn(`Retry ${attemptNumber}/3 after ${retryDelay}ms: ${cause instanceof Error ? cause.message : String(cause)}`);
       },
     });
   } catch (error) {
-    if (error instanceof RetryableTypeError) throw error.originalError;
+    if (error instanceof RetryableError) throw error.originalError;
     throw error;
   }
 }

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -1,6 +1,7 @@
-import { dispatchUpstreamFetch, getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
 import pRetry, { AbortError as RetryAbortError } from 'p-retry';
+
 import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
+import { dispatchUpstreamFetch, getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
 
 // Version constants pinned to a known-good fingerprint that mirrors what a
 // current VSCode Copilot Chat install sends. The Copilot Chat plugin version,

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -1,6 +1,6 @@
-import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
 import { dispatchUpstreamFetch, getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
 import pRetry, { AbortError as RetryAbortError } from 'p-retry';
+import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
 
 // Version constants pinned to a known-good fingerprint that mirrors what a
 // current VSCode Copilot Chat install sends. The Copilot Chat plugin version,
@@ -117,7 +117,7 @@ const retryCopilotTokenFetch = async <T>(fn: () => Promise<T>, signal: AbortSign
     if (error instanceof NonErrorAbort) throw error.originalError;
     throw error;
   }
-}
+};
 
 function isTokenValid(token: string | null, expiresAt: number): boolean {
   if (!token) return false;

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -1,5 +1,6 @@
 import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
 import { dispatchUpstreamFetch, getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
+import pRetry, { AbortError as RetryAbortError } from 'p-retry';
 
 // Version constants pinned to a known-good fingerprint that mirrors what a
 // current VSCode Copilot Chat install sends. The Copilot Chat plugin version,
@@ -71,44 +72,44 @@ export function clearInProcessCopilotTokenCache(): void {
   inProcessTokenCache.clear();
 }
 
-async function withRetry<T>(fn: () => Promise<T>, signal: AbortSignal | undefined, maxRetries = 3, baseDelayMs = 1000): Promise<T> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (e) {
-      // AbortError is a deliberate caller cancellation — propagate
-      // immediately rather than walk N retries with the same already-
-      // aborted signal, which would burn the proxy chain on each cycle.
-      if (isAbortError(e)) throw e;
-      if (isCopilotTokenFetchError(e) && isCopilotTokenFetchTerminalStatus(e.status)) {
-        throw e;
-      }
-      if (attempt >= maxRetries) throw e;
-      const delay = baseDelayMs * Math.pow(2, attempt);
-      console.warn(`Retry ${attempt + 1}/${maxRetries} after ${delay}ms: ${e instanceof Error ? e.message : String(e)}`);
-      // Honour the signal during backoff so a cancellation that fires
-      // mid-sleep also unwinds promptly. `{ once: true }` only fires-then-
-      // detaches; on the timer-resolve happy path we have to remove the
-      // listener ourselves, otherwise a long-lived caller signal (one
-      // shared across many retries / requests) accumulates one closure
-      // per sleep pinning the closed-over `reject`.
-      await new Promise<void>((resolve, reject) => {
-        let onAbort: (() => void) | null = null;
-        const timer = setTimeout(() => {
-          if (onAbort && signal) signal.removeEventListener('abort', onAbort);
-          resolve();
-        }, delay);
-        if (signal) {
-          onAbort = (): void => {
-            clearTimeout(timer);
-            reject(signal.reason ?? new DOMException('aborted', 'AbortError'));
-          };
-          signal.addEventListener('abort', onAbort, { once: true });
-        }
-      });
-    }
+class RetryableTypeError extends Error {
+  constructor(readonly originalError: TypeError) {
+    super(originalError.message, { cause: originalError });
   }
-  throw new Error('Unreachable');
+}
+
+const retryCopilotTokenFetch = async <T>(fn: () => Promise<T>, signal: AbortSignal | undefined): Promise<T> => {
+  try {
+    return await pRetry(async () => {
+      try {
+        return await fn();
+      } catch (error) {
+        if (error instanceof Error && (isAbortError(error) || (isCopilotTokenFetchError(error) && isCopilotTokenFetchTerminalStatus(error.status)))) {
+          throw new RetryAbortError(error);
+        }
+
+        // p-retry deliberately rejects non-network TypeErrors immediately.
+        // The token exchange previously retried every non-terminal failure,
+        // and proxy fetchers can use TypeError for failures that the library's
+        // browser-message heuristic does not recognize.
+        if (error instanceof TypeError) throw new RetryableTypeError(error);
+        throw error;
+      }
+    }, {
+      retries: 3,
+      factor: 2,
+      minTimeout: 1000,
+      signal,
+      onFailedAttempt: ({ error, attemptNumber, retryDelay }) => {
+        if (retryDelay === 0) return;
+        const cause = error instanceof RetryableTypeError ? error.originalError : error;
+        console.warn(`Retry ${attemptNumber}/3 after ${retryDelay}ms: ${cause.message}`);
+      },
+    });
+  } catch (error) {
+    if (error instanceof RetryableTypeError) throw error.originalError;
+    throw error;
+  }
 }
 
 function isTokenValid(token: string | null, expiresAt: number): boolean {
@@ -138,7 +139,7 @@ async function getCopilotToken(upstreamId: string, githubToken: string, fetcher:
   // proxy chain that carries the data-plane traffic; without this, a working
   // Copilot proxy would still see periodic auth-refresh failures every
   // ~25 minutes per process.
-  return await withRetry(async () => {
+  return await retryCopilotTokenFetch(async () => {
     const entry = await exchangeCopilotToken(githubToken, fetcher, signal);
     inProcessTokenCache.set(upstreamId, { entry, cachedAt: Date.now() });
     // Best-effort: the caller is about to satisfy a live request with this

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       '@floway-dev/provider':
         specifier: workspace:*
         version: link:../provider
+      p-retry:
+        specifier: ^8.0.0
+        version: 8.0.0
     devDependencies:
       '@floway-dev/test-utils':
         specifier: workspace:*
@@ -3748,6 +3751,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -4258,6 +4265,10 @@ packages:
   p-map@7.0.6:
     resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
     engines: {node: '>=18'}
+
+  p-retry@8.0.0:
+    resolution: {integrity: sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==}
+    engines: {node: '>=22'}
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
@@ -8934,6 +8945,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.3.2: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -9681,6 +9694,10 @@ snapshots:
       p-limit: 3.1.0
 
   p-map@7.0.6: {}
+
+  p-retry@8.0.0:
+    dependencies:
+      is-network-error: 1.3.2
 
   package-manager-detector@1.6.0: {}
 


### PR DESCRIPTION
## Problem

Copilot token exchange maintained a custom retry loop whose sleep missed an already-aborted signal, allowing a failed request to wait through another backoff.

## Change

- Use `p-retry` for four attempts with the existing 1, 2, and 4 second schedule.
- Propagate already-aborted and mid-backoff cancellation with the exact signal reason.
- Preserve terminal 403, 429, and AbortError behavior.
- Preserve warning text and final identity for arbitrary rejection values.

## Test Plan

- [x] Copilot token retry and cancellation suites
- [x] Provider Copilot typecheck
- [x] Changed-file lint and diff checks
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
