### PR TITLE
fix(gateway): bound how long a disconnected client's upstream is held

### DIFF
--- a/packages/gateway/__tests__/data-plane/shared/retained-response_test.ts
+++ b/packages/gateway/__tests__/data-plane/shared/retained-response_test.ts
@@ -1,7 +1,8 @@
 import { test } from 'vitest';
 
 import { retainResponse } from '../../../src/data-plane/shared/retained-response.ts';
-import { assertEquals } from '@floway-dev/test-utils';
+import { FakeTime } from '../../test-time.ts';
+import { assertEquals, assertStringIncludes } from '@floway-dev/test-utils';
 
 test('retainResponse drains the source without canceling it when its consumer disconnects', async () => {
   let sourceController!: ReadableStreamDefaultController<Uint8Array>;
@@ -35,4 +36,71 @@ test('retainResponse drains the source without canceling it when its consumer di
   sourceController.close();
   await Promise.all(backgroundTasks);
   assertEquals(sourceCanceled, false);
+});
+
+// The drain is the only reader left once the client is gone, so an upstream
+// that stalls without ending the stream would pin its transport forever.
+test('retainResponse abandons a drain whose upstream stops producing', async () => {
+  const time = new FakeTime();
+  try {
+    let sourceCanceled = false;
+    let cancelReason: unknown;
+    const backgroundTasks: Promise<unknown>[] = [];
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+      // Never produces again and never closes, which is what a hung upstream
+      // looks like from here.
+      pull() { return new Promise<never>(() => {}); },
+      cancel(reason) {
+        sourceCanceled = true;
+        cancelReason = reason;
+      },
+    });
+    const retained = retainResponse(new Response(source), task => { backgroundTasks.push(task); });
+    const reader = retained.body!.getReader();
+    assertEquals(await reader.read(), { done: false, value: new Uint8Array([1]) });
+    await reader.cancel('client disconnected');
+
+    // Well inside the budget the upstream is still held, so usage and dump
+    // records for a slow generation still settle.
+    await time.tickAsync(14 * 60 * 1000);
+    assertEquals(sourceCanceled, false);
+
+    await time.tickAsync(60 * 1000 + 1);
+    assertEquals(sourceCanceled, true);
+    assertEquals(cancelReason instanceof Error, true);
+    assertStringIncludes((cancelReason as Error).message, 'after the client disconnected');
+    await Promise.all(backgroundTasks.map(task => task.catch(() => undefined)));
+  } finally {
+    time.restore();
+  }
+});
+
+test('retainResponse leaves the upstream alone when the drain finishes inside the budget', async () => {
+  const time = new FakeTime();
+  try {
+    let sourceController!: ReadableStreamDefaultController<Uint8Array>;
+    let sourceCanceled = false;
+    const backgroundTasks: Promise<unknown>[] = [];
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) { sourceController = controller; },
+      cancel() { sourceCanceled = true; },
+    });
+    const retained = retainResponse(new Response(source), task => { backgroundTasks.push(task); });
+    const reader = retained.body!.getReader();
+    sourceController.enqueue(new Uint8Array([1]));
+    assertEquals(await reader.read(), { done: false, value: new Uint8Array([1]) });
+    await reader.cancel('client disconnected');
+
+    sourceController.close();
+    await Promise.all(backgroundTasks);
+
+    // The abandon timer must not outlive the drain it was guarding.
+    await time.tickAsync(20 * 60 * 1000);
+    assertEquals(sourceCanceled, false);
+  } finally {
+    time.restore();
+  }
 });

--- a/packages/gateway/src/data-plane/shared/retained-response.ts
+++ b/packages/gateway/src/data-plane/shared/retained-response.ts
@@ -1,6 +1,17 @@
 import type { BackgroundScheduler } from '@floway-dev/platform';
 import type { Fetcher } from '@floway-dev/provider';
 
