### PR TITLE
refactor(platform): delegate secret comparison to runtime crypto

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,11 +237,8 @@ middleware and do not receive a Hono `Context`/`Next` pair.
 The `@floway-dev/platform` package owns abstract runtime contracts
 (`FileStore`, `ChannelBroker`, `ImageCacheStore`, `RuntimeKind`,
 `ImageProcessor`, `ExternalResourceFetcher`, `SqlDatabase`,
-`BackgroundScheduler`, `EnvGetter`, `SocketDial`, `TimingSafeEqual`) and
-portable helpers. Each `apps/platform-*` app supplies concrete implementations
-and its own entry. The timing-safe boundary rejects unequal byte lengths before
-dispatch because both runtime primitives require equal lengths; equal-length
-secret comparison always reaches the runtime implementation.
+`BackgroundScheduler`, `EnvGetter`, `SocketDial`) and portable helpers. Each
+`apps/platform-*` app supplies concrete implementations and its own entry.
 
 ## Workspace Layout
 
@@ -307,11 +304,10 @@ Both `apps/platform-*` apps depend on `gateway` + `http` + `platform`. The
 Cloudflare app declares only the workerd surfaces it uses in local ambient
 files (`cloudflare-workers.d.ts`, `cloudflare-sockets.d.ts`, and
 `cf-websocket.d.ts`) and supplies D1, R2, Images, KV, Durable Object, socket,
-runtime-root-CA, and `crypto.subtle.timingSafeEqual` implementations. The Node
-app supplies `node:sqlite`, filesystem, `sharp`, WebSocket, socket,
-runtime-root-CA, and `node:crypto.timingSafeEqual` implementations; its migrator
-consumes the gateway's exported migration directory. These apps are the only
-deployment-target composition roots.
+and runtime-root-CA implementations. The Node app supplies `node:sqlite`,
+filesystem, `sharp`, WebSocket, socket, and runtime-root-CA implementations;
+its migrator consumes the gateway's exported migration directory. These apps
+are the only deployment-target composition roots.
 
 `apps/web` depends at runtime on `protocols`, `provider`, and `proxy`.
 Its protocol imports use `/common`, `/chat-completions`, `/completions`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,8 +237,11 @@ middleware and do not receive a Hono `Context`/`Next` pair.
 The `@floway-dev/platform` package owns abstract runtime contracts
 (`FileStore`, `ChannelBroker`, `ImageCacheStore`, `RuntimeKind`,
 `ImageProcessor`, `ExternalResourceFetcher`, `SqlDatabase`,
-`BackgroundScheduler`, `EnvGetter`, `SocketDial`) and portable helpers. Each
-`apps/platform-*` app supplies concrete implementations and its own entry.
+`BackgroundScheduler`, `EnvGetter`, `SocketDial`, `TimingSafeEqual`) and
+portable helpers. Each `apps/platform-*` app supplies concrete implementations
+and its own entry. The timing-safe boundary rejects unequal byte lengths before
+dispatch because both runtime primitives require equal lengths; equal-length
+secret comparison always reaches the runtime implementation.
 
 ## Workspace Layout
 
@@ -304,10 +307,11 @@ Both `apps/platform-*` apps depend on `gateway` + `http` + `platform`. The
 Cloudflare app declares only the workerd surfaces it uses in local ambient
 files (`cloudflare-workers.d.ts`, `cloudflare-sockets.d.ts`, and
 `cf-websocket.d.ts`) and supplies D1, R2, Images, KV, Durable Object, socket,
-and runtime-root-CA implementations. The Node app supplies `node:sqlite`,
-filesystem, `sharp`, WebSocket, socket, and runtime-root-CA implementations;
-its migrator consumes the gateway's exported migration directory. These apps
-are the only deployment-target composition roots.
+runtime-root-CA, and `crypto.subtle.timingSafeEqual` implementations. The Node
+app supplies `node:sqlite`, filesystem, `sharp`, WebSocket, socket,
+runtime-root-CA, and `node:crypto.timingSafeEqual` implementations; its migrator
+consumes the gateway's exported migration directory. These apps are the only
+deployment-target composition roots.
 
 `apps/web` depends at runtime on `protocols`, `provider`, and `proxy`.
 Its protocol imports use `/common`, `/chat-completions`, `/completions`,

