### PR TITLE
fix(proxy): give a dialed socket teardown that needs no reader

### DIFF
--- a/apps/platform-node/src/socket-dial.ts
+++ b/apps/platform-node/src/socket-dial.ts
@@ -4,6 +4,11 @@ import tls from 'node:tls';
 
 import { normalizeDialHost, throwAbort, type DialedSocket, type SocketDial } from '@floway-dev/platform';
 
+// Idle time before the first keepalive probe. Node then follows the OS
+// settings for probe interval and count, so a dead peer is reaped within a
+// few minutes of going silent without us restating the platform's tuning.
+const KEEPALIVE_INITIAL_DELAY_MS = 60_000;
+
 // Readable.toWeb(socket) waits for `finished(socket)`, which treats the
 // net.Socket as both readable and writable. Projecting the read side through a
 // PassThrough keeps Node's own backpressure, Buffer copying, error propagation,
@@ -101,6 +106,16 @@ export const nodeSocketDial: SocketDial = {
       socket.once(readyEvent, onReady);
       socket.once('error', onError);
     });
+
+    // A dialed socket is otherwise torn down only by the response body's own
+    // read-to-end or cancel path, so a peer that disappears without sending
+    // FIN — a dropped NAT/conntrack entry, a killed daemon — leaves the socket
+    // and everything the read pipeline holds behind it alive indefinitely.
+    // TCP keepalive is the teardown that does not depend on anyone reading:
+    // probes only fire once the connection is idle at the TCP layer, so a live
+    // upstream that is merely slow (a long prompt-processing pause before the
+    // first token) answers them and is never disturbed.
+    socket.setKeepAlive(true, KEEPALIVE_INITIAL_DELAY_MS);
 
     const readable = socketToReadable(socket);
     const writable = socketToWritable(socket);

--- a/packages/proxy/__tests__/dialer_test.ts
+++ b/packages/proxy/__tests__/dialer_test.ts
@@ -248,6 +248,56 @@ describe('runDirectConnectRequest', () => {
     expect(direct.closeCalls()).toBe(1);
   });
 
