### PR TITLE
fix(web): keep expander chevron clickable

### DIFF
--- a/apps/web/__tests__/components/ui/settings-card_test.tsx
+++ b/apps/web/__tests__/components/ui/settings-card_test.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SettingsExpander } from '../../../src/components/ui/settings-card';
+import { renderInApp } from '../../render';
+
+describe('settings expander', () => {
+  it('keeps its chevron inside the disclosure hit target', () => {
+    const { container } = renderInApp(<SettingsExpander header="Advanced settings">Contents</SettingsExpander>);
+    const disclosure = screen.getByRole('button', { name: 'Advanced settings' });
+    const chevron = container.querySelector('svg')?.parentElement;
+    if (!chevron) throw new Error('the settings expander drew no chevron');
+
+    expect(getComputedStyle(chevron).pointerEvents).toBe('none');
+    fireEvent.click(disclosure);
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true');
+  });
+});

--- a/apps/web/src/components/ui/settings-card.tsx
+++ b/apps/web/src/components/ui/settings-card.tsx
@@ -312,6 +312,8 @@ const useStyles = makeStyles({
     flexBasis: 'auto',
     height: '32px',
     justifyContent: 'center',
+    // The stretched disclosure beneath this decorative box owns the click.
+    pointerEvents: 'none',
     width: '32px',
   },
   // The chevron's turn is the AnimatedIcon's own, not the region's: ten frames


### PR DESCRIPTION
## Summary

The settings expander chevron is decorative and now opts out of pointer hit-testing, allowing the stretched disclosure button beneath it to own clicks across the header and chevron. Trailing action controls remain independently interactive above the disclosure target.

A component regression test locks down the chevron hit-target contract and verifies that the disclosure still updates its expanded state.

## Test Plan

- [x] Run all web tests (102 files, 559 tests)
- [x] Run the web TypeScript checks
- [x] Build the production web application and run its asset checks
- [x] Run repository ESLint
- [x] Run the agent protocol check
- [x] Verify in headless Chrome that chevron clicks collapse and expand the row while a trailing action leaves its state unchanged
- [x] Confirm all seven GitHub Verify checks pass