--- a/apps/platform-cloudflare/__tests__/timing-safe-equal_test.ts
+++ b/apps/platform-cloudflare/__tests__/timing-safe-equal_test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { timingSafeEqual } from '../src/timing-safe-equal.ts';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Cloudflare timingSafeEqual adapter', () => {
+  it('delegates byte comparison to crypto.subtle.timingSafeEqual', () => {
+    const primitive = vi.fn(() => true);
+    vi.stubGlobal('crypto', { subtle: { timingSafeEqual: primitive } });
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([1, 2, 3]);
+
+    expect(timingSafeEqual(a, b)).toBe(true);
+    expect(primitive).toHaveBeenCalledWith(a, b);
+  });
+});

--- a/apps/platform-cloudflare/src/bootstrap.ts
+++ b/apps/platform-cloudflare/src/bootstrap.ts
@@ -5,6 +5,7 @@ import { KvImageCacheStore, type KvNamespace } from './kv-image-cache-store.ts';
 import { R2FileStore, type R2BucketLike } from './r2-file-store.ts';
 import { cloudflareRuntimeRootCAs } from './runtime-root-cas.ts';
 import { cloudflareSocketDial } from './socket-dial.ts';
+import { timingSafeEqual } from './timing-safe-equal.ts';
 import { FileDumpStore, initDumpBroker, initDumpStore } from '@floway-dev/gateway';
 import { dumpCodec } from '@floway-dev/gateway/dump-codec';
 import type { DumpMetadata } from '@floway-dev/gateway/dump-types';
@@ -18,6 +19,7 @@ import {
   initImageProcessor,
   initRuntimeKind,
   initSocketDial,
+  initTimingSafeEqual,
   type SqlDatabase,
 } from '@floway-dev/platform';
 
@@ -52,6 +54,7 @@ export const bootstrapCloudflarePlatform = (env: CloudflareEnv): { db: SqlDataba
     return value;
   });
   initRuntimeKind('cloudflare');
+  initTimingSafeEqual(timingSafeEqual);
   initExternalResourceFetcher(createCloudflareExternalResourceFetcher());
   const files = new R2FileStore(env.FILES);
   initFileStore(files);

--- a/apps/platform-cloudflare/src/cloudflare-workers.d.ts
+++ b/apps/platform-cloudflare/src/cloudflare-workers.d.ts
@@ -26,3 +26,9 @@ interface DurableObjectState {
   acceptWebSocket(server: WebSocket): void;
   getWebSockets(): WebSocket[];
 }
+
+// Cloudflare extends Web Crypto with a constant-time comparison primitive.
+// https://developers.cloudflare.com/workers/runtime-apis/web-crypto/#timingsafeequal
+interface SubtleCrypto {
+  timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean;
+}

--- a/apps/platform-cloudflare/src/timing-safe-equal.ts
+++ b/apps/platform-cloudflare/src/timing-safe-equal.ts
@@ -1,0 +1,3 @@
+import type { TimingSafeEqual } from '@floway-dev/platform';
+
+export const timingSafeEqual: TimingSafeEqual = (a, b) => crypto.subtle.timingSafeEqual(a, b);

--- a/apps/platform-node/__tests__/timing-safe-equal_test.ts
+++ b/apps/platform-node/__tests__/timing-safe-equal_test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { timingSafeEqual } from '../src/timing-safe-equal.ts';
+
+describe('Node timingSafeEqual adapter', () => {
+  it('delegates byte comparison to node:crypto', () => {
+    expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(true);
+    expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 4]))).toBe(false);
+  });
+});

--- a/apps/platform-node/src/bootstrap.ts
+++ b/apps/platform-node/src/bootstrap.ts
@@ -6,6 +6,7 @@ import { nodeRuntimeRootCAs } from './runtime-root-cas.ts';
 import { createSharpImageProcessor } from './sharp-image-processor.ts';
 import { nodeSocketDial } from './socket-dial.ts';
 import { SqliteImageCacheStore } from './sqlite-image-cache-store.ts';
