### PR TITLE
fix(web): keep the dashboard off the provider barrel

### DIFF
--- a/apps/web/__tests__/components/upstream-editor/disabled-models_test.ts
+++ b/apps/web/__tests__/components/upstream-editor/disabled-models_test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildDisabledModelOptions } from '../../../src/components/upstream-editor/config-sidebar';
-import type { UpstreamModelConfig } from '@floway-dev/provider';
+import type { UpstreamModelConfig } from '@floway-dev/provider/model-config';
 
 const model = (upstreamModelId: string, publicModelId?: string): UpstreamModelConfig => ({
   upstreamModelId,

--- a/apps/web/__tests__/components/upstream-editor/model-contract_test.ts
+++ b/apps/web/__tests__/components/upstream-editor/model-contract_test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { discoveredModelsFromResponse } from '../../../src/components/upstream-editor/data';
 import { modelsAreValid } from '../../../src/components/upstream-editor/model-validation';
-import type { UpstreamModelConfig } from '@floway-dev/provider';
+import type { UpstreamModelConfig } from '@floway-dev/provider/model-config';
 
 describe('custom discovered model projection', () => {
   it('maps fixed kinds to their own endpoint families', () => {

--- a/apps/web/src/components/upstream-editor/config-sidebar.tsx
+++ b/apps/web/src/components/upstream-editor/config-sidebar.tsx
@@ -17,7 +17,7 @@ import { ScrollArea } from '../ui/scroll-area';
 import { StatusBadge } from '../ui/status-badge';
 import { TooltipIconButton } from '../ui/tooltip-icon-button';
 import { HuePicker } from '../upstreams/hue-picker';
-import type { UpstreamModelConfig } from '@floway-dev/provider';
+import type { UpstreamModelConfig } from '@floway-dev/provider/model-config';
 import { MODEL_PREFIX_MAX_LENGTH } from '@floway-dev/provider/model-prefix';
 
 const { Button, Checkbox, Field, MessageBar, MessageBarBody, Option, Text } = fluentComponents;

--- a/apps/web/src/components/upstream-editor/data.ts
+++ b/apps/web/src/components/upstream-editor/data.ts
@@ -11,8 +11,8 @@ import type {
 } from '../../api/types';
 import type { MODEL_LISTING_FAILURE_CODE as GatewayModelListingFailureCode } from '@floway-dev/gateway/data-plane/models/shared';
 import { kindForEndpoints, type ModelEndpoints } from '@floway-dev/protocols/common';
-import type { UpstreamModelConfig } from '@floway-dev/provider';
 import type { UpstreamProviderKind } from '@floway-dev/provider/model';
+import type { UpstreamModelConfig } from '@floway-dev/provider/model-config';
 import { MODEL_PREFIX_MAX_LENGTH, MODEL_PREFIX_REGEX } from '@floway-dev/provider/model-prefix';
 
 type CreateUpstreamBody = InferRequestType<typeof api.api.upstreams.$post>['json'];

--- a/apps/web/src/components/upstream-editor/model-detail.tsx
+++ b/apps/web/src/components/upstream-editor/model-detail.tsx
@@ -18,7 +18,7 @@ import { Checkbox, Dropdown, Input, Switch } from '../ui/fluent-form-controls';
 import { CHECKBOX_LIST_CLASS, PANE_GAP_CLASS, TWO_COLUMN_FORM_CLASS } from '../ui/layout';
 import { MultiselectCombobox, valuesAsOptions } from '../ui/multiselect-combobox';
 import { SectionHeader } from '../ui/section-header';
-import type { UpstreamChatModelConfig, UpstreamModelConfig } from '@floway-dev/provider';
+import type { UpstreamChatModelConfig, UpstreamModelConfig } from '@floway-dev/provider/model-config';
 
 const {
   Button,

--- a/apps/web/src/components/upstream-editor/model-validation.ts
+++ b/apps/web/src/components/upstream-editor/model-validation.ts
@@ -1,6 +1,7 @@
 import { pricingEntryDraftsFor, pricingIsValid } from './pricing-model';
 import { kindForEndpoints } from '@floway-dev/protocols/common';
-import { modelsField, type UpstreamModelConfig, validateUpstreamPath } from '@floway-dev/provider';
+import { validateUpstreamPath } from '@floway-dev/provider/join';
+import { modelsField, type UpstreamModelConfig } from '@floway-dev/provider/model-config';
 
 export type ModelValidationField = 'configuration' | 'endpoints' | 'pricing' | 'reasoning' | 'rerankTarget' | 'upstreamModelId';
 

--- a/apps/web/src/components/upstream-editor/models-yaml.ts
+++ b/apps/web/src/components/upstream-editor/models-yaml.ts
@@ -1,7 +1,7 @@
 import { parse, stringify } from 'yaml';
 
 import { errorMessage } from '../../lib/error-message';
-import { modelsField, type UpstreamModelConfig } from '@floway-dev/provider';
+import { modelsField, type UpstreamModelConfig } from '@floway-dev/provider/model-config';
 
 export const serializeModels = (models: UpstreamModelConfig[]): string => stringify(models, {
   indent: 2,

--- a/apps/web/src/components/upstream-editor/workspace.tsx
+++ b/apps/web/src/components/upstream-editor/workspace.tsx
@@ -41,7 +41,7 @@ import { TooltipIconButton } from '../ui/tooltip-icon-button';
 import { TruncationTooltip } from '../ui/truncation-tooltip';
 import { copyOutcomeIcon, useCopyLabel, useCopyToClipboard } from '../ui/use-copy-to-clipboard';
 import { useDialogInvocation } from '../ui/use-dialog-invocation';
-import type { UpstreamModelConfig } from '@floway-dev/provider';
+import type { UpstreamModelConfig } from '@floway-dev/provider/model-config';
 
 const {
   Button,

--- a/apps/web/src/routes/dashboard-providers-upstreams-new.tsx
+++ b/apps/web/src/routes/dashboard-providers-upstreams-new.tsx
@@ -11,7 +11,7 @@ import {
 import { UpstreamEditorPage } from '../components/upstream-editor/page';
 import { dashboardWorkspaceHandle } from '../lib/dashboard-route-handle';
 import { pickDistinctHue } from '../lib/hue';
-import { ALL_PROVIDER_KINDS } from '@floway-dev/provider';
+import { ALL_PROVIDER_KINDS } from '@floway-dev/provider/model';
 
 export const handle = dashboardWorkspaceHandle;
 

--- a/apps/web/src/routes/dashboard-providers-upstreams.tsx
+++ b/apps/web/src/routes/dashboard-providers-upstreams.tsx
@@ -35,8 +35,7 @@ import { fluentComponents } from '../fluent';
 import { dateTime } from '../lib/format-time';
 import { pageNavigation, useEntryRewrite } from '../lib/page-navigation';
 import { useLocale } from '../lib/use-locale';
-import { ALL_PROVIDER_KINDS } from '@floway-dev/provider';
-import type { UpstreamProviderKind } from '@floway-dev/provider/model';
+import { ALL_PROVIDER_KINDS, type UpstreamProviderKind } from '@floway-dev/provider/model';
 
 const {
   Menu,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { isBuiltin } from 'node:module';
 import { resolve } from 'node:path';
 
 import { reactRouter } from '@react-router/dev/vite';
@@ -152,6 +153,30 @@ const legacyCssBuild = {
   cssTarget: 'chrome61',
 } as const;
 
+// A Node builtin reaching the browser graph resolves, by default, to a stub
+// that throws on first property access, behind a warning a passing build
+// scrolls away. What it costs is not one broken import: a route module that
+// throws while it evaluates is a route module React Router could not load, and
+// the answer to that is `window.location.reload()` — so the page reloads, fails
+// the same way, and reloads again, with nothing on screen to read.
+// https://github.com/remix-run/react-router/blob/2edaca7a4f12a50cad002d55d84f73b0cdd462b6/packages/react-router/lib/dom/ssr/routeModules.ts#L280-L308
+// The edge is almost never written in this app: it arrives through a workspace
+// barrel that re-exports server-side transport, and the module graph is the
+// only place it is visible. So the client environment refuses to resolve a
+// builtin at all, and names the importer that pulled it in.
+const browserSafeGraph = (): Plugin => ({
+  name: 'floway-browser-safe-graph',
+  enforce: 'pre',
+  applyToEnvironment: environment => environment.name === 'client',
+  resolveId(source, importer) {
+    if (!isBuiltin(source)) return;
+    throw new Error(
+      `${importer ?? '<entry>'} imports the Node builtin "${source}", which cannot run in a browser. `
+      + 'Reach the module you need through a browser-safe export instead.',
+    );
+  },
+});
+
 export default defineConfig({
   build: legacyCssBuild,
   // React Router discovers route modules lazily. Pre-bundle their browser
@@ -200,6 +225,7 @@ export default defineConfig({
     ],
   },
   plugins: [
+    browserSafeGraph(),
     prismComponentsEsm(),
     typescriptStylesheets(),
     reactRouter(),

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -55,6 +55,10 @@ const WEB_RESTRICTED_IMPORT_PATTERNS = [
     regex: '^@floway-dev/proxy$',
     message: 'apps/web must reach @floway-dev/proxy only via its /url, /url-kind, /proxy-config, or /constants subpath exports — the root pulls in dialers and userspace TLS.',
   },
+  {
+    regex: '^@floway-dev/provider$',
+    message: 'apps/web must reach @floway-dev/provider only via its /flags, /join, /model, /model-config, or /model-prefix subpath exports — the root reaches the outbound fetch contract, and through it @floway-dev/http and userspace TLS.',
+  },
 ];
 
 const projectList = [

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -6,7 +6,9 @@
   "exports": {
     ".": { "import": "./src/index.ts", "types": "./src/index.ts" },
     "./flags": { "import": "./src/flags.ts", "types": "./src/flags.ts" },
+    "./join": { "import": "./src/join.ts", "types": "./src/join.ts" },
     "./model": { "import": "./src/model.ts", "types": "./src/model.ts" },
+    "./model-config": { "import": "./src/model-config.ts", "types": "./src/model-config.ts" },
     "./model-prefix": { "import": "./src/model-prefix.ts", "types": "./src/model-prefix.ts" }
   },
   "scripts": {


### PR DESCRIPTION
The Upstreams page reloaded itself forever and never painted, on every origin. Its route module imported `ALL_PROVIDER_KINDS` from the `@floway-dev/provider` root, and that barrel re-exports the outbound fetch contract, which since #433 comes from `@floway-dev/http` — whose root export reaches userspace TLS and, through it, `@reclaimprotocol/tls/webcrypto`, a module that reads `webcrypto.subtle` off Node's `crypto` at evaluation. In a browser bundle that specifier is externalized to a stub, so the read threw, the route module failed to evaluate, and React Router answered a failed route-module load with [`window.location.reload()`](https://github.com/remix-run/react-router/blob/2edaca7a4f12a50cad002d55d84f73b0cdd462b6/packages/react-router/lib/dom/ssr/routeModules.ts#L280-L308) — which fetched the same chunk and failed the same way. The new-upstream and upstream-editor routes imported the same barrel and were lost with it.

Every other workspace import the dashboard makes already goes through a subpath; these eight were the exception. `@floway-dev/provider` gains `/join` and `/model-config` alongside the subpaths it already published, and the dashboard reaches the four values it wants — `ALL_PROVIDER_KINDS`, `UpstreamModelConfig`, `modelsField`, `validateUpstreamPath` — through `/model`, `/model-config` and `/join`. ESLint restricts the root the way it already restricts `@floway-dev/proxy`'s.

The build knew: it printed the externalization as a warning and exited 0, so nothing between the merge and the operator's browser could see it. The client environment now refuses to resolve a Node builtin at all and names the importer, so any future edge into server-side transport — from any package, written or transitive — fails the build that would have shipped it.

## Test Plan

- [x] `pnpm run verify` on the synchronized branch. One 5s timeout in `tools/__tests__/backfill-usage-pricing/cli_test.ts`, a file this branch does not touch; it passes on its own in 5.2s and the same class of timeout appears on an unmodified tree.
- [x] Production bundle in headless Chromium, served against a Node-target gateway: the Upstreams list, `providers/upstreams/new/custom`, and an upstream editor each load once, with no console error and no repeated navigation. The list fetches `/api/upstreams` and `/api/models` once each and renders its rows.
- [x] The same page from the pre-fix bundle (`4c00e1f50`) takes 62 navigations in ten seconds and logs `Error loading route module …, reloading page...` followed by `TypeError: Cannot read properties of undefined (reading 'subtle')`.
- [x] Reinstating the root import fails `pnpm run build:web` with `@reclaimprotocol/tls/lib/crypto/webcrypto.js imports the Node builtin "crypto"`, and fails ESLint with the subpath message.
