### PR TITLE
refactor(web): parse Fontsource descriptors with PostCSS

### DIFF
--- a/apps/web/__tests__/fontsource-woff2-only_test.ts
+++ b/apps/web/__tests__/fontsource-woff2-only_test.ts
@@ -57,8 +57,8 @@ describe('Fontsource WOFF2-only transform', () => {
     const css = `@font-face {
       src: url('./example.woff2?fallback=.woff') format('woff2'),
         url('./example-alt.woff2#fallback=.woff') format('woff2'),
-        url('./example.woff?cache=1') format('woff'),
-        url('./example-alt.woff#cache') format('woff');
+        url('./example.woff?cache=1'),
+        url('./example-alt.woff#cache');
     }`;
 
     const output = await process(css);

--- a/apps/web/__tests__/fontsource-woff2-only_test.ts
+++ b/apps/web/__tests__/fontsource-woff2-only_test.ts
@@ -110,6 +110,12 @@ describe('Fontsource WOFF2-only transform', () => {
     await expect(process(css)).rejects.toThrow('still declares a WOFF source');
   });
 
+  it('does not interpret format functions outside src descriptors as font sources', async () => {
+    const css = `:root { --font-format-label: format('woff'); }`;
+
+    expect(await process(css)).toBe(css);
+  });
+
   it.each(['400.css', '600.css', '700.css'])('processes the installed Maple Mono %s stylesheet', async file => {
     const path = import.meta.resolve(`@fontsource/maple-mono/${file}`);
     const css = await readFile(new URL(path), 'utf8');

--- a/apps/web/__tests__/fontsource-woff2-only_test.ts
+++ b/apps/web/__tests__/fontsource-woff2-only_test.ts
@@ -41,6 +41,34 @@ describe('Fontsource WOFF2-only transform', () => {
     expect(output).not.toContain(String.raw`example.wo\66 f')`);
   });
 
+  it('recognizes escaped src descriptors', async () => {
+    const css = String.raw`@font-face {
+      s\72 c: url('./example.woff2') format('woff2'),
+        url('./example.woff') format('woff');
+    }`;
+
+    const output = await process(css);
+
+    expect(output).toContain(String.raw`s\72 c: url('./example.woff2') format('woff2')`);
+    expect(output).not.toContain("url('./example.woff')");
+  });
+
+  it('classifies URL pathnames independently of query strings and fragments', async () => {
+    const css = `@font-face {
+      src: url('./example.woff2?fallback=.woff') format('woff2'),
+        url('./example-alt.woff2#fallback=.woff') format('woff2'),
+        url('./example.woff?cache=1') format('woff'),
+        url('./example-alt.woff#cache') format('woff');
+    }`;
+
+    const output = await process(css);
+
+    expect(output).toContain("url('./example.woff2?fallback=.woff') format('woff2')");
+    expect(output).toContain("url('./example-alt.woff2#fallback=.woff') format('woff2')");
+    expect(output).not.toContain("url('./example.woff?cache=1')");
+    expect(output).not.toContain("url('./example-alt.woff#cache')");
+  });
+
   it('treats data URL commas as URL content', async () => {
     const css = `@font-face {
       src: url('data:font/woff2;base64,d09GMg==') format('woff2'),
@@ -66,6 +94,20 @@ describe('Fontsource WOFF2-only transform', () => {
     const css = `@font-face { src: url('./example.woff') format('woff'); }`;
 
     expect(await process(css, '/workspace/src/global.css')).toBe(css);
+  });
+
+  it.each(['?inline', '#transform-only'])('matches Fontsource IDs carrying %s', async suffix => {
+    const css = `@font-face {
+      src: url('./example.woff2') format('woff2'), url('./example.woff') format('woff');
+    }`;
+
+    expect(await process(css, `${fontsourcePath}${suffix}`)).not.toContain("format('woff')");
+  });
+
+  it('fails if WOFF remains anywhere in a Fontsource stylesheet', async () => {
+    const css = `:root { --unexpected-font: url('./example.woff') format('woff'); }`;
+
+    await expect(process(css)).rejects.toThrow('still declares a WOFF source');
   });
 
   it.each(['400.css', '600.css', '700.css'])('processes the installed Maple Mono %s stylesheet', async file => {

--- a/apps/web/__tests__/fontsource-woff2-only_test.ts
+++ b/apps/web/__tests__/fontsource-woff2-only_test.ts
@@ -1,0 +1,80 @@
+import { readFile } from 'node:fs/promises';
+
+import postcss from 'postcss';
+import { describe, expect, it } from 'vitest';
+
+import { fontsourceWoff2Only } from '../postcss.config';
+
+const fontsourcePath = '/workspace/node_modules/@fontsource/example/400.css';
+
+const process = async (css: string, from = fontsourcePath): Promise<string> =>
+  (await postcss([fontsourceWoff2Only()]).process(css, { from })).css;
+
+describe('Fontsource WOFF2-only transform', () => {
+  it('removes WOFF list items while preserving every other source', async () => {
+    const css = `@font-face {
+      SRC: local("Example"),
+        URL( './example.WOFF' ) FORMAT( "WOFF" ),
+        url('./example.woff2') format('woff2'),
+        url('./example-bold.woff') format('woff'),
+        local('Example fallback');
+    }`;
+
+    const output = await process(css);
+
+    expect(output).toContain('local("Example")');
+    expect(output).toContain("url('./example.woff2') format('woff2')");
+    expect(output).toContain("local('Example fallback')");
+    expect(output).not.toMatch(/example(?:-bold)?\.woff(?:['")?#]|$)/i);
+    expect(postcss.parse(output).nodes).toHaveLength(1);
+  });
+
+  it('understands escaped URL and format values', async () => {
+    const css = String.raw`@font-face {
+      src: url('./example.wo\66 f2') format('\77 off2'),
+        url('./example.wo\66 f') format('\77 off');
+    }`;
+
+    const output = await process(css);
+
+    expect(output).toContain(String.raw`url('./example.wo\66 f2') format('\77 off2')`);
+    expect(output).not.toContain(String.raw`example.wo\66 f')`);
+  });
+
+  it('treats data URL commas as URL content', async () => {
+    const css = `@font-face {
+      src: url('data:font/woff2;base64,d09GMg==') format('woff2'),
+        url('data:font/woff;base64,d09GRg==') format('woff');
+    }`;
+
+    const output = await process(css);
+
+    expect(output).toContain("url('data:font/woff2;base64,d09GMg==') format('woff2')");
+    expect(output).not.toContain('d09GRg==');
+  });
+
+  it('rejects malformed upstream source values', async () => {
+    await expect(process(`@font-face { src: url('./example.woff2') format('woff2'),; }`))
+      .rejects.toThrow('contains an empty font source');
+    await expect(process(`@font-face { src: url('./example.woff') format('woff' }`))
+      .rejects.toThrow('contains an unclosed font source');
+    await expect(process(`@font-face { src: url('./example.woff') format('woff'); }`))
+      .rejects.toThrow('does not declare a non-WOFF font source');
+  });
+
+  it('does not transform non-Fontsource stylesheets', async () => {
+    const css = `@font-face { src: url('./example.woff') format('woff'); }`;
+
+    expect(await process(css, '/workspace/src/global.css')).toBe(css);
+  });
+
+  it.each(['400.css', '600.css', '700.css'])('processes the installed Maple Mono %s stylesheet', async file => {
+    const path = import.meta.resolve(`@fontsource/maple-mono/${file}`);
+    const css = await readFile(new URL(path), 'utf8');
+    const output = await process(css, new URL(path).pathname);
+
+    expect(output).toContain("format('woff2')");
+    expect(output).not.toContain("format('woff')");
+    expect(output).not.toMatch(/\.woff(?:['")?#]|$)/i);
+  });
+});

--- a/apps/web/__tests__/fontsource-woff2-only_test.ts
+++ b/apps/web/__tests__/fontsource-woff2-only_test.ts
@@ -57,7 +57,7 @@ describe('Fontsource WOFF2-only transform', () => {
     await expect(process(`@font-face { src: url('./example.woff2') format('woff2'),; }`))
       .rejects.toThrow('contains an empty font source');
     await expect(process(`@font-face { src: url('./example.woff') format('woff' }`))
-      .rejects.toThrow('contains an unclosed font source');
+      .rejects.toThrow('Unclosed bracket');
     await expect(process(`@font-face { src: url('./example.woff') format('woff'); }`))
       .rejects.toThrow('does not declare a non-WOFF font source');
   });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "jiti": "2.6.1",
     "jsonc-parser": "^3.3.1",
     "magic-string": "^1.1.0",
+    "postcss-value-parser": "^4.2.0",
     "unocss": "^66.7.5",
     "vite": "^8.1.5",
     "vitest": "4.1.10"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "jiti": "2.6.1",
     "jsonc-parser": "^3.3.1",
     "magic-string": "^1.1.0",
+    "postcss": "^8.5.23",
     "postcss-value-parser": "^4.2.0",
     "unocss": "^66.7.5",
     "vite": "^8.1.5",

--- a/apps/web/postcss.config.ts
+++ b/apps/web/postcss.config.ts
@@ -1,4 +1,108 @@
 import UnoCSS from '@unocss/postcss';
+import type { Plugin } from 'postcss';
+import valueParser from 'postcss-value-parser';
+
+const fontsourceStylesheet = /\/@fontsource(?:-variable)?\/[^/]+\/[^/]+\.css$/;
+
+const cssUnescape = (value: string): string =>
+  value.replaceAll(/\\(?:([\da-f]{1,6})[\t\n\f\r ]?|\r\n|([\s\S]))/gi, (_, hex: string | undefined, escaped: string | undefined) => {
+    if (hex !== undefined) {
+      const codePoint = Number.parseInt(hex, 16);
+      return codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+        ? '\uFFFD'
+        : String.fromCodePoint(codePoint);
+    }
+    return escaped === '\n' || escaped === '\r' || escaped === '\f' ? '' : (escaped ?? '');
+  });
+
+const significant = (nodes: valueParser.Node[]): valueParser.Node[] =>
+  nodes.filter(node => node.type !== 'space' && node.type !== 'comment');
+
+const functionArgument = (node: valueParser.FunctionNode): string | undefined => {
+  const nodes = significant(node.nodes);
+  if (nodes.length !== 1 || (nodes[0]!.type !== 'string' && nodes[0]!.type !== 'word')) return;
+  return cssUnescape(nodes[0]!.value);
+};
+
+const hasUnclosedNode = (nodes: valueParser.Node[]): boolean =>
+  nodes.some(node =>
+    ('unclosed' in node && node.unclosed === true)
+    || (node.type === 'function' && hasUnclosedNode(node.nodes)),
+  );
+
+const isWoffSource = (nodes: valueParser.Node[]): boolean => {
+  let woff = false;
+  valueParser.walk(nodes, node => {
+    if (node.type !== 'function') return;
+    const name = cssUnescape(node.value).toLowerCase();
+    const argument = functionArgument(node);
+    if (argument === undefined) return;
+    if (name === 'format' && argument.toLowerCase() === 'woff') woff = true;
+    if (name === 'url' && !argument.toLowerCase().startsWith('data:') && /\.woff(?:[?#]|$)/i.test(argument)) woff = true;
+  });
+  return woff;
+};
+
+interface FontSource {
+  delimiterBefore?: valueParser.DivNode;
+  nodes: valueParser.Node[];
+}
+
+const splitSources = (nodes: valueParser.Node[]): FontSource[] => {
+  const sources: FontSource[] = [{ nodes: [] }];
+  for (const node of nodes) {
+    if (node.type === 'div' && node.value === ',') {
+      sources.push({ delimiterBefore: node, nodes: [] });
+    } else {
+      sources.at(-1)!.nodes.push(node);
+    }
+  }
+  return sources;
+};
+
+const stripWoffSources = (value: string, source: string): string => {
+  const parsed = valueParser(value);
+  if (hasUnclosedNode(parsed.nodes)) throw new Error(`${source} contains an unclosed font source`);
+  const sources = splitSources(parsed.nodes);
+  if (sources.some(({ nodes }) => significant(nodes).length === 0)) {
+    throw new Error(`${source} contains an empty font source`);
+  }
+
+  const retained = sources.filter(({ nodes }) => !isWoffSource(nodes));
+  if (retained.length === 0) throw new Error(`${source} does not declare a non-WOFF font source`);
+
+  parsed.nodes = retained.flatMap(({ delimiterBefore, nodes }, index) =>
+    index === 0 ? nodes : [delimiterBefore!, ...nodes],
+  );
+  if (isWoffSource(parsed.nodes)) throw new Error(`${source} still declares a WOFF source`);
+  return valueParser.stringify(parsed.nodes);
+};
+
+// Fontsource writes every static face with a WOFF source behind the WOFF2 one,
+// so importing one of its stylesheets pulls a second, larger copy of each face
+// into the bundle:
+// https://github.com/fontsource/fontsource/blob/e50a906d3026beac81ebc47b5436c9d7c2e3a070/packages/core/src/css/face-rule.ts#L26-L44
+// No browser this app is built for can ask for it. `build.target` is left at
+// Vite's default `baseline-widely-available`, which at this version resolves to
+// chrome111, edge111, firefox114, safari16.4 and ios16.4
+// (https://github.com/vitejs/vite/blob/v8.1.5/packages/vite/src/node/constants.ts#L90-L96),
+// while WOFF2 has been answered since Chrome 36, Firefox 39, Safari 10 and iOS
+// 10 (https://caniuse.com/woff2).
+//
+// Removing the source in the existing PostCSS pass leaves the family, weights,
+// subset, style and `font-display` upstream's to state. Parsing both the rule
+// and its `src` value means whitespace, quoting, escapes, and embedded data-URL
+// commas remain CSS syntax rather than assumptions in a text substitution.
+export const fontsourceWoff2Only = (): Plugin => ({
+  postcssPlugin: 'fontsource-woff2-only',
+  Once(root, { result }) {
+    const path = result.opts.from?.replaceAll('\\', '/');
+    if (path === undefined || !fontsourceStylesheet.test(path)) return;
+    root.walkDecls(/^src$/i, declaration => {
+      declaration.value = stripWoffSources(declaration.value, path);
+    });
+  },
+});
 
 // UnoCSS generates through PostCSS rather than `unocss/vite`, whose global mode
 // emits nothing under React Router: it keys its `vite:css-post` handle by the
@@ -22,4 +126,4 @@ import UnoCSS from '@unocss/postcss';
 // keeps a build launched from the workspace root scanning the same files as one
 // launched from this package.
 // https://github.com/unocss/unocss/blob/e28a47c557fe179935a37a4fbeb650292d0d1d5a/packages-integrations/postcss/src/esm.ts#L21-L110
-export default { plugins: [UnoCSS({ cwd: import.meta.dirname })] };
+export default { plugins: [fontsourceWoff2Only(), UnoCSS({ cwd: import.meta.dirname })] };

--- a/apps/web/postcss.config.ts
+++ b/apps/web/postcss.config.ts
@@ -25,9 +25,9 @@ const functionArgument = (node: valueParser.FunctionNode): string | undefined =>
 };
 
 const hasUnclosedNode = (nodes: valueParser.Node[]): boolean =>
-  nodes.some(node =>
-    ('unclosed' in node && node.unclosed === true)
-    || (node.type === 'function' && hasUnclosedNode(node.nodes)),
+  nodes.some(
+    node => ('unclosed' in node && node.unclosed === true)
+      || (node.type === 'function' && hasUnclosedNode(node.nodes)),
   );
 
 const isWoffSource = (nodes: valueParser.Node[]): boolean => {
@@ -71,8 +71,8 @@ const stripWoffSources = (value: string, source: string): string => {
   const retained = sources.filter(({ nodes }) => !isWoffSource(nodes));
   if (retained.length === 0) throw new Error(`${source} does not declare a non-WOFF font source`);
 
-  parsed.nodes = retained.flatMap(({ delimiterBefore, nodes }, index) =>
-    index === 0 ? nodes : [delimiterBefore!, ...nodes],
+  parsed.nodes = retained.flatMap(
+    ({ delimiterBefore, nodes }, index) => index === 0 ? nodes : [delimiterBefore!, ...nodes],
   );
   if (isWoffSource(parsed.nodes)) throw new Error(`${source} still declares a WOFF source`);
   return valueParser.stringify(parsed.nodes);

--- a/apps/web/postcss.config.ts
+++ b/apps/web/postcss.config.ts
@@ -30,18 +30,30 @@ const hasUnclosedNode = (nodes: valueParser.Node[]): boolean =>
       || (node.type === 'function' && hasUnclosedNode(node.nodes)),
   );
 
-const isWoffSource = (nodes: valueParser.Node[]): boolean => {
-  let woff = false;
+interface WoffReferences {
+  format: boolean;
+  url: boolean;
+}
+
+const woffReferences = (nodes: valueParser.Node[]): WoffReferences => {
+  const references: WoffReferences = { format: false, url: false };
   valueParser.walk(nodes, node => {
     if (node.type !== 'function') return;
     const name = cssUnescape(node.value).toLowerCase();
     const argument = functionArgument(node);
     if (argument === undefined) return;
-    if (name === 'format' && argument.toLowerCase() === 'woff') woff = true;
+    if (name === 'format' && argument.toLowerCase() === 'woff') references.format = true;
     const pathname = argument.split(/[?#]/, 1)[0]!;
-    if (name === 'url' && !argument.toLowerCase().startsWith('data:') && /\.woff$/i.test(pathname)) woff = true;
+    if (name === 'url' && !argument.toLowerCase().startsWith('data:') && /\.woff$/i.test(pathname)) {
+      references.url = true;
+    }
   });
-  return woff;
+  return references;
+};
+
+const isWoffSource = (nodes: valueParser.Node[]): boolean => {
+  const references = woffReferences(nodes);
+  return references.format || references.url;
 };
 
 interface FontSource {
@@ -103,7 +115,9 @@ export const fontsourceWoff2Only = (): Plugin => ({
       declaration.value = stripWoffSources(declaration.value, path);
     });
     root.walkDecls(declaration => {
-      if (isWoffSource(valueParser(declaration.value).nodes)) {
+      const references = woffReferences(valueParser(declaration.value).nodes);
+      const src = cssUnescape(declaration.prop).toLowerCase() === 'src';
+      if (references.url || (src && references.format)) {
         throw new Error(`${path} still declares a WOFF source`);
       }
     });

--- a/apps/web/postcss.config.ts
+++ b/apps/web/postcss.config.ts
@@ -38,7 +38,8 @@ const isWoffSource = (nodes: valueParser.Node[]): boolean => {
     const argument = functionArgument(node);
     if (argument === undefined) return;
     if (name === 'format' && argument.toLowerCase() === 'woff') woff = true;
-    if (name === 'url' && !argument.toLowerCase().startsWith('data:') && /\.woff(?:[?#]|$)/i.test(argument)) woff = true;
+    const pathname = argument.split(/[?#]/, 1)[0]!;
+    if (name === 'url' && !argument.toLowerCase().startsWith('data:') && /\.woff$/i.test(pathname)) woff = true;
   });
   return woff;
 };
@@ -74,7 +75,6 @@ const stripWoffSources = (value: string, source: string): string => {
   parsed.nodes = retained.flatMap(
     ({ delimiterBefore, nodes }, index) => index === 0 ? nodes : [delimiterBefore!, ...nodes],
   );
-  if (isWoffSource(parsed.nodes)) throw new Error(`${source} still declares a WOFF source`);
   return valueParser.stringify(parsed.nodes);
 };
 
@@ -96,10 +96,16 @@ const stripWoffSources = (value: string, source: string): string => {
 export const fontsourceWoff2Only = (): Plugin => ({
   postcssPlugin: 'fontsource-woff2-only',
   Once(root, { result }) {
-    const path = result.opts.from?.replaceAll('\\', '/');
+    const path = result.opts.from?.replaceAll('\\', '/').split(/[?#]/, 1)[0];
     if (path === undefined || !fontsourceStylesheet.test(path)) return;
-    root.walkDecls(/^src$/i, declaration => {
+    root.walkDecls(declaration => {
+      if (cssUnescape(declaration.prop).toLowerCase() !== 'src') return;
       declaration.value = stripWoffSources(declaration.value, path);
+    });
+    root.walkDecls(declaration => {
+      if (isWoffSource(valueParser(declaration.value).nodes)) {
+        throw new Error(`${path} still declares a WOFF source`);
+      }
     });
   },
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -112,36 +112,6 @@ const prismComponentsEsm = (): Plugin => ({
   },
 });
 
-// Fontsource writes every static face with a WOFF source behind the WOFF2 one,
-// so importing one of its stylesheets pulls a second, larger copy of each face
-// into the bundle:
-// https://github.com/fontsource/fontsource/blob/e50a906d3026beac81ebc47b5436c9d7c2e3a070/packages/core/src/css/face-rule.ts#L26-L44
-// No browser this app is built for can ask for it. `build.target` is left at
-// Vite's default `baseline-widely-available`, which at this version resolves to
-// chrome111, edge111, firefox114, safari16.4 and ios16.4
-// (https://github.com/vitejs/vite/blob/v8.1.5/packages/vite/src/node/constants.ts#L90-L96),
-// while WOFF2 has been answered since Chrome 36, Firefox 39, Safari 10 and iOS
-// 10 (https://caniuse.com/woff2).
-//
-// Dropping the source before `vite:css` resolves it, rather than transcribing
-// the rules by hand, leaves the family, weights, subset, style and
-// `font-display` upstream's to state, so no copy of them can drift from the
-// installed package.
-const fontsourceWoff2Only = (): Plugin => ({
-  name: 'fontsource-woff2-only',
-  enforce: 'pre',
-  transform(code, id) {
-    const path = id.split('?', 1)[0]!.replaceAll('\\', '/');
-    if (!/\/@fontsource(?:-variable)?\/[^/]+\/[^/]+\.css$/.test(path)) return;
-    const woff2Only = code.replaceAll(/,\s*url\([^()]+\.woff\)\s*format\(['"]?woff['"]?\)/g, '');
-    // A rewrite of the rule upstream would otherwise put the fallback back
-    // silently, since the strip that no longer matches anything looks the same
-    // from here as a sheet that never carried one.
-    if (/\.woff\b/.test(woff2Only)) throw new Error(`${path} still declares a WOFF source`);
-    return woff2Only;
-  },
-});
-
 // The Worker runs at 8788 in `wrangler dev`. Vite proxies every path the Worker
 // owns so the SPA can call relative URLs in both dev and prod. Anything not
 // matched falls through to the Vite dev server, which serves the SPA itself.
@@ -219,7 +189,6 @@ export default defineConfig({
     ],
   },
   plugins: [
-    fontsourceWoff2Only(),
     prismComponentsEsm(),
     typescriptStylesheets(),
     reactRouter(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       magic-string:
         specifier: ^1.1.0
         version: 1.1.0
+      postcss-value-parser:
+        specifier: ^4.2.0
+        version: 4.2.0
       unocss:
         specifier: ^66.7.5
         version: 66.7.5(@unocss/postcss@66.7.5(postcss@8.5.23))(vite@8.1.5(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -4312,6 +4315,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -9731,6 +9737,8 @@ snapshots:
       pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.23:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       magic-string:
         specifier: ^1.1.0
         version: 1.1.0
+      postcss:
+        specifier: ^8.5.23
+        version: 8.5.23
       postcss-value-parser:
         specifier: ^4.2.0
         version: 4.2.0


### PR DESCRIPTION
## Purpose

The Vite build removed Fontsource WOFF fallbacks with one stylesheet regex that depended on exact formatting and could mishandle URL queries or escaped CSS identifiers.

## Change

- Parse Fontsource stylesheets through PostCSS and `postcss-value-parser`.
- Remove only `.woff` URL sources and their associated `format(woff)` nodes.
- Preserve WOFF2 sources containing `.woff` text in query or fragment values.
- Handle Vite query-bearing module ids and CSS-escaped descriptor names.
- Retain a whole-root safety gate for actual WOFF assets.

## Test Plan

- [x] Fontsource transform suite — 14 passed
- [x] Web lint and typecheck
- [x] Production build emitted only the three expected WOFF2 assets
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
