### PR TITLE
feat(ollama): read the Cloud account's plan

### DIFF
--- a/apps/web/__tests__/components/upstreams/signals_test.ts
+++ b/apps/web/__tests__/components/upstreams/signals_test.ts
@@ -176,10 +176,24 @@ describe('upstream readout by provider', () => {
     expect(planFor('prolite')).toBe('ChatGPT Pro Lite');
   });
 
+  it('names the Ollama Cloud account by the plan the probe read', () => {
+    const planFor = (plan: string | null) => readoutOf({
+      kind: 'ollama',
+      state: { account: { fetchedAt: Date.parse(OBSERVED), plan } },
+    }).plan;
+
+    expect(planFor('max')).toBe('Ollama Max');
+    // The identifiers are plain words, so one this table has not seen reads as
+    // itself rather than as nothing.
+    expect(planFor('enterprise')).toBe('Ollama enterprise');
+    expect(planFor(null)).toBe('Ollama');
+  });
+
   it('reads the Ollama Cloud windows and the activity cost the probe stored', () => {
     const record = {
       kind: 'ollama',
       state: {
+        account: { fetchedAt: Date.parse(OBSERVED), plan: 'pro' },
         usageProbe: {
           attemptedAt: Date.parse(OBSERVED), error: null, observation: {
             fetchedAt: Date.parse(OBSERVED),
@@ -188,7 +202,7 @@ describe('upstream readout by provider', () => {
         },
       },
     };
-    expect(rowOf(record)).toBe('Ollama | 25% 5h | 40% 7d | $24.34');
+    expect(rowOf(record)).toBe('Ollama Pro | 25% 5h | 40% 7d | $24.34');
   });
 
   it('shows an Ollama Cloud account that has spent nothing as zero rather than as unreported', () => {

--- a/apps/web/src/components/upstreams/ollama-account.ts
+++ b/apps/web/src/components/upstreams/ollama-account.ts
@@ -1,0 +1,16 @@
+import type { OllamaRecord } from './ollama-usage';
+
+// Ollama's own plan identifiers, which are plain words rather than internal
+// SKUs, so one this table does not know is forwarded as it arrived.
+// https://github.com/ollama/ollama/blob/f0078ae4766d0d570e196158f20dde309bd96124/api/client.go#L506
+const PLAN_NAMES: Record<string, string> = {
+  free: 'Free',
+  pro: 'Pro',
+  max: 'Max',
+  team: 'Team',
+};
+
+export const planLabel = (record: OllamaRecord): string | null => {
+  const plan = record.state?.account?.plan ?? null;
+  return plan === null ? null : `Ollama ${PLAN_NAMES[plan] ?? plan}`;
+};

--- a/apps/web/src/components/upstreams/signals.tsx
+++ b/apps/web/src/components/upstreams/signals.tsx
@@ -7,6 +7,7 @@
 import { findCredential, planLabel as claudeCodePlanLabel, quotaWindows, WINDOW_MINUTES } from './claude-code-account';
 import { latestCredits, latestQuotaEntry, planLabel as codexPlanLabel, quotaEntries } from './codex-account';
 import { copilotQuota, readBuckets, shownBuckets } from './copilot-quota';
+import { planLabel as ollamaPlanLabel } from './ollama-account';
 import { activityCostText, readActivityCost, readWindows } from './ollama-usage';
 import { providerLabel } from './provider-badge';
 import { quotaRingTone, WALL_CLOCK_REFRESH_MS, windowLengthLabel } from './subscription-quota';
@@ -181,8 +182,8 @@ const upstreamPlan = (record: UpstreamRecord): string | null => {
   case 'custom':
   case 'azure':
   case 'copilot':
-  case 'ollama':
     return null;
+  case 'ollama': return ollamaPlanLabel(record);
   case 'codex': return codexPlanLabel(record.config.accounts[0]);
   case 'claude-code': return claudeCodePlanLabel(record.config.accounts[0]);
   }

--- a/packages/provider-ollama/__tests__/account-probe_test.ts
+++ b/packages/provider-ollama/__tests__/account-probe_test.ts
@@ -1,0 +1,137 @@
+import { test } from 'vitest';
+
+import { OLLAMA_ACCOUNT_PROBE_MIN_INTERVAL_MS, refreshOllamaAccount } from '../src/account-probe.ts';
+import { assertOllamaUpstreamRecord } from '../src/config.ts';
+import { createOllamaProvider } from '../src/provider.ts';
+import { readOllamaUpstreamState } from '../src/state.ts';
+import { directFetcher, initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
+import { assertEquals, assertRejects, noopUpstreamCallOptions, stubProviderModel, withMockedFetch } from '@floway-dev/test-utils';
+
+const UPSTREAM_ID = 'up_ollama_account';
+
+const cloudRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => ({
+  id: UPSTREAM_ID,
+  kind: 'ollama',
+  name: 'Ollama Cloud',
+  enabled: true,
+  sortOrder: 0,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  config: { baseUrl: 'https://ollama.com', apiKey: 'ollama_test', models: [] },
+  state: null,
+  flagOverrides: {},
+  disabledPublicModelIds: [],
+  proxyFallbackList: [],
+  modelPrefix: null,
+  modelsCache: null,
+  hue: 210,
+  ...overrides,
+});
+
+const withStateRepo = (state: unknown = null) => {
+  let current = state;
+  initProviderRepo(() => ({
+    upstreams: {
+      getById: async () => ({ ...cloudRecord(), state: current }),
+      saveState: async (_id, mutate) => {
+        current = mutate(current);
+      },
+    },
+  }));
+  return { read: () => readOllamaUpstreamState(current) };
+};
+
+test('the account probe posts to ollama.com with the upstream API key and keeps the plan', async () => {
+  const repo = withStateRepo();
+  const seen: { url: string; method: string; authorization: string | null }[] = [];
+  await withMockedFetch(
+    async request => {
+      seen.push({ url: request.url, method: request.method, authorization: request.headers.get('authorization') });
+      // More arrives than the Go client's own type declares, in a second casing.
+      return new Response(JSON.stringify({
+        ID: 'usr_1', Email: 'a@example.com', plan: 'pro',
+        SubscriptionPeriodStart: '2026-08-01T00:00:00Z', CustomerID: 'cus_1',
+      }), { status: 200 });
+    },
+    async () => {
+      const entry = await refreshOllamaAccount(UPSTREAM_ID, assertOllamaUpstreamRecord(cloudRecord()).config, directFetcher);
+      assertEquals(entry.plan, 'pro');
+      assertEquals(repo.read().account?.plan, 'pro');
+    },
+  );
+  assertEquals(seen, [{ url: 'https://ollama.com/api/me', method: 'POST', authorization: 'Bearer ollama_test' }]);
+});
+
+// The server fills an empty plan in with "free" itself, so an absent field is a
+// fact about the response rather than about the plan.
+test('an account naming no plan is recorded as naming none', async () => {
+  const repo = withStateRepo();
+  await withMockedFetch(
+    async () => new Response(JSON.stringify({ ID: 'usr_1', Email: 'a@example.com' }), { status: 200 }),
+    async () => {
+      await refreshOllamaAccount(UPSTREAM_ID, assertOllamaUpstreamRecord(cloudRecord()).config, directFetcher);
+      assertEquals(repo.read().account?.plan, null);
+    },
+  );
+});
+
+test('a failed account read leaves the last known plan in place', async () => {
+  const repo = withStateRepo({ account: { fetchedAt: 1_000, plan: 'max' } });
+  await withMockedFetch(
+    async () => new Response('{"error":"unauthorized"}\n', { status: 401 }),
+    async () => {
+      await assertRejects(
+        () => refreshOllamaAccount(UPSTREAM_ID, assertOllamaUpstreamRecord(cloudRecord()).config, directFetcher),
+        Error,
+        'Ollama /api/me returned 401: {"error":"unauthorized"}',
+      );
+      assertEquals(repo.read().account?.plan, 'max');
+    },
+  );
+});
+
+// Driven through the provider rather than the scheduler, so the arming path is
+// what the assertion covers.
+test('an inference call reads the plan once a day and the usage windows every minute', async () => {
+  const probesFor = async (state: unknown): Promise<{ me: number; usage: number }> => {
+    withStateRepo(state);
+    const counts = { me: 0, usage: 0 };
+    const provider = createOllamaProvider(cloudRecord({ state }));
+    const pending: Promise<unknown>[] = [];
+    await withMockedFetch(
+      request => {
+        const { pathname } = new URL(request.url);
+        if (pathname === '/api/me') counts.me++;
+        if (pathname === '/api/usage') counts.usage++;
+        if (pathname === '/api/me' || pathname === '/api/usage') return new Response('{}', { status: 200 });
+        return new Response('data: [DONE]\n\n', { status: 200, headers: { 'content-type': 'text/event-stream' } });
+      },
+      async () => {
+        await provider.instance.callChatCompletions(
+          stubProviderModel({ providerData: 'gpt-oss:120b' }),
+          { messages: [] },
+          undefined,
+          noopUpstreamCallOptions({ waitUntil: promise => { pending.push(promise); } }),
+        );
+        await Promise.all(pending);
+      },
+    );
+    return counts;
+  };
+
+  assertEquals(await probesFor(null), { me: 1, usage: 1 });
+
+  const now = Date.now();
+  assertEquals(
+    await probesFor({ account: { fetchedAt: now, plan: 'pro' }, usageProbe: { attemptedAt: now, observation: null, error: null } }),
+    { me: 0, usage: 0 },
+  );
+  // A day-old plan beside a minute-old set of windows: only the plan is due.
+  assertEquals(
+    await probesFor({
+      account: { fetchedAt: now - OLLAMA_ACCOUNT_PROBE_MIN_INTERVAL_MS, plan: 'pro' },
+      usageProbe: { attemptedAt: now, observation: null, error: null },
+    }),
+    { me: 1, usage: 0 },
+  );
+});

--- a/packages/provider-ollama/__tests__/provider_test.ts
+++ b/packages/provider-ollama/__tests__/provider_test.ts
@@ -231,9 +231,11 @@ test('Messages methods serialize typed anthropic-beta metadata only on Messages 
           model_info: { 'general.architecture': 'gptoss', 'gptoss.context_length': 131072 },
         });
       }
-      // A cloud call arms the background usage probe. It is not a wire call
-      // of the protocol under test, so it stays out of the beta record.
+      // A cloud call arms the background account and usage probes. Neither is
+      // a wire call of the protocol under test, so they stay out of the beta
+      // record.
       if (path === '/api/usage') return jsonResponse({ limits: {} });
+      if (path === '/api/me') return jsonResponse({ plan: 'pro' });
       betas[path] = request.headers.get('anthropic-beta');
       if (path === '/v1/messages') {
         return new Response('', { status: 200, headers: { 'content-type': 'text/event-stream' } });

--- a/packages/provider-ollama/src/account-probe.ts
+++ b/packages/provider-ollama/src/account-probe.ts
@@ -1,0 +1,98 @@
+// Ollama Cloud account probe.
+//
+// ollama.com serves `POST /api/me` behind the same API key the data plane
+// already uses, and answers with the account's identity and the plan it is on:
+//
+//   {"ID": "...", "Email": "...", "Name": "...", "plan": "pro", ...}
+//
+// The endpoint is undocumented like the usage one beside it, but unlike that
+// one it is in the official Go client, which is what names the field and its
+// values -- `free`, `pro`, `max`, `team`, with an empty plan meaning free.
+// https://github.com/ollama/ollama/blob/f0078ae4766d0d570e196158f20dde309bd96124/api/client.go#L506
+// https://github.com/ollama/ollama/blob/f0078ae4766d0d570e196158f20dde309bd96124/server/routes.go#L2207
+//
+// The live body carries more than `UserResponse` declares -- subscription
+// period and billing identifiers, in a different casing -- so only the one
+// field this reads is taken, and an account naming no plan reads as naming
+// none rather than as free: the defaulting above is the server's, and an
+// absent field on the wire is a fact about the response, not about the plan.
+
+import { type OllamaUpstreamConfig } from './config.ts';
+import { ollamaFetchMe } from './fetch.ts';
+import { type OllamaAccountEntry, type OllamaUpstreamState, readOllamaUpstreamState } from './state.ts';
+import { isOllamaCloudConfig } from './usage-probe.ts';
+import { type Fetcher, getProviderRepo, identityWrapUpstreamCall } from '@floway-dev/provider';
+
+// A subscription changes on a billing boundary at most, so this is refreshed on
+// a wholly different cadence from the usage windows beside it: an upstream
+// serving traffic re-reads its plan once a day.
+export const OLLAMA_ACCOUNT_PROBE_MIN_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export const fetchOllamaAccount = async (
+  config: OllamaUpstreamConfig,
+  fetcher: Fetcher,
+): Promise<OllamaAccountEntry> => {
+  const response = await ollamaFetchMe(
+    config,
+    { method: 'POST', headers: new Headers({ accept: 'application/json' }), body: '{}' },
+    { fetcher, wrapUpstreamCall: identityWrapUpstreamCall },
+  );
+  const rawText = await response.text();
+  if (!response.ok) {
+    throw new Error(`Ollama /api/me returned ${response.status}: ${rawText.trim().slice(0, 256)}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (cause) {
+    throw new Error(`Ollama /api/me returned a non-JSON body (${response.status})`, { cause: cause as Error });
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Ollama /api/me returned a non-object body (${response.status})`);
+  }
+  const plan = (parsed as Record<string, unknown>).plan;
+  return { fetchedAt: Date.now(), plan: typeof plan === 'string' && plan !== '' ? plan : null };
+};
+
+const persistAccountEntry = async (upstreamId: string, entry: OllamaAccountEntry): Promise<void> => {
+  await getProviderRepo().upstreams.saveState(upstreamId, current => {
+    const state = readOllamaUpstreamState(current);
+    // Races resolve by read time rather than by write order, as the usage slot
+    // beside this one does.
+    if (state.account && state.account.fetchedAt >= entry.fetchedAt) return current;
+    return { ...state, account: entry } satisfies OllamaUpstreamState;
+  });
+};
+
+export const refreshOllamaAccount = async (
+  upstreamId: string,
+  config: OllamaUpstreamConfig,
+  fetcher: Fetcher,
+): Promise<OllamaAccountEntry> => {
+  const entry = await fetchOllamaAccount(config, fetcher);
+  await persistAccountEntry(upstreamId, entry);
+  return entry;
+};
+
+const isOllamaAccountProbeDue = (state: OllamaUpstreamState, now: number): boolean => {
+  const account = state.account;
+  return account === null || now - account.fetchedAt >= OLLAMA_ACCOUNT_PROBE_MIN_INTERVAL_MS;
+};
+
+// Fire-and-forget, armed by the same data-plane calls that arm the usage probe
+// and behind its own interval. A failure is logged and dropped: unlike a usage
+// window, a plan the dashboard could not read costs the row a name and nothing
+// else, so it earns no slot of its own on the record.
+export const scheduleOllamaAccountProbe = (
+  upstreamId: string,
+  config: OllamaUpstreamConfig,
+  state: OllamaUpstreamState,
+  fetcher: Fetcher,
+  waitUntil: (promise: Promise<unknown>) => void,
+): void => {
+  if (!isOllamaCloudConfig(config)) return;
+  if (!isOllamaAccountProbeDue(state, Date.now())) return;
+  waitUntil(refreshOllamaAccount(upstreamId, config, fetcher).catch((error: unknown) => {
+    console.warn(`Failed to refresh Ollama account for ${upstreamId}:`, error);
+  }));
+};

--- a/packages/provider-ollama/src/fetch.ts
+++ b/packages/provider-ollama/src/fetch.ts
@@ -55,3 +55,9 @@ export const ollamaFetchShow = (config: OllamaUpstreamConfig, init: FetchInit, o
 // endpoint's provenance and the shape it returns.
 export const ollamaFetchUsage = (config: OllamaUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
   ollamaFetchInternal(config, '/api/usage', init, options);
+// The account behind the API key, including its plan. Cloud-only — see
+// account-probe.ts for the endpoint's provenance. POST, not GET: the route is
+// registered for POST only and answers 405 otherwise.
+// https://github.com/ollama/ollama/blob/f0078ae4766d0d570e196158f20dde309bd96124/api/client.go#L506
+export const ollamaFetchMe = (config: OllamaUpstreamConfig, init: FetchInit, options: UpstreamFetchOptions): Promise<Response> =>
+  ollamaFetchInternal(config, '/api/me', init, options);

--- a/packages/provider-ollama/src/index.ts
+++ b/packages/provider-ollama/src/index.ts
@@ -10,5 +10,6 @@ export const ollamaProviderModule: ProviderModule = {
 export { createOllamaProvider } from './provider.ts';
 export { assertOllamaUpstreamRecord, parseOllamaUpstreamConfig, type OllamaUpstreamConfig, type OllamaUpstreamRecord } from './config.ts';
 export { pricingForOllamaModelKey } from './pricing.ts';
-export { readOllamaUpstreamState, type OllamaUpstreamState } from './state.ts';
+export { readOllamaUpstreamState, type OllamaAccountEntry, type OllamaUpstreamState } from './state.ts';
+export { fetchOllamaAccount, refreshOllamaAccount } from './account-probe.ts';
 export { fetchOllamaUsageProbe, isOllamaCloudConfig, refreshOllamaUsageProbe } from './usage-probe.ts';

--- a/packages/provider-ollama/src/provider.ts
+++ b/packages/provider-ollama/src/provider.ts
@@ -24,6 +24,7 @@
 // catalog, and an auto row carrying the same upstreamModelId is dropped so the
 // manual copy is the only one for that id.
 
+import { scheduleOllamaAccountProbe } from './account-probe.ts';
 import { chatFromOllamaRaw } from './chat-from-raw.ts';
 import { assertOllamaUpstreamRecord, type OllamaUpstreamConfig } from './config.ts';
 import { OLLAMA_DEFAULT_FLAGS } from './defaults.ts';
@@ -85,8 +86,15 @@ export const createOllamaProvider = (record: UpstreamRecord): Provider => {
   // calls, and exposes them nowhere but its usage endpoint, so each such call
   // arms a debounced background refresh. Token counting never reaches a model
   // and leaves the windows untouched, so it does not arm one.
-  const armUsageProbe = (opts: UpstreamCallOptions): void =>
+  //
+  // The account's plan rides along on the same trigger behind its own, far
+  // longer interval: it changes on a billing boundary at most, and there is no
+  // other moment at which the gateway is already holding this upstream's key
+  // and a place to put background work.
+  const armUsageProbe = (opts: UpstreamCallOptions): void => {
     scheduleOllamaUsageProbe(record.id, config, state, opts.fetcher, opts.waitUntil);
+    scheduleOllamaAccountProbe(record.id, config, state, opts.fetcher, opts.waitUntil);
+  };
 
   // Arms once the upstream round-trip has produced a response, so the probe
   // reads windows that already account for this call. A rate-limited response

--- a/packages/provider-ollama/src/state.ts
+++ b/packages/provider-ollama/src/state.ts
@@ -1,5 +1,7 @@
 // Gateway-managed Ollama upstream state, persisted in upstreams.state_json.
-// One slot: the most recent Ollama Cloud usage probe. Writes go through
+// Two slots, both Ollama Cloud account facts on their own refresh cadence: the
+// most recent usage probe, and the account the API key belongs to. Writes go
+// through
 // UpstreamRepo.saveState as a mutator that spreads the state it is handed and
 // replaces its own slot, so a concurrent write on another slot survives.
 
@@ -31,12 +33,28 @@ export interface OllamaUsageObservation {
   data: unknown;
 }
 
+// The account behind the API key. `plan` is Ollama's own identifier, kept as
+// the open string it is; null when the account named none. There is no error
+// field beside it: a plan the probe could not read costs the dashboard a name
+// and nothing an operator would act on, so the slot simply stays as it was.
+export interface OllamaAccountEntry {
+  fetchedAt: number;
+  plan: string | null;
+}
+
 export interface OllamaUpstreamState {
   usageProbe: OllamaUsageProbeEntry | null;
+  account: OllamaAccountEntry | null;
 }
 
 const ALLOWED_STATE_KEYS_MAP: Record<keyof OllamaUpstreamState, true> = {
   usageProbe: true,
+  account: true,
+};
+
+const ALLOWED_ACCOUNT_KEYS_MAP: Record<keyof OllamaAccountEntry, true> = {
+  fetchedAt: true,
+  plan: true,
 };
 
 const ALLOWED_PROBE_KEYS_MAP: Record<keyof OllamaUsageProbeEntry, true> = {
@@ -90,14 +108,25 @@ const assertOllamaUsageProbeEntry = (value: unknown, where: string): void => {
   }
 };
 
+const assertOllamaAccountEntry = (value: unknown, where: string): void => {
+  const obj = assertClosedObject(value, where, ALLOWED_ACCOUNT_KEYS_MAP);
+  assertUnixMs(obj.fetchedAt, `${where}.fetchedAt`);
+  if (obj.plan !== null && obj.plan !== undefined && typeof obj.plan !== 'string') {
+    throw new TypeError(`${where}.plan must be a string`);
+  }
+};
+
 export function assertOllamaUpstreamState(value: unknown): asserts value is OllamaUpstreamState {
   const obj = assertClosedObject(value, 'OllamaUpstreamState', ALLOWED_STATE_KEYS_MAP);
   if (obj.usageProbe !== null && obj.usageProbe !== undefined) {
     assertOllamaUsageProbeEntry(obj.usageProbe, 'OllamaUpstreamState.usageProbe');
   }
+  if (obj.account !== null && obj.account !== undefined) {
+    assertOllamaAccountEntry(obj.account, 'OllamaUpstreamState.account');
+  }
 }
 
-export const emptyOllamaUpstreamState = (): OllamaUpstreamState => ({ usageProbe: null });
+export const emptyOllamaUpstreamState = (): OllamaUpstreamState => ({ usageProbe: null, account: null });
 
 // The asserter treats an absent optional key as null, so the entry is rebuilt
 // here rather than passed through: readers get the three fields the type
@@ -106,12 +135,15 @@ export const readOllamaUpstreamState = (raw: unknown): OllamaUpstreamState => {
   if (raw === null || raw === undefined) return emptyOllamaUpstreamState();
   assertOllamaUpstreamState(raw);
   const probe = raw.usageProbe;
-  if (!probe) return emptyOllamaUpstreamState();
+  const account = raw.account;
   return {
-    usageProbe: {
-      attemptedAt: probe.attemptedAt,
-      observation: probe.observation ?? null,
-      error: probe.error ?? null,
-    },
+    usageProbe: probe
+      ? {
+          attemptedAt: probe.attemptedAt,
+          observation: probe.observation ?? null,
+          error: probe.error ?? null,
+        }
+      : null,
+    account: account ? { fetchedAt: account.fetchedAt, plan: account.plan ?? null } : null,
   };
 };


### PR DESCRIPTION
Stacked on #450 (itself stacked on #443), and a sibling of #451 — both add the one plan name the routing list could not yet show. Draft until its bases land.

## Why

After #450 an upstream row leads with the plan it serves on. Ollama Cloud led with the provider's name, because `/api/usage` reports windows and a cost and says nothing about the account.

`POST https://ollama.com/api/me` answers with the account and its `plan`. Unlike the usage endpoint beside it, this one is in the official Go client — which is what names the field and its values, `free` / `pro` / `max` / `team`:

- [`api/client.go` `Whoami` → `UserResponse.Plan`](https://github.com/ollama/ollama/blob/f0078ae4766d0d570e196158f20dde309bd96124/api/client.go#L506)
- [`server/routes.go` — an empty plan defaults to `free`](https://github.com/ollama/ollama/blob/f0078ae4766d0d570e196158f20dde309bd96124/server/routes.go#L2207)

Everything else was ruled out: `/api/usage` carries no plan field, and `/api/user`, `/api/account`, `/api/whoami`, `/api/subscription`, `/api/billing`, `/api/plan`, `/api/limits`, `/api/tier`, `/api/quota` and `/api/profile` all 404.

## What changes

- `ollamaFetchMe` beside `ollamaFetchUsage`; POST, because the route is registered for POST only and answers 405 otherwise.
- A second state slot, `account: { fetchedAt, plan }`, on its own refresh cadence.
- Armed by the same data-plane calls that arm the usage probe, behind `OLLAMA_ACCOUNT_PROBE_MIN_INTERVAL_MS` = 24h: a subscription changes on a billing boundary at most, so a busy upstream re-reads its plan once a day rather than once a minute.
- `apps/web/src/components/upstreams/ollama-account.ts` maps the plan onto `Ollama Free / Pro / Max / Team`, forwarding an unknown value as itself — these are plain words, not internal SKUs.

## Two deliberate asymmetries with the usage slot

- **No error field.** A usage window the probe could not read is something an operator acts on; a plan it could not read costs the row a name and nothing else. The failure is logged and the last known plan stands.
- **An absent `plan` is recorded as null, not as `free`.** The defaulting to free is the *server's*, in its own handler — an absent field on the wire is a fact about the response, not about the plan. The row then falls back to `Ollama`.

Only the one field is taken: the live body also carries subscription-period and billing identifiers that `UserResponse` does not declare, in a second casing.

## Verification

`lint`, `typecheck`, and the full suite pass (532 files / 5528 tests). New tests: the probe posts to the right URL with the upstream key and keeps the plan through a body richer than the declared type; an account naming no plan records none; a 401 leaves the last known plan in place; and, driven through the provider rather than the scheduler, one inference call reads both probes cold, neither when both are fresh, and only the plan when it is a day old beside minute-old windows.