### PR TITLE
fix(web): correct the agent configuration heading to a verb phrase

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -395,7 +395,7 @@ const en = {
               'Saving will delete stored Responses items older than the new window. A follow-up request that references one by id will no longer find it.',
         },
         configuration: {
-          title: 'Setup Your Agents',
+          title: 'Set Up Your Agents',
           usingKey: 'This uses the <strong>{{name}}</strong> API key.',
           claudeCode: 'Claude Code',
           codex: 'Codex',


### PR DESCRIPTION
The agent configuration card on the API keys page was titled **Setup Your Agents**, which uses the noun `setup` where the heading is an imperative verb phrase and needs `set up`.

The rest of the dashboard copy already keeps the two apart — `Set up Base pricing` for the action, `Setup script` / `Setup token` / `Agent Setup` for the nouns — so this is the single instance out of line. A sweep for `setup <determiner>` across the repository found no other verb-phrase misuse.

`zh-Hans` is unaffected, and the key structure is unchanged.

## Test Plan

- [x] `pnpm run verify` — every stage passes except two tests that time out identically on unmodified `main` on the same machine (`tools` backfill CLI, and the upstream model workspace duplicate-ID swap), so they are pre-existing and unrelated to this change.