### PR TITLE
fix(web): restore model editor back navigation

### DIFF
--- a/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
@@ -76,6 +76,17 @@ const deleteCommandStem = i18n.t('dashboard.upstreamEditor.models.deleteNamed', 
 const deleteCommands = () => screen.getAllByLabelText(new RegExp(`^${deleteCommandStem}`));
 
 describe('upstream model workspace field-array transitions', () => {
+  it('returns from a model detail to the model list', async () => {
+    renderInApp(<Harness />);
+    const table = screen.getByRole('table', { name: models('title') });
+
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('dashboard.upstreamEditor.models.editNamed', { name: 'model-a' }) }));
+    await waitFor(() => expect(table.isConnected).toBe(false));
+
+    fireEvent.click(screen.getByRole('button', { name: models('back') }));
+    expect(await screen.findByRole('table', { name: models('title') })).toBeTruthy();
+  });
+
   it('deletes a newly appended model and applies a shorter YAML catalog', async () => {
     renderInApp(<Harness />);
     expect(deleteCommands()).toHaveLength(2);

--- a/apps/web/src/components/ui/back-navigation-button.tsx
+++ b/apps/web/src/components/ui/back-navigation-button.tsx
@@ -25,16 +25,17 @@ const useStyles = makeStyles({
   },
 });
 
-// `to` is for the back that leaves the page rather than the one that steps back
-// within it: an anchor there is what a middle click can open, and Fluent's
-// anchor root keeps Enter and Space through react-aria's button props.
+// `to` is for a destination that remains useful beside the current view, while
+// `onClick` moves within one editing session. The former gives middle and
+// modified clicks a real address; Fluent's anchor root keeps Enter and Space
+// through react-aria's button props.
 // https://github.com/microsoft/fluentui/blob/6dee27b023a2d989f032b4adacb2135d336a67fb/packages/react-components/react-aria/library/src/button/useARIAButtonProps.ts#L84-L120
 export function BackNavigationButton(props: { children: ReactNode } & (
   | { onClick: () => void; to?: never }
   | { onClick?: never; to: string }
 )) {
   return props.to === undefined
-    ? <BackButton>{props.children}</BackButton>
+    ? <BackButton onClick={props.onClick}>{props.children}</BackButton>
     : <AddressedBackButton to={props.to}>{props.children}</AddressedBackButton>;
 }
 


### PR DESCRIPTION
## Summary

Forward the intra-editor click handler through `BackNavigationButton` so **Back to models** returns from model detail to the current upstream model list. Preserve the addressed anchor variant for destinations that remain useful beside the current editing view.

Add a workspace regression test that opens a model detail, activates **Back to models**, and verifies that the model table returns.

## Test plan

- [x] `pnpm --filter @floway-dev/web exec vitest run __tests__/components/upstream-editor/workspace-interactions_test.tsx`
- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`