### PR TITLE
feat(copilot): keep the seat SKU the token exchange already carries

### DIFF
--- a/packages/gateway/src/control-plane/upstreams/serialize.ts
+++ b/packages/gateway/src/control-plane/upstreams/serialize.ts
@@ -77,7 +77,9 @@ export const upstreamRecordToJson = (upstream: UpstreamRecord): RedactedSerializ
     if (upstream.state !== null) {
       assertCopilotUpstreamState(upstream.state);
       state = {
-        copilotToken: upstream.state.copilotToken === null ? null : { baseUrl: upstream.state.copilotToken.baseUrl },
+        copilotToken: upstream.state.copilotToken === null
+          ? null
+          : { baseUrl: upstream.state.copilotToken.baseUrl, sku: upstream.state.copilotToken.sku },
         // The whole snapshot is upstream-owned numbers with no secret in it, so
         // it round-trips verbatim. Rows written before the slot existed carry
         // no key at all -- the same absent-is-null boundary the state reader

--- a/packages/gateway/src/control-plane/upstreams/types.ts
+++ b/packages/gateway/src/control-plane/upstreams/types.ts
@@ -67,7 +67,9 @@ export type CopilotUpstreamConfig = Omit<StoredCopilotUpstreamConfig, 'githubTok
 };
 
 export interface CopilotUpstreamState {
-  copilotToken: { baseUrl: string } | null;
+  // The token itself is the secret; the host it routes to and the seat's plan
+  // are not, so those two cross and the rest stays behind.
+  copilotToken: { baseUrl: string; sku: string | null } | null;
   // The quota snapshot is upstream-owned numbers with no secret in it, so
   // unlike the token beside it there is nothing to redact and it crosses
   // whole. Whichever source saw the seat last wrote it: the data plane

--- a/packages/provider-copilot/__tests__/auth_test.ts
+++ b/packages/provider-copilot/__tests__/auth_test.ts
@@ -477,3 +477,45 @@ test('copilotAuthedFetch persists a minted token even when the row changed durin
   // the row as it stands now, not the snapshot taken before the round trip.
   assertEquals(persisted.quotaSnapshot?.fetchedAt, 1);
 });
+
+describe('Copilot seat SKU', () => {
+  // `runAuthedFetch` installs a repo of its own, so these drive the authed
+  // fetch directly against the one whose state they then read back.
+  const authedFetch = () => copilotAuthedFetch(
+    '/v1/messages',
+    { method: 'POST', body: '{}' },
+    { id: UPSTREAM_ID, githubHost: 'github.com', githubToken: 'ghu_test' },
+    { fetcher: directFetcher, wrapUpstreamCall: identityWrapUpstreamCall },
+  );
+
+  test('the token exchange persists the SKU the seat is billed under', async () => {
+    const { readPersistedState } = await installRepoAndClearCache();
+    await withMockedFetch(
+      async () => jsonResponse({
+        token: 'tok-test',
+        expires_at: 4_102_444_800,
+        refresh_in: 1800,
+        endpoints: { api: TOKEN_BASE_URL },
+        sku: 'plus_monthly_subscriber_quota',
+      }),
+      async () => {
+        await authedFetch();
+        assertEquals(readPersistedState()?.copilotToken?.sku, 'plus_monthly_subscriber_quota');
+      },
+    );
+  });
+
+  // GitHub introduces a SKU whenever it introduces a plan, and an enterprise
+  // host may answer without one at all, so neither case may cost a token.
+  test('a response naming no SKU still mints a usable token', async () => {
+    const { readPersistedState } = await installRepoAndClearCache();
+    await withMockedFetch(
+      async () => tokenResponse(),
+      async () => {
+        const response = await authedFetch();
+        assertEquals(response.status, 200);
+        assertEquals(readPersistedState()?.copilotToken?.sku, null);
+      },
+    );
+  });
+});

--- a/packages/provider-copilot/__tests__/provider_test.ts
+++ b/packages/provider-copilot/__tests__/provider_test.ts
@@ -943,7 +943,7 @@ test('readCopilotUpstreamState round-trips a persisted state with both knownMode
       { object: 'list', data: [{ id: 'm1', name: 'm1', version: '1', supported_endpoints: [], capabilities: { type: 'chat', limits: {} } }] },
       1_000_000,
     ),
-    copilotToken: { token: 'tok', expiresAt: 2_000_000, baseUrl: 'https://api.individual.githubcopilot.com' },
+    copilotToken: { token: 'tok', expiresAt: 2_000_000, baseUrl: 'https://api.individual.githubcopilot.com', sku: 'monthly_subscriber_quota' },
     quotaSnapshot: null,
   };
   const round = readCopilotUpstreamState(JSON.parse(JSON.stringify(seeded)));

