### PR TITLE
fix(web): retain fetched chat model metadata

### DIFF
--- a/apps/web/__tests__/components/upstream-editor/model-contract_test.ts
+++ b/apps/web/__tests__/components/upstream-editor/model-contract_test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { discoveredModelsFromResponse } from '../../../src/components/upstream-editor/data';
 import { modelsAreValid } from '../../../src/components/upstream-editor/model-detail';
+import type { UpstreamModelConfig } from '@floway-dev/provider';
 
 describe('custom discovered model projection', () => {
   it('maps fixed kinds to their own endpoint families', () => {
@@ -25,6 +26,19 @@ describe('custom discovered model projection', () => {
 
     expect(models[0]?.endpoints).toEqual({ embeddings: {} });
     expect(models[1]?.endpoints).toEqual({ embeddings: {} });
+  });
+
+  it('preserves chat metadata exactly when the configured endpoints resolve to chat', () => {
+    const chat = {
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      reasoning: { effort: { supported: ['none', 'high'], default: 'high' } },
+    } satisfies NonNullable<UpstreamModelConfig['chat']>;
+
+    const chatModel = discoveredModelsFromResponse({ kind: 'custom', data: [{ id: 'vision', chat }] }, { responses: {} });
+    const embeddingModel = discoveredModelsFromResponse({ kind: 'custom', data: [{ id: 'vision', chat }] }, { embeddings: {} });
+
+    expect(chatModel[0]?.chat).toEqual(chat);
+    expect(embeddingModel[0]?.chat).toBeUndefined();
   });
 
   it('projects every discovered row into a shape the gateway accepts', () => {

--- a/apps/web/src/components/upstream-editor/data.ts
+++ b/apps/web/src/components/upstream-editor/data.ts
@@ -10,7 +10,7 @@ import type {
   UpstreamRecordEnvelope,
 } from '../../api/types';
 import type { MODEL_LISTING_FAILURE_CODE as GatewayModelListingFailureCode } from '@floway-dev/gateway/data-plane/models/shared';
-import type { ModelEndpoints } from '@floway-dev/protocols/common';
+import { kindForEndpoints, type ModelEndpoints } from '@floway-dev/protocols/common';
 import type { UpstreamModelConfig } from '@floway-dev/provider';
 import type { UpstreamProviderKind } from '@floway-dev/provider/model';
 import { MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX } from '@floway-dev/provider/model-prefix';
@@ -323,14 +323,16 @@ export const discoveredModelsFromResponse = (
   if (response.kind !== 'custom') return response.data;
   return response.data.map(model => {
     const kind = model.kind ?? 'chat';
+    const shape = kind === 'chat' ? { endpoints: configuredEndpoints(endpoints) } : shapeForKind(kind, { endpoints });
     return {
       upstreamModelId: model.id,
       publicModelId: model.id,
       kind,
-      ...(kind === 'chat' ? { endpoints: configuredEndpoints(endpoints) } : shapeForKind(kind, { endpoints })),
+      ...shape,
       ...(model.display_name ?? model.name ? { display_name: model.display_name ?? model.name } : {}),
       ...(model.limits ? { limits: model.limits } : {}),
       ...(model.pricing ? { pricing: model.pricing } : {}),
+      ...(model.chat !== undefined && kindForEndpoints(shape.endpoints) === 'chat' ? { chat: model.chat } : {}),
     };
   });
 };


### PR DESCRIPTION
## Summary

- preserve validated Custom catalog `chat` metadata in automatic model rows when their effective endpoint shape is chat-capable
- keep image-input and reasoning-effort capabilities intact when an automatic model is adopted as manual
- cover exact metadata preservation and non-chat exclusion

## Verification

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` (516 files, 5426 tests)
- `pnpm run test:agent-setup-installers` (105 passed, 5 environment skips)
- `pnpm --filter @floway-dev/agent-setup run generate-assets --check`
- `pnpm run check:agent-protocol`
- `pnpm run build:web`
- production build opened in local Chrome with a Floway-shaped Custom catalog; Image input and Effort levels render enabled, with `none, high` and default `high`