### PR TITLE
fix(gateway): keep performance overview within D1 select limit

### DIFF
--- a/packages/gateway/__tests__/repo/performance_test.ts
+++ b/packages/gateway/__tests__/repo/performance_test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { InMemoryRepo } from './memory.ts';
 import { type CompletedStatement, recordCompletedStatements } from './recording-sql.ts';
-import { createSqliteTestDb } from './test-sqlite.ts';
+import { assertD1CompoundSelectLimit, createSqliteTestDb } from './test-sqlite.ts';
 import { SqlRepo } from '../../src/repo/sql.ts';
 import type {
   ApiKey,
@@ -433,6 +433,7 @@ it('SQL Performance overview uses actor indexes and returns aggregate cardinalit
   const aggregates = completed.filter(statement => statement.query.startsWith('/* performance-overview */'));
   const aggregate = aggregates.at(-1);
   if (!aggregate) throw new Error('Performance overview SQL evidence was not captured');
+  assertD1CompoundSelectLimit(aggregate.query);
   const { results } = await db.prepare(`EXPLAIN QUERY PLAN ${aggregate.query}`)
     .bind(...aggregate.binds)
     .all<{ detail: string }>();

--- a/packages/gateway/src/repo/performance-overview-sql.ts
+++ b/packages/gateway/src/repo/performance-overview-sql.ts
@@ -49,15 +49,8 @@ const overviewHoursSql = (scoped: boolean) => `/* performance-overview-hours */
   GROUP BY performance_summary.hour
   ORDER BY performance_summary.hour`;
 
-type PerformanceBreakdownAxis = Exclude<PerformanceOverviewAxis, 'series'>;
-
-interface PerformanceBreakdownSql {
-  axis: PerformanceBreakdownAxis;
-  group: (source: string) => string;
-  where?: (source: string) => string;
-}
-
-const seriesGroupSql = (source: string) => `CASE settings.series_group_by
+const axisGroupSql = (source: string) => `CASE axes.grouping
+  WHEN 'none' THEN 'all'
   WHEN 'keyId' THEN ${source}.key_id
   WHEN 'userId' THEN CAST(${source}.user_id AS TEXT)
   WHEN 'model' THEN ${source}.model
@@ -65,96 +58,9 @@ const seriesGroupSql = (source: string) => `CASE settings.series_group_by
   WHEN 'operation' THEN ${source}.operation
   WHEN 'runtimeLocation' THEN ${source}.runtime_location
 END`;
-const seriesWhereSql = (source: string) =>
-  `settings.series_group_by != 'userId' OR ${source}.user_id IS NOT NULL`;
-
-const performanceBreakdownSql: readonly PerformanceBreakdownSql[] = [
-  { axis: 'none', group: () => "'all'" },
-  { axis: 'keyId', group: source => `${source}.key_id`, where: source => `${source}.owned = 1` },
-  {
-    axis: 'userId',
-    group: source => `CAST(${source}.user_id AS TEXT)`,
-    where: source => `settings.is_admin = 1 AND ${source}.user_id IS NOT NULL`,
-  },
-  { axis: 'model', group: source => `${source}.model` },
-  { axis: 'upstream', group: source => `${source}.upstream` },
-  { axis: 'operation', group: source => `${source}.operation` },
-  { axis: 'runtimeLocation', group: source => `${source}.runtime_location` },
-];
-
-const summarySeriesSql = `
-  SELECT
-    'series' AS axis,
-    bucket_map.bucket,
-    ${seriesGroupSql('filtered_summary')} AS group_value,
-    SUM(filtered_summary.requests) AS requests,
-    SUM(filtered_summary.errors_with_output) + SUM(filtered_summary.errors_no_output) AS errors,
-    SUM(filtered_summary.ttft_samples_ok) + SUM(filtered_summary.errors_with_output) AS ttft_samples,
-    SUM(filtered_summary.tpot_samples) AS tpot_samples,
-    SUM(filtered_summary.neutral) AS neutral
-  FROM filtered_summary
-  CROSS JOIN settings
-  JOIN bucket_map ON bucket_map.hour = filtered_summary.hour
-  WHERE ${seriesWhereSql('filtered_summary')}
-  GROUP BY bucket_map.bucket, group_value`;
-
-const summaryBreakdownSql = performanceBreakdownSql.map(({ axis, group, where }) => {
-  const source = 'summary_cube';
-  const groupSql = group(source);
-  return `
-  SELECT
-    '${axis}' AS axis,
-    'all' AS bucket,
-    ${groupSql} AS group_value,
-    SUM(${source}.requests) AS requests,
-    SUM(${source}.errors_with_output) + SUM(${source}.errors_no_output) AS errors,
-    SUM(${source}.ttft_samples_ok) + SUM(${source}.errors_with_output) AS ttft_samples,
-    SUM(${source}.tpot_samples) AS tpot_samples,
-    SUM(${source}.neutral) AS neutral
-  FROM ${source}
-  CROSS JOIN settings
-  ${where === undefined ? '' : `WHERE ${where(source)}`}
-  GROUP BY ${groupSql}`;
-}).join('\n  UNION ALL');
-
-const summaryAggregateSql = `${summarySeriesSql}
-  UNION ALL${summaryBreakdownSql}`;
-
-const histogramSeriesSql = `
-  SELECT
-    'series' AS axis,
-    bucket_map.bucket,
-    ${seriesGroupSql('filtered_histogram')} AS group_value,
-    filtered_histogram.metric,
-    filtered_histogram.lower,
-    MAX(filtered_histogram.upper) AS upper,
-    SUM(filtered_histogram.count) AS count
-  FROM filtered_histogram
-  CROSS JOIN settings
-  JOIN bucket_map ON bucket_map.hour = filtered_histogram.hour
-  WHERE ${seriesWhereSql('filtered_histogram')}
-  GROUP BY bucket_map.bucket, group_value, filtered_histogram.metric, filtered_histogram.lower`;
-
-const histogramBreakdownSql = performanceBreakdownSql.map(({ axis, group, where }) => {
-  const source = 'histogram_cube';
-  const groupSql = group(source);
-  return `
-  SELECT
-    '${axis}' AS axis,
-    'all' AS bucket,
-    ${groupSql} AS group_value,
-    ${source}.metric,
-    ${source}.lower,
-    MAX(${source}.upper) AS upper,
-    SUM(${source}.count) AS count
-  FROM ${source}
-  CROSS JOIN settings
-  ${where === undefined ? '' : `WHERE ${where(source)}`}
-  GROUP BY ${groupSql}, ${source}.metric, ${source}.lower`;
-}).join('\n  UNION ALL');
-
-const histogramAggregateSql = `${histogramSeriesSql}
-  UNION ALL${histogramBreakdownSql}`;
+const axisAccessSql = (source: string) => `(axes.owned_only = 0 OR ${source}.owned = 1)
+    AND (axes.admin_only = 0 OR settings.is_admin = 1)
+    AND (axes.grouping != 'userId' OR ${source}.user_id IS NOT NULL)`;
 
 const performanceCubeDimensions = [
   'key_id', 'user_id', 'owned', 'model', 'upstream', 'operation', 'runtime_location',
@@ -163,8 +69,22 @@ const performanceCubeCoordinateSql = performanceCubeDimensions.join(', ');
 
 const overviewSql = (scoped: boolean) => `/* performance-overview */
 WITH
-settings(actor_user_id, is_admin, series_group_by) AS (
-  VALUES (?, ?, ?)
+settings(actor_user_id, is_admin) AS (
+  VALUES (?, ?)
+),
+-- workerd caps compound SELECTs at five terms. Keep the extensible overview
+-- axes in data so every projection below needs at most two SELECT terms.
+-- https://github.com/cloudflare/workerd/blob/c16efad94a926dff547d3e3d853feae4fc8988a6/src/workerd/util/sqlite.c%2B%2B#L1382-L1384
+axes(axis, grouping, bucketed, owned_only, admin_only, facet) AS (
+  VALUES
+    ('series', ?, 1, 0, 0, 0),
+    ('none', 'none', 0, 0, 0, 0),
+    ('keyId', 'keyId', 0, 1, 0, 1),
+    ('userId', 'userId', 0, 0, 1, 1),
+    ('model', 'model', 0, 0, 0, 1),
+    ('upstream', 'upstream', 0, 0, 0, 1),
+    ('operation', 'operation', 0, 0, 0, 1),
+    ('runtimeLocation', 'runtimeLocation', 0, 0, 0, 1)
 ),
 model_filter(value) AS MATERIALIZED (
   SELECT CAST(value AS TEXT) FROM json_each(?)
@@ -257,8 +177,50 @@ histogram_cube AS MATERIALIZED (
   FROM filtered_histogram
   GROUP BY ${performanceCubeCoordinateSql}, metric, lower
 ),
+summary_terms AS MATERIALIZED (
+  SELECT
+    axes.axis,
+    bucket_map.bucket,
+    ${axisGroupSql('filtered_summary')} AS group_value,
+    filtered_summary.requests,
+    filtered_summary.ttft_samples_ok,
+    filtered_summary.errors_with_output,
+    filtered_summary.errors_no_output,
+    filtered_summary.neutral,
+    filtered_summary.tpot_samples
+  FROM filtered_summary
+  CROSS JOIN axes
+  CROSS JOIN settings
+  JOIN bucket_map ON bucket_map.hour = filtered_summary.hour
+  WHERE axes.bucketed = 1 AND ${axisAccessSql('filtered_summary')}
+  UNION ALL
+  SELECT
+    axes.axis,
+    'all',
+    ${axisGroupSql('summary_cube')},
+    summary_cube.requests,
+    summary_cube.ttft_samples_ok,
+    summary_cube.errors_with_output,
+    summary_cube.errors_no_output,
+    summary_cube.neutral,
+    summary_cube.tpot_samples
+  FROM summary_cube
+  CROSS JOIN axes
+  CROSS JOIN settings
+  WHERE axes.bucketed = 0 AND ${axisAccessSql('summary_cube')}
+),
 summary_aggregates AS MATERIALIZED (
-  ${summaryAggregateSql}
+  SELECT
+    axis,
+    bucket,
+    group_value,
+    SUM(requests) AS requests,
+    SUM(errors_with_output) + SUM(errors_no_output) AS errors,
+    SUM(ttft_samples_ok) + SUM(errors_with_output) AS ttft_samples,
+    SUM(tpot_samples) AS tpot_samples,
+    SUM(neutral) AS neutral
+  FROM summary_terms
+  GROUP BY axis, bucket, group_value
 ),
 invalid_histogram_bounds AS MATERIALIZED (
   SELECT 1 AS present
@@ -267,8 +229,45 @@ invalid_histogram_bounds AS MATERIALIZED (
   HAVING COUNT(DISTINCT COALESCE(CAST(upper AS TEXT), 'null')) > 1
   LIMIT 1
 ),
+histogram_terms AS MATERIALIZED (
+  SELECT
+    axes.axis,
+    bucket_map.bucket,
+    ${axisGroupSql('filtered_histogram')} AS group_value,
+    filtered_histogram.metric,
+    filtered_histogram.lower,
+    filtered_histogram.upper,
+    filtered_histogram.count
+  FROM filtered_histogram
+  CROSS JOIN axes
+  CROSS JOIN settings
+  JOIN bucket_map ON bucket_map.hour = filtered_histogram.hour
+  WHERE axes.bucketed = 1 AND ${axisAccessSql('filtered_histogram')}
+  UNION ALL
+  SELECT
+    axes.axis,
+    'all',
+    ${axisGroupSql('histogram_cube')},
+    histogram_cube.metric,
+    histogram_cube.lower,
+    histogram_cube.upper,
+    histogram_cube.count
+  FROM histogram_cube
+  CROSS JOIN axes
+  CROSS JOIN settings
+  WHERE axes.bucketed = 0 AND ${axisAccessSql('histogram_cube')}
+),
 histogram AS MATERIALIZED (
-  ${histogramAggregateSql}
+  SELECT
+    axis,
+    bucket,
+    group_value,
+    metric,
+    lower,
+    MAX(upper) AS upper,
+    SUM(count) AS count
+  FROM histogram_terms
+  GROUP BY axis, bucket, group_value, metric, lower
 ),
 ranked_histogram AS MATERIALIZED (
   SELECT
@@ -344,36 +343,16 @@ aggregate_rows AS (
 ),
 facet_rows AS (
   SELECT 'facet' AS row_kind, NULL AS axis, NULL AS bucket, NULL AS group_value,
-    'keyId' AS dimension, key_id AS facet_value,
+    axes.axis AS dimension, ${axisGroupSql('scoped_summary')} AS facet_value,
     NULL AS requests_text, NULL AS errors_text, NULL AS ttft_samples_text,
     NULL AS tpot_samples_text, NULL AS neutral_text,
     NULL AS ttft_ms_p50, NULL AS ttft_ms_p95, NULL AS ttft_ms_p99,
     NULL AS tpot_us_p50, NULL AS tpot_us_p95, NULL AS tpot_us_p99
   FROM scoped_summary
-  WHERE owned = 1
-  GROUP BY key_id
-  UNION ALL
-  SELECT 'facet', NULL, NULL, NULL, 'userId', CAST(user_id AS TEXT),
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
-  FROM scoped_summary CROSS JOIN settings
-  WHERE settings.is_admin = 1 AND user_id IS NOT NULL
-  GROUP BY user_id
-  UNION ALL
-  SELECT 'facet', NULL, NULL, NULL, 'model', model,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
-  FROM scoped_summary GROUP BY model
-  UNION ALL
-  SELECT 'facet', NULL, NULL, NULL, 'upstream', upstream,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
-  FROM scoped_summary GROUP BY upstream
-  UNION ALL
-  SELECT 'facet', NULL, NULL, NULL, 'operation', operation,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
-  FROM scoped_summary GROUP BY operation
-  UNION ALL
-  SELECT 'facet', NULL, NULL, NULL, 'runtimeLocation', runtime_location,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
-  FROM scoped_summary GROUP BY runtime_location
+  CROSS JOIN axes
+  CROSS JOIN settings
+  WHERE axes.facet = 1 AND ${axisAccessSql('scoped_summary')}
+  GROUP BY axes.axis, facet_value
 ),
 orphan_rows AS (
   SELECT 'orphan' AS row_kind,

--- a/packages/gateway/src/repo/performance-overview-sql.ts
+++ b/packages/gateway/src/repo/performance-overview-sql.ts
@@ -49,8 +49,29 @@ const overviewHoursSql = (scoped: boolean) => `/* performance-overview-hours */
   GROUP BY performance_summary.hour
   ORDER BY performance_summary.hour`;
 
-const axisGroupSql = (source: string) => `CASE axes.grouping
-  WHEN 'none' THEN 'all'
+type PerformanceBreakdownAxis = Exclude<PerformanceOverviewAxis, 'series'>;
+
+interface PerformanceBreakdownSql {
+  axis: PerformanceBreakdownAxis;
+  group: (source: string) => string;
+  where?: (source: string) => string;
+}
+
+// workerd caps every compound SELECT at five terms. Build a tree of bounded
+// compounds so adding future Performance dimensions cannot cross that limit.
+// https://github.com/cloudflare/workerd/blob/c16efad94a926dff547d3e3d853feae4fc8988a6/src/workerd/util/sqlite.c%2B%2B#L1382-L1384
+const D1_COMPOUND_SELECT_LIMIT = 5;
+const boundedUnionAll = (terms: readonly string[]): string => {
+  if (terms.length === 0) throw new Error('A compound SELECT requires at least one term');
+  if (terms.length <= D1_COMPOUND_SELECT_LIMIT) return terms.join('\n  UNION ALL\n');
+  const groups: string[] = [];
+  for (let index = 0; index < terms.length; index += D1_COMPOUND_SELECT_LIMIT) {
+    groups.push(`SELECT * FROM (\n${boundedUnionAll(terms.slice(index, index + D1_COMPOUND_SELECT_LIMIT))}\n  )`);
+  }
+  return boundedUnionAll(groups);
+};
+
+const seriesGroupSql = (source: string) => `CASE settings.series_group_by
   WHEN 'keyId' THEN ${source}.key_id
   WHEN 'userId' THEN CAST(${source}.user_id AS TEXT)
   WHEN 'model' THEN ${source}.model
@@ -58,9 +79,111 @@ const axisGroupSql = (source: string) => `CASE axes.grouping
   WHEN 'operation' THEN ${source}.operation
   WHEN 'runtimeLocation' THEN ${source}.runtime_location
 END`;
-const axisAccessSql = (source: string) => `(axes.owned_only = 0 OR ${source}.owned = 1)
-    AND (axes.admin_only = 0 OR settings.is_admin = 1)
-    AND (axes.grouping != 'userId' OR ${source}.user_id IS NOT NULL)`;
+const seriesWhereSql = (source: string) =>
+  `settings.series_group_by != 'userId' OR ${source}.user_id IS NOT NULL`;
+
+const performanceBreakdownSql: readonly PerformanceBreakdownSql[] = [
+  { axis: 'none', group: () => "'all'" },
+  { axis: 'keyId', group: source => `${source}.key_id`, where: source => `${source}.owned = 1` },
+  {
+    axis: 'userId',
+    group: source => `CAST(${source}.user_id AS TEXT)`,
+    where: source => `settings.is_admin = 1 AND ${source}.user_id IS NOT NULL`,
+  },
+  { axis: 'model', group: source => `${source}.model` },
+  { axis: 'upstream', group: source => `${source}.upstream` },
+  { axis: 'operation', group: source => `${source}.operation` },
+  { axis: 'runtimeLocation', group: source => `${source}.runtime_location` },
+];
+
+const summarySeriesSql = `
+  SELECT
+    'series' AS axis,
+    bucket_map.bucket,
+    ${seriesGroupSql('filtered_summary')} AS group_value,
+    SUM(filtered_summary.requests) AS requests,
+    SUM(filtered_summary.errors_with_output) + SUM(filtered_summary.errors_no_output) AS errors,
+    SUM(filtered_summary.ttft_samples_ok) + SUM(filtered_summary.errors_with_output) AS ttft_samples,
+    SUM(filtered_summary.tpot_samples) AS tpot_samples,
+    SUM(filtered_summary.neutral) AS neutral
+  FROM filtered_summary
+  CROSS JOIN settings
+  JOIN bucket_map ON bucket_map.hour = filtered_summary.hour
+  WHERE ${seriesWhereSql('filtered_summary')}
+  GROUP BY bucket_map.bucket, group_value`;
+
+const summaryBreakdownSql = performanceBreakdownSql.map(({ axis, group, where }) => {
+  const source = 'summary_cube';
+  const groupSql = group(source);
+  return `
+  SELECT
+    '${axis}' AS axis,
+    'all' AS bucket,
+    ${groupSql} AS group_value,
+    SUM(${source}.requests) AS requests,
+    SUM(${source}.errors_with_output) + SUM(${source}.errors_no_output) AS errors,
+    SUM(${source}.ttft_samples_ok) + SUM(${source}.errors_with_output) AS ttft_samples,
+    SUM(${source}.tpot_samples) AS tpot_samples,
+    SUM(${source}.neutral) AS neutral
+  FROM ${source}
+  CROSS JOIN settings
+  ${where === undefined ? '' : `WHERE ${where(source)}`}
+  GROUP BY ${groupSql}`;
+});
+
+const summaryAggregateSql = boundedUnionAll([summarySeriesSql, ...summaryBreakdownSql]);
+
+const histogramSeriesSql = `
+  SELECT
+    'series' AS axis,
+    bucket_map.bucket,
+    ${seriesGroupSql('filtered_histogram')} AS group_value,
+    filtered_histogram.metric,
+    filtered_histogram.lower,
+    MAX(filtered_histogram.upper) AS upper,
+    SUM(filtered_histogram.count) AS count
+  FROM filtered_histogram
+  CROSS JOIN settings
+  JOIN bucket_map ON bucket_map.hour = filtered_histogram.hour
+  WHERE ${seriesWhereSql('filtered_histogram')}
+  GROUP BY bucket_map.bucket, group_value, filtered_histogram.metric, filtered_histogram.lower`;
+
+const histogramBreakdownSql = performanceBreakdownSql.map(({ axis, group, where }) => {
+  const source = 'histogram_cube';
+  const groupSql = group(source);
+  return `
+  SELECT
+    '${axis}' AS axis,
+    'all' AS bucket,
+    ${groupSql} AS group_value,
+    ${source}.metric,
+    ${source}.lower,
+    MAX(${source}.upper) AS upper,
+    SUM(${source}.count) AS count
+  FROM ${source}
+  CROSS JOIN settings
+  ${where === undefined ? '' : `WHERE ${where(source)}`}
+  GROUP BY ${groupSql}, ${source}.metric, ${source}.lower`;
+});
+
+const histogramAggregateSql = boundedUnionAll([histogramSeriesSql, ...histogramBreakdownSql]);
+
+const facetRowsSql = boundedUnionAll(performanceBreakdownSql
+  .filter(({ axis }) => axis !== 'none')
+  .map(({ axis, group, where }) => {
+    const source = 'scoped_summary';
+    const groupSql = group(source);
+    return `SELECT 'facet' AS row_kind, NULL AS axis, NULL AS bucket, NULL AS group_value,
+    '${axis}' AS dimension, ${groupSql} AS facet_value,
+    NULL AS requests_text, NULL AS errors_text, NULL AS ttft_samples_text,
+    NULL AS tpot_samples_text, NULL AS neutral_text,
+    NULL AS ttft_ms_p50, NULL AS ttft_ms_p95, NULL AS ttft_ms_p99,
+    NULL AS tpot_us_p50, NULL AS tpot_us_p95, NULL AS tpot_us_p99
+  FROM ${source}
+  CROSS JOIN settings
+  ${where === undefined ? '' : `WHERE ${where(source)}`}
+  GROUP BY ${groupSql}`;
+  }));
 
 const performanceCubeDimensions = [
   'key_id', 'user_id', 'owned', 'model', 'upstream', 'operation', 'runtime_location',
@@ -69,22 +192,8 @@ const performanceCubeCoordinateSql = performanceCubeDimensions.join(', ');
 
 const overviewSql = (scoped: boolean) => `/* performance-overview */
 WITH
-settings(actor_user_id, is_admin) AS (
-  VALUES (?, ?)
-),
--- workerd caps compound SELECTs at five terms. Keep the extensible overview
--- axes in data so every projection below needs at most two SELECT terms.
--- https://github.com/cloudflare/workerd/blob/c16efad94a926dff547d3e3d853feae4fc8988a6/src/workerd/util/sqlite.c%2B%2B#L1382-L1384
-axes(axis, grouping, bucketed, owned_only, admin_only, facet) AS (
-  VALUES
-    ('series', ?, 1, 0, 0, 0),
-    ('none', 'none', 0, 0, 0, 0),
-    ('keyId', 'keyId', 0, 1, 0, 1),
-    ('userId', 'userId', 0, 0, 1, 1),
-    ('model', 'model', 0, 0, 0, 1),
-    ('upstream', 'upstream', 0, 0, 0, 1),
-    ('operation', 'operation', 0, 0, 0, 1),
-    ('runtimeLocation', 'runtimeLocation', 0, 0, 0, 1)
+settings(actor_user_id, is_admin, series_group_by) AS (
+  VALUES (?, ?, ?)
 ),
 model_filter(value) AS MATERIALIZED (
   SELECT CAST(value AS TEXT) FROM json_each(?)
@@ -177,50 +286,8 @@ histogram_cube AS MATERIALIZED (
   FROM filtered_histogram
   GROUP BY ${performanceCubeCoordinateSql}, metric, lower
 ),
-summary_terms AS MATERIALIZED (
-  SELECT
-    axes.axis,
-    bucket_map.bucket,
-    ${axisGroupSql('filtered_summary')} AS group_value,
-    filtered_summary.requests,
-    filtered_summary.ttft_samples_ok,
-    filtered_summary.errors_with_output,
-    filtered_summary.errors_no_output,
-    filtered_summary.neutral,
-    filtered_summary.tpot_samples
-  FROM filtered_summary
-  CROSS JOIN axes
-  CROSS JOIN settings
-  JOIN bucket_map ON bucket_map.hour = filtered_summary.hour
-  WHERE axes.bucketed = 1 AND ${axisAccessSql('filtered_summary')}
-  UNION ALL
-  SELECT
-    axes.axis,
-    'all',
-    ${axisGroupSql('summary_cube')},
-    summary_cube.requests,
-    summary_cube.ttft_samples_ok,
-    summary_cube.errors_with_output,
-    summary_cube.errors_no_output,
-    summary_cube.neutral,
-    summary_cube.tpot_samples
-  FROM summary_cube
-  CROSS JOIN axes
-  CROSS JOIN settings
-  WHERE axes.bucketed = 0 AND ${axisAccessSql('summary_cube')}
-),
 summary_aggregates AS MATERIALIZED (
-  SELECT
-    axis,
-    bucket,
-    group_value,
-    SUM(requests) AS requests,
-    SUM(errors_with_output) + SUM(errors_no_output) AS errors,
-    SUM(ttft_samples_ok) + SUM(errors_with_output) AS ttft_samples,
-    SUM(tpot_samples) AS tpot_samples,
-    SUM(neutral) AS neutral
-  FROM summary_terms
-  GROUP BY axis, bucket, group_value
+  ${summaryAggregateSql}
 ),
 invalid_histogram_bounds AS MATERIALIZED (
   SELECT 1 AS present
@@ -229,45 +296,8 @@ invalid_histogram_bounds AS MATERIALIZED (
   HAVING COUNT(DISTINCT COALESCE(CAST(upper AS TEXT), 'null')) > 1
   LIMIT 1
 ),
-histogram_terms AS MATERIALIZED (
-  SELECT
-    axes.axis,
-    bucket_map.bucket,
-    ${axisGroupSql('filtered_histogram')} AS group_value,
-    filtered_histogram.metric,
-    filtered_histogram.lower,
-    filtered_histogram.upper,
-    filtered_histogram.count
-  FROM filtered_histogram
-  CROSS JOIN axes
-  CROSS JOIN settings
-  JOIN bucket_map ON bucket_map.hour = filtered_histogram.hour
-  WHERE axes.bucketed = 1 AND ${axisAccessSql('filtered_histogram')}
-  UNION ALL
-  SELECT
-    axes.axis,
-    'all',
-    ${axisGroupSql('histogram_cube')},
-    histogram_cube.metric,
-    histogram_cube.lower,
-    histogram_cube.upper,
-    histogram_cube.count
-  FROM histogram_cube
-  CROSS JOIN axes
-  CROSS JOIN settings
-  WHERE axes.bucketed = 0 AND ${axisAccessSql('histogram_cube')}
-),
 histogram AS MATERIALIZED (
-  SELECT
-    axis,
-    bucket,
-    group_value,
-    metric,
-    lower,
-    MAX(upper) AS upper,
-    SUM(count) AS count
-  FROM histogram_terms
-  GROUP BY axis, bucket, group_value, metric, lower
+  ${histogramAggregateSql}
 ),
 ranked_histogram AS MATERIALIZED (
   SELECT
@@ -342,17 +372,7 @@ aggregate_rows AS (
   LEFT JOIN percentile_values USING (axis, bucket, group_value)
 ),
 facet_rows AS (
-  SELECT 'facet' AS row_kind, NULL AS axis, NULL AS bucket, NULL AS group_value,
-    axes.axis AS dimension, ${axisGroupSql('scoped_summary')} AS facet_value,
-    NULL AS requests_text, NULL AS errors_text, NULL AS ttft_samples_text,
-    NULL AS tpot_samples_text, NULL AS neutral_text,
-    NULL AS ttft_ms_p50, NULL AS ttft_ms_p95, NULL AS ttft_ms_p99,
-    NULL AS tpot_us_p50, NULL AS tpot_us_p95, NULL AS tpot_us_p99
-  FROM scoped_summary
-  CROSS JOIN axes
-  CROSS JOIN settings
-  WHERE axes.facet = 1 AND ${axisAccessSql('scoped_summary')}
-  GROUP BY axes.axis, facet_value
+  ${facetRowsSql}
 ),
 orphan_rows AS (
   SELECT 'orphan' AS row_kind,


### PR DESCRIPTION
## Summary

- bound every generated Performance overview compound SELECT to workerd's five-term limit while preserving the existing per-axis aggregate query plan
- route summary, histogram, and facet term generation through one recursive builder, so adding future dimensions cannot recreate this D1 prepare failure
- apply the existing D1 SQL-shape verifier to the captured Performance overview query, closing the sql.js/D1 coverage gap left after #415

## Root cause

The Performance SQL aggregation introduced in #402 contains three independently invalid compounds:

- summary aggregates: 8 terms (`series` plus 7 breakdown axes)
- histogram aggregates: 8 terms
- facets: 6 terms

workerd sets `SQLITE_LIMIT_COMPOUND_SELECT` to 5. D1 therefore rejects the entire statement during prepare with `too many terms in compound SELECT`, before filters or stored data can affect execution. #415 fixed the analogous six-term Usage axis catalog and added the repository verifier, but the Performance query did not use that verifier.

The fix builds a recursive tree of compound SELECTs where every node has at most five terms. It retains the existing cube aggregation and per-axis SELECTs; the final wire compound remains at its valid five-term boundary.

Primary evidence:

- [workerd sets the limit to 5](https://github.com/cloudflare/workerd/blob/c16efad94a926dff547d3e3d853feae4fc8988a6/src/workerd/util/sqlite.c%2B%2B#L1382-L1384)
- [workerd's boundary test accepts 5 terms and rejects 6 with this error](https://github.com/cloudflare/workerd/blob/c16efad94a926dff547d3e3d853feae4fc8988a6/src/workerd/api/tests/sql-test.js#L479-L492)

## Benchmark

The benchmark uses 34,560 synthetic Performance telemetry rows in the current schema: 11,520 summary rows plus 23,040 histogram rows, covering 30 days, two API keys, eight models, four upstreams, three operations, three runtime locations, and hourly buckets. Each measurement uses an administrator's unfiltered `group_by=model` overview, 3 warmups, 15 measured warm-cache runs, and a separate clean worktree for `main`.

Local sql.js A/B isolates the query-shape change:

| Range | `main` median / p95 | Branch median / p95 | Median change |
| --- | ---: | ---: | ---: |
| 24h | 28.52 / 29.30 ms | 29.02 / 29.78 ms | +1.7% (+0.50 ms) |
| 7d | 92.53 / 99.29 ms | 94.03 / 94.92 ms | +1.6% (+1.50 ms) |
| 30d | 341.85 / 354.08 ms | 351.24 / 354.54 ms | +2.7% (+9.39 ms) |

The response SHA-256 matches between `main` and the branch for every range:

- 24h: `2da60e43bd048d48373439dfe30d3f971f7f53e5421c2e84f7a8aa0313fadec7`
- 7d: `905576ebadbdbf4f44672e82f39405eb82cf6dad8a07f6c6c0233f6456e77e3a`
- 30d: `0460f4885e2cd0e9c0df2e3e09cca84492e93ef9297c320ee3dfca7b361d3102`

The fixed query was also executed end-to-end through local workerd/D1 against the same data. `main` returns HTTP 500 with the reported D1 prepare error; the branch completes every measured run:

| Range | Branch median / p95 | Response SHA-256 |
| --- | ---: | --- |
| 24h | 18.77 / 20.10 ms | `2da60e43bd048d48373439dfe30d3f971f7f53e5421c2e84f7a8aa0313fadec7` |
| 7d | 59.87 / 63.49 ms | `905576ebadbdbf4f44672e82f39405eb82cf6dad8a07f6c6c0233f6456e77e3a` |
| 30d | 218.93 / 221.82 ms | `0460f4885e2cd0e9c0df2e3e09cca84492e93ef9297c320ee3dfca7b361d3102` |

## Test Plan

- [x] local workerd/D1 reproduces the exact `D1_ERROR: too many terms in compound SELECT: SQLITE_ERROR` on `main`
- [x] local workerd/D1 prepares and executes the fixed Performance overview across 24h, 7d, and 30d windows
- [x] Performance SQL matches the in-memory oracle across every grouping and filter
- [x] captured Performance SQL passes the D1 compound SELECT verifier
- [x] `pnpm test` — 516 files, 5,425 tests passed
- [x] `pnpm typecheck`
- [x] `pnpm run check:agent-protocol`
- [x] `pnpm lint`
- [x] `git diff --check`