--- a/packages/provider-copilot/__tests__/state_test.ts
+++ b/packages/provider-copilot/__tests__/state_test.ts
@@ -6,7 +6,7 @@ import { assertEquals, assertThrows } from '@floway-dev/test-utils';
 test('readCopilotUpstreamState passes through a complete new-shape entry verbatim', () => {
   const seeded = {
     knownModels: null,
-    copilotToken: { token: 'tok', expiresAt: 2_000_000, baseUrl: 'https://api.individual.githubcopilot.com' },
+    copilotToken: { token: 'tok', expiresAt: 2_000_000, baseUrl: 'https://api.individual.githubcopilot.com', sku: 'monthly_subscriber_quota' },
     quotaSnapshot: null,
   } satisfies CopilotUpstreamState;
   const round = readCopilotUpstreamState(JSON.parse(JSON.stringify(seeded)));
@@ -81,4 +81,17 @@ test('assertCopilotUpstreamState rejects prototype-named keys', () => {
       `CopilotUpstreamState.copilotToken has unexpected key '${key}'`,
     );
   }
+});
+
+// The slot was added after the shape shipped, so a row minted before it has no
+// key at all. That is the one absent-key case the reader normalizes rather than
+// rejects: the seat is still usable, and the next mint fills the plan in.
+test('readCopilotUpstreamState reads a token entry minted before the SKU slot as having none', () => {
+  const round = readCopilotUpstreamState({
+    knownModels: null,
+    copilotToken: { token: 'tok', expiresAt: 2_000_000, baseUrl: 'https://api.individual.githubcopilot.com' },
+    quotaSnapshot: null,
+  });
+  assertEquals(round.copilotToken?.token, 'tok');
+  assertEquals(round.copilotToken?.sku, null);
 });

--- a/packages/provider-copilot/src/auth.ts
+++ b/packages/provider-copilot/src/auth.ts
@@ -194,6 +194,7 @@ export async function exchangeCopilotToken(githubHost: string, githubToken: stri
     expires_at: number;
     refresh_in: number;
     endpoints?: { api?: string };
+    sku?: string;
   };
 
   const baseUrl = data.endpoints?.api;
@@ -205,6 +206,13 @@ export async function exchangeCopilotToken(githubHost: string, githubToken: stri
     token: data.token,
     expiresAt: data.expires_at,
     baseUrl,
+    // The seat's plan travels with the token, which is why the dashboard can
+    // name a plan without an operator asking for one: this exchange runs on
+    // every request whose token has expired. `copilot_internal/user` carries
+    // the same fact under `copilot_plan`, but only the operator's refresh ever
+    // calls it. GitHub's own clients read it from here as well.
+    // https://github.com/microsoft/vscode/blob/5fb9376dbdc8b0f1bdc9eb8186f429e023503f92/extensions/copilot/src/platform/authentication/common/copilotToken.ts#L330-L376
+    sku: typeof data.sku === 'string' && data.sku !== '' ? data.sku : null,
   };
 }
 