+// How long the gateway keeps reading an upstream response after its client has
+// disconnected. Generous on purpose: an LLM generation the client abandoned may
+// still have minutes of work left, and cutting it short loses the usage and
+// dump records this retention exists to settle. It is a backstop against an
+// upstream that never finishes, not a request deadline.
+//
+// Only Node can spend the whole budget. On Cloudflare the retention runs inside
+// executionCtx.waitUntil, which the runtime ends on its own schedule well
+// before this, so the effective window there is whatever the platform grants.
+const RETAINED_DRAIN_BUDGET_MS = 15 * 60 * 1000;
+
 export interface RetainedDispatchLifecycle {
   clientDisconnectSignal: AbortSignal;
   backgroundScheduler: BackgroundScheduler;
@@ -63,7 +74,19 @@ export const retainResponse = (
   const startDrain = (): void => {
     if (drainStarted) return;
     drainStarted = true;
-    void drain();
+    // The drain exists so usage and dump records settle after the client walks
+    // away, not so an upstream can hold its transport open forever. An upstream
+    // that stops producing without ending the stream would otherwise pin the
+    // dialed socket and everything behind it for the life of the process, and
+    // nothing else is watching: the ordinary teardown is the body reaching EOF
+    // or being cancelled, and this drain is the only remaining reader.
+    const abandon = setTimeout(() => {
+      void reader.cancel(new Error(`upstream retained past ${RETAINED_DRAIN_BUDGET_MS}ms after the client disconnected`)).catch(() => {});
+    }, RETAINED_DRAIN_BUDGET_MS);
+    // Node keeps the process alive for a pending timer; a shutdown should not
+    // wait out the budget. Workers has no unref and needs none.
+    (abandon as { unref?: () => void }).unref?.();
+    void drain().finally(() => clearTimeout(abandon));
   };
 
   const body = new ReadableStream<Uint8Array>({


### PR DESCRIPTION
## Summary

- give the post-disconnect drain a 15-minute budget and cancel the upstream when it expires

## The defect

When a client disconnects mid-response the gateway keeps reading the upstream so usage and dump records settle — the body's `cancel` hook starts a background drain instead of cancelling the source (#409). Nothing bounded that drain.

The drain is the only reader left. The ordinary teardown for a dialed socket is the body reaching EOF or being cancelled, and the drain is precisely what replaced the cancel, so an upstream that stops producing without ending the stream pinned its socket, its read pipeline and its parser state for the life of the process. On Cloudflare `waitUntil` truncates this on its own; on Node the scheduler is fire-and-forget and nothing was watching.

## Design

`startDrain` arms a timer alongside the drain and cancels the upstream reader when it fires, releasing the transport through the same cancel path a connected client would have used. The timer is cleared when the drain finishes, and `unref`'d so a shutdown does not wait out the budget on Node.

**Why 15 minutes.** An abandoned generation may genuinely have minutes of work left, and cutting it short loses exactly the records this retention exists to produce. The budget is a backstop against an upstream that never finishes, not a request deadline, so it is set well above any legitimate generation rather than tuned close to one.

**Platform asymmetry.** Only Node can spend the whole budget. On Cloudflare the drain runs inside `executionCtx.waitUntil`, which the runtime ends on its own schedule long before this, so the effective window there is whatever the platform grants. The constant documents that rather than pretending the two targets behave alike.

## Test Plan

- [x] A drain whose upstream stalls is abandoned after the budget, and the upstream sees the cancel — verified to fail when the budget is removed
- [x] The upstream is still held well inside the budget, so a slow generation's records still settle
- [x] A drain that finishes inside the budget leaves the upstream alone, and the timer does not outlive it
- [x] `packages/gateway` suite: 2305 tests
- [x] Workspace typecheck
- [x] Repository lint
- [x] Agent guide check
- [x] GitHub Verify workflow

## Not in this change

The provider call sites still pass `undefined` where an `AbortSignal` would go, so a client disconnect does not reach the upstream call itself — it reaches the retained body, which is what this bounds. Threading the signal through would change #409's policy rather than bound it, and is a separate decision.

