### PR TITLE
fix(web): preserve comma-separated effort drafts

### DIFF
--- a/apps/web/__tests__/components/model-alias/metadata-editor_test.tsx
+++ b/apps/web/__tests__/components/model-alias/metadata-editor_test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { MetadataEditor } from '../../../src/components/model-alias/metadata-editor';
+import { i18n } from '../../../src/i18n';
+import { renderInApp } from '../../render';
+import type { AnnouncedMetadata } from '@floway-dev/protocols/common';
+
+const initialValue: AnnouncedMetadata = {
+  chat: {
+    reasoning: {
+      effort: { supported: ['low'], default: 'low' },
+    },
+  },
+};
+
+function Harness() {
+  const [value, setValue] = useState(initialValue);
+  return <>
+    <MetadataEditor disabled={false} issues={{}} kind="chat" onChange={setValue} readOnly={false} value={value} />
+    <output>{JSON.stringify(value.chat?.reasoning?.effort?.supported)}</output>
+  </>;
+}
+
+describe('model alias metadata editor', () => {
+  it('preserves a comma while another supported effort is being entered', () => {
+    renderInApp(<Harness />);
+    const input = screen.getByRole<HTMLInputElement>('textbox', { name: i18n.t('dashboard.modelAliases.metadata.efforts') });
+
+    fireEvent.change(input, { target: { value: 'low,' } });
+    expect(input.value).toBe('low,');
+
+    fireEvent.change(input, { target: { value: 'low, custom' } });
+    expect(input.value).toBe('low, custom');
+    expect(screen.getByRole('status').textContent).toBe('["low","custom"]');
+
+    fireEvent.blur(input);
+    expect(input.value).toBe('low, custom');
+  });
+});

--- a/apps/web/src/components/model-alias/metadata-editor.tsx
+++ b/apps/web/src/components/model-alias/metadata-editor.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import type { AnnouncedMetadataField, AnnouncedMetadataIssues } from './validation';
 import { fluentComponents } from '../../fluent';
 import { useTranslation } from '../../i18n/translation';
@@ -9,6 +11,9 @@ import type { AnnouncedMetadata, ModelKind } from '@floway-dev/protocols/common'
 const { Field, Option } = fluentComponents;
 
 const numberValue = (value: string) => value === '' ? undefined : Number(value);
+const commaSeparatedValues = (value: string) => value.split(',').map(item => item.trim()).filter(Boolean);
+const sameOrderedValues = (left: readonly string[], right: readonly string[]) =>
+  left.length === right.length && left.every((item, index) => item === right[index]);
 
 export function MetadataEditor({ disabled, issues, kind, onChange, readOnly, value }: {
   disabled: boolean;
@@ -69,7 +74,14 @@ export function MetadataEditor({ disabled, issues, kind, onChange, readOnly, val
             <Switch checked={value.chat?.reasoning?.mandatory === true} disabled={disabled || effort !== undefined || budget !== undefined || value.chat?.reasoning?.adaptive === true} readOnly={readOnly} label={t('dashboard.modelAliases.metadata.mandatory')} onChange={(_, data) => patchReasoning({ mandatory: data.checked ? true : undefined })} />
           </div>
           {effort && <div className={`${TWO_COLUMN_FORM_CLASS} gap-3`}>
-            <Field hint={t('dashboard.modelAliases.metadata.effortsHint')} label={t('dashboard.modelAliases.metadata.efforts')}><Input disabled={disabled} readOnly={readOnly} value={effort.supported.join(', ')} onChange={(_, data) => { const supported = data.value.split(',').map(item => item.trim()).filter(Boolean); patchReasoning({ effort: { supported, default: supported.includes(effort.default) ? effort.default : supported[0] ?? '' } }); }} /></Field>
+            <CommaSeparatedEffortsInput
+              disabled={disabled}
+              label={t('dashboard.modelAliases.metadata.efforts')}
+              hint={t('dashboard.modelAliases.metadata.effortsHint')}
+              onChange={supported => patchReasoning({ effort: { supported, default: supported.includes(effort.default) ? effort.default : supported[0] ?? '' } })}
+              readOnly={readOnly}
+              value={effort.supported}
+            />
             <Field label={t('dashboard.modelAliases.metadata.defaultEffort')}><Dropdown disabled={disabled || effort.supported.length === 0} readOnly={readOnly} selectedOptions={[effort.default]} value={effort.default} onOptionSelect={(_, data) => data.optionValue !== undefined && patchReasoning({ effort: { supported: effort.supported, default: data.optionValue } })}>{effort.supported.map(item => <Option key={item} value={item}>{item}</Option>)}</Dropdown></Field>
           </div>}
           {budget && <div className={`${TWO_COLUMN_FORM_CLASS} gap-3`}>
@@ -80,4 +92,33 @@ export function MetadataEditor({ disabled, issues, kind, onChange, readOnly, val
       </>}
     </div>
   );
+}
+
+function CommaSeparatedEffortsInput({ disabled, hint, label, onChange, readOnly, value }: {
+  disabled: boolean;
+  hint: string;
+  label: string;
+  onChange: (value: string[]) => void;
+  readOnly: boolean;
+  value: readonly string[];
+}) {
+  const [draft, setDraft] = useState(() => ({ projected: [...value], text: value.join(', ') }));
+  const currentDraft = sameOrderedValues(draft.projected, value)
+    ? draft
+    : { projected: [...value], text: value.join(', ') };
+  if (currentDraft !== draft) setDraft(currentDraft);
+
+  return <Field hint={hint} label={label}>
+    <Input
+      disabled={disabled}
+      readOnly={readOnly}
+      value={currentDraft.text}
+      onBlur={() => setDraft({ projected: [...value], text: value.join(', ') })}
+      onChange={(_, data) => {
+        const projected = commaSeparatedValues(data.value);
+        setDraft({ projected, text: data.value });
+        onChange(projected);
+      }}
+    />
+  </Field>;
 }


### PR DESCRIPTION
## Summary

Preserve the raw **Supported efforts** input while projecting it into announced model metadata, so a trailing comma remains available while the next effort is entered. Track the text draft with the structured values it represents so an external metadata replacement still resynchronizes the field.

Add a component regression test that enters a trailing comma, completes a custom effort, verifies the structured values, and checks the normalized blur result.

## Test plan

- [x] `pnpm --filter @floway-dev/web exec vitest run __tests__/components/model-alias/metadata-editor_test.tsx`
- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`