### PR TITLE
fix(web): submit model YAML from the page action

### DIFF
--- a/apps/web/__tests__/components/upstream-editor/page-yaml-submit_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/page-yaml-submit_test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { forwardRef } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OutcomeToastProvider } from '../../../src/components/ui/outcome-toast';
+import { UpstreamEditorPage } from '../../../src/components/upstream-editor/page';
+import { i18n } from '../../../src/i18n';
+import { upstreamRecord } from '../../api/upstream-fixture';
+import { renderInApp } from '../../render';
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock('../../../src/api/client', () => ({
+  api: {
+    api: {
+      upstreams: {
+        ':id': {
+          $get: apiMocks.get,
+          $patch: apiMocks.patch,
+        },
+      },
+    },
+  },
+  callApi: (operation: () => unknown) => operation(),
+}));
+
+vi.mock('../../../src/components/upstream-editor/config-sidebar', () => ({
+  UpstreamConfigSidebar: () => null,
+}));
+
+vi.mock('../../../src/components/upstream-editor/models-yaml-editor', () => ({
+  default: ({ onChange, value }: { onChange: (value: string) => void; value: string }) => (
+    <textarea aria-label="YAML models" onChange={event => onChange(event.target.value)} value={value} />
+  ),
+}));
+
+vi.mock('../../../src/components/ui/scroll-area', () => ({
+  ScrollArea: forwardRef<HTMLDivElement, PropsWithChildren>(({ children }, ref) => <div ref={ref}>{children}</div>),
+}));
+
+const model = (id: string) => ({
+  upstreamModelId: id,
+  publicModelId: id,
+  display_name: id,
+  kind: 'chat' as const,
+  endpoints: { responses: {} },
+});
+
+const record = upstreamRecord('up_test', {
+  name: 'Test',
+  kind: 'custom',
+  config: {
+    baseUrl: 'https://example.com',
+    authStyle: 'bearer',
+    apiKey: '',
+    endpoints: { responses: {} },
+    ingressHeadersRules: [],
+    modelsFetch: { enabled: false },
+    models: [model('model-a')],
+  },
+  state: null,
+});
+
+const replacementYaml = '- upstreamModelId: replacement\n  publicModelId: replacement\n  kind: chat\n  endpoints:\n    responses: {}\n';
+
+const renderPage = () => {
+  const router = createMemoryRouter([{
+    path: '/editor',
+    element: <OutcomeToastProvider><UpstreamEditorPage data={{
+      backoffs: [],
+      discovered: [],
+      mode: 'edit',
+      modelsError: null,
+      proxies: [],
+      record,
+      runtime: { kind: 'node', runtimeLocation: 'test' },
+      upstreams: [record],
+    }} /></OutcomeToastProvider>,
+  }], { initialEntries: ['/editor?view=yaml'] });
+  return renderInApp(<RouterProvider router={router} />);
+};
+
+describe('upstream editor YAML submission', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('enables the page save action and submits the YAML draft', async () => {
+    const saved = {
+      ...record,
+      config: { ...record.config, models: [model('replacement')] },
+    };
+    apiMocks.patch.mockResolvedValue({ data: saved, error: null });
+    apiMocks.get.mockResolvedValue({ data: saved, error: null });
+    renderPage();
+
+    const save = screen.getByRole('button', { name: i18n.t('dashboard.upstreamEditor.actions.save') }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(await screen.findByLabelText('YAML models'), { target: { value: replacementYaml } });
+    expect(save.disabled).toBe(false);
+    fireEvent.click(save);
+
+    await waitFor(() => expect(apiMocks.patch).toHaveBeenCalledWith({
+      json: expect.objectContaining({
+        config: expect.objectContaining({
+          models: [expect.objectContaining({ upstreamModelId: 'replacement' })],
+        }),
+      }),
+      param: { id: record.id },
+    }));
+  });
+
+  it('keeps invalid YAML in the editor and does not submit it', async () => {
+    renderPage();
+    const save = screen.getByRole('button', { name: i18n.t('dashboard.upstreamEditor.actions.save') }) as HTMLButtonElement;
+
+    fireEvent.change(await screen.findByLabelText('YAML models'), { target: { value: '- upstreamModelId: [' } });
+    fireEvent.click(save);
+
+    expect(apiMocks.patch).not.toHaveBeenCalled();
+    expect(await screen.findByText(/line 1, column 21/i)).toBeTruthy();
+    expect((screen.getByLabelText('YAML models') as HTMLTextAreaElement).value).toBe('- upstreamModelId: [');
+  });
+});