+import { timingSafeEqual } from './timing-safe-equal.ts';
 import { FileDumpStore, initDumpBroker, initDumpStore } from '@floway-dev/gateway';
 import { dumpCodec } from '@floway-dev/gateway/dump-codec';
 import type { DumpMetadata } from '@floway-dev/gateway/dump-types';
@@ -20,12 +21,14 @@ import {
   initImageProcessor,
   initRuntimeKind,
   initSocketDial,
+  initTimingSafeEqual,
   type SqlDatabase,
 } from '@floway-dev/platform';
 
 export const bootstrapNodePlatform = (): { db: SqlDatabase } => {
   initEnv(name => process.env[name]);
   initRuntimeKind('node');
+  initTimingSafeEqual(timingSafeEqual);
   initExternalResourceFetcher(createNodeExternalResourceFetcher());
 
   const filesDir = getEnvOptional('FLOWAY_FILES_DIR', './data/files');

--- a/apps/platform-node/src/timing-safe-equal.ts
+++ b/apps/platform-node/src/timing-safe-equal.ts
@@ -1,0 +1,5 @@
+import { timingSafeEqual as nodeTimingSafeEqual } from 'node:crypto';
+
+import type { TimingSafeEqual } from '@floway-dev/platform';
+
+export const timingSafeEqual: TimingSafeEqual = (a, b) => nodeTimingSafeEqual(a, b);

--- a/packages/gateway/__tests__/control-plane/auth/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/auth/routes_test.ts
@@ -38,6 +38,16 @@ test('/auth/login with blank username + wrong ADMIN_KEY rejects', async () => {
   assertEquals(response.status, 401);
 });
 
+test('/auth/login rejects a same-length ADMIN_KEY mismatch', async () => {
+  await setupAppTest({ adminKey: 'real-admin' });
+  const response = await requestApp('/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: '', password: 'fake-admin' }),
+  });
+  assertEquals(response.status, 401);
+});
+
 // Zero-config passwordless admin login: with no ADMIN_KEY set, a brand-new
 // local instance still lets the operator in. The four cases below cover the
 // dev/prod matrix on both runtimes — dev accepts, prod refuses. Node prod

--- a/packages/gateway/__tests__/vitest.setup.ts
+++ b/packages/gateway/__tests__/vitest.setup.ts
@@ -4,7 +4,7 @@ import { initDumpBroker, initDumpStore } from '../src/dump/registry.ts';
 import type { DumpStore } from '../src/dump/store-contract.ts';
 import type { DumpMetadata, StoredDumpRecord, DumpRecordId } from '../src/dump/types.ts';
 import { initBackgroundSchedulerResolver } from '../src/runtime/background.ts';
-import { initEnv, initRuntimeKind } from '@floway-dev/platform';
+import { initEnv, initRuntimeKind, initTimingSafeEqual } from '@floway-dev/platform';
 
 // Production always initializes the environment getter at boot. Mirror that
 // here with a neutral default; tests needing real values (RUNTIME_LOCATION,
@@ -13,6 +13,7 @@ initEnv(() => '');
 // Tests run as 'node' by default. The few tests that exercise CF-specific
 // runtime behaviour re-init this with 'cloudflare'.
 initRuntimeKind('node');
+initTimingSafeEqual((a, b) => a.every((byte, index) => byte === b[index]));
 
 initBackgroundSchedulerResolver(_c => trackBackground);
 

--- a/packages/gateway/src/control-plane/auth/routes.ts
+++ b/packages/gateway/src/control-plane/auth/routes.ts
@@ -5,11 +5,10 @@ import { SEED_ADMIN_USER_ID } from '../../repo/seed-admin.ts';
 import type { User } from '../../repo/types.ts';
 import { isProductionRequest } from '../../runtime/is-production-request.ts';
 import { dummyPasswordHash, verifyPassword } from '../../shared/passwords.ts';
-import { timingSafeEqual } from '../../shared/timing-safe-equal.ts';
 import type { authLoginBody } from '../schemas.ts';
 import { loadKnownUpstreamIds } from '../shared/upstream-ids.ts';
 import { userToSessionWire } from '../users/wire.ts';
