### PR TITLE
fix(codex): read the reset instant upstream renamed

### DIFF
--- a/packages/provider-codex/__tests__/quota_test.ts
+++ b/packages/provider-codex/__tests__/quota_test.ts
@@ -88,6 +88,58 @@ describe('parseCodexQuotaHeaders', () => {
     expect(snapshot.ratelimited_until).toBeUndefined();
   });
 
+  // Upstream added `-reset-at` on 2025-10-17 and kept sending the offset it
+  // replaced, so the absolute instant wins and the offset is the fallback.
+  test('prefers the absolute reset instant over the offset it replaced', () => {
+    const headers = new Headers({
+      'x-codex-primary-reset-at': '1780272000',
+      'x-codex-primary-reset-after-seconds': '18000',
+      'x-codex-secondary-reset-after-seconds': '7200',
+    });
+    const snapshot = parseCodexQuotaHeaders(headers, { now: new Date('2026-06-05T00:00:00.000Z'), isRateLimited: false });
+    expect(snapshot.primary_reset_after_at).toBe(new Date(1780272000 * 1000).toISOString());
+    // No absolute instant for the secondary, so the offset still dates it.
+    expect(snapshot.secondary_reset_after_at).toBe('2026-06-05T02:00:00.000Z');
+  });
+
+  // Builds from the three days after the header landed sent RFC 3339 instead of
+  // epoch seconds, which is why every client that reads it accepts both.
+  test('reads an absolute reset instant sent as RFC 3339', () => {
+    const headers = new Headers({ 'x-codex-primary-reset-at': '2026-06-05T05:00:00.000Z' });
+    const snapshot = parseCodexQuotaHeaders(headers, { now: new Date('2026-06-05T00:00:00.000Z'), isRateLimited: false });
+    expect(snapshot.primary_reset_after_at).toBe('2026-06-05T05:00:00.000Z');
+  });
+
+  // A plan whose secondary window is zero minutes wide reports a blank instant
+  // beside a zero offset. That is "no such window", not "it resets now".
+  test('reports no reset for a window this plan does not have', () => {
+    const headers = new Headers({
+      'x-codex-secondary-window-minutes': '0',
+      'x-codex-secondary-reset-at': '',
+      'x-codex-secondary-reset-after-seconds': '0',
+    });
+    const snapshot = parseCodexQuotaHeaders(headers, { now: new Date('2026-06-05T00:00:00.000Z'), isRateLimited: false });
+    expect(snapshot.secondary_reset_after_at).toBeUndefined();
+  });
+
+  // `Number('')` is 0, so a blank reading would otherwise land as a confident
+  // zero balance rather than as nothing observed.
+  test('reads a blank numeric header as absent rather than as zero', () => {
+    const headers = new Headers({ 'x-codex-credits-balance': '', 'x-codex-secondary-used-percent': '  ' });
+    const snapshot = parseCodexQuotaHeaders(headers, { now: new Date('2026-06-05T00:00:00.000Z'), isRateLimited: false });
+    expect(snapshot.credits_balance).toBeUndefined();
+    expect(snapshot.secondary_used_percent).toBeUndefined();
+  });
+
+  test('dates a 429 from the absolute instant when only that header arrives', () => {
+    const headers = new Headers({
+      'x-codex-primary-reset-at': '1780272000',
+      'x-codex-secondary-reset-at': '1780358400',
+    });
+    const snapshot = parseCodexQuotaHeaders(headers, { now: new Date('2026-06-05T00:00:00.000Z'), isRateLimited: true });
+    expect(snapshot.ratelimited_until).toBe(new Date(1780358400 * 1000).toISOString());
+  });
+
   test('sets ratelimited_until from max(primary, secondary) reset window on 429', () => {
     const headers = new Headers({
       'x-codex-primary-reset-after-seconds': '3600',

--- a/packages/provider-codex/src/quota.ts
+++ b/packages/provider-codex/src/quota.ts
@@ -52,6 +52,10 @@ export const parseCodexQuotaHeaders = (headers: Headers, options: ParseCodexQuot
   const setNumber = (key: keyof CodexQuotaSnapshot, header: string): void => {
     const v = headers.get(header);
     if (v === null) return;
+    // Blank rather than absent is how this backend reports a field that does
+    // not apply -- a plan with no secondary window, an account with no credit
+    // balance -- and `Number('')` is 0, which would render as a confident zero.
+    if (v.trim() === '') return;
     const n = Number(v);
     if (Number.isFinite(n)) assign[key] = n;
   };
@@ -62,31 +66,59 @@ export const parseCodexQuotaHeaders = (headers: Headers, options: ParseCodexQuot
     if (lower === 'true') assign[key] = true;
     else if (lower === 'false') assign[key] = false;
   };
-  const setResetAfter = (key: keyof CodexQuotaSnapshot, header: string): void => {
-    const v = headers.get(header);
-    if (v === null) return;
-    const seconds = Number(v);
-    if (!Number.isFinite(seconds)) return;
-    assign[key] = new Date(options.now.getTime() + seconds * 1000).toISOString();
+  // Upstream renamed this reading on 2025-10-17: `-reset-at` states the instant
+  // outright, where `-reset-after-seconds` states the offset from receipt. Both
+  // are still sent, and a capture from 2025-09 carries only the offset, so the
+  // rename added a header rather than replacing one. The instant is preferred
+  // and the offset is the fallback, which is the shape the third-party clients
+  // that read both settled on -- and which keeps this working on the day the
+  // offset stops being sent.
+  // https://github.com/openai/codex/commit/0e08dd605
+  //
+  // Zero and blank both mean "this plan has no such window" rather than "it
+  // resets now": a capture pairs a blank `-reset-at` with a zero
+  // `-reset-after-seconds` on a plan whose secondary window is 0 minutes wide.
+  const resetInstant = (prefix: string): string | undefined => {
+    const at = headers.get(`${prefix}-reset-at`)?.trim();
+    if (at !== undefined && at !== '') {
+      const epochSeconds = Number(at);
+      // Epoch seconds today; RFC 3339 in builds from the three days after the
+      // header landed, which is why clients that read it accept both.
+      const instant = Number.isFinite(epochSeconds) ? epochSeconds * 1000 : Date.parse(at);
+      if (Number.isFinite(instant) && instant > 0) return new Date(instant).toISOString();
+    }
+    const after = headers.get(`${prefix}-reset-after-seconds`)?.trim();
+    if (after === undefined || after === '') return undefined;
+    const seconds = Number(after);
+    if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+    return new Date(options.now.getTime() + seconds * 1000).toISOString();
+  };
+
+  const setReset = (key: keyof CodexQuotaSnapshot, prefix: string): void => {
+    const instant = resetInstant(prefix);
+    if (instant !== undefined) assign[key] = instant;
   };
 
   setString('active_limit', 'x-codex-active-limit');
   setString('plan_type', 'x-codex-plan-type');
   setNumber('primary_used_percent', 'x-codex-primary-used-percent');
   setNumber('primary_window_minutes', 'x-codex-primary-window-minutes');
-  setResetAfter('primary_reset_after_at', 'x-codex-primary-reset-after-seconds');
+  setReset('primary_reset_after_at', 'x-codex-primary');
   setNumber('secondary_used_percent', 'x-codex-secondary-used-percent');
   setNumber('secondary_window_minutes', 'x-codex-secondary-window-minutes');
-  setResetAfter('secondary_reset_after_at', 'x-codex-secondary-reset-after-seconds');
+  setReset('secondary_reset_after_at', 'x-codex-secondary');
   setBool('credits_has_credits', 'x-codex-credits-has-credits');
   setNumber('credits_balance', 'x-codex-credits-balance');
 
+  // The furthest window is when the block lifts, read through the same
+  // preference so a response carrying only the new header still dates it.
   if (options.isRateLimited) {
-    const primary = Number(headers.get('x-codex-primary-reset-after-seconds'));
-    const secondary = Number(headers.get('x-codex-secondary-reset-after-seconds'));
-    const seconds = Math.max(Number.isFinite(primary) ? primary : 0, Number.isFinite(secondary) ? secondary : 0);
-    if (seconds > 0) {
-      snapshot.ratelimited_until = new Date(options.now.getTime() + seconds * 1000).toISOString();
+    const horizons = [snapshot.primary_reset_after_at, snapshot.secondary_reset_after_at]
+      .filter((instant): instant is string => instant !== undefined)
+      .map(instant => Date.parse(instant))
+      .filter(Number.isFinite);
+    if (horizons.length > 0) {
+      snapshot.ratelimited_until = new Date(Math.max(...horizons)).toISOString();
     }
   }
 


### PR DESCRIPTION
Codex added `x-codex-<window>-reset-at` in [`0e08dd605`](https://github.com/openai/codex/commit/0e08dd605) (2025-10-17) and kept sending the `-reset-after-seconds` it replaced. A capture from 2025-09 carries only the offset and one from 2026-07 carries both, so the rename **added** a header rather than swapping one — and we read only the one being replaced. Every reset horizon, and the rate-limit deadline synthesised from them, would go silently absent on the day the old header stops being sent.

That deadline is what tells the dashboard an account is currently blocked, which is why this is worth fixing before the upstreams page starts showing that state.

## What changes

- The absolute instant is preferred; the offset is the fallback, dated from receipt. That is the shape the third-party clients reading both settled on ([CLIProxyAPIHome `quota_ingestion.go#L465-L473`](https://github.com/router-for-me/CLIProxyAPIHome/blob/1787f4b1937e9e78e0dfe5d167f009243f4a56e4/internal/cluster/quota_ingestion.go#L465-L473)).
- It is accepted as epoch seconds **and** as RFC 3339: builds from the three days after the header landed sent the latter, which is why clients that read it tolerate both.
- `ratelimited_until` is dated through the same preference instead of off the legacy header alone.

## Two readings that were being taken for zeros

- **A window the plan does not have.** Captured on an account whose secondary window is zero minutes wide: a blank `-reset-at` beside a zero `-reset-after-seconds`. That means "no such window", not "it resets now" — it was being dated at the instant of receipt.
- **A blank numeric header.** `Number('')` is `0`, and this backend reports an inapplicable numeric field blank rather than absent, so a credit balance it declined to state landed as a confident zero balance.

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 538 files, 5568 tests. New: the absolute instant wins over the offset while the offset still dates a window that has none; RFC 3339 is read; a window the plan does not have reports no reset; a blank numeric header reads as absent rather than zero; a 429 carrying only the new header is still dated. One unrelated file (`tools` backfill CLI) trips a 5-second per-test timeout under parallel load and passes in isolation
- [ ] Observed against a live Codex account — needs a real ChatGPT subscription, which this environment has no credential for