### PR TITLE
fix(web): open new models in editor

### DIFF
--- a/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
@@ -76,6 +76,16 @@ const deleteCommandStem = i18n.t('dashboard.upstreamEditor.models.deleteNamed', 
 const deleteCommands = () => screen.getAllByLabelText(new RegExp(`^${deleteCommandStem}`));
 
 describe('upstream model workspace field-array transitions', () => {
+  it('opens a newly added model in the detail editor', async () => {
+    renderInApp(<Harness />);
+    const table = screen.getByRole('table', { name: models('title') });
+
+    fireEvent.click(screen.getByRole('button', { name: models('add') }));
+
+    await waitFor(() => expect(table.isConnected).toBe(false));
+    expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('');
+  });
+
   it('returns from a model detail to the model list', async () => {
     renderInApp(<Harness />);
     const table = screen.getByRole('table', { name: models('title') });
@@ -92,6 +102,7 @@ describe('upstream model workspace field-array transitions', () => {
     expect(deleteCommands()).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: models('add') }));
+    fireEvent.click(screen.getByRole('button', { name: models('back') }));
     expect(deleteCommands()).toHaveLength(3);
     fireEvent.click(deleteCommands()[2]!);
     fireEvent.click(await screen.findByRole('button', { name: models('deleteConfirm') }));

--- a/apps/web/src/components/upstream-editor/workspace.tsx
+++ b/apps/web/src/components/upstream-editor/workspace.tsx
@@ -241,6 +241,10 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
   const filtered = rows.filter(row => `${row.config.display_name ?? ''} ${publicModelId(row.config)} ${row.config.upstreamModelId}`.toLowerCase().includes(search.toLowerCase()));
 
   const setEnabled = (id: string, enabled: boolean) => setValue('disabledPublicModelIds', enabled ? disabled.filter(item => item !== id) : [...new Set([...disabled, id])], { shouldDirty: true });
+  const addModel = () => {
+    append({ upstreamModelId: '', kind: 'chat', ...shapeForKind('chat', { endpoints: {} }) });
+    onSelectUpstreamModel('');
+  };
   // A one-shot handoff, not synchronised state: the placeholder is dropped
   // once the row the pending manual model produced exists.
   const settledManualRow = pendingManualUpstreamModelId === null
@@ -333,7 +337,7 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
       level={2}
       title={t('dashboard.upstreamEditor.models.title')}
       actions={<>
-        {!readOnly && <Button appearance="primary" icon={<AddRegular />} onClick={() => append({ upstreamModelId: '', kind: 'chat', ...shapeForKind('chat', { endpoints: {} }) })}>{t('dashboard.upstreamEditor.models.add')}</Button>}
+        {!readOnly && <Button appearance="primary" icon={<AddRegular />} onClick={addModel}>{t('dashboard.upstreamEditor.models.add')}</Button>}
         {!readOnly && <Button className="!min-w-[160px]" icon={<CodeRegular />} onClick={() => onViewChange('yaml')}>{t('dashboard.upstreamEditor.models.editAsYaml')}</Button>}
         {record.kind !== 'azure' && <>
           <ModelsCacheStatus cache={record.modelsCache} />


### PR DESCRIPTION
## Summary

- open a newly appended manual model directly in its detail editor
- preserve delete and YAML field-array transitions after returning to the list
- cover the add-to-detail interaction with a regression test

## Test Plan

- [x] `pnpm --filter @floway-dev/web exec vitest run __tests__/components/upstream-editor/workspace-interactions_test.tsx`
- [x] Verify workflow: lint, typecheck, test, installers, generated assets, agent protocol, and Web build