--- a/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
+++ b/apps/web/__tests__/components/upstream-editor/workspace-interactions_test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { MemoryRouter } from 'react-router';
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { ModelListingFailure, UpstreamEditorValues } from '../../../src/components/upstream-editor/data';
 import { valuesFromRecord } from '../../../src/components/upstream-editor/data';
-import { UpstreamWorkspace } from '../../../src/components/upstream-editor/workspace';
+import { UpstreamWorkspace, type ModelsYamlDraft } from '../../../src/components/upstream-editor/workspace';
 import { i18n } from '../../../src/i18n';
 import { upstreamRecord } from '../../api/upstream-fixture';
 import { renderInApp } from '../../render';
@@ -47,6 +47,7 @@ const record = upstreamRecord('up_test', {
 
 function Harness({ modelsError = null }: { modelsError?: ModelListingFailure | null }) {
   const form = useForm<UpstreamEditorValues>({ defaultValues: valuesFromRecord(record) });
+  const [modelsYamlDraft, setModelsYamlDraft] = useState<ModelsYamlDraft | null>(null);
   return (
     // The workspace reads which tab and which model it is on out of the search,
     // so it needs a router to read one from.
@@ -54,8 +55,10 @@ function Harness({ modelsError = null }: { modelsError?: ModelListingFailure | n
       <FormProvider {...form}>
         <UpstreamWorkspace
           discovered={[]}
+          modelsYamlDraft={modelsYamlDraft}
           modelsLoading={false}
           modelsError={modelsError}
+          onModelsYamlDraftChange={setModelsYamlDraft}
           onRefreshModels={vi.fn()}
           record={record}
         />

--- a/apps/web/src/components/upstream-editor/page.tsx
+++ b/apps/web/src/components/upstream-editor/page.tsx
@@ -18,7 +18,8 @@ import {
   type UpstreamEditorValues,
 } from './data';
 import { modelsAreValid } from './model-detail';
-import { UpstreamWorkspace } from './workspace';
+import { parseModels } from './models-yaml';
+import { UpstreamWorkspace, type ModelsYamlDraft } from './workspace';
 import { api, callApi } from '../../api/client';
 import type { UpstreamRecord } from '../../api/types';
 import { fluentComponents } from '../../fluent';
@@ -55,6 +56,7 @@ export function UpstreamEditorPage({ data }: { data: UpstreamEditorLoaderData })
   const [modelsError, setModelsError] = useState<ModelListingFailure | null>(data.modelsError);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [modelsYamlDraft, setModelsYamlDraft] = useState<ModelsYamlDraft | null>(null);
   // A create hands off to the created record's own route. The blocker reads the
   // form's saved state, so the hand-off is state rather than a call: naming the
   // id lets the navigation wait for the render that the save made clean instead
@@ -92,7 +94,8 @@ export function UpstreamEditorPage({ data }: { data: UpstreamEditorLoaderData })
     resolver: zodResolver(schema),
   });
   const { formState, getValues, handleSubmit, reset, setValue } = form;
-  const hasUnsavedChanges = formState.isDirty;
+  const hasPendingModelsYaml = modelsYamlDraft !== null && modelsYamlDraft.text !== modelsYamlDraft.baseline;
+  const hasUnsavedChanges = formState.isDirty || hasPendingModelsYaml;
 
   // The editor carries its own position — workspace tab, selected model, model
   // section, YAML view — in the search params of one route, so a move between
@@ -165,33 +168,44 @@ export function UpstreamEditorPage({ data }: { data: UpstreamEditorLoaderData })
     });
   };
 
-  const submitForm = () => handleSubmit(async values => {
-    setSaving(true); setSaveError(null);
-    // A save is one round-trip on create and two on edit, so it announces
-    // itself while it runs. The dashboard's toaster sits above the outlet, so
-    // the create branch's toast outlives the navigation that follows it.
-    const handle = toasts.start(t('dashboard.upstreamEditor.toast.saving', { name: values.name }));
-    const result = data.mode === 'create'
-      ? await callApi(() => api.api.upstreams.$post({ json: createBody(record, values) }))
-      : await callApi(() => api.api.upstreams[':id'].$patch({ param: { id: record.id }, json: updateBody(record, values) }));
-    if (result.error) { handle.settle(); setSaving(false); setSaveError(result.error.message); return; }
-    let saved: UpstreamRecord = result.data;
-    if (data.mode === 'edit') {
-      const full = await callApi(() => api.api.upstreams[':id'].$get({ param: { id: record.id } }));
-      if (!full.error) saved = full.data;
+  const submitForm = () => {
+    if (modelsYamlDraft !== null) {
+      const parsed = parseModels(modelsYamlDraft.text, { allowRerank: record.kind === 'custom' });
+      if (!parsed.ok) {
+        setModelsYamlDraft({ ...modelsYamlDraft, error: parsed.message });
+        return;
+      }
+      setValue('manualModels', parsed.models, { shouldDirty: true, shouldTouch: true });
+      setModelsYamlDraft(null);
     }
-    updateRecord(saved);
-    reset(valuesFromRecord(saved));
-    handle.succeed(t('dashboard.upstreamEditor.toast.saved'));
-    // `saving` is left set on create: the created record's loader probes the
-    // provider for its catalog, so the page stays mounted and interactive
-    // across the hand-off, and a Save left live there posts a second create.
-    if (data.mode === 'create') setCreatedUpstreamId(saved.id); else setSaving(false);
-  }, () => {
-    // Field rejections render on the control that produced them; the
-    // page-level bar is only where a server says no.
-    setSaveError(null);
-  })();
+    return handleSubmit(async values => {
+      setSaving(true); setSaveError(null);
+      // A save is one round-trip on create and two on edit, so it announces
+      // itself while it runs. The dashboard's toaster sits above the outlet, so
+      // the create branch's toast outlives the navigation that follows it.
+      const handle = toasts.start(t('dashboard.upstreamEditor.toast.saving', { name: values.name }));
+      const result = data.mode === 'create'
+        ? await callApi(() => api.api.upstreams.$post({ json: createBody(record, values) }))
+        : await callApi(() => api.api.upstreams[':id'].$patch({ param: { id: record.id }, json: updateBody(record, values) }));
+      if (result.error) { handle.settle(); setSaving(false); setSaveError(result.error.message); return; }
+      let saved: UpstreamRecord = result.data;
+      if (data.mode === 'edit') {
+        const full = await callApi(() => api.api.upstreams[':id'].$get({ param: { id: record.id } }));
+        if (!full.error) saved = full.data;
+      }
+      updateRecord(saved);
+      reset(valuesFromRecord(saved));
+      handle.succeed(t('dashboard.upstreamEditor.toast.saved'));
+      // `saving` is left set on create: the created record's loader probes the
+      // provider for its catalog, so the page stays mounted and interactive
+      // across the hand-off, and a Save left live there posts a second create.
+      if (data.mode === 'create') setCreatedUpstreamId(saved.id); else setSaving(false);
+    }, () => {
+      // Field rejections render on the control that produced them; the
+      // page-level bar is only where a server says no.
+      setSaveError(null);
+    })();
+  };
 
   return <FormProvider {...form}>
     {/* A column rather than a row template: the error bar is only sometimes
@@ -225,7 +239,7 @@ export function UpstreamEditorPage({ data }: { data: UpstreamEditorLoaderData })
           />
         </Panel>
         <Panel className="min-h-0 min-w-0 overflow-hidden" padding="flush">
-          <UpstreamWorkspace record={record} discovered={discovered} modelsLoading={modelsLoading} modelsError={modelsError} onRefreshModels={() => void refreshModels()} />
+          <UpstreamWorkspace record={record} discovered={discovered} modelsLoading={modelsLoading} modelsError={modelsError} modelsYamlDraft={modelsYamlDraft} onModelsYamlDraftChange={setModelsYamlDraft} onRefreshModels={() => void refreshModels()} />
         </Panel>
       </div>
     </div>

--- a/apps/web/src/components/upstream-editor/workspace.tsx
+++ b/apps/web/src/components/upstream-editor/workspace.tsx
@@ -7,7 +7,7 @@ import {
   EditRegular,
   WarningRegular,
 } from '@fluentui/react-icons';
-import { lazy, Suspense, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 import { useSearchParams } from 'react-router';
 
@@ -61,7 +61,8 @@ const {
 type ModelView = 'list' | 'detail' | 'yaml';
 type WorkspaceTab = 'models' | 'flags';
 /** An edit typed into the YAML view and not yet applied, with whatever the last apply said about it. */
-interface YamlDraft {
+export interface ModelsYamlDraft {
+  baseline: string;
   text: string;
   error: string | null;
 }
@@ -82,14 +83,18 @@ const ModelsYamlEditor = lazy(() => import('./models-yaml-editor'));
 
 export function UpstreamWorkspace({
   discovered,
+  modelsYamlDraft,
   modelsError,
   modelsLoading,
+  onModelsYamlDraftChange,
   onRefreshModels,
   record,
 }: {
   discovered: UpstreamModelConfig[];
+  modelsYamlDraft: ModelsYamlDraft | null;
   modelsError: ModelListingFailure | null;
   modelsLoading: boolean;
+  onModelsYamlDraftChange: (draft: ModelsYamlDraft | null) => void;
   onRefreshModels: () => void;
   record: UpstreamRecord;
 }) {
@@ -103,7 +108,6 @@ export function UpstreamWorkspace({
   // an edit that has not been applied yet. Holding just that draft is what lets
   // every entrance into the view show the same text: there is nothing for a
   // link, a reload or the button to remember to seed.
-  const [yamlDraft, setYamlDraft] = useState<YamlDraft | null>(null);
   const workspaceScrollRef = useRef<HTMLDivElement>(null);
 
   // A model is named in the URL by its upstream id: row keys are rebuilt per
@@ -123,7 +127,9 @@ export function UpstreamWorkspace({
   // The draft lives exactly as long as the view it belongs to, and the view is
   // the URL rather than any mounted component. Leaving drops it, so re-entering
   // projects the models again instead of resurrecting an abandoned edit.
-  if (modelView !== 'yaml' && yamlDraft !== null) setYamlDraft(null);
+  useEffect(() => {
+    if (modelView !== 'yaml' && modelsYamlDraft !== null) onModelsYamlDraftChange(null);
+  }, [modelView, modelsYamlDraft, onModelsYamlDraftChange]);
 
   // Replace rather than push: moving around inside one editor is not a place
   // the back button should have to walk out of a step at a time.
@@ -152,7 +158,7 @@ export function UpstreamWorkspace({
   useLayoutEffect(() => {
     workspaceScrollRef.current?.scrollTo({ left: 0, top: 0 });
   }, [modelDetailTab, modelView, tab]);
-  const modelsWorkspace = <ModelsWorkspace detailSection={modelDetailTab} onSelectUpstreamModel={selectModel} selectedUpstreamModelId={selectedUpstreamModelId} discovered={discovered} modelsLoading={modelsLoading} modelsError={modelsError} onRefreshModels={onRefreshModels} onViewChange={changeModelView} readOnly={!editableCatalog} record={record} view={modelView} yamlDraft={yamlDraft} onYamlDraftChange={setYamlDraft} />;
+  const modelsWorkspace = <ModelsWorkspace detailSection={modelDetailTab} onSelectUpstreamModel={selectModel} selectedUpstreamModelId={selectedUpstreamModelId} discovered={discovered} modelsLoading={modelsLoading} modelsError={modelsError} onRefreshModels={onRefreshModels} onViewChange={changeModelView} readOnly={!editableCatalog} record={record} view={modelView} yamlDraft={modelsYamlDraft} onYamlDraftChange={onModelsYamlDraftChange} />;
   return <section className="grid grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] h-full min-h-0 min-w-0 max-[1050px]:h-auto">
     <div className="flex items-center gap-2 border-0 border-b border-solid border-fui-divider px-5 pt-2">
       {showModelDetail
@@ -198,12 +204,12 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
   onRefreshModels: () => void;
   onSelectUpstreamModel: (id: string | null) => void;
   onViewChange: (view: ModelView) => void;
-  onYamlDraftChange: (draft: YamlDraft) => void;
+  onYamlDraftChange: (draft: ModelsYamlDraft | null) => void;
   readOnly: boolean;
   record: UpstreamRecord;
   selectedUpstreamModelId: string | null;
   view: ModelView;
-  yamlDraft: YamlDraft | null;
+  yamlDraft: ModelsYamlDraft | null;
 }) {
   const { t } = useTranslation();
   const { control, setValue } = useFormContext<UpstreamEditorValues>();
@@ -290,13 +296,15 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
   />;
 
   if (view === 'yaml') {
-    const text = yamlDraft?.text ?? serializeModels(manual);
+    const baseline = yamlDraft?.baseline ?? serializeModels(manual);
+    const text = yamlDraft?.text ?? baseline;
     // A failed apply keeps the text as the draft, so the message stays attached
     // to the buffer that produced it.
     const applyAndLeave = () => {
       const parsed = parseModels(text, { allowRerank: record.kind === 'custom' });
-      if (!parsed.ok) { onYamlDraftChange({ text, error: parsed.message }); return; }
+      if (!parsed.ok) { onYamlDraftChange({ baseline, text, error: parsed.message }); return; }
       replace(parsed.models);
+      onYamlDraftChange(null);
       onViewChange('list');
     };
     return <><div className="grid grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto] h-full min-h-[480px] min-w-0">
@@ -312,7 +320,7 @@ function ModelsWorkspace({ detailSection, discovered, modelsError, modelsLoading
       </div>
       <div className="h-full min-h-0 overflow-hidden border-0 border-y border-solid border-fui-divider">
         <Suspense fallback={<ContentLoadingScreen label={t('common.loading')} />}>
-          <ModelsYamlEditor value={text} onChange={value => onYamlDraftChange({ text: value, error: null })} />
+          <ModelsYamlEditor value={text} onChange={value => onYamlDraftChange({ baseline, text: value, error: null })} />
         </Suspense>
       </div>
       {yamlDraft?.error && <div className="px-5 py-3"><OutcomeMessageBar>{yamlDraft.error}</OutcomeMessageBar></div>}


### PR DESCRIPTION
## Summary

- Lift the Models YAML draft into the upstream editor page so YAML edits participate in dirty-state tracking, navigation guards, and the page-level Save changes action.
- Parse and apply pending YAML before submitting the upstream form, while retaining invalid input in the editor with its validation error.
- Cover valid page-level YAML submission and invalid-draft rejection without coupling the tests to Monaco.

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (517 files, 5428 tests)
- [x] `pnpm run test:agent-setup-installers` (106 passed, 4 skipped)
- [x] `pnpm --filter @floway-dev/agent-setup run generate-assets --check`
- [x] `pnpm run check:agent-protocol`
- [x] `pnpm run build:web`
- [x] In headless Chrome, signed in to the local dashboard without credentials, edited a custom upstream as YAML, and persisted the YAML draft through the page action.