--- a/packages/provider-copilot/src/state.ts
+++ b/packages/provider-copilot/src/state.ts
@@ -18,6 +18,14 @@ export interface CopilotTokenEntry {
   token: string;
   expiresAt: number;
   baseUrl: string;
+  // The seat's plan, as GitHub's own SKU identifier. Typed open because
+  // Microsoft types its own as `WellKnownSku | string`: GitHub introduces a SKU
+  // whenever it introduces a plan.
+  // https://github.com/microsoft/vscode/blob/5fb9376dbdc8b0f1bdc9eb8186f429e023503f92/extensions/copilot/src/platform/authentication/common/copilotToken.ts#L330-L376
+  //
+  // Null on an entry minted before this slot existed; the next mint fills it,
+  // which is at most one token lifetime of traffic away.
+  sku: string | null;
 }
 
 // Most recent entitlement observation, from either quota source. `fetchedAt`
@@ -50,6 +58,7 @@ const ALLOWED_TOKEN_KEYS_MAP: Record<keyof CopilotTokenEntry, true> = {
   token: true,
   expiresAt: true,
   baseUrl: true,
+  sku: true,
 };
 
 const ALLOWED_QUOTA_SNAPSHOT_KEYS_MAP: Record<keyof CopilotQuotaSnapshotEntry, true> = {
@@ -75,6 +84,9 @@ const assertCopilotTokenEntry = (value: unknown, where: string): void => {
   }
   if (typeof obj.baseUrl !== 'string' || obj.baseUrl === '') {
     throw new TypeError(`${where}.baseUrl must be a non-empty string`);
+  }
+  if (obj.sku !== null && obj.sku !== undefined && (typeof obj.sku !== 'string' || obj.sku === '')) {
+    throw new TypeError(`${where}.sku must be a non-empty string or null`);
   }
 };
 
@@ -146,7 +158,9 @@ export const readCopilotUpstreamState = (raw: unknown): CopilotUpstreamState => 
   assertCopilotUpstreamState(raw);
   return {
     knownModels: raw.knownModels ?? null,
-    copilotToken: raw.copilotToken ?? null,
+    copilotToken: raw.copilotToken === null || raw.copilotToken === undefined
+      ? null
+      : { ...raw.copilotToken, sku: raw.copilotToken.sku ?? null },
     quotaSnapshot: raw.quotaSnapshot ?? null,
   };
 };


### PR DESCRIPTION
GitHub reports a Copilot seat's plan as a SKU, and it travels on `GET /copilot_internal/v2/token` — the exchange the data plane already runs whenever a token has expired. So it is the one Copilot plan signal that stays current without an operator asking for one. We were reading three fields off that response and dropping it.

`copilot_internal/user` carries the same fact as `copilot_plan`, but only the operator's quota refresh ever calls it, and the device-flow import path never does.

Evidence for the field: Microsoft's declared type for that response body, [`microsoft/vscode` copilotToken.ts @ 5fb9376 L330-L376](https://github.com/microsoft/vscode/blob/5fb9376dbdc8b0f1bdc9eb8186f429e023503f92/extensions/copilot/src/platform/authentication/common/copilotToken.ts#L330-L376).

## What changes

- `exchangeCopilotToken` reads `sku`; it is persisted on `CopilotTokenEntry` beside the token it was minted with.
- The redacted record widens from `{ baseUrl }` to `{ baseUrl, sku }` — the host and the plan are the two non-secrets on that entry.

Nothing renders it yet; the upstreams page is where it will be read.

## Typed open, on purpose

Microsoft types its own as `WellKnownSku | string` — GitHub introduces a SKU whenever it introduces a plan — so this is a `string | null`, never a union of today's values.

## Compatibility

Entries minted before this slot existed have no `sku` key. The state reader normalizes that one absent key to `null` rather than rejecting it: the seat is still usable, and the next mint fills it in, at most one token lifetime of traffic away. Covered by a test.

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 538 files, 5563 tests. New: the exchange persists the SKU; a response naming no SKU still mints a usable token; a pre-slot entry reads as having none
- [ ] Observed against a live Copilot seat — needs a real GitHub account with a Copilot subscription, which this environment has no credential for
