### PR TITLE
refactor(agents): close protocol index schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 | Scope | Requirement | Enforcement |
 |---|---|---|
 | Protocol shape | Keep this file as the two tables named `Requirements` and `Index`. | `pnpm run check:agent-protocol` |
+| Index inventory | Keep `Index` as the complete sorted inventory of CI workflows, skills, and workspace package directories with a short responsibility overview. | `pnpm run check:agent-protocol` |
 | Task scope | Derive every action from the user's request and preserve unrelated working-tree state. | Final diff review |
 | Questions | Answer requested questions from read-only evidence. | Final diff review |
 | Findings | Reproduce the reported scenario and validate third-party findings against primary sources before acting. | Investigation evidence |
@@ -43,28 +44,31 @@
 
 ## Index
 
-| Scope | Canonical source |
-|---|---|
-| Project use and operator setup | `README.md` |
-| Workspace commands | `package.json` |
-| Continuous verification | `.github/workflows/verify.yaml` |
-| TypeScript projects | `tsconfig.base.json`, `tsconfig.scripts.json`, and package `tsconfig.json` files |
-| Lint boundaries | `eslint.config.ts` |
-| Test discovery | `vitest.config.ts` and package `vitest.config.ts` files |
-| Workspace dependency graph | `pnpm-workspace.yaml` and package manifests |
-| Protocol contracts | `packages/protocols` |
-| Protocol translation | `packages/translate` |
-| Provider contracts | `packages/provider` |
-| Provider implementations | `packages/provider-*` |
-| Gateway composition | `packages/gateway` |
-| Portable runtime contracts | `packages/platform` |
-| Deployment runtimes | `apps/platform-*` |
-| Dashboard | `apps/web` |
-| Agent Setup generation | `packages/agent-setup/scripts/generate-assets.ts` |
-| Database migrations | `packages/gateway/migrations` |
-| Wrangler configuration shape | `wrangler.example.jsonc` and `scripts/check-wrangler.ts` |
-| Cloudflare deployment | `$deploy-to-cloudflare` |
-| Copilot upstream probing | `$probing-copilot` |
-| Copilot workaround audit | `$audit-copilot-workarounds` |
-| Model pricing research | `$fetching-models-pricing` |
-| Recorded usage repricing | `$backfill-model-pricing` |
+| Category | Entry | Overview |
+|---|---|---|
+| CI | `.github/workflows/build.yaml` | Builds and publishes deployment images. |
+| CI | `.github/workflows/verify.yaml` | Validates every repository change. |
+| Skill | `$audit-copilot-workarounds` | Audits Copilot compatibility workarounds. |
+| Skill | `$backfill-model-pricing` | Reprices recorded model usage. |
+| Skill | `$deploy-to-cloudflare` | Deploys Floway to Cloudflare. |
+| Skill | `$fetching-models-pricing` | Researches provider model pricing. |
+| Skill | `$probing-copilot` | Probes Copilot upstream behavior. |
+| Package | `apps/platform-cloudflare` | Hosts Floway on Cloudflare. |
+| Package | `apps/platform-node` | Hosts Floway on Node. |
+| Package | `apps/web` | Provides the operator dashboard. |
+| Package | `packages/agent-setup` | Configures supported coding agents. |
+| Package | `packages/gateway` | Composes gateway services. |
+| Package | `packages/http` | Provides HTTP transport primitives. |
+| Package | `packages/interceptor` | Intercepts gateway traffic. |
+| Package | `packages/platform` | Defines portable runtime contracts. |
+| Package | `packages/protocols` | Defines protocol contracts. |
+| Package | `packages/provider` | Defines provider contracts. |
+| Package | `packages/provider-azure` | Integrates Azure OpenAI. |
+| Package | `packages/provider-claude-code` | Integrates Claude Code subscriptions. |
+| Package | `packages/provider-codex` | Integrates OpenAI Codex subscriptions. |
+| Package | `packages/provider-copilot` | Integrates GitHub Copilot subscriptions. |
+| Package | `packages/provider-custom` | Integrates OpenAI-compatible providers. |
+| Package | `packages/provider-ollama` | Integrates Ollama. |
+| Package | `packages/proxy` | Routes traffic through configured proxies. |
+| Package | `packages/test-utils` | Provides shared test infrastructure. |
+| Package | `packages/translate` | Translates between protocol contracts. |

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ pnpm run lint
 pnpm run typecheck
 ```
 
-More detail lives in [AGENTS.md](./AGENTS.md) — architecture, workspace layout,
-verification, and contributor rules.
+[AGENTS.md](./AGENTS.md) defines the repository-wide agent requirements and
+indexes its CI workflows, skills, workspace packages, and their responsibilities.
 
 ## License
 

--- a/scripts/check-agent-protocol.ts
+++ b/scripts/check-agent-protocol.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -6,13 +6,106 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const AGENTS_PATH = resolve(ROOT, 'AGENTS.md');
 const EXPECTED_TITLE = '# Repository Agent Protocol';
 const EXPECTED_SECTIONS = ['## Requirements', '## Index'] as const;
+const PACKAGE_ROOTS = ['packages', 'apps'] as const;
 const EXPECTED_TABLE_HEADERS = [
   '| Scope | Requirement | Enforcement |',
-  '| Scope | Canonical source |',
+  '| Category | Entry | Overview |',
 ] as const;
+const OVERVIEW_MAX_LENGTH = 64;
+const OVERVIEW_MAX_WORDS = 6;
+
+type IndexCategory = 'CI' | 'Skill' | 'Package';
+
+interface IndexEntry {
+  category: IndexCategory;
+  entry: string;
+}
+
+interface IndexRow extends IndexEntry {
+  overview: string;
+}
+
+const INDEX_CATEGORY_ORDER: Record<IndexCategory, number> = {
+  CI: 0,
+  Skill: 1,
+  Package: 2,
+};
 
 const fail = (message: string): never => {
   throw new Error(`AGENTS.md protocol violation: ${message}`);
+};
+
+const isIndexCategory = (value: string | undefined): value is IndexCategory =>
+  value === 'CI' || value === 'Skill' || value === 'Package';
+
+const isHighLevelOverview = (value: string | undefined): value is string => {
+  if (!value || value.length > OVERVIEW_MAX_LENGTH) return false;
+  const wordCount = value.split(/\s+/).length;
+  return (
+    wordCount <= OVERVIEW_MAX_WORDS &&
+    /^[A-Z][A-Za-z0-9 .-]*\.$/.test(value)
+  );
+};
+
+const listFileNames = async (directory: string): Promise<string[]> =>
+  (await readdir(resolve(ROOT, directory), { withFileTypes: true }))
+    .filter(entry => entry.isFile())
+    .map(entry => entry.name);
+
+const listDirectoryNames = async (directory: string): Promise<string[]> =>
+  (await readdir(resolve(ROOT, directory), { withFileTypes: true }))
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name);
+
+const discoverIndex = async (): Promise<IndexEntry[]> => {
+  const workspaceConfig = await readFile(resolve(ROOT, 'pnpm-workspace.yaml'), 'utf8');
+  const workspacePackageBlock = /^packages:\n((?:  - .+\n)+)/m.exec(workspaceConfig)?.[1];
+  const workspacePackagePatterns = workspacePackageBlock
+    ?.trimEnd()
+    .split('\n')
+    .map(line => line.slice('  - '.length));
+  const expectedPackagePatterns = PACKAGE_ROOTS.map(root => `${root}/*`);
+  if (JSON.stringify(workspacePackagePatterns) !== JSON.stringify(expectedPackagePatterns)) {
+    fail(
+      `package discovery must match pnpm-workspace.yaml; expected ${JSON.stringify(expectedPackagePatterns)}`,
+    );
+  }
+
+  const workflows = (await listFileNames('.github/workflows'))
+    .filter(name => name.endsWith('.yaml') || name.endsWith('.yml'))
+    .map(entry => ({ category: 'CI', entry: `.github/workflows/${entry}` }) satisfies IndexEntry);
+
+  const skills = await Promise.all(
+    (await listDirectoryNames('.agents/skills')).map(async name => ({
+      name,
+      files: await listFileNames(`.agents/skills/${name}`),
+    })),
+  );
+  const skillEntries = skills
+    .filter(({ files }) => files.includes('SKILL.md'))
+    .map(({ name }) => ({ category: 'Skill', entry: `$${name}` }) satisfies IndexEntry);
+
+  const packageDirectories = (
+    await Promise.all(
+      PACKAGE_ROOTS.map(async parent =>
+        (await listDirectoryNames(parent)).map(name => `${parent}/${name}`)),
+    )
+  ).flat();
+  const packages = await Promise.all(
+    packageDirectories.map(async directory => ({
+      directory,
+      files: await listFileNames(directory),
+    })),
+  );
+  const packageEntries = packages
+    .filter(({ files }) => files.includes('package.json'))
+    .map(({ directory }) => ({ category: 'Package', entry: directory }) satisfies IndexEntry);
+
+  return [...workflows, ...skillEntries, ...packageEntries].sort(
+    (left, right) =>
+      INDEX_CATEGORY_ORDER[left.category] - INDEX_CATEGORY_ORDER[right.category] ||
+      left.entry.localeCompare(right.entry),
+  );
 };
 
 const lines = (await readFile(AGENTS_PATH, 'utf8')).trimEnd().split('\n');
@@ -48,8 +141,46 @@ for (const [index, section] of sectionEntries.entries()) {
   if (!/^\|(?:-+\|)+$/.test(content[1]?.replaceAll(' ', '') ?? '')) {
     fail(`${section.line} must use a Markdown table separator as its second row`);
   }
-  const expectedColumns = index === 0 ? 3 : 2;
+  const expectedColumns = 3;
   if (content.some(line => line.split('|').length !== expectedColumns + 2)) {
     fail(`${section.line} must keep its ${expectedColumns} prescribed columns`);
   }
+}
+
+const indexSection = sectionEntries[1];
+const indexEnd = lines.length;
+const indexRows = lines
+  .slice((indexSection?.index ?? 0) + 1, indexEnd)
+  .filter(line => line !== '')
+  .slice(2)
+  .map((line): IndexRow => {
+    const cells = line
+      .slice(1, -1)
+      .split('|')
+      .map(cell => cell.trim());
+    const category = cells[0];
+    const encodedEntry = cells[1];
+    const overview = cells[2];
+    if (!isIndexCategory(category)) {
+      return fail(
+        `Index category must be CI, Skill, or Package; received ${JSON.stringify(category)}`,
+      );
+    }
+    if (!encodedEntry?.startsWith('`') || !encodedEntry.endsWith('`')) {
+      fail(`Index entries must be single code spans; received ${JSON.stringify(encodedEntry)}`);
+    }
+    if (!isHighLevelOverview(overview)) {
+      fail(
+        `Index overviews must be plain sentences of at most ${OVERVIEW_MAX_WORDS} words and ${OVERVIEW_MAX_LENGTH} characters; received ${JSON.stringify(overview)}`,
+      );
+    }
+    return { category, entry: encodedEntry.slice(1, -1), overview };
+  });
+
+const expectedIndexRows = await discoverIndex();
+const indexedEntries = indexRows.map(({ category, entry }) => ({ category, entry }));
+if (JSON.stringify(indexedEntries) !== JSON.stringify(expectedIndexRows)) {
+  fail(
+    `Index must exactly inventory CI workflows, skills, and package directories in sorted order; expected ${JSON.stringify(expectedIndexRows)}`,
+  );
 }


### PR DESCRIPTION
## Summary

- replace the descriptive agent-protocol index with a closed inventory of CI workflows, skills, and workspace package directories
- give every indexed entry a short, high-level responsibility overview
- derive the expected inventory from the repository and reject unknown categories, arbitrary entries, omissions, duplicates, ordering drift, workspace-root drift, and detailed overview prose
- synchronize the README description with the constrained protocol

## Test Plan

- [x] `pnpm run check:agent-protocol`
- [x] negative check: reject an unknown `Document` category
- [x] negative check: reject `README.md` disguised as a `CI` entry
- [x] negative check: reject a detailed overview exceeding six words
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (517 files, 5426 tests)
- [x] `pnpm run test:agent-setup-installers`
- [x] `pnpm --filter @floway-dev/agent-setup run generate-assets --check`
- [x] `pnpm run build:web`