### PR TITLE
refactor(web): drop the cache hit rate metric

### DIFF
--- a/apps/web/src/components/usage/callout.tsx
+++ b/apps/web/src/components/usage/callout.tsx
@@ -25,7 +25,7 @@ export function UsageChartCallout({ chart, labelByTime, point, valueFormatter }:
     <ScrollArea axes="horizontal" className="max-w-[min(650px,calc(100vw-48px))] min-w-[220px]" contentClassName="grid gap-1">
       {chart.kind === 'token' && bucketDetails ? (
         <ChartCalloutTable
-          columns={(['requests', 'cost', 'total', 'cached', 'cachedRate', 'prefill', 'output', 'hitRate'] as const).map(key => ({ key, label: t(`dashboard.usage.callout.${key}`) }))}
+          columns={(['requests', 'cost', 'total', 'cached', 'cachedRate', 'prefill', 'output'] as const).map(key => ({ key, label: t(`dashboard.usage.callout.${key}`) }))}
           rows={rows.flatMap(item => {
             const counters = bucketDetails.get(item.id);
             if (!counters) return [];
@@ -34,7 +34,7 @@ export function UsageChartCallout({ chart, labelByTime, point, valueFormatter }:
               color: item.color,
               key: item.id,
               label: item.label,
-              values: [formatCount(summary.requests, locale), formatUsd(summary.cost), formatCompactDecimalCount(summary.total, locale), formatCompactDecimalCount(summary.cacheRead, locale), formatRatePercent(summary.cachedRate), formatCompactDecimalCount(summary.prefill, locale), formatCompactDecimalCount(summary.output, locale), formatRatePercent(summary.cacheHitRate)],
+              values: [formatCount(summary.requests, locale), formatUsd(summary.cost), formatCompactDecimalCount(summary.total, locale), formatCompactDecimalCount(summary.cacheRead, locale), formatRatePercent(summary.cachedRate), formatCompactDecimalCount(summary.prefill, locale), formatCompactDecimalCount(summary.output, locale)],
             }];
           })}
           title={title}

--- a/apps/web/src/components/usage/format.ts
+++ b/apps/web/src/components/usage/format.ts
@@ -24,8 +24,7 @@ export const formatSummaryMetric = (
   case 'cost':
     return formatUsd(summary.cost);
   case 'cachedRate':
-  case 'cacheHitRate':
-    return formatRatePercent(summary[metric]);
+    return formatRatePercent(summary.cachedRate);
   default:
     return formatDecimalQuantity(summary[summaryFieldForMetric[metric]]);
   }

--- a/apps/web/src/components/usage/metrics.ts
+++ b/apps/web/src/components/usage/metrics.ts
@@ -19,10 +19,6 @@ export const metricConfig: Record<
     labelKey: 'dashboard.usage.metrics.cacheCreation',
     kind: 'tokens',
   },
-  cacheHitRate: {
-    labelKey: 'dashboard.usage.metrics.cacheHitRate',
-    kind: 'percent',
-  },
 };
 
 // A metric id is the reader's vocabulary and a summary field is the algebra's;
@@ -38,7 +34,6 @@ export const summaryFieldForMetric = {
   cached: 'cacheRead',
   cacheCreation: 'cacheCreation',
   cachedRate: 'cachedRate',
-  cacheHitRate: 'cacheHitRate',
 } as const satisfies Record<UsageMetric, keyof TokenSummary>;
 
 export const summaryMetrics: UsageMetric[][] = [
@@ -46,5 +41,5 @@ export const summaryMetrics: UsageMetric[][] = [
   ['total', 'output'],
   ['input', 'prefill'],
   ['cached', 'cachedRate'],
-  ['cacheCreation', 'cacheHitRate'],
+  ['cacheCreation'],
 ];

--- a/apps/web/src/components/usage/plot.ts
+++ b/apps/web/src/components/usage/plot.ts
@@ -271,7 +271,6 @@ export const summarizeCounters = (counters: TokenCounters): TokenSummary => {
     total: sumDecimalStrings(counters.input, counters.output, counters.cacheRead, counters.cacheCreation, counters.inputImage, counters.outputImage),
     prefill: sumDecimalStrings(counters.input, counters.cacheCreation, counters.inputImage),
     cachedRate: percentOf(counters.cacheRead, prompt),
-    cacheHitRate: percentOf(counters.cacheRead, sumDecimalStrings(counters.cacheRead, counters.cacheCreation)),
   };
 };
 

