### PR TITLE
refactor(gateway): decode data-transfer imports with Zod

### DIFF
--- a/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
@@ -885,6 +885,75 @@ test('import rejects invalid records before clearing existing data', async () =>
   assertEquals(await repo.webSearchUsage.listAll(), [WEB_SEARCH_USAGE_1]);
 });
 
+test('import strips unknown fields at transferable record boundaries', async () => {
+  const { app, repo } = setup();
+  const result = await doImport(app, 'replace', latestImportData({
+    users: [{ ...SEED_ADMIN, smuggled: true }],
+    apiKeys: [{ ...KEY_A, smuggled: true }],
+    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), smuggled: true }],
+    proxies: [{ id: 'p1', name: 'Proxy', url: HTTP_PROXY_URL, dial_timeout_seconds: null, smuggled: true }],
+    usage: [{
+      ...USAGE_1,
+      smuggled: true,
+      metrics: USAGE_1.metrics.map(metric => ({ ...metric, smuggled: true })),
+    }],
+    searchUsage: [{ ...WEB_SEARCH_USAGE_1, smuggled: true }],
+    performanceIncluded: true,
+    performance: [{
+      ...PERFORMANCE_1,
+      smuggled: true,
+      buckets: PERFORMANCE_1.buckets.map(bucket => ({ ...bucket, smuggled: true })),
+    }],
+  }));
+
+  assertEquals(result.status, 200);
+  for (const record of [
+    ...(await repo.users.listIncludingDeleted()),
+    ...(await repo.apiKeys.listIncludingDeleted()),
+    ...(await repo.upstreams.list()),
+    ...(await repo.proxies.list()),
+    ...(await repo.usage.listAll()),
+    ...(await repo.webSearchUsage.listAll()),
+    ...(await repo.performance.listAll()),
+  ]) {
+    assertEquals('smuggled' in record, false);
+  }
+  assertEquals((await repo.usage.listAll())[0].metrics.some(metric => 'smuggled' in metric), false);
+  assertEquals((await repo.performance.listAll())[0].buckets.some(bucket => 'smuggled' in bucket), false);
+});
+
+test('import reports the earliest duplicate before later malformed records', async () => {
+  const { app } = setup();
+  const duplicateUser = await doImport(app, 'replace', latestImportData({
+    users: [SEED_ADMIN, { ...USER_BOB, id: SEED_ADMIN.id }, { ...USER_BOB, deletedAt: 42 }],
+  }));
+  const duplicateMetric = await doImport(app, 'replace', latestImportData({
+    usage: [{
+      ...USAGE_1,
+      metrics: [
+        { metric: 'input_tokens', quantity: '1', unitPrice: null },
+        { metric: 'input_tokens', quantity: '2', unitPrice: null },
+        { metric: 'output_tokens', quantity: -1, unitPrice: null },
+      ],
+    }],
+  }));
+  const duplicateBucket = await doImport(app, 'replace', latestImportData({
+    performanceIncluded: true,
+    performance: [{
+      ...PERFORMANCE_1,
+      buckets: [
+        { metric: 'ttft_ms', lower: 0, upper: 1_000, count: 1 },
+        { metric: 'ttft_ms', lower: 0, upper: 1_000, count: 1 },
+        { metric: 'tpot_us', lower: -1, upper: null, count: 1 },
+      ],
+    }],
+  }));
+
+  assertEquals(duplicateUser.body.error, 'invalid users at index 1: duplicate user id 1');
+  assertEquals(duplicateMetric.body.error, 'invalid usage at index 0: duplicate usage metric: input_tokens');
+  assertEquals(duplicateBucket.body.error, 'invalid performance record at index 0: duplicate bucket entry for {metric: ttft_ms, lower: 0}');
+});
+
 test('import rejects api key unique identity conflicts before mutating', async () => {
   const { app, repo } = setup();
   await repo.apiKeys.save(KEY_A);

--- a/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
@@ -22,7 +22,7 @@ import type { ApiKey, PerformanceTelemetryRecord, WebSearchUsageRecord, StoredRe
 import { tokenUsageMetrics } from '../../../src/repo/usage-metrics.ts';
 import { installDumpStubs } from '../../dump/test-fixtures.ts';
 import { InMemoryRepo } from '../../repo/memory.ts';
-import type { UpstreamRecord } from '@floway-dev/provider';
+import { ALL_PROVIDER_KINDS, type UpstreamRecord } from '@floway-dev/provider';
 import { assertEquals } from '@floway-dev/test-utils';
 
 const hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
@@ -922,6 +922,70 @@ test('import strips unknown fields at transferable record boundaries', async () 
   assertEquals((await repo.performance.listAll())[0].buckets.some(bucket => 'smuggled' in bucket), false);
 });
 
+test('import trims every formerly normalized non-empty string field', async () => {
+  const { app, repo } = setup();
+  const upstream = upstreamRecordToFullJson(CUSTOM_UPSTREAM);
+  const result = await doImport(app, 'replace', latestImportData({
+    users: [{ ...SEED_ADMIN, createdAt: `  ${SEED_ADMIN.createdAt}  ` }],
+    apiKeys: [{
+      ...KEY_A,
+      id: `  ${KEY_A.id}  `,
+      name: `  ${KEY_A.name}  `,
+      key: `  ${KEY_A.key}  `,
+      createdAt: `  ${KEY_A.createdAt}  `,
+      lastUsedAt: '  2026-03-01T00:00:00.000Z  ',
+    }],
+    upstreams: [{
+      ...upstream,
+      id: `  ${upstream.id}  `,
+      name: `  ${upstream.name}  `,
+      created_at: `  ${upstream.created_at}  `,
+      updated_at: `  ${upstream.updated_at}  `,
+    }],
+    proxies: [{ id: '  p1  ', name: '  Proxy  ', url: `  ${HTTP_PROXY_URL}  `, dial_timeout_seconds: null }],
+  }));
+
+  assertEquals(result.status, 200);
+  assertEquals((await repo.users.listIncludingDeleted())[0].createdAt, SEED_ADMIN.createdAt);
+  assertEquals(await repo.apiKeys.listIncludingDeleted(), [{ ...KEY_A, lastUsedAt: '2026-03-01T00:00:00.000Z' }]);
+  assertEquals((await repo.upstreams.list())[0].id, CUSTOM_UPSTREAM.id);
+  assertEquals((await repo.upstreams.list())[0].name, CUSTOM_UPSTREAM.name);
+  assertEquals((await repo.upstreams.list())[0].createdAt, CUSTOM_UPSTREAM.createdAt);
+  assertEquals((await repo.upstreams.list())[0].updatedAt, CUSTOM_UPSTREAM.updatedAt);
+  assertEquals(await repo.proxies.list(), [{ id: 'p1', name: 'Proxy', url: HTTP_PROXY_URL, dialTimeoutSeconds: null }]);
+
+  const whitespaceOnly = await doImport(app, 'merge', latestImportData({ apiKeys: [{ ...KEY_A, key: '   ' }] }));
+  assertEquals(whitespaceOnly.body.error, 'invalid apiKeys at index 0: key must be a non-empty string');
+});
+
+test('import retains optional defaults from the v19 wire contract', async () => {
+  const { app, repo } = setup();
+  const { disabled_public_model_ids: _disabled, model_prefix: _prefix, ...upstream } = upstreamRecordToFullJson(CUSTOM_UPSTREAM);
+  const result = await doImport(app, 'replace', latestImportData({
+    apiKeys: [{ ...KEY_A, dumpRetentionSeconds: undefined }],
+    upstreams: [upstream],
+  }));
+
+  assertEquals(result.status, 200);
+  assertEquals((await repo.apiKeys.listIncludingDeleted())[0].dumpRetentionSeconds, null);
+  assertEquals((await repo.upstreams.list())[0].disabledPublicModelIds, []);
+  assertEquals((await repo.upstreams.list())[0].modelPrefix, null);
+});
+
+test('positive-integer import fields preserve Number.isInteger semantics', async () => {
+  const { app, repo } = setup();
+  const beyondSafeInteger = Number.MAX_SAFE_INTEGER + 1;
+  const result = await doImport(app, 'replace', latestImportData({
+    users: [SEED_ADMIN, { ...USER_BOB, id: beyondSafeInteger }],
+    apiKeys: [{ ...KEY_A, userId: beyondSafeInteger }],
+    proxies: [{ id: 'p1', name: 'Proxy', url: HTTP_PROXY_URL, dial_timeout_seconds: beyondSafeInteger }],
+  }));
+
+  assertEquals(result.status, 200);
+  assertEquals((await repo.apiKeys.listIncludingDeleted())[0].userId, beyondSafeInteger);
+  assertEquals((await repo.proxies.list())[0].dialTimeoutSeconds, beyondSafeInteger);
+});
+
 test('import reports the earliest duplicate before later malformed records', async () => {
   const { app } = setup();
   const duplicateUser = await doImport(app, 'replace', latestImportData({
@@ -952,6 +1016,52 @@ test('import reports the earliest duplicate before later malformed records', asy
   assertEquals(duplicateUser.body.error, 'invalid users at index 1: duplicate user id 1');
   assertEquals(duplicateMetric.body.error, 'invalid usage at index 0: duplicate usage metric: input_tokens');
   assertEquals(duplicateBucket.body.error, 'invalid performance record at index 0: duplicate bucket entry for {metric: ttft_ms, lower: 0}');
+});
+
+test('import preserves staged intra-record error precedence', async () => {
+  const { app } = setup();
+  const badUpstream = await doImport(app, 'replace', latestImportData({
+    upstreams: [{ ...upstreamRecordToFullJson(CUSTOM_UPSTREAM), kind: 'invalid', id: '' }],
+  }));
+  const badApiKey = await doImport(app, 'replace', latestImportData({
+    apiKeys: [{ ...KEY_A, upstreamIds: {}, id: '' }],
+  }));
+  const duplicateMalformedUser = await doImport(app, 'replace', latestImportData({
+    users: [SEED_ADMIN, { ...USER_BOB, id: SEED_ADMIN.id, username: 'bad username' }],
+  }));
+  const badUsage = await doImport(app, 'replace', latestImportData({
+    usage: [{ ...USAGE_1, requests: -1, pricingSelector: null }],
+  }));
+  const badPerformance = await doImport(app, 'replace', latestImportData({
+    performanceIncluded: true,
+    performance: [{ ...PERFORMANCE_1, requests: PERFORMANCE_1.requests + 1, buckets: [null] }],
+  }));
+
+  assertEquals(badUpstream.body.error, `invalid upstreams at index 0: kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}`);
+  assertEquals(badApiKey.body.error, 'invalid apiKeys at index 0: upstream_ids must be null or an array of upstream ids');
+  assertEquals(duplicateMalformedUser.body.error, 'invalid users at index 1: duplicate user id 1');
+  assertEquals(badUsage.body.error, 'invalid usage at index 0: record has invalid usage fields');
+  assertEquals(badPerformance.body.error, 'invalid performance record at index 0: ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests');
+});
+
+test('import preserves collection-specific array-record boundaries', async () => {
+  const { app } = setup();
+  const upstream = await doImport(app, 'replace', latestImportData({ upstreams: [[]] }));
+  const apiKey = await doImport(app, 'replace', latestImportData({ apiKeys: [[]] }));
+  const usage = await doImport(app, 'replace', latestImportData({ usage: [[]] }));
+  const searchUsage = await doImport(app, 'replace', latestImportData({ searchUsage: [[]] }));
+  const performance = await doImport(app, 'replace', latestImportData({ performanceIncluded: true, performance: [[]] }));
+  const bucket = await doImport(app, 'replace', latestImportData({
+    performanceIncluded: true,
+    performance: [{ ...PERFORMANCE_1, buckets: [[]] }],
+  }));
+
+  assertEquals(upstream.body.error, 'invalid upstreams at index 0: record must be an object');
+  assertEquals(apiKey.body.error, 'invalid apiKeys at index 0: record must be an object');
+  assertEquals(usage.body.error, 'invalid usage at index 0: record must be an object');
+  assertEquals(searchUsage.body.error, 'invalid searchUsage at index 0: invalid provider');
+  assertEquals(performance.body.error, 'invalid performance record at index 0: record fields are missing or malformed');
+  assertEquals(bucket.body.error, 'invalid performance record at index 0: bucket metric/lower/upper/count fields are missing or malformed');
 });
 
 test('import rejects api key unique identity conflicts before mutating', async () => {

--- a/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
@@ -952,7 +952,12 @@ test('import trims every formerly normalized non-empty string field', async () =
   assertEquals((await repo.upstreams.list())[0].name, CUSTOM_UPSTREAM.name);
   assertEquals((await repo.upstreams.list())[0].createdAt, CUSTOM_UPSTREAM.createdAt);
   assertEquals((await repo.upstreams.list())[0].updatedAt, CUSTOM_UPSTREAM.updatedAt);
-  assertEquals(await repo.proxies.list(), [{ id: 'p1', name: 'Proxy', url: HTTP_PROXY_URL, dialTimeoutSeconds: null }]);
+  assertEquals((await repo.proxies.list()).map(proxy => ({
+    id: proxy.id,
+    name: proxy.name,
+    url: proxy.url,
+    dialTimeoutSeconds: proxy.dialTimeoutSeconds,
+  })), [{ id: 'p1', name: 'Proxy', url: HTTP_PROXY_URL, dialTimeoutSeconds: null }]);
 
   const whitespaceOnly = await doImport(app, 'merge', latestImportData({ apiKeys: [{ ...KEY_A, key: '   ' }] }));
   assertEquals(whitespaceOnly.body.error, 'invalid apiKeys at index 0: key must be a non-empty string');

--- a/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
+++ b/packages/gateway/__tests__/control-plane/data-transfer/routes_test.ts
@@ -1031,8 +1031,14 @@ test('import preserves staged intra-record error precedence', async () => {
   const badApiKey = await doImport(app, 'replace', latestImportData({
     apiKeys: [{ ...KEY_A, upstreamIds: {}, id: '' }],
   }));
+  const badApiKeyConstruction = await doImport(app, 'replace', latestImportData({
+    apiKeys: [{ ...KEY_A, id: '', lastUsedAt: '' }],
+  }));
   const duplicateMalformedUser = await doImport(app, 'replace', latestImportData({
     users: [SEED_ADMIN, { ...USER_BOB, id: SEED_ADMIN.id, username: 'bad username' }],
+  }));
+  const badUserConstruction = await doImport(app, 'replace', latestImportData({
+    users: [SEED_ADMIN, { ...USER_BOB, deletedAt: 42, createdAt: '' }],
   }));
   const badUsage = await doImport(app, 'replace', latestImportData({
     usage: [{ ...USAGE_1, requests: -1, pricingSelector: null }],
@@ -1044,7 +1050,9 @@ test('import preserves staged intra-record error precedence', async () => {
 
   assertEquals(badUpstream.body.error, `invalid upstreams at index 0: kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}`);
   assertEquals(badApiKey.body.error, 'invalid apiKeys at index 0: upstream_ids must be null or an array of upstream ids');
+  assertEquals(badApiKeyConstruction.body.error, 'invalid apiKeys at index 0: id must be a non-empty string');
   assertEquals(duplicateMalformedUser.body.error, 'invalid users at index 1: duplicate user id 1');
+  assertEquals(badUserConstruction.body.error, 'invalid users at index 1: deletedAt must be null or an ISO string');
   assertEquals(badUsage.body.error, 'invalid usage at index 0: record has invalid usage fields');
   assertEquals(badPerformance.body.error, 'invalid performance record at index 0: ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests');
 });

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -134,7 +134,7 @@ const upstreamWireShapeSchema = z.object({
   hue: parsedBy(normalizeUpstreamHue),
   config: z.unknown(),
   state: z.unknown().optional(),
-}).loose().superRefine((wire, ctx) => {
+}).superRefine((wire, ctx) => {
   if (isLegacyUpstreamIdentity(wire.id)) {
     addIssue(ctx, 'id must use a raw upstream id, not a legacy provider-prefixed identity');
   }

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -1,20 +1,20 @@
 import { z } from 'zod';
 
-import { parseWebSearchConfigStrict } from '../../../data-plane/tools/web-search/config.ts';
-import type { WebSearchConfig } from '../../../data-plane/tools/web-search/types.ts';
-import { parseDisabledPublicModelIdsWire } from '../../../repo/disabled-public-models.ts';
-import { isDirectFallbackId, normalizeProxyFallbackList } from '../../../repo/proxy-fallback-list.ts';
-import { isResponsesRetentionSeconds, RESPONSES_RETENTION_MAX_SECONDS, RESPONSES_RETENTION_MIN_SECONDS } from '../../../repo/responses-retention.ts';
-import { SEED_ADMIN_USER_ID } from '../../../repo/seed-admin.ts';
-import type { ApiKey, PerformanceMetric, PerformanceTelemetryRecord, UsageRecord, User, WebSearchUsageRecord } from '../../../repo/types.ts';
-import { PASSWORD_HASH_SCHEME } from '../../../shared/passwords.ts';
-import { RETENTION_MAX_SECONDS } from '../../../shared/retention.ts';
-import { parseServerSecret } from '../../../shared/server-secret.ts';
-import { isWebSearchProviderName } from '../../../shared/web-search-providers.ts';
-import { USERNAME_PATTERN } from '../../schemas.ts';
-import { isRecord } from '../../shared/field-validators.ts';
-import { parseUpstreamIdsValue } from '../../shared/upstream-ids.ts';
-import { BILLING_METRICS, canonicalizePricingSelector, type BillingMetric, parseNonNegativeDecimalString } from '@floway-dev/protocols/common';
+import { parseWebSearchConfigStrict } from '../../data-plane/tools/web-search/config.ts';
+import type { WebSearchConfig } from '../../data-plane/tools/web-search/types.ts';
+import { parseDisabledPublicModelIdsWire } from '../../repo/disabled-public-models.ts';
+import { isDirectFallbackId, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
+import { isResponsesRetentionSeconds, RESPONSES_RETENTION_MAX_SECONDS, RESPONSES_RETENTION_MIN_SECONDS } from '../../repo/responses-retention.ts';
+import { SEED_ADMIN_USER_ID } from '../../repo/seed-admin.ts';
+import type { ApiKey, PerformanceMetric, PerformanceTelemetryRecord, UsageRecord, User, WebSearchUsageRecord } from '../../repo/types.ts';
+import { PASSWORD_HASH_SCHEME } from '../../shared/passwords.ts';
+import { RETENTION_MAX_SECONDS } from '../../shared/retention.ts';
+import { parseServerSecret } from '../../shared/server-secret.ts';
+import { isWebSearchProviderName } from '../../shared/web-search-providers.ts';
+import { USERNAME_PATTERN } from '../schemas.ts';
+import { isRecord } from '../shared/field-validators.ts';
+import { parseUpstreamIdsValue } from '../shared/upstream-ids.ts';
+import { BILLING_METRICS, canonicalizePricingSelector, type BillingMetric, parseNonNegativeDecimalString, type PricingSelector } from '@floway-dev/protocols/common';
 import { ALL_PROVIDER_KINDS, normalizeModelPrefix, normalizeUpstreamHue, parseFlagOverridesWire, parsePerformanceOperation, type ProxyFallbackEntry, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
 import { assertAzureUpstreamRecord } from '@floway-dev/provider-azure';
 import { assertClaudeCodeUpstreamRecord, assertClaudeCodeUpstreamState } from '@floway-dev/provider-claude-code';
@@ -52,19 +52,20 @@ const PERFORMANCE_METRICS = ['ttft_ms', 'tpot_us'] as const satisfies readonly P
 const hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
 const isLegacyUpstreamIdentity = (value: string): boolean => LEGACY_UPSTREAM_PREFIXES.some(prefix => value.startsWith(prefix));
 const messageFor = (cause: unknown): string => cause instanceof Error ? cause.message : String(cause);
-const addIssue = (ctx: z.RefinementCtx, input: unknown, message: string) => ctx.addIssue({ code: 'custom', input, message });
+const addIssue = (ctx: z.RefinementCtx, message: string, path?: PropertyKey[]) => ctx.addIssue({ code: 'custom', message, path });
 
 const parsedBy = <T>(parser: (value: unknown) => T) => z.unknown().transform((value, ctx): T => {
   try {
     return parser(value);
   } catch (cause) {
-    addIssue(ctx, value, messageFor(cause));
+    addIssue(ctx, messageFor(cause));
     return z.NEVER;
   }
 });
 
 const nonEmptyStringSchema = (field: string) => z.string({ error: `${field} must be a non-empty string` })
   .min(1, { error: `${field} must be a non-empty string` });
+const nonEmptyStringWithError = (message: string) => z.string({ error: message }).min(1, { error: message });
 const nullableStringSchema = (field: string) => z.union([
   z.string(),
   z.null(),
@@ -135,10 +136,10 @@ const upstreamWireSchema = z.object({
   state: z.unknown().optional(),
 }).loose().superRefine((wire, ctx) => {
   if (hasOwn(wire, 'enabled_fixes')) {
-    addIssue(ctx, wire.enabled_fixes, "legacy 'enabled_fixes' field is no longer supported; re-export with current code");
+    addIssue(ctx, "legacy 'enabled_fixes' field is no longer supported; re-export with current code");
   }
   if (isLegacyUpstreamIdentity(wire.id)) {
-    addIssue(ctx, wire.id, 'id must use a raw upstream id, not a legacy provider-prefixed identity');
+    addIssue(ctx, 'id must use a raw upstream id, not a legacy provider-prefixed identity');
   }
 }).transform((wire, ctx): UpstreamRecord => {
   try {
@@ -161,7 +162,7 @@ const upstreamWireSchema = z.object({
     };
     return { ...record, config: normalizeUpstreamConfig(record) };
   } catch (cause) {
-    addIssue(ctx, wire, messageFor(cause));
+    addIssue(ctx, messageFor(cause));
     return z.NEVER;
   }
 });
@@ -176,7 +177,7 @@ const proxySchema = z.object({
       parseProxyUri(url);
       return url;
     } catch (cause) {
-      addIssue(ctx, url, `url did not parse: ${messageFor(cause)}`);
+      addIssue(ctx, `url did not parse: ${messageFor(cause)}`);
       return z.NEVER;
     }
   }),
@@ -231,7 +232,7 @@ const userSchema = z.object({
 const usersSchema = z.array(userSchema, { error: 'users must be an array' }).superRefine((users, ctx) => {
   const seen = new Set<number>();
   for (let index = 0; index < users.length; index++) {
-    if (seen.has(users[index].id)) addIssue(ctx, users[index].id, `duplicate user id ${users[index].id}`);
+    if (seen.has(users[index].id)) addIssue(ctx, `duplicate user id ${users[index].id}`, [index]);
     seen.add(users[index].id);
   }
 });
@@ -239,7 +240,7 @@ const usersSchema = z.array(userSchema, { error: 'users must be an array' }).sup
 const metricSchema = z.object({
   metric: z.unknown().transform((value, ctx): BillingMetric => {
     if (typeof value !== 'string' || !BILLING_METRICS.includes(value as BillingMetric)) {
-      addIssue(ctx, value, `unknown usage metric: ${JSON.stringify(value)}`);
+      addIssue(ctx, `unknown usage metric: ${JSON.stringify(value)}`);
       return z.NEVER;
     }
     return value as BillingMetric;
@@ -250,7 +251,7 @@ const metricSchema = z.object({
     try {
       return parseNonNegativeDecimalString(value, 'metric unitPrice');
     } catch (cause) {
-      addIssue(ctx, value, messageFor(cause));
+      addIssue(ctx, messageFor(cause));
       return z.NEVER;
     }
   }),
@@ -260,23 +261,23 @@ const metricsSchema = z.array(metricSchema, { error: 'metrics must be an array' 
   const seen = new Set<BillingMetric>();
   for (let index = 0; index < metrics.length; index++) {
     const metric = metrics[index].metric;
-    if (seen.has(metric)) addIssue(ctx, metric, `duplicate usage metric: ${metric}`);
+    if (seen.has(metric)) addIssue(ctx, `duplicate usage metric: ${metric}`, [index]);
     seen.add(metric);
   }
 });
 
 const invalidUsageField = 'record has invalid usage fields';
 const usageSchema = z.object({
-  keyId: nonEmptyStringSchema(invalidUsageField),
-  model: nonEmptyStringSchema(invalidUsageField),
+  keyId: nonEmptyStringWithError(invalidUsageField),
+  model: nonEmptyStringWithError(invalidUsageField),
   upstream: z.union([z.string(), z.null()], { error: invalidUsageField }),
-  modelKey: nonEmptyStringSchema(invalidUsageField),
+  modelKey: nonEmptyStringWithError(invalidUsageField),
   hour: z.string({ error: invalidUsageField }).regex(SEARCH_USAGE_HOUR_PATTERN, { error: invalidUsageField }),
   pricingSelector: z.record(z.string(), z.unknown(), { error: 'pricingSelector must be an object' }).transform((selector, ctx) => {
     try {
-      return canonicalizePricingSelector(selector);
+      return canonicalizePricingSelector(selector as PricingSelector);
     } catch (cause) {
-      addIssue(ctx, selector, `invalid pricingSelector: ${messageFor(cause)}`);
+      addIssue(ctx, `invalid pricingSelector: ${messageFor(cause)}`);
       return z.NEVER;
     }
   }),
@@ -284,14 +285,14 @@ const usageSchema = z.object({
   metrics: metricsSchema,
 }, { error: 'record must be an object' }).superRefine((record, ctx) => {
   if (typeof record.upstream === 'string' && isLegacyUpstreamIdentity(record.upstream)) {
-    addIssue(ctx, record.upstream, 'upstream must use a raw upstream id, not a legacy provider-prefixed identity');
+    addIssue(ctx, 'upstream must use a raw upstream id, not a legacy provider-prefixed identity');
   }
 });
 
 const searchUsageSchema = z.object({
   provider: z.unknown().transform((value, ctx) => {
     if (!isWebSearchProviderName(value)) {
-      addIssue(ctx, value, 'invalid provider');
+      addIssue(ctx, 'invalid provider');
       return z.NEVER;
     }
     return value;
@@ -315,15 +316,15 @@ const performanceBucketSchema = z.object({
   count: nonNegativeSafeIntegerSchema('bucket metric/lower/upper/count fields are missing or malformed'),
 }, { error: 'bucket is not an object' }).superRefine((bucket, ctx) => {
   if (bucket.upper !== null && bucket.upper <= bucket.lower) {
-    addIssue(ctx, bucket.upper, 'bucket metric/lower/upper/count fields are missing or malformed');
+    addIssue(ctx, 'bucket metric/lower/upper/count fields are missing or malformed');
   }
 });
 
 const performanceSchema = z.object({
   hour: z.string({ error: malformedPerformance }).regex(SEARCH_USAGE_HOUR_PATTERN, { error: malformedPerformance }),
-  keyId: nonEmptyStringSchema(malformedPerformance),
-  model: nonEmptyStringSchema(malformedPerformance),
-  upstream: nonEmptyStringSchema(malformedPerformance).refine(value => !isLegacyUpstreamIdentity(value), { error: malformedPerformance }),
+  keyId: nonEmptyStringWithError(malformedPerformance),
+  model: nonEmptyStringWithError(malformedPerformance),
+  upstream: nonEmptyStringWithError(malformedPerformance).refine(value => !isLegacyUpstreamIdentity(value), { error: malformedPerformance }),
   operation: parsedBy(value => {
     try {
       return parsePerformanceOperation(value);
@@ -331,7 +332,7 @@ const performanceSchema = z.object({
       throw new Error(malformedPerformance);
     }
   }),
-  runtimeLocation: nonEmptyStringSchema(malformedPerformance),
+  runtimeLocation: nonEmptyStringWithError(malformedPerformance),
   requests: performanceInteger,
   ttftSamplesOk: performanceInteger,
   errorsWithOutput: performanceInteger,
@@ -344,11 +345,11 @@ const performanceSchema = z.object({
 }, { error: 'record is not an object' }).superRefine((record, ctx) => {
   const ttftSamples = record.ttftSamplesOk + record.errorsWithOutput;
   if (ttftSamples + record.errorsNoOutput + record.neutral !== record.requests) {
-    addIssue(ctx, record.requests, 'ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests');
+    addIssue(ctx, 'ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests');
     return;
   }
   if (record.tpotSamples > ttftSamples) {
-    addIssue(ctx, record.tpotSamples, 'tpotSamples must not exceed ttftSamplesOk + errorsWithOutput');
+    addIssue(ctx, 'tpotSamples must not exceed ttftSamplesOk + errorsWithOutput');
     return;
   }
 
@@ -358,7 +359,7 @@ const performanceSchema = z.object({
   for (const bucket of record.buckets) {
     const dedupKey = `${bucket.metric}\0${bucket.lower}`;
     if (bucketKeys.has(dedupKey)) {
-      addIssue(ctx, bucket, `duplicate bucket entry for {metric: ${bucket.metric}, lower: ${bucket.lower}}`);
+      addIssue(ctx, `duplicate bucket entry for {metric: ${bucket.metric}, lower: ${bucket.lower}}`);
       return;
     }
     bucketKeys.add(dedupKey);
@@ -366,9 +367,9 @@ const performanceSchema = z.object({
     else tpotBucketCount += bucket.count;
   }
   if (ttftBucketCount !== ttftSamples) {
-    addIssue(ctx, record.buckets, `ttft_ms bucket sum (${ttftBucketCount}) must equal ttftSamplesOk + errorsWithOutput (${ttftSamples})`);
+    addIssue(ctx, `ttft_ms bucket sum (${ttftBucketCount}) must equal ttftSamplesOk + errorsWithOutput (${ttftSamples})`);
   } else if (tpotBucketCount !== record.tpotSamples) {
-    addIssue(ctx, record.buckets, `tpot_us bucket sum (${tpotBucketCount}) must equal tpotSamples (${record.tpotSamples})`);
+    addIssue(ctx, `tpot_us bucket sum (${tpotBucketCount}) must equal tpotSamples (${record.tpotSamples})`);
   }
 });
 

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -427,7 +427,6 @@ interface CollectionOptions<T> {
   arrayError: string;
   optional?: boolean;
   validateInput?: (value: unknown, index: number, prior: readonly T[]) => string | null;
-  validateRecord?: (record: T, index: number, prior: readonly T[]) => string | null;
 }
 
 // Zod reports every invalid array element in one result. Imports historically
@@ -451,8 +450,6 @@ const parseCollection = <T>(
     if (!result.success) {
       return { type: 'invalid', error: `invalid ${label} at index ${index}: ${result.error.issues[0].message}` };
     }
-    const validationError = options.validateRecord?.(result.data, index, records);
-    if (validationError) return { type: 'invalid', error: `invalid ${label} at index ${index}: ${validationError}` };
     records.push(result.data);
   }
   return { type: 'ok', records };

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -118,7 +118,7 @@ const normalizeUpstreamState = (kind: UpstreamProviderKind, value: unknown): unk
   return value;
 };
 
-const upstreamWireSchema = z.object({
+const upstreamWireShapeSchema = z.object({
   id: nonEmptyStringSchema('id'),
   kind: z.enum(ALL_PROVIDER_KINDS, { error: `kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}` }),
   name: nonEmptyStringSchema('name'),
@@ -135,9 +135,6 @@ const upstreamWireSchema = z.object({
   config: z.unknown(),
   state: z.unknown().optional(),
 }).loose().superRefine((wire, ctx) => {
-  if (hasOwn(wire, 'enabled_fixes')) {
-    addIssue(ctx, "legacy 'enabled_fixes' field is no longer supported; re-export with current code");
-  }
   if (isLegacyUpstreamIdentity(wire.id)) {
     addIssue(ctx, 'id must use a raw upstream id, not a legacy provider-prefixed identity');
   }
@@ -166,6 +163,14 @@ const upstreamWireSchema = z.object({
     return z.NEVER;
   }
 });
+
+const upstreamWireSchema = z.unknown().transform((value, ctx) => {
+  if (isRecord(value) && hasOwn(value, 'enabled_fixes')) {
+    addIssue(ctx, "legacy 'enabled_fixes' field is no longer supported; re-export with current code");
+    return z.NEVER;
+  }
+  return value;
+}).pipe(upstreamWireShapeSchema);
 
 const proxySchema = z.object({
   id: nonEmptyStringSchema('id').refine(id => !isDirectFallbackId(id), {
@@ -220,11 +225,18 @@ const userSchema = z.object({
   username: z.string({ error: 'username must match ^[a-zA-Z0-9_.-]{1,64}$' })
     .regex(USERNAME_PATTERN, { error: 'username must match ^[a-zA-Z0-9_.-]{1,64}$' }),
   passwordHash: z.union([
-    z.string().refine(value => value.startsWith(`${PASSWORD_HASH_SCHEME}$`)),
+    z.string().refine(value => value.startsWith(`${PASSWORD_HASH_SCHEME}$`), {
+      error: `passwordHash must be null or start with ${PASSWORD_HASH_SCHEME}$`,
+    }),
     z.null(),
   ], { error: `passwordHash must be null or start with ${PASSWORD_HASH_SCHEME}$` }),
   isAdmin: z.boolean({ error: 'isAdmin must be a boolean' }),
-  upstreamIds: upstreamIdsSchema,
+  upstreamIds: parsedBy(value => {
+    if (value === undefined) throw new Error('upstreamIds must be present (null or array)');
+    const result = parseUpstreamIdsValue(value);
+    if (!result.ok) throw new Error(result.error);
+    return result.value;
+  }),
   createdAt: nonEmptyStringSchema('createdAt'),
   deletedAt: nullableStringSchema('deletedAt'),
 });

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -241,14 +241,6 @@ const userSchema = z.object({
   deletedAt: nullableStringSchema('deletedAt'),
 });
 
-const usersSchema = z.array(userSchema, { error: 'users must be an array' }).superRefine((users, ctx) => {
-  const seen = new Set<number>();
-  for (let index = 0; index < users.length; index++) {
-    if (seen.has(users[index].id)) addIssue(ctx, `duplicate user id ${users[index].id}`, [index]);
-    seen.add(users[index].id);
-  }
-});
-
 const metricSchema = z.object({
   metric: z.unknown().transform((value, ctx): BillingMetric => {
     if (typeof value !== 'string' || !BILLING_METRICS.includes(value as BillingMetric)) {
@@ -385,28 +377,49 @@ const performanceSchema = z.object({
   }
 });
 
-const apiKeysSchema = z.array(apiKeySchema, { error: 'apiKeys must be an array' });
-const upstreamsSchema = z.array(upstreamWireSchema, { error: 'upstreams must be an array' });
-const proxiesSchema = z.array(proxySchema, { error: 'proxies must be an array' }).optional().default([]);
-const usageRecordsSchema = z.array(usageSchema, { error: 'usage must be an array' });
-const searchUsageRecordsSchema = z.array(searchUsageSchema, { error: 'searchUsage must be an array' });
-const performanceRecordsSchema = z.array(performanceSchema, { error: 'performance must be an array when included' });
+interface CollectionOptions<T> {
+  arrayError: string;
+  optional?: boolean;
+  validateRecord?: (record: T, index: number, prior: readonly T[]) => string | null;
+}
 
-const parseCollection = <T>(label: string, schema: z.ZodType<T[]>, value: unknown): { type: 'ok'; records: T[] } | { type: 'invalid'; error: string } => {
-  const result = schema.safeParse(value);
-  if (result.success) return { type: 'ok', records: result.data };
-  const issue = result.error.issues[0];
-  const index = typeof issue.path[0] === 'number' ? issue.path[0] : -1;
-  const location = index >= 0 ? ` at index ${index}` : '';
-  return { type: 'invalid', error: `invalid ${label}${location}: ${issue.message}` };
+// Zod reports every invalid array element in one result. Imports historically
+// stop at the first record, so parse each element independently after Zod owns
+// the array boundary; this retains deterministic index and error precedence.
+const parseCollection = <T>(
+  label: string,
+  schema: z.ZodType<T>,
+  value: unknown,
+  options: CollectionOptions<T>,
+): { type: 'ok'; records: T[] } | { type: 'invalid'; error: string } => {
+  if (options.optional && value === undefined) return { type: 'ok', records: [] };
+  const array = z.array(z.unknown(), { error: options.arrayError }).safeParse(value);
+  if (!array.success) return { type: 'invalid', error: `invalid ${label}: ${array.error.issues[0].message}` };
+
+  const records: T[] = [];
+  for (let index = 0; index < array.data.length; index++) {
+    const result = schema.safeParse(array.data[index]);
+    if (!result.success) {
+      return { type: 'invalid', error: `invalid ${label} at index ${index}: ${result.error.issues[0].message}` };
+    }
+    const validationError = options.validateRecord?.(result.data, index, records);
+    if (validationError) return { type: 'invalid', error: `invalid ${label} at index ${index}: ${validationError}` };
+    records.push(result.data);
+  }
+  return { type: 'ok', records };
 };
 
 export const parseImportData = (value: unknown): ImportDataParseResult => {
   if (!isRecord(value)) return { type: 'invalid', error: 'data is required' };
 
-  const apiKeys = parseCollection('apiKeys', apiKeysSchema, value.apiKeys);
+  const apiKeys = parseCollection('apiKeys', apiKeySchema, value.apiKeys, { arrayError: 'apiKeys must be an array' });
   if (apiKeys.type === 'invalid') return apiKeys;
-  const users = parseCollection('users', usersSchema, value.users);
+  const users = parseCollection('users', userSchema, value.users, {
+    arrayError: 'users must be an array',
+    validateRecord: (user, _index, prior) => prior.some(candidate => candidate.id === user.id)
+      ? `duplicate user id ${user.id}`
+      : null,
+  });
   if (users.type === 'invalid') return users;
   if (!users.records.some(user => user.id === SEED_ADMIN_USER_ID)) {
     return { type: 'invalid', error: 'invalid users: payload must include user 1 (the seed admin)' };
@@ -418,11 +431,11 @@ export const parseImportData = (value: unknown): ImportDataParseResult => {
     }
   }
 
-  const usage = parseCollection('usage', usageRecordsSchema, value.usage);
+  const usage = parseCollection('usage', usageSchema, value.usage, { arrayError: 'usage must be an array' });
   if (usage.type === 'invalid') return usage;
-  const upstreams = parseCollection('upstreams', upstreamsSchema, value.upstreams);
+  const upstreams = parseCollection('upstreams', upstreamWireSchema, value.upstreams, { arrayError: 'upstreams must be an array' });
   if (upstreams.type === 'invalid') return upstreams;
-  const proxies = parseCollection('proxies', proxiesSchema, value.proxies);
+  const proxies = parseCollection('proxies', proxySchema, value.proxies, { arrayError: 'proxies must be an array', optional: true });
   if (proxies.type === 'invalid') return proxies;
   const proxyIds = new Map<string, number>();
   for (let index = 0; index < proxies.records.length; index++) {
@@ -433,7 +446,7 @@ export const parseImportData = (value: unknown): ImportDataParseResult => {
     proxyIds.set(proxies.records[index].id, index);
   }
 
-  const searchUsage = parseCollection('searchUsage', searchUsageRecordsSchema, value.searchUsage);
+  const searchUsage = parseCollection('searchUsage', searchUsageSchema, value.searchUsage, { arrayError: 'searchUsage must be an array' });
   if (searchUsage.type === 'invalid') return searchUsage;
 
   let searchConfig: WebSearchConfig;
@@ -451,7 +464,7 @@ export const parseImportData = (value: unknown): ImportDataParseResult => {
   }
   let performance: PerformanceTelemetryRecord[] = [];
   if (value.performanceIncluded) {
-    const parsed = parseCollection('performance', performanceRecordsSchema, value.performance);
+    const parsed = parseCollection('performance', performanceSchema, value.performance, { arrayError: 'performance must be an array when included' });
     if (parsed.type === 'invalid') {
       return { type: 'invalid', error: parsed.error.replace(/^invalid performance at index /, 'invalid performance record at index ') };
     }

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -151,28 +151,24 @@ const upstreamWireSchema = parsedBy((value): UpstreamRecord => {
     throw new Error('id must use a raw upstream id, not a legacy provider-prefixed identity');
   }
 
-  try {
-    const record: UpstreamRecord = {
-      id,
-      kind,
-      name: parseValue(nonEmptyStringSchema('name'), wire.name),
-      enabled,
-      sortOrder,
-      createdAt: parseValue(nonEmptyStringSchema('created_at'), wire.created_at),
-      updatedAt: parseValue(nonEmptyStringSchema('updated_at'), wire.updated_at),
-      flagOverrides: parseValue(parsedBy(parseFlagOverridesWire), wire.flag_overrides),
-      disabledPublicModelIds: parseValue(parsedBy(parseDisabledPublicModelIdsWire).optional().default([]), wire.disabled_public_model_ids),
-      proxyFallbackList: parseValue(proxyFallbackListSchema, wire.proxy_fallback_list),
-      modelPrefix: parseValue(parsedBy(normalizeModelPrefix).optional().default(null), wire.model_prefix),
-      hue: parseValue(parsedBy(normalizeUpstreamHue), wire.hue),
-      config: wire.config,
-      state: normalizeUpstreamState(kind, wire.state),
-      modelsCache: null,
-    };
-    return { ...record, config: normalizeUpstreamConfig(record) };
-  } catch (cause) {
-    throw new Error(messageFor(cause));
-  }
+  const record: UpstreamRecord = {
+    id,
+    kind,
+    name: parseValue(nonEmptyStringSchema('name'), wire.name),
+    enabled,
+    sortOrder,
+    createdAt: parseValue(nonEmptyStringSchema('created_at'), wire.created_at),
+    updatedAt: parseValue(nonEmptyStringSchema('updated_at'), wire.updated_at),
+    flagOverrides: parseValue(parsedBy(parseFlagOverridesWire), wire.flag_overrides),
+    disabledPublicModelIds: parseValue(parsedBy(parseDisabledPublicModelIdsWire).optional().default([]), wire.disabled_public_model_ids),
+    proxyFallbackList: parseValue(proxyFallbackListSchema, wire.proxy_fallback_list),
+    modelPrefix: parseValue(parsedBy(normalizeModelPrefix).optional().default(null), wire.model_prefix),
+    hue: parseValue(parsedBy(normalizeUpstreamHue), wire.hue),
+    config: wire.config,
+    state: normalizeUpstreamState(kind, wire.state),
+    modelsCache: null,
+  };
+  return { ...record, config: normalizeUpstreamConfig(record) };
 });
 
 const proxySchema = parsedBy((value): SerializedProxy => {

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -63,16 +63,29 @@ const parsedBy = <T>(parser: (value: unknown) => T) => z.unknown().transform((va
   }
 });
 
-const nonEmptyStringSchema = (field: string) => z.string({ error: `${field} must be a non-empty string` })
-  .min(1, { error: `${field} must be a non-empty string` });
+const parseValue = <T>(schema: z.ZodType<T>, value: unknown): T => {
+  const result = schema.safeParse(value);
+  if (!result.success) throw new Error(result.error.issues[0].message);
+  return result.data;
+};
+
+const recordBoundarySchema = (message: string) => z.object({}, { error: message }).loose();
+const parseRecord = (value: unknown, message: string): Record<string, unknown> => parseValue(recordBoundarySchema(message), value);
+const objectIncludingArraySchema = (message: string) => z.custom<Record<string, unknown>>(
+  value => typeof value === 'object' && value !== null,
+  { error: message },
+);
+
+const nonEmptyStringSchema = (field: string) => z.string({ error: `${field} must be a string` })
+  .transform(value => value.trim())
+  .refine(value => value !== '', { error: `${field} must be a non-empty string` });
 const nonEmptyStringWithError = (message: string) => z.string({ error: message }).min(1, { error: message });
 const nullableStringSchema = (field: string) => z.union([
   z.string(),
   z.null(),
 ], { error: `${field} must be null or an ISO string` });
 const positiveIntegerSchema = (field: string) => z.number({ error: `${field} must be a positive integer` })
-  .int({ error: `${field} must be a positive integer` })
-  .positive({ error: `${field} must be a positive integer` });
+  .refine(value => Number.isInteger(value) && value > 0, { error: `${field} must be a positive integer` });
 const nonNegativeSafeIntegerSchema = (message: string) => z.number({ error: message })
   .int({ error: message })
   .nonnegative({ error: message })
@@ -110,6 +123,9 @@ const normalizeUpstreamConfig = (record: UpstreamRecord): unknown => {
   }
 };
 
+// Codex and Claude Code state contains refresh credentials and health that
+// cannot be re-derived, so it round-trips through their strict runtime
+// assertions. Every other provider owns no durable state or can re-mint it.
 const normalizeUpstreamState = (kind: UpstreamProviderKind, value: unknown): unknown => {
   if (kind !== 'codex' && kind !== 'claude-code') return null;
   if (value === null || value === undefined) throw new Error(`${kind} upstream is missing state — re-export with current code`);
@@ -118,78 +134,63 @@ const normalizeUpstreamState = (kind: UpstreamProviderKind, value: unknown): unk
   return value;
 };
 
-const upstreamWireShapeSchema = z.object({
-  id: nonEmptyStringSchema('id'),
-  kind: z.enum(ALL_PROVIDER_KINDS, { error: `kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}` }),
-  name: nonEmptyStringSchema('name'),
-  enabled: z.boolean({ error: 'enabled must be a boolean' }),
-  sort_order: z.number({ error: 'sort_order must be a finite number' })
-    .finite({ error: 'sort_order must be a finite number' }),
-  created_at: nonEmptyStringSchema('created_at'),
-  updated_at: nonEmptyStringSchema('updated_at'),
-  flag_overrides: parsedBy(parseFlagOverridesWire),
-  disabled_public_model_ids: parsedBy(parseDisabledPublicModelIdsWire),
-  proxy_fallback_list: proxyFallbackListSchema,
-  model_prefix: parsedBy(normalizeModelPrefix),
-  hue: parsedBy(normalizeUpstreamHue),
-  config: z.unknown(),
-  state: z.unknown().optional(),
-}).superRefine((wire, ctx) => {
-  if (isLegacyUpstreamIdentity(wire.id)) {
-    addIssue(ctx, 'id must use a raw upstream id, not a legacy provider-prefixed identity');
+const upstreamKindSchema = z.enum(ALL_PROVIDER_KINDS, { error: `kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}` });
+const finiteSortOrderSchema = z.number({ error: 'sort_order must be a finite number' })
+  .finite({ error: 'sort_order must be a finite number' });
+
+const upstreamWireSchema = parsedBy((value): UpstreamRecord => {
+  const wire = parseRecord(value, 'record must be an object');
+  if (hasOwn(wire, 'enabled_fixes')) {
+    throw new Error("legacy 'enabled_fixes' field is no longer supported; re-export with current code");
   }
-}).transform((wire, ctx): UpstreamRecord => {
+  const kind = parseValue(upstreamKindSchema, wire.kind);
+  const enabled = parseValue(z.boolean({ error: 'enabled must be a boolean' }), wire.enabled);
+  const sortOrder = Math.floor(parseValue(finiteSortOrderSchema, wire.sort_order));
+  const id = parseValue(nonEmptyStringSchema('id'), wire.id);
+  if (isLegacyUpstreamIdentity(id)) {
+    throw new Error('id must use a raw upstream id, not a legacy provider-prefixed identity');
+  }
+
   try {
     const record: UpstreamRecord = {
-      id: wire.id,
-      kind: wire.kind,
-      name: wire.name,
-      enabled: wire.enabled,
-      sortOrder: Math.floor(wire.sort_order),
-      createdAt: wire.created_at,
-      updatedAt: wire.updated_at,
-      flagOverrides: wire.flag_overrides,
-      disabledPublicModelIds: wire.disabled_public_model_ids,
-      proxyFallbackList: wire.proxy_fallback_list,
-      modelPrefix: wire.model_prefix,
-      hue: wire.hue,
+      id,
+      kind,
+      name: parseValue(nonEmptyStringSchema('name'), wire.name),
+      enabled,
+      sortOrder,
+      createdAt: parseValue(nonEmptyStringSchema('created_at'), wire.created_at),
+      updatedAt: parseValue(nonEmptyStringSchema('updated_at'), wire.updated_at),
+      flagOverrides: parseValue(parsedBy(parseFlagOverridesWire), wire.flag_overrides),
+      disabledPublicModelIds: parseValue(parsedBy(parseDisabledPublicModelIdsWire).optional().default([]), wire.disabled_public_model_ids),
+      proxyFallbackList: parseValue(proxyFallbackListSchema, wire.proxy_fallback_list),
+      modelPrefix: parseValue(parsedBy(normalizeModelPrefix).optional().default(null), wire.model_prefix),
+      hue: parseValue(parsedBy(normalizeUpstreamHue), wire.hue),
       config: wire.config,
-      state: normalizeUpstreamState(wire.kind, wire.state),
+      state: normalizeUpstreamState(kind, wire.state),
       modelsCache: null,
     };
     return { ...record, config: normalizeUpstreamConfig(record) };
   } catch (cause) {
-    addIssue(ctx, messageFor(cause));
-    return z.NEVER;
+    throw new Error(messageFor(cause));
   }
 });
 
-const upstreamWireSchema = z.unknown().transform((value, ctx) => {
-  if (isRecord(value) && hasOwn(value, 'enabled_fixes')) {
-    addIssue(ctx, "legacy 'enabled_fixes' field is no longer supported; re-export with current code");
-    return z.NEVER;
+const proxySchema = parsedBy((value): SerializedProxy => {
+  const wire = parseRecord(value, 'record must be an object');
+  const id = parseValue(nonEmptyStringSchema('id'), wire.id);
+  if (isDirectFallbackId(id)) throw new Error('id must not be a reserved direct-transport sentinel');
+  const name = parseValue(nonEmptyStringSchema('name'), wire.name);
+  const url = parseValue(nonEmptyStringSchema('url'), wire.url);
+  try {
+    parseProxyUri(url);
+  } catch (cause) {
+    throw new Error(`url did not parse: ${messageFor(cause)}`);
   }
-  return value;
-}).pipe(upstreamWireShapeSchema);
-
-const proxySchema = z.object({
-  id: nonEmptyStringSchema('id').refine(id => !isDirectFallbackId(id), {
-    error: 'id must not be a reserved direct-transport sentinel',
-  }),
-  name: nonEmptyStringSchema('name'),
-  url: nonEmptyStringSchema('url').transform((url, ctx) => {
-    try {
-      parseProxyUri(url);
-      return url;
-    } catch (cause) {
-      addIssue(ctx, `url did not parse: ${messageFor(cause)}`);
-      return z.NEVER;
-    }
-  }),
-  dial_timeout_seconds: z.union([
+  const dialTimeoutSeconds = parseValue(z.union([
     positiveIntegerSchema('dial_timeout_seconds'),
     z.null(),
-  ], { error: 'dial_timeout_seconds must be null or a positive integer' }),
+  ], { error: 'dial_timeout_seconds must be null or a positive integer' }), wire.dial_timeout_seconds);
+  return { id, name, url, dial_timeout_seconds: dialTimeoutSeconds };
 });
 
 const dumpRetentionSchema = parsedBy((value): number | null => {
@@ -206,18 +207,27 @@ const responsesRetentionSchema = parsedBy((value): number => {
   return value;
 });
 
-const apiKeySchema = z.object({
-  id: nonEmptyStringSchema('id'),
-  userId: positiveIntegerSchema('userId'),
-  name: nonEmptyStringSchema('name'),
-  key: nonEmptyStringSchema('key'),
-  serverSecret: parsedBy(parseServerSecret),
-  createdAt: nonEmptyStringSchema('createdAt'),
-  lastUsedAt: nonEmptyStringSchema('lastUsedAt').optional(),
-  upstreamIds: upstreamIdsSchema,
-  deletedAt: nullableStringSchema('deletedAt'),
-  dumpRetentionSeconds: dumpRetentionSchema,
-  responsesRetentionSeconds: responsesRetentionSchema,
+const apiKeySchema = parsedBy((value): ApiKey => {
+  const wire = parseRecord(value, 'record must be an object');
+  const upstreamIds = parseValue(upstreamIdsSchema, wire.upstreamIds);
+  const userId = parseValue(positiveIntegerSchema('userId'), wire.userId);
+  const deletedAt = parseValue(nullableStringSchema('deletedAt'), wire.deletedAt);
+  const lastUsedAt = wire.lastUsedAt === undefined
+    ? {}
+    : { lastUsedAt: parseValue(nonEmptyStringSchema('lastUsedAt'), wire.lastUsedAt) };
+  return {
+    id: parseValue(nonEmptyStringSchema('id'), wire.id),
+    userId,
+    name: parseValue(nonEmptyStringSchema('name'), wire.name),
+    key: parseValue(nonEmptyStringSchema('key'), wire.key),
+    serverSecret: parseValue(parsedBy(parseServerSecret), wire.serverSecret),
+    createdAt: parseValue(nonEmptyStringSchema('createdAt'), wire.createdAt),
+    ...lastUsedAt,
+    upstreamIds,
+    deletedAt,
+    dumpRetentionSeconds: parseValue(dumpRetentionSchema.optional().default(null), wire.dumpRetentionSeconds),
+    responsesRetentionSeconds: parseValue(responsesRetentionSchema, wire.responsesRetentionSeconds),
+  };
 });
 
 const userSchema = z.object({
@@ -298,57 +308,57 @@ const metricsSchema = sequentialArraySchema(
 );
 
 const invalidUsageField = 'record has invalid usage fields';
-const usageSchema = z.object({
+const usageFieldsSchema = z.object({
   keyId: nonEmptyStringWithError(invalidUsageField),
   model: nonEmptyStringWithError(invalidUsageField),
   upstream: z.union([z.string(), z.null()], { error: invalidUsageField }),
   modelKey: nonEmptyStringWithError(invalidUsageField),
   hour: z.string({ error: invalidUsageField }).regex(SEARCH_USAGE_HOUR_PATTERN, { error: invalidUsageField }),
-  pricingSelector: z.record(z.string(), z.unknown(), { error: 'pricingSelector must be an object' }).transform((selector, ctx) => {
-    try {
-      return canonicalizePricingSelector(selector as PricingSelector);
-    } catch (cause) {
-      addIssue(ctx, `invalid pricingSelector: ${messageFor(cause)}`);
-      return z.NEVER;
-    }
-  }),
   requests: nonNegativeSafeIntegerSchema(invalidUsageField),
-  metrics: metricsSchema,
-}, { error: 'record must be an object' }).superRefine((record, ctx) => {
-  if (typeof record.upstream === 'string' && isLegacyUpstreamIdentity(record.upstream)) {
-    addIssue(ctx, 'upstream must use a raw upstream id, not a legacy provider-prefixed identity');
-  }
 });
 
-const searchUsageSchema = z.object({
-  provider: z.unknown().transform((value, ctx) => {
-    if (!isWebSearchProviderName(value)) {
-      addIssue(ctx, 'invalid provider');
-      return z.NEVER;
-    }
-    return value;
-  }),
-  keyId: nonEmptyStringSchema('keyId'),
-  action: z.enum(['search', 'fetch_page'], { error: 'action must be "search" or "fetch_page"' }),
-  hour: z.string({ error: 'hour must match the SEARCH_USAGE_HOUR_PATTERN' })
-    .regex(SEARCH_USAGE_HOUR_PATTERN, { error: 'hour must match the SEARCH_USAGE_HOUR_PATTERN' }),
-  requests: nonNegativeSafeIntegerSchema('requests must be a non-negative safe integer'),
-}, { error: 'record must be an object' });
+const usageSchema = parsedBy((value): UsageRecord => {
+  const wire = parseRecord(value, 'record must be an object');
+  const fields = parseValue(usageFieldsSchema, wire);
+  if (typeof fields.upstream === 'string' && isLegacyUpstreamIdentity(fields.upstream)) {
+    throw new Error('upstream must use a raw upstream id, not a legacy provider-prefixed identity');
+  }
+  const rawPricingSelector = parseRecord(wire.pricingSelector, 'pricingSelector must be an object');
+  let pricingSelector: PricingSelector;
+  try {
+    pricingSelector = canonicalizePricingSelector(rawPricingSelector as PricingSelector);
+  } catch (cause) {
+    throw new Error(`invalid pricingSelector: ${messageFor(cause)}`);
+  }
+  const metrics = parseValue(metricsSchema, wire.metrics);
+  return { ...fields, pricingSelector, metrics };
+});
+
+const searchUsageSchema = parsedBy((value): WebSearchUsageRecord => {
+  const wire = parseValue(objectIncludingArraySchema('record must be an object'), value);
+  if (!isWebSearchProviderName(wire.provider)) throw new Error('invalid provider');
+  const keyId = parseValue(nonEmptyStringWithError('keyId must be a non-empty string'), wire.keyId);
+  const action = parseValue(z.enum(['search', 'fetch_page'], { error: 'action must be "search" or "fetch_page"' }), wire.action);
+  const hour = parseValue(z.string({ error: 'hour must match the SEARCH_USAGE_HOUR_PATTERN' })
+    .regex(SEARCH_USAGE_HOUR_PATTERN, { error: 'hour must match the SEARCH_USAGE_HOUR_PATTERN' }), wire.hour);
+  const requests = parseValue(nonNegativeSafeIntegerSchema('requests must be a non-negative safe integer'), wire.requests);
+  return { provider: wire.provider, keyId, action, hour, requests };
+});
 
 const malformedPerformance = 'record fields are missing or malformed';
 const performanceInteger = nonNegativeSafeIntegerSchema(malformedPerformance);
-const performanceBucketSchema = z.object({
-  metric: z.enum(PERFORMANCE_METRICS, { error: 'bucket metric/lower/upper/count fields are missing or malformed' }),
-  lower: nonNegativeSafeIntegerSchema('bucket metric/lower/upper/count fields are missing or malformed'),
-  upper: z.union([
+const malformedBucket = 'bucket metric/lower/upper/count fields are missing or malformed';
+const performanceBucketSchema = parsedBy((value) => {
+  const wire = parseValue(objectIncludingArraySchema('bucket is not an object'), value);
+  const metric = parseValue(z.enum(PERFORMANCE_METRICS, { error: malformedBucket }), wire.metric);
+  const lower = parseValue(nonNegativeSafeIntegerSchema(malformedBucket), wire.lower);
+  const upper = parseValue(z.union([
     nonNegativeSafeIntegerSchema('bucket metric/lower/upper/count fields are missing or malformed'),
     z.null(),
-  ], { error: 'bucket metric/lower/upper/count fields are missing or malformed' }),
-  count: nonNegativeSafeIntegerSchema('bucket metric/lower/upper/count fields are missing or malformed'),
-}, { error: 'bucket is not an object' }).superRefine((bucket, ctx) => {
-  if (bucket.upper !== null && bucket.upper <= bucket.lower) {
-    addIssue(ctx, 'bucket metric/lower/upper/count fields are missing or malformed');
-  }
+  ], { error: malformedBucket }), wire.upper);
+  const count = parseValue(nonNegativeSafeIntegerSchema(malformedBucket), wire.count);
+  if (upper !== null && upper <= lower) throw new Error(malformedBucket);
+  return { metric, lower, upper, count };
 });
 
 const performanceBucketsSchema = sequentialArraySchema(
@@ -359,18 +369,11 @@ const performanceBucketsSchema = sequentialArraySchema(
     : null,
 );
 
-const performanceSchema = z.object({
+const performanceFieldsSchema = z.object({
   hour: z.string({ error: malformedPerformance }).regex(SEARCH_USAGE_HOUR_PATTERN, { error: malformedPerformance }),
   keyId: nonEmptyStringWithError(malformedPerformance),
   model: nonEmptyStringWithError(malformedPerformance),
   upstream: nonEmptyStringWithError(malformedPerformance).refine(value => !isLegacyUpstreamIdentity(value), { error: malformedPerformance }),
-  operation: parsedBy(value => {
-    try {
-      return parsePerformanceOperation(value);
-    } catch {
-      throw new Error(malformedPerformance);
-    }
-  }),
   runtimeLocation: nonEmptyStringWithError(malformedPerformance),
   requests: performanceInteger,
   ttftSamplesOk: performanceInteger,
@@ -380,34 +383,47 @@ const performanceSchema = z.object({
   tpotSamples: performanceInteger,
   ttftMsSum: performanceInteger,
   tpotUsSum: performanceInteger,
-  buckets: performanceBucketsSchema,
-}, { error: 'record is not an object' }).superRefine((record, ctx) => {
-  const ttftSamples = record.ttftSamplesOk + record.errorsWithOutput;
-  if (ttftSamples + record.errorsNoOutput + record.neutral !== record.requests) {
-    addIssue(ctx, 'ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests');
-    return;
+  buckets: z.array(z.unknown(), { error: malformedPerformance }),
+}, { error: malformedPerformance });
+
+const performanceSchema = parsedBy((value): PerformanceTelemetryRecord => {
+  const wire = parseValue(objectIncludingArraySchema('record is not an object'), value);
+  let operation: ReturnType<typeof parsePerformanceOperation>;
+  try {
+    operation = parsePerformanceOperation(wire.operation);
+  } catch {
+    throw new Error(malformedPerformance);
   }
-  if (record.tpotSamples > ttftSamples) {
-    addIssue(ctx, 'tpotSamples must not exceed ttftSamplesOk + errorsWithOutput');
-    return;
+  const fields = parseValue(performanceFieldsSchema, wire);
+  const ttftSamples = fields.ttftSamplesOk + fields.errorsWithOutput;
+  if (ttftSamples + fields.errorsNoOutput + fields.neutral !== fields.requests) {
+    throw new Error('ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests');
+  }
+  if (fields.tpotSamples > ttftSamples) {
+    throw new Error('tpotSamples must not exceed ttftSamplesOk + errorsWithOutput');
   }
 
+  const buckets = parseValue(performanceBucketsSchema, fields.buckets);
   let ttftBucketCount = 0;
   let tpotBucketCount = 0;
-  for (const bucket of record.buckets) {
+  for (const bucket of buckets) {
     if (bucket.metric === 'ttft_ms') ttftBucketCount += bucket.count;
     else tpotBucketCount += bucket.count;
   }
   if (ttftBucketCount !== ttftSamples) {
-    addIssue(ctx, `ttft_ms bucket sum (${ttftBucketCount}) must equal ttftSamplesOk + errorsWithOutput (${ttftSamples})`);
-  } else if (tpotBucketCount !== record.tpotSamples) {
-    addIssue(ctx, `tpot_us bucket sum (${tpotBucketCount}) must equal tpotSamples (${record.tpotSamples})`);
+    throw new Error(`ttft_ms bucket sum (${ttftBucketCount}) must equal ttftSamplesOk + errorsWithOutput (${ttftSamples})`);
   }
+  if (tpotBucketCount !== fields.tpotSamples) {
+    throw new Error(`tpot_us bucket sum (${tpotBucketCount}) must equal tpotSamples (${fields.tpotSamples})`);
+  }
+  const { buckets: _rawBuckets, ...recordFields } = fields;
+  return { ...recordFields, operation, buckets };
 });
 
 interface CollectionOptions<T> {
   arrayError: string;
   optional?: boolean;
+  validateInput?: (value: unknown, index: number, prior: readonly T[]) => string | null;
   validateRecord?: (record: T, index: number, prior: readonly T[]) => string | null;
 }
 
@@ -426,6 +442,8 @@ const parseCollection = <T>(
 
   const records: T[] = [];
   for (let index = 0; index < array.data.length; index++) {
+    const inputValidationError = options.validateInput?.(array.data[index], index, records);
+    if (inputValidationError) return { type: 'invalid', error: `invalid ${label} at index ${index}: ${inputValidationError}` };
     const result = schema.safeParse(array.data[index]);
     if (!result.success) {
       return { type: 'invalid', error: `invalid ${label} at index ${index}: ${result.error.issues[0].message}` };
@@ -444,9 +462,15 @@ export const parseImportData = (value: unknown): ImportDataParseResult => {
   if (apiKeys.type === 'invalid') return apiKeys;
   const users = parseCollection('users', userSchema, value.users, {
     arrayError: 'users must be an array',
-    validateRecord: (user, _index, prior) => prior.some(candidate => candidate.id === user.id)
-      ? `duplicate user id ${user.id}`
-      : null,
+    validateInput: (input, _index, prior) => {
+      try {
+        const wire = parseRecord(input, 'record must be an object');
+        const id = parseValue(positiveIntegerSchema('id'), wire.id);
+        return prior.some(candidate => candidate.id === id) ? `duplicate user id ${id}` : null;
+      } catch (cause) {
+        return messageFor(cause);
+      }
+    },
   });
   if (users.type === 'invalid') return users;
   if (!users.records.some(user => user.id === SEED_ADMIN_USER_ID)) {

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -1,0 +1,462 @@
+import { z } from 'zod';
+
+import { parseWebSearchConfigStrict } from '../../../data-plane/tools/web-search/config.ts';
+import type { WebSearchConfig } from '../../../data-plane/tools/web-search/types.ts';
+import { parseDisabledPublicModelIdsWire } from '../../../repo/disabled-public-models.ts';
+import { isDirectFallbackId, normalizeProxyFallbackList } from '../../../repo/proxy-fallback-list.ts';
+import { isResponsesRetentionSeconds, RESPONSES_RETENTION_MAX_SECONDS, RESPONSES_RETENTION_MIN_SECONDS } from '../../../repo/responses-retention.ts';
+import { SEED_ADMIN_USER_ID } from '../../../repo/seed-admin.ts';
+import type { ApiKey, PerformanceMetric, PerformanceTelemetryRecord, UsageRecord, User, WebSearchUsageRecord } from '../../../repo/types.ts';
+import { PASSWORD_HASH_SCHEME } from '../../../shared/passwords.ts';
+import { RETENTION_MAX_SECONDS } from '../../../shared/retention.ts';
+import { parseServerSecret } from '../../../shared/server-secret.ts';
+import { isWebSearchProviderName } from '../../../shared/web-search-providers.ts';
+import { USERNAME_PATTERN } from '../../schemas.ts';
+import { isRecord } from '../../shared/field-validators.ts';
+import { parseUpstreamIdsValue } from '../../shared/upstream-ids.ts';
+import { BILLING_METRICS, canonicalizePricingSelector, type BillingMetric, parseNonNegativeDecimalString } from '@floway-dev/protocols/common';
+import { ALL_PROVIDER_KINDS, normalizeModelPrefix, normalizeUpstreamHue, parseFlagOverridesWire, parsePerformanceOperation, type ProxyFallbackEntry, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
+import { assertAzureUpstreamRecord } from '@floway-dev/provider-azure';
+import { assertClaudeCodeUpstreamRecord, assertClaudeCodeUpstreamState } from '@floway-dev/provider-claude-code';
+import { assertCodexUpstreamRecord, assertCodexUpstreamState } from '@floway-dev/provider-codex';
+import { parseCopilotUpstreamConfig } from '@floway-dev/provider-copilot';
+import { assertCustomUpstreamRecord } from '@floway-dev/provider-custom';
+import { assertOllamaUpstreamRecord } from '@floway-dev/provider-ollama';
+import { parseProxyUri } from '@floway-dev/proxy';
+
+export interface SerializedProxy {
+  id: string;
+  name: string;
+  url: string;
+  dial_timeout_seconds: number | null;
+}
+
+export interface ParsedImportData {
+  users: User[];
+  apiKeys: ApiKey[];
+  upstreams: UpstreamRecord[];
+  proxies: SerializedProxy[];
+  usage: UsageRecord[];
+  searchUsage: WebSearchUsageRecord[];
+  performance: PerformanceTelemetryRecord[];
+  performanceIncluded: boolean;
+  searchConfig: WebSearchConfig;
+}
+
+export type ImportDataParseResult = { type: 'ok'; data: ParsedImportData } | { type: 'invalid'; error: string };
+
+const SEARCH_USAGE_HOUR_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}$/;
+const LEGACY_UPSTREAM_PREFIXES = ['openai:', 'copilot:'];
+const PERFORMANCE_METRICS = ['ttft_ms', 'tpot_us'] as const satisfies readonly PerformanceMetric[];
+
+const hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
+const isLegacyUpstreamIdentity = (value: string): boolean => LEGACY_UPSTREAM_PREFIXES.some(prefix => value.startsWith(prefix));
+const messageFor = (cause: unknown): string => cause instanceof Error ? cause.message : String(cause);
+const addIssue = (ctx: z.RefinementCtx, input: unknown, message: string) => ctx.addIssue({ code: 'custom', input, message });
+
+const parsedBy = <T>(parser: (value: unknown) => T) => z.unknown().transform((value, ctx): T => {
+  try {
+    return parser(value);
+  } catch (cause) {
+    addIssue(ctx, value, messageFor(cause));
+    return z.NEVER;
+  }
+});
+
+const nonEmptyStringSchema = (field: string) => z.string({ error: `${field} must be a non-empty string` })
+  .min(1, { error: `${field} must be a non-empty string` });
+const nullableStringSchema = (field: string) => z.union([
+  z.string(),
+  z.null(),
+], { error: `${field} must be null or an ISO string` });
+const positiveIntegerSchema = (field: string) => z.number({ error: `${field} must be a positive integer` })
+  .int({ error: `${field} must be a positive integer` })
+  .positive({ error: `${field} must be a positive integer` });
+const nonNegativeSafeIntegerSchema = (message: string) => z.number({ error: message })
+  .int({ error: message })
+  .nonnegative({ error: message })
+  .max(Number.MAX_SAFE_INTEGER, { error: message });
+
+const upstreamIdsSchema = parsedBy(value => {
+  const result = parseUpstreamIdsValue(value);
+  if (!result.ok) throw new Error(result.error);
+  return result.value;
+});
+
+const proxyFallbackEntrySchema = z.object({
+  id: z.string({ error: 'proxy_fallback_list entry .id must be a string' }),
+  colos: z.array(z.string({ error: 'proxy_fallback_list entry .colos members must be strings' }), {
+    error: 'proxy_fallback_list entry .colos must be an array',
+  }).optional(),
+}, { error: 'proxy_fallback_list entries must be objects' });
+
+const proxyFallbackListSchema = z.array(proxyFallbackEntrySchema, { error: 'proxy_fallback_list must be an array' })
+  .optional()
+  .transform((value): ProxyFallbackEntry[] => normalizeProxyFallbackList(value ?? []));
+
+const normalizeUpstreamConfig = (record: UpstreamRecord): unknown => {
+  switch (record.kind) {
+  case 'custom': return assertCustomUpstreamRecord(record).config;
+  case 'azure': return assertAzureUpstreamRecord(record).config;
+  case 'ollama': return assertOllamaUpstreamRecord(record).config;
+  case 'codex':
+    assertCodexUpstreamRecord(record);
+    return record.config;
+  case 'claude-code':
+    assertClaudeCodeUpstreamRecord(record);
+    return record.config;
+  case 'copilot': return parseCopilotUpstreamConfig(record.config, (field, expected) => new Error(`${field} must be ${expected}`));
+  }
+};
+
+const normalizeUpstreamState = (kind: UpstreamProviderKind, value: unknown): unknown => {
+  if (kind !== 'codex' && kind !== 'claude-code') return null;
+  if (value === null || value === undefined) throw new Error(`${kind} upstream is missing state — re-export with current code`);
+  if (kind === 'codex') assertCodexUpstreamState(value);
+  else assertClaudeCodeUpstreamState(value);
+  return value;
+};
+
+const upstreamWireSchema = z.object({
+  id: nonEmptyStringSchema('id'),
+  kind: z.enum(ALL_PROVIDER_KINDS, { error: `kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}` }),
+  name: nonEmptyStringSchema('name'),
+  enabled: z.boolean({ error: 'enabled must be a boolean' }),
+  sort_order: z.number({ error: 'sort_order must be a finite number' })
+    .finite({ error: 'sort_order must be a finite number' }),
+  created_at: nonEmptyStringSchema('created_at'),
+  updated_at: nonEmptyStringSchema('updated_at'),
+  flag_overrides: parsedBy(parseFlagOverridesWire),
+  disabled_public_model_ids: parsedBy(parseDisabledPublicModelIdsWire),
+  proxy_fallback_list: proxyFallbackListSchema,
+  model_prefix: parsedBy(normalizeModelPrefix),
+  hue: parsedBy(normalizeUpstreamHue),
+  config: z.unknown(),
+  state: z.unknown().optional(),
+}).loose().superRefine((wire, ctx) => {
+  if (hasOwn(wire, 'enabled_fixes')) {
+    addIssue(ctx, wire.enabled_fixes, "legacy 'enabled_fixes' field is no longer supported; re-export with current code");
+  }
+  if (isLegacyUpstreamIdentity(wire.id)) {
+    addIssue(ctx, wire.id, 'id must use a raw upstream id, not a legacy provider-prefixed identity');
+  }
+}).transform((wire, ctx): UpstreamRecord => {
+  try {
+    const record: UpstreamRecord = {
+      id: wire.id,
+      kind: wire.kind,
+      name: wire.name,
+      enabled: wire.enabled,
+      sortOrder: Math.floor(wire.sort_order),
+      createdAt: wire.created_at,
+      updatedAt: wire.updated_at,
+      flagOverrides: wire.flag_overrides,
+      disabledPublicModelIds: wire.disabled_public_model_ids,
+      proxyFallbackList: wire.proxy_fallback_list,
+      modelPrefix: wire.model_prefix,
+      hue: wire.hue,
+      config: wire.config,
+      state: normalizeUpstreamState(wire.kind, wire.state),
+      modelsCache: null,
+    };
+    return { ...record, config: normalizeUpstreamConfig(record) };
+  } catch (cause) {
+    addIssue(ctx, wire, messageFor(cause));
+    return z.NEVER;
+  }
+});
+
+const proxySchema = z.object({
+  id: nonEmptyStringSchema('id').refine(id => !isDirectFallbackId(id), {
+    error: 'id must not be a reserved direct-transport sentinel',
+  }),
+  name: nonEmptyStringSchema('name'),
+  url: nonEmptyStringSchema('url').transform((url, ctx) => {
+    try {
+      parseProxyUri(url);
+      return url;
+    } catch (cause) {
+      addIssue(ctx, url, `url did not parse: ${messageFor(cause)}`);
+      return z.NEVER;
+    }
+  }),
+  dial_timeout_seconds: z.union([
+    positiveIntegerSchema('dial_timeout_seconds'),
+    z.null(),
+  ], { error: 'dial_timeout_seconds must be null or a positive integer' }),
+});
+
+const dumpRetentionSchema = parsedBy((value): number | null => {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > RETENTION_MAX_SECONDS) {
+    throw new Error(`dumpRetentionSeconds must be null or a positive integer up to ${RETENTION_MAX_SECONDS}`);
+  }
+  return value;
+});
+const responsesRetentionSchema = parsedBy((value): number => {
+  if (!isResponsesRetentionSeconds(value)) {
+    throw new Error(`responsesRetentionSeconds must be 0 or a whole-day integer from ${RESPONSES_RETENTION_MIN_SECONDS} to ${RESPONSES_RETENTION_MAX_SECONDS}`);
+  }
+  return value;
+});
+
+const apiKeySchema = z.object({
+  id: nonEmptyStringSchema('id'),
+  userId: positiveIntegerSchema('userId'),
+  name: nonEmptyStringSchema('name'),
+  key: nonEmptyStringSchema('key'),
+  serverSecret: parsedBy(parseServerSecret),
+  createdAt: nonEmptyStringSchema('createdAt'),
+  lastUsedAt: nonEmptyStringSchema('lastUsedAt').optional(),
+  upstreamIds: upstreamIdsSchema,
+  deletedAt: nullableStringSchema('deletedAt'),
+  dumpRetentionSeconds: dumpRetentionSchema,
+  responsesRetentionSeconds: responsesRetentionSchema,
+});
+
+const userSchema = z.object({
+  id: positiveIntegerSchema('id'),
+  username: z.string({ error: 'username must match ^[a-zA-Z0-9_.-]{1,64}$' })
+    .regex(USERNAME_PATTERN, { error: 'username must match ^[a-zA-Z0-9_.-]{1,64}$' }),
+  passwordHash: z.union([
+    z.string().refine(value => value.startsWith(`${PASSWORD_HASH_SCHEME}$`)),
+    z.null(),
+  ], { error: `passwordHash must be null or start with ${PASSWORD_HASH_SCHEME}$` }),
+  isAdmin: z.boolean({ error: 'isAdmin must be a boolean' }),
+  upstreamIds: upstreamIdsSchema,
+  createdAt: nonEmptyStringSchema('createdAt'),
+  deletedAt: nullableStringSchema('deletedAt'),
+});
+
+const usersSchema = z.array(userSchema, { error: 'users must be an array' }).superRefine((users, ctx) => {
+  const seen = new Set<number>();
+  for (let index = 0; index < users.length; index++) {
+    if (seen.has(users[index].id)) addIssue(ctx, users[index].id, `duplicate user id ${users[index].id}`);
+    seen.add(users[index].id);
+  }
+});
+
+const metricSchema = z.object({
+  metric: z.unknown().transform((value, ctx): BillingMetric => {
+    if (typeof value !== 'string' || !BILLING_METRICS.includes(value as BillingMetric)) {
+      addIssue(ctx, value, `unknown usage metric: ${JSON.stringify(value)}`);
+      return z.NEVER;
+    }
+    return value as BillingMetric;
+  }),
+  quantity: parsedBy(value => parseNonNegativeDecimalString(value, 'metric quantity')),
+  unitPrice: z.unknown().transform((value, ctx): string | null => {
+    if (value === null) return null;
+    try {
+      return parseNonNegativeDecimalString(value, 'metric unitPrice');
+    } catch (cause) {
+      addIssue(ctx, value, messageFor(cause));
+      return z.NEVER;
+    }
+  }),
+}, { error: 'metrics must contain objects' });
+
+const metricsSchema = z.array(metricSchema, { error: 'metrics must be an array' }).superRefine((metrics, ctx) => {
+  const seen = new Set<BillingMetric>();
+  for (let index = 0; index < metrics.length; index++) {
+    const metric = metrics[index].metric;
+    if (seen.has(metric)) addIssue(ctx, metric, `duplicate usage metric: ${metric}`);
+    seen.add(metric);
+  }
+});
+
+const invalidUsageField = 'record has invalid usage fields';
+const usageSchema = z.object({
+  keyId: nonEmptyStringSchema(invalidUsageField),
+  model: nonEmptyStringSchema(invalidUsageField),
+  upstream: z.union([z.string(), z.null()], { error: invalidUsageField }),
+  modelKey: nonEmptyStringSchema(invalidUsageField),
+  hour: z.string({ error: invalidUsageField }).regex(SEARCH_USAGE_HOUR_PATTERN, { error: invalidUsageField }),
+  pricingSelector: z.record(z.string(), z.unknown(), { error: 'pricingSelector must be an object' }).transform((selector, ctx) => {
+    try {
+      return canonicalizePricingSelector(selector);
+    } catch (cause) {
+      addIssue(ctx, selector, `invalid pricingSelector: ${messageFor(cause)}`);
+      return z.NEVER;
+    }
+  }),
+  requests: nonNegativeSafeIntegerSchema(invalidUsageField),
+  metrics: metricsSchema,
+}, { error: 'record must be an object' }).superRefine((record, ctx) => {
+  if (typeof record.upstream === 'string' && isLegacyUpstreamIdentity(record.upstream)) {
+    addIssue(ctx, record.upstream, 'upstream must use a raw upstream id, not a legacy provider-prefixed identity');
+  }
+});
+
+const searchUsageSchema = z.object({
+  provider: z.unknown().transform((value, ctx) => {
+    if (!isWebSearchProviderName(value)) {
+      addIssue(ctx, value, 'invalid provider');
+      return z.NEVER;
+    }
+    return value;
+  }),
+  keyId: nonEmptyStringSchema('keyId'),
+  action: z.enum(['search', 'fetch_page'], { error: 'action must be "search" or "fetch_page"' }),
+  hour: z.string({ error: 'hour must match the SEARCH_USAGE_HOUR_PATTERN' })
+    .regex(SEARCH_USAGE_HOUR_PATTERN, { error: 'hour must match the SEARCH_USAGE_HOUR_PATTERN' }),
+  requests: nonNegativeSafeIntegerSchema('requests must be a non-negative safe integer'),
+}, { error: 'record must be an object' });
+
+const malformedPerformance = 'record fields are missing or malformed';
+const performanceInteger = nonNegativeSafeIntegerSchema(malformedPerformance);
+const performanceBucketSchema = z.object({
+  metric: z.enum(PERFORMANCE_METRICS, { error: 'bucket metric/lower/upper/count fields are missing or malformed' }),
+  lower: nonNegativeSafeIntegerSchema('bucket metric/lower/upper/count fields are missing or malformed'),
+  upper: z.union([
+    nonNegativeSafeIntegerSchema('bucket metric/lower/upper/count fields are missing or malformed'),
+    z.null(),
+  ], { error: 'bucket metric/lower/upper/count fields are missing or malformed' }),
+  count: nonNegativeSafeIntegerSchema('bucket metric/lower/upper/count fields are missing or malformed'),
+}, { error: 'bucket is not an object' }).superRefine((bucket, ctx) => {
+  if (bucket.upper !== null && bucket.upper <= bucket.lower) {
+    addIssue(ctx, bucket.upper, 'bucket metric/lower/upper/count fields are missing or malformed');
+  }
+});
+
+const performanceSchema = z.object({
+  hour: z.string({ error: malformedPerformance }).regex(SEARCH_USAGE_HOUR_PATTERN, { error: malformedPerformance }),
+  keyId: nonEmptyStringSchema(malformedPerformance),
+  model: nonEmptyStringSchema(malformedPerformance),
+  upstream: nonEmptyStringSchema(malformedPerformance).refine(value => !isLegacyUpstreamIdentity(value), { error: malformedPerformance }),
+  operation: parsedBy(value => {
+    try {
+      return parsePerformanceOperation(value);
+    } catch {
+      throw new Error(malformedPerformance);
+    }
+  }),
+  runtimeLocation: nonEmptyStringSchema(malformedPerformance),
+  requests: performanceInteger,
+  ttftSamplesOk: performanceInteger,
+  errorsWithOutput: performanceInteger,
+  errorsNoOutput: performanceInteger,
+  neutral: performanceInteger,
+  tpotSamples: performanceInteger,
+  ttftMsSum: performanceInteger,
+  tpotUsSum: performanceInteger,
+  buckets: z.array(performanceBucketSchema, { error: malformedPerformance }),
+}, { error: 'record is not an object' }).superRefine((record, ctx) => {
+  const ttftSamples = record.ttftSamplesOk + record.errorsWithOutput;
+  if (ttftSamples + record.errorsNoOutput + record.neutral !== record.requests) {
+    addIssue(ctx, record.requests, 'ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests');
+    return;
+  }
+  if (record.tpotSamples > ttftSamples) {
+    addIssue(ctx, record.tpotSamples, 'tpotSamples must not exceed ttftSamplesOk + errorsWithOutput');
+    return;
+  }
+
+  const bucketKeys = new Set<string>();
+  let ttftBucketCount = 0;
+  let tpotBucketCount = 0;
+  for (const bucket of record.buckets) {
+    const dedupKey = `${bucket.metric}\0${bucket.lower}`;
+    if (bucketKeys.has(dedupKey)) {
+      addIssue(ctx, bucket, `duplicate bucket entry for {metric: ${bucket.metric}, lower: ${bucket.lower}}`);
+      return;
+    }
+    bucketKeys.add(dedupKey);
+    if (bucket.metric === 'ttft_ms') ttftBucketCount += bucket.count;
+    else tpotBucketCount += bucket.count;
+  }
+  if (ttftBucketCount !== ttftSamples) {
+    addIssue(ctx, record.buckets, `ttft_ms bucket sum (${ttftBucketCount}) must equal ttftSamplesOk + errorsWithOutput (${ttftSamples})`);
+  } else if (tpotBucketCount !== record.tpotSamples) {
+    addIssue(ctx, record.buckets, `tpot_us bucket sum (${tpotBucketCount}) must equal tpotSamples (${record.tpotSamples})`);
+  }
+});
+
+const apiKeysSchema = z.array(apiKeySchema, { error: 'apiKeys must be an array' });
+const upstreamsSchema = z.array(upstreamWireSchema, { error: 'upstreams must be an array' });
+const proxiesSchema = z.array(proxySchema, { error: 'proxies must be an array' }).optional().default([]);
+const usageRecordsSchema = z.array(usageSchema, { error: 'usage must be an array' });
+const searchUsageRecordsSchema = z.array(searchUsageSchema, { error: 'searchUsage must be an array' });
+const performanceRecordsSchema = z.array(performanceSchema, { error: 'performance must be an array when included' });
+
+const parseCollection = <T>(label: string, schema: z.ZodType<T[]>, value: unknown): { type: 'ok'; records: T[] } | { type: 'invalid'; error: string } => {
+  const result = schema.safeParse(value);
+  if (result.success) return { type: 'ok', records: result.data };
+  const issue = result.error.issues[0];
+  const index = typeof issue.path[0] === 'number' ? issue.path[0] : -1;
+  const location = index >= 0 ? ` at index ${index}` : '';
+  return { type: 'invalid', error: `invalid ${label}${location}: ${issue.message}` };
+};
+
+export const parseImportData = (value: unknown): ImportDataParseResult => {
+  if (!isRecord(value)) return { type: 'invalid', error: 'data is required' };
+
+  const apiKeys = parseCollection('apiKeys', apiKeysSchema, value.apiKeys);
+  if (apiKeys.type === 'invalid') return apiKeys;
+  const users = parseCollection('users', usersSchema, value.users);
+  if (users.type === 'invalid') return users;
+  if (!users.records.some(user => user.id === SEED_ADMIN_USER_ID)) {
+    return { type: 'invalid', error: 'invalid users: payload must include user 1 (the seed admin)' };
+  }
+  const userIds = new Set(users.records.map(user => user.id));
+  for (let index = 0; index < apiKeys.records.length; index++) {
+    if (!userIds.has(apiKeys.records[index].userId)) {
+      return { type: 'invalid', error: `invalid apiKeys at index ${index}: user_id ${apiKeys.records[index].userId} does not match any user in the payload` };
+    }
+  }
+
+  const usage = parseCollection('usage', usageRecordsSchema, value.usage);
+  if (usage.type === 'invalid') return usage;
+  const upstreams = parseCollection('upstreams', upstreamsSchema, value.upstreams);
+  if (upstreams.type === 'invalid') return upstreams;
+  const proxies = parseCollection('proxies', proxiesSchema, value.proxies);
+  if (proxies.type === 'invalid') return proxies;
+  const proxyIds = new Map<string, number>();
+  for (let index = 0; index < proxies.records.length; index++) {
+    const prior = proxyIds.get(proxies.records[index].id);
+    if (prior !== undefined) {
+      return { type: 'invalid', error: `invalid proxies: duplicate proxies id ${proxies.records[index].id} at indexes ${prior} and ${index}` };
+    }
+    proxyIds.set(proxies.records[index].id, index);
+  }
+
+  const searchUsage = parseCollection('searchUsage', searchUsageRecordsSchema, value.searchUsage);
+  if (searchUsage.type === 'invalid') return searchUsage;
+
+  let searchConfig: WebSearchConfig;
+  try {
+    searchConfig = parseWebSearchConfigStrict(value.searchConfig);
+  } catch (cause) {
+    return { type: 'invalid', error: `invalid searchConfig: ${messageFor(cause)}` };
+  }
+
+  if (typeof value.performanceIncluded !== 'boolean') {
+    return { type: 'invalid', error: 'performanceIncluded must be a boolean' };
+  }
+  if (!value.performanceIncluded && hasOwn(value, 'performance')) {
+    return { type: 'invalid', error: 'performance must be omitted unless performanceIncluded is true' };
+  }
+  let performance: PerformanceTelemetryRecord[] = [];
+  if (value.performanceIncluded) {
+    const parsed = parseCollection('performance', performanceRecordsSchema, value.performance);
+    if (parsed.type === 'invalid') {
+      return { type: 'invalid', error: parsed.error.replace(/^invalid performance at index /, 'invalid performance record at index ') };
+    }
+    performance = parsed.records;
+  }
+
+  return {
+    type: 'ok',
+    data: {
+      users: users.records,
+      apiKeys: apiKeys.records,
+      upstreams: upstreams.records,
+      proxies: proxies.records,
+      usage: usage.records,
+      searchUsage: searchUsage.records,
+      performance,
+      performanceIncluded: value.performanceIncluded,
+      searchConfig,
+    },
+  };
+};

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -52,7 +52,7 @@ const PERFORMANCE_METRICS = ['ttft_ms', 'tpot_us'] as const satisfies readonly P
 const hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
 const isLegacyUpstreamIdentity = (value: string): boolean => LEGACY_UPSTREAM_PREFIXES.some(prefix => value.startsWith(prefix));
 const messageFor = (cause: unknown): string => cause instanceof Error ? cause.message : String(cause);
-const addIssue = (ctx: z.RefinementCtx, message: string, path?: PropertyKey[]) => ctx.addIssue({ code: 'custom', message, path });
+const addIssue = (ctx: z.RefinementCtx, message: string) => ctx.addIssue({ code: 'custom', message });
 
 const parsedBy = <T>(parser: (value: unknown) => T) => z.unknown().transform((value, ctx): T => {
   try {
@@ -241,6 +241,34 @@ const userSchema = z.object({
   deletedAt: nullableStringSchema('deletedAt'),
 });
 
+const sequentialArraySchema = <T>(
+  schema: z.ZodType<T>,
+  arrayError: string,
+  validateRecord?: (record: T, index: number, prior: readonly T[]) => string | null,
+) => z.unknown().transform((value, ctx): T[] => {
+  const array = z.array(z.unknown(), { error: arrayError }).safeParse(value);
+  if (!array.success) {
+    addIssue(ctx, array.error.issues[0].message);
+    return z.NEVER;
+  }
+
+  const records: T[] = [];
+  for (let index = 0; index < array.data.length; index++) {
+    const result = schema.safeParse(array.data[index]);
+    if (!result.success) {
+      addIssue(ctx, result.error.issues[0].message);
+      return z.NEVER;
+    }
+    const validationError = validateRecord?.(result.data, index, records);
+    if (validationError) {
+      addIssue(ctx, validationError);
+      return z.NEVER;
+    }
+    records.push(result.data);
+  }
+  return records;
+});
+
 const metricSchema = z.object({
   metric: z.unknown().transform((value, ctx): BillingMetric => {
     if (typeof value !== 'string' || !BILLING_METRICS.includes(value as BillingMetric)) {
@@ -261,14 +289,13 @@ const metricSchema = z.object({
   }),
 }, { error: 'metrics must contain objects' });
 
-const metricsSchema = z.array(metricSchema, { error: 'metrics must be an array' }).superRefine((metrics, ctx) => {
-  const seen = new Set<BillingMetric>();
-  for (let index = 0; index < metrics.length; index++) {
-    const metric = metrics[index].metric;
-    if (seen.has(metric)) addIssue(ctx, `duplicate usage metric: ${metric}`, [index]);
-    seen.add(metric);
-  }
-});
+const metricsSchema = sequentialArraySchema(
+  metricSchema,
+  'metrics must be an array',
+  (row, _index, prior) => prior.some(candidate => candidate.metric === row.metric)
+    ? `duplicate usage metric: ${row.metric}`
+    : null,
+);
 
 const invalidUsageField = 'record has invalid usage fields';
 const usageSchema = z.object({
@@ -324,6 +351,14 @@ const performanceBucketSchema = z.object({
   }
 });
 
+const performanceBucketsSchema = sequentialArraySchema(
+  performanceBucketSchema,
+  malformedPerformance,
+  (bucket, _index, prior) => prior.some(candidate => candidate.metric === bucket.metric && candidate.lower === bucket.lower)
+    ? `duplicate bucket entry for {metric: ${bucket.metric}, lower: ${bucket.lower}}`
+    : null,
+);
+
 const performanceSchema = z.object({
   hour: z.string({ error: malformedPerformance }).regex(SEARCH_USAGE_HOUR_PATTERN, { error: malformedPerformance }),
   keyId: nonEmptyStringWithError(malformedPerformance),
@@ -345,7 +380,7 @@ const performanceSchema = z.object({
   tpotSamples: performanceInteger,
   ttftMsSum: performanceInteger,
   tpotUsSum: performanceInteger,
-  buckets: z.array(performanceBucketSchema, { error: malformedPerformance }),
+  buckets: performanceBucketsSchema,
 }, { error: 'record is not an object' }).superRefine((record, ctx) => {
   const ttftSamples = record.ttftSamplesOk + record.errorsWithOutput;
   if (ttftSamples + record.errorsNoOutput + record.neutral !== record.requests) {
@@ -357,16 +392,9 @@ const performanceSchema = z.object({
     return;
   }
 
-  const bucketKeys = new Set<string>();
   let ttftBucketCount = 0;
   let tpotBucketCount = 0;
   for (const bucket of record.buckets) {
-    const dedupKey = `${bucket.metric}\0${bucket.lower}`;
-    if (bucketKeys.has(dedupKey)) {
-      addIssue(ctx, `duplicate bucket entry for {metric: ${bucket.metric}, lower: ${bucket.lower}}`);
-      return;
-    }
-    bucketKeys.add(dedupKey);
     if (bucket.metric === 'ttft_ms') ttftBucketCount += bucket.count;
     else tpotBucketCount += bucket.count;
   }

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -348,7 +348,7 @@ const searchUsageSchema = parsedBy((value): WebSearchUsageRecord => {
 const malformedPerformance = 'record fields are missing or malformed';
 const performanceInteger = nonNegativeSafeIntegerSchema(malformedPerformance);
 const malformedBucket = 'bucket metric/lower/upper/count fields are missing or malformed';
-const performanceBucketSchema = parsedBy((value) => {
+const performanceBucketSchema = parsedBy(value => {
   const wire = parseValue(objectIncludingArraySchema('bucket is not an object'), value);
   const metric = parseValue(z.enum(PERFORMANCE_METRICS, { error: malformedBucket }), wire.metric);
   const lower = parseValue(nonNegativeSafeIntegerSchema(malformedBucket), wire.lower);

--- a/packages/gateway/src/control-plane/data-transfer/import-schema.ts
+++ b/packages/gateway/src/control-plane/data-transfer/import-schema.ts
@@ -212,21 +212,28 @@ const apiKeySchema = parsedBy((value): ApiKey => {
   const upstreamIds = parseValue(upstreamIdsSchema, wire.upstreamIds);
   const userId = parseValue(positiveIntegerSchema('userId'), wire.userId);
   const deletedAt = parseValue(nullableStringSchema('deletedAt'), wire.deletedAt);
+  const id = parseValue(nonEmptyStringSchema('id'), wire.id);
+  const name = parseValue(nonEmptyStringSchema('name'), wire.name);
+  const key = parseValue(nonEmptyStringSchema('key'), wire.key);
+  const serverSecret = parseValue(parsedBy(parseServerSecret), wire.serverSecret);
+  const createdAt = parseValue(nonEmptyStringSchema('createdAt'), wire.createdAt);
   const lastUsedAt = wire.lastUsedAt === undefined
     ? {}
     : { lastUsedAt: parseValue(nonEmptyStringSchema('lastUsedAt'), wire.lastUsedAt) };
+  const dumpRetentionSeconds = parseValue(dumpRetentionSchema.optional().default(null), wire.dumpRetentionSeconds);
+  const responsesRetentionSeconds = parseValue(responsesRetentionSchema, wire.responsesRetentionSeconds);
   return {
-    id: parseValue(nonEmptyStringSchema('id'), wire.id),
+    id,
     userId,
-    name: parseValue(nonEmptyStringSchema('name'), wire.name),
-    key: parseValue(nonEmptyStringSchema('key'), wire.key),
-    serverSecret: parseValue(parsedBy(parseServerSecret), wire.serverSecret),
-    createdAt: parseValue(nonEmptyStringSchema('createdAt'), wire.createdAt),
+    name,
+    key,
+    serverSecret,
+    createdAt,
     ...lastUsedAt,
     upstreamIds,
     deletedAt,
-    dumpRetentionSeconds: parseValue(dumpRetentionSchema.optional().default(null), wire.dumpRetentionSeconds),
-    responsesRetentionSeconds: parseValue(responsesRetentionSchema, wire.responsesRetentionSeconds),
+    dumpRetentionSeconds,
+    responsesRetentionSeconds,
   };
 });
 
@@ -247,8 +254,8 @@ const userSchema = z.object({
     if (!result.ok) throw new Error(result.error);
     return result.value;
   }),
-  createdAt: nonEmptyStringSchema('createdAt'),
   deletedAt: nullableStringSchema('deletedAt'),
+  createdAt: nonEmptyStringSchema('createdAt'),
 });
 
 const sequentialArraySchema = <T>(

--- a/packages/gateway/src/control-plane/data-transfer/routes.ts
+++ b/packages/gateway/src/control-plane/data-transfer/routes.ts
@@ -8,44 +8,18 @@
 // credential-bearing proxy URIs. The endpoint is admin-only; handle the file
 // with the same care as a DB backup.
 
+import { parseImportData, type SerializedProxy } from './import-schema.ts';
 import { parseWebSearchConfigDefault, parseWebSearchConfigStrict } from '../../data-plane/tools/web-search/config.ts';
 import type { WebSearchConfig } from '../../data-plane/tools/web-search/types.ts';
 import { notifyDisabledBestEffort } from '../../dump/registry.ts';
 import { type CtxWithJson, type CtxWithQuery } from '../../middleware/zod-validator.ts';
-import { parseDisabledPublicModelIdsWire } from '../../repo/disabled-public-models.ts';
 import { getRepo } from '../../repo/index.ts';
-import { DIRECT_FALLBACK_IDS, isDirectFallbackId, normalizeProxyFallbackList } from '../../repo/proxy-fallback-list.ts';
-import { isResponsesRetentionSeconds, RESPONSES_RETENTION_MAX_SECONDS, RESPONSES_RETENTION_MIN_SECONDS } from '../../repo/responses-retention.ts';
-import { SEED_ADMIN_USER_ID } from '../../repo/seed-admin.ts';
-import type { ApiKey, PerformanceBucketRow, PerformanceMetric, PerformanceTelemetryRecord, WebSearchUsageRecord, UsageMetricRecord, UsageRecord, User } from '../../repo/types.ts';
-import { PASSWORD_HASH_SCHEME } from '../../shared/passwords.ts';
-import { RETENTION_MAX_SECONDS } from '../../shared/retention.ts';
-import { parseServerSecret } from '../../shared/server-secret.ts';
-import { isWebSearchProviderName } from '../../shared/web-search-providers.ts';
-import { USERNAME_PATTERN, type exportQuery, type importBody } from '../schemas.ts';
-import { isRecord, nonEmptyStringField } from '../shared/field-validators.ts';
-import { parseUpstreamIdsValue } from '../shared/upstream-ids.ts';
+import { DIRECT_FALLBACK_IDS } from '../../repo/proxy-fallback-list.ts';
+import type { ApiKey, PerformanceTelemetryRecord, UsageRecord, User, WebSearchUsageRecord } from '../../repo/types.ts';
+import { type exportQuery, type importBody } from '../schemas.ts';
 import { warmModelsCache } from '../shared/warm-models-cache.ts';
 import { type FullSerializedUpstreamRecord, upstreamRecordToFullJson } from '../upstreams/serialize.ts';
-import { BILLING_METRICS, canonicalizePricingSelector, type BillingMetric, parseNonNegativeDecimalString, type PricingSelector } from '@floway-dev/protocols/common';
-import { ALL_PROVIDER_KINDS, normalizeModelPrefix, normalizeUpstreamHue, parseFlagOverridesWire, parsePerformanceOperation, type ProxyFallbackEntry, type UpstreamProviderKind, type UpstreamRecord } from '@floway-dev/provider';
-import { assertAzureUpstreamRecord } from '@floway-dev/provider-azure';
-import { assertClaudeCodeUpstreamRecord, assertClaudeCodeUpstreamState } from '@floway-dev/provider-claude-code';
-import { assertCodexUpstreamRecord, assertCodexUpstreamState } from '@floway-dev/provider-codex';
-import { parseCopilotUpstreamConfig } from '@floway-dev/provider-copilot';
-import { assertCustomUpstreamRecord } from '@floway-dev/provider-custom';
-import { assertOllamaUpstreamRecord } from '@floway-dev/provider-ollama';
-import { parseProxyUri } from '@floway-dev/proxy';
-
-// Wire shape of a proxy entry in the export/import payload. The backoff rows
-// are deliberately excluded — they describe what this deployment saw, not
-// what the operator configured.
-interface SerializedProxy {
-  id: string;
-  name: string;
-  url: string;
-  dial_timeout_seconds: number | null;
-}
+import type { UpstreamRecord } from '@floway-dev/provider';
 
 interface ExportPayload {
   version: 19;
@@ -64,303 +38,6 @@ interface ExportPayload {
 }
 
 const EXPORT_VERSION = 19;
-const SEARCH_USAGE_HOUR_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}$/;
-const PERFORMANCE_METRICS = new Set<PerformanceMetric>(['ttft_ms', 'tpot_us']);
-const UPSTREAM_PROVIDERS = new Set<UpstreamProviderKind>(ALL_PROVIDER_KINDS);
-const LEGACY_UPSTREAM_PREFIXES = ['openai:', 'copilot:'];
-
-const hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
-
-const isLegacyUpstreamIdentity = (value: string): boolean => LEGACY_UPSTREAM_PREFIXES.some(prefix => value.startsWith(prefix));
-
-const isNonNegativeSafeInteger = (value: unknown): value is number => typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
-
-const isPerformanceMetric = (value: unknown): value is PerformanceMetric => typeof value === 'string' && PERFORMANCE_METRICS.has(value as PerformanceMetric);
-
-const importErrorBuilder = (field: string, expected: string) => new Error(`${field} must be ${expected}`);
-
-const nonEmptyString = (value: unknown, field: string): string => nonEmptyStringField(value, field, importErrorBuilder);
-
-const normalizeUpstreamConfig = (record: UpstreamRecord): unknown => {
-  switch (record.kind) {
-  case 'custom':
-    return assertCustomUpstreamRecord(record).config;
-  case 'azure':
-    return assertAzureUpstreamRecord(record).config;
-  case 'ollama':
-    return assertOllamaUpstreamRecord(record).config;
-  case 'codex':
-    assertCodexUpstreamRecord(record);
-    return record.config;
-  case 'claude-code':
-    assertClaudeCodeUpstreamRecord(record);
-    return record.config;
-  case 'copilot':
-    return parseCopilotUpstreamConfig(record.config, importErrorBuilder);
-  }
-};
-
-// Only Codex and Claude Code carry state across an import: their per-account
-// refresh tokens and credential health cannot be re-derived, so they
-// round-trip through the same shape assertion the runtime uses and a corrupt
-// or hand-edited payload can't smuggle unknown fields onto the column.
-// Copilot's state is a cached model catalog plus a short-lived exchanged
-// token, both re-minted on demand, so it lands as null; Custom, Azure, and
-// Ollama own no state at all.
-const normalizeUpstreamState = (provider: UpstreamProviderKind, value: unknown): unknown => {
-  if (provider !== 'codex' && provider !== 'claude-code') return null;
-  if (value === null || value === undefined) {
-    throw new Error(`${provider} upstream is missing state — re-export with current code`);
-  }
-  if (provider === 'codex') assertCodexUpstreamState(value);
-  else assertClaudeCodeUpstreamState(value);
-  return value;
-};
-
-const parseProxyFallbackListField = (value: unknown): ProxyFallbackEntry[] => {
-  if (value === undefined) return [];
-  if (!Array.isArray(value)) throw new Error('proxy_fallback_list must be an array');
-  const entries: ProxyFallbackEntry[] = [];
-  for (const raw of value) {
-    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
-      throw new Error('proxy_fallback_list entries must be objects');
-    }
-    const entry = raw as { id?: unknown; colos?: unknown };
-    if (typeof entry.id !== 'string') throw new Error('proxy_fallback_list entry .id must be a string');
-    let colos: string[] | undefined;
-    if (entry.colos !== undefined) {
-      if (!Array.isArray(entry.colos)) throw new Error('proxy_fallback_list entry .colos must be an array');
-      const list: string[] = [];
-      for (const c of entry.colos) {
-        if (typeof c !== 'string') throw new Error('proxy_fallback_list entry .colos members must be strings');
-        list.push(c);
-      }
-      colos = list;
-    }
-    entries.push(colos === undefined ? { id: entry.id } : { id: entry.id, colos });
-  }
-  return normalizeProxyFallbackList(entries);
-};
-
-const parseUpstreamRecords = (value: unknown): { type: 'ok'; records: UpstreamRecord[] } | { type: 'invalid'; index: number; error: string } => {
-  if (!Array.isArray(value)) return { type: 'invalid', index: -1, error: 'upstreams must be an array' };
-
-  const records: UpstreamRecord[] = [];
-  for (let i = 0; i < value.length; i++) {
-    try {
-      const item = value[i];
-      if (!isRecord(item)) throw new Error('record must be an object');
-      if (hasOwn(item, 'enabled_fixes')) {
-        throw new Error("legacy 'enabled_fixes' field is no longer supported; re-export with current code");
-      }
-      if (typeof item.kind !== 'string' || !UPSTREAM_PROVIDERS.has(item.kind as UpstreamProviderKind)) {
-        throw new Error(`kind must be one of ${ALL_PROVIDER_KINDS.join(', ')}`);
-      }
-      if (typeof item.enabled !== 'boolean') throw new Error('enabled must be a boolean');
-      if (typeof item.sort_order !== 'number' || !Number.isFinite(item.sort_order)) throw new Error('sort_order must be a finite number');
-
-      const id = nonEmptyString(item.id, 'id');
-      if (isLegacyUpstreamIdentity(id)) throw new Error('id must use a raw upstream id, not a legacy provider-prefixed identity');
-
-      const kind = item.kind as UpstreamProviderKind;
-      const record: UpstreamRecord = {
-        id,
-        kind,
-        name: nonEmptyString(item.name, 'name'),
-        enabled: item.enabled,
-        sortOrder: Math.floor(item.sort_order),
-        createdAt: nonEmptyString(item.created_at, 'created_at'),
-        updatedAt: nonEmptyString(item.updated_at, 'updated_at'),
-        flagOverrides: parseFlagOverridesWire(item.flag_overrides),
-        disabledPublicModelIds: parseDisabledPublicModelIdsWire(item.disabled_public_model_ids),
-        proxyFallbackList: parseProxyFallbackListField(item.proxy_fallback_list),
-        modelPrefix: normalizeModelPrefix(item.model_prefix),
-        hue: normalizeUpstreamHue(item.hue),
-        config: item.config,
-        state: normalizeUpstreamState(kind, item.state),
-        // The catalog cache is gateway bookkeeping, not transferable content:
-        // the import re-warms each restored upstream from its own upstream.
-        modelsCache: null,
-      };
-      records.push({ ...record, config: normalizeUpstreamConfig(record) });
-    } catch (error) {
-      return { type: 'invalid', index: i, error: error instanceof Error ? error.message : String(error) };
-    }
-  }
-
-  return { type: 'ok', records };
-};
-
-const parseProxyRecords = (value: unknown): { type: 'ok'; records: SerializedProxy[] } | { type: 'invalid'; index: number; error: string } => {
-  // Proxies are optional in the import contract: an absent or empty array
-  // means "the source deployment had no proxies".
-  if (value === undefined) return { type: 'ok', records: [] };
-  if (!Array.isArray(value)) return { type: 'invalid', index: -1, error: 'proxies must be an array' };
-
-  const records: SerializedProxy[] = [];
-  for (let i = 0; i < value.length; i++) {
-    try {
-      const item = value[i];
-      if (!isRecord(item)) throw new Error('record must be an object');
-      const id = nonEmptyString(item.id, 'id');
-      if (isDirectFallbackId(id)) throw new Error('id must not be a reserved direct-transport sentinel');
-      const name = nonEmptyString(item.name, 'name');
-      const url = nonEmptyString(item.url, 'url');
-      try {
-        parseProxyUri(url);
-      } catch (err) {
-        throw new Error(`url did not parse: ${err instanceof Error ? err.message : String(err)}`);
-      }
-      const dialTimeoutSeconds = item.dial_timeout_seconds;
-      if (dialTimeoutSeconds !== null && (typeof dialTimeoutSeconds !== 'number' || !Number.isInteger(dialTimeoutSeconds) || dialTimeoutSeconds < 1)) {
-        throw new Error('dial_timeout_seconds must be null or a positive integer');
-      }
-      records.push({ id, name, url, dial_timeout_seconds: dialTimeoutSeconds });
-    } catch (error) {
-      return { type: 'invalid', index: i, error: error instanceof Error ? error.message : String(error) };
-    }
-  }
-
-  return { type: 'ok', records };
-};
-
-const validateProxyIdentities = (records: readonly SerializedProxy[]): string | null => {
-  const seen = new Map<string, number>();
-  for (let i = 0; i < records.length; i++) {
-    const prior = seen.get(records[i].id);
-    if (prior !== undefined) return `duplicate proxies id ${records[i].id} at indexes ${prior} and ${i}`;
-    seen.set(records[i].id, i);
-  }
-  return null;
-};
-
-// Every entry in every upstream's proxy_fallback_list must resolve to a proxy
-// id that will exist after the import completes — that is, an imported proxy,
-// an existing local proxy (merge mode only; replace mode wipes them first),
-// or one of the built-in direct transports. A dangling reference would
-// silently disable that fallback in the dial layer, which is exactly the
-// silent-truncation behavior the import contract is supposed to prevent.
-const validateProxyFallbackReferences = (
-  upstreams: readonly UpstreamRecord[],
-  proxies: readonly SerializedProxy[],
-  existingProxyIds: readonly string[],
-): string | null => {
-  const knownIds = new Set<string>(proxies.map(p => p.id));
-  for (const id of existingProxyIds) knownIds.add(id);
-  for (const id of DIRECT_FALLBACK_IDS) knownIds.add(id);
-  for (const upstream of upstreams) {
-    for (const ref of upstream.proxyFallbackList) {
-      if (!knownIds.has(ref.id)) {
-        return `upstream ${upstream.id} references unknown proxy ${ref.id}`;
-      }
-    }
-  }
-  return null;
-};
-
-const parseImportedDumpRetention = (value: unknown): number | null => {
-  if (value === undefined || value === null) return null;
-  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > RETENTION_MAX_SECONDS) {
-    throw new Error(`dumpRetentionSeconds must be null or a positive integer up to ${RETENTION_MAX_SECONDS}`);
-  }
-  return value;
-};
-
-const parseImportedResponsesRetention = (value: unknown): number => {
-  if (
-    !isResponsesRetentionSeconds(value)
-  ) {
-    throw new Error(
-      `responsesRetentionSeconds must be 0 or a whole-day integer from ${RESPONSES_RETENTION_MIN_SECONDS} to ${RESPONSES_RETENTION_MAX_SECONDS}`,
-    );
-  }
-  return value;
-};
-
-const parseApiKeyRecords = (value: unknown): { type: 'ok'; records: ApiKey[] } | { type: 'invalid'; index: number; error: string } => {
-  if (!Array.isArray(value)) return { type: 'invalid', index: -1, error: 'apiKeys must be an array' };
-
-  const records: ApiKey[] = [];
-  for (let i = 0; i < value.length; i++) {
-    const record = value[i];
-    if (!isRecord(record)) return { type: 'invalid', index: i, error: 'record must be an object' };
-    try {
-      const upstreamIdsParsed = parseUpstreamIdsValue(record.upstreamIds);
-      if (!upstreamIdsParsed.ok) throw new Error(upstreamIdsParsed.error);
-
-      if (typeof record.userId !== 'number' || !Number.isInteger(record.userId) || record.userId < 1) {
-        throw new Error('userId must be a positive integer');
-      }
-      if (record.deletedAt !== null && typeof record.deletedAt !== 'string') {
-        throw new Error('deletedAt must be null or an ISO string');
-      }
-      records.push({
-        id: nonEmptyString(record.id, 'id'),
-        userId: record.userId,
-        name: nonEmptyString(record.name, 'name'),
-        key: nonEmptyString(record.key, 'key'),
-        serverSecret: parseServerSecret(record.serverSecret),
-        createdAt: nonEmptyString(record.createdAt, 'createdAt'),
-        ...(record.lastUsedAt !== undefined ? { lastUsedAt: nonEmptyString(record.lastUsedAt, 'lastUsedAt') } : {}),
-        upstreamIds: upstreamIdsParsed.value,
-        deletedAt: record.deletedAt,
-        dumpRetentionSeconds: parseImportedDumpRetention(record.dumpRetentionSeconds),
-        responsesRetentionSeconds: parseImportedResponsesRetention(record.responsesRetentionSeconds),
-      });
-    } catch (error) {
-      return { type: 'invalid', index: i, error: error instanceof Error ? error.message : String(error) };
-    }
-  }
-
-  return { type: 'ok', records };
-};
-
-const parseUserRecords = (value: unknown): { type: 'ok'; records: User[] } | { type: 'invalid'; index: number; error: string } => {
-  if (!Array.isArray(value)) return { type: 'invalid', index: -1, error: 'users must be an array' };
-
-  const records: User[] = [];
-  const seenIds = new Set<number>();
-  for (let i = 0; i < value.length; i++) {
-    const record = value[i];
-    if (!isRecord(record)) return { type: 'invalid', index: i, error: 'record must be an object' };
-    try {
-      if (typeof record.id !== 'number' || !Number.isInteger(record.id) || record.id < 1) {
-        throw new Error('id must be a positive integer');
-      }
-      if (seenIds.has(record.id)) throw new Error(`duplicate user id ${record.id}`);
-      seenIds.add(record.id);
-
-      if (typeof record.username !== 'string' || !USERNAME_PATTERN.test(record.username)) {
-        throw new Error('username must match ^[a-zA-Z0-9_.-]{1,64}$');
-      }
-      if (record.passwordHash !== null && (typeof record.passwordHash !== 'string' || !record.passwordHash.startsWith(`${PASSWORD_HASH_SCHEME}$`))) {
-        throw new Error(`passwordHash must be null or start with ${PASSWORD_HASH_SCHEME}$`);
-      }
-      if (typeof record.isAdmin !== 'boolean') throw new Error('isAdmin must be a boolean');
-
-      if (record.upstreamIds === undefined) throw new Error('upstreamIds must be present (null or array)');
-      const upstreamIdsParsed = parseUpstreamIdsValue(record.upstreamIds);
-      if (!upstreamIdsParsed.ok) throw new Error(upstreamIdsParsed.error);
-      if (record.deletedAt !== null && typeof record.deletedAt !== 'string') {
-        throw new Error('deletedAt must be null or an ISO string');
-      }
-
-      records.push({
-        id: record.id,
-        username: record.username,
-        passwordHash: record.passwordHash,
-        isAdmin: record.isAdmin,
-        upstreamIds: upstreamIdsParsed.value,
-        createdAt: nonEmptyString(record.createdAt, 'createdAt'),
-        deletedAt: record.deletedAt,
-      });
-    } catch (error) {
-      return { type: 'invalid', index: i, error: error instanceof Error ? error.message : String(error) };
-    }
-  }
-
-  return { type: 'ok', records };
-};
 
 const validateApiKeyIdentities = (records: readonly ApiKey[], existing: readonly ApiKey[], mode: 'merge' | 'replace'): string | null => {
   const ids = new Map<string, number>();
@@ -400,254 +77,23 @@ const validateApiKeyIdentities = (records: readonly ApiKey[], existing: readonly
   return null;
 };
 
-const parseImportedMetrics = (value: unknown): { type: 'ok'; metrics: UsageMetricRecord[] } | { type: 'invalid'; error: string } => {
-  if (!Array.isArray(value)) return { type: 'invalid', error: 'metrics must be an array' };
-  const metrics: UsageMetricRecord[] = [];
-  const seen = new Set<BillingMetric>();
-  for (const row of value) {
-    if (!isRecord(row)) return { type: 'invalid', error: 'metrics must contain objects' };
-    if (typeof row.metric !== 'string' || !BILLING_METRICS.includes(row.metric as BillingMetric)) {
-      return { type: 'invalid', error: `unknown usage metric: ${JSON.stringify(row.metric)}` };
+// Every fallback must resolve in the post-import catalog. Merge mode may refer
+// to an existing local proxy; replace mode may only refer to imported proxies
+// and the built-in direct transports because it clears the proxy repository.
+const validateProxyFallbackReferences = (
+  upstreams: readonly UpstreamRecord[],
+  proxies: readonly SerializedProxy[],
+  existingProxyIds: readonly string[],
+): string | null => {
+  const knownIds = new Set<string>(proxies.map(proxy => proxy.id));
+  for (const id of existingProxyIds) knownIds.add(id);
+  for (const id of DIRECT_FALLBACK_IDS) knownIds.add(id);
+  for (const upstream of upstreams) {
+    for (const ref of upstream.proxyFallbackList) {
+      if (!knownIds.has(ref.id)) return `upstream ${upstream.id} references unknown proxy ${ref.id}`;
     }
-    let quantity: string;
-    let unitPrice: string | null;
-    try {
-      quantity = parseNonNegativeDecimalString(row.quantity, 'metric quantity');
-      unitPrice = row.unitPrice === null ? null : parseNonNegativeDecimalString(row.unitPrice, 'metric unitPrice');
-    } catch (cause) {
-      return { type: 'invalid', error: cause instanceof Error ? cause.message : String(cause) };
-    }
-    const metric = row.metric as BillingMetric;
-    if (seen.has(metric)) return { type: 'invalid', error: `duplicate usage metric: ${metric}` };
-    seen.add(metric);
-    metrics.push({ metric, quantity, unitPrice });
   }
-  return { type: 'ok', metrics };
-};
-
-const parseUsageRecords = (value: unknown): { type: 'ok'; records: UsageRecord[] } | { type: 'invalid'; index: number; error: string } => {
-  if (!Array.isArray(value)) return { type: 'invalid', index: -1, error: 'usage must be an array' };
-
-  const records: UsageRecord[] = [];
-  for (let i = 0; i < value.length; i++) {
-    const record = value[i];
-    if (!isRecord(record)) return { type: 'invalid', index: i, error: 'record must be an object' };
-    if (
-      typeof record.keyId !== 'string' ||
-      record.keyId.length === 0 ||
-      typeof record.model !== 'string' ||
-      record.model.length === 0 ||
-      (record.upstream !== null && typeof record.upstream !== 'string') ||
-      typeof record.modelKey !== 'string' ||
-      record.modelKey.length === 0 ||
-      typeof record.hour !== 'string' ||
-      !SEARCH_USAGE_HOUR_PATTERN.test(record.hour) ||
-      !isNonNegativeSafeInteger(record.requests)
-    ) {
-      return { type: 'invalid', index: i, error: 'record has invalid usage fields' };
-    }
-    if (typeof record.upstream === 'string' && isLegacyUpstreamIdentity(record.upstream)) {
-      return { type: 'invalid', index: i, error: 'upstream must use a raw upstream id, not a legacy provider-prefixed identity' };
-    }
-    if (!isRecord(record.pricingSelector)) return { type: 'invalid', index: i, error: 'pricingSelector must be an object' };
-    let pricingSelector: PricingSelector;
-    try {
-      pricingSelector = canonicalizePricingSelector(record.pricingSelector as PricingSelector);
-    } catch (cause) {
-      return { type: 'invalid', index: i, error: `invalid pricingSelector: ${cause instanceof Error ? cause.message : String(cause)}` };
-    }
-    const metricsResult = parseImportedMetrics(record.metrics);
-    if (metricsResult.type === 'invalid') return { type: 'invalid', index: i, error: metricsResult.error };
-    records.push({
-      keyId: record.keyId,
-      model: record.model,
-      upstream: record.upstream,
-      modelKey: record.modelKey,
-      hour: record.hour,
-      pricingSelector,
-      requests: record.requests,
-      metrics: metricsResult.metrics,
-    });
-  }
-
-  return { type: 'ok', records };
-};
-
-const parseWebSearchUsageRecords = (value: unknown): { type: 'ok'; records: WebSearchUsageRecord[] } | { type: 'invalid'; index: number; error: string } => {
-  if (!Array.isArray(value)) return { type: 'invalid', index: -1, error: 'searchUsage must be an array' };
-
-  const records: WebSearchUsageRecord[] = [];
-  for (let i = 0; i < value.length; i++) {
-    const record = value[i];
-    if (!record || typeof record !== 'object') return { type: 'invalid', index: i, error: 'record must be an object' };
-
-    const item = record as Record<string, unknown>;
-    const provider = item.provider;
-    const keyId = item.keyId;
-    const action = item.action;
-    const hour = item.hour;
-    const requests = item.requests;
-    if (!isWebSearchProviderName(provider)) return { type: 'invalid', index: i, error: 'invalid provider' };
-    if (typeof keyId !== 'string' || keyId.length === 0) return { type: 'invalid', index: i, error: 'keyId must be a non-empty string' };
-    if (action !== 'search' && action !== 'fetch_page') return { type: 'invalid', index: i, error: 'action must be "search" or "fetch_page"' };
-    if (typeof hour !== 'string' || !SEARCH_USAGE_HOUR_PATTERN.test(hour)) return { type: 'invalid', index: i, error: 'hour must match the SEARCH_USAGE_HOUR_PATTERN' };
-    if (typeof requests !== 'number' || !Number.isSafeInteger(requests) || requests < 0) return { type: 'invalid', index: i, error: 'requests must be a non-negative safe integer' };
-
-    records.push({ provider, keyId, action, hour, requests });
-  }
-
-  return { type: 'ok', records };
-};
-
-const parseWebSearchConfig = (value: unknown): { type: 'ok'; config: WebSearchConfig } | { type: 'invalid'; error: string } => {
-  // Delegate to the shared strict parser so the import layer and the
-  // load/save helpers cannot drift on what counts as a valid stored
-  // config. The strict parser throws a descriptive Error; we map that
-  // back into the route's structured invalid envelope here.
-  try {
-    return { type: 'ok', config: parseWebSearchConfigStrict(value) };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return { type: 'invalid', error: message };
-  }
-};
-
-const parsePerformanceIncluded = (data: Record<string, unknown>): { type: 'ok'; included: boolean } | { type: 'invalid'; error: string } => {
-  if (typeof data.performanceIncluded !== 'boolean') return { type: 'invalid', error: 'performanceIncluded must be a boolean' };
-  if (!data.performanceIncluded && hasOwn(data, 'performance')) {
-    return { type: 'invalid', error: 'performance must be omitted unless performanceIncluded is true' };
-  }
-  return { type: 'ok', included: data.performanceIncluded };
-};
-
-const parsePerformanceRecords = (value: unknown): { type: 'ok'; records: PerformanceTelemetryRecord[] } | { type: 'invalid'; index: number; error: string } => {
-  if (!Array.isArray(value)) return { type: 'invalid', index: -1, error: 'performance must be an array when included' };
-
-  const records: PerformanceTelemetryRecord[] = [];
-  for (let i = 0; i < value.length; i++) {
-    const record = value[i];
-    if (!record || typeof record !== 'object') return { type: 'invalid', index: i, error: 'record is not an object' };
-
-    const item = record as Record<string, unknown>;
-    let operation: ReturnType<typeof parsePerformanceOperation>;
-    try {
-      operation = parsePerformanceOperation(item.operation);
-    } catch {
-      return { type: 'invalid', index: i, error: 'record fields are missing or malformed' };
-    }
-    if (
-      typeof item.hour !== 'string' ||
-      !SEARCH_USAGE_HOUR_PATTERN.test(item.hour) ||
-      typeof item.keyId !== 'string' ||
-      item.keyId.length === 0 ||
-      typeof item.model !== 'string' ||
-      item.model.length === 0 ||
-      typeof item.upstream !== 'string' ||
-      item.upstream.length === 0 ||
-      isLegacyUpstreamIdentity(item.upstream) ||
-      typeof item.runtimeLocation !== 'string' ||
-      item.runtimeLocation.length === 0 ||
-      !isNonNegativeSafeInteger(item.requests) ||
-      !isNonNegativeSafeInteger(item.ttftSamplesOk) ||
-      !isNonNegativeSafeInteger(item.errorsWithOutput) ||
-      !isNonNegativeSafeInteger(item.errorsNoOutput) ||
-      !isNonNegativeSafeInteger(item.neutral) ||
-      !isNonNegativeSafeInteger(item.tpotSamples) ||
-      !isNonNegativeSafeInteger(item.ttftMsSum) ||
-      !isNonNegativeSafeInteger(item.tpotUsSum) ||
-      !Array.isArray(item.buckets)
-    ) {
-      return { type: 'invalid', index: i, error: 'record fields are missing or malformed' };
-    }
-
-    // Partition-first invariant: every request lands in exactly one of the
-    // four counters, so their sum equals `requests` on any row the recorder
-    // wrote. `tpotSamples` is orthogonal (a subset of TTFT-carrying rows —
-    // ttftSamplesOk + errorsWithOutput — where at least two output tokens
-    // streamed).
-    const ttftSamplesOk = item.ttftSamplesOk as number;
-    const errorsWithOutput = item.errorsWithOutput as number;
-    const errorsNoOutput = item.errorsNoOutput as number;
-    const neutral = item.neutral as number;
-    const requests = item.requests as number;
-    const tpotSamples = item.tpotSamples as number;
-    if (ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral !== requests) {
-      return {
-        type: 'invalid',
-        index: i,
-        error: 'ttftSamplesOk + errorsWithOutput + errorsNoOutput + neutral must equal requests',
-      };
-    }
-    if (tpotSamples > ttftSamplesOk + errorsWithOutput) {
-      return {
-        type: 'invalid',
-        index: i,
-        error: 'tpotSamples must not exceed ttftSamplesOk + errorsWithOutput',
-      };
-    }
-
-    const buckets: PerformanceBucketRow[] = [];
-    const bucketKeys = new Set<string>();
-    let ttftBucketCount = 0;
-    let tpotBucketCount = 0;
-    for (const bucket of item.buckets) {
-      if (!bucket || typeof bucket !== 'object') return { type: 'invalid', index: i, error: 'bucket is not an object' };
-      const b = bucket as Record<string, unknown>;
-      if (
-        !isPerformanceMetric(b.metric) ||
-        !isNonNegativeSafeInteger(b.lower) ||
-        (b.upper !== null && !isNonNegativeSafeInteger(b.upper)) ||
-        (b.upper !== null && (b.upper as number) <= (b.lower as number)) ||
-        !isNonNegativeSafeInteger(b.count)
-      ) {
-        return { type: 'invalid', index: i, error: 'bucket metric/lower/upper/count fields are missing or malformed' };
-      }
-      // Duplicate {metric, lower} tuples would silently over-count in
-      // aggregation because updateAggregate merges bucket entries by lower
-      // edge and adds their counts.
-      const dedupKey = `${b.metric}\0${b.lower as number}`;
-      if (bucketKeys.has(dedupKey)) {
-        return { type: 'invalid', index: i, error: `duplicate bucket entry for {metric: ${b.metric}, lower: ${b.lower as number}}` };
-      }
-      bucketKeys.add(dedupKey);
-      if (b.metric === 'ttft_ms') ttftBucketCount += b.count as number;
-      else tpotBucketCount += b.count as number;
-      buckets.push({ metric: b.metric, lower: b.lower as number, upper: b.upper as number | null, count: b.count as number });
-    }
-
-    // Every ttft/tpot sample the recorder logs also increments exactly one
-    // bucket entry for its metric. If the per-metric bucket sum doesn't match
-    // the declared sample count, the histogram is inconsistent with the
-    // counters and percentile queries would return misleading values. TTFT
-    // buckets cover both healthy and partial-output-failure samples, so the
-    // sum matches `ttftSamplesOk + errorsWithOutput`.
-    if (ttftBucketCount !== ttftSamplesOk + errorsWithOutput) {
-      return { type: 'invalid', index: i, error: `ttft_ms bucket sum (${ttftBucketCount}) must equal ttftSamplesOk + errorsWithOutput (${ttftSamplesOk + errorsWithOutput})` };
-    }
-    if (tpotBucketCount !== tpotSamples) {
-      return { type: 'invalid', index: i, error: `tpot_us bucket sum (${tpotBucketCount}) must equal tpotSamples (${tpotSamples})` };
-    }
-
-    records.push({
-      hour: item.hour,
-      keyId: item.keyId,
-      model: item.model,
-      upstream: item.upstream,
-      operation,
-      runtimeLocation: item.runtimeLocation,
-      requests,
-      ttftSamplesOk,
-      errorsWithOutput,
-      errorsNoOutput,
-      neutral,
-      tpotSamples,
-      ttftMsSum: item.ttftMsSum,
-      tpotUsSum: item.tpotUsSum,
-      buckets,
-    });
-  }
-
-  return { type: 'ok', records };
+  return null;
 };
 
 export const exportData = async (c: CtxWithQuery<typeof exportQuery>) => {
@@ -672,7 +118,7 @@ export const exportData = async (c: CtxWithQuery<typeof exportQuery>) => {
       users,
       apiKeys,
       upstreams: upstreams.map(upstreamRecordToFullJson),
-      proxies: proxies.map(p => ({ id: p.id, name: p.name, url: p.url, dial_timeout_seconds: p.dialTimeoutSeconds })),
+      proxies: proxies.map(proxy => ({ id: proxy.id, name: proxy.name, url: proxy.url, dial_timeout_seconds: proxy.dialTimeoutSeconds })),
       usage,
       searchUsage: webSearchUsage,
       performanceIncluded: includePerformance,
@@ -685,81 +131,10 @@ export const exportData = async (c: CtxWithQuery<typeof exportQuery>) => {
 };
 
 export const importData = async (c: CtxWithJson<typeof importBody>) => {
-  const body = c.req.valid('json');
-  const { mode, data } = body;
-
-  if (!isRecord(data)) return c.json({ error: 'data is required' }, 400);
-
-  const apiKeysResult = parseApiKeyRecords(data.apiKeys);
-  if (apiKeysResult.type === 'invalid') {
-    const location = apiKeysResult.index >= 0 ? ` at index ${apiKeysResult.index}` : '';
-    return c.json({ error: `invalid apiKeys${location}: ${apiKeysResult.error}` }, 400);
-  }
-  const apiKeys = apiKeysResult.records;
-
-  const usersResult = parseUserRecords(data.users);
-  if (usersResult.type === 'invalid') {
-    const location = usersResult.index >= 0 ? ` at index ${usersResult.index}` : '';
-    return c.json({ error: `invalid users${location}: ${usersResult.error}` }, 400);
-  }
-  const users = usersResult.records;
-  if (!users.some(user => user.id === SEED_ADMIN_USER_ID)) {
-    return c.json({ error: 'invalid users: payload must include user 1 (the seed admin)' }, 400);
-  }
-  const known = new Set(users.map(u => u.id));
-  for (let i = 0; i < apiKeys.length; i++) {
-    if (!known.has(apiKeys[i].userId)) {
-      return c.json({ error: `invalid apiKeys at index ${i}: user_id ${apiKeys[i].userId} does not match any user in the payload` }, 400);
-    }
-  }
-
-  const usageResult = parseUsageRecords(data.usage);
-  if (usageResult.type === 'invalid') {
-    const location = usageResult.index >= 0 ? ` at index ${usageResult.index}` : '';
-    return c.json({ error: `invalid usage${location}: ${usageResult.error}` }, 400);
-  }
-  const usage = usageResult.records;
-
-  const upstreamsResult = parseUpstreamRecords(data.upstreams);
-  if (upstreamsResult.type === 'invalid') {
-    const location = upstreamsResult.index >= 0 ? ` at index ${upstreamsResult.index}` : '';
-    return c.json({ error: `invalid upstreams${location}: ${upstreamsResult.error}` }, 400);
-  }
-  const upstreams = upstreamsResult.records;
-
-  const proxiesResult = parseProxyRecords(data.proxies);
-  if (proxiesResult.type === 'invalid') {
-    const location = proxiesResult.index >= 0 ? ` at index ${proxiesResult.index}` : '';
-    return c.json({ error: `invalid proxies${location}: ${proxiesResult.error}` }, 400);
-  }
-  const proxies = proxiesResult.records;
-
-  const proxyIdentityError = validateProxyIdentities(proxies);
-  if (proxyIdentityError) return c.json({ error: `invalid proxies: ${proxyIdentityError}` }, 400);
-
-  const webSearchUsageResult = parseWebSearchUsageRecords(data.searchUsage);
-  if (webSearchUsageResult.type === 'invalid') {
-    const location = webSearchUsageResult.index >= 0 ? ` at index ${webSearchUsageResult.index}` : '';
-    return c.json({ error: `invalid searchUsage${location}: ${webSearchUsageResult.error}` }, 400);
-  }
-  const webSearchUsage = webSearchUsageResult.records;
-
-  const webSearchConfigResult = parseWebSearchConfig(data.searchConfig);
-  if (webSearchConfigResult.type === 'invalid') {
-    return c.json({ error: `invalid searchConfig: ${webSearchConfigResult.error}` }, 400);
-  }
-  const webSearchConfig = webSearchConfigResult.config;
-
-  const performanceIncludedResult = parsePerformanceIncluded(data);
-  if (performanceIncludedResult.type === 'invalid') {
-    return c.json({ error: performanceIncludedResult.error }, 400);
-  }
-  const performanceIncluded = performanceIncludedResult.included;
-  const performanceResult = performanceIncluded ? parsePerformanceRecords(data.performance) : { type: 'ok' as const, records: [] };
-  if (performanceResult.type === 'invalid') {
-    return c.json({ error: performanceResult.index >= 0 ? `invalid performance record at index ${performanceResult.index}: ${performanceResult.error}` : `invalid performance: ${performanceResult.error}` }, 400);
-  }
-  const performance = performanceResult.records;
+  const { mode, data: rawData } = c.req.valid('json');
+  const parsed = parseImportData(rawData);
+  if (parsed.type === 'invalid') return c.json({ error: parsed.error }, 400);
+  const { users, apiKeys, upstreams, proxies, usage, searchUsage, performance, performanceIncluded, searchConfig } = parsed.data;
 
   const repo = getRepo();
   // Merge mode needs each key's prior dump policy to identify transitions that
@@ -767,26 +142,18 @@ export const importData = async (c: CtxWithJson<typeof importBody>) => {
   const preImportKeys = await repo.apiKeys.listIncludingDeleted();
   const apiKeyIdentityError = validateApiKeyIdentities(apiKeys, mode === 'merge' ? preImportKeys : [], mode);
   if (apiKeyIdentityError) return c.json({ error: `invalid apiKeys: ${apiKeyIdentityError}` }, 400);
-  const preImportRetentionById = new Map<string, number | null>(preImportKeys.map(k => [k.id, k.dumpRetentionSeconds]));
+  const preImportRetentionById = new Map<string, number | null>(preImportKeys.map(key => [key.id, key.dumpRetentionSeconds]));
 
-  // In merge mode an imported upstream's proxy_fallback_list may reference an
-  // existing local proxy alongside an imported one; replace mode wipes the
-  // table first, so only the imported ids count.
-  const existingProxyIdsForRefs = mode === 'merge' ? (await repo.proxies.list()).map(p => p.id) : [];
+  const existingProxyIdsForRefs = mode === 'merge' ? (await repo.proxies.list()).map(proxy => proxy.id) : [];
   const fallbackRefError = validateProxyFallbackReferences(upstreams, proxies, existingProxyIdsForRefs);
   if (fallbackRefError) return c.json({ error: `invalid upstreams: ${fallbackRefError}` }, 400);
 
   if (mode === 'replace') {
-    // Disconnect subscribers before the API-key deletion atomically schedules
-    // existing stored state for bounded reclamation.
-    for (const k of preImportKeys) {
-      await notifyDisabledBestEffort(k.id, 'replace-mode import');
-    }
+    for (const key of preImportKeys) await notifyDisabledBestEffort(key.id, 'replace-mode import');
 
-    // Replace mode is intentionally non-atomic across repos: D1 binding does not expose multi-repo
-    // transactions, and a coordinated batch would require every repo to surface its writes as
-    // prepared statements. A failure between the deleteAll wave and the per-record save loop
-    // leaves the deployment partially wiped. Operators should back up before running replace mode.
+    // D1 does not expose a transaction spanning these repositories. Complete
+    // validation therefore happens before this delete wave; a storage failure
+    // after it begins can still leave a partially restored deployment.
     const deletes: Promise<unknown>[] = [
       repo.sessions.deleteAll(),
       repo.apiKeys.deleteAll(),
@@ -794,10 +161,6 @@ export const importData = async (c: CtxWithJson<typeof importBody>) => {
       repo.webSearchUsage.deleteAll(),
       repo.upstreams.deleteAll(),
       repo.proxies.deleteAll(),
-      // proxy_upstream_backoffs is per-deployment runtime state keyed on
-      // proxy_id; replace mode wipes the proxies table, so leaving the
-      // backoff rows behind would cool-down freshly imported proxies that
-      // happen to reuse a deleted id. Same intent as wiping sessions.
       repo.proxyBackoffs.deleteAll(),
       repo.responsesSnapshots.deleteAll(),
       repo.responsesItems.deleteAll(),
@@ -807,10 +170,7 @@ export const importData = async (c: CtxWithJson<typeof importBody>) => {
     await Promise.all(deletes);
   }
 
-  // Users land before api keys so the FK from api_keys.user_id can resolve.
-  // Proxies land before upstreams so any concurrent reader (e.g. a request
-  // resolving an upstream's fallback list) sees the row referenced by an
-  // upstream's proxy_fallback_list as soon as the upstream is visible.
+  // Users precede their API keys, and proxies precede upstream fallback refs.
   for (const user of users) await repo.users.save(user);
   for (const proxy of proxies) {
     await repo.proxies.save({
@@ -823,18 +183,16 @@ export const importData = async (c: CtxWithJson<typeof importBody>) => {
   for (const key of apiKeys) {
     const previous = preImportRetentionById.get(key.id) ?? null;
     await repo.apiKeys.save(key);
-    if (mode === 'merge' && previous !== key.dumpRetentionSeconds) {
-      if (key.dumpRetentionSeconds === null && previous !== null) {
-        await notifyDisabledBestEffort(key.id, 'merge-mode retention disable');
-      }
+    if (mode === 'merge' && key.dumpRetentionSeconds === null && previous !== null) {
+      await notifyDisabledBestEffort(key.id, 'merge-mode retention disable');
     }
   }
   for (const record of usage) await repo.usage.set(record);
-  for (const record of webSearchUsage) await repo.webSearchUsage.set(record);
+  for (const record of searchUsage) await repo.webSearchUsage.set(record);
   for (const upstream of upstreams) await repo.upstreams.save(upstream);
   await Promise.all(upstreams.map(upstream => warmModelsCache(upstream, c)));
   for (const record of performance) await repo.performance.set(record);
-  await repo.webSearchConfig.save(webSearchConfig);
+  await repo.webSearchConfig.save(searchConfig);
 
   return c.json({
     ok: true,
@@ -844,7 +202,7 @@ export const importData = async (c: CtxWithJson<typeof importBody>) => {
       upstreams: upstreams.length,
       proxies: proxies.length,
       usage: usage.length,
-      searchUsage: webSearchUsage.length,
+      searchUsage: searchUsage.length,
       performance: performance.length,
     },
   });


### PR DESCRIPTION
## Purpose

The v19 data-transfer import path maintained hundreds of lines of parallel structural checks even though the gateway already uses Zod at its HTTP boundaries.

## Change

- Move structural decoding into owned Zod schemas and staged transforms.
- Preserve the complete v19 wire format, exact error text and first-failure precedence, trimming, defaults, duplicates, cross references, and provider-owned validation.
- Preserve validate-before-mutate behavior and provider-state retention.
- Keep domain normalization and repository-dependent checks in their imperative layer.

The route implementation falls from 851 to 223 lines while retaining established import behavior.

## Test Plan

- [x] Data-transfer suite — 59 passed, including differential multi-error precedence cases
- [x] `pnpm --filter @floway-dev/gateway run typecheck`
- [x] Changed-file lint and diff checks
- [x] GitHub Verify — lint, typecheck, test, installers, generated-assets, build
