### PR TITLE
fix(platform-node): propagate peer FIN through socket streams

### DIFF
--- a/apps/platform-node/__tests__/socket-dial_test.ts
+++ b/apps/platform-node/__tests__/socket-dial_test.ts
@@ -25,6 +25,18 @@ const startEchoServer = async (): Promise<{ port: number; close: () => Promise<v
   };
 };
 
+const withDeadline = async <T>(promise: Promise<T>, label: string): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), 1_000);
+  });
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+};
+
 describe('nodeSocketDial', () => {
   let server: Awaited<ReturnType<typeof startEchoServer>>;
   beforeEach(async () => { server = await startEchoServer(); });
@@ -40,6 +52,58 @@ describe('nodeSocketDial', () => {
     expect(new TextDecoder().decode(value)).toBe('hi');
     reader.releaseLock();
     await dialed.close();
+  });
+
+  it('ends the readable on peer FIN while leaving the writable half open', async () => {
+    let receivedAfterFinResolve!: () => void;
+    const receivedAfterFin = new Promise<void>(resolve => { receivedAfterFinResolve = resolve; });
+    const halfCloseServer = net.createServer({ allowHalfOpen: true }, socket => {
+      let received = '';
+      socket.on('data', chunk => {
+        received += chunk.toString();
+        if (received === 'still-open') receivedAfterFinResolve();
+      });
+      socket.end('bye');
+    });
+    await new Promise<void>(resolve => halfCloseServer.listen(0, '127.0.0.1', resolve));
+    const address = halfCloseServer.address();
+    if (!address || typeof address === 'string') throw new Error('half-close server has no address');
+
+    const dialed = await nodeSocketDial.connect('127.0.0.1', address.port);
+    try {
+      // Adapted from workerd's allowHalfOpen=true contract test: read through
+      // peer EOF, then prove the same connection's writable side remains open.
+      // https://github.com/cloudflare/workerd/blob/243fd41f8944c2446c46e415373b107ecb9bc789/src/workerd/api/tests/outbound-interceptor-socket-test.js#L169-L183
+      await expect(withDeadline(new Response(dialed.readable).text(), 'peer FIN')).resolves.toBe('bye');
+
+      const writer = dialed.writable.getWriter();
+      await writer.write(new TextEncoder().encode('still-open'));
+      writer.releaseLock();
+      await withDeadline(receivedAfterFin, 'data written after peer FIN');
+    } finally {
+      await dialed.close();
+      await new Promise<void>(resolve => halfCloseServer.close(() => resolve()));
+    }
+  });
+
+  it('destroys the socket when the readable is canceled', async () => {
+    const dialed = await nodeSocketDial.connect('127.0.0.1', server.port);
+    try {
+      const writer = dialed.writable.getWriter();
+      await writer.write(new TextEncoder().encode('warmup'));
+      writer.releaseLock();
+      const reader = dialed.readable.getReader();
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe('warmup');
+      reader.releaseLock();
+
+      const remote = server.lastSocket();
+      if (!remote) throw new Error('echo server did not accept the socket');
+      const remoteClosed = new Promise<void>(resolve => remote.once('close', () => resolve()));
+      await dialed.readable.cancel(new Error('consumer canceled'));
+      await withDeadline(remoteClosed, 'peer close after readable cancellation');
+    } finally {
+      await dialed.close();
+    }
   });
 
   it('rejects a connect against a closed port', async () => {

--- a/apps/platform-node/src/socket-dial.ts
+++ b/apps/platform-node/src/socket-dial.ts
@@ -1,8 +1,29 @@
 import net from 'node:net';
-import { Readable } from 'node:stream';
+import { PassThrough, pipeline, Readable } from 'node:stream';
 import tls from 'node:tls';
 
 import { normalizeDialHost, throwAbort, type DialedSocket, type SocketDial } from '@floway-dev/platform';
+
+// Readable.toWeb(socket) waits for `finished(socket)`, which treats the
+// net.Socket as both readable and writable. Projecting the read side through a
+// PassThrough keeps Node's own backpressure, Buffer copying, error propagation,
+// and cancellation teardown while letting peer FIN finish the read side
+// independently. pipeline() observes the socket only as its readable source,
+// so normal EOF does not close the socket's writable half. Node fixed the
+// direct adapter upstream after our supported Node 22 line; this projection can
+// disappear once our minimum runtime includes that fix.
+// https://github.com/nodejs/node/blob/aa4c77582be995286fc6e00aaf530dc7ade102a9/lib/internal/webstreams/adapters.js#L424-L502
+// https://github.com/nodejs/node/blob/783b3824831053fb020c17d456505ed76dfaef87/lib/internal/webstreams/adapters.js#L500-L527
+// https://github.com/nodejs/node/blob/aa4c77582be995286fc6e00aaf530dc7ade102a9/lib/internal/streams/pipeline.js#L213-L267
+const socketToReadable = (socket: net.Socket): ReadableStream<Uint8Array> => {
+  const readable = new PassThrough({ highWaterMark: socket.readableHighWaterMark });
+  pipeline(socket, readable, error => {
+    // pipeline has already propagated the error into readable; keep the
+    // callback as a final invariant guard for non-standard stream behavior.
+    if (error && !readable.errored) readable.destroy(error);
+  });
+  return Readable.toWeb(readable) as ReadableStream<Uint8Array>;
+};
 
 // Hand-rolled adapter from a node:net.Socket to a WritableStream<Uint8Array>.
 // Writable.toWeb only wires `close()` to socket.end(); writer.abort() is
@@ -81,17 +102,7 @@ export const nodeSocketDial: SocketDial = {
       socket.once('error', onError);
     });
 
-    // net.Socket recycles its emitted Buffers from a shared pool, so any
-    // chunk our handshake state machines retain across an await can read
-    // overwritten bytes. Copy on the way out.
-    const rawReadable = Readable.toWeb(socket) as ReadableStream<Uint8Array>;
-    const readable = rawReadable.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        const owned = new Uint8Array(chunk.byteLength);
-        owned.set(chunk);
-        controller.enqueue(owned);
-      },
-    }));
+    const readable = socketToReadable(socket);
     const writable = socketToWritable(socket);
 
     // Listen on 'close' rather than the toWeb readable's own close signal:

