### PR TITLE
fix(docker): start the Podman Quadlet units independently

### DIFF
--- a/docker/systemd/README.md
+++ b/docker/systemd/README.md
@@ -8,6 +8,8 @@ Podman Quadlets allow you to manage containers as native systemd services. These
 
    Podman should be preinstalled on Red Hat systems, and can be installed on-demand on other systems.
 
+   On Debian, the Podman package might be missing a `catatonit` dependency. Install it, or Pods might not start.
+
 2. ```bash
    mkdir -p ~/.config/containers/systemd/
    cp floway-data.volume floway-server.container.example floway-web.container floway.pod ~/.config/containers/systemd/
@@ -29,6 +31,8 @@ Podman Quadlets allow you to manage containers as native systemd services. These
 1. Install [Podman](https://podman.io).
 
    Podman should be preinstalled on Red Hat systems, and can be installed on-demand on other systems.
+
+   On Debian, the Podman package might be missing a `catatonit` dependency. Install it, or Pods might not start.
 
 2. ```bash
    sudo mkdir -p /etc/containers/systemd/

--- a/docker/systemd/floway-server.container.example
+++ b/docker/systemd/floway-server.container.example
@@ -17,3 +17,7 @@ Pull=newer
 
 [Service]
 Restart=always
+
+[Install]
+# Auto-start
+WantedBy=default.target

--- a/docker/systemd/floway-web.container
+++ b/docker/systemd/floway-web.container
@@ -1,7 +1,3 @@
-[Unit]
-After=floway-server.service
-Requires=floway-server.service
-
 [Container]
 ContainerName=floway-web
 Image=ghcr.io/menci/floway-web:latest


### PR DESCRIPTION
Remove unit dependency between `floway-server.container` and `floway-web.container` so each of them can be restarted independently.