### PR TITLE
fix(web): keep the switch still while its knob swells

### DIFF
--- a/apps/web/src/winui/controls/switch.css.ts
+++ b/apps/web/src/winui/controls/switch.css.ts
@@ -81,11 +81,11 @@ export const switchCss = `
 }
 
 /* The indicator paints nothing and animates nothing: the two capsules below
-   carry the fill and stroke, and the knob paints its own. */
+   carry the fill and stroke, and the knob paints its own. It lays nothing out
+   either -- every part it holds is positioned against it. */
 .fui-Switch__indicator.fui-Switch__indicator {
-  align-items: center;
   align-self: center;
-  display: flex;
+  display: block;
   /* Fluent's own eight-pixel inline ring is dropped for the twelve the
      template's gap column states, declared on the root because that is the only
      form which survives the label moving to either side; WinUI's 40px block
@@ -101,6 +101,11 @@ export const switchCss = `
 .fui-Switch.fui-Switch {
   align-items: center;
   gap: 12px;
+  /* The control draws no text of its own, so it has nothing to seat on a line
+     box's baseline and takes its centre against the surrounding text instead.
+     Without this it borrows a baseline from the first thing inside it, which is
+     the knob -- and the knob changes size with the pointer. */
+  vertical-align: middle;
 }
 
 /* Fluent's label padding is the last thing holding the root taller than the
@@ -212,9 +217,22 @@ export const switchCss = `
   border-radius: 999px;
   height: calc(12 * var(--winui-switch-unit));
   margin-inline-start: calc(2.5 * var(--winui-switch-unit));
-  /* Above both capsules. Positioned children paint in tree order against a
-     positioned sibling, which would put the accent one over the knob. */
-  position: relative;
+  /* XAML hangs the resizing knob inside SwitchKnob, a fixed 20x20 cell that
+     carries the travel transform, so the swell below is drawn inside a box the
+     control's layout never sees. One element cannot be both, and an in-flow
+     knob is the only thing the indicator contains, which makes it the whole
+     control's baseline: growing it moved every switch seated in a line box.
+     Out of flow, the indicator's own box is all the control offers, and the
+     block insets with auto margins hold the knob centred in it at whatever size
+     the state asks for -- the same centring the flex box gave it.
+
+     Above both capsules, which are positioned siblings that would otherwise
+     paint over it in tree order.
+     https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/ToggleSwitch_themeresources.xaml#L509-L523 */
+  inset-block: 0;
+  inset-inline-start: 0;
+  margin-block: auto;
+  position: absolute;
   z-index: 1;
   /* Three animations, not one: size and margin on the template's own keyframes,
      travel on the RepositionThemeAnimation timing the OS supplies (transcribed


### PR DESCRIPTION
The models list and the upstreams list both seat a `Switch` in a table cell, and hovering one moves the whole control up by a pixel.

## What happens

`.fui-Switch` is `display: inline-flex`, so in a `<td>` — whose content is a line box — the control is placed by its baseline. A flex container synthesises its baseline from its first in-flow item, and the indicator's only in-flow child was the knob `<svg>`, so the control's baseline was the knob's bottom edge. The knob grows from 12px to 14px under the pointer, centred in the 20px track, which moves that edge down 1px: the line box grows, the cell re-centres it, and the control lands 0.5px higher.

Blink snaps paint offsets to whole CSS pixels, so that 0.5px becomes visible ink only when the row's fractional offset crosses a rounding boundary — and then it jumps a full pixel. At a headless viewport's default zoom the rows land on integers and nothing paints; at any other browser zoom it paints on every device pixel ratio tried. Both themes and `prefers-reduced-motion: reduce` behave identically: this is geometry, not paint or timing.

Only an unlabelled switch in a line box is affected. A labelled switch resolves as a flex item and does not move, and a disabled one does not swell at all.

## Why it is a defect

WinUI has no such coupling. The knobs that resize — `SwitchKnobOn` and `SwitchKnobOff` — sit inside [`SwitchKnob`](https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/CommonStyles/ToggleSwitch_themeresources.xaml#L509-L523), a fixed 20x20 cell that carries the travel transform, so their Width and Height animations never reach the control's own layout. Our transcription collapsed those two into one element, which is what let the swell reach layout.

## The change

Restore the fixed cell by taking the knob out of flow inside the track. The indicator's own box is then everything the control exposes, so no state of the knob can move the control — the defect cannot recur by construction rather than by a compensating value. The indicator no longer lays anything out, so its flex centring goes with it.

The control's alignment is then stated rather than borrowed from a part: a switch draws no text and has nothing to seat on a baseline, so it takes its centre against the surrounding text.

## One consequence to weigh

Stating the alignment moves a switch's resting position in a table cell down by 1.25px. The old position came from the accidental knob baseline and sat 0.5px above the row's centre; the new one sits 0.75px below it, aligned instead to the centre of the row's text. Both are within a pixel, in opposite directions. If the old resting position is preferred, the alternative is to have `TableCentredCell` centre its content as a box in the block axis, which lands exactly on the row centre — but that is a change at the cell rather than at the control.

## Test Plan

- [x] Knob geometry relative to the track is unchanged in every state — rest `3.5,4 12x12`, pointer-over `2.5,3 14x14`, pressed `3,3 17x14`, and the same after travel.
- [x] No movement of the switch's rect or its painted ink on hover or press, across all ten switches on the two affected pages, in Chromium at device pixel ratios 1 / 1.25 / 1.5 / 2, in both colour schemes, and at browser zooms 0.9 / 1.1 / 1.25 — every combination that previously reproduced.
- [x] Same result in WebKit and in Firefox.
- [x] Same result against a production build served by `wrangler dev`, not only the dev server.
- [x] Switches outside a line box — the model detail panel and the WinUI gallery — do not move at rest or on hover.
- [x] `pnpm run lint`
- [x] `pnpm --filter @floway-dev/web run typecheck`
- [x] `pnpm --filter @floway-dev/web run test` (105 files, 592 tests)