--- a/apps/web/src/components/usage/summary-metrics.tsx
+++ b/apps/web/src/components/usage/summary-metrics.tsx
@@ -127,7 +127,7 @@ export function SummaryMetrics({ metric, onMetricChange, summary }: { metric: Us
   const { t } = useTranslation();
   const locale = useLocale();
   return <div className="grid gap-2.5 grid-cols-5 max-[900px]:grid-cols-2 max-[520px]:grid-cols-1">
-    {summaryMetrics.map(group => <div className="grid gap-2 min-w-0" key={group.join('-')}>
+    {summaryMetrics.map(group => <div className="grid gap-2 content-start min-w-0" key={group.join('-')}>
       {group.map(item => <SummaryMetricButton active={metric === item} key={item} label={t(metricConfig[item].labelKey)} onClick={() => onMetricChange(item)} value={formatSummaryMetric(summary, item, locale)} />)}
     </div>)}
   </div>;

--- a/apps/web/src/components/usage/types.ts
+++ b/apps/web/src/components/usage/types.ts
@@ -10,7 +10,7 @@ export type UsageGroupBy = 'keyId' | 'userId' | 'model' | 'upstream';
 export type UsageFilters = Record<UsageGroupBy, string[]>;
 export type UsageMetric =
   | 'requests' | 'cost' | 'total' | 'input' | 'output' | 'prefill'
-  | 'cached' | 'cachedRate' | 'cacheCreation' | 'cacheHitRate';
+  | 'cached' | 'cachedRate' | 'cacheCreation';
 
 export interface DisplayUsageRecord {
   bucket: string;
@@ -66,7 +66,7 @@ export interface TokenCounters {
   outputImage: DecimalString;
 }
 // Folded: `prompt` is the whole billed prompt side, `output` includes images.
-// The rates are percentages, null where their denominator has no reading at all.
+// `cachedRate` is a percentage, null where its denominator has no reading at all.
 export interface TokenSummary {
   requests: number;
   cost: DecimalString | null;
@@ -77,7 +77,6 @@ export interface TokenSummary {
   cacheRead: DecimalString;
   cacheCreation: DecimalString;
   cachedRate: number | null;
-  cacheHitRate: number | null;
 }
 
 export type ChartPlot =

--- a/apps/web/src/components/usage/url-state.ts
+++ b/apps/web/src/components/usage/url-state.ts
@@ -13,7 +13,7 @@ export interface UsageUrlState {
 }
 
 const usageRangeValues: UsageRange[] = ['today', '7d', '30d'];
-const usageMetricValues: UsageMetric[] = ['requests', 'cost', 'total', 'input', 'output', 'prefill', 'cached', 'cachedRate', 'cacheCreation', 'cacheHitRate'];
+const usageMetricValues: UsageMetric[] = ['requests', 'cost', 'total', 'input', 'output', 'prefill', 'cached', 'cachedRate', 'cacheCreation'];
 const usageGroupByValues: UsageGroupBy[] = ['model', 'upstream', 'keyId', 'userId'];
 
 export const parseUsageUrlState = (search: URLSearchParams): UsageUrlState => {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -942,7 +942,7 @@ const en = {
       telemetry: { currentUserOnly: 'Only me' },
       usage: {
         empty: 'No usage records in this range',
-        callout: { requests: 'Req', cost: 'Cost', total: 'Total', cached: 'Cached', cachedRate: 'Cached%', prefill: 'Prefill', output: 'Output', hitRate: 'Hit%' },
+        callout: { requests: 'Req', cost: 'Cost', total: 'Total', cached: 'Cached', cachedRate: 'Cached%', prefill: 'Prefill', output: 'Output' },
         apiKeyScopeInfo: 'API key grouping and filters include only keys owned by your account. Choosing By API Key sets User to Only me; choosing another user clears API key filters and returns to By Model.',
         apiKeyScopeLabel: 'About API key telemetry scope',
         groupBy: { label: 'Group by', model: 'By Model', upstream: 'By Upstream', userId: 'By User', keyId: 'By API Key' },
@@ -978,7 +978,6 @@ const en = {
           cached: 'Cached Input',
           cachedRate: 'Cached Rate',
           cacheCreation: 'Cache Write',
-          cacheHitRate: 'Cache Hit Rate',
         },
       },
       performance: {

--- a/apps/web/src/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/i18n/locales/zh-Hans.ts
@@ -900,7 +900,7 @@ const zhHansCN = {
       telemetry: { currentUserOnly: '仅自己' },
       usage: {
         empty: '此时间范围内没有使用记录',
-        callout: { requests: '请求', cost: '费用', total: '总量', cached: '缓存', cachedRate: '缓存率', prefill: '预填充', output: '输出', hitRate: '命中率' },
+        callout: { requests: '请求', cost: '费用', total: '总量', cached: '缓存', cachedRate: '缓存率', prefill: '预填充', output: '输出' },
         apiKeyScopeInfo: 'API 密钥分组和筛选仅包含当前账号拥有的密钥。选择“按 API 密钥”会将用户设为“仅自己”；选择其他用户会清空 API 密钥筛选并回到“按模型”。',
         apiKeyScopeLabel: '关于 API 密钥遥测范围',
         groupBy: { label: '分组依据', model: '按模型', upstream: '按上游', userId: '按用户', keyId: '按 API 密钥' },
@@ -935,7 +935,6 @@ const zhHansCN = {
           cached: '缓存输入',
           cachedRate: '缓存比例',
           cacheCreation: '缓存写入',
-          cacheHitRate: '缓存命中率',
         },
       },
       performance: {


### PR DESCRIPTION
## What

Removes the **Cache Hit Rate** metric from the Usage dashboard: the summary tile, the selectable chart metric, the chart callout column, its URL-state value and both locales' strings.

## Why

The metric never measured what its name claims. It has always been

```
cacheHitRate = cacheRead / (cacheRead + cacheCreation)
```

which is the share of *cacheable tokens* that were reused — not the share of *requests* that hit the cache. That quantity carries no signal:

| slice (last 7 days, production) | cache read | cache write | metric |
|---|---|---|---|
| all traffic | 45.6 B | 2.66 B | 94.5% |
| `claude-opus-5` | 21.9 B | 1.22 B | 94.7% |
| `gpt-5.4` | 36.1 M | 0 | **100.00%** |
| `deepseek-v4-flash` | 19.0 M | 0 | **100.00%** |
| `gemini-3.6-flash` | 2.08 M | 0 | **100.00%** |

Once a conversation's prefix is cached, later requests report a large `cacheRead` against little or no `cacheCreation`, so the ratio sits just under 100% for everything — and lands on exactly 100.00% for every upstream that reports cache reads without reporting cache writes.

The reading that would be useful — *a request billed for any cached input is a hit* — cannot be computed from what is stored. `usage` and `usage_requests` each aggregate an hour of requests into a single row per (key, model, upstream, model key, pricing selector), and neither carries a per-request cache marker. Recovering it would take a new recorded counter plus a migration whose historical backfill could only be invented. So the metric is removed rather than redefined.

**`Cached%` stays.** It is `cacheRead / prompt`, denominated in the whole billed prompt, so it neither saturates nor depends on an upstream reporting cache writes.

## Layout

The tile grid keeps its five columns and now holds nine tiles, so its last column carries one. Column tiles now pin to the top of the column, where a stretched single tile had centred itself across both rows.

## Test Plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`
- [x] Usage page rendered in headless Chrome against a local Node instance with seeded usage across cache-write-reporting and non-reporting models: no Cache Hit Rate tile, `Cached Rate` reads a non-saturated value, and `Cache Write` aligns with the first tile row