-import { getEnvOptional } from '@floway-dev/platform';
+import { getEnvOptional, timingSafeEqual } from '@floway-dev/platform';
 
 const resolveLoginUser = async (c: CtxWithJson<typeof authLoginBody>): Promise<User | null> => {
   const { username, password } = c.req.valid('json');

--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -2,8 +2,7 @@ import type { Context, Next } from 'hono';
 
 import { getRepo } from '../repo/index.ts';
 import type { ApiKey, User } from '../repo/types.ts';
-import { timingSafeEqual } from '../shared/timing-safe-equal.ts';
-import { getEnvOptional } from '@floway-dev/platform';
+import { getEnvOptional, timingSafeEqual } from '@floway-dev/platform';
 
 const PUBLIC_PATHS = new Set(['/api/health', '/favicon.ico']);
 const AUTH_VALIDATE_PATHS = new Set(['/auth/login']);

--- a/packages/gateway/src/shared/passwords.ts
+++ b/packages/gateway/src/shared/passwords.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from './timing-safe-equal.ts';
+import { timingSafeEqual } from '@floway-dev/platform';
 
 // Cloudflare Workers' Web Crypto refuses PBKDF2 with iterations above 100k as a
 // CPU-time DoS guard ("Pbkdf2 failed: iteration counts above 100000 are not

--- a/packages/gateway/src/shared/timing-safe-equal.ts
+++ b/packages/gateway/src/shared/timing-safe-equal.ts
@@ -1,6 +1,0 @@
-export const timingSafeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
-  return diff === 0;
-};

