### PR TITLE
fix(web): keep the loading ring track transparent

### DIFF
--- a/apps/web/__tests__/components/ui/loading-screen-styles_test.ts
+++ b/apps/web/__tests__/components/ui/loading-screen-styles_test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadingCss } from '../../../src/components/ui/loading-screen.css';
+
+describe('the critical loading screen styles', () => {
+  it('keep the ProgressRing track transparent before the WinUI stylesheet loads', () => {
+    const provider = document.createElement('div');
+    const loadingScreen = document.createElement('main');
+    const spinner = document.createElement('span');
+    const style = document.createElement('style');
+
+    provider.style.setProperty('--colorBrandStroke2Contrast', 'hotpink');
+    loadingScreen.className = 'floway-loading';
+    spinner.className = 'fui-Spinner__spinner';
+    style.textContent = loadingCss;
+    try {
+      loadingScreen.append(spinner);
+      provider.append(loadingScreen);
+      document.head.append(style);
+      document.body.append(provider);
+
+      expect(getComputedStyle(spinner).backgroundColor).toBe('#ffffff00');
+    } finally {
+      style.remove();
+      provider.remove();
+    }
+  });
+});

--- a/apps/web/src/components/ui/loading-screen.css.ts
+++ b/apps/web/src/components/ui/loading-screen.css.ts
@@ -3,9 +3,11 @@
 //
 // Plain CSS because the prerendered HTML paints the boot screen before any
 // Griffel rule exists; it restates the medium Spinner that ../../winui/controls/progress.css.ts
-// later restyles into WinUI's ProgressRing. Each colour goes through the Fluent
-// custom property that layer rewrites, with the literal beside it covering the
-// frames before.
+// later restyles into WinUI's ProgressRing. The foreground and text colours go
+// through the Fluent custom properties that layer rewrites, with literals
+// covering the frames before. The track is the transparent value WinUI states
+// in both themes; keeping that literal here makes this critical surface
+// complete even when the linked WinUI stylesheet is unavailable.
 //
 // No reduced-motion branch, unlike Fluent: WinUI's ProgressRing is an
 // AnimatedVisualPlayer and keeps its animation with animations off.
@@ -45,7 +47,7 @@ export const loadingCss = `
   .floway-loading .fui-Spinner__spinner {
     --fui-Spinner--strokeWidth: 25%;
     animation: floway-loading-spin 1.5s linear infinite;
-    background-color: var(--colorBrandStroke2Contrast, #ffffff00);
+    background-color: #ffffff00;
     color: var(--colorBrandStroke1, #0067c0);
     flex-shrink: 0;
     height: 32px;


### PR DESCRIPTION
## Summary

- keep the critical loading screen's ProgressRing track transparent without depending on the linked WinUI stylesheet
- cover the pre-WinUI cascade when FluentProvider has already published a non-transparent `--colorBrandStroke2Contrast`
- preserve the existing arc colour, animation, geometry, label, forced-colour behavior, and the fully loaded WinUI state

## Root cause and trigger

The attachment contains two overlaid effects:

1. The tilted light-blue square is Chrome DevTools' node highlight for the selected rotating `spinnerTail`. Its sampled colour is exactly DevTools' `rgba(111, 168, 220, .66)` composited over the page, and Blink highlights the transformed content-box quad without applying the element's CSS mask.
2. A real pale-blue circular track is visible below that overlay. Fluent Spinner paints its track from `colorBrandStroke2Contrast` (`#b4d6fa` in the light theme). The critical CSS used `var(--colorBrandStroke2Contrast, #ffffff00)`, but FluentProvider SSR always defines the variable, so the transparent fallback cannot win. The later WinUI stylesheet normally remaps the token to transparent.

The application defect appears when the linked WinUI stylesheet is blocked, fails, is disabled, or is missing from a preview. Ordinary slow loading alone does not expose it because the head stylesheet is render-blocking. The DevTools square appears while hovering/selecting that DOM node and is not application paint.

WinUI defines the ProgressRing background as `ControlFillColorTransparentBrush` in both themes, so the critical surface now owns that invariant directly as `#ffffff00`.

Primary sources:

- [Fluent Spinner track](https://github.com/microsoft/fluentui/blob/6dee27b023a2d989f032b4adacb2135d336a67fb/packages/react-components/react-spinner/library/src/components/Spinner/useSpinnerStyles.styles.ts#L39-L56)
- [WinUI ProgressRing resources](https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/ProgressRing/ProgressRing_themeresources.xaml#L5-L10)
- [DevTools highlight colour](https://github.com/ChromeDevTools/devtools-frontend/blob/0752dc778afeaf02877268dd0fac46801d28602a/front_end/core/common/Color.ts#L2415-L2423)
- [Blink inspector highlight quad](https://github.com/chromium/chromium/blob/a87f3d09515490392383058c644f63dcb1d27832/third_party/blink/renderer/core/inspector/inspector_highlight.cc#L2011-L2095)

## Visual reproduction

Captured from the actual SSR loading component in local Google Chrome with JavaScript disabled and the WinUI stylesheet request deliberately failed in both cases:

| State | Computed track colour | Visible result |
|---|---|---|
| Before | `rgb(180, 214, 250)` | pale-blue full ring behind the accent arc |
| After | `rgba(255, 255, 255, 0)` | only the accent arc; label and 32 px geometry unchanged |

## Verification

- regression test fails before the change with `expected #ffffff00, received #b4d6fa`, then passes after the change
- real Chrome before/after capture under the same failed-stylesheet condition
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build:web`
- `pnpm run test:agent-setup-installers` — 106 passed, 4 environment-dependent skips
- `pnpm --filter @floway-dev/agent-setup run generate-assets --check`
- `pnpm run check:agent-protocol`
- `pnpm run test` — 5,411 passed; two existing Web interaction tests exceeded the local 5 s timeout with no assertion failure
- isolated rerun of those two files with a 15 s runner ceiling — 12 passed
