### PR TITLE
refactor(gateway): decode dump storage with Zod

### DIFF
--- a/packages/gateway/__tests__/dump/storage-codec_test.ts
+++ b/packages/gateway/__tests__/dump/storage-codec_test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from 'vitest';
 
+import { fakeMeta } from './test-fixtures.ts';
 import { dumpCodec } from '../../src/dump/codec.ts';
 import {
   decodeDumpHeaders,
   encodeDumpHeaders,
 } from '../../src/dump/storage-codec.ts';
-import { fakeMeta } from './test-fixtures.ts';
 
 test('dump storage headers preserve duplicate pairs and their order', () => {
   const headers: Array<[string, string]> = [

--- a/packages/gateway/__tests__/dump/storage-codec_test.ts
+++ b/packages/gateway/__tests__/dump/storage-codec_test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest';
+
+import { dumpCodec } from '../../src/dump/codec.ts';
+import {
+  decodeDumpHeaders,
+  encodeDumpHeaders,
+} from '../../src/dump/storage-codec.ts';
+import { fakeMeta } from './test-fixtures.ts';
+
+test('dump storage headers preserve duplicate pairs and their order', () => {
+  const headers: Array<[string, string]> = [
+    ['set-cookie', 'a=1'],
+    ['x-empty', ''],
+    ['set-cookie', 'b=2'],
+  ];
+
+  expect(decodeDumpHeaders(encodeDumpHeaders(headers, 'test headers'), 'test headers')).toEqual(headers);
+});
+
+test('dump broker frames round-trip metadata through the shared schema', () => {
+  const metadata = fakeMeta({
+    upstream: { id: 'upstream-a', name: 'A', kind: 'custom', hue: 42 },
+    error: { kind: 'failed', reason: 'connection closed' },
+  });
+
+  expect(dumpCodec.decode(dumpCodec.encode(metadata))).toEqual(metadata);
+});
+
+test('dump broker frames reject valid JSON with malformed metadata', () => {
+  const frame = {
+    event: 'appended',
+    data: { ...fakeMeta(), status: '200' },
+  };
+
+  expect(() => dumpCodec.decode(JSON.stringify(frame)))
+    .toThrow(/Invalid dump broker frame.*status/su);
+});

--- a/packages/gateway/__tests__/repo/dump-store_test.ts
+++ b/packages/gateway/__tests__/repo/dump-store_test.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path';
 import { expect, test } from 'vitest';
 
 import { createSqliteTestDb } from './test-sqlite.ts';
+import { decodeDumpBodyDescriptor } from '../../src/dump/storage-codec.ts';
 import type { DumpWriteRecord } from '../../src/dump/types.ts';
 import { FileDumpStore } from '../../src/repo/dump-store.ts';
 import { initRepo } from '../../src/repo/index.ts';
@@ -166,6 +167,74 @@ test('FileDumpStore round-trips an SSE record as a stream events array', async (
   if (fetched.response.body.type !== 'stream') throw new Error('expected stream');
   assertEquals(fetched.response.body.events.length, 2);
   assertEquals(fetched.response.body.events[0]!.frame.type, 'event');
+});
+
+test('FileDumpStore rejects malformed metadata with its row identity', async () => {
+  const db = await openDb();
+  const store = new FileDumpStore(db, new MemoryFileStore());
+  const record = baseRecord('01HZZ000000000000000000BADM', Date.UTC(2026, 5, 1, 12));
+  await store.put('key_x', record);
+  await db.prepare('UPDATE dump_records SET meta_json = ? WHERE key_id = ? AND id = ?')
+    .bind(JSON.stringify({ ...record.meta, upstream: undefined, status: '200' }), 'key_x', record.meta.id)
+    .run();
+
+  await expect(store.list('key_x', { limit: 10 }))
+    .rejects.toThrow(/Invalid dump record 01HZZ000000000000000000BADM metadata.*status/su);
+});
+
+test('FileDumpStore rejects malformed header pairs with their record and side', async () => {
+  const db = await openDb();
+  const store = new FileDumpStore(db, new MemoryFileStore());
+  const record = baseRecord('01HZZ000000000000000000BADH', Date.UTC(2026, 5, 1, 12));
+  await store.put('key_x', record);
+  await db.prepare('UPDATE dump_records SET request_headers_json = ? WHERE key_id = ? AND id = ?')
+    .bind(JSON.stringify([['x-bad', 1]]), 'key_x', record.meta.id)
+    .run();
+
+  await expect(store.get('key_x', record.meta.id))
+    .rejects.toThrow(/Invalid dump record 01HZZ000000000000000000BADH request headers/u);
+});
+
+test('FileDumpStore rejects malformed body descriptors before file access', async () => {
+  const db = await openDb();
+  const store = new FileDumpStore(db, new MemoryFileStore());
+  const record = baseRecord('01HZZ000000000000000000BADD', Date.UTC(2026, 5, 1, 12));
+  await store.put('key_x', record);
+  await db.prepare('UPDATE dump_records SET request_body_descriptor = ? WHERE key_id = ? AND id = ?')
+    .bind(JSON.stringify({ key: 'dumps/v1/key_x/request.gz', type: 'chunks' }), 'key_x', record.meta.id)
+    .run();
+
+  await expect(store.get('key_x', record.meta.id))
+    .rejects.toThrow(/Invalid dump record 01HZZ000000000000000000BADD request body descriptor.*type/su);
+});
+
+test('FileDumpStore rejects malformed stream events with record and file context', async () => {
+  const db = await openDb();
+  const files = new MemoryFileStore();
+  const store = new FileDumpStore(db, files);
+  const record: DumpWriteRecord = {
+    ...baseRecord('01HZZ000000000000000000BADE', Date.UTC(2026, 5, 1, 12)),
+    response: {
+      status: 200,
+      headers: [['content-type', 'text/event-stream']],
+      body: { type: 'stream', events: [{ frame: { type: 'done' }, ts: 1 }] },
+    },
+  };
+  await store.put('key_x', record);
+  const row = await db.prepare('SELECT response_body_descriptor FROM dump_records WHERE key_id = ? AND id = ?')
+    .bind('key_x', record.meta.id)
+    .first<{ response_body_descriptor: string }>();
+  if (row === null) throw new Error('expected stored dump row');
+  const descriptor = decodeDumpBodyDescriptor(row.response_body_descriptor, 'test response descriptor');
+  const malformedEvents = utf8(JSON.stringify([{ frame: { type: 'done' }, ts: 'late' }]));
+  const compressed = new Uint8Array(await new Response(
+    new Blob([malformedEvents as BlobPart]).stream().pipeThrough(new CompressionStream('gzip')),
+  ).arrayBuffer());
+  await files.put(descriptor.key, compressed);
+
+  await expect(store.get('key_x', record.meta.id)).rejects.toThrow(
+    new RegExp(`Invalid dump record ${record.meta.id} response events at key=${descriptor.key}.*ts`, 'su'),
+  );
 });
 
 test('FileDumpStore.list paginates newest-first with the (createdAt, id) cursor', async () => {

--- a/packages/gateway/__tests__/scheduled/expiration-sweeps_test.ts
+++ b/packages/gateway/__tests__/scheduled/expiration-sweeps_test.ts
@@ -9,7 +9,7 @@ import { SqlRepo } from '../../src/repo/sql.ts';
 import type { ApiKey, StoredResponsesItem } from '../../src/repo/types.ts';
 import { sweepExpirations } from '../../src/scheduled/expiration-sweeps.ts';
 import { InMemoryRepo } from '../repo/memory.ts';
-import { createSqliteTestDb, createSqlJsDatabase, migrationSqlByFilename } from '../repo/test-sqlite.ts';
+import { createSqliteTestDb, createSqlJsDatabase, migrationSqlByFilename, wrapSqlJsDatabase } from '../repo/test-sqlite.ts';
 import { initFileStore, MemoryFileStore } from '@floway-dev/platform';
 
 afterEach(() => vi.useRealTimers());
@@ -248,6 +248,39 @@ test('migration 0066 bounds existing-row discovery and tracks older dump files o
     db.run("DELETE FROM dump_records WHERE key_id = 'key-old-dump'");
     expect(db.exec("SELECT file_key, owner_kind, state FROM spilled_files WHERE owner_key = json_array('key-old-dump', '01K00000000000000000OLD0')")[0].values)
       .toEqual([['dumps/v1/key-old-dump/old.req.gz', 'dump-request', 'retired']]);
+  } finally {
+    db.close();
+  }
+});
+
+test('expiration backfill rejects malformed legacy dump descriptors with row context', async () => {
+  const db = await createSqlJsDatabase();
+  try {
+    for (const [filename, sql] of migrationSqlByFilename) {
+      if (filename === '0066_expiration_sweeps.sql') break;
+      db.run(sql);
+    }
+    db.run(
+      `INSERT INTO api_keys
+       (id, user_id, name, key, created_at, upstream_ids, deleted_at, dump_retention_seconds, server_secret, responses_retention_seconds)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['key-legacy', 1, 'Legacy', 'raw-legacy', '2026-01-01T00:00:00Z', null, null, 3600, '66'.repeat(32), 0],
+    );
+    const recordId = '01K00000000000000000BAD0';
+    db.run(
+      `INSERT INTO dump_records
+       (key_id, id, created_at, upstream_id, meta_json, request_headers_json, response_headers_json, request_body_descriptor, response_body_descriptor)
+       VALUES (?, ?, ?, NULL, '{}', '[]', NULL, ?, NULL)`,
+      ['key-legacy', recordId, 1_000, JSON.stringify({ key: 'dumps/v1/key-legacy/old.req.gz', type: 'chunks' })],
+    );
+    const migration = migrationSqlByFilename.find(([filename]) => filename === '0066_expiration_sweeps.sql');
+    if (migration === undefined) throw new Error('missing migration 0066_expiration_sweeps.sql');
+    db.run(migration[1]);
+
+    const repo = new SqlRepo(wrapSqlJsDatabase(db));
+    await expect(repo.expirationSweeps.backfillCleanupTracking(500)).rejects.toThrow(
+      new RegExp(`Invalid dump record key-legacy/${recordId} request body descriptor during expiration backfill.*type`, 'su'),
+    );
   } finally {
     db.close();
   }

--- a/packages/gateway/src/dump/codec.ts
+++ b/packages/gateway/src/dump/codec.ts
@@ -1,20 +1,15 @@
+import { dumpBrokerFrameSchema } from './schemas.ts';
 import type { DumpMetadata } from './types.ts';
 import type { ChannelCodec } from '@floway-dev/platform';
 
-const APPENDED_EVENT = 'appended';
-
-interface AppendedFrame {
-  event: typeof APPENDED_EVENT;
-  data: DumpMetadata;
-}
-
 export const dumpCodec: ChannelCodec<DumpMetadata> = {
-  encode: meta => JSON.stringify({ event: APPENDED_EVENT, data: meta } satisfies AppendedFrame),
+  encode: meta => JSON.stringify(dumpBrokerFrameSchema.parse({ event: 'appended', data: meta })),
   decode: text => {
-    const parsed = JSON.parse(text) as { event: unknown; data: unknown };
-    if (parsed.event !== APPENDED_EVENT) {
-      throw new Error(`dump broker frame had unexpected event ${String(parsed.event)}`);
+    try {
+      return dumpBrokerFrameSchema.parse(JSON.parse(text)).data;
+    } catch (cause) {
+      const detail = cause instanceof Error ? `: ${cause.message}` : '';
+      throw new Error(`Invalid dump broker frame${detail}`, { cause });
     }
-    return parsed.data as DumpMetadata;
   },
 };

--- a/packages/gateway/src/dump/schemas.ts
+++ b/packages/gateway/src/dump/schemas.ts
@@ -1,5 +1,6 @@
-import { ALL_PROVIDER_KINDS } from '@floway-dev/provider';
 import { z } from 'zod';
+
+import { ALL_PROVIDER_KINDS } from '@floway-dev/provider';
 
 export const dumpErrorSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.enum(['upstream', 'gateway']) }).strict(),

--- a/packages/gateway/src/dump/schemas.ts
+++ b/packages/gateway/src/dump/schemas.ts
@@ -1,0 +1,57 @@
+import { ALL_PROVIDER_KINDS } from '@floway-dev/provider';
+import { z } from 'zod';
+
+export const dumpErrorSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.enum(['upstream', 'gateway']) }).strict(),
+  z.object({ kind: z.literal('failed'), reason: z.string() }).strict(),
+]);
+
+export const dumpUpstreamRefSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  kind: z.enum(ALL_PROVIDER_KINDS),
+  hue: z.number(),
+}).strict();
+
+export const dumpMetadataSchema = z.object({
+  id: z.string(),
+  startedAt: z.number(),
+  completedAt: z.number(),
+  method: z.string(),
+  path: z.string(),
+  status: z.number().nullable(),
+  upstream: dumpUpstreamRefSchema.nullable(),
+  model: z.string().nullable(),
+  inputTokens: z.number().nullable(),
+  outputTokens: z.number().nullable(),
+  requestBytes: z.number(),
+  responseBytes: z.number(),
+  durationMs: z.number(),
+  error: dumpErrorSchema.nullable(),
+}).strict();
+
+export const persistedDumpMetadataSchema = dumpMetadataSchema.omit({ upstream: true });
+
+export const dumpHeadersSchema = z.array(z.tuple([z.string(), z.string()]));
+
+export const dumpBodyDescriptorSchema = z.object({
+  key: z.string(),
+  type: z.enum(['bytes', 'events']),
+}).strict();
+
+const dumpProtocolFrameSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('event'), event: z.unknown() }).strict(),
+  z.object({ type: z.literal('done') }).strict(),
+]);
+
+export const dumpStreamEventSchema = z.object({
+  frame: dumpProtocolFrameSchema,
+  ts: z.number(),
+}).strict();
+
+export const dumpStreamEventsSchema = z.array(dumpStreamEventSchema);
+
+export const dumpBrokerFrameSchema = z.object({
+  event: z.literal('appended'),
+  data: dumpMetadataSchema,
+}).strict();

--- a/packages/gateway/src/dump/storage-codec.ts
+++ b/packages/gateway/src/dump/storage-codec.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+
 import {
   dumpBodyDescriptorSchema,
   dumpHeadersSchema,
@@ -5,7 +7,6 @@ import {
   dumpStreamEventsSchema,
 } from './schemas.ts';
 import type { DumpMetadata, DumpStreamEvent } from './types.ts';
-import type { z } from 'zod';
 
 export type DumpBodyDescriptor = z.infer<typeof dumpBodyDescriptorSchema>;
 type PersistedDumpMetadata = z.infer<typeof persistedDumpMetadataSchema>;

--- a/packages/gateway/src/dump/storage-codec.ts
+++ b/packages/gateway/src/dump/storage-codec.ts
@@ -1,0 +1,55 @@
+import {
+  dumpBodyDescriptorSchema,
+  dumpHeadersSchema,
+  persistedDumpMetadataSchema,
+  dumpStreamEventsSchema,
+} from './schemas.ts';
+import type { DumpMetadata, DumpStreamEvent } from './types.ts';
+import type { z } from 'zod';
+
+export type DumpBodyDescriptor = z.infer<typeof dumpBodyDescriptorSchema>;
+type PersistedDumpMetadata = z.infer<typeof persistedDumpMetadataSchema>;
+
+const parseJson = <T>(text: string, context: string, schema: z.ZodType<T>): T => {
+  try {
+    return schema.parse(JSON.parse(text));
+  } catch (cause) {
+    const detail = cause instanceof Error ? `: ${cause.message}` : '';
+    throw new Error(`Invalid ${context}${detail}`, { cause });
+  }
+};
+
+const encodeJson = <T>(value: T, context: string, schema: z.ZodType<T>): string => {
+  try {
+    return JSON.stringify(schema.parse(value));
+  } catch (cause) {
+    const detail = cause instanceof Error ? `: ${cause.message}` : '';
+    throw new Error(`Invalid ${context}${detail}`, { cause });
+  }
+};
+
+export const encodePersistedDumpMetadata = (metadata: DumpMetadata, context: string): string => {
+  const { upstream: _upstream, ...persisted } = metadata;
+  return encodeJson(persisted, context, persistedDumpMetadataSchema);
+};
+
+export const decodePersistedDumpMetadata = (text: string, context: string): PersistedDumpMetadata =>
+  parseJson(text, context, persistedDumpMetadataSchema);
+
+export const encodeDumpHeaders = (headers: Array<[string, string]>, context: string): string =>
+  encodeJson(headers, context, dumpHeadersSchema);
+
+export const decodeDumpHeaders = (text: string, context: string): Array<[string, string]> =>
+  parseJson(text, context, dumpHeadersSchema);
+
+export const encodeDumpBodyDescriptor = (descriptor: DumpBodyDescriptor, context: string): string =>
+  encodeJson(descriptor, context, dumpBodyDescriptorSchema);
+
+export const decodeDumpBodyDescriptor = (text: string, context: string): DumpBodyDescriptor =>
+  parseJson(text, context, dumpBodyDescriptorSchema);
+
+export const encodeDumpStreamEvents = (events: DumpStreamEvent[], context: string): string =>
+  encodeJson(events, context, dumpStreamEventsSchema);
+
+export const decodeDumpStreamEvents = (text: string, context: string): DumpStreamEvent[] =>
+  parseJson(text, context, dumpStreamEventsSchema);

--- a/packages/gateway/src/dump/types.ts
+++ b/packages/gateway/src/dump/types.ts
@@ -9,13 +9,14 @@
 //
 // `DumpMetadata` and `DumpStreamEvent` are body-free and shared verbatim.
 
+import type { z } from 'zod';
+
 import type {
   dumpErrorSchema,
   dumpMetadataSchema,
   dumpStreamEventSchema,
   dumpUpstreamRefSchema,
 } from './schemas.ts';
-import type { z } from 'zod';
 
 export type DumpRecordId = string;
 

--- a/packages/gateway/src/dump/types.ts
+++ b/packages/gateway/src/dump/types.ts
@@ -9,17 +9,17 @@
 //
 // `DumpMetadata` and `DumpStreamEvent` are body-free and shared verbatim.
 
-import type { ProtocolFrame } from '@floway-dev/protocols/common';
-import type { UpstreamProviderKind } from '@floway-dev/provider';
+import type {
+  dumpErrorSchema,
+  dumpMetadataSchema,
+  dumpStreamEventSchema,
+  dumpUpstreamRefSchema,
+} from './schemas.ts';
+import type { z } from 'zod';
 
 export type DumpRecordId = string;
 
-export interface DumpUpstreamRef {
-  id: string;
-  name: string;
-  kind: UpstreamProviderKind;
-  hue: number;
-}
+export type DumpUpstreamRef = z.infer<typeof dumpUpstreamRefSchema>;
 
 // What went wrong on a failed turn. Either a categorized api-error envelope
 // (real upstream non-2xx or a gateway-synthesized envelope — `kind` matches
@@ -28,29 +28,9 @@ export interface DumpUpstreamRef {
 // exceptions, source-emitted error events, downstream cancels, write
 // errors) carrying its one-line reason text. The categorized form stores
 // no status — `DumpMetadata.status` already does.
-export type DumpErrorMeta =
-  | { kind: 'upstream' | 'gateway' }
-  | { kind: 'failed'; reason: string };
+export type DumpErrorMeta = z.infer<typeof dumpErrorSchema>;
 
-export interface DumpMetadata {
-  id: DumpRecordId;
-  startedAt: number;        // unix ms
-  completedAt: number;      // unix ms
-  method: string;
-  path: string;             // includes query string
-  status: number | null;    // null when no upstream response status was produced
-  upstream: DumpUpstreamRef | null;
-  model: string | null;
-  inputTokens: number | null;
-  outputTokens: number | null;
-  // Captured application-payload bytes. HTTP counts body bytes; WebSocket
-  // counts UTF-8 message payloads. Transport framing/compression and the
-  // dump store's gzip encoding are excluded.
-  requestBytes: number;
-  responseBytes: number;
-  durationMs: number;
-  error: DumpErrorMeta | null;
-}
+export type DumpMetadata = z.infer<typeof dumpMetadataSchema>;
 
 // Canonical protocol frame the gateway's respond layer fans out to every
 // dump-enabled key. Stored as ProtocolFrame (not the SSE-serialized form)
@@ -61,10 +41,7 @@ export interface DumpMetadata {
 // `unknown` for the event payload because the storage layer is protocol-
 // agnostic — the dashboard dispatches the right per-protocol serializer
 // based on `meta.path`.
-export interface DumpStreamEvent {
-  frame: ProtocolFrame<unknown>;
-  ts: number;               // ms relative to startedAt
-}
+export type DumpStreamEvent = z.infer<typeof dumpStreamEventSchema>;
 
 // --- Storage shape (in-process, never serialized) ---
 

--- a/packages/gateway/src/repo/dump-store.ts
+++ b/packages/gateway/src/repo/dump-store.ts
@@ -1,10 +1,20 @@
 import { DUMP_FILE_PREFIX, SPILLED_FILE_STAGE_GRACE_MS } from './spilled-files-policy.ts';
 import { parseUpstreamHue, parseUpstreamKind } from './upstream-parse.ts';
+import {
+  decodeDumpBodyDescriptor,
+  decodeDumpHeaders,
+  decodeDumpStreamEvents,
+  decodePersistedDumpMetadata,
+  encodeDumpBodyDescriptor,
+  encodeDumpHeaders,
+  encodeDumpStreamEvents,
+  encodePersistedDumpMetadata,
+} from '../dump/storage-codec.ts';
 import type { DumpListOptions, DumpStore } from '../dump/store-contract.ts';
+import type { DumpBodyDescriptor } from '../dump/storage-codec.ts';
 import type {
   DumpMetadata,
   DumpRecordId,
-  DumpStreamEvent,
   DumpUpstreamRef,
   DumpWriteRecord,
   PreparedDumpRequestBody,
@@ -21,12 +31,8 @@ import type { FileStore, SqlDatabase } from '@floway-dev/platform';
 
 const HOUR_MS = 60 * 60 * 1000;
 
-interface BodyDescriptor {
-  key: string;
-  type: 'bytes' | 'events';
-}
-
 interface DumpRow {
+  id: string;
   upstream_id: string | null;
   upstream_name: string | null;
   upstream_kind: string | null;
@@ -83,7 +89,7 @@ const putRawBody = async (
   key: string,
   rawBytes: Uint8Array,
   type: 'bytes' | 'events',
-): Promise<BodyDescriptor> => {
+): Promise<DumpBodyDescriptor> => {
   const gz = await gzip(rawBytes);
   await files.put(key, gz);
   return { key, type };
@@ -93,13 +99,13 @@ const putPreparedBody = async (
   files: FileStore,
   key: string,
   prepared: PreparedDumpRequestBody,
-): Promise<BodyDescriptor> => {
+): Promise<DumpBodyDescriptor> => {
   const gz = prepared.encoding === 'gzip' ? prepared.bytes : await gzip(prepared.bytes);
   await files.put(key, gz);
   return { key, type: 'bytes' };
 };
 
-const fetchBody = async (files: FileStore, descriptor: BodyDescriptor): Promise<Uint8Array> => {
+const fetchBody = async (files: FileStore, descriptor: DumpBodyDescriptor): Promise<Uint8Array> => {
   const gz = await files.get(descriptor.key);
   if (!gz) throw new Error(`dump body missing for key=${descriptor.key}`);
   return await gunzip(gz);
@@ -149,18 +155,19 @@ export class FileDumpStore implements DumpStore {
       ? null
       : await putPreparedBody(this.files, requestFileKey!, record.request.body);
 
-    let responseDescriptor: BodyDescriptor | null = null;
+    let responseDescriptor: DumpBodyDescriptor | null = null;
     if (record.response.body.type === 'bytes') {
       if (record.response.body.body.byteLength > 0) {
         responseDescriptor = await putRawBody(this.files, responseFileKey!, record.response.body.body, 'bytes');
       }
     } else if (record.response.body.type === 'stream') {
-      responseDescriptor = await putRawBody(this.files, responseFileKey!, new TextEncoder().encode(JSON.stringify(record.response.body.events)), 'events');
+      responseDescriptor = await putRawBody(
+        this.files,
+        responseFileKey!,
+        new TextEncoder().encode(encodeDumpStreamEvents(record.response.body.events, `dump record ${record.meta.id} response events`)),
+        'events',
+      );
     }
-
-    // Strip the in-memory `upstream` field; the ref is rebuilt from the join
-    // at read time so renames and deletes are honored on historical rows.
-    const { upstream: _upstream, ...metaToStore } = record.meta;
 
     // Files before row — a partial failure leaves orphan files the sweep
     // collects, never an orphan row whose detail fetch would 404.
@@ -173,11 +180,17 @@ export class FileDumpStore implements DumpStore {
       record.meta.id,
       record.meta.completedAt,
       record.meta.upstream?.id ?? null,
-      JSON.stringify(metaToStore),
-      JSON.stringify(record.request.headers),
-      record.response.body.type === 'none' ? null : JSON.stringify(record.response.headers),
-      requestDescriptor === null ? null : JSON.stringify(requestDescriptor),
-      responseDescriptor === null ? null : JSON.stringify(responseDescriptor),
+      encodePersistedDumpMetadata(record.meta, `dump record ${record.meta.id} metadata`),
+      encodeDumpHeaders(record.request.headers, `dump record ${record.meta.id} request headers`),
+      record.response.body.type === 'none'
+        ? null
+        : encodeDumpHeaders(record.response.headers, `dump record ${record.meta.id} response headers`),
+      requestDescriptor === null
+        ? null
+        : encodeDumpBodyDescriptor(requestDescriptor, `dump record ${record.meta.id} request body descriptor`),
+      responseDescriptor === null
+        ? null
+        : encodeDumpBodyDescriptor(responseDescriptor, `dump record ${record.meta.id} response body descriptor`),
     ).run();
   }
 
@@ -195,7 +208,7 @@ export class FileDumpStore implements DumpStore {
     // millisecond still page deterministically — ULID lex order matches
     // creation order within the ms.
     const select
-      = 'SELECT d.meta_json, d.upstream_id, u.name AS upstream_name, u.provider AS upstream_kind, u.hue AS upstream_hue '
+      = 'SELECT d.id, d.meta_json, d.upstream_id, u.name AS upstream_name, u.provider AS upstream_kind, u.hue AS upstream_hue '
       + 'FROM dump_records d LEFT JOIN upstreams u ON u.id = d.upstream_id '
       + 'JOIN api_keys k ON k.id = d.key_id AND k.deleted_at IS NULL AND k.dump_retention_seconds IS NOT NULL ';
     const visible = 'd.key_id = ? AND d.created_at >= ? - k.dump_retention_seconds * 1000';
@@ -206,16 +219,16 @@ export class FileDumpStore implements DumpStore {
     const stmt = beforeTs === null
       ? this.db.prepare(sql).bind(keyId, now, opts.limit)
       : this.db.prepare(sql).bind(keyId, now, beforeTs, beforeTs, beforeId, opts.limit);
-    const { results } = await stmt.all<Pick<DumpRow, 'meta_json' | 'upstream_id' | 'upstream_name' | 'upstream_kind' | 'upstream_hue'>>();
+    const { results } = await stmt.all<Pick<DumpRow, 'id' | 'meta_json' | 'upstream_id' | 'upstream_name' | 'upstream_kind' | 'upstream_hue'>>();
     return results.map(row => ({
-      ...JSON.parse(row.meta_json) as Omit<DumpMetadata, 'upstream'>,
+      ...decodePersistedDumpMetadata(row.meta_json, `dump record ${row.id} metadata`),
       upstream: hydrateUpstream(row),
     }));
   }
 
   async get(keyId: string, recordId: DumpRecordId): Promise<StoredDumpRecord | null> {
     const row = await this.db.prepare(
-      'SELECT d.upstream_id, u.name AS upstream_name, u.provider AS upstream_kind, u.hue AS upstream_hue, '
+      'SELECT d.id, d.upstream_id, u.name AS upstream_name, u.provider AS upstream_kind, u.hue AS upstream_hue, '
       + 'd.meta_json, d.request_headers_json, d.response_headers_json, d.request_body_descriptor, d.response_body_descriptor '
       + 'FROM dump_records d LEFT JOIN upstreams u ON u.id = d.upstream_id '
       + 'JOIN api_keys k ON k.id = d.key_id AND k.deleted_at IS NULL AND k.dump_retention_seconds IS NOT NULL '
@@ -224,13 +237,19 @@ export class FileDumpStore implements DumpStore {
     if (!row) return null;
 
     const meta: DumpMetadata = {
-      ...JSON.parse(row.meta_json) as Omit<DumpMetadata, 'upstream'>,
+      ...decodePersistedDumpMetadata(row.meta_json, `dump record ${recordId} metadata`),
       upstream: hydrateUpstream(row),
     };
-    const requestHeaders = JSON.parse(row.request_headers_json) as Array<[string, string]>;
-    const requestDescriptor = row.request_body_descriptor ? JSON.parse(row.request_body_descriptor) as BodyDescriptor : null;
-    const responseHeaders = row.response_headers_json ? JSON.parse(row.response_headers_json) as Array<[string, string]> : null;
-    const responseDescriptor = row.response_body_descriptor ? JSON.parse(row.response_body_descriptor) as BodyDescriptor : null;
+    const requestHeaders = decodeDumpHeaders(row.request_headers_json, `dump record ${recordId} request headers`);
+    const requestDescriptor = row.request_body_descriptor === null
+      ? null
+      : decodeDumpBodyDescriptor(row.request_body_descriptor, `dump record ${recordId} request body descriptor`);
+    const responseHeaders = row.response_headers_json === null
+      ? null
+      : decodeDumpHeaders(row.response_headers_json, `dump record ${recordId} response headers`);
+    const responseDescriptor = row.response_body_descriptor === null
+      ? null
+      : decodeDumpBodyDescriptor(row.response_body_descriptor, `dump record ${recordId} response body descriptor`);
 
     const request: StoredDumpRequest = {
       method: meta.method,
@@ -248,9 +267,11 @@ export class FileDumpStore implements DumpStore {
     } else if (responseDescriptor === null) {
       responseBody = { type: 'bytes', body: new Uint8Array() };
     } else if (responseDescriptor.type === 'events') {
-      const parsed = JSON.parse(new TextDecoder().decode(await fetchBody(this.files, responseDescriptor))) as unknown;
-      if (!Array.isArray(parsed)) throw new Error(`dump events payload not an array at key=${responseDescriptor.key}`);
-      responseBody = { type: 'stream', events: parsed as DumpStreamEvent[] };
+      const text = new TextDecoder().decode(await fetchBody(this.files, responseDescriptor));
+      responseBody = {
+        type: 'stream',
+        events: decodeDumpStreamEvents(text, `dump record ${recordId} response events at key=${responseDescriptor.key}`),
+      };
     } else {
       responseBody = { type: 'bytes', body: await fetchBody(this.files, responseDescriptor) };
     }

--- a/packages/gateway/src/repo/dump-store.ts
+++ b/packages/gateway/src/repo/dump-store.ts
@@ -10,8 +10,8 @@ import {
   encodeDumpStreamEvents,
   encodePersistedDumpMetadata,
 } from '../dump/storage-codec.ts';
-import type { DumpListOptions, DumpStore } from '../dump/store-contract.ts';
 import type { DumpBodyDescriptor } from '../dump/storage-codec.ts';
+import type { DumpListOptions, DumpStore } from '../dump/store-contract.ts';
 import type {
   DumpMetadata,
   DumpRecordId,

--- a/packages/gateway/src/repo/expiration-sweeps-sql.ts
+++ b/packages/gateway/src/repo/expiration-sweeps-sql.ts
@@ -4,6 +4,7 @@ import type {
   ExpirationSweepCompletion,
   ExpirationSweepsRepo,
 } from './types.ts';
+import { decodeDumpBodyDescriptor } from '../dump/storage-codec.ts';
 import type { SqlDatabase } from '@floway-dev/platform';
 
 interface CleanupBackfillSourceState {
@@ -38,14 +39,6 @@ const CLEANUP_BACKFILL_SOURCES = {
 type CleanupBackfillSource = keyof typeof CLEANUP_BACKFILL_SOURCES;
 
 const isCleanupBackfillSource = (source: string): source is CleanupBackfillSource => source in CLEANUP_BACKFILL_SOURCES;
-
-const dumpFileKey = (descriptor: string, source: string): string => {
-  const parsed: unknown = JSON.parse(descriptor);
-  if (typeof parsed !== 'object' || parsed === null || !('key' in parsed) || typeof parsed.key !== 'string') {
-    throw new Error(`Dump ${source} descriptor is missing its file key`);
-  }
-  return parsed.key;
-};
 
 export class SqlExpirationSweepsRepo implements ExpirationSweepsRepo {
   constructor(private readonly db: SqlDatabase) {}
@@ -110,13 +103,19 @@ export class SqlExpirationSweepsRepo implements ExpirationSweepsRepo {
   private async registerDumpFiles(rows: readonly DumpBackfillRow[]): Promise<void> {
     const files: DumpFileOwner[] = rows.flatMap(row => [
       ...(row.request_body_descriptor === null ? [] : [{
-        fileKey: dumpFileKey(row.request_body_descriptor, 'request body'),
+        fileKey: decodeDumpBodyDescriptor(
+          row.request_body_descriptor,
+          `dump record ${row.key_id}/${row.id} request body descriptor during expiration backfill`,
+        ).key,
         ownerKind: 'dump-request' as const,
         keyId: row.key_id,
         recordId: row.id,
       }]),
       ...(row.response_body_descriptor === null ? [] : [{
-        fileKey: dumpFileKey(row.response_body_descriptor, 'response body'),
+        fileKey: decodeDumpBodyDescriptor(
+          row.response_body_descriptor,
+          `dump record ${row.key_id}/${row.id} response body descriptor during expiration backfill`,
+        ).key,
         ownerKind: 'dump-response' as const,
         keyId: row.key_id,
         recordId: row.id,


### PR DESCRIPTION
## Purpose

Dump persistence and broker boundaries decoded stored structures with unchecked casts and parallel shape checks. Corrupt but valid JSON could travel until a distant property access without identifying its record or field.

## Change

- Define one Zod schema and codec family for dump metadata, headers, body descriptors, protocol frames, stream events, and broker messages.
- Reuse the descriptor codec in expiration backfill handling.
- Derive storage-facing TypeScript shapes from the schemas.
- Report invalid data with record id, request or response side, file key, or backfill context while preserving valid stored shapes.

## Test Plan

- [x] Dump codec, store, broker, and expiration suites — 30 passed
- [x] Gateway, Node platform, and Cloudflare platform typechecks
- [x] Combined package verification
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