--- a/packages/platform/__tests__/timing-safe-equal_test.ts
+++ b/packages/platform/__tests__/timing-safe-equal_test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
-
-import { initTimingSafeEqual, resetTimingSafeEqualForTesting, timingSafeEqual } from '../src/timing-safe-equal.ts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('timingSafeEqual', () => {
-  it('delegates equal-length inputs to the runtime primitive', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('delegates equal-length inputs to the runtime primitive', async () => {
+    const { initTimingSafeEqual, timingSafeEqual } = await import('../src/timing-safe-equal.ts');
     const impl = vi.fn(() => true);
     const a = new Uint8Array([1, 2, 3]);
     const b = new Uint8Array([1, 2, 3]);
@@ -13,7 +16,8 @@ describe('timingSafeEqual', () => {
     expect(impl).toHaveBeenCalledWith(a, b);
   });
 
-  it('returns false for unequal lengths without calling the runtime primitive', () => {
+  it('returns false for unequal lengths without calling the runtime primitive', async () => {
+    const { initTimingSafeEqual, timingSafeEqual } = await import('../src/timing-safe-equal.ts');
     const impl = vi.fn(() => true);
     initTimingSafeEqual(impl);
 
@@ -21,8 +25,8 @@ describe('timingSafeEqual', () => {
     expect(impl).not.toHaveBeenCalled();
   });
 
-  it('exposes missing runtime initialization for equal and unequal lengths', () => {
-    resetTimingSafeEqualForTesting();
+  it('exposes missing runtime initialization for equal and unequal lengths', async () => {
+    const { timingSafeEqual } = await import('../src/timing-safe-equal.ts');
 
     expect(() => timingSafeEqual(new Uint8Array([1]), new Uint8Array([1])))
       .toThrow('TimingSafeEqual not initialized');

--- a/packages/platform/__tests__/timing-safe-equal_test.ts
+++ b/packages/platform/__tests__/timing-safe-equal_test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { initTimingSafeEqual, timingSafeEqual } from '../src/timing-safe-equal.ts';
+import { initTimingSafeEqual, resetTimingSafeEqualForTesting, timingSafeEqual } from '../src/timing-safe-equal.ts';
 
 describe('timingSafeEqual', () => {
   it('delegates equal-length inputs to the runtime primitive', () => {
@@ -19,5 +19,14 @@ describe('timingSafeEqual', () => {
 
     expect(timingSafeEqual(new Uint8Array([1]), new Uint8Array([1, 2]))).toBe(false);
     expect(impl).not.toHaveBeenCalled();
+  });
+
+  it('exposes missing runtime initialization for equal and unequal lengths', () => {
+    resetTimingSafeEqualForTesting();
+
+    expect(() => timingSafeEqual(new Uint8Array([1]), new Uint8Array([1])))
+      .toThrow('TimingSafeEqual not initialized');
+    expect(() => timingSafeEqual(new Uint8Array([1]), new Uint8Array([1, 2])))
+      .toThrow('TimingSafeEqual not initialized');
   });
 });

--- a/packages/platform/__tests__/timing-safe-equal_test.ts
+++ b/packages/platform/__tests__/timing-safe-equal_test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { initTimingSafeEqual, timingSafeEqual } from '../src/timing-safe-equal.ts';
+
+describe('timingSafeEqual', () => {
+  it('delegates equal-length inputs to the runtime primitive', () => {
+    const impl = vi.fn(() => true);
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([1, 2, 3]);
+    initTimingSafeEqual(impl);
+
+    expect(timingSafeEqual(a, b)).toBe(true);
+    expect(impl).toHaveBeenCalledWith(a, b);
+  });
+
+  it('returns false for unequal lengths without calling the runtime primitive', () => {
+    const impl = vi.fn(() => true);
+    initTimingSafeEqual(impl);
+
+    expect(timingSafeEqual(new Uint8Array([1]), new Uint8Array([1, 2]))).toBe(false);
+    expect(impl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -9,3 +9,4 @@ export * from './runtime-kind.ts';
 export * from './sha256.ts';
 export * from './socket-dial.ts';
 export * from './sql-database.ts';
+export * from './timing-safe-equal.ts';

--- a/packages/platform/src/timing-safe-equal.ts
+++ b/packages/platform/src/timing-safe-equal.ts
@@ -11,7 +11,3 @@ export const timingSafeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
   if (a.byteLength !== b.byteLength) return false;
   return impl(a, b);
 };
-
-export const resetTimingSafeEqualForTesting = (): void => {
-  impl = null;
-};

--- a/packages/platform/src/timing-safe-equal.ts
+++ b/packages/platform/src/timing-safe-equal.ts
@@ -7,7 +7,11 @@ export const initTimingSafeEqual = (timingSafeEqual: TimingSafeEqual): void => {
 };
 
 export const timingSafeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
-  if (a.byteLength !== b.byteLength) return false;
   if (!impl) throw new Error('TimingSafeEqual not initialized — call initTimingSafeEqual() first');
+  if (a.byteLength !== b.byteLength) return false;
   return impl(a, b);
+};
+
+export const resetTimingSafeEqualForTesting = (): void => {
+  impl = null;
 };

--- a/packages/platform/src/timing-safe-equal.ts
+++ b/packages/platform/src/timing-safe-equal.ts
@@ -1,0 +1,13 @@
+export type TimingSafeEqual = (a: Uint8Array, b: Uint8Array) => boolean;
+
+let impl: TimingSafeEqual | null = null;
+
+export const initTimingSafeEqual = (timingSafeEqual: TimingSafeEqual): void => {
+  impl = timingSafeEqual;
+};
+
+export const timingSafeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
+  if (a.byteLength !== b.byteLength) return false;
+  if (!impl) throw new Error('TimingSafeEqual not initialized — call initTimingSafeEqual() first');
+  return impl(a, b);
+};


### PR DESCRIPTION
## Purpose

Gateway authentication used a JavaScript XOR loop as a constant-time secret comparison. JavaScript and JIT execution do not provide that timing guarantee, while both deployment runtimes expose native constant-time primitives.

## Change

- Add a runtime-neutral timing-safe comparison contract to the platform package.
- Initialize it with `node:crypto.timingSafeEqual` on Node and Cloudflare's BoringSSL-backed `crypto.subtle.timingSafeEqual` on Workers.
- Preserve the public `false` result for unequal-length inputs while surfacing missing runtime bootstrap before input-dependent behavior.
- Route password, `ADMIN_KEY`, and API-key comparison through the shared runtime boundary.

## Test Plan

- [x] Platform suite — 26 tests passed
- [x] Node and Cloudflare timing-safe adapter suites passed
- [x] Gateway authentication and password suites — 31 tests passed
- [x] Platform, Gateway, Node, and Cloudflare typechecks passed
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, and build passed
