### PR TITLE
feat(web): supply Web Crypto's secure-context members

### DIFF
--- a/apps/web/__tests__/lib/secure-context-crypto_test.ts
+++ b/apps/web/__tests__/lib/secure-context-crypto_test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  installSecureContextCrypto,
+  portableRandomUUID,
+  portableSubtle,
+} from '../../src/lib/secure-context-crypto';
+
+// Captured before any install call, so that the digests below are compared
+// against the engine's own implementation rather than against the subject.
+const nativeSubtle = crypto.subtle;
+const message = new TextEncoder().encode('abc');
+
+const nativeDigest = async (algorithm: string) =>
+  new Uint8Array(await nativeSubtle.digest(algorithm, message));
+
+// Installing writes own properties onto the platform `Crypto`, whose real
+// members live on the prototype; deleting them is what hands the engine's own
+// back to the rest of the run.
+const withInstalled = async <T>(body: () => Promise<T>): Promise<T> => {
+  installSecureContextCrypto();
+  try {
+    return await body();
+  } finally {
+    delete (crypto as Partial<Crypto>).randomUUID;
+    Reflect.deleteProperty(crypto, 'subtle');
+  }
+};
+
+describe('portable randomUUID', () => {
+  it('mints version 4 UUIDs', () => {
+    expect(portableRandomUUID()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('draws a fresh value each time', () => {
+    expect(new Set(Array.from({ length: 128 }, portableRandomUUID)).size).toBe(128);
+  });
+});
+
+describe('portable digest', () => {
+  it('matches the platform digest for every algorithm Web Crypto defines', async () => {
+    for (const algorithm of ['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512']) {
+      const digest = new Uint8Array(await portableSubtle.digest(algorithm, message));
+      expect(digest, algorithm).toStrictEqual(await nativeDigest(algorithm));
+    }
+  });
+
+  it('accepts the algorithm as an object and matches its name case-insensitively', async () => {
+    const digest = new Uint8Array(await portableSubtle.digest({ name: 'sha-256' }, message));
+    expect(digest).toStrictEqual(await nativeDigest('SHA-256'));
+  });
+
+  it('reads a view without reaching past its bounds', async () => {
+    const backing = new Uint8Array([0xff, ...message, 0xff]);
+    const digest = new Uint8Array(
+      await portableSubtle.digest('SHA-256', backing.subarray(1, 1 + message.length)),
+    );
+    expect(digest).toStrictEqual(await nativeDigest('SHA-256'));
+  });
+
+  it('reads a bare ArrayBuffer', async () => {
+    const buffer = new ArrayBuffer(message.length);
+    new Uint8Array(buffer).set(message);
+    const digest = new Uint8Array(await portableSubtle.digest('SHA-256', buffer));
+    expect(digest).toStrictEqual(await nativeDigest('SHA-256'));
+  });
+
+  it('rejects an unrecognized algorithm', async () => {
+    await expect(portableSubtle.digest('MD5', message)).rejects.toThrow(
+      expect.objectContaining({ name: 'NotSupportedError' }),
+    );
+  });
+});
+
+describe('portable key operations', () => {
+  it('report themselves unsupplied rather than answering wrongly', async () => {
+    await expect(
+      portableSubtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']),
+    ).rejects.toThrow(expect.objectContaining({ name: 'NotSupportedError' }));
+  });
+});
+
+describe('installSecureContextCrypto', () => {
+  it('takes over both members even where the engine supplies its own', async () => {
+    expect(nativeSubtle).not.toBe(portableSubtle);
+    await withInstalled(async () => {
+      expect(crypto.randomUUID).toBe(portableRandomUUID);
+      expect(crypto.subtle).toBe(portableSubtle);
+    });
+  });
+
+  it('answers on a Crypto that carries neither', async () => {
+    const platform = crypto;
+    const gated = { getRandomValues: platform.getRandomValues.bind(platform) };
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: gated });
+    try {
+      installSecureContextCrypto();
+      expect(crypto.randomUUID()).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
+      const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', message));
+      expect(digest).toStrictEqual(await nativeDigest('SHA-256'));
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', { configurable: true, value: platform });
+    }
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@fluentui/react-toast": "^9.8.1",
     "@hookform/resolvers": "^5.5.7",
     "@jridgewell/trace-mapping": "^0.3.31",
+    "@noble/hashes": "^2.2.0",
     "culori": "^4.0.2",
     "d3-shape": "^3.2.0",
     "hono": "^4",

--- a/apps/web/src/entry.client.tsx
+++ b/apps/web/src/entry.client.tsx
@@ -2,6 +2,13 @@ import { startTransition, StrictMode } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
+import { installSecureContextCrypto } from './lib/secure-context-crypto';
+
+// Runs before hydration loads the first route module, so that every call site
+// past this point reads one `crypto.randomUUID` and one `crypto.subtle` —
+// including on the plain-HTTP origins where a browser withholds them.
+installSecureContextCrypto();
+
 // A recoverable error is not recoverable here: React answers a hydration
 // mismatch by rebuilding the document, silently dropping every node it did not
 // create, which has switched OverlayScrollbars off app-wide. Rethrowing from

--- a/apps/web/src/lib/secure-context-crypto.ts
+++ b/apps/web/src/lib/secure-context-crypto.ts
@@ -1,0 +1,104 @@
+// `Crypto.randomUUID` and `Crypto.subtle` carry WebIDL's `[SecureContext]`
+// extended attribute, so a browser exposes neither over plain HTTP unless the
+// host is a loopback literal. The dashboard is reached that way in the
+// deployment we document — nginx publishes it on 18088 behind whatever LAN
+// address the operator's host has — and the two are what mints the PKCE
+// challenge for an OAuth upstream and the ids of playground messages.
+// https://w3c.github.io/webcrypto/#crypto-interface
+// https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts
+//
+// Neither needs anything a secure context supplies: a version 4 UUID is
+// formatting over `Crypto.getRandomValues`, which is exposed everywhere, and a
+// digest is pure computation. So we supply both at boot and let every call site
+// read the platform's names, rather than route each one around an API that is
+// missing only by origin.
+import type { CHash } from '@noble/hashes/utils.js';
+
+// https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-4
+const UUID_VERSION_BYTE = 6;
+const UUID_VARIANT_BYTE = 8;
+
+export const portableRandomUUID = (): ReturnType<Crypto['randomUUID']> => {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[UUID_VERSION_BYTE] = (bytes[UUID_VERSION_BYTE]! & 0x0f) | 0x40;
+  bytes[UUID_VARIANT_BYTE] = (bytes[UUID_VARIANT_BYTE]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+// The four digests Web Crypto defines, loaded on the call so that a dashboard
+// that never opens an OAuth flow does not carry them.
+// https://w3c.github.io/webcrypto/#algorithm-overview
+const HASHES: Record<string, () => Promise<CHash>> = {
+  'SHA-1': async () => (await import('@noble/hashes/legacy.js')).sha1,
+  'SHA-256': async () => (await import('@noble/hashes/sha2.js')).sha256,
+  'SHA-384': async () => (await import('@noble/hashes/sha2.js')).sha384,
+  'SHA-512': async () => (await import('@noble/hashes/sha2.js')).sha512,
+};
+
+// Algorithm names are matched ASCII case-insensitively, and an unrecognized one
+// is a `NotSupportedError` — both are what `digest` inherits from normalizing
+// its algorithm argument.
+// https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm
+const digest = async (algorithm: AlgorithmIdentifier, data: BufferSource): Promise<ArrayBuffer> => {
+  const name = (typeof algorithm === 'string' ? algorithm : algorithm.name).toUpperCase();
+  const load = HASHES[name];
+  if (!load) throw new DOMException(`Unrecognized digest algorithm ${name}`, 'NotSupportedError');
+  const hash = await load();
+  const bytes = data instanceof ArrayBuffer
+    ? new Uint8Array(data)
+    : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  const output = hash(bytes);
+  const result = new ArrayBuffer(output.length);
+  new Uint8Array(result).set(output);
+  return result;
+};
+
+// Keys are the rest of `SubtleCrypto`, and a key needs an origin's key store,
+// an algorithm registry, and a structured-clone-safe `CryptoKey` — a body of
+// work no call site here asks for. Naming each one keeps the shape of the
+// interface honest and makes an unimplemented operation say so.
+const unsupported = (operation: string) => async (): Promise<never> => {
+  throw new DOMException(
+    `crypto.subtle.${operation} is not supplied by the dashboard, which implements digests only`,
+    'NotSupportedError',
+  );
+};
+
+export const portableSubtle: SubtleCrypto = {
+  digest,
+  decrypt: unsupported('decrypt'),
+  deriveBits: unsupported('deriveBits'),
+  deriveKey: unsupported('deriveKey'),
+  encrypt: unsupported('encrypt'),
+  exportKey: unsupported('exportKey'),
+  generateKey: unsupported('generateKey'),
+  importKey: unsupported('importKey'),
+  sign: unsupported('sign'),
+  unwrapKey: unsupported('unwrapKey'),
+  verify: unsupported('verify'),
+  wrapKey: unsupported('wrapKey'),
+};
+
+// Both are installed unconditionally, deliberately: never behind a capability
+// check. One implementation on every origin is what makes the dashboard behave
+// the same way wherever it is served, so what an operator reports from
+// http://<lan-address> is what a developer reproduces on https, down to the
+// error a call site raises. A check would leave two implementations in the
+// field and exercise the fallback only where nobody is looking.
+//
+// Do not turn this back into `if (!crypto.subtle)`. The members are absent by
+// origin, not by engine, so the presence of a native one says nothing about the
+// origin the next reader is debugging.
+export const installSecureContextCrypto = (): void => {
+  Object.defineProperty(crypto, 'randomUUID', {
+    configurable: true,
+    writable: true,
+    value: portableRandomUUID,
+  });
+  Object.defineProperty(crypto, 'subtle', {
+    configurable: true,
+    writable: true,
+    value: portableSubtle,
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.31
         version: 0.3.31
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       culori:
         specifier: ^4.0.2
         version: 4.0.2
@@ -8854,7 +8857,7 @@ snapshots:
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -10669,7 +10672,7 @@ snapshots:
       picomatch: 4.0.5
       postcss: 8.5.23
       rolldown: 1.1.5
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.19
       esbuild: 0.28.0


### PR DESCRIPTION
## Why

`Crypto.randomUUID` and `Crypto.subtle` carry WebIDL's `[SecureContext]` attribute, so a browser exposes neither over plain HTTP unless the host is a loopback literal ([Web Crypto API](https://w3c.github.io/webcrypto/#crypto-interface), [MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts)).

That is how the documented self-hosted deployment is reached — nginx publishes the dashboard on 18088 and an operator opens it at their host's LAN address — and the dashboard calls both there:

- `apps/web/src/components/upstream-editor/pkce.ts` mints the PKCE challenge for a Codex or Claude Code upstream with `crypto.subtle.digest('SHA-256', …)`, so the OAuth flow threw before an authorize URL was ever requested.
- `apps/web/src/routes/dashboard-playground.tsx` mints playground message ids with `crypto.randomUUID()`.

## What this does

Neither member needs anything a secure context supplies: a version 4 UUID is formatting over `Crypto.getRandomValues`, which is not gated, and a digest is pure computation. `apps/web/src/lib/secure-context-crypto.ts` supplies both, and `entry.client` installs them before hydration loads the first route module, so every call site keeps reading the platform's names.

**Both are installed unconditionally, with no capability check.** The source says so, so that it is not later "fixed" into an `if (!crypto.subtle)`: one implementation on every origin is what makes the dashboard behave the same way wherever it is served, down to the error a call site raises, and a check would leave a second implementation in the field exercised only where nobody is looking.

- `digest` covers the four SHA algorithms Web Crypto defines, backed by `@noble/hashes` and imported on the call, so a session that never opens an OAuth flow does not carry them. Algorithm names are matched ASCII case-insensitively and an unrecognized one raises `NotSupportedError`, as [normalizing an algorithm](https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm) requires.
- The rest of `SubtleCrypto` is key operations, which need an origin key store, an algorithm registry and a structured-clone-safe `CryptoKey`. Each is named and rejects with `NotSupportedError` rather than answering wrongly.

Taking over `crypto.subtle` on every origin means a bundled third-party library wanting a key operation is refused where the native implementation would have served it. Nothing in the bundle does: the only other reader is `@reclaimprotocol/tls`, reached through the proxy chunk, which registers a crypto provider at import and never runs a handshake in the browser.

## Test Plan

- [x] `pnpm run lint`, `pnpm run typecheck`, `pnpm run test`, `pnpm run test:installers`, `pnpm run check:agents-md`, `pnpm run check:generated-assets`, `pnpm run check:verify-parity`, `pnpm run build:web`
- [x] Unit coverage in `apps/web/__tests__/lib/secure-context-crypto_test.ts`: UUID version and variant bits, every digest compared against the engine's own `crypto.subtle` captured before installation (including a subarray view and a bare `ArrayBuffer`), installation taking over both members where the engine supplies its own, and installation onto a `Crypto` that carries neither
- [x] Headless Chrome against the production bundle served over plain HTTP at a LAN address: a control page on that origin has `isSecureContext: false` with both members `undefined`, while the dashboard on the same origin answers with a v4 UUID, `SHA-256("abc") = ba7816bf…f20015ad`, and `NotSupportedError` from a key operation
- [x] Same bundle over loopback (`isSecureContext: true`): the installed implementations are still the ones in effect, confirming the override is unconditional
- [x] `@noble/hashes` stays out of the entry chunk in the production build — the SHA-256 round constants appear only in the lazily imported `sha2-*.js`
