### PR TITLE
fix(web): align settings description punctuation

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1129,7 +1129,7 @@ const en = {
         columns: { alias: 'Alias', kind: 'Kind', targets: 'Targets', selection: 'Selection', visibility: 'Models list', actions: 'Actions' },
         actions: { create: 'New alias', refresh: 'Refresh aliases', save: 'Save', delete: 'Delete', addTarget: 'Add target', editNamed: 'Edit alias {{name}}', deleteNamed: 'Delete alias {{name}}' },
         dialog: { createTitle: 'Create alias', editTitle: 'Edit alias: {{name}}' },
-        form: { name: 'Alias ID', namePlaceholder: 'my-alias-id', displayName: 'Display name', displayPlaceholder: 'Optional display name', kind: 'Kind', selection: 'Selection', visible: 'Visible in /v1/models', visibleHint: 'A hidden alias stays out of the listing but can still be requested by name.' },
+        form: { name: 'Alias ID', namePlaceholder: 'my-alias-id', displayName: 'Display name', displayPlaceholder: 'Optional display name', kind: 'Kind', selection: 'Selection', visible: 'Visible in /v1/models', visibleHint: 'A hidden alias stays out of the listing but can still be requested by name' },
         kind: { chat: 'Chat', embedding: 'Embedding', image: 'Image', rerank: 'Rerank', transcription: 'Transcription' },
         selection: { first: 'First available', random: 'Random' },
         visibility: { visible: 'Visible', hidden: 'Hidden' },

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -266,8 +266,8 @@ const en = {
           administrator: 'Administrator',
           administratorDescription:
               'Can manage users, upstreams, search configuration, and data transfer',
-          userOneLocked: 'The seed administrator cannot be demoted.',
-          selfLocked: 'You cannot demote your own account.',
+          userOneLocked: 'The seed administrator cannot be demoted',
+          selfLocked: 'You cannot demote your own account',
         },
         validation: {
           username: 'Use 1-64 letters, numbers, underscores, dots, or hyphens.',
@@ -284,7 +284,7 @@ const en = {
       },
       upstreamAccess: {
         title: 'Limit available upstreams',
-        description: 'When off, access inherits every upstream from its parent scope.',
+        description: 'When off, access inherits every upstream from its parent scope',
         tableLabel: 'Available upstreams',
         enabled: 'Enabled',
         order: 'Order',
@@ -362,7 +362,7 @@ const en = {
           responsesRetention: 'Stateful Responses retention',
           responsesRetentionHint: 'How long this key\'s Responses items stay available for a follow-up request to reference by id (off persists nothing)',
           retentionHint:
-              'When enabled, model-invoking requests through this key are captured for the configured window.',
+              'When enabled, model-invoking requests through this key are captured for the configured window',
         },
         validation: {
           nameRequired: 'Name is required.',
@@ -1102,7 +1102,7 @@ const en = {
         },
         passthrough: {
           title: 'Passthrough OpenAI search',
-          description: 'Route /alpha/search and Responses hosted search through a selected Codex or OpenAI-compatible upstream.',
+          description: 'Route /alpha/search and Responses hosted search through a selected Codex or OpenAI-compatible upstream',
           upstream: 'Search upstream',
           model: 'Search model',
           empty: 'Add an enabled Codex or Custom upstream with a chat model to use passthrough search.',

--- a/apps/web/src/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/i18n/locales/zh-Hans.ts
@@ -1065,7 +1065,7 @@ const zhHansCN = {
         columns: { alias: '别名', kind: '类型', targets: '目标', selection: '选择策略', visibility: '模型列表', actions: '操作' },
         actions: { create: '新建别名', refresh: '刷新别名', save: '保存', delete: '删除', addTarget: '添加目标', editNamed: '编辑别名 {{name}}', deleteNamed: '删除别名 {{name}}' },
         dialog: { createTitle: '创建别名', editTitle: '编辑别名：{{name}}' },
-        form: { name: '别名 ID', namePlaceholder: 'my-alias-id', displayName: '显示名称', displayPlaceholder: '可选显示名称', kind: '类型', selection: '选择策略', visible: '在 /v1/models 中可见', visibleHint: '关闭只是不在列表中展示，别名仍然可以按名称请求。' },
+        form: { name: '别名 ID', namePlaceholder: 'my-alias-id', displayName: '显示名称', displayPlaceholder: '可选显示名称', kind: '类型', selection: '选择策略', visible: '在 /v1/models 中可见', visibleHint: '关闭只是不在列表中展示，别名仍然可以按名称请求' },
         kind: { 'chat': '对话', 'embedding': '嵌入', 'image': '图像', 'rerank': '重排', 'transcription': '转录' }, selection: { first: '首个可用', random: '随机' }, visibility: { visible: '可见', hidden: '隐藏' },
         target: { heading: '模型', description: '使用“首个可用”时将按顺序尝试目标。可选择建议或输入任意模型 ID。', label: '目标 {{number, number}}', modelId: '目标模型 ID', placeholder: '目标模型 ID', toggle: '展开目标规则', moveUp: '上移目标', moveDown: '下移目标', remove: '移除目标', count_other: '{{count, number}} 个目标' },
         rules: { effort: '思考强度', budget: '思考预算 token', adaptive: '自适应思考', adaptiveAuto: '自动（遵循模型）', adaptiveOn: '开启（强制自适应）', adaptiveOff: '关闭（强制非自适应）', summary: '思考摘要', verbosity: '详细程度', serviceTier: '服务等级' },

--- a/apps/web/src/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/i18n/locales/zh-Hans.ts
@@ -253,8 +253,8 @@ const zhHansCN = {
           confirmPassword: '确认新密码',
           administrator: '管理员',
           administratorDescription: '可以管理用户、上游、搜索配置和数据迁移',
-          userOneLocked: '初始管理员不能被降级。',
-          selfLocked: '不能降级自己的账号。',
+          userOneLocked: '初始管理员不能被降级',
+          selfLocked: '不能降级自己的账号',
         },
         validation: {
           username: '用户名须为 1-64 位字母、数字、下划线、点或连字符。',
@@ -271,7 +271,7 @@ const zhHansCN = {
       },
       upstreamAccess: {
         title: '限制可用上游',
-        description: '关闭时，访问权限会继承上一级范围内的全部上游。',
+        description: '关闭时，访问权限会继承上一级范围内的全部上游',
         tableLabel: '可用上游',
         enabled: '启用',
         order: '顺序',
@@ -348,7 +348,7 @@ const zhHansCN = {
           responsesRetention: 'Stateful Responses 保留',
           responsesRetentionHint: '该 API 密钥的 Responses 条目可被后续请求按 id 引用的时长（关闭表示不做持久化）',
           retentionHint:
-              '启用后，通过该 API 密钥发起的模型请求会在配置窗口内被记录。',
+              '启用后，通过该 API 密钥发起的模型请求会在配置窗口内被记录',
         },
         validation: {
           nameRequired: '名称不能为空。',
@@ -1044,7 +1044,7 @@ const zhHansCN = {
           microsoftWebIq: 'Microsoft Web IQ',
           jina: 'Jina',
         },
-        passthrough: { title: '透传 OpenAI 搜索', description: '将 /alpha/search 和 Responses 托管搜索转发到指定的 Codex 或 OpenAI 兼容上游。', upstream: '搜索上游', model: '搜索模型', empty: '请添加一个已启用且包含聊天模型的 Codex 或自定义上游。' },
+        passthrough: { title: '透传 OpenAI 搜索', description: '将 /alpha/search 和 Responses 托管搜索转发到指定的 Codex 或 OpenAI 兼容上游', upstream: '搜索上游', model: '搜索模型', empty: '请添加一个已启用且包含聊天模型的 Codex 或自定义上游。' },
         unavailable: '{{id}}（不可用）',
         getKeyLink: '获取 API 密钥',
         apiKeyLabel: 'API 密钥',


### PR DESCRIPTION
## Summary

- Remove terminal punctuation from secondary text rendered by `SettingsCard` and `SettingsExpander`.
- Apply the convention to alias visibility, upstream access, request retention, search passthrough, and administrator lock states.
- Keep the English and Simplified Chinese resources aligned.

## Test Plan

- [x] `pnpm --dir apps/web exec vitest run __tests__/i18n/resources_test.ts`
- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] Open the alias editor in headless Chrome and confirm its visibility description renders without terminal punctuation.