### PR TITLE
perf(provider): stream JSON request bodies

### DIFF
--- a/packages/provider-azure/src/fetch.ts
+++ b/packages/provider-azure/src/fetch.ts
@@ -1,12 +1,12 @@
 import type { AzureUpstreamConfig } from './config.ts';
 import { azureAnthropicBaseUrl, azureOpenAiV1BaseUrl } from './endpoint.ts';
-import { type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
+import { type FetchInit, type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
 
 const azureFetchUrl = async (
   config: AzureUpstreamConfig,
   surface: 'openai' | 'anthropic',
   url: string,
-  init: RequestInit,
+  init: FetchInit,
   options: UpstreamFetchOptions,
 ): Promise<Response> => {
   const headers = new Headers(init.headers);
@@ -29,7 +29,7 @@ const azureFetchInternal = async (
   config: AzureUpstreamConfig,
   surface: 'openai' | 'anthropic',
   path: string,
-  init: RequestInit,
+  init: FetchInit,
   options: UpstreamFetchOptions,
   query?: string,
 ): Promise<Response> => {
@@ -54,22 +54,22 @@ const azureDeploymentScopedAudioTranscriptionUrl = (config: AzureUpstreamConfig,
   return url.href;
 };
 
-export const azureFetchChatCompletions = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchChatCompletions = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/chat/completions', init, options);
-export const azureFetchResponses = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchResponses = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/responses', init, options);
-export const azureFetchResponsesCompact = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchResponsesCompact = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/responses/compact', init, options);
-export const azureFetchEmbeddings = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchEmbeddings = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/embeddings', init, options);
-export const azureFetchCompletions = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchCompletions = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/completions', init, options);
 // gpt-image-2 (released 2026-04-21) and the gpt-image-1 family are exposed
 // only under Azure's preview lifecycle today. We will drop the query suffix
 // once Azure promotes the image endpoints to the GA default.
-export const azureFetchImagesGenerations = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchImagesGenerations = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/images/generations', init, options, 'api-version=preview');
-export const azureFetchImagesEdits = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchImagesEdits = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'openai', '/images/edits', init, options, 'api-version=preview');
 // Azure selects the transcription deployment in the operation path, so the
 // multipart body must omit `model`. The 2025-04 preview route covers both
@@ -77,9 +77,9 @@ export const azureFetchImagesEdits = (config: AzureUpstreamConfig, init: Request
 // reduce to their resource host before this operation-specific path is set.
 // https://github.com/Azure/azure-rest-api-specs/blob/b0a48bcbffead733affe03944ef09f5e8d12f8c8/specification/cognitiveservices/OpenAI.Inference/models/audio/audio_transcription.tsp#L119-L126
 // https://github.com/Azure/azure-rest-api-specs/blob/928047803788f7377fa003a26ba2bdc2e0fcccc0/specification/cognitiveservices/OpenAI.Inference/routes/audio_transcription.tsp#L19-L49
-export const azureFetchAudioTranscriptions = (config: AzureUpstreamConfig, deployment: string, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchAudioTranscriptions = (config: AzureUpstreamConfig, deployment: string, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchUrl(config, 'openai', azureDeploymentScopedAudioTranscriptionUrl(config, deployment), init, options);
-export const azureFetchMessages = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchMessages = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'anthropic', '/v1/messages', init, options);
-export const azureFetchMessagesCountTokens = (config: AzureUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const azureFetchMessagesCountTokens = (config: AzureUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   azureFetchInternal(config, 'anthropic', '/v1/messages/count_tokens', init, options);

--- a/packages/provider-azure/src/provider.ts
+++ b/packages/provider-azure/src/provider.ts
@@ -5,11 +5,11 @@ import { parseChatCompletionsStream } from '@floway-dev/protocols/chat-completio
 import { kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type ResponsesCompactionResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { headersForMessagesCall, serializeModelPathAudioTranscriptionRequest, serializeOpenAIImagesEditsRequest, type ProviderInstance, type Provider, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
+import { headersForMessagesCall, jsonRequestBody, serializeModelPathAudioTranscriptionRequest, serializeOpenAIImagesEditsRequest, type FetchInit, type ProviderInstance, type Provider, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord, publicModelId, resolveEffectiveFlags, streamingProviderCall } from '@floway-dev/provider';
 
 const upstreamModelIdOf = (model: ProviderModel): string => (model.providerData as { upstreamModelId: string }).upstreamModelId;
 
-type AzureTypedFetch = (config: ReturnType<typeof assertAzureUpstreamRecord>['config'], init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>;
+type AzureTypedFetch = (config: ReturnType<typeof assertAzureUpstreamRecord>['config'], init: FetchInit, options: UpstreamFetchOptions) => Promise<Response>;
 
 export const createAzureProvider = (record: UpstreamRecord): Provider => {
   const azure = assertAzureUpstreamRecord(record);
@@ -27,7 +27,7 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
     return streamingProviderCall(
       transport(
         azure.config,
-        { method: 'POST', body: JSON.stringify({ ...body, stream: true, model: upstreamModelId }), signal },
+        { method: 'POST', body: jsonRequestBody({ ...body, stream: true, model: upstreamModelId }), signal },
         { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall },
       ),
       parser,
@@ -38,7 +38,7 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
 
   const callNonStreaming = async (transport: AzureTypedFetch, model: ProviderModel, body: Record<string, unknown>, signal: AbortSignal | undefined, headers: Headers, opts: UpstreamCallOptions) => {
     const upstreamModelId = upstreamModelIdOf(model);
-    const response = await transport(azure.config, { method: 'POST', body: JSON.stringify({ ...body, model: upstreamModelId }), signal }, { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall });
+    const response = await transport(azure.config, { method: 'POST', body: jsonRequestBody({ ...body, model: upstreamModelId }), signal }, { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall });
     return { response, modelKey: upstreamModelId };
   };
 
@@ -75,7 +75,7 @@ export const createAzureProvider = (record: UpstreamRecord): Provider => {
         const upstreamModelId = upstreamModelIdOf(model);
         const response = await azureFetchResponsesCompact(
           azure.config,
-          { method: 'POST', body: JSON.stringify({ ...toCompactPayloadShape(body), model: upstreamModelId }), signal },
+          { method: 'POST', body: jsonRequestBody({ ...toCompactPayloadShape(body), model: upstreamModelId }), signal },
           { extraHeaders: opts.headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall },
         );
         return response.ok

--- a/packages/provider-claude-code/__tests__/fetch_test.ts
+++ b/packages/provider-claude-code/__tests__/fetch_test.ts
@@ -8,8 +8,9 @@ import type {
   ClaudeCodeQuotaSnapshotEntry,
   ClaudeCodeUpstreamState,
 } from '../src/state.ts';
+import type { MessagesPayload } from '@floway-dev/protocols/messages';
 import { initProviderRepo, type MessagesUpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
-import { noopMessagesUpstreamCallOptions as noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
+import { noopMessagesUpstreamCallOptions as noopUpstreamCallOptions, readJsonRequest, stubProviderModel } from '@floway-dev/test-utils';
 
 const upstreamId = 'up_cc';
 
@@ -281,7 +282,7 @@ describe('callClaudeCodeMessages — wire body', () => {
       body: { ...minimalBody, stream: false },
       shaped: false, call: noopUpstreamCallOptions(),
     });
-    const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    const body = await readJsonRequest(fetchSpy.mock.calls[0]![1] as RequestInit) as MessagesPayload;
     expect(body.stream).toBe(true);
     expect(body.model).toBe('claude-sonnet-4-5-20250929');
   });

--- a/packages/provider-claude-code/__tests__/provider_test.ts
+++ b/packages/provider-claude-code/__tests__/provider_test.ts
@@ -4,10 +4,16 @@ import { buildClaudeCodeCatalog, type ClaudeCodeApiModel } from '../src/models.t
 import { pricingForClaudeCodeModelKey } from '../src/pricing.ts';
 import { createClaudeCodeProvider } from '../src/provider.ts';
 import type { ClaudeCodeAccessTokenEntry, ClaudeCodeAccountCredential, ClaudeCodeUpstreamState } from '../src/state.ts';
+import type { MessagesPayload, MessagesTextBlock } from '@floway-dev/protocols/messages';
 import { initProviderRepo, type FlagId, type MessagesUpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
-import { noopMessagesUpstreamCallOptions, noopUpstreamCallOptions } from '@floway-dev/test-utils';
+import { noopMessagesUpstreamCallOptions, noopUpstreamCallOptions, readJsonRequest } from '@floway-dev/test-utils';
 
 const upstreamId = 'up_cc_provider';
+
+type WireMessagesPayload = MessagesPayload & {
+  system: MessagesTextBlock[];
+  metadata: { user_id: string };
+};
 
 // Canned `/v1/models` payload the fetcher mock returns; mirrors the live
 // June-2026 catalog shape (mixed dated and alias-shape ids).
@@ -186,7 +192,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
     expect(wireHeaders.get('user-agent')).toMatch(/^claude-cli\//);
     expect(wireHeaders.get('anthropic-beta')).toBeTruthy();
 
-    const body = JSON.parse(init.body as string);
+    const body = await readJsonRequest(init) as WireMessagesPayload;
     expect(Array.isArray(body.system)).toBe(true);
     expect(body.system).toHaveLength(3);
     expect(body.system[0].text).toMatch(/^x-anthropic-billing-header:/);
@@ -214,7 +220,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
     );
 
     const init = fetchSpy.mock.calls[0]![1] as RequestInit;
-    const body = JSON.parse(init.body as string);
+    const body = await readJsonRequest(init) as WireMessagesPayload;
     // System stays as the operator sent it — the chain did NOT mutate to
     // the 3-block re-mimicry shape.
     expect(body.system).toHaveLength(1);
@@ -244,7 +250,7 @@ describe('createClaudeCodeProvider — callMessages routes through chain', () =>
     );
 
     const init = fetchSpy.mock.calls[0]![1] as RequestInit;
-    const body = JSON.parse(init.body as string);
+    const body = await readJsonRequest(init) as WireMessagesPayload;
     // Re-mimicry ran: system was rebuilt into the 3-block shape.
     expect(body.system).toHaveLength(3);
   });

--- a/packages/provider-claude-code/src/fetch.ts
+++ b/packages/provider-claude-code/src/fetch.ts
@@ -14,6 +14,7 @@ import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import {
   getProviderRepo,
   headersForMessagesCall,
+  jsonRequestBody,
   streamingProviderCall,
   type MessagesUpstreamCallOptions,
   type ProviderModel,
@@ -389,7 +390,7 @@ const performUpstreamCall = async (
   const upstreamFetch = opts.call.wrapUpstreamCall(() => opts.call.fetcher(ANTHROPIC_MESSAGES_ENDPOINT, {
     method: 'POST',
     headers,
-    body: JSON.stringify(wireBody),
+    body: jsonRequestBody(wireBody),
     signal: opts.signal,
   })).then(response => {
     // `opts.call.waitUntil` is set by the gateway on Workers so the

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -6,7 +6,7 @@ import { callCodexAlphaSearch, callCodexResponses, callCodexResponsesCompact, ty
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotEntryMap, CodexUpstreamState } from '../src/state.ts';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
-import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
+import { noopUpstreamCallOptions, readJsonRequest, stubProviderModel } from '@floway-dev/test-utils';
 
 const makeEffects = (): CodexCallEffects => ({
   persistRefreshTokenRotation: vi.fn(async () => {}),
@@ -192,7 +192,7 @@ describe('callCodexResponses — upstream classification', () => {
       model, body: { input: [], stream: false as unknown as true, store: true } as unknown as Parameters<typeof callCodexResponses>[0]['body'],
       headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
     });
-    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    const body = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
     expect(body.model).toBe('gpt-5.4');
     expect(body.store).toBe(false);
     expect(body.stream).toBe(true);
@@ -260,7 +260,7 @@ describe('callCodexResponses — upstream classification', () => {
     expect(headers.get('openai-beta')).toBeNull();
     expect(headers.get('x-real-ip')).toBeNull();
 
-    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    const body = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
     expect(body.prompt_cache_key).toBe('downstream-session');
     expect(body.client_metadata).toEqual({
       'x-codex-installation-id': 'downstream-installation',
@@ -370,9 +370,9 @@ describe('callCodexResponses — upstream classification', () => {
       call: noopUpstreamCallOptions(),
     });
 
-    const injectedBody = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
-    const preservedStringBody = JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string) as Record<string, unknown>;
-    const preservedNullBody = JSON.parse((fetchSpy.mock.calls[2][1] as RequestInit).body as string) as Record<string, unknown>;
+    const injectedBody = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
+    const preservedStringBody = await readJsonRequest(fetchSpy.mock.calls[1][1] as RequestInit) as Record<string, unknown>;
+    const preservedNullBody = await readJsonRequest(fetchSpy.mock.calls[2][1] as RequestInit) as Record<string, unknown>;
     expect(injectedBody.prompt_cache_key).toBe('cache-session');
     expect(preservedStringBody.prompt_cache_key).toBe('caller-cache-key');
     expect(preservedNullBody).toHaveProperty('prompt_cache_key', null);
@@ -523,7 +523,7 @@ describe('callCodexResponses — upstream classification', () => {
     const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
     const turnMetadata = JSON.parse(headers.get('x-codex-turn-metadata') ?? 'null') as Record<string, unknown>;
     expect(turnMetadata.installation_id).toBe(deviceId);
-    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    const body = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
     expect((body.client_metadata as Record<string, unknown>)['x-codex-installation-id']).toBe(deviceId);
   });
 
@@ -545,7 +545,7 @@ describe('callCodexResponses — upstream classification', () => {
     const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
     const turnMetadata = JSON.parse(headers.get('x-codex-turn-metadata') ?? 'null') as Record<string, unknown>;
     expect(turnMetadata.installation_id).toBe('caller-installation-id');
-    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    const body = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
     expect((body.client_metadata as Record<string, unknown>)['x-codex-installation-id']).toBe('caller-installation-id');
   });
 
@@ -603,7 +603,7 @@ describe('callCodexResponses — upstream classification', () => {
     // turn_id propagates to body's client_metadata as well so the three
     // surfaces (header turn_metadata, body client_metadata, body
     // client_metadata.x-codex-turn-metadata) stay consistent.
-    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    const body = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
     expect((body.client_metadata as Record<string, unknown>).turn_id).toBe('caller-turn');
   });
 
@@ -621,7 +621,7 @@ describe('callCodexResponses — upstream classification', () => {
       call: noopUpstreamCallOptions(),
     });
 
-    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    const body = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
     const clientMetadata = body.client_metadata as Record<string, unknown>;
     // Non-identity extras pass through verbatim.
     expect(clientMetadata['x-extra-key']).toBe('caller-supplied');
@@ -773,7 +773,7 @@ describe('callCodexResponsesCompact', () => {
     expect(new Headers(init.headers).get('accept')).toBe('application/json');
     expect(new Headers(init.headers).get('authorization')).toBe('Bearer at_kv');
 
-    const body = JSON.parse(init.body as string);
+    const body = await readJsonRequest(init) as Record<string, unknown>;
     expect(body.model).toBe('gpt-5.4');
     expect(body.input).toEqual([{ type: 'message', role: 'user', content: 'hello' }]);
     expect(body.stream).toBeUndefined();
@@ -887,7 +887,7 @@ describe('callCodexAlphaSearch', () => {
     expect(headers.get('authorization')).toBe('Bearer at_kv');
     expect(headers.get('chatgpt-account-id')).toBe('acc');
     expect(headers.get('x-codex-turn-metadata')).toBe('{"turn_id":"turn-search"}');
-    expect(JSON.parse(init.body as string)).toMatchObject({
+    expect(await readJsonRequest(init)).toMatchObject({
       id: 'search-session',
       model: 'gpt-5.4',
       commands: { search_query: [{ q: 'Floway' }] },
@@ -910,7 +910,7 @@ describe('callCodexAlphaSearch', () => {
 
     const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     const headers = new Headers(init.headers);
-    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const body = await readJsonRequest(init) as Record<string, unknown>;
     expect(headers.has('x-codex-turn-metadata')).toBe(false);
     expect(typeof body.id).toBe('string');
     expect(headers.get('session-id')).toBe(body.id);

--- a/packages/provider-codex/__tests__/interceptors/responses/action-pivot_test.ts
+++ b/packages/provider-codex/__tests__/interceptors/responses/action-pivot_test.ts
@@ -4,7 +4,7 @@ import type { ResponsesBoundaryCtx } from '../../../src/interceptors/responses/t
 import { createUpstreamStateRepoStub } from '../../upstream-state-repo.ts';
 import type { Interceptor } from '@floway-dev/interceptor';
 import { initProviderRepo, type ProviderResponsesResult, type UpstreamRecord } from '@floway-dev/provider';
-import { assertEquals } from '@floway-dev/test-utils';
+import { assertEquals, readJsonRequest } from '@floway-dev/test-utils';
 
 // Codex's terminal handler in provider.ts switches on `ctx.action` (the
 // post-chain value), so an interceptor that flips it mid-chain reroutes
@@ -80,7 +80,8 @@ test('Codex terminal dispatches on post-chain ctx.action (interceptor flip gener
     const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : (input as Request).url);
     if (url.endsWith('/codex/responses/compact')) {
       compactUrl = url;
-      compactBody = JSON.parse(init?.body as string) as Record<string, unknown>;
+      if (init === undefined) throw new Error('expected compact request init');
+      compactBody = await readJsonRequest(init) as Record<string, unknown>;
       return compactJsonResponse();
     }
     throw new Error(`unexpected fetch ${url}`);

--- a/packages/provider-codex/__tests__/provider_test.ts
+++ b/packages/provider-codex/__tests__/provider_test.ts
@@ -4,7 +4,7 @@ import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstr
 import { createCodexProvider } from '../src/provider.ts';
 import type { CodexAccessTokenEntry, CodexUpstreamState } from '../src/state.ts';
 import { directFetcher, initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
-import { noopUpstreamCallOptions, stubProviderModel } from '@floway-dev/test-utils';
+import { noopUpstreamCallOptions, readJsonRequest, stubProviderModel } from '@floway-dev/test-utils';
 
 const farFutureMs = Date.now() + 24 * 60 * 60 * 1000;
 
@@ -183,8 +183,8 @@ describe('createCodexProvider', () => {
     expect(result.ok).toBe(true);
     expect(result.action).toBe('generate');
     const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
-    expect(init).toBeDefined();
-    const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+    if (init === undefined) throw new Error('expected a Codex upstream request');
+    const body = await readJsonRequest(init) as Record<string, unknown>;
     expect(body.instructions).toBe("You're a helpful assistant.");
     expect(body.input).toEqual([
       { type: 'message', role: 'developer', content: 'base instructions' },

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -17,7 +17,7 @@ import type { CodexAccountCredential } from './state.ts';
 import { isEventStreamMediaType } from '@floway-dev/protocols/common';
 import type { CanonicalResponsesCompactPayload, CanonicalResponsesPayload, ResponsesCompactionResult, ResponsesInputItem, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
-import { type ProviderCallResult, type ProviderModel, type ProviderStreamResult, streamingProviderCall, type UpstreamCallOptions } from '@floway-dev/provider';
+import { jsonRequestBody, type ProviderCallResult, type ProviderModel, type ProviderStreamResult, streamingProviderCall, type UpstreamCallOptions } from '@floway-dev/provider';
 
 export type ProviderCompactionResult =
   | { ok: true; result: ResponsesCompactionResult; modelKey: string }
@@ -339,7 +339,7 @@ const dispatchCodexHttpCall = async (
   const response = await opts.call.wrapUpstreamCall(() => opts.call.fetcher(`${CODEX_BACKEND_BASE}${path}`, {
     method: 'POST',
     headers,
-    body: JSON.stringify(body),
+    body: jsonRequestBody(body),
     signal: opts.signal,
   }));
 

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -2,7 +2,7 @@ import pRetry, { AbortError as RetryAbortError } from 'p-retry';
 
 import { githubApiOrigin } from './github-host.ts';
 import { readCopilotUpstreamState, type CopilotTokenEntry, type CopilotUpstreamState } from './state.ts';
-import { dispatchUpstreamFetch, getProviderRepo as getRepo, isAbortError, type Fetcher } from '@floway-dev/provider';
+import { dispatchUpstreamFetch, getProviderRepo as getRepo, isAbortError, type Fetcher, type FetchInit } from '@floway-dev/provider';
 
 // Version constants pinned to a known-good fingerprint that mirrors what a
 // current VSCode Copilot Chat install sends. The Copilot Chat plugin version,
@@ -225,9 +225,9 @@ export interface CopilotAuth {
   githubToken: string;
 }
 
-export async function copilotAuthedFetch(path: string, init: RequestInit, auth: CopilotAuth, options: CopilotFetchOptions): Promise<Response> {
+export async function copilotAuthedFetch(path: string, init: FetchInit, auth: CopilotAuth, options: CopilotFetchOptions): Promise<Response> {
   const signal = init.signal ?? undefined;
-  let ownedInit: RequestInit | undefined = init;
+  let ownedInit: FetchInit | undefined = init;
   // The token exchange is the only await before the data-plane dispatch. Keep
   // the body in an explicit owner and replace the generator parameter so the
   // final network wait cannot retain both copies after ownership transfers.

--- a/packages/provider-copilot/src/fetch.ts
+++ b/packages/provider-copilot/src/fetch.ts
@@ -1,6 +1,6 @@
 import { copilotAuthedFetch, isCopilotTokenFetchError, type CopilotAuth } from './auth.ts';
 import { parseCopilotQuotaHeaders, putCopilotQuota } from './quota.ts';
-import type { UpstreamFetchOptions } from '@floway-dev/provider';
+import type { FetchInit, UpstreamFetchOptions } from '@floway-dev/provider';
 
 export type CopilotFetchConfig = CopilotAuth;
 
@@ -39,7 +39,7 @@ const captureQuotaFireAndForget = (
 const copilotFetchInternal = async (
   config: CopilotFetchConfig,
   path: string,
-  init: RequestInit,
+  init: FetchInit,
   options: CopilotDataPlaneFetchOptions,
 ): Promise<Response> => {
   const response = await copilotAuthedFetch(path, init, config, {
@@ -57,15 +57,15 @@ const copilotFetchInternal = async (
   return response;
 };
 
-export const copilotFetchChatCompletions = (config: CopilotFetchConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
+export const copilotFetchChatCompletions = (config: CopilotFetchConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
   copilotFetchInternal(config, '/chat/completions', init, options);
-export const copilotFetchResponses = (config: CopilotFetchConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
+export const copilotFetchResponses = (config: CopilotFetchConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
   copilotFetchInternal(config, '/responses', init, options);
-export const copilotFetchMessages = (config: CopilotFetchConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
+export const copilotFetchMessages = (config: CopilotFetchConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
   copilotFetchInternal(config, '/v1/messages', init, options);
-export const copilotFetchMessagesCountTokens = (config: CopilotFetchConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
+export const copilotFetchMessagesCountTokens = (config: CopilotFetchConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
   copilotFetchInternal(config, '/v1/messages/count_tokens', init, options);
-export const copilotFetchEmbeddings = (config: CopilotFetchConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
+export const copilotFetchEmbeddings = (config: CopilotFetchConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
   copilotFetchInternal(config, '/embeddings', init, options);
-export const copilotFetchModels = (config: CopilotFetchConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
+export const copilotFetchModels = (config: CopilotFetchConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions): Promise<Response> =>
   copilotFetchInternal(config, '/models', init, options);

--- a/packages/provider-copilot/src/provider.ts
+++ b/packages/provider-copilot/src/provider.ts
@@ -22,7 +22,7 @@ import { parseChatCompletionsStream, type ChatCompletionsPayload, type ChatCompl
 import { type ModelEndpointKey, type ModelEndpoints, type ProtocolFrame, kindForEndpoints } from '@floway-dev/protocols/common';
 import { parseMessagesStream, type MessagesPayload, type MessagesStreamEvent } from '@floway-dev/protocols/messages';
 import { parseResponsesStream, type CanonicalResponsesPayload, type ResponsesResult } from '@floway-dev/protocols/responses';
-import { eventResult, getProviderRepo, headersForMessagesCall, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, resolveEffectiveFlags, type ExecuteResult, type FlagOverrides, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { eventResult, getProviderRepo, headersForMessagesCall, jsonRequestBody, readUpstreamApiError, streamingProviderCall, apiErrorToResponse, resolveEffectiveFlags, type ExecuteResult, type FetchInit, type FlagOverrides, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderResponsesResult, type ProviderStreamResult, type TelemetryModelIdentity, type UpstreamCallOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 interface CopilotProviderData {
   rawModels: CopilotRawModel[];
@@ -206,7 +206,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
   const upstreamConfig = { id: copilot.id, githubHost: copilot.config.githubHost, githubToken: copilot.config.githubToken };
 
   const call = async (
-    transport: (config: typeof upstreamConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions) => Promise<Response>,
+    transport: (config: typeof upstreamConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions) => Promise<Response>,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
     rawModel: CopilotRawModel,
@@ -217,7 +217,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
       upstreamConfig,
       {
         method: 'POST',
-        body: JSON.stringify({ ...body, model: rawModel.id }),
+        body: jsonRequestBody({ ...body, model: rawModel.id }),
         signal,
       },
       { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall, waitUntil: opts.waitUntil },
@@ -226,7 +226,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
   };
 
   const callStreaming = <TEvent>(
-    transport: (config: typeof upstreamConfig, init: RequestInit, options: CopilotDataPlaneFetchOptions) => Promise<Response>,
+    transport: (config: typeof upstreamConfig, init: FetchInit, options: CopilotDataPlaneFetchOptions) => Promise<Response>,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
     rawModel: CopilotRawModel,
@@ -239,7 +239,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
         upstreamConfig,
         {
           method: 'POST',
-          body: JSON.stringify({ ...body, stream: true, model: rawModel.id }),
+          body: jsonRequestBody({ ...body, stream: true, model: rawModel.id }),
           signal,
         },
         { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall, waitUntil: opts.waitUntil },
@@ -380,7 +380,7 @@ export const createCopilotProvider = (record: UpstreamRecord): Provider => {
             const triggered = { ...wireBody, input: [...input, COMPACTION_TRIGGER], stream: false, model: rawModel.id };
             const response = await copilotFetchResponses(
               upstreamConfig,
-              { method: 'POST', body: JSON.stringify(triggered), signal },
+              { method: 'POST', body: jsonRequestBody(triggered), signal },
               { extraHeaders: ctx.headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall, waitUntil: opts.waitUntil },
             );
             if (!response.ok) return { action: 'compact', ok: false, response, modelKey: rawModel.id };

--- a/packages/provider-custom/src/fetch.ts
+++ b/packages/provider-custom/src/fetch.ts
@@ -1,5 +1,5 @@
 import type { CustomPathOverrideKey, CustomUpstreamConfig } from './config.ts';
-import { type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
+import { type FetchInit, type UpstreamFetchOptions, joinBaseAndPath } from '@floway-dev/provider';
 
 // https://docs.anthropic.com/en/api/versioning
 const ANTHROPIC_VERSION = '2023-06-01';
@@ -16,7 +16,7 @@ const pathOverrideFor = (config: CustomUpstreamConfig, key: CustomPathOverrideKe
 const customFetchInternal = async (
   config: CustomUpstreamConfig,
   path: string,
-  init: RequestInit,
+  init: FetchInit,
   options: UpstreamFetchOptions,
 ): Promise<Response> => {
   const headers = new Headers(init.headers);
@@ -38,32 +38,32 @@ const customFetchInternal = async (
   return await options.wrapUpstreamCall(() => options.fetcher(joinBaseAndPath(config.baseUrl, path), { ...init, headers }));
 };
 
-export const customFetchRerank = (config: CustomUpstreamConfig, path: string, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchRerank = (config: CustomUpstreamConfig, path: string, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, path, init, options);
 
-export const customFetchChatCompletions = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchChatCompletions = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/chat/completions'), init, options);
-export const customFetchResponses = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchResponses = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/responses'), init, options);
-export const customFetchResponsesCompact = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchResponsesCompact = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, `${pathOverrideFor(config, '/responses')}/compact`, init, options);
-export const customFetchMessages = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchMessages = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/messages'), init, options);
-export const customFetchMessagesCountTokens = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchMessagesCountTokens = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, `${pathOverrideFor(config, '/messages')}/count_tokens`, init, options);
-export const customFetchEmbeddings = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchEmbeddings = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/embeddings'), init, options);
-export const customFetchCompletions = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchCompletions = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/completions'), init, options);
-export const customFetchImagesGenerations = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchImagesGenerations = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/images/generations'), init, options);
-export const customFetchImagesEdits = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchImagesEdits = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/images/edits'), init, options);
-export const customFetchAudioTranscriptions = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchAudioTranscriptions = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/audio/transcriptions'), init, options);
-export const customFetchAlphaSearch = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchAlphaSearch = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, pathOverrideFor(config, '/alpha/search'), init, options);
 // /models lives on its own fetch toggle (see config.modelsFetch.endpoint),
 // not in pathOverrides.
-export const customFetchModels = (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions): Promise<Response> =>
+export const customFetchModels = (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   customFetchInternal(config, config.modelsFetch.endpoint ?? '/v1/models', init, options);

--- a/packages/provider-custom/src/provider.ts
+++ b/packages/provider-custom/src/provider.ts
@@ -8,7 +8,7 @@ import { type ModelEndpoints, kindForEndpoints } from '@floway-dev/protocols/com
 import { parseMessagesStream } from '@floway-dev/protocols/messages';
 import { DEFAULT_RERANK_PATHS, serializeRerankRequest } from '@floway-dev/protocols/rerank';
 import { parseResponsesStream, type ResponsesCompactionResult, toCompactPayloadShape } from '@floway-dev/protocols/responses';
-import { headersForMessagesCall, serializeOpenAIAudioTranscriptionRequest, serializeOpenAIImagesEditsRequest, publicModelId, resolveEffectiveFlags, streamingProviderCall, type FlagId, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
+import { headersForMessagesCall, jsonRequestBody, serializeOpenAIAudioTranscriptionRequest, serializeOpenAIImagesEditsRequest, publicModelId, resolveEffectiveFlags, streamingProviderCall, type FetchInit, type FlagId, type ProviderInstance, type Provider, type ProviderCallResult, type ProviderModel, type ProviderStreamParser, type UpstreamCallOptions, type UpstreamFetchOptions, type UpstreamRecord } from '@floway-dev/provider';
 
 const rawModelIdOf = (model: ProviderModel): string => model.providerData as string;
 
@@ -127,7 +127,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     return resolved;
   };
   const call = (
-    transport: (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,
+    transport: (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions) => Promise<Response>,
     model: ProviderModel,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
@@ -135,7 +135,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     opts: UpstreamCallOptions,
   ): Promise<ProviderCallResult> => {
     const rawModelId = rawModelIdOf(model);
-    return transport(config, { method: 'POST', body: JSON.stringify({ ...body, model: rawModelId }), signal }, { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall })
+    return transport(config, { method: 'POST', body: jsonRequestBody({ ...body, model: rawModelId }), signal }, { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall })
       .then(response => ({
         response,
         modelKey: rawModelId,
@@ -143,7 +143,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
   };
 
   const callStreaming = <TEvent>(
-    transport: (config: CustomUpstreamConfig, init: RequestInit, options: UpstreamFetchOptions) => Promise<Response>,
+    transport: (config: CustomUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions) => Promise<Response>,
     model: ProviderModel,
     body: Record<string, unknown>,
     signal: AbortSignal | undefined,
@@ -155,7 +155,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
     return streamingProviderCall(
       transport(
         config,
-        { method: 'POST', body: JSON.stringify({ ...body, stream: true, model: rawModelId }), signal },
+        { method: 'POST', body: jsonRequestBody({ ...body, stream: true, model: rawModelId }), signal },
         { extraHeaders: headers, fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall },
       ),
       parser,
@@ -185,7 +185,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
         const rawModelId = rawModelIdOf(model);
         const response = await customFetchResponsesCompact(
           config,
-          { method: 'POST', body: JSON.stringify({ ...toCompactPayloadShape(body), model: rawModelId }), signal },
+          { method: 'POST', body: jsonRequestBody({ ...toCompactPayloadShape(body), model: rawModelId }), signal },
           { extraHeaders: headersForCall(opts.headers), fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall },
         );
         return response.ok
@@ -221,7 +221,7 @@ export const createCustomProvider = (record: UpstreamRecord): Provider => {
       const response = await customFetchRerank(
         config,
         target.path ?? DEFAULT_RERANK_PATHS[target.protocol],
-        { method: 'POST', body: JSON.stringify(body), signal },
+        { method: 'POST', body: jsonRequestBody(body), signal },
         { extraHeaders: headersForCall(opts.headers), fetcher: opts.fetcher, wrapUpstreamCall: opts.wrapUpstreamCall },
       );
       return { response, modelKey: rawModelId, target };

--- a/packages/provider/__tests__/images_test.ts
+++ b/packages/provider/__tests__/images_test.ts
@@ -3,6 +3,11 @@ import { test } from 'vitest';
 import { serializeOpenAIImagesEditsRequest } from '../src/images.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
+const parseJsonBody = async (body: Awaited<ReturnType<typeof serializeOpenAIImagesEditsRequest>>): Promise<unknown> => {
+  if (body instanceof FormData) throw new Error('expected a JSON image-edit body');
+  return await new Response(body.open()).json();
+};
+
 test('serializeOpenAIImagesEditsRequest preserves reference fields and encodes mixed uploads from their bytes', async () => {
   const serialized = await serializeOpenAIImagesEditsRequest({
     images: [
@@ -12,8 +17,7 @@ test('serializeOpenAIImagesEditsRequest preserves reference fields and encodes m
     mask: { type: 'reference', reference: { file_id: 'file-mask' } },
     parameters: { prompt: 'edit', background: null },
   }, 'gpt-image');
-  assertEquals(typeof serialized, 'string');
-  const body = JSON.parse(serialized as string) as Record<string, unknown>;
+  const body = await parseJsonBody(serialized);
   assertEquals(body, {
     prompt: 'edit',
     background: null,
@@ -57,8 +61,7 @@ test('serializeOpenAIImagesEditsRequest leaves malformed inline data for upstrea
     }],
     parameters: { prompt: 'edit' },
   }, 'gpt-image');
-  assertEquals(typeof serialized, 'string');
-  assertEquals(JSON.parse(serialized as string), {
+  assertEquals(await parseJsonBody(serialized), {
     prompt: 'edit',
     images: [{ image_url: 'data:image/png;base64,%%%' }],
     model: 'gpt-image',
@@ -73,8 +76,7 @@ test('serializeOpenAIImagesEditsRequest preserves extra inline reference fields 
     }],
     parameters: { prompt: 'edit' },
   }, 'gpt-image');
-  assertEquals(typeof serialized, 'string');
-  assertEquals(JSON.parse(serialized as string), {
+  assertEquals(await parseJsonBody(serialized), {
     prompt: 'edit',
     images: [{ image_url: 'data:image/png;base64,aW1hZ2U=', future_field: 'keep' }],
     model: 'gpt-image',

--- a/packages/provider/src/images.ts
+++ b/packages/provider/src/images.ts
@@ -1,4 +1,6 @@
 import { base64ToBytes, bytesToBase64, parseBase64ImageDataUrl } from './image-helpers.ts';
+import { jsonRequestBody } from './json-request.ts';
+import type { ReplayableBody } from './options.ts';
 import type { ImageEditReference } from '@floway-dev/protocols/images';
 
 // Each source stores one authoritative representation. Multipart requires
@@ -84,8 +86,8 @@ const multipartBody = (request: ImagesEditsRequest, model: string): FormData | n
   return form;
 };
 
-export const serializeOpenAIImagesEditsRequest = async (request: ImagesEditsRequest, model: string): Promise<BodyInit> => {
+export const serializeOpenAIImagesEditsRequest = async (request: ImagesEditsRequest, model: string): Promise<FormData | ReplayableBody> => {
   const multipart = multipartBody(request, model);
   if (multipart !== null) return multipart;
-  return JSON.stringify({ ...await jsonBody(request), model });
+  return jsonRequestBody({ ...await jsonBody(request), model });
 };

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -7,5 +7,5 @@ export {
   assertStringIncludes,
   assertThrows,
 } from './assert.ts';
-export { jsonResponse, sseResponse, testFetcher, withMockedFetch } from './mock-fetch.ts';
+export { jsonResponse, readJsonRequest, sseResponse, testFetcher, withMockedFetch } from './mock-fetch.ts';
 export { mockPerfTelemetryContext, noopMessagesUpstreamCallOptions, noopUpstreamCallOptions, stubInternalModel, stubProvider, stubProviderModel, stubModelCandidate, testTelemetryModelIdentity } from './stubs.ts';

--- a/packages/test-utils/src/mock-fetch.ts
+++ b/packages/test-utils/src/mock-fetch.ts
@@ -12,6 +12,9 @@ export const testFetcher: Fetcher = (url, init) => {
   return fetch(url, request);
 };
 
+export const readJsonRequest = async (init: RequestInit): Promise<unknown> =>
+  await new Response(init.body).json();
+
 // Tests share a single globalThis.fetch slot; the lock serializes overlapping
 // withMockedFetch calls in the same process so each handler sees only its own
 // requests.


### PR DESCRIPTION
## Summary

- migrate Azure, Custom, Copilot, Codex, and Claude Code data-plane JSON to the replayable serializer
- stream Custom rerank and shared Images Edits JSON bodies, including inline base64 references
- preserve multipart image/audio uploads
- widen provider transport seams to the portable `FetchInit` contract

This draft is stacked on #434.

## Scope

The small Claude Code OAuth request, internal hash inputs, metadata headers, local response bodies, validation, and logging retain native `JSON.stringify`; they are not provider data-plane request serialization.

## Test Plan

- [x] Full test suite: 523 files, 5476 tests
- [x] Provider wire tests across Azure, Custom, Copilot, Codex, and Claude Code
- [x] Agent protocol check
- [x] Workspace typecheck
- [x] Repository lint
- [x] Diff check
- [x] GitHub Verify workflow
