### PR TITLE
fix(web): keep CSS Color Level 4 out of browser output

### DIFF
--- a/apps/web/__tests__/components/ui/loading-screen-styles_test.ts
+++ b/apps/web/__tests__/components/ui/loading-screen-styles_test.ts
@@ -19,7 +19,7 @@ describe('the critical loading screen styles', () => {
       document.head.append(style);
       document.body.append(provider);
 
-      expect(getComputedStyle(spinner).backgroundColor).toBe('#ffffff00');
+      expect(getComputedStyle(spinner).backgroundColor).toBe('rgba(255, 255, 255, 0)');
     } finally {
       style.remove();
       provider.remove();

--- a/apps/web/__tests__/lib/color_test.ts
+++ b/apps/web/__tests__/lib/color_test.ts
@@ -1,7 +1,7 @@
 import { convertRgbToHsv, parseHex } from 'culori/fn';
 import { describe, expect, it } from 'vitest';
 
-import { alphaHex, blendHex, readableTone } from '../../src/lib/color';
+import { alphaColor, blendHex, readableTone } from '../../src/lib/color';
 import { hueBadgeTone } from '../../src/lib/hue';
 
 // The subject decides by contrast, so the assertions compute it independently
@@ -98,8 +98,6 @@ describe('readableTone', () => {
 describe('blendHex', () => {
   it('accepts Culori hex forms', () => {
     expect(blendHex('#f00', 1, '#fff')).toBe('#FF0000');
-    expect(blendHex('#f00', 0, '#0000')).toBe('#00000000');
-    expect(blendHex('#ff000080', 0.5, '#0000')).toBe('#FF000040');
   });
 
   it('returns the backdrop at zero alpha and the top colour at one', () => {
@@ -115,12 +113,13 @@ describe('blendHex', () => {
   it('rejects an unparseable value on either side', () => {
     expect(() => blendHex('nope', 0.5, '#FFFFFF')).toThrow(TypeError);
     expect(() => blendHex('#FF0000', 0.5, 'nope')).toThrow(TypeError);
+    expect(() => blendHex('#FF0000', 0.5, '#0000')).toThrow('Hex blending requires an opaque backdrop');
   });
 });
 
-describe('alphaHex', () => {
-  it('serializes the combined opacity through Culori', () => {
-    expect(alphaHex('#0000006B', 0.1)).toBe('#0000000B');
+describe('alphaColor', () => {
+  it('serializes the combined opacity with legacy rgba syntax', () => {
+    expect(alphaColor('#0000006B', 0.1)).toBe('rgba(0, 0, 0, 0.04)');
   });
 });
 

--- a/apps/web/__tests__/lib/legacy-css-color_test.ts
+++ b/apps/web/__tests__/lib/legacy-css-color_test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { toLegacyCssColor } from '../../src/lib/legacy-css-color';
+
+describe('legacy CSS color serialization', () => {
+  it.each([
+    ['#0000', 'rgba(0, 0, 0, 0)'],
+    ['#11223344', 'rgba(17, 34, 51, 0.266667)'],
+    ['rgb(1 2 3)', 'rgb(1, 2, 3)'],
+    ['rgb(1 2 3 / 50%)', 'rgba(1, 2, 3, 0.5)'],
+    ['hsl(120 50% 25% / .4)', 'hsla(120, 50%, 25%, .4)'],
+  ])('converts %s', (source, expected) => {
+    expect(toLegacyCssColor(source)).toBe(expected);
+  });
+
+  it('leaves legacy and non-color text untouched', () => {
+    const source = 'rgba(1, 2, 3, .5) var(--surface) #123456';
+    expect(toLegacyCssColor(source)).toBe(source);
+  });
+});

--- a/apps/web/__tests__/scripts/css-color-level-4_test.ts
+++ b/apps/web/__tests__/scripts/css-color-level-4_test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { findCssColorLevel4 } from '../../scripts/css-color-level-4';
+
+describe('CSS Color Level 4 browser boundary', () => {
+  it.each([
+    '#0000',
+    '#11223344',
+    'hwb(120 30% 50%)',
+    'lab(50% 40 30)',
+    'lch(50% 40 30)',
+    'oklab(50% 0.1 0.1)',
+    'oklch(50% 0.1 30)',
+    'color(display-p3 1 0 0)',
+    'rgb(255 0 0)',
+    'rgb(from red r g b)',
+    'hsl(120 50% 50% / 50%)',
+  ])('rejects %s', syntax => {
+    expect(findCssColorLevel4(`color: ${syntax};`)).toEqual([
+      expect.objectContaining({ syntax }),
+    ]);
+  });
+
+  it.each([
+    '#000000',
+    '#112233',
+    'rgb(255, 0, 0)',
+    'rgba(255, 0, 0, 0.5)',
+    'hsl(120, 50%, 50%)',
+    'hsla(120, 50%, 50%, 0.5)',
+    "{ mode: 'oklch', l: 0.7, c: 0.13, h: hue }",
+  ])('accepts %s', syntax => {
+    expect(findCssColorLevel4(`color: ${syntax};`)).toEqual([]);
+  });
+});

--- a/apps/web/__tests__/winui/folded-derivations_test.ts
+++ b/apps/web/__tests__/winui/folded-derivations_test.ts
@@ -1,4 +1,4 @@
-import { parseHex } from 'culori/fn';
+import { parse, parseHex } from 'culori';
 import { describe, expect, it } from 'vitest';
 
 import { blendHex } from '../../src/lib/color';
@@ -85,7 +85,7 @@ describe('folded winui derivations', () => {
     const schemes = declarationsByScheme(winuiTokenCss);
     // The rule appears once at the top level and once under the dark query, in
     // that order, and the source already carries an alpha of its own.
-    const declared = [...listCss.matchAll(/\[aria-disabled='true'\]\s*\{[^}]*?color:\s*(#[0-9a-f]{8})/g)].map(([, hex]) => hex);
+    const declared = [...listCss.matchAll(/\[aria-disabled='true'\]\s*\{[^}]*?color:\s*(rgba\([^)]+\))/g)].map(([, color]) => color);
     expect(declared).toHaveLength(2);
     const shares = statedShare(listCss, '--winui-text-fill-primary');
     expect(shares).toHaveLength(2);
@@ -93,10 +93,19 @@ describe('folded winui derivations', () => {
     const stale: string[] = [];
     for (const [index, scheme] of (['light', 'dark'] as const).entries()) {
       const source = resolve(schemes[index]!, '--winui-text-fill-primary');
-      const sourceAlpha = source.length === 9 ? parseInt(source.slice(7, 9), 16) / 255 : 1;
+      const sourceColor = parse(source);
+      const declaredColor = parse(declared[index]!);
+      if (sourceColor?.mode !== 'rgb' || declaredColor?.mode !== 'rgb') throw new TypeError('Expected RGB colors');
       const share = shares[index]!;
-      const expected = `${source.slice(0, 7)}${Math.round(sourceAlpha * share * 255).toString(16).padStart(2, '0')}`;
-      if (declared[index] !== expected) stale.push(`${scheme} disabled row is ${declared[index]}, but ${share * 100}% of ${source} is ${expected}`);
+      const expectedAlpha = Math.round((sourceColor.alpha ?? 1) * share * 255) / 255;
+      if (
+        declaredColor.r !== sourceColor.r
+        || declaredColor.g !== sourceColor.g
+        || declaredColor.b !== sourceColor.b
+        || Math.abs((declaredColor.alpha ?? 1) - expectedAlpha) > 0.000001
+      ) {
+        stale.push(`${scheme} disabled row is ${declared[index]}, but ${share * 100}% of ${source} has alpha ${expectedAlpha}`);
+      }
     }
     expect(stale).toEqual([]);
   });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "exports": {},
   "scripts": {
     "dev": "react-router dev",
-    "build": "react-router build && jiti scripts/check-web-monaco-lazy.ts && jiti scripts/check-web-gallery-dev-only.ts && jiti scripts/check-web-locales-split.ts",
+    "build": "react-router build && jiti scripts/check-web-monaco-lazy.ts && jiti scripts/check-web-gallery-dev-only.ts && jiti scripts/check-web-locales-split.ts && jiti scripts/check-web-css-color-compatibility.ts",
     "test": "vitest run",
     "typecheck": "react-router typegen && tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json"
   },

--- a/apps/web/postcss.config.ts
+++ b/apps/web/postcss.config.ts
@@ -1,5 +1,7 @@
 import UnoCSS from '@unocss/postcss';
 
+import { toLegacyCssColor } from './src/lib/legacy-css-color';
+
 // UnoCSS generates through PostCSS rather than `unocss/vite`, whose global mode
 // emits nothing under React Router: it keys its `vite:css-post` handle by the
 // top-level `build.outDir`, while React Router sets `outDir` only per
@@ -22,4 +24,14 @@ import UnoCSS from '@unocss/postcss';
 // keeps a build launched from the workspace root scanning the same files as one
 // launched from this package.
 // https://github.com/unocss/unocss/blob/e28a47c557fe179935a37a4fbeb650292d0d1d5a/packages-integrations/postcss/src/esm.ts#L21-L110
-export default { plugins: [UnoCSS({ cwd: import.meta.dirname })] };
+const legacyCssColors = {
+  postcssPlugin: 'floway-legacy-css-colors',
+  Declaration: (declaration: { value: string }) => {
+    declaration.value = toLegacyCssColor(declaration.value);
+  },
+  AtRule: (rule: { params: string }) => {
+    rule.params = toLegacyCssColor(rule.params);
+  },
+};
+
+export default { plugins: [UnoCSS({ cwd: import.meta.dirname }), legacyCssColors] };

--- a/apps/web/scripts/check-web-css-color-compatibility.ts
+++ b/apps/web/scripts/check-web-css-color-compatibility.ts
@@ -1,0 +1,77 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { extname, relative, resolve } from 'node:path';
+
+import ts from 'typescript';
+
+import { findCssColorLevel4, type ColorLevel4Violation } from './css-color-level-4';
+
+const webRoot = resolve(import.meta.dirname, '..');
+const sourceRoot = resolve(webRoot, 'src');
+const clientRoot = resolve(webRoot, 'dist/client');
+const scriptExtensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const documentExtensions = new Set(['.css', '.html']);
+
+interface LocatedViolation extends ColorLevel4Violation {
+  file: string;
+  line: number;
+}
+
+const filesBelow = async (directory: string): Promise<string[]> => {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return (await Promise.all(entries.map(async entry => {
+    const path = resolve(directory, entry.name);
+    return entry.isDirectory() ? await filesBelow(path) : [path];
+  }))).flat();
+};
+
+const lineAt = (source: string, index: number): number => source.slice(0, index).split('\n').length;
+
+const locate = (file: string, source: string, offset: number, text: string): LocatedViolation[] =>
+  findCssColorLevel4(text).map(violation => ({
+    ...violation,
+    file: relative(webRoot, file),
+    line: lineAt(source, offset + violation.index),
+  }));
+
+const sourceViolations = async (file: string): Promise<LocatedViolation[]> => {
+  const source = await readFile(file, 'utf8');
+  const extension = extname(file);
+  if (documentExtensions.has(extension)) return locate(file, source, 0, source);
+  if (!scriptExtensions.has(extension)) return [];
+
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, false, extension.endsWith('x') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+  const violations: LocatedViolation[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isStringLiteral(node)
+      || ts.isNoSubstitutionTemplateLiteral(node)
+      || ts.isTemplateHead(node)
+      || ts.isTemplateMiddle(node)
+      || ts.isTemplateTail(node)
+    ) {
+      violations.push(...locate(file, source, node.getStart(sourceFile) + 1, node.text));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return violations;
+};
+
+const builtViolations = async (file: string): Promise<LocatedViolation[]> => {
+  if (!documentExtensions.has(extname(file))) return [];
+  const source = await readFile(file, 'utf8');
+  return locate(file, source, 0, source);
+};
+
+const violations = [
+  ...(await Promise.all((await filesBelow(sourceRoot)).map(sourceViolations))).flat(),
+  ...(await Promise.all((await filesBelow(clientRoot)).map(builtViolations))).flat(),
+];
+
+if (violations.length > 0) {
+  throw new Error(`CSS Color Level 4 reached the browser boundary:\n${violations
+    .map(violation => `${violation.file}:${violation.line}: ${violation.syntax}`)
+    .join('\n')}`);
+}
+
+console.log('Browser styles use only legacy CSS color syntax');

--- a/apps/web/scripts/css-color-level-4.ts
+++ b/apps/web/scripts/css-color-level-4.ts
@@ -1,0 +1,33 @@
+const LEVEL_4_FUNCTIONS = new Set(['color', 'hwb', 'lab', 'lch', 'oklab', 'oklch']);
+const LEGACY_COLOR_FUNCTIONS = new Set(['rgb', 'rgba', 'hsl', 'hsla']);
+
+export interface ColorLevel4Violation {
+  index: number;
+  syntax: string;
+}
+
+export const findCssColorLevel4 = (source: string): ColorLevel4Violation[] => {
+  const violations: ColorLevel4Violation[] = [];
+  const alphaHex = /(?<![\da-f])#(?:[\da-f]{8}|[\da-f]{4})(?![\da-f])/giu;
+  for (const match of source.matchAll(alphaHex)) {
+    violations.push({ index: match.index, syntax: match[0] });
+  }
+
+  const colorFunction = /\b([a-z-]+)\s*\(([^()]*)\)/giu;
+  for (const match of source.matchAll(colorFunction)) {
+    const name = match[1]!.toLowerCase();
+    const parameters = match[2]!;
+    if (
+      LEVEL_4_FUNCTIONS.has(name)
+      || (LEGACY_COLOR_FUNCTIONS.has(name) && (
+        !parameters.includes(',')
+        || parameters.includes('/')
+        || /\b(?:from|none)\b/iu.test(parameters)
+      ))
+    ) {
+      violations.push({ index: match.index, syntax: match[0] });
+    }
+  }
+
+  return violations.toSorted((left, right) => left.index - right.index);
+};

--- a/apps/web/src/components/requests/detail.tsx
+++ b/apps/web/src/components/requests/detail.tsx
@@ -36,7 +36,8 @@ const { Tab, TabList, Text, makeStyles, mergeClasses } = fluentComponents;
 // The band is the one surface here that fills: it holds still while the region
 // below it scrolls, so it has to occlude. WinUI's counterpart is ContentDialog's
 // fixed band over its scrolling content, `ContentDialogTopOverlay` =
-// LayerFillColorAlt, which is #FFFFFF in light and #0DFFFFFF over the dialog's
+// LayerFillColorAlt, which is #FFFFFF in light and #0DFFFFFF (WinUI ARGB) over
+// the dialog's
 // #202020 in dark -- the flat #FFFFFF/#2C2C2C that `colorNeutralBackground1`
 // already carries. WinUI seams that band with CardStrokeColorDefault; the
 // divider stands in because the card stroke is black-alpha and disappears into a

--- a/apps/web/src/components/ui/badge-hue.ts
+++ b/apps/web/src/components/ui/badge-hue.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 
 import { fluentComponents } from '../../fluent';
-import { alphaHex, blendHex, readableTone } from '../../lib/color';
+import { alphaColor, blendHex, readableTone } from '../../lib/color';
 
 const { makeStyles } = fluentComponents;
 
@@ -10,7 +10,7 @@ export type BadgeHue = string | { light: string; dark: string };
 
 // The hardest end of each scheme's badge-surface range: in light the selected
 // request row (Fluent brand 160); in dark a card washed by
-// SubtleFillColorSecondary (#ffffff0f over #373737).
+// SubtleFillColorSecondary (rgba(255, 255, 255, 0.058824) over #373737).
 // https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L26
 // https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L56
 // https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L71
@@ -52,18 +52,18 @@ const useStyles = makeStyles({
 export const useBadgeHue = (hue: BadgeHue): { className: string; style: CSSProperties } => {
   const styles = useStyles();
   const pair = typeof hue === 'string' ? { light: hue, dark: hue } : hue;
-  const fill = { light: alphaHex(pair.light, BADGE_FILL_ALPHA), dark: alphaHex(pair.dark, BADGE_FILL_ALPHA) };
-  const label = (own: string, ownFill: string, surface: string) => readableTone(own, blendHex(ownFill, 1, surface));
+  const fill = { light: alphaColor(pair.light, BADGE_FILL_ALPHA), dark: alphaColor(pair.dark, BADGE_FILL_ALPHA) };
+  const label = (own: string, surface: string) => readableTone(own, blendHex(own, BADGE_FILL_ALPHA, surface));
 
   return {
     className: styles.scheme,
     style: {
       '--floway-badge-fill-light': fill.light,
       '--floway-badge-fill-dark': fill.dark,
-      '--floway-badge-stroke-light': alphaHex(pair.light, BADGE_STROKE_ALPHA),
-      '--floway-badge-stroke-dark': alphaHex(pair.dark, BADGE_STROKE_ALPHA),
-      '--floway-badge-label-light': label(pair.light, fill.light, HARDEST_BADGE_SURFACE.light),
-      '--floway-badge-label-dark': label(pair.dark, fill.dark, HARDEST_BADGE_SURFACE.dark),
+      '--floway-badge-stroke-light': alphaColor(pair.light, BADGE_STROKE_ALPHA),
+      '--floway-badge-stroke-dark': alphaColor(pair.dark, BADGE_STROKE_ALPHA),
+      '--floway-badge-label-light': label(pair.light, HARDEST_BADGE_SURFACE.light),
+      '--floway-badge-label-dark': label(pair.dark, HARDEST_BADGE_SURFACE.dark),
       backgroundColor: 'var(--floway-badge-fill)',
       borderColor: 'var(--floway-chip-stroke)',
       color: 'var(--floway-badge-label)',

--- a/apps/web/src/components/ui/loading-screen.css.ts
+++ b/apps/web/src/components/ui/loading-screen.css.ts
@@ -47,7 +47,7 @@ export const loadingCss = `
   .floway-loading .fui-Spinner__spinner {
     --fui-Spinner--strokeWidth: 25%;
     animation: floway-loading-spin 1.5s linear infinite;
-    background-color: #ffffff00;
+    background-color: rgba(255, 255, 255, 0);
     color: var(--colorBrandStroke1, #0067c0);
     flex-shrink: 0;
     height: 32px;
@@ -89,7 +89,7 @@ export const loadingCss = `
      https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/TextBlock_themeresources.xaml#L4
      https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/TextBlock_themeresources.xaml#L23-L25 */
   .floway-loading .fui-Spinner__label {
-    color: var(--colorNeutralForeground1, #000000e4);
+    color: var(--colorNeutralForeground1, rgba(0, 0, 0, 0.894118));
     font-family: var(--fontFamilyBase, sans-serif);
     font-size: var(--fontSizeBase300, 14px);
     font-weight: var(--fontWeightRegular, 400);

--- a/apps/web/src/lib/color.ts
+++ b/apps/web/src/lib/color.ts
@@ -4,9 +4,9 @@ import {
   convertRgbToHsv,
   convertRgbToLrgb,
   formatHex,
-  formatHex8,
   modeRgb,
   parseHex,
+  serializeRgb,
   useMode as registerMode,
   wcagContrast,
 } from 'culori/fn';
@@ -21,9 +21,11 @@ const parseHexColor = (hex: string) => {
 
 const linearRgb = (rgb: ReturnType<typeof parseHexColor>) => convertRgbToLrgb(rgb);
 
-export const alphaHex = (hex: string, opacity: number): string => {
+export const alphaColor = (hex: string, opacity: number): string => {
   const rgb = parseHexColor(hex);
-  return formatHex8({ ...rgb, alpha: (rgb.alpha ?? 1) * opacity }).toUpperCase();
+  const serialized = serializeRgb({ ...rgb, alpha: (rgb.alpha ?? 1) * opacity });
+  if (serialized === undefined) throw new TypeError(`Could not serialize hex colour: ${hex}`);
+  return serialized;
 };
 
 export const blendHex = (hex: string, alpha: number, backdrop: string): string => {
@@ -31,7 +33,8 @@ export const blendHex = (hex: string, alpha: number, backdrop: string): string =
   const foreground = { ...parsed, alpha: (parsed.alpha ?? 1) * alpha };
   const mixed = blend([parseHexColor(backdrop), foreground], 'normal', 'rgb');
   if (mixed.alpha === undefined) throw new TypeError('Culori blend returned no alpha');
-  return (mixed.alpha < 1 ? formatHex8(mixed) : formatHex(mixed)).toUpperCase();
+  if (mixed.alpha < 1) throw new TypeError('Hex blending requires an opaque backdrop');
+  return formatHex(mixed).toUpperCase();
 };
 
 // WCAG 2.2 requires at least 4.5:1 contrast for normal text.

--- a/apps/web/src/lib/legacy-css-color.ts
+++ b/apps/web/src/lib/legacy-css-color.ts
@@ -1,0 +1,24 @@
+const alphaHexToRgba = (hex: string): string => {
+  const digits = hex.slice(1);
+  const expanded = digits.length === 4
+    ? [...digits].map(digit => digit.repeat(2)).join('')
+    : digits;
+  const channels = expanded.match(/../g)?.map(channel => Number.parseInt(channel, 16));
+  if (channels?.length !== 4) throw new TypeError(`Invalid alpha hex color: ${hex}`);
+  const [red, green, blue, alpha] = channels;
+  return `rgba(${red}, ${green}, ${blue}, ${Number((alpha! / 255).toFixed(6))})`;
+};
+
+const legacyFunction = (source: string, name: string, channels: string, alpha?: string): string => {
+  const components = channels.trim().split(/\s+/u);
+  if (components.length !== 3) return source;
+  const legacyName = alpha === undefined ? name.slice(0, 3) : `${name.slice(0, 3)}a`;
+  const legacyAlpha = alpha?.trim().endsWith('%')
+    ? String(Number.parseFloat(alpha) / 100)
+    : alpha?.trim();
+  return `${legacyName}(${[...components, ...(legacyAlpha === undefined ? [] : [legacyAlpha])].join(', ')})`;
+};
+
+export const toLegacyCssColor = (source: string): string => source
+  .replace(/(?<![\da-f])#(?:[\da-f]{8}|[\da-f]{4})(?![\da-f])/giu, alphaHexToRgba)
+  .replace(/\b(rgb|rgba|hsl|hsla)\(\s*([^,()]+?)(?:\s*\/\s*([^()]+?))?\s*\)/giu, legacyFunction);

--- a/apps/web/src/winui/controls/list.css.ts
+++ b/apps/web/src/winui/controls/list.css.ts
@@ -117,14 +117,14 @@ ${reducedMotion([
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/dxaml/xcp/core/core/elements/ListViewBaseItemChrome.cpp#L888-L916
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/dxaml/xcp/core/core/elements/ListViewBaseItemChrome.cpp#L3290-L3312 */
 .fui-ListItem.fui-ListItem[aria-disabled='true'] {
-  /* 30% of --winui-text-fill-primary (#000000e4). */
-  color: #00000044;
+  /* 30% of --winui-text-fill-primary (rgba(0, 0, 0, 0.894118)). */
+  color: rgba(0, 0, 0, 0.266667);
 }
 
 @media (prefers-color-scheme: dark) {
   /* 30% of --winui-text-fill-primary (#ffffff). */
   .fui-ListItem.fui-ListItem[aria-disabled='true'] {
-    color: #ffffff4d;
+    color: rgba(255, 255, 255, 0.301961);
   }
 }
 

--- a/apps/web/src/winui/controls/menu.css.ts
+++ b/apps/web/src/winui/controls/menu.css.ts
@@ -16,7 +16,7 @@ export const menuCss = `
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/MenuFlyout_themeresources.xaml#L285
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/MenuFlyout_themeresources.xaml#L41
 
-   The presenter's own fill is DesktopAcrylicTransparentBrush -- #00000000, a
+   The presenter's own fill is DesktopAcrylicTransparentBrush -- rgba(0, 0, 0, 0), a
    sentinel that hands the material to the window's DesktopAcrylicBackdrop. A
    web flyout floats over no such backdrop, so we paint the acrylic material's
    FallbackColor, which is what WinUI shows when transparency effects are off.

--- a/apps/web/src/winui/controls/message-bar.css.ts
+++ b/apps/web/src/winui/controls/message-bar.css.ts
@@ -20,8 +20,8 @@ export const messageBarCss = `
 /* InfoBarMinHeight, and InfoBarContentRootPadding — the thickness 16,0,0,0, so
    leading only. The stroke is restated because InfoBar takes InfoBarBorderBrush
    from the card stroke family where Fluent's border reads the neutral control
-   stroke; the two agree in light (#0000000f) but not in dark (#00000019 against
-   #ffffff12).
+   stroke; the two agree in light (rgba(0, 0, 0, 0.058824)) but not in dark
+   (rgba(0, 0, 0, 0.098039) against rgba(255, 255, 255, 0.070588)).
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/InfoBar/InfoBar_themeresources.xaml#L66
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/InfoBar/InfoBar_themeresources.xaml#L75
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/InfoBar/InfoBar_themeresources.xaml#L20 */

--- a/apps/web/src/winui/theme.ts
+++ b/apps/web/src/winui/theme.ts
@@ -1,5 +1,6 @@
 import type { Theme } from '@fluentui/react-components';
 
+import { toLegacyCssColor } from '../lib/legacy-css-color';
 import { flowayDarkTheme, flowayLightTheme } from '../theme';
 
 // Shared and status colors have no one-to-one WinUI counterpart and are spent
@@ -147,24 +148,28 @@ const radii = {
 // list whose first layer is the elevation, and `none` is only valid as a whole
 // box-shadow, so it invalidates the list and drops the focus ring entirely.
 const shadows = {
-  shadow2: '0 0 #0000',
-  shadow2Brand: '0 0 #0000',
-  shadow4: '0 0 #0000',
-  shadow4Brand: '0 0 #0000',
-  shadow8: '0 0 #0000',
-  shadow8Brand: '0 0 #0000',
+  shadow2: '0 0 rgba(0, 0, 0, 0)',
+  shadow2Brand: '0 0 rgba(0, 0, 0, 0)',
+  shadow4: '0 0 rgba(0, 0, 0, 0)',
+  shadow4Brand: '0 0 rgba(0, 0, 0, 0)',
+  shadow8: '0 0 rgba(0, 0, 0, 0)',
+  shadow8Brand: '0 0 rgba(0, 0, 0, 0)',
 } as const satisfies Partial<Theme>;
 
-export const winuiLightTheme: Theme = {
+const legacyTheme = (theme: Theme): Theme => Object.fromEntries(
+  Object.entries(theme).map(([token, value]) => [token, typeof value === 'string' ? toLegacyCssColor(value) : value]),
+) as unknown as Theme;
+
+export const winuiLightTheme: Theme = legacyTheme({
   ...flowayLightTheme,
   ...palette,
   ...radii,
   ...shadows,
-};
+});
 
-export const winuiDarkTheme: Theme = {
+export const winuiDarkTheme: Theme = legacyTheme({
   ...flowayDarkTheme,
   ...palette,
   ...radii,
   ...shadows,
-};
+});

--- a/apps/web/src/winui/tokens.ts
+++ b/apps/web/src/winui/tokens.ts
@@ -66,23 +66,23 @@ export const winuiTokenCss = `
 /* Control fills — the body of a button, combo box, or check box.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L219-L225 */
 :root {
-  --winui-control-fill-default: #ffffffb3;
-  --winui-control-fill-secondary: #f9f9f980;
-  --winui-control-fill-tertiary: #f9f9f94d;
-  --winui-control-fill-disabled: #f9f9f94d;
-  --winui-control-fill-transparent: #ffffff00;
+  --winui-control-fill-default: rgba(255, 255, 255, 0.701961);
+  --winui-control-fill-secondary: rgba(249, 249, 249, 0.501961);
+  --winui-control-fill-tertiary: rgba(249, 249, 249, 0.301961);
+  --winui-control-fill-disabled: rgba(249, 249, 249, 0.301961);
+  --winui-control-fill-transparent: rgba(255, 255, 255, 0);
   --winui-control-fill-input-active: #ffffff;
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L15-L21 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-control-fill-default: #ffffff0f;
-    --winui-control-fill-secondary: #ffffff15;
-    --winui-control-fill-tertiary: #ffffff08;
-    --winui-control-fill-disabled: #ffffff0b;
-    --winui-control-fill-transparent: #ffffff00;
-    --winui-control-fill-input-active: #1e1e1eb3;
+    --winui-control-fill-default: rgba(255, 255, 255, 0.058824);
+    --winui-control-fill-secondary: rgba(255, 255, 255, 0.082353);
+    --winui-control-fill-tertiary: rgba(255, 255, 255, 0.031373);
+    --winui-control-fill-disabled: rgba(255, 255, 255, 0.043137);
+    --winui-control-fill-transparent: rgba(255, 255, 255, 0);
+    --winui-control-fill-input-active: rgba(30, 30, 30, 0.701961);
   }
 }
 
@@ -90,25 +90,25 @@ export const winuiTokenCss = `
    the text-control bottom edge is painted with.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L243-L253 */
 :root {
-  --winui-control-stroke-default: #0000000f;
-  --winui-control-stroke-secondary: #00000029;
-  --winui-control-stroke-on-accent-default: #ffffff14;
-  --winui-control-stroke-on-accent-secondary: #00000066;
-  --winui-control-stroke-on-accent-tertiary: #00000037;
-  --winui-control-strong-stroke-default: #00000072;
-  --winui-control-strong-stroke-disabled: #00000037;
+  --winui-control-stroke-default: rgba(0, 0, 0, 0.058824);
+  --winui-control-stroke-secondary: rgba(0, 0, 0, 0.160784);
+  --winui-control-stroke-on-accent-default: rgba(255, 255, 255, 0.078431);
+  --winui-control-stroke-on-accent-secondary: rgba(0, 0, 0, 0.4);
+  --winui-control-stroke-on-accent-tertiary: rgba(0, 0, 0, 0.215686);
+  --winui-control-strong-stroke-default: rgba(0, 0, 0, 0.447059);
+  --winui-control-strong-stroke-disabled: rgba(0, 0, 0, 0.215686);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L39-L49 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-control-stroke-default: #ffffff12;
-    --winui-control-stroke-secondary: #ffffff18;
-    --winui-control-stroke-on-accent-default: #ffffff14;
-    --winui-control-stroke-on-accent-secondary: #00000023;
-    --winui-control-stroke-on-accent-tertiary: #00000037;
-    --winui-control-strong-stroke-default: #ffffff8b;
-    --winui-control-strong-stroke-disabled: #ffffff28;
+    --winui-control-stroke-default: rgba(255, 255, 255, 0.070588);
+    --winui-control-stroke-secondary: rgba(255, 255, 255, 0.094118);
+    --winui-control-stroke-on-accent-default: rgba(255, 255, 255, 0.078431);
+    --winui-control-stroke-on-accent-secondary: rgba(0, 0, 0, 0.137255);
+    --winui-control-stroke-on-accent-tertiary: rgba(0, 0, 0, 0.215686);
+    --winui-control-strong-stroke-default: rgba(255, 255, 255, 0.545098);
+    --winui-control-strong-stroke-disabled: rgba(255, 255, 255, 0.156863);
   }
 }
 
@@ -119,7 +119,7 @@ export const winuiTokenCss = `
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L226
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L228 */
 :root {
-  --winui-control-strong-fill-default: #00000072;
+  --winui-control-strong-fill-default: rgba(0, 0, 0, 0.447059);
   --winui-control-solid-fill-default: #ffffff;
 }
 
@@ -127,44 +127,44 @@ export const winuiTokenCss = `
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L24 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-control-strong-fill-default: #ffffff8b;
+    --winui-control-strong-fill-default: rgba(255, 255, 255, 0.545098);
     --winui-control-solid-fill-default: #454545;
   }
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L229-L231 */
 :root {
-  --winui-subtle-fill-transparent: #ffffff00;
-  --winui-subtle-fill-secondary: #00000009;
-  --winui-subtle-fill-tertiary: #00000006;
+  --winui-subtle-fill-transparent: rgba(255, 255, 255, 0);
+  --winui-subtle-fill-secondary: rgba(0, 0, 0, 0.035294);
+  --winui-subtle-fill-tertiary: rgba(0, 0, 0, 0.023529);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L25-L27 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-subtle-fill-transparent: #ffffff00;
-    --winui-subtle-fill-secondary: #ffffff0f;
-    --winui-subtle-fill-tertiary: #ffffff0a;
+    --winui-subtle-fill-transparent: rgba(255, 255, 255, 0);
+    --winui-subtle-fill-secondary: rgba(255, 255, 255, 0.058824);
+    --winui-subtle-fill-tertiary: rgba(255, 255, 255, 0.039216);
   }
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L250-L265 */
 :root {
-  --winui-card-background-fill-default: #ffffffb3;
-  --winui-card-background-fill-secondary: #f6f6f680;
-  --winui-card-stroke-default: #0000000f;
-  --winui-layer-fill-default: #ffffff80;
+  --winui-card-background-fill-default: rgba(255, 255, 255, 0.701961);
+  --winui-card-background-fill-secondary: rgba(246, 246, 246, 0.501961);
+  --winui-card-stroke-default: rgba(0, 0, 0, 0.058824);
+  --winui-layer-fill-default: rgba(255, 255, 255, 0.501961);
   --winui-layer-fill-alt: #ffffff;
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L46-L61 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-card-background-fill-default: #ffffff0d;
-    --winui-card-background-fill-secondary: #ffffff08;
-    --winui-card-stroke-default: #00000019;
-    --winui-layer-fill-default: #3a3a3a4c;
-    --winui-layer-fill-alt: #ffffff0d;
+    --winui-card-background-fill-default: rgba(255, 255, 255, 0.05098);
+    --winui-card-background-fill-secondary: rgba(255, 255, 255, 0.031373);
+    --winui-card-stroke-default: rgba(0, 0, 0, 0.098039);
+    --winui-layer-fill-default: rgba(58, 58, 58, 0.298039);
+    --winui-layer-fill-alt: rgba(255, 255, 255, 0.05098);
   }
 }
 
@@ -173,7 +173,7 @@ export const winuiTokenCss = `
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L59
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L263 */
 :root {
-  --winui-smoke-fill-default: #0000004d;
+  --winui-smoke-fill-default: rgba(0, 0, 0, 0.301961);
 }
 
 /* The in-app acrylic material, taken as the flat FallbackColor the brush
@@ -206,12 +206,12 @@ export const winuiTokenCss = `
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/dxaml/xcp/components/graphics/inc/DropShadowRecipe.h#L108-L162
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/dxaml/xcp/components/comptree/HWCompNodeWinRT.cpp#L1608-L1675 */
 :root {
-  --winui-tooltip-shadow-color: #00000023;
+  --winui-tooltip-shadow-color: rgba(0, 0, 0, 0.137255);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-tooltip-shadow-color: #00000042;
+    --winui-tooltip-shadow-color: rgba(0, 0, 0, 0.258824);
   }
 }
 
@@ -239,17 +239,17 @@ export const winuiTokenCss = `
    hairline between list sections.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L254-L257 */
 :root {
-  --winui-surface-stroke-default: #75757566;
-  --winui-surface-stroke-flyout: #0000000f;
-  --winui-divider-stroke-default: #0000000f;
+  --winui-surface-stroke-default: rgba(117, 117, 117, 0.4);
+  --winui-surface-stroke-flyout: rgba(0, 0, 0, 0.058824);
+  --winui-divider-stroke-default: rgba(0, 0, 0, 0.058824);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L50-L53 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-surface-stroke-default: #75757566;
-    --winui-surface-stroke-flyout: #00000033;
-    --winui-divider-stroke-default: #ffffff15;
+    --winui-surface-stroke-default: rgba(117, 117, 117, 0.4);
+    --winui-surface-stroke-flyout: rgba(0, 0, 0, 0.2);
+    --winui-divider-stroke-default: rgba(255, 255, 255, 0.082353);
   }
 }
 
@@ -258,10 +258,10 @@ export const winuiTokenCss = `
    primary.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L209-L213 */
 :root {
-  --winui-text-fill-primary: #000000e4;
-  --winui-text-fill-secondary: #0000009e;
-  --winui-text-fill-tertiary: #00000072;
-  --winui-text-fill-disabled: #0000005c;
+  --winui-text-fill-primary: rgba(0, 0, 0, 0.894118);
+  --winui-text-fill-secondary: rgba(0, 0, 0, 0.619608);
+  --winui-text-fill-tertiary: rgba(0, 0, 0, 0.447059);
+  --winui-text-fill-disabled: rgba(0, 0, 0, 0.360784);
   --winui-text-fill-inverse: #ffffff;
 }
 
@@ -269,10 +269,10 @@ export const winuiTokenCss = `
 @media (prefers-color-scheme: dark) {
   :root {
     --winui-text-fill-primary: #ffffff;
-    --winui-text-fill-secondary: #ffffffc5;
-    --winui-text-fill-tertiary: #ffffff87;
-    --winui-text-fill-disabled: #ffffff5d;
-    --winui-text-fill-inverse: #000000e4;
+    --winui-text-fill-secondary: rgba(255, 255, 255, 0.772549);
+    --winui-text-fill-tertiary: rgba(255, 255, 255, 0.529412);
+    --winui-text-fill-disabled: rgba(255, 255, 255, 0.364706);
+    --winui-text-fill-inverse: rgba(0, 0, 0, 0.894118);
   }
 }
 
@@ -285,13 +285,13 @@ export const winuiTokenCss = `
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/dxaml/xcp/dxaml/themes/generic.xaml#L321-L327
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/dxaml/xcp/dxaml/themes/generic.xaml#L4134 */
 :root {
-  --winui-text-base-medium: #00000099;
+  --winui-text-base-medium: rgba(0, 0, 0, 0.6);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/dxaml/xcp/dxaml/themes/generic.xaml#L209 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-text-base-medium: #ffffff99;
+    --winui-text-base-medium: rgba(255, 255, 255, 0.6);
   }
 }
 
@@ -382,13 +382,13 @@ export const winuiTokenCss = `
 /* The disabled accent fill is a literal rather than a step of that ramp.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L242 */
 :root {
-  --winui-accent-fill-disabled: #00000037;
+  --winui-accent-fill-disabled: rgba(0, 0, 0, 0.215686);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L38 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-accent-fill-disabled: #ffffff28;
+    --winui-accent-fill-disabled: rgba(255, 255, 255, 0.156863);
   }
 }
 
@@ -397,13 +397,14 @@ export const winuiTokenCss = `
    at about 1.7:1 there against AccentFillColorDisabled. That is WinUI's own
    result -- measured off Microsoft's screenshots on the issue below, which
    they closed as not planned -- so it is transcribed, not corrected; raising it
-   would be a departure of ours to own. Dark's #87ffffff reaches about 3.7:1.
+   would be a departure of ours to own. Dark's WinUI ARGB value uses alpha 87
+   over white and reaches about 3.7:1.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L214-L218
    https://github.com/microsoft/microsoft-ui-xaml/issues/6500 */
 :root {
-  --winui-accent-text-fill-disabled: #0000005c;
+  --winui-accent-text-fill-disabled: rgba(0, 0, 0, 0.360784);
   --winui-text-on-accent-fill-primary: #ffffff;
-  --winui-text-on-accent-fill-secondary: #ffffffb3;
+  --winui-text-on-accent-fill-secondary: rgba(255, 255, 255, 0.701961);
   --winui-text-on-accent-fill-disabled: #ffffff;
   --winui-text-on-accent-fill-selected-text: #ffffff;
 }
@@ -411,10 +412,10 @@ export const winuiTokenCss = `
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L10-L14 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-accent-text-fill-disabled: #ffffff5d;
+    --winui-accent-text-fill-disabled: rgba(255, 255, 255, 0.364706);
     --winui-text-on-accent-fill-primary: #000000;
-    --winui-text-on-accent-fill-secondary: #00000080;
-    --winui-text-on-accent-fill-disabled: #ffffff87;
+    --winui-text-on-accent-fill-secondary: rgba(0, 0, 0, 0.501961);
+    --winui-text-on-accent-fill-disabled: rgba(255, 255, 255, 0.529412);
     --winui-text-on-accent-fill-selected-text: #ffffff;
   }
 }
@@ -460,19 +461,19 @@ export const winuiTokenCss = `
    transparent in both dictionaries rather than a faint wash.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L233-L237 */
 :root {
-  --winui-control-alt-fill-secondary: #00000006;
-  --winui-control-alt-fill-tertiary: #0000000f;
-  --winui-control-alt-fill-quarternary: #00000018;
-  --winui-control-alt-fill-disabled: #ffffff00;
+  --winui-control-alt-fill-secondary: rgba(0, 0, 0, 0.023529);
+  --winui-control-alt-fill-tertiary: rgba(0, 0, 0, 0.058824);
+  --winui-control-alt-fill-quarternary: rgba(0, 0, 0, 0.094118);
+  --winui-control-alt-fill-disabled: rgba(255, 255, 255, 0);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L29-L33 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-control-alt-fill-secondary: #00000019;
-    --winui-control-alt-fill-tertiary: #ffffff0b;
-    --winui-control-alt-fill-quarternary: #ffffff12;
-    --winui-control-alt-fill-disabled: #ffffff00;
+    --winui-control-alt-fill-secondary: rgba(0, 0, 0, 0.098039);
+    --winui-control-alt-fill-tertiary: rgba(255, 255, 255, 0.043137);
+    --winui-control-alt-fill-quarternary: rgba(255, 255, 255, 0.070588);
+    --winui-control-alt-fill-disabled: rgba(255, 255, 255, 0);
   }
 }
 
@@ -480,15 +481,15 @@ export const winuiTokenCss = `
    surface color, so the ring stays visible on any fill including accent.
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L258-L259 */
 :root {
-  --winui-focus-stroke-outer: #000000e4;
-  --winui-focus-stroke-inner: #ffffffb3;
+  --winui-focus-stroke-outer: rgba(0, 0, 0, 0.894118);
+  --winui-focus-stroke-inner: rgba(255, 255, 255, 0.701961);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L54-L55 */
 @media (prefers-color-scheme: dark) {
   :root {
     --winui-focus-stroke-outer: #ffffff;
-    --winui-focus-stroke-inner: #000000b3;
+    --winui-focus-stroke-inner: rgba(0, 0, 0, 0.701961);
   }
 }
 
@@ -498,13 +499,13 @@ export const winuiTokenCss = `
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/TextBox_themeresources.xaml#L129
    https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/TextBox_themeresources.xaml#L141 */
 :root {
-  --winui-temporary-text-fill-disabled: #0101015c;
+  --winui-temporary-text-fill-disabled: rgba(1, 1, 1, 0.360784);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/TextBox_themeresources.xaml#L22 */
 @media (prefers-color-scheme: dark) {
   :root {
-    --winui-temporary-text-fill-disabled: #fefefe5d;
+    --winui-temporary-text-fill-disabled: rgba(254, 254, 254, 0.364706);
   }
 }
 
@@ -520,7 +521,7 @@ export const winuiTokenCss = `
   --winui-system-fill-success-background: #dff6dd;
   --winui-system-fill-caution-background: #fff4ce;
   --winui-system-fill-critical-background: #fde7e9;
-  --winui-system-fill-attention-background: #f6f6f680;
+  --winui-system-fill-attention-background: rgba(246, 246, 246, 0.501961);
 }
 
 /* https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/Common_themeresources_any.xaml#L76-L87
@@ -534,7 +535,7 @@ export const winuiTokenCss = `
     --winui-system-fill-success-background: #393d1b;
     --winui-system-fill-caution-background: #433519;
     --winui-system-fill-critical-background: #442726;
-    --winui-system-fill-attention-background: #ffffff08;
+    --winui-system-fill-attention-background: rgba(255, 255, 255, 0.031373);
   }
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -142,7 +142,18 @@ const sourceMapOutput = {
   sourcemapExcludeSources: true,
 } as const;
 
+// React Router's Environment API resolves the shared CSS pipeline from the
+// root build and the client minifier from the client environment. Both must
+// carry the same pre-Color-Level-4 policy: Chrome 61 predates alpha hex, and
+// esbuild uses that target to serialize alpha with legacy rgba().
+// https://vite.dev/config/build-options.html#build-csstarget
+const legacyCssBuild = {
+  cssMinify: 'esbuild',
+  cssTarget: 'chrome61',
+} as const;
+
 export default defineConfig({
+  build: legacyCssBuild,
   // React Router discovers route modules lazily. Pre-bundle their browser
   // dependencies at startup so the first visit to a route never makes Vite
   // re-optimize and reload the already-mounted dashboard.
@@ -243,6 +254,7 @@ export default defineConfig({
   environments: {
     client: {
       build: {
+        ...legacyCssBuild,
         // The maps ship, and the chunks keep the trailing `sourceMappingURL`
         // comment that names them: the ErrorBoundary in src/root.tsx restores
         // its trace through src/lib/source-mapped-stack.ts, and the same


### PR DESCRIPTION
## Summary

- enforce legacy CSS color syntax in browser-authored literals and final client CSS/HTML
- normalize alpha colors emitted by WinUI, UnoCSS, Fluent themes, dependencies, and dynamic style helpers to legacy `rgba()`
- configure the shared and client Vite CSS pipelines so minification cannot reintroduce CSS Color Level 4 output
- run the compatibility verifier as part of every web production build

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run test:agent-setup-installers`
- [x] `pnpm --filter @floway-dev/agent-setup run generate-assets --check`
- [x] `pnpm run check:agent-protocol`
- [x] `pnpm run build:web`
- [x] Review the production-backed local dashboard UX
