### PR TITLE
refactor(platform): stream channel subscriptions natively

### DIFF
--- a/apps/platform-cloudflare/__tests__/durable-object-channel-broker_test.ts
+++ b/apps/platform-cloudflare/__tests__/durable-object-channel-broker_test.ts
@@ -223,6 +223,8 @@ test('DurableObjectChannelBroker.subscribe closes the socket when the iterator r
   const controller = new AbortController();
   const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
 
+  await Promise.resolve();
+  await Promise.resolve();
   await iter.return?.();
 
   assertEquals(socket.closed?.code, 1000);

--- a/apps/platform-cloudflare/__tests__/durable-object-channel-broker_test.ts
+++ b/apps/platform-cloudflare/__tests__/durable-object-channel-broker_test.ts
@@ -167,6 +167,23 @@ test('DurableObjectChannelBroker.subscribe rejects every pending read when decod
   assertEquals((results[1] as PromiseRejectedResult).reason.message, 'stringCodec rejected payload: bad:payload');
 });
 
+test('DurableObjectChannelBroker.subscribe drains buffered payloads before surfacing a decode failure', async () => {
+  const socket = new FakeServerSocket();
+  const broker = new DurableObjectChannelBroker<string>(buildNamespace(socket), stringCodec);
+  const controller = new AbortController();
+  const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+
+  await Promise.resolve();
+  await Promise.resolve();
+  socket.emit('message', new MessageEvent('message', { data: 'good' }));
+  socket.emit('message', new MessageEvent('message', { data: 'bad:payload' }));
+
+  assertEquals((await iter.next()).value, 'good');
+  const failed = await Promise.allSettled([iter.next()]);
+  assertEquals(failed[0].status, 'rejected');
+  assertEquals((failed[0] as PromiseRejectedResult).reason.message, 'stringCodec rejected payload: bad:payload');
+});
+
 test('DurableObjectChannelBroker.subscribe ends the iterator on a server-initiated socket close', async () => {
   const socket = new FakeServerSocket();
   const broker = new DurableObjectChannelBroker<string>(buildNamespace(socket), stringCodec);

--- a/apps/platform-cloudflare/__tests__/durable-object-channel-broker_test.ts
+++ b/apps/platform-cloudflare/__tests__/durable-object-channel-broker_test.ts
@@ -45,7 +45,12 @@ class FakeServerSocket {
   }
 }
 
-const buildNamespace = (socket: FakeServerSocket, broadcasts: string[] = [], closeAlls: string[] = []) => {
+const buildNamespace = (
+  socket: FakeServerSocket,
+  broadcasts: string[] = [],
+  closeAlls: string[] = [],
+  fetches?: { count: number },
+) => {
   const ns: BroadcastNamespace = {
     idFromName(_name) { return {}; },
     get(_id) {
@@ -53,6 +58,7 @@ const buildNamespace = (socket: FakeServerSocket, broadcasts: string[] = [], clo
         broadcast: async payload => { broadcasts.push(payload); },
         closeAll: async reason => { closeAlls.push(reason); },
         fetch: async () => {
+          if (fetches) fetches.count += 1;
           // Real CF returns 101; Node's `Response` rejects status 101 in its
           // constructor, so synthesise it by overriding `status` after the
           // fact. The broker only reads `status` and `webSocket`.
@@ -92,6 +98,38 @@ test('DurableObjectChannelBroker.subscribe drives payloads through the broadcast
   assertEquals(socket.closed?.code, 1000);
 });
 
+test('DurableObjectChannelBroker.subscribe does not open a socket for an already-aborted signal', async () => {
+  const socket = new FakeServerSocket();
+  const fetches = { count: 0 };
+  const broker = new DurableObjectChannelBroker<string>(buildNamespace(socket, [], [], fetches), stringCodec);
+  const controller = new AbortController();
+  controller.abort();
+
+  const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+
+  assertEquals((await iter.next()).done, true);
+  assertEquals(fetches.count, 0);
+  assertEquals(socket.closed, null);
+});
+
+test('DurableObjectChannelBroker.subscribe resolves concurrent reads in socket order', async () => {
+  const socket = new FakeServerSocket();
+  const broker = new DurableObjectChannelBroker<string>(buildNamespace(socket), stringCodec);
+  const controller = new AbortController();
+  const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+  const first = iter.next();
+  const second = iter.next();
+
+  await Promise.resolve();
+  await Promise.resolve();
+  socket.emit('message', new MessageEvent('message', { data: 'a1' }));
+  socket.emit('message', new MessageEvent('message', { data: 'a2' }));
+
+  assertEquals((await first).value, 'a1');
+  assertEquals((await second).value, 'a2');
+  controller.abort();
+});
+
 test('DurableObjectChannelBroker.publish encodes the payload through the codec', async () => {
   const broadcasts: string[] = [];
   const ns = buildNamespace(new FakeServerSocket(), broadcasts);
@@ -110,24 +148,23 @@ test('DurableObjectChannelBroker.closeChannel forwards the reason to the actor',
   assertEquals(closeAlls[0], 'custom-reason');
 });
 
-test('DurableObjectChannelBroker.subscribe surfaces a codec decode failure by throwing from .next()', async () => {
+test('DurableObjectChannelBroker.subscribe rejects every pending read when decoding fails', async () => {
   const socket = new FakeServerSocket();
   const broker = new DurableObjectChannelBroker<string>(buildNamespace(socket), stringCodec);
   const controller = new AbortController();
   const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
 
+  const first = iter.next();
+  const second = iter.next();
+
   await Promise.resolve();
   await Promise.resolve();
   socket.emit('message', new MessageEvent('message', { data: 'bad:payload' }));
 
-  let caught: unknown = null;
-  try {
-    await iter.next();
-  } catch (err) {
-    caught = err;
-  }
-  assertEquals(caught instanceof Error, true);
-  assertEquals((caught as Error).message.includes('bad:payload'), true);
+  const results = await Promise.allSettled([first, second]);
+  assertEquals(results.map(result => result.status), ['rejected', 'rejected']);
+  assertEquals((results[0] as PromiseRejectedResult).reason.message, 'stringCodec rejected payload: bad:payload');
+  assertEquals((results[1] as PromiseRejectedResult).reason.message, 'stringCodec rejected payload: bad:payload');
 });
 
 test('DurableObjectChannelBroker.subscribe ends the iterator on a server-initiated socket close', async () => {
@@ -178,4 +215,18 @@ test('DurableObjectChannelBroker.subscribe delivers a frame buffered before the 
   socket.emit('message', new MessageEvent('message', { data: 'pre-buffered' }));
   const first = await iter.next();
   assertEquals(first.value, 'pre-buffered');
+});
+
+test('DurableObjectChannelBroker.subscribe closes the socket when the iterator returns', async () => {
+  const socket = new FakeServerSocket();
+  const broker = new DurableObjectChannelBroker<string>(buildNamespace(socket), stringCodec);
+  const controller = new AbortController();
+  const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+
+  await iter.return?.();
+
+  assertEquals(socket.closed?.code, 1000);
+  assertEquals(socket.listeners.get('message')?.size, 0);
+  assertEquals(socket.listeners.get('close')?.size, 0);
+  assertEquals(socket.listeners.get('error')?.size, 0);
 });

--- a/apps/platform-cloudflare/src/durable-object-channel-broker.ts
+++ b/apps/platform-cloudflare/src/durable-object-channel-broker.ts
@@ -56,7 +56,6 @@ const iterateFromBroadcastSocket = <T>(
 
       let socket: WebSocket | null = null;
       let terminated = false;
-      let openPromise: Promise<void>;
       let pendingError: { error: unknown } | null = null;
 
       const detach = (): void => {
@@ -112,7 +111,7 @@ const iterateFromBroadcastSocket = <T>(
       };
       pull = flushError;
 
-      openPromise = (async (): Promise<void> => {
+      const openPromise = (async (): Promise<void> => {
         const response = await stub.fetch(new Request('https://broadcast.do/subscribe', {
           headers: { Upgrade: 'websocket' },
         }));

--- a/apps/platform-cloudflare/src/durable-object-channel-broker.ts
+++ b/apps/platform-cloudflare/src/durable-object-channel-broker.ts
@@ -45,6 +45,7 @@ const iterateFromBroadcastSocket = <T>(
   codec: ChannelCodec<T>,
 ): ReadableStream<T> => {
   let cancel = async (): Promise<void> => {};
+  let pull = (): void => {};
 
   return new ReadableStream<T>({
     start(controller) {
@@ -56,6 +57,7 @@ const iterateFromBroadcastSocket = <T>(
       let socket: WebSocket | null = null;
       let terminated = false;
       let openPromise: Promise<void>;
+      let pendingError: { error: unknown } | null = null;
 
       const detach = (): void => {
         signal.removeEventListener('abort', onAbort);
@@ -67,12 +69,25 @@ const iterateFromBroadcastSocket = <T>(
         await openPromise.catch(() => {});
         socket?.close(1000, 'subscriber done');
       };
-      const finish = (error?: unknown, closeUpstream = true): void => {
+      const close = (closeUpstream = true): void => {
         if (terminated) return;
         terminated = true;
         detach();
-        if (error === undefined) controller.close();
-        else controller.error(error);
+        controller.close();
+        if (closeUpstream) void closeSocket();
+      };
+      const flushError = (): void => {
+        if (!pendingError || (controller.desiredSize ?? 0) <= 0) return;
+        const { error } = pendingError;
+        pendingError = null;
+        controller.error(error);
+      };
+      const fail = (error: unknown, closeUpstream = true): void => {
+        if (terminated) return;
+        terminated = true;
+        detach();
+        pendingError = { error };
+        flushError();
         if (closeUpstream) void closeSocket();
       };
       const onMessage = (event: MessageEvent): void => {
@@ -82,12 +97,12 @@ const iterateFromBroadcastSocket = <T>(
           const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
           controller.enqueue(codec.decode(text));
         } catch (error) {
-          finish(error);
+          fail(error);
         }
       };
-      const onClose = (): void => finish(undefined, false);
-      const onError = (): void => finish(new Error('BroadcastDO socket error'));
-      const onAbort = (): void => finish();
+      const onClose = (): void => close(false);
+      const onError = (): void => fail(new Error('BroadcastDO socket error'));
+      const onAbort = (): void => close();
 
       cancel = async (): Promise<void> => {
         if (terminated) return;
@@ -95,6 +110,7 @@ const iterateFromBroadcastSocket = <T>(
         detach();
         await closeSocket();
       };
+      pull = flushError;
 
       openPromise = (async (): Promise<void> => {
         const response = await stub.fetch(new Request('https://broadcast.do/subscribe', {
@@ -115,8 +131,9 @@ const iterateFromBroadcastSocket = <T>(
         socket.accept();
       })();
       signal.addEventListener('abort', onAbort, { once: true });
-      void openPromise.catch(error => finish(error, false));
+      void openPromise.catch(error => fail(error, false));
     },
     cancel: () => cancel(),
+    pull: () => pull(),
   });
 };

--- a/apps/platform-cloudflare/src/durable-object-channel-broker.ts
+++ b/apps/platform-cloudflare/src/durable-object-channel-broker.ts
@@ -43,91 +43,79 @@ const iterateFromBroadcastSocket = <T>(
   stub: BroadcastStub,
   signal: AbortSignal,
   codec: ChannelCodec<T>,
-): AsyncIterable<T> => {
-  const queue: T[] = [];
-  let resolveNext: ((value: IteratorResult<T>) => void) | null = null;
-  let pendingError: unknown = null;
-  let closed = false;
+): ReadableStream<T> => {
+  let cancel = async (): Promise<void> => {};
 
-  const deliver = (value: IteratorResult<T>): void => {
-    if (resolveNext) {
-      const r = resolveNext;
-      resolveNext = null;
-      r(value);
-    } else if (!value.done) {
-      queue.push(value.value);
-    }
-  };
-
-  const openPromise = (async (): Promise<WebSocket> => {
-    const response = await stub.fetch(new Request('https://broadcast.do/subscribe', {
-      headers: { Upgrade: 'websocket' },
-    }));
-    if (response.status !== 101) {
-      throw new Error(`BroadcastDO subscribe returned HTTP ${response.status} instead of 101`);
-    }
-    const socket = response.webSocket;
-    if (!socket) throw new Error('BroadcastDO returned 101 without a webSocket');
-    socket.accept();
-    socket.addEventListener('message', event => {
-      if (closed) return;
-      try {
-        const raw = event.data as string | ArrayBuffer;
-        const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
-        deliver({ value: codec.decode(text), done: false });
-      } catch (err) {
-        pendingError = err;
-        void closeAndEnd();
+  return new ReadableStream<T>({
+    start(controller) {
+      if (signal.aborted) {
+        controller.close();
+        return;
       }
-    });
-    socket.addEventListener('close', () => {
-      closed = true;
-      deliver({ value: undefined as never, done: true });
-    });
-    socket.addEventListener('error', () => {
-      if (pendingError === null) pendingError = new Error('BroadcastDO socket error');
-      void closeAndEnd();
-    });
-    return socket;
-  })();
-  openPromise.catch(err => {
-    pendingError = err;
-    closed = true;
-    deliver({ value: undefined as never, done: true });
-  });
 
-  // Every path that flips `closed` must close the upstream socket too,
-  // otherwise each aborted or errored subscriber leaks one WS in the DO's
-  // hibernation registry. Awaiting `openPromise` handles a teardown that
-  // races the still-handshaking open.
-  const closeAndEnd = async (): Promise<void> => {
-    if (closed) return;
-    closed = true;
-    deliver({ value: undefined as never, done: true });
-    const s = await openPromise.catch(() => null);
-    if (s) s.close(1000, 'subscriber done');
-  };
+      let socket: WebSocket | null = null;
+      let terminated = false;
 
-  signal.addEventListener('abort', () => {
-    void closeAndEnd();
-  }, { once: true });
-
-  return {
-    [Symbol.asyncIterator]: (): AsyncIterator<T> => ({
-      async next(): Promise<IteratorResult<T>> {
-        if (queue.length > 0) return { value: queue.shift()!, done: false };
-        if (closed) {
-          if (pendingError) throw pendingError;
-          return { value: undefined as never, done: true };
+      const detach = (): void => {
+        signal.removeEventListener('abort', onAbort);
+        socket?.removeEventListener('message', onMessage);
+        socket?.removeEventListener('close', onClose);
+        socket?.removeEventListener('error', onError);
+      };
+      const openPromise = (async (): Promise<void> => {
+        const response = await stub.fetch(new Request('https://broadcast.do/subscribe', {
+          headers: { Upgrade: 'websocket' },
+        }));
+        if (response.status !== 101) {
+          throw new Error(`BroadcastDO subscribe returned HTTP ${response.status} instead of 101`);
         }
-        const result = await new Promise<IteratorResult<T>>(resolve => { resolveNext = resolve; });
-        if (result.done && pendingError) throw pendingError;
-        return result;
-      },
-      async return(): Promise<IteratorResult<T>> {
-        await closeAndEnd();
-        return { value: undefined as never, done: true };
-      },
-    }),
-  };
+        const openedSocket = response.webSocket;
+        if (!openedSocket) throw new Error('BroadcastDO returned 101 without a webSocket');
+
+        socket = openedSocket;
+        if (!terminated) {
+          socket.addEventListener('message', onMessage);
+          socket.addEventListener('close', onClose);
+          socket.addEventListener('error', onError);
+        }
+        socket.accept();
+      })();
+      const closeSocket = async (): Promise<void> => {
+        await openPromise.catch(() => {});
+        socket?.close(1000, 'subscriber done');
+      };
+      const finish = (error?: unknown, closeUpstream = true): void => {
+        if (terminated) return;
+        terminated = true;
+        detach();
+        if (error === undefined) controller.close();
+        else controller.error(error);
+        if (closeUpstream) void closeSocket();
+      };
+      const onMessage = (event: MessageEvent): void => {
+        if (terminated) return;
+        try {
+          const raw = event.data as string | ArrayBuffer;
+          const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+          controller.enqueue(codec.decode(text));
+        } catch (error) {
+          finish(error);
+        }
+      };
+      const onClose = (): void => finish(undefined, false);
+      const onError = (): void => finish(new Error('BroadcastDO socket error'));
+      const onAbort = (): void => finish();
+
+      cancel = async (): Promise<void> => {
+        if (terminated) return;
+        terminated = true;
+        detach();
+        await closeSocket();
+      };
+
+      signal.addEventListener('abort', onAbort, { once: true });
+      void openPromise.catch(error => finish(error, false));
+    },
+    cancel: () => cancel(),
+  });
 };

--- a/apps/platform-cloudflare/src/durable-object-channel-broker.ts
+++ b/apps/platform-cloudflare/src/durable-object-channel-broker.ts
@@ -55,6 +55,7 @@ const iterateFromBroadcastSocket = <T>(
 
       let socket: WebSocket | null = null;
       let terminated = false;
+      let openPromise: Promise<void>;
 
       const detach = (): void => {
         signal.removeEventListener('abort', onAbort);
@@ -62,24 +63,6 @@ const iterateFromBroadcastSocket = <T>(
         socket?.removeEventListener('close', onClose);
         socket?.removeEventListener('error', onError);
       };
-      const openPromise = (async (): Promise<void> => {
-        const response = await stub.fetch(new Request('https://broadcast.do/subscribe', {
-          headers: { Upgrade: 'websocket' },
-        }));
-        if (response.status !== 101) {
-          throw new Error(`BroadcastDO subscribe returned HTTP ${response.status} instead of 101`);
-        }
-        const openedSocket = response.webSocket;
-        if (!openedSocket) throw new Error('BroadcastDO returned 101 without a webSocket');
-
-        socket = openedSocket;
-        if (!terminated) {
-          socket.addEventListener('message', onMessage);
-          socket.addEventListener('close', onClose);
-          socket.addEventListener('error', onError);
-        }
-        socket.accept();
-      })();
       const closeSocket = async (): Promise<void> => {
         await openPromise.catch(() => {});
         socket?.close(1000, 'subscriber done');
@@ -113,6 +96,24 @@ const iterateFromBroadcastSocket = <T>(
         await closeSocket();
       };
 
+      openPromise = (async (): Promise<void> => {
+        const response = await stub.fetch(new Request('https://broadcast.do/subscribe', {
+          headers: { Upgrade: 'websocket' },
+        }));
+        if (response.status !== 101) {
+          throw new Error(`BroadcastDO subscribe returned HTTP ${response.status} instead of 101`);
+        }
+        const openedSocket = response.webSocket;
+        if (!openedSocket) throw new Error('BroadcastDO returned 101 without a webSocket');
+
+        socket = openedSocket;
+        if (!terminated) {
+          socket.addEventListener('message', onMessage);
+          socket.addEventListener('close', onClose);
+          socket.addEventListener('error', onError);
+        }
+        socket.accept();
+      })();
       signal.addEventListener('abort', onAbort, { once: true });
       void openPromise.catch(error => finish(error, false));
     },

--- a/apps/platform-cloudflare/src/durable-object-channel-broker.ts
+++ b/apps/platform-cloudflare/src/durable-object-channel-broker.ts
@@ -1,4 +1,4 @@
-import type { ChannelBroker, ChannelCodec } from '@floway-dev/platform';
+import { iterateReadableStream, type ChannelBroker, type ChannelCodec } from '@floway-dev/platform';
 
 // Minimal namespace surface for BROADCAST_DO — declared locally so this
 // file stays off `@cloudflare/workers-types`.
@@ -32,7 +32,7 @@ export class DurableObjectChannelBroker<T> implements ChannelBroker<T> {
   }
 
   subscribe(channelId: string, signal: AbortSignal): AsyncIterable<T> {
-    return iterateFromBroadcastSocket<T>(this.stub(channelId), signal, this.codec);
+    return iterateReadableStream(iterateFromBroadcastSocket<T>(this.stub(channelId), signal, this.codec));
   }
 }
 

--- a/apps/platform-cloudflare/src/durable-object-channel-broker.ts
+++ b/apps/platform-cloudflare/src/durable-object-channel-broker.ts
@@ -64,6 +64,9 @@ const iterateFromBroadcastSocket = <T>(
         socket?.removeEventListener('close', onClose);
         socket?.removeEventListener('error', onError);
       };
+      // Subscriber termination must remove its WebSocket from the Durable
+      // Object hibernation registry. Waiting for the eager open also covers a
+      // cancellation or error that arrives while the handshake is in flight.
       const closeSocket = async (): Promise<void> => {
         await openPromise.catch(() => {});
         socket?.close(1000, 'subscriber done');

--- a/apps/platform-node/__tests__/event-target-channel-broker_test.ts
+++ b/apps/platform-node/__tests__/event-target-channel-broker_test.ts
@@ -15,7 +15,8 @@ const stringCodec: ChannelCodec<string> = {
 const rejectingStringCodec: ChannelCodec<string> = {
   encode: value => value,
   decode: payload => {
-    throw new Error(`rejected payload: ${payload}`);
+    if (payload === 'bad') throw new Error(`rejected payload: ${payload}`);
+    return payload;
   },
 };
 
@@ -83,6 +84,20 @@ test('EventTargetChannelBroker rejects every pending read when decoding fails', 
   assertEquals(results.map(result => result.status), ['rejected', 'rejected']);
   assertEquals((results[0] as PromiseRejectedResult).reason.message, 'rejected payload: bad');
   assertEquals((results[1] as PromiseRejectedResult).reason.message, 'rejected payload: bad');
+});
+
+test('EventTargetChannelBroker drains buffered payloads before surfacing a decode failure', async () => {
+  const broker = new EventTargetChannelBroker<string>(rejectingStringCodec);
+  const controller = new AbortController();
+  const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+
+  await broker.publish('k', 'good');
+  await broker.publish('k', 'bad');
+
+  assertEquals((await iter.next()).value, 'good');
+  const failed = await Promise.allSettled([iter.next()]);
+  assertEquals(failed[0].status, 'rejected');
+  assertEquals((failed[0] as PromiseRejectedResult).reason.message, 'rejected payload: bad');
 });
 
 test('EventTargetChannelBroker isolates traffic across channels', async () => {

--- a/apps/platform-node/__tests__/event-target-channel-broker_test.ts
+++ b/apps/platform-node/__tests__/event-target-channel-broker_test.ts
@@ -12,7 +12,14 @@ const stringCodec: ChannelCodec<string> = {
   decode: payload => payload,
 };
 
-test('EventTargetChannelBroker delivers published payloads to a live subscriber', async () => {
+const rejectingStringCodec: ChannelCodec<string> = {
+  encode: value => value,
+  decode: payload => {
+    throw new Error(`rejected payload: ${payload}`);
+  },
+};
+
+test('EventTargetChannelBroker buffers published payloads before the first read', async () => {
   const broker = new EventTargetChannelBroker<string>(stringCodec);
   const controller = new AbortController();
   const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
@@ -25,6 +32,57 @@ test('EventTargetChannelBroker delivers published payloads to a live subscriber'
   assertEquals((await iter.next()).value, 'a1');
   assertEquals((await iter.next()).value, 'a2');
   assertEquals((await iter.next()).done, true);
+});
+
+test('EventTargetChannelBroker does not attach listeners for an already-aborted subscription', async () => {
+  const originalAdd = EventTarget.prototype.addEventListener;
+  let adds = 0;
+  EventTarget.prototype.addEventListener = function (...args: Parameters<EventTarget['addEventListener']>) {
+    adds += 1;
+    return originalAdd.apply(this, args);
+  };
+  try {
+    const broker = new EventTargetChannelBroker<string>(stringCodec);
+    const controller = new AbortController();
+    controller.abort();
+
+    const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+
+    assertEquals((await iter.next()).done, true);
+    assertEquals(adds, 0);
+  } finally {
+    EventTarget.prototype.addEventListener = originalAdd;
+  }
+});
+
+test('EventTargetChannelBroker resolves concurrent reads in publish order', async () => {
+  const broker = new EventTargetChannelBroker<string>(stringCodec);
+  const controller = new AbortController();
+  const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+  const first = iter.next();
+  const second = iter.next();
+
+  await broker.publish('k', 'a1');
+  await broker.publish('k', 'a2');
+
+  assertEquals((await first).value, 'a1');
+  assertEquals((await second).value, 'a2');
+  controller.abort();
+});
+
+test('EventTargetChannelBroker rejects every pending read when decoding fails', async () => {
+  const broker = new EventTargetChannelBroker<string>(rejectingStringCodec);
+  const controller = new AbortController();
+  const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+  const first = iter.next();
+  const second = iter.next();
+
+  await broker.publish('k', 'bad');
+
+  const results = await Promise.allSettled([first, second]);
+  assertEquals(results.map(result => result.status), ['rejected', 'rejected']);
+  assertEquals((results[0] as PromiseRejectedResult).reason.message, 'rejected payload: bad');
+  assertEquals((results[1] as PromiseRejectedResult).reason.message, 'rejected payload: bad');
 });
 
 test('EventTargetChannelBroker isolates traffic across channels', async () => {
@@ -72,6 +130,27 @@ test('EventTargetChannelBroker detaches its EventTarget listeners when the subsc
     controller.abort();
     // Two listeners on the EventTarget (frame + close) plus the abort
     // listener on the signal must be removed.
+    assertEquals(removes - removesBefore, 3);
+  } finally {
+    EventTarget.prototype.removeEventListener = originalRemove;
+  }
+});
+
+test('EventTargetChannelBroker detaches its EventTarget listeners when the iterator returns', async () => {
+  const originalRemove = EventTarget.prototype.removeEventListener;
+  let removes = 0;
+  EventTarget.prototype.removeEventListener = function (...args: Parameters<EventTarget['removeEventListener']>) {
+    removes += 1;
+    return originalRemove.apply(this, args);
+  };
+  try {
+    const broker = new EventTargetChannelBroker<string>(stringCodec);
+    const controller = new AbortController();
+    const iter = broker.subscribe('k', controller.signal)[Symbol.asyncIterator]();
+    const removesBefore = removes;
+
+    await iter.return?.();
+
     assertEquals(removes - removesBefore, 3);
   } finally {
     EventTarget.prototype.removeEventListener = originalRemove;

--- a/apps/platform-node/src/event-target-channel-broker.ts
+++ b/apps/platform-node/src/event-target-channel-broker.ts
@@ -29,75 +29,69 @@ export class EventTargetChannelBroker<T> implements ChannelBroker<T> {
   }
 
   subscribe(channelId: string, signal: AbortSignal): AsyncIterable<T> {
-    return iterateFromTarget<T>(this.targetFor(channelId), signal, this.codec);
+    if (signal.aborted) return closedStream<T>();
+    return streamFromTarget<T>(this.targetFor(channelId), signal, this.codec);
   }
 }
 
-// Listener registration happens eagerly inside `iterateFromTarget` so that a
+const closedStream = <T>(): ReadableStream<T> => new ReadableStream({
+  start: controller => controller.close(),
+});
+
+// Listener registration happens eagerly inside `streamFromTarget` so that a
 // caller who awaits subscribe and then publishes before draining the iterator
 // still receives the buffered frame. A generator that registers in its body
 // would miss the publish because the body doesn't run until the first
 // `.next()` call.
-const iterateFromTarget = <T>(
+const streamFromTarget = <T>(
   target: EventTarget,
   signal: AbortSignal,
   codec: ChannelCodec<T>,
-): AsyncIterable<T> => {
-  const queue: T[] = [];
-  let resolveNext: ((value: IteratorResult<T>) => void) | null = null;
-  let closed = false;
+): ReadableStream<T> => {
+  let cancel = (): void => {};
 
-  const deliver = (value: IteratorResult<T>): void => {
-    if (resolveNext) {
-      const r = resolveNext;
-      resolveNext = null;
-      r(value);
-    } else if (!value.done) {
-      queue.push(value.value);
-    }
-  };
+  return new ReadableStream<T>({
+    start(controller) {
+      let terminated = false;
 
-  const onFrame = (event: Event): void => {
-    if (closed) return;
-    const payload = (event as CustomEvent<string>).detail;
-    deliver({ value: codec.decode(payload), done: false });
-  };
-  const onClose = (): void => {
-    if (closed) return;
-    closed = true;
-    detach();
-    deliver({ value: undefined as never, done: true });
-  };
-  const onAbort = (): void => {
-    if (closed) return;
-    closed = true;
-    detach();
-    deliver({ value: undefined as never, done: true });
-  };
-  const detach = (): void => {
-    target.removeEventListener('frame', onFrame);
-    target.removeEventListener('close', onClose);
-    signal.removeEventListener('abort', onAbort);
-  };
-
-  target.addEventListener('frame', onFrame);
-  target.addEventListener('close', onClose);
-  signal.addEventListener('abort', onAbort, { once: true });
-
-  return {
-    [Symbol.asyncIterator]: (): AsyncIterator<T> => ({
-      async next(): Promise<IteratorResult<T>> {
-        if (queue.length > 0) return { value: queue.shift()!, done: false };
-        if (closed) return { value: undefined as never, done: true };
-        return await new Promise<IteratorResult<T>>(resolve => { resolveNext = resolve; });
-      },
-      async return(): Promise<IteratorResult<T>> {
-        if (!closed) {
-          closed = true;
-          detach();
+      const detach = (): void => {
+        target.removeEventListener('frame', onFrame);
+        target.removeEventListener('close', onClose);
+        signal.removeEventListener('abort', onAbort);
+      };
+      const close = (): void => {
+        if (terminated) return;
+        terminated = true;
+        detach();
+        controller.close();
+      };
+      const fail = (error: unknown): void => {
+        if (terminated) return;
+        terminated = true;
+        detach();
+        controller.error(error);
+      };
+      const onFrame = (event: Event): void => {
+        if (terminated) return;
+        try {
+          controller.enqueue(codec.decode((event as CustomEvent<string>).detail));
+        } catch (error) {
+          fail(error);
         }
-        return { value: undefined as never, done: true };
-      },
-    }),
-  };
+      };
+      const onClose = (): void => close();
+      const onAbort = (): void => close();
+
+      cancel = (): void => {
+        if (terminated) return;
+        terminated = true;
+        detach();
+      };
+
+      target.addEventListener('frame', onFrame);
+      target.addEventListener('close', onClose);
+      signal.addEventListener('abort', onAbort, { once: true });
+    },
+    cancel: () => cancel(),
+  });
 };

--- a/apps/platform-node/src/event-target-channel-broker.ts
+++ b/apps/platform-node/src/event-target-channel-broker.ts
@@ -49,10 +49,12 @@ const streamFromTarget = <T>(
   codec: ChannelCodec<T>,
 ): ReadableStream<T> => {
   let cancel = (): void => {};
+  let pull = (): void => {};
 
   return new ReadableStream<T>({
     start(controller) {
       let terminated = false;
+      let pendingError: { error: unknown } | null = null;
 
       const detach = (): void => {
         target.removeEventListener('frame', onFrame);
@@ -65,11 +67,18 @@ const streamFromTarget = <T>(
         detach();
         controller.close();
       };
+      const flushError = (): void => {
+        if (!pendingError || (controller.desiredSize ?? 0) <= 0) return;
+        const { error } = pendingError;
+        pendingError = null;
+        controller.error(error);
+      };
       const fail = (error: unknown): void => {
         if (terminated) return;
         terminated = true;
         detach();
-        controller.error(error);
+        pendingError = { error };
+        flushError();
       };
       const onFrame = (event: Event): void => {
         if (terminated) return;
@@ -87,11 +96,13 @@ const streamFromTarget = <T>(
         terminated = true;
         detach();
       };
+      pull = flushError;
 
       target.addEventListener('frame', onFrame);
       target.addEventListener('close', onClose);
       signal.addEventListener('abort', onAbort, { once: true });
     },
     cancel: () => cancel(),
+    pull: () => pull(),
   });
 };

--- a/apps/platform-node/src/event-target-channel-broker.ts
+++ b/apps/platform-node/src/event-target-channel-broker.ts
@@ -1,4 +1,4 @@
-import type { ChannelBroker, ChannelCodec } from '@floway-dev/platform';
+import { iterateReadableStream, type ChannelBroker, type ChannelCodec } from '@floway-dev/platform';
 
 // In-process per-channel fan-out backed by EventTarget. The Node deployment
 // target only ever runs one worker process per gateway instance, so a Map of
@@ -29,8 +29,8 @@ export class EventTargetChannelBroker<T> implements ChannelBroker<T> {
   }
 
   subscribe(channelId: string, signal: AbortSignal): AsyncIterable<T> {
-    if (signal.aborted) return closedStream<T>();
-    return streamFromTarget<T>(this.targetFor(channelId), signal, this.codec);
+    if (signal.aborted) return iterateReadableStream(closedStream<T>());
+    return iterateReadableStream(streamFromTarget<T>(this.targetFor(channelId), signal, this.codec));
   }
 }
 

--- a/packages/platform/__tests__/channel-broker_test.ts
+++ b/packages/platform/__tests__/channel-broker_test.ts
@@ -1,0 +1,25 @@
+import { test } from 'vitest';
+
+import { iterateReadableStream } from '../src/channel-broker.ts';
+import { assertEquals } from '@floway-dev/test-utils';
+
+test('iterateReadableStream releases its reader after every pending read observes an error', async () => {
+  let controller!: ReadableStreamDefaultController<string>;
+  const stream = new ReadableStream<string>({
+    start: value => { controller = value; },
+  });
+  const iter = iterateReadableStream(stream)[Symbol.asyncIterator]();
+  const first = iter.next();
+  const second = iter.next();
+  const error = new Error('terminal');
+
+  controller.error(error);
+
+  const results = await Promise.allSettled([first, second]);
+  assertEquals(results.map(result => result.status), ['rejected', 'rejected']);
+  assertEquals((results[0] as PromiseRejectedResult).reason, error);
+  assertEquals((results[1] as PromiseRejectedResult).reason, error);
+  assertEquals(stream.locked, false);
+  assertEquals((await iter.return?.())?.done, true);
+  assertEquals(stream.locked, false);
+});

--- a/packages/platform/__tests__/channel-broker_test.ts
+++ b/packages/platform/__tests__/channel-broker_test.ts
@@ -40,7 +40,7 @@ test('iterateReadableStream releases its reader before pending cancellation fini
   const returned = iter.return?.('subscriber done')!;
   let returnSettled = false;
   void returned.then(() => { returnSettled = true; });
-  await pendingRead;
+  assertEquals((await pendingRead).done, true);
   await Promise.resolve();
 
   assertEquals(cancelReason, 'subscriber done');

--- a/packages/platform/__tests__/channel-broker_test.ts
+++ b/packages/platform/__tests__/channel-broker_test.ts
@@ -20,6 +20,59 @@ test('iterateReadableStream releases its reader after every pending read observe
   assertEquals((results[0] as PromiseRejectedResult).reason, error);
   assertEquals((results[1] as PromiseRejectedResult).reason, error);
   assertEquals(stream.locked, false);
-  assertEquals((await iter.return?.())?.done, true);
+  assertEquals(await iter.return?.('terminal'), { done: true, value: 'terminal' });
   assertEquals(stream.locked, false);
+});
+
+test('iterateReadableStream releases its reader before pending cancellation finishes', async () => {
+  let cancelReason: unknown;
+  let resolveCancellation!: () => void;
+  const cancellation = new Promise<void>(resolve => { resolveCancellation = resolve; });
+  const stream = new ReadableStream<string>({
+    cancel: reason => {
+      cancelReason = reason;
+      return cancellation;
+    },
+  });
+  const iter = iterateReadableStream(stream)[Symbol.asyncIterator]();
+  const pendingRead = iter.next();
+
+  const returned = iter.return?.('subscriber done')!;
+  let returnSettled = false;
+  void returned.then(() => { returnSettled = true; });
+  await pendingRead;
+  await Promise.resolve();
+
+  assertEquals(cancelReason, 'subscriber done');
+  assertEquals(stream.locked, false);
+  assertEquals(returnSettled, false);
+
+  resolveCancellation();
+  assertEquals(await returned, { done: true, value: 'subscriber done' });
+  assertEquals(await iter.return?.('already done'), { done: true, value: 'already done' });
+});
+
+test('iterateReadableStream propagates one cancellation rejection to concurrent returns', async () => {
+  let cancelReason: unknown;
+  let rejectCancellation!: (error: unknown) => void;
+  const error = new Error('cancel failed');
+  const stream = new ReadableStream<string>({
+    cancel: reason => {
+      cancelReason = reason;
+      return new Promise<void>((_resolve, reject) => { rejectCancellation = reject; });
+    },
+  });
+  const iter = iterateReadableStream(stream)[Symbol.asyncIterator]();
+
+  const first = iter.return?.('first')!;
+  const second = iter.return?.('second')!;
+
+  assertEquals(cancelReason, 'first');
+  assertEquals(stream.locked, false);
+  rejectCancellation(error);
+
+  const results = await Promise.allSettled([first, second]);
+  assertEquals(results.map(result => result.status), ['rejected', 'rejected']);
+  assertEquals((results[0] as PromiseRejectedResult).reason, error);
+  assertEquals((results[1] as PromiseRejectedResult).reason, error);
 });

--- a/packages/platform/src/channel-broker.ts
+++ b/packages/platform/src/channel-broker.ts
@@ -11,3 +11,39 @@ export interface ChannelBroker<T> {
   subscribe(channelId: string, signal: AbortSignal): AsyncIterable<T>;
   closeChannel(channelId: string, reason: string): Promise<void>;
 }
+
+// The built-in ReadableStream async iterator serializes next() calls. A stream
+// error can therefore reject the active call and complete a concurrently queued
+// call. Channel consumers may issue concurrent reads, so each next() maps
+// directly to the reader's pending-read queue, which rejects every read on
+// error: https://streams.spec.whatwg.org/#default-reader-read
+export const iterateReadableStream = <T>(stream: ReadableStream<T>): AsyncIterable<T> => ({
+  [Symbol.asyncIterator]() {
+    const reader = stream.getReader();
+    let active = true;
+    const release = (): void => {
+      if (!active) return;
+      active = false;
+      reader.releaseLock();
+    };
+
+    return {
+      async next(): Promise<IteratorResult<T>> {
+        if (!active) return { done: true, value: undefined };
+        const result = await reader.read();
+        if (result.done) release();
+        return result;
+      },
+      async return(): Promise<IteratorResult<T>> {
+        if (active) {
+          try {
+            await reader.cancel();
+          } finally {
+            release();
+          }
+        }
+        return { done: true, value: undefined };
+      },
+    };
+  },
+});

--- a/packages/platform/src/channel-broker.ts
+++ b/packages/platform/src/channel-broker.ts
@@ -20,28 +20,48 @@ export interface ChannelBroker<T> {
 export const iterateReadableStream = <T>(stream: ReadableStream<T>): AsyncIterable<T> => ({
   [Symbol.asyncIterator]() {
     const reader = stream.getReader();
-    let active = true;
-    const release = (): void => {
-      if (!active) return;
-      active = false;
+    let state: 'open' | 'terminal' | 'released' = 'open';
+    let pendingReads = 0;
+    let resolveReleased!: () => void;
+    const released = new Promise<void>(resolve => { resolveReleased = resolve; });
+    const releaseWhenIdle = (): void => {
+      if (state !== 'terminal' || pendingReads !== 0) return;
+      state = 'released';
       reader.releaseLock();
+      resolveReleased();
     };
 
     return {
       async next(): Promise<IteratorResult<T>> {
-        if (!active) return { done: true, value: undefined };
-        const result = await reader.read();
-        if (result.done) release();
-        return result;
+        if (state !== 'open') return { done: true, value: undefined };
+        pendingReads += 1;
+        try {
+          const result = await reader.read();
+          if (result.done) state = 'terminal';
+          return result;
+        } catch (error) {
+          state = 'terminal';
+          throw error;
+        } finally {
+          pendingReads -= 1;
+          releaseWhenIdle();
+        }
       },
       async return(): Promise<IteratorResult<T>> {
-        if (active) {
+        if (state === 'released') return { done: true, value: undefined };
+
+        let cancelError: unknown;
+        if (state === 'open') {
+          state = 'terminal';
           try {
             await reader.cancel();
-          } finally {
-            release();
+          } catch (error) {
+            cancelError = error;
           }
+          releaseWhenIdle();
         }
+        await released;
+        if (cancelError !== undefined) throw cancelError;
         return { done: true, value: undefined };
       },
     };

--- a/packages/platform/src/channel-broker.ts
+++ b/packages/platform/src/channel-broker.ts
@@ -50,18 +50,18 @@ export const iterateReadableStream = <T>(stream: ReadableStream<T>): AsyncIterab
       async return(): Promise<IteratorResult<T>> {
         if (state === 'released') return { done: true, value: undefined };
 
-        let cancelError: unknown;
+        let cancellation: { error: unknown } | null = null;
         if (state === 'open') {
           state = 'terminal';
           try {
             await reader.cancel();
           } catch (error) {
-            cancelError = error;
+            cancellation = { error };
           }
           releaseWhenIdle();
         }
         await released;
-        if (cancelError !== undefined) throw cancelError;
+        if (cancellation) throw cancellation.error;
         return { done: true, value: undefined };
       },
     };

--- a/packages/platform/src/channel-broker.ts
+++ b/packages/platform/src/channel-broker.ts
@@ -22,6 +22,7 @@ export const iterateReadableStream = <T>(stream: ReadableStream<T>): AsyncIterab
     const reader = stream.getReader();
     let state: 'open' | 'terminal' | 'released' = 'open';
     let pendingReads = 0;
+    let cancellation: Promise<{ ok: true } | { ok: false; error: unknown }> | null = null;
     let resolveReleased!: () => void;
     const released = new Promise<void>(resolve => { resolveReleased = resolve; });
     const releaseWhenIdle = (): void => {
@@ -47,22 +48,21 @@ export const iterateReadableStream = <T>(stream: ReadableStream<T>): AsyncIterab
           releaseWhenIdle();
         }
       },
-      async return(): Promise<IteratorResult<T>> {
-        if (state === 'released') return { done: true, value: undefined };
-
-        let cancellation: { error: unknown } | null = null;
+      async return(value?: unknown): Promise<IteratorResult<T>> {
         if (state === 'open') {
+          cancellation = reader.cancel(value).then(
+            () => ({ ok: true as const }),
+            error => ({ ok: false as const, error }),
+          );
           state = 'terminal';
-          try {
-            await reader.cancel();
-          } catch (error) {
-            cancellation = { error };
-          }
           releaseWhenIdle();
         }
-        await released;
-        if (cancellation) throw cancellation.error;
-        return { done: true, value: undefined };
+        if (state !== 'released') await released;
+        if (cancellation) {
+          const result = await cancellation;
+          if (!result.ok) throw result.error;
+        }
+        return { done: true, value };
       },
     };
   },


### PR DESCRIPTION
## Problem

Both ChannelBroker runtimes maintained a push-to-AsyncIterable queue with one mutable resolver. Pre-aborted subscriptions could hang, and concurrent `next()` calls could orphan an earlier read.

## Change

- Use native `ReadableStream` queues for Node EventTarget and Cloudflare Durable Object WebSocket subscriptions.
- Map iterator reads directly to stream-reader reads so concurrent reads settle FIFO.
- Preserve eager buffering, delivery order, buffered frames before terminal errors, close, and cleanup semantics.
- Preserve pre-abort, handshake cancellation, cancel reasons, `return(value)`, reader lock release, and error identity.

## Test Plan

- [x] Channel lifecycle suites — 23 passed
- [x] Platform, Node platform, and Cloudflare platform typechecks
- [x] Changed-file lint and diff checks
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
