### PR TITLE
test: compare large codec buffers linearly

### DIFF
--- a/apps/web/__tests__/lib/base-encoding_test.ts
+++ b/apps/web/__tests__/lib/base-encoding_test.ts
@@ -26,7 +26,9 @@ describe('browser base encoding', () => {
         binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
       }
       const encoded = encodeBase64BinaryString(binary);
-      expect(decodeWebBase64(encoded)).toEqual(bytes);
+      const decoded = decodeWebBase64(encoded);
+      expect(decoded).toHaveLength(bytes.length);
+      expect(decoded.every((byte, index) => byte === bytes[index])).toBe(true);
       expect(decodeWebBase64BinaryString(encoded)).toBe(binary);
     } finally {
       if (fromBase64) Object.defineProperty(Uint8Array, 'fromBase64', fromBase64);

--- a/packages/protocols/__tests__/common/base-encoding_test.ts
+++ b/packages/protocols/__tests__/common/base-encoding_test.ts
@@ -33,6 +33,8 @@ describe('base encoding', () => {
 
   test('round-trips a large byte buffer', () => {
     const bytes = Uint8Array.from({ length: 1024 * 1024 }, (_, index) => index & 0xff);
-    expect(decodeForgivingBase64(encodeBase64(bytes))).toEqual(bytes);
+    const decoded = decodeForgivingBase64(encodeBase64(bytes));
+    expect(decoded).toHaveLength(bytes.length);
+    expect(decoded.every((byte, index) => byte === bytes[index])).toBe(true);
   });
 });

--- a/packages/provider/__tests__/image-helpers_test.ts
+++ b/packages/provider/__tests__/image-helpers_test.ts
@@ -13,7 +13,9 @@ test('base64 helpers preserve forgiving trailing-bit acceptance', () => {
 
 test('base64 helpers round-trip large image buffers', () => {
   const bytes = Uint8Array.from({ length: 1024 * 1024 }, (_, index) => index & 0xff);
-  expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes);
+  const decoded = base64ToBytes(bytesToBase64(bytes));
+  expect(decoded).toHaveLength(bytes.length);
+  expect(decoded.every((byte, index) => byte === bytes[index])).toBe(true);
 });
 
 test('parseBase64ImageDataUrl normalizes valid image media types', () => {


### PR DESCRIPTION
## Summary

Keep the full 1 MiB round-trip coverage for browser, protocol, and provider Base64 codecs while avoiding Vitest deep-diff traversal across every typed-array element.

Check decoded lengths and compare every byte in one linear pass at all remaining large-buffer sites. This retains complete data validation without making assertion formatting consume the five-second per-test budget.

## Test plan

- [x] `pnpm run test` (510 files, 5383 tests; the local Node 25 run supplied a valid temporary `--localstorage-file`)
- [x] `pnpm run lint`
- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] `pnpm --filter @floway-dev/protocols run typecheck`
- [x] `pnpm --filter @floway-dev/provider run typecheck`