### PR TITLE
fix(gateway): stop retaining every payload we gzip

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -230,6 +230,20 @@ const config: Linter.Config[] = [
     },
   },
   {
+    // Server-side production sources only. `apps/web` runs in a browser, where
+    // Blob is the ordinary way to hand bytes to a download, and tests construct
+    // Blobs deliberately as fixtures for code that must accept a caller-supplied
+    // one — the hazard is retention across a long-lived process.
+    files: ['packages/**/*.ts', 'apps/platform-*/**/*.ts', 'tools/**/*.ts', 'scripts/**/*.ts'],
+    ignores: ['**/__tests__/**'],
+    rules: {
+      'no-restricted-syntax': ['error', {
+        selector: 'NewExpression[callee.name="Blob"]',
+        message: 'Blob is a Node BaseObject rooted in the realm, and Blob.prototype.stream() never releases the source buffer, so the bytes are retained for the process lifetime and stay invisible to heapUsed. Build a ReadableStream directly — packages/gateway/src/shared/gzip.ts shows the shape. https://github.com/nodejs/node/issues/63574',
+      }],
+    },
+  },
+  {
     // Custom hooks live in plain .ts files, so scoping the React rules to .tsx
     // would leave rules-of-hooks unenforced exactly where it matters most.
     files: ['apps/web/**/*.{ts,tsx}'],

--- a/packages/gateway/__tests__/shared/gzip_test.ts
+++ b/packages/gateway/__tests__/shared/gzip_test.ts
@@ -1,0 +1,54 @@
+import { test } from 'vitest';
+
+import { gunzipBytes, gzipBytes } from '../../src/shared/gzip.ts';
+import { assert, assertEquals } from '@floway-dev/test-utils';
+
+const roundTrip = async (bytes: Uint8Array): Promise<Uint8Array> => await gunzipBytes(await gzipBytes(bytes));
+
+test('gzipBytes emits the gzip container the stored artifacts are read back as', async () => {
+  const gz = await gzipBytes(new TextEncoder().encode('floway'));
+  // Stored payloads and dump bodies are persisted as `.gz` and decoded by
+  // whichever runtime reads them later, so the magic number is part of the
+  // on-disk contract rather than an implementation detail.
+  assertEquals(gz[0], 0x1f);
+  assertEquals(gz[1], 0x8b);
+});
+
+test('gzipBytes round-trips an empty payload', async () => {
+  assertEquals((await roundTrip(new Uint8Array(0))).byteLength, 0);
+});
+
+test('gzipBytes round-trips text', async () => {
+  const original = new TextEncoder().encode(JSON.stringify({ item: { type: 'message', content: '你好, Floway' } }));
+  assertEquals(new TextDecoder().decode(await roundTrip(original)), new TextDecoder().decode(original));
+});
+
+test('gzipBytes round-trips every byte value', async () => {
+  const original = new Uint8Array(256);
+  for (let i = 0; i < original.length; i++) original[i] = i;
+  assertEquals([...await roundTrip(original)], [...original]);
+});
+
+test('gzipBytes round-trips a payload larger than one stream chunk', async () => {
+  const original = new Uint8Array(1024 * 1024);
+  // A repeating byte pattern rather than a constant fill, so the assertion
+  // would catch a chunk that arrived out of order as well as one that was lost.
+  for (let i = 0; i < original.length; i++) original[i] = (i * 31) & 0xff;
+  const restored = await roundTrip(original);
+  assertEquals(restored.byteLength, original.byteLength);
+  assert(restored.every((byte, index) => byte === original[index]), 'restored bytes diverged from the original');
+});
+
+test('gzipBytes accepts a view over a larger buffer', async () => {
+  const backing = new Uint8Array(64);
+  backing.fill(7);
+  const view = backing.subarray(16, 48);
+  assertEquals([...await roundTrip(view)], [...view]);
+});
+
+test('gunzipBytes rejects input that is not gzip', async () => {
+  await gunzipBytes(new Uint8Array([1, 2, 3])).then(
+    () => { throw new Error('expected gunzipBytes to reject non-gzip input'); },
+    () => undefined,
+  );
+});

--- a/packages/gateway/src/repo/dump-store.ts
+++ b/packages/gateway/src/repo/dump-store.ts
@@ -23,6 +23,7 @@ import type {
   StoredDumpResponse,
   StoredDumpResponseBody,
 } from '../dump/types.ts';
+import { gunzipBytes, gzipBytes } from '../shared/gzip.ts';
 import type { FileStore, SqlDatabase } from '@floway-dev/platform';
 
 // Bodies live at `dumps/v1/{keyId}/{YYYYMMDDHH}/{recordId}-{uniqueSuffix}.{req|resp}.gz`.
@@ -74,23 +75,13 @@ const hourBucket = (ms: number): string => {
 const bodyPath = (keyId: string, bucket: string, recordId: string, side: 'req' | 'resp'): string =>
   `${DUMP_FILE_PREFIX}${keyId}/${bucket}/${recordId}-${crypto.randomUUID()}.${side}.gz`;
 
-const gzip = async (bytes: Uint8Array): Promise<Uint8Array> => {
-  const stream = new Response(new Blob([bytes as BlobPart]).stream().pipeThrough(new CompressionStream('gzip')));
-  return new Uint8Array(await stream.arrayBuffer());
-};
-
-const gunzip = async (bytes: Uint8Array): Promise<Uint8Array> => {
-  const stream = new Response(new Blob([bytes as BlobPart]).stream().pipeThrough(new DecompressionStream('gzip')));
-  return new Uint8Array(await stream.arrayBuffer());
-};
-
 const putRawBody = async (
   files: FileStore,
   key: string,
   rawBytes: Uint8Array,
   type: 'bytes' | 'events',
 ): Promise<DumpBodyDescriptor> => {
-  const gz = await gzip(rawBytes);
+  const gz = await gzipBytes(rawBytes);
   await files.put(key, gz);
   return { key, type };
 };
@@ -100,7 +91,7 @@ const putPreparedBody = async (
   key: string,
   prepared: PreparedDumpRequestBody,
 ): Promise<DumpBodyDescriptor> => {
-  const gz = prepared.encoding === 'gzip' ? prepared.bytes : await gzip(prepared.bytes);
+  const gz = prepared.encoding === 'gzip' ? prepared.bytes : await gzipBytes(prepared.bytes);
   await files.put(key, gz);
   return { key, type: 'bytes' };
 };
@@ -108,7 +99,7 @@ const putPreparedBody = async (
 const fetchBody = async (files: FileStore, descriptor: DumpBodyDescriptor): Promise<Uint8Array> => {
   const gz = await files.get(descriptor.key);
   if (!gz) throw new Error(`dump body missing for key=${descriptor.key}`);
-  return await gunzip(gz);
+  return await gunzipBytes(gz);
 };
 
 export class FileDumpStore implements DumpStore {
@@ -117,7 +108,7 @@ export class FileDumpStore implements DumpStore {
   async prepareRequestBody(body: Uint8Array): Promise<PreparedDumpRequestBody> {
     return {
       encoding: 'gzip',
-      bytes: await gzip(body),
+      bytes: await gzipBytes(body),
       decodedByteLength: body.byteLength,
     };
   }

--- a/packages/gateway/src/repo/responses-payload.ts
+++ b/packages/gateway/src/repo/responses-payload.ts
@@ -1,4 +1,5 @@
 import type { StoredResponsesItemPayload } from './types.ts';
+import { gunzipBytes, gzipBytes } from '../shared/gzip.ts';
 import { getFileStore, sha256Hex } from '@floway-dev/platform';
 import { decodeForgivingBase64, encodeBase64, encodeBase64url } from '@floway-dev/protocols/common';
 
@@ -146,19 +147,8 @@ const assertPayloadObject = (id: string, value: unknown): StoredResponsesItemPay
   return payload;
 };
 
-// Copying through `new Uint8Array(bytes)` gives Blob a concrete
-// ArrayBuffer-backed view regardless of the caller's ArrayBufferLike type
-// parameter; the cast-free form fails strict-mode BufferSource on slices and
-// SharedArrayBuffer-backed inputs (same pattern as sha256.ts).
-const gzipBytes = async (bytes: Uint8Array): Promise<Uint8Array> => {
-  const stream = new Blob([new Uint8Array(bytes)]).stream().pipeThrough(new CompressionStream('gzip'));
-  return new Uint8Array(await new Response(stream).arrayBuffer());
-};
-
-const ungzipToString = async (bytes: Uint8Array): Promise<string> => {
-  const stream = new Blob([new Uint8Array(bytes)]).stream().pipeThrough(new DecompressionStream('gzip'));
-  return decoder.decode(await new Response(stream).arrayBuffer());
-};
+const ungzipToString = async (bytes: Uint8Array): Promise<string> =>
+  decoder.decode(await gunzipBytes(bytes));
 
 const randomFileSuffix = (): string => {
   const bytes = new Uint8Array(16);

--- a/packages/gateway/src/shared/gzip.ts
+++ b/packages/gateway/src/shared/gzip.ts
@@ -1,0 +1,36 @@
+// gzip helpers built on the web-standard compression streams, so the same code
+// runs on both deployment targets.
+//
+// The source stream is assembled by hand rather than taken from
+// `new Blob([bytes]).stream()`: a Blob is a Node `BaseObject` registered in the
+// realm's `BaseObjectList`, which is a GC root, and `Blob.prototype.stream()`
+// leaves the source buffer attached to it. Nothing ever collects it, and
+// because the bytes are native the retention is invisible in `heapUsed` — a
+// gateway storing Responses payloads leaked one full copy of every payload it
+// compressed, and only RSS showed it. Feeding the transform from a plain
+// `ReadableStream` keeps the pipeline identical and allocates no Blob.
+// https://github.com/nodejs/node/issues/63574
+// https://github.com/nodejs/node/issues/64105
+// The chunk type is `BufferSource` rather than `Uint8Array` to match what
+// CompressionStream's writable half declares, so `pipeThrough` lines up without
+// a cast. The enqueue itself is cast because `BufferSource` narrows to views
+// over a plain `ArrayBuffer`, while callers hand us the default
+// `Uint8Array<ArrayBufferLike>`; both runtimes accept any view here, and the
+// alternative — copying through `new Uint8Array(bytes)` to satisfy the lib
+// type — would allocate a second full copy of every payload we compress.
+const bytesStream = (bytes: Uint8Array): ReadableStream<BufferSource> =>
+  new ReadableStream<BufferSource>({
+    start(controller) {
+      controller.enqueue(bytes as BufferSource);
+      controller.close();
+    },
+  });
+
+const collect = async (stream: ReadableStream): Promise<Uint8Array> =>
+  new Uint8Array(await new Response(stream).arrayBuffer());
+
+export const gzipBytes = async (bytes: Uint8Array): Promise<Uint8Array> =>
+  await collect(bytesStream(bytes).pipeThrough(new CompressionStream('gzip')));
+
+export const gunzipBytes = async (bytes: Uint8Array): Promise<Uint8Array> =>
+  await collect(bytesStream(bytes).pipeThrough(new DecompressionStream('gzip')));


### PR DESCRIPTION
## Summary

- compress through a `ReadableStream` we build instead of `new Blob([bytes]).stream()`, which pins its source buffer to a GC root for the life of the process
- share one gzip module between the Responses payload store and the dump store, which had each grown their own copy of it
- drop the `new Uint8Array(bytes)` copy that existed only to satisfy the lib's `BufferSource` narrowing
- ban `new Blob` in server-side production sources so the retention cannot return through a new call site

## The defect

`Blob` is a Node `BaseObject` registered in the realm's `BaseObjectList`, which is a GC root, and `Blob.prototype.stream()` leaves the source buffer attached to it. Every payload the gateway compressed therefore stayed resident for the life of the process. The retained bytes are native, so `heapUsed` stayed flat while RSS climbed — a gateway storing Responses payloads leaks roughly one full copy of every stored item, and nothing in the heap profile shows it.

Upstream: [nodejs/node#63574](https://github.com/nodejs/node/issues/63574) (confirmed-bug), [nodejs/node#64105](https://github.com/nodejs/node/issues/64105).

The bug is present on Node v24.16.0 through v24.18.0. `docker/Dockerfile` pins `NODE_VERSION=22.23.1`, where the old code measures flat, so the shipped image was not affected — a self-built or self-hosted deployment on the 24.x line was.

## Memory benchmark

Node 24.18.0 on macOS arm64, forced GC before every sample.

Helper in isolation, 300 gzips of a 256 KiB payload:

| | peak `arrayBuffers` | RSS |
|---|---:|---:|
| Before | 75.5 MiB, linear at 250 KiB/call | 187.8 MiB |
| After | 0.5 MiB, flat | 82.4 MiB |

Whole gateway on a real SQLite database, 200 `/v1/responses` requests with `store: true` and a 256 KiB input, stubbed Ollama upstream:

| | `arrayBuffers` growth | RSS growth | `heapUsed` growth |
|---|---:|---:|---:|
| Before | +49.0 MiB | +96.5 MiB | +1.7 MiB |
| After | **+0.0 MiB** | +34.9 MiB | -0.5 MiB |

The residual RSS growth is present with and without the change and decelerates; it does not track payload size.

## Guard

The ESLint rule covers `packages/`, `apps/platform-*`, `tools/` and `scripts/`, and exempts `__tests__` and `apps/web`: tests construct Blobs deliberately as fixtures for code that must accept a caller-supplied one, the dashboard uses Blob to hand bytes to a browser download, and the hazard is retention across a long-lived process. The rule was verified to fire on a probe in production code and to stay silent on `apps/web`.

A runtime regression test was considered and rejected: the retention only reproduces on the affected Node line, so on CI's Node the assertion would pass against the defective code as well and give false assurance. The lint rule is the version-independent guard.

## Test Plan

- [x] gzip container and round-trip tests, including empty input, every byte value, a 1 MiB payload, a view over a larger buffer, and non-gzip input
- [x] Responses payload store and dump store suites
- [x] Helper-level and whole-gateway memory benchmarks above
- [x] Lint rule fires on server-side production code and spares `apps/web`
- [x] Workspace typecheck
- [x] Repository lint
- [x] Agent protocol check
- [x] GitHub Verify workflow