--- a/packages/platform/src/socket-dial.ts
+++ b/packages/platform/src/socket-dial.ts
@@ -21,6 +21,7 @@ interface SocketDialOptions {
 }
 
 export interface DialedSocket {
+  /** Reaches EOF when the peer sends FIN, independently of the writable side. */
   readable: ReadableStream<Uint8Array>;
   writable: WritableStream<Uint8Array>;
   /** Idempotent close. */


### PR DESCRIPTION
## Summary

- project the Node socket read side through `PassThrough` and `pipeline` before converting it to a Web `ReadableStream`
- propagate peer FIN as readable EOF without closing the half-open writable side
- preserve backpressure, Buffer ownership, upstream errors, and cancellation teardown through Node stream primitives
- define the cross-platform `SocketDial` EOF contract and cover it with real loopback sockets

## Motivation

On the supported Node 22 runtime, `Readable.toWeb(net.Socket)` waits for both halves of the Duplex to finish. With `allowHalfOpen: true`, an upstream FIN ends the Node readable but leaves the writable open, so the Web reader never reaches EOF. HTTPS direct-connect requests then remain stuck in `CLOSE_WAIT`, and the userspace TLS, HTTP, and SSE layers cannot observe the truncated upstream stream.

Node fixed the direct adapter in [nodejs/node#62394](https://github.com/nodejs/node/pull/62394), first released in Node 26.3. Floway supports Node 22.19, while the tested Node 22 and 24 releases retain the old behavior. The `PassThrough` and `pipeline` projection supplies the corrected read-side semantics with Node built-ins until the minimum runtime includes the upstream fix.

The half-open regression follows [workerd's `allowHalfOpen: true` contract test](https://github.com/cloudflare/workerd/blob/243fd41f8944c2446c46e415373b107ecb9bc789/src/workerd/api/tests/outbound-interceptor-socket-test.js#L169-L183): consume peer EOF, then successfully write through the same connection. A second loopback test verifies that canceling the Web readable destroys the underlying socket.

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 513 files, 5414 tests
- [x] `pnpm run test:agent-setup-installers` — 106 passed, 4 skipped
- [x] `pnpm --filter @floway-dev/agent-setup run generate-assets --check`
- [x] `pnpm run check:agent-protocol`
- [x] `pnpm run build:web`
- [x] Run the Floway HTTP peer-FIN experiment before and after this fix on Node 22.23.1, 22.23.2, 24.19.0, 26.3.0, and 26.7.0
- [x] Run the native Node adapter matrix and the equivalent workerd half-open experiment with in-container `netstat` evidence — [experiment code and results](https://github.com/Menci/Floway/pull/418#issuecomment-5206741548)
