### PR TITLE
fix(web): keep model edits anchored to rows

### DIFF
--- a/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
@@ -86,6 +86,20 @@ describe('upstream model workspace field-array transitions', () => {
     expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('');
   });
 
+  it('keeps a newly added model open while its upstream ID changes', async () => {
+    renderInApp(<Harness />);
+    const table = screen.getByRole('table', { name: models('title') });
+
+    fireEvent.click(screen.getByRole('button', { name: models('add') }));
+    const input = screen.getByRole('textbox', { name: models('upstreamId') });
+    fireEvent.change(input, { target: { value: 'm' } });
+
+    await waitFor(() => expect(screen.queryByRole('table', { name: models('title') })).toBe(null));
+    expect(table.isConnected).toBe(false);
+    fireEvent.change(screen.getByRole('textbox', { name: models('upstreamId') }), { target: { value: 'model-new' } });
+    expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('model-new');
+  });
+
   it('returns from a model detail to the model list', async () => {
     renderInApp(<Harness />);
     const table = screen.getByRole('table', { name: models('title') });

--- a/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
@@ -76,6 +76,16 @@ const deleteCommandStem = i18n.t('dashboard.upstreamEditor.models.deleteNamed', 
 const deleteCommands = () => screen.getAllByLabelText(new RegExp(`^${deleteCommandStem}`));
 
 describe('upstream model workspace field-array transitions', () => {
+  it('opens a newly added model in the detail editor', async () => {
+    renderInApp(<Harness />);
+    const table = screen.getByRole('table', { name: models('title') });
+
+    fireEvent.click(screen.getByRole('button', { name: models('add') }));
+
+    await waitFor(() => expect(table.isConnected).toBe(false));
+    expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('');
+  });
+
   it('returns from a model detail to the model list', async () => {
     renderInApp(<Harness />);
     const table = screen.getByRole('table', { name: models('title') });
@@ -92,6 +102,7 @@ describe('upstream model workspace field-array transitions', () => {
     expect(deleteCommands()).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: models('add') }));
+    fireEvent.click(screen.getByRole('button', { name: models('back') }));
     expect(deleteCommands()).toHaveLength(3);
     fireEvent.click(deleteCommands()[2]!);
     fireEvent.click(await screen.findByRole('button', { name: models('deleteConfirm') }));

--- a/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
@@ -106,6 +106,33 @@ describe('upstream model workspace field-array transitions', () => {
     expect(screen.getByRole('textbox', { name: models('upstreamId') })).toBe(input);
   });
 
+  it('keeps temporarily duplicate IDs attached to separate rows while swapping them', async () => {
+    renderInApp(<Harness />);
+
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('dashboard.upstreamEditor.models.editNamed', { name: 'model-a' }) }));
+    const firstInput = screen.getByRole('textbox', { name: models('upstreamId') });
+    fireEvent.change(firstInput, { target: { value: 'model-b' } });
+    fireEvent.blur(firstInput);
+    expect(screen.getByRole('textbox', { name: models('upstreamId') })).toBe(firstInput);
+    fireEvent.click(screen.getByRole('button', { name: models('back') }));
+
+    await screen.findByRole('table', { name: models('title') });
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('dashboard.upstreamEditor.models.editNamed', { name: 'model-b' }) }));
+    const secondInput = screen.getByRole('textbox', { name: models('upstreamId') });
+    expect(secondInput).not.toBe(firstInput);
+    fireEvent.change(secondInput, { target: { value: 'model-a' } });
+    fireEvent.blur(secondInput);
+    expect(screen.getByRole('textbox', { name: models('upstreamId') })).toBe(secondInput);
+    fireEvent.click(screen.getByRole('button', { name: models('back') }));
+
+    await screen.findByRole('table', { name: models('title') });
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('dashboard.upstreamEditor.models.editNamed', { name: 'model-a' }) }));
+    expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('model-b');
+    fireEvent.click(screen.getByRole('button', { name: models('back') }));
+    fireEvent.click(await screen.findByRole('button', { name: i18n.t('dashboard.upstreamEditor.models.editNamed', { name: 'model-b' }) }));
+    expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('model-a');
+  });
+
   it('prevents returning to the list from an incomplete new model', () => {
     renderInApp(<Harness />);
 

--- a/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
@@ -86,18 +86,34 @@ describe('upstream model workspace field-array transitions', () => {
     expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('');
   });
 
-  it('keeps a newly added model open while its upstream ID changes', async () => {
+  it('keeps the same focused input while a new model ID changes', async () => {
     renderInApp(<Harness />);
     const table = screen.getByRole('table', { name: models('title') });
 
     fireEvent.click(screen.getByRole('button', { name: models('add') }));
     const input = screen.getByRole('textbox', { name: models('upstreamId') });
+    input.focus();
     fireEvent.change(input, { target: { value: 'm' } });
 
     await waitFor(() => expect(screen.queryByRole('table', { name: models('title') })).toBe(null));
     expect(table.isConnected).toBe(false);
-    fireEvent.change(screen.getByRole('textbox', { name: models('upstreamId') }), { target: { value: 'model-new' } });
-    expect((screen.getByRole('textbox', { name: models('upstreamId') }) as HTMLInputElement).value).toBe('model-new');
+    expect(screen.getByRole('textbox', { name: models('upstreamId') })).toBe(input);
+    expect(document.activeElement).toBe(input);
+    fireEvent.change(input, { target: { value: 'model-new' } });
+    expect(screen.getByRole('textbox', { name: models('upstreamId') })).toBe(input);
+    expect((input as HTMLInputElement).value).toBe('model-new');
+    fireEvent.blur(input);
+    expect(screen.getByRole('textbox', { name: models('upstreamId') })).toBe(input);
+  });
+
+  it('prevents returning to the list from an incomplete new model', () => {
+    renderInApp(<Harness />);
+
+    fireEvent.click(screen.getByRole('button', { name: models('add') }));
+    fireEvent.click(screen.getByRole('button', { name: models('back') }));
+
+    expect(screen.queryByRole('table', { name: models('title') })).toBe(null);
+    expect(screen.getByRole('textbox', { name: models('upstreamId') })).toBeTruthy();
   });
 
   it('returns from a model detail to the model list', async () => {
@@ -116,6 +132,7 @@ describe('upstream model workspace field-array transitions', () => {
     expect(deleteCommands()).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: models('add') }));
+    fireEvent.change(screen.getByRole('textbox', { name: models('upstreamId') }), { target: { value: 'temporary' } });
     fireEvent.click(screen.getByRole('button', { name: models('back') }));
     expect(deleteCommands()).toHaveLength(3);
     fireEvent.click(deleteCommands()[2]!);

--- a/apps/web/src/components/upstream-editor/model-detail.tsx
+++ b/apps/web/src/components/upstream-editor/model-detail.tsx
@@ -35,6 +35,7 @@ export function ModelDetail({
   onChange,
   onDelete,
   onSourceChange,
+  onUpstreamModelIdCommit,
   readOnly,
   record,
   row,
@@ -44,6 +45,7 @@ export function ModelDetail({
   onChange: (value: UpstreamModelConfig) => void;
   onDelete: () => void;
   onSourceChange: (source: 'auto' | 'manual') => void;
+  onUpstreamModelIdCommit: (upstreamModelId: string) => void;
   readOnly: boolean;
   record: UpstreamRecord;
   row: ModelRow;
@@ -127,7 +129,7 @@ export function ModelDetail({
               </Dropdown>
             </Field>
             <Field className="min-w-0" label={record.kind === 'azure' ? t('dashboard.upstreamEditor.models.deployment') : t('dashboard.upstreamEditor.models.upstreamId')}>
-              <Input className="!w-full font-mono" placeholder={record.kind === 'azure' ? t('dashboard.upstreamEditor.models.deploymentPlaceholder') : t('dashboard.upstreamEditor.models.upstreamIdPlaceholder')} readOnly={fieldsReadOnly || row.hasAuto} value={row.config.upstreamModelId} onChange={(_, data) => patch({ upstreamModelId: data.value })} />
+              <Input className="!w-full font-mono" placeholder={record.kind === 'azure' ? t('dashboard.upstreamEditor.models.deploymentPlaceholder') : t('dashboard.upstreamEditor.models.upstreamIdPlaceholder')} readOnly={fieldsReadOnly || row.hasAuto} value={row.config.upstreamModelId} onBlur={() => onUpstreamModelIdCommit(row.config.upstreamModelId)} onChange={(_, data) => patch({ upstreamModelId: data.value })} />
             </Field>
             <Field className="min-w-0" label={t('dashboard.upstreamEditor.models.publicId')}>
               <Input className="!w-full font-mono" placeholder={row.config.upstreamModelId || t('dashboard.upstreamEditor.models.publicIdPlaceholder')} readOnly={fieldsReadOnly} value={row.config.publicModelId ?? ''} onChange={(_, data) => patch({ publicModelId: data.value || undefined })} />

--- a/apps/web/src/components/upstream-editor/workspace.tsx
+++ b/apps/web/src/components/upstream-editor/workspace.tsx
@@ -7,7 +7,7 @@ import {
   EditRegular,
   WarningRegular,
 } from '@fluentui/react-icons';
-import { lazy, Suspense, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { useSearchParams } from 'react-router';
 
@@ -15,7 +15,7 @@ import type { ModelListingFailure, ModelRow, UpstreamEditorValues } from './data
 import { canFetchModelCatalog, manualModelsSupported, publicModelId } from './data';
 import { shapeForKind } from './endpoints';
 import { FeatureFlagsEditor } from './feature-flags';
-import { ModelDetail } from './model-detail';
+import { ModelDetail, modelsAreValid } from './model-detail';
 import { parseModels, serializeModels } from './models-yaml';
 import type { UpstreamRecord } from '../../api/types';
 import { fluentComponents } from '../../fluent';
@@ -71,6 +71,11 @@ interface WorkspaceLocation {
   section: ModelDetailTab;
   view: 'list' | 'yaml';
 }
+interface ModelSelection {
+  locator: string;
+  manualIndex: number | null;
+  rowKey: string | null;
+}
 
 const TAB_PARAM = 'tab';
 const MODEL_PARAM = 'model';
@@ -95,7 +100,7 @@ export function UpstreamWorkspace({
 }) {
   const { t } = useTranslation();
   const dangerText = useDangerTextClass();
-  const { formState: { errors } } = useFormContext<UpstreamEditorValues>();
+  const { formState: { errors }, getValues } = useFormContext<UpstreamEditorValues>();
   const [params, setParams] = useSearchParams();
   const rewrite = useEntryRewrite();
   // The YAML text is a projection of the manual models — serialized on the way
@@ -104,10 +109,12 @@ export function UpstreamWorkspace({
   // every entrance into the view show the same text: there is nothing for a
   // link, a reload or the button to remember to seed.
   const [yamlDraft, setYamlDraft] = useState<YamlDraft | null>(null);
+  const [modelSelection, setModelSelection] = useState<ModelSelection | null>(null);
   const workspaceScrollRef = useRef<HTMLDivElement>(null);
 
-  // A model is named in the URL by its upstream id: row keys are rebuilt per
-  // render for manual entries and do not survive a reload.
+  // The URL uses the upstream id as a durable locator. Once resolved, the
+  // mounted editor keeps the field-array row identity separately so editing
+  // that id cannot replace the form subtree holding focus and selection.
   const tab = params.get(TAB_PARAM) === 'flags' ? 'flags' : 'models';
   const selectedUpstreamModelId = params.get(MODEL_PARAM);
   // A provider-owned catalog has no manual models to write, so its editor is
@@ -148,16 +155,36 @@ export function UpstreamWorkspace({
     section: 'details',
     view: next === 'yaml' ? 'yaml' : 'list',
   });
-  const selectModel = (id: string | null) => navigate({ tab, model: id, section: 'details', view: 'list' });
+  const openModel = (selection: ModelSelection | null) => {
+    setModelSelection(selection);
+    navigate({ tab, model: selection?.locator ?? null, section: 'details', view: 'list' });
+  };
+  const selectedManualIndex = modelSelection
+    ? modelSelection.manualIndex
+    : selectedUpstreamModelId === null
+      ? null
+      : getValues('manualModels').findIndex(model => model.upstreamModelId === selectedUpstreamModelId);
+  const leaveModel = () => {
+    if (selectedManualIndex !== null && selectedManualIndex >= 0) {
+      const model = getValues('manualModels')[selectedManualIndex];
+      if (model && !modelsAreValid([model])) return;
+    }
+    openModel(null);
+  };
+  const commitModelLocator = (upstreamModelId: string) => {
+    if (!modelSelection || upstreamModelId === modelSelection.locator) return;
+    setModelSelection({ ...modelSelection, locator: upstreamModelId });
+    navigate({ tab, model: upstreamModelId, section: modelDetailTab, view: 'list' });
+  };
   useLayoutEffect(() => {
     workspaceScrollRef.current?.scrollTo({ left: 0, top: 0 });
   }, [modelDetailTab, modelView, tab]);
-  const modelsWorkspace = <ModelsWorkspace detailSection={modelDetailTab} onSelectUpstreamModel={selectModel} selectedUpstreamModelId={selectedUpstreamModelId} discovered={discovered} modelsLoading={modelsLoading} modelsError={modelsError} onRefreshModels={onRefreshModels} onViewChange={changeModelView} readOnly={!editableCatalog} record={record} view={modelView} yamlDraft={yamlDraft} onYamlDraftChange={setYamlDraft} />;
+  const modelsWorkspace = <ModelsWorkspace detailSection={modelDetailTab} modelSelection={modelSelection} onModelLocatorCommit={commitModelLocator} onModelSelectionChange={setModelSelection} onOpenModel={openModel} selectedUpstreamModelId={selectedUpstreamModelId} discovered={discovered} modelsLoading={modelsLoading} modelsError={modelsError} onRefreshModels={onRefreshModels} onViewChange={changeModelView} readOnly={!editableCatalog} record={record} view={modelView} yamlDraft={yamlDraft} onYamlDraftChange={setYamlDraft} />;
   return <section className="grid grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] h-full min-h-0 min-w-0 max-[1050px]:h-auto">
     <div className="flex items-center gap-2 border-0 border-b border-solid border-fui-divider px-5 pt-2">
       {showModelDetail
         ? <>
-            <BackNavigationButton onClick={() => selectModel(null)}>{t('dashboard.upstreamEditor.models.back')}</BackNavigationButton>
+            <BackNavigationButton onClick={leaveModel}>{t('dashboard.upstreamEditor.models.back')}</BackNavigationButton>
             <TabList aria-label={t('dashboard.upstreamEditor.models.sections')} selectedValue={modelDetailTab} onTabSelect={(_, data) => navigate({ tab, model: selectedUpstreamModelId, section: data.value as ModelDetailTab, view: 'list' })}>
               <Tab value="details">{t('dashboard.upstreamEditor.models.details')}</Tab>
               <Tab value="flags">{t('dashboard.upstreamEditor.models.flags')}</Tab>
@@ -190,13 +217,16 @@ export function UpstreamWorkspace({
   </section>;
 }
 
-function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading, onRefreshModels, onSelectUpstreamModel, onViewChange, onYamlDraftChange, readOnly, record, selectedUpstreamModelId, view, yamlDraft }: {
+function ModelsWorkspace({ detailSection, discovered, modelSelection, modelsError, modelsLoading, onModelLocatorCommit, onModelSelectionChange, onOpenModel, onRefreshModels, onViewChange, onYamlDraftChange, readOnly, record, selectedUpstreamModelId, view, yamlDraft }: {
   detailSection: ModelDetailTab;
   discovered: UpstreamModelConfig[];
+  modelSelection: ModelSelection | null;
   modelsError: ModelListingFailure | null;
   modelsLoading: boolean;
+  onModelLocatorCommit: (upstreamModelId: string) => void;
   onRefreshModels: () => void;
-  onSelectUpstreamModel: (id: string | null) => void;
+  onModelSelectionChange: (selection: ModelSelection) => void;
+  onOpenModel: (selection: ModelSelection | null) => void;
   onViewChange: (view: ModelView) => void;
   onYamlDraftChange: (draft: YamlDraft) => void;
   readOnly: boolean;
@@ -229,7 +259,11 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
     for (const item of visibleDiscovered) if (!manualIds.has(item.upstreamModelId)) result.push({ key: `auto:${item.upstreamModelId}`, source: 'auto', config: item, manualIndex: null, hasAuto: true });
     return result;
   }, [autoFetchEnabled, discovered, fields, manual]);
-  const selectedRow = rows.find(row => row.config.upstreamModelId === selectedUpstreamModelId) ?? null;
+  const sessionRow = modelSelection
+    ? rows.find(row => row.key === modelSelection.rowKey)
+      ?? (modelSelection.manualIndex === null ? undefined : rows.find(row => row.manualIndex === modelSelection.manualIndex))
+    : undefined;
+  const selectedRow = sessionRow ?? rows.find(row => row.config.upstreamModelId === selectedUpstreamModelId) ?? null;
   const pendingManualRow: ModelRow | null = pendingManualConfig === null ? null : {
     key: 'pending-manual',
     source: 'manual',
@@ -242,9 +276,15 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
 
   const setEnabled = (id: string, enabled: boolean) => setValue('disabledPublicModelIds', enabled ? disabled.filter(item => item !== id) : [...new Set([...disabled, id])], { shouldDirty: true });
   const addModel = () => {
+    const manualIndex = manual.length;
     append({ upstreamModelId: '', kind: 'chat', ...shapeForKind('chat', { endpoints: {} }) });
-    onSelectUpstreamModel('');
+    onOpenModel({ locator: '', manualIndex, rowKey: null });
   };
+  useEffect(() => {
+    if (view !== 'detail' || selectedUpstreamModelId === null || !activeDetailRow) return;
+    if (modelSelection?.rowKey === activeDetailRow.key && modelSelection.manualIndex === activeDetailRow.manualIndex) return;
+    onModelSelectionChange({ locator: selectedUpstreamModelId, manualIndex: activeDetailRow.manualIndex, rowKey: activeDetailRow.key });
+  }, [activeDetailRow, modelSelection, onModelSelectionChange, selectedUpstreamModelId, view]);
   // A one-shot handoff, not synchronised state: the placeholder is dropped
   // once the row the pending manual model produced exists.
   const settledManualRow = pendingManualUpstreamModelId === null
@@ -261,17 +301,19 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
       setPendingManualUpstreamModelId(row.config.upstreamModelId);
       const manualConfig = structuredClone(row.config);
       setPendingManualConfig(manualConfig);
+      onModelSelectionChange({ locator: row.config.upstreamModelId, manualIndex: manual.length, rowKey: null });
       append(manualConfig);
       return;
     }
     if (source === 'auto' && row.manualIndex !== null && row.hasAuto) {
+      onModelSelectionChange({ locator: row.config.upstreamModelId, manualIndex: null, rowKey: `auto:${row.config.upstreamModelId}` });
       remove(row.manualIndex);
     }
   };
 
   const deleteModel = (target: ModelRow & { manualIndex: number }) => {
     remove(target.manualIndex);
-    if (selectedRow?.key === target.key) onSelectUpstreamModel(null);
+    if (selectedRow?.key === target.key) onOpenModel(null);
     deleteDialog.close();
   };
 
@@ -323,13 +365,12 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
     </div>{deleteConfirmation}</>;
   }
 
-  if (view === 'detail' && activeDetailRow) return <><ModelDetail section={detailSection} row={activeDetailRow} readOnly={readOnly} onDelete={() => deleteDialog.open(activeDetailRow)} onSourceChange={source => setModelSource(activeDetailRow, source)} onChange={value => {
+  if (view === 'detail' && activeDetailRow) return <><ModelDetail section={detailSection} row={activeDetailRow} readOnly={readOnly} onDelete={() => deleteDialog.open(activeDetailRow)} onSourceChange={source => setModelSource(activeDetailRow, source)} onUpstreamModelIdCommit={onModelLocatorCommit} onChange={value => {
     if (activeDetailRow.manualIndex === null) return;
     setValue(`manualModels.${activeDetailRow.manualIndex}`, value, {
       shouldDirty: true,
       shouldTouch: true,
     });
-    if (value.upstreamModelId !== activeDetailRow.config.upstreamModelId) onSelectUpstreamModel(value.upstreamModelId);
   }} record={record} upstreamFlags={upstreamFlags} />{deleteConfirmation}</>;
 
   return <><div className="grid grid-cols-[minmax(0,1fr)] gap-4 min-w-0">
@@ -361,7 +402,7 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
             <TableCentredCell><Switch aria-label={t('dashboard.upstreamEditor.models.enabledFor', { name: row.config.display_name ?? id })} checked={!disabled.includes(id)} onChange={(_, data) => setEnabled(id, data.checked)} /></TableCentredCell>
             <TableCell className="overflow-hidden">
               <TruncationTooltip content={row.config.display_name ?? id} relationship="label">
-                {measureRef => <RowTitleButton onClick={() => onSelectUpstreamModel(row.config.upstreamModelId)} ref={measureRef}>
+                {measureRef => <RowTitleButton onClick={() => onOpenModel({ locator: row.config.upstreamModelId, manualIndex: row.manualIndex, rowKey: row.key })} ref={measureRef}>
                   {row.config.display_name ?? id}
                 </RowTitleButton>}
               </TruncationTooltip>
@@ -369,7 +410,7 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
             <TableCentredCell>{t(`dashboard.upstreamEditor.models.kindValue.${row.config.kind}`)}</TableCentredCell>
             <TableCell className="overflow-hidden"><span className="flex items-center gap-1 min-w-0 max-w-full"><TruncationTooltip content={id} relationship="label">{measureRef => <code className="winui-focus-rect block min-w-0 max-w-[calc(100%-36px)] truncate leading-[var(--lineHeightBase300)]" ref={measureRef} tabIndex={0}>{id}</code>}</TruncationTooltip><TooltipIconButton className="flex-none" icon={copyOutcomeIcon(outcomeFor(id))} label={copyLabel(outcomeFor(id), t('dashboard.upstreamEditor.models.copy'))} onClick={() => copy(id, id)} /></span></TableCell>
             <TableCentredCell>{t(`dashboard.upstreamEditor.models.${row.source}`)}</TableCentredCell>
-            <TableCell><TableActions><TooltipIconButton icon={<EditRegular />} label={t('dashboard.upstreamEditor.models.editNamed', { name: row.config.display_name ?? id })} onClick={() => onSelectUpstreamModel(row.config.upstreamModelId)} />{row.manualIndex !== null && <TooltipIconButton danger icon={<DeleteRegular />} label={t('dashboard.upstreamEditor.models.deleteNamed', { name: row.config.display_name ?? id })} onClick={() => deleteDialog.open(row)} />}</TableActions></TableCell>
+            <TableCell><TableActions><TooltipIconButton icon={<EditRegular />} label={t('dashboard.upstreamEditor.models.editNamed', { name: row.config.display_name ?? id })} onClick={() => onOpenModel({ locator: row.config.upstreamModelId, manualIndex: row.manualIndex, rowKey: row.key })} />{row.manualIndex !== null && <TooltipIconButton danger icon={<DeleteRegular />} label={t('dashboard.upstreamEditor.models.deleteNamed', { name: row.config.display_name ?? id })} onClick={() => deleteDialog.open(row)} />}</TableActions></TableCell>
           </TableRow>;
         })}</TableBody>
       </Table>

--- a/apps/web/src/components/upstream-editor/workspace.tsx
+++ b/apps/web/src/components/upstream-editor/workspace.tsx
@@ -241,6 +241,10 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
   const filtered = rows.filter(row => `${row.config.display_name ?? ''} ${publicModelId(row.config)} ${row.config.upstreamModelId}`.toLowerCase().includes(search.toLowerCase()));
 
   const setEnabled = (id: string, enabled: boolean) => setValue('disabledPublicModelIds', enabled ? disabled.filter(item => item !== id) : [...new Set([...disabled, id])], { shouldDirty: true });
+  const addModel = () => {
+    append({ upstreamModelId: '', kind: 'chat', ...shapeForKind('chat', { endpoints: {} }) });
+    onSelectUpstreamModel('');
+  };
   // A one-shot handoff, not synchronised state: the placeholder is dropped
   // once the row the pending manual model produced exists.
   const settledManualRow = pendingManualUpstreamModelId === null
@@ -333,7 +337,7 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
       level={2}
       title={t('dashboard.upstreamEditor.models.title')}
       actions={<>
-        {!readOnly && <Button appearance="primary" icon={<AddRegular />} onClick={() => append({ upstreamModelId: '', kind: 'chat', ...shapeForKind('chat', { endpoints: {} }) })}>{t('dashboard.upstreamEditor.models.add')}</Button>}
+        {!readOnly && <Button appearance="primary" icon={<AddRegular />} onClick={addModel}>{t('dashboard.upstreamEditor.models.add')}</Button>}
         {!readOnly && <Button className="!min-w-[160px]" icon={<CodeRegular />} onClick={() => onViewChange('yaml')}>{t('dashboard.upstreamEditor.models.editAsYaml')}</Button>}
         {record.kind !== 'azure' && <>
           <ModelsCacheStatus cache={record.modelsCache} />

--- a/apps/web/src/components/upstream-editor/workspace.tsx
+++ b/apps/web/src/components/upstream-editor/workspace.tsx
@@ -112,9 +112,9 @@ export function UpstreamWorkspace({
   const [modelSelection, setModelSelection] = useState<ModelSelection | null>(null);
   const workspaceScrollRef = useRef<HTMLDivElement>(null);
 
-  // The URL uses the upstream id as a durable locator. Once resolved, the
-  // mounted editor keeps the field-array row identity separately so editing
-  // that id cannot replace the form subtree holding focus and selection.
+  // `model` is only a reloadable locator. The mounted editor uses the
+  // field-array row id, so renames and temporary duplicate ids cannot retarget
+  // or remount it.
   const tab = params.get(TAB_PARAM) === 'flags' ? 'flags' : 'models';
   const selectedUpstreamModelId = params.get(MODEL_PARAM);
   // A provider-owned catalog has no manual models to write, so its editor is

--- a/apps/web/src/components/upstream-editor/workspace.tsx
+++ b/apps/web/src/components/upstream-editor/workspace.tsx
@@ -329,6 +329,7 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
       shouldDirty: true,
       shouldTouch: true,
     });
+    if (value.upstreamModelId !== activeDetailRow.config.upstreamModelId) onSelectUpstreamModel(value.upstreamModelId);
   }} record={record} upstreamFlags={upstreamFlags} />{deleteConfirmation}</>;
 
   return <><div className="grid grid-cols-[minmax(0,1fr)] gap-4 min-w-0">


### PR DESCRIPTION
## Summary

- separate the reloadable URL model locator from the mounted editor's stable field-array row identity
- preserve the input node, focus, and selected row while an ID is renamed or temporarily duplicated
- synchronize the URL locator when the ID field loses focus
- prevent Back to models from leaving an invalid model draft

## Test Plan

- [x] `pnpm --filter @floway-dev/web exec vitest run __tests__/components/upstream-editor/workspace-interactions_test.tsx __tests__/components/upstream-editor/page-yaml-submit_test.tsx __tests__/components/upstream-editor/model-contract_test.ts`
- [x] Verify workflow run 31168956087: lint, typecheck, test, installers, generated assets, agent protocol, and Web build