### PR TITLE
fix(codex): keep every quota reading the dashboard could show

### DIFF
--- a/packages/provider-codex/__tests__/quota_test.ts
+++ b/packages/provider-codex/__tests__/quota_test.ts
@@ -4,7 +4,6 @@ import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstr
 import {
   CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT,
   codexQuotaActiveLimitKey,
-  computeCodexQuotaTtlMs,
   getCodexQuota,
   parseCodexQuotaHeaders,
   putCodexQuota,
@@ -188,26 +187,27 @@ describe('getCodexQuota', () => {
     expect(await getCodexQuota(upstreamId, accountId)).toEqual({ premium: snap });
   });
 
-  test('returns null when every bucket is past its TTL window', async () => {
-    const snap: CodexQuotaSnapshot = { observed_at: '2026-06-01T00:00:00.000Z' };
-    const fetchedAt = Date.now() - 2 * 24 * 60 * 60 * 1000;
-    current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: { premium: { fetchedAt, data: snap } } }] });
-    expect(await getCodexQuota(upstreamId, accountId)).toBeNull();
-  });
-
-  test('filters stale buckets independently', async () => {
-    const freshSnap: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'fresh' };
-    const staleSnap: CodexQuotaSnapshot = { observed_at: '2026-06-01T00:00:00.000Z', active_limit: 'stale' };
+  // An old reading rendered with the instant it was taken tells an operator
+  // more than an empty card, so age withholds nothing -- the dashboard is the
+  // only reader, and traffic on the upstream replaces what it shows.
+  test('returns every bucket however long ago it was observed', async () => {
+    const recent: CodexQuotaSnapshot = { observed_at: '2026-06-05T00:00:00.000Z', active_limit: 'recent' };
+    const ancient: CodexQuotaSnapshot = { observed_at: '2026-06-01T00:00:00.000Z', active_limit: 'ancient' };
     current = makeRecord({
       accounts: [{
         ...baseAccount,
         quotaSnapshot: {
-          fresh: { fetchedAt: Date.now(), data: freshSnap },
-          stale: { fetchedAt: Date.now() - 2 * 24 * 60 * 60 * 1000, data: staleSnap },
+          recent: { fetchedAt: Date.now(), data: recent },
+          ancient: { fetchedAt: Date.now() - 90 * 24 * 60 * 60 * 1000, data: ancient },
         },
       }],
     });
-    expect(await getCodexQuota(upstreamId, accountId)).toEqual({ fresh: freshSnap });
+    expect(await getCodexQuota(upstreamId, accountId)).toEqual({ recent, ancient });
+  });
+
+  test('returns null when the account has an empty snapshot map', async () => {
+    current = makeRecord({ accounts: [{ ...baseAccount, quotaSnapshot: {} }] });
+    expect(await getCodexQuota(upstreamId, accountId)).toBeNull();
   });
 
   test('returns null when the requested account is not in the pool', async () => {
@@ -260,21 +260,5 @@ describe('putCodexQuota', () => {
   test('throws when the requested account is not in the pool', async () => {
     await expect(putCodexQuota(upstreamId, 'acc_other', { observed_at: 'now' })).rejects.toThrow(/not found in upstream/);
     expect(repo.writes).toEqual([]);
-  });
-});
-
-describe('computeCodexQuotaTtlMs', () => {
-  test('floors at 24h when no reset horizons are present', () => {
-    const now = new Date('2026-06-05T00:00:00.000Z');
-    expect(computeCodexQuotaTtlMs({ observed_at: now.toISOString() }, now)).toBe(24 * 60 * 60 * 1000);
-  });
-
-  test('extends past floor to the furthest reset horizon', () => {
-    const now = new Date('2026-06-05T00:00:00.000Z');
-    const snap: CodexQuotaSnapshot = {
-      observed_at: now.toISOString(),
-      primary_reset_after_at: '2026-06-08T00:00:00.000Z',
-    };
-    expect(computeCodexQuotaTtlMs(snap, now)).toBe(3 * 24 * 60 * 60 * 1000);
   });
 });

--- a/packages/provider-codex/src/quota.ts
+++ b/packages/provider-codex/src/quota.ts
@@ -32,8 +32,6 @@ export const codexQuotaActiveLimitKey = (snapshot: CodexQuotaSnapshot): string =
   return key && !isUnsafeActiveLimitKey(key) ? key : CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT;
 };
 
-const TTL_FLOOR_MS = 24 * 60 * 60 * 1000;
-
 interface ParseCodexQuotaOptions {
   now: Date;
   isRateLimited: boolean;
@@ -125,20 +123,13 @@ export const parseCodexQuotaHeaders = (headers: Headers, options: ParseCodexQuot
   return snapshot;
 };
 
-// Bound TTL by the furthest reset horizon to keep a hot account's state
-// alive through its entire window; floor at 24h so dashboard reads survive
-// quiet periods between bursts.
-export const computeCodexQuotaTtlMs = (snapshot: CodexQuotaSnapshot, now: Date): number => {
-  const horizons = [snapshot.primary_reset_after_at, snapshot.secondary_reset_after_at, snapshot.ratelimited_until]
-    .map(s => s ? new Date(s).getTime() - now.getTime() : 0)
-    .filter(ms => ms > 0);
-  return Math.max(TTL_FLOOR_MS, ...horizons);
-};
-
-// Returns all fresh quota snapshots keyed by active limit. Stale buckets read as
-// absent — the next upstream response for that active limit will overwrite it.
-// state_json is unbounded, so freshness is gated inline by
-// computeCodexQuotaTtlMs.
+// Every quota snapshot this account has observed, keyed by active limit.
+//
+// No TTL, which is the rule the other three providers state at their own slots:
+// a reading rendered with the instant it was taken tells an operator more than
+// an empty card does, and any traffic on the upstream replaces it. Only the
+// dashboard reads this -- the data plane routes without consulting it -- so
+// withholding a reading buys nothing and costs the page the only answer it has.
 export const getCodexQuota = async (
   upstreamId: string,
   accountId: string,
@@ -147,14 +138,9 @@ export const getCodexQuota = async (
   if (!fresh) return null;
   const state = readCodexUpstreamState(fresh.state);
   const account = state.accounts.find(a => a.chatgptAccountId === accountId);
-  if (!account?.quotaSnapshot) return null;
-  const now = new Date();
-  const freshSnapshots: CodexQuotaSnapshotMap = {};
-  for (const [key, entry] of Object.entries(account.quotaSnapshot)) {
-    const ttlMs = computeCodexQuotaTtlMs(entry.data, now);
-    if (now.getTime() - entry.fetchedAt <= ttlMs) freshSnapshots[key] = entry.data;
-  }
-  return Object.keys(freshSnapshots).length ? freshSnapshots : null;
+  const snapshots = account?.quotaSnapshot;
+  if (!snapshots || Object.keys(snapshots).length === 0) return null;
+  return Object.fromEntries(Object.entries(snapshots).map(([key, entry]) => [key, entry.data]));
 };
 
 export const putCodexQuota = async (


### PR DESCRIPTION
A Codex quota snapshot was withheld once it aged past a TTL, so an upstream quiet for a day showed an empty card rather than the last thing it reported. The other three providers keep theirs and say why at their own slots — Copilot's is explicit: *"an old snapshot rendered with its timestamp is more useful to an operator than an empty card, and any traffic on the upstream replaces it."* Codex is the only one that disagreed.

## Nothing was bought by withholding it

- **Only the dashboard reads this.** `getCodexQuota` has exactly one caller, `GET /api/upstreams`. The data plane routes without consulting it, so a hidden reading costs the page its only answer and protects nothing.
- **The TTL never deleted anything.** `putCodexQuota` merges into the map and no path prunes it, so the `state_json is unbounded` the comment cited as its reason was not addressed by it.

## The horizon argued against itself

`computeCodexQuotaTtlMs` took `Math.max(24h, ...resetHorizons)`, which is two rules pulling opposite ways:

- The **ceiling** kept a reading alive for the window it describes — correct, since a percentage is about that window and stays true until it closes.
- The **floor** outlived that window, and because it was a `max` it also overrode any shorter horizon. A five-hour window's percentage stayed on the page for nineteen hours after the allowance it measured had already reset.

Both are gone with the TTL.

## Test Plan

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 540 files, 5593 tests. The TTL tests are replaced by one asserting every bucket returns however long ago it was observed, plus an empty-map case
- [ ] Observed against a live Codex account — needs a real ChatGPT subscription, which this environment has no credential for
