### PR TITLE
fix(gateway): keep usage overview within D1 select limit

### DIFF
--- a/packages/gateway/__tests__/repo/test-sqlite.ts
+++ b/packages/gateway/__tests__/repo/test-sqlite.ts
@@ -48,6 +48,83 @@ const assertBindable = (values: readonly SqlBindValue[]): readonly SqlBindValue[
   return values;
 };
 
+// D1 lowers SQLite's compound-select ceiling from the upstream default of 500
+// to 5. Deployment-bound query tests use this verifier because sql.js would
+// otherwise accept SQL that D1 rejects while preparing it.
+// https://github.com/cloudflare/workerd/blob/243fd41f8944c2446c46e415373b107ecb9bc789/src/workerd/util/sqlite.c%2B%2B#L1380-L1385
+export const assertD1CompoundSelectLimit = (query: string) => {
+  const compoundTerms = [1];
+  let quote: "'" | '"' | '`' | ']' | null = null;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < query.length;) {
+    const current = query[index]!;
+    const next = query[index + 1];
+    if (lineComment) {
+      if (current === '\n') lineComment = false;
+      index++;
+      continue;
+    }
+    if (blockComment) {
+      if (current === '*' && next === '/') {
+        blockComment = false;
+        index += 2;
+      } else index++;
+      continue;
+    }
+    if (quote !== null) {
+      const closingQuote = quote === ']' ? ']' : quote;
+      if (current === closingQuote) {
+        if (next === closingQuote && quote !== ']') index += 2;
+        else {
+          quote = null;
+          index++;
+        }
+      } else index++;
+      continue;
+    }
+    if (current === '-' && next === '-') {
+      lineComment = true;
+      index += 2;
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      blockComment = true;
+      index += 2;
+      continue;
+    }
+    if (current === "'" || current === '"' || current === '`' || current === '[') {
+      quote = current === '[' ? ']' : current;
+      index++;
+      continue;
+    }
+    if (current === '(') {
+      compoundTerms.push(1);
+      index++;
+      continue;
+    }
+    if (current === ')') {
+      compoundTerms.pop();
+      index++;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(current)) {
+      let end = index + 1;
+      while (end < query.length && /[A-Za-z0-9_]/.test(query[end]!)) end++;
+      const keyword = query.slice(index, end).toUpperCase();
+      if (keyword === 'UNION' || keyword === 'INTERSECT' || keyword === 'EXCEPT') {
+        const depth = compoundTerms.length - 1;
+        compoundTerms[depth]!++;
+        if (compoundTerms[depth]! > 5) throw new Error('SQL query exceeds D1 compound SELECT limit of 5 terms');
+      }
+      index = end;
+      continue;
+    }
+    index++;
+  }
+};
+
 class SqlJsPreparedStatement implements SqlPreparedStatement {
   constructor(private readonly db: SqlJsDatabase, private readonly query: string, private readonly bound: readonly SqlBindValue[] = []) {}
 

--- a/packages/gateway/__tests__/repo/test-sqlite_test.ts
+++ b/packages/gateway/__tests__/repo/test-sqlite_test.ts
@@ -1,0 +1,14 @@
+import { test } from 'vitest';
+
+import { assertD1CompoundSelectLimit } from './test-sqlite.ts';
+import { assertThrows } from '@floway-dev/test-utils';
+
+test('D1 compound SELECT verifier accepts five terms and rejects six', () => {
+  assertD1CompoundSelectLimit('SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5');
+  assertThrows(
+    () => assertD1CompoundSelectLimit('SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6'),
+    Error,
+    'SQL query exceeds D1 compound SELECT limit of 5 terms',
+  );
+  assertD1CompoundSelectLimit("SELECT 'UNION UNION UNION UNION UNION' /* UNION */");
+});

--- a/packages/gateway/__tests__/repo/usage_test.ts
+++ b/packages/gateway/__tests__/repo/usage_test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 
 import { InMemoryRepo } from './memory.ts';
 import { type CapturedStatement, type CompletedStatement, recordBoundStatements, recordCompletedStatements } from './recording-sql.ts';
-import { createSqliteTestDb, createSqlJsDatabase, migrationSqlByFilename } from './test-sqlite.ts';
+import { assertD1CompoundSelectLimit, createSqliteTestDb, createSqlJsDatabase, migrationSqlByFilename } from './test-sqlite.ts';
 import { SqlRepo } from '../../src/repo/sql.ts';
 import type { ApiKey, Repo, UsageOverviewQueryOptions, UsageRecord } from '../../src/repo/types.ts';
 import { tokenCountsFromUsage, tokenRatesFromUsage, tokenUsageMetrics } from '../../src/repo/usage-metrics.ts';
@@ -439,6 +439,7 @@ test('SQL usage overview uses key-hour indexes for an actor-scoped aggregate', a
 
   const statement = captured.find(candidate => candidate.query.startsWith('/* usage-overview */'));
   if (!statement) throw new Error('Usage overview SQL was not captured');
+  assertD1CompoundSelectLimit(statement.query);
   const { results } = await db.prepare(`EXPLAIN QUERY PLAN ${statement.query}`)
     .bind(...statement.binds)
     .all<{ detail: string }>();

--- a/packages/gateway/src/repo/usage-overview-sql.ts
+++ b/packages/gateway/src/repo/usage-overview-sql.ts
@@ -58,8 +58,8 @@ const overviewHoursSql = (scoped: boolean) => `/* usage-overview-hours */
 
 const overviewSql = (scoped: boolean) => `/* usage-overview */
 WITH
-settings(actor_user_id, is_admin, series_group_by, unattributed_user_id, no_upstream_value, upstream_prefix) AS (
-  VALUES (?, ?, ?, ?, ?, ?)
+settings(actor_user_id, is_admin, unattributed_user_id, no_upstream_value, upstream_prefix) AS (
+  VALUES (?, ?, ?, ?, ?)
 ),
 model_filter(value) AS MATERIALIZED (
   SELECT CAST(value AS TEXT) FROM json_each(?)
@@ -127,13 +127,17 @@ filtered AS MATERIALIZED (
     AND (NOT EXISTS (SELECT 1 FROM user_filter) OR user_id IN (SELECT value FROM user_filter))
     AND (NOT EXISTS (SELECT 1 FROM key_filter) OR key_id IN (SELECT value FROM key_filter))
 ),
+-- workerd caps compound SELECTs at five terms, so this extensible axis catalog
+-- is a VALUES table rather than a UNION ALL chain.
+-- https://github.com/cloudflare/workerd/blob/243fd41f8944c2446c46e415373b107ecb9bc789/src/workerd/util/sqlite.c%2B%2B#L1380-L1385
 axes(axis, grouping, bucketed, owned_only, admin_only) AS (
-  SELECT 'series', series_group_by, 1, 0, 0 FROM settings
-  UNION ALL SELECT 'none', 'none', 0, 0, 0
-  UNION ALL SELECT 'keyId', 'keyId', 0, 1, 0
-  UNION ALL SELECT 'userId', 'userId', 0, 0, 1
-  UNION ALL SELECT 'model', 'model', 0, 0, 0
-  UNION ALL SELECT 'upstream', 'upstream', 0, 0, 0
+  VALUES
+    ('series', ?, 1, 0, 0),
+    ('none', 'none', 0, 0, 0),
+    ('keyId', 'keyId', 0, 1, 0),
+    ('userId', 'userId', 0, 0, 1),
+    ('model', 'model', 0, 0, 0),
+    ('upstream', 'upstream', 0, 0, 0)
 ),
 projected AS MATERIALIZED (
   SELECT
@@ -405,7 +409,6 @@ export const querySqlUsageOverview = async (
     const binds: SqlBindValue[] = [
       opts.actorUserId,
       opts.isAdmin ? 1 : 0,
-      opts.groupBy,
       tokenUsageUnattributedUserId,
       usageWithoutUpstreamDimensionValue,
       usageUpstreamDimensionPrefix,
@@ -416,6 +419,7 @@ export const querySqlUsageOverview = async (
       JSON.stringify(buckets),
       ...range,
       ...range,
+      opts.groupBy,
     ];
     const { results } = await db.prepare(overviewSql(scoped)).bind(...binds).all<UsageOverviewSqlRow>();
     const missingHours = results


### PR DESCRIPTION
## Summary

- replace the six-term Usage overview axis `UNION ALL` with a `VALUES` catalog so D1 can prepare the query under workerd's five-term compound SELECT limit
- keep the selected series grouping as a bound value and preserve every existing axis, filter, facet, and aggregate result
- add a SQL-shape verifier to the repository test support and apply it to the captured Usage overview query, closing the sql.js/D1 coverage gap

## Root cause

The SQL aggregation introduced in #402 constructs six axes (`series`, `none`, `keyId`, `userId`, `model`, and `upstream`) as six compound SELECT terms. workerd sets `SQLITE_LIMIT_COMPOUND_SELECT` to 5, so D1 rejects the statement during prepare with `too many terms in compound SELECT` before reading any data.

Primary evidence:

- [workerd sets the limit to 5](https://github.com/cloudflare/workerd/blob/243fd41f8944c2446c46e415373b107ecb9bc789/src/workerd/util/sqlite.c%2B%2B#L1380-L1385)
- [workerd's own boundary test accepts 5 terms and rejects 6](https://github.com/cloudflare/workerd/blob/243fd41f8944c2446c46e415373b107ecb9bc789/src/workerd/api/tests/sql-test.js#L479-L492)

## Benchmark

The benchmark uses 34,560 synthetic usage rows in the current schema: 11,520 request rows plus 23,040 metric rows, covering 30 days, two API keys, eight models, and hourly buckets. Each measurement uses an administrator's unfiltered `group_by=model` overview, 3 warmups, 15 measured warm-cache runs, and a separate clean worktree for `main`.

Local sql.js A/B isolates the query-shape change:

| Range | `main` median / p95 | Branch median / p95 | Median change |
| --- | ---: | ---: | ---: |
| 24h | 27.52 / 29.22 ms | 29.69 / 33.26 ms | +7.9% (+2.17 ms) |
| 7d | 181.69 / 191.69 ms | 178.16 / 208.85 ms | -1.9% (-3.53 ms) |
| 30d | 818.28 / 881.82 ms | 829.85 / 1,349.19 ms | +1.4% (+11.57 ms) |

The 30d branch p95 contains one local outlier; medians show no material query-planner regression from replacing six constant terms.

The fixed query was also executed end-to-end through local workerd/D1 against the same data. `main` completes 0/15 runs because prepare fails; the branch completes every run:

| Range | Branch median / p95 | Response SHA-256 |
| --- | ---: | --- |
| 24h | 13 / 15 ms | `19f900d5f3fd1b9baf4b22c3acdad0ff11878562bb6b4e77a19a5bf9418f5b76` |
| 7d | 107 / 113 ms | `d59ff1ae06dd84297b239dcb54ec22ac425f3968468c6e3f8e6505438453e6d6` |
| 30d | 714 / 810 ms | `28560efbe002b457a02707e10d3e68c37705f0a7a22ff56d6566fce1639bef9c` |

## Verification

- [x] local workerd/D1 reproduces the exact 5-success / 6-failure boundary
- [x] local workerd/D1 prepares and executes the fixed Usage overview across 24h, 7d, and 30d windows
- [x] `pnpm test` — 514 files, 5,413 tests passed
- [x] `pnpm typecheck`
- [x] `pnpm run check:agent-protocol`
- [x] ESLint on all changed files
- [x] `git diff --check`

Full-workspace `pnpm lint` currently also reports the pre-existing, unchanged `apps/web/src/routes/dashboard-services-api-keys.tsx:176` `prefer-nullish-coalescing` finding.