+  // Reading the body to EOF and cancelling it both require someone to still be
+  // holding the body. An abandoned response has neither, so the caller's signal
+  // is the only teardown left once the dial has resolved.
+  it('closes its socket when the caller aborts after the response was returned', async () => {
+    const direct = makeSocketDial('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok');
+    const controller = new AbortController();
+    await runDirectConnectRequest(
+      { host: 'api.example.com', port: 80, tls: false },
+      { method: 'GET', path: '/', headers: {} },
+      { socketDial: direct.socketDial, signal: controller.signal },
+    );
+
+    expect(direct.closeCalls()).toBe(0);
+    controller.abort('client gone');
+    await Promise.resolve();
+    expect(direct.closeCalls()).toBe(1);
+  });
+
+  // addEventListener on an already-aborted signal never fires, so the abort
+  // that lands while the request is in flight has to be picked up synchronously.
+  it('closes its socket when the caller aborted while the request was in flight', async () => {
+    const controller = new AbortController();
+    // Abort once the socket exists but before the response is handed back, so
+    // the dial itself still succeeds and the abort lands in the window the
+    // listener install would otherwise miss.
+    const direct = makeSocketDial('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok', () => controller.abort('client gone'));
+    await runDirectConnectRequest(
+      { host: 'api.example.com', port: 80, tls: false },
+      { method: 'GET', path: '/', headers: {} },
+      { socketDial: direct.socketDial, signal: controller.signal },
+    );
+
+    expect(direct.closeCalls()).toBe(1);
+  });
+
+  it('closes its socket once when an abort follows a completed body', async () => {
+    const direct = makeSocketDial('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok');
+    const controller = new AbortController();
+    const response = await runDirectConnectRequest(
+      { host: 'api.example.com', port: 80, tls: false },
+      { method: 'GET', path: '/', headers: {} },
+      { socketDial: direct.socketDial, signal: controller.signal },
+    );
+
+    expect(await response.text()).toBe('ok');
+    controller.abort('client gone');
+    await Promise.resolve();
+    expect(direct.closeCalls()).toBe(1);
+  });
+
   it('bounds the raw TCP connect with the direct-connect dial deadline', async () => {
     const socketDial: SocketDial = {
       connect: async (_host, _port, options) => {

--- a/packages/proxy/src/dialer.ts
+++ b/packages/proxy/src/dialer.ts
@@ -150,7 +150,7 @@ export const runDirectConnectRequest = async (
 
   try {
     const response = await runRequestOnStream(socket, target, request, options);
-    return closeSocketWithResponse(response, socket);
+    return closeSocketWithResponse(response, socket, options.signal);
   } catch (error) {
     await socket.close().catch(() => {});
     throw error;
@@ -219,12 +219,27 @@ const runRequestOnStream = async (
   }
 };
 
-const closeSocketWithResponse = (response: Response, socket: DialedSocket): Response => {
+const closeSocketWithResponse = (response: Response, socket: DialedSocket, signal?: AbortSignal): Response => {
   let closePromise: Promise<void> | null = null;
   const close = (): Promise<void> => {
     closePromise ??= socket.close().catch(() => {});
+    if (signal !== undefined) signal.removeEventListener('abort', onAbort);
     return closePromise;
   };
+  const onAbort = (): void => { void close(); };
+
+  // Reading the body to its end and cancelling it are the ordinary teardown
+  // paths, and both of them require someone to still be holding the body. An
+  // abort raised after the dial resolved has no other way to reach this
+  // socket: the dial-stage listener is detached once `withDialDeadline`
+  // returns, and the runtime's own `signal` support on connect() covers the
+  // handshake only.
+  if (signal !== undefined) {
+    signal.addEventListener('abort', onAbort, { once: true });
+    // addEventListener on an already-aborted signal never fires, so an abort
+    // that landed while the request was in flight would otherwise be lost.
+    if (signal.aborted) void close();
+  }
 
   if (response.body === null) {
     void close();


### PR DESCRIPTION
## Summary

- let the caller's abort signal close a direct-connect socket after the dial has resolved
- enable TCP keepalive on Node-dialed sockets

## The defect

`closeSocketWithResponse` closes the socket from the response body's `pull` when it reaches EOF or errors, and from the body's `cancel` hook. Nothing else closes it. Direct-connect is the default egress on Node — deliberately, to avoid undici's `bodyTimeout` — so there is no pool and no idle reaper behind it either.

That leaves two states with no teardown at all: a response nobody reads and nobody cancels, and a peer that disappears without sending FIN (a dropped NAT/conntrack entry, a killed daemon). The socket, its `PassThrough`, the HTTP parser and everything the read pipeline holds stay alive for the life of the process.

## Design

**Caller signal, post-dial.** `withDialDeadline` multiplexes the caller signal into an internal controller for the dial stage and detaches it in its `finally`, which is correct for the dial but leaves nothing downstream of a successful dial able to act on an abort. The signal is now also handed to `closeSocketWithResponse`, which closes on abort and drops the listener when the socket closes, so a signal shared across dials does not accumulate a closure per request. An abort that lands while the request is in flight is picked up synchronously — `addEventListener` on an already-aborted signal never fires.

This is also the mechanism a bounded post-disconnect retention needs later: when the budget expires, the abort has somewhere to land.

**TCP keepalive.** Probes fire only once the connection is idle at the TCP layer, so a live-but-slow upstream answers them and is never disturbed, while a dead peer is reaped. The initial delay is 60s and the probe interval and count are left to the OS.

**No application-level idle timeout.** Any value large enough to be safe for local inference — a long prompt-processing pause before the first token is legitimate — is too large to be the mechanism that matters, and keepalive already covers the state that actually leaks. Adding one would trade a real leak fix for a new way to kill valid requests.

## Test Plan

- [x] Socket closes when the caller aborts after the response was returned
- [x] Socket closes when the caller aborted while the request was in flight — verified to fail when the synchronous already-aborted branch is removed
- [x] Socket closes exactly once when an abort follows a completed body
- [x] `packages/proxy` and `apps/platform-node` suites: 379 tests
- [x] Workspace typecheck
- [x] Repository lint
- [x] Agent guide check
- [x] GitHub Verify workflow

## Not in this change

Nothing yet aborts on client disconnect: the provider call sites still pass `undefined` for the signal, and `retainResponse` deliberately drains rather than cancels so telemetry can settle (#409). Wiring that up as a bounded retention window is a separate change; this one gives the abort somewhere to land.

