### PR TITLE
feat(codex): expose ChatGPT image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ responses retain their upstream wire shape.
 | Provider | Connection | Model catalog |
 | --- | --- | --- |
 | GitHub Copilot | GitHub device OAuth on `github.com` or a `*.ghe.com` tenant | Fetched live from Copilot |
-| Codex | ChatGPT subscription through the Codex CLI OAuth client | Fetched live from the Codex backend |
+| Codex | ChatGPT subscription through the Codex CLI OAuth client | Live inference catalog plus the account's built-in GPT Image capability |
 | Claude Code | Claude.ai Pro, Max, Team, or Enterprise subscription through the Claude Code CLI OAuth client | Fetched live from Anthropic |
 | Custom | Configurable multi-protocol HTTP endpoint, credential, and per-header ingress passthrough/overwrite rules | Live `/models` (OpenAI, Anthropic, or superset shapes), manual models, or both |
 | Azure | Azure AI resource or Foundry project endpoint and API key | Configured models |

--- a/packages/gateway/__tests__/data-plane/codex/routes_images_test.ts
+++ b/packages/gateway/__tests__/data-plane/codex/routes_images_test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest';
 
 import type { InMemoryRepo } from '../../repo/memory.ts';
 import { copilotModels, MOCKED_FETCH_EGRESS, requestApp, setupAppTest } from '../../test-utils/app.ts';
+import { CODEX_USER_AGENT } from '@floway-dev/provider-codex';
 import { assertEquals, assertExists, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
 const PNG_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/wEAAAAASUVORK5CYII=';
@@ -30,6 +31,38 @@ const saveAzureImages = async (repo: InMemoryRepo): Promise<void> => {
       }],
     },
     state: null,
+  });
+};
+
+const saveCodexImages = async (repo: InMemoryRepo): Promise<void> => {
+  await repo.upstreams.save({
+    id: 'codex-image',
+    kind: 'codex',
+    name: 'ChatGPT Team',
+    enabled: true,
+    sortOrder: 0,
+    createdAt: '2026-08-09T00:00:00Z',
+    updatedAt: '2026-08-09T00:00:00Z',
+    flagOverrides: {},
+    disabledPublicModelIds: [],
+    proxyFallbackList: MOCKED_FETCH_EGRESS,
+    modelPrefix: null,
+    modelsCache: null,
+    hue: 210,
+    config: {
+      accounts: [{ email: 'team@example.test', chatgptAccountId: 'account', chatgptUserId: 'user', planType: 'team' }],
+    },
+    state: {
+      accounts: [{
+        chatgptAccountId: 'account',
+        refresh_token: 'refresh',
+        state: 'active',
+        state_updated_at: '2026-08-09T00:00:00Z',
+        openaiDeviceId: '11111111-2222-4333-8444-555555555555',
+        accessToken: { token: 'access', expiresAt: 4102444800000, refreshedAt: '2026-08-09T00:00:00Z' },
+        quotaSnapshot: null,
+      }],
+    },
   });
 };
 
@@ -78,6 +111,53 @@ test('Codex provider-relative image generation reuses the public image-generatio
   assertExists(observedBody);
   assertEquals(observedBody.prompt, 'a fox in space');
   assertEquals(observedBody.quality, 'high');
+});
+
+test('ChatGPT Codex accounts expose and serve the implicit gpt-image-2 model', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  await saveCodexImages(repo);
+  let observedBody: Record<string, unknown> | undefined;
+
+  await withMockedFetch(
+    async request => {
+      const control = controlPlaneFetch(request);
+      if (control) return control;
+      const url = new URL(request.url);
+      if (url.pathname === '/backend-api/codex/models') {
+        return jsonResponse({ models: [{ slug: 'gpt-5.6-sol', display_name: 'GPT-5.6 Sol', context_window: 1000000 }] });
+      }
+      if (url.pathname === '/backend-api/codex/images/generations') {
+        observedBody = await request.json() as Record<string, unknown>;
+        return jsonResponse({ created: 1, data: [{ b64_json: 'aGk=' }], background: 'opaque', quality: 'low', size: '1254x1254' });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => {
+      const publicModels = await requestApp('/v1/models', {
+        headers: { authorization: `Bearer ${apiKey.key}` },
+      });
+      assertEquals(publicModels.status, 200);
+      const publicCatalog = await publicModels.json() as { data: { id: string }[] };
+      assertEquals(publicCatalog.data.some(model => model.id === 'gpt-image-2'), true);
+
+      const codexModels = await requestApp('/azure-api.codex/models?client_version=0.147.0', {
+        headers: { authorization: `Bearer ${apiKey.key}`, 'user-agent': CODEX_USER_AGENT },
+      });
+      assertEquals(codexModels.status, 200);
+      const codexCatalog = await codexModels.json() as { models: { slug: string }[] };
+      assertEquals(codexCatalog.models.some(model => model.slug === 'gpt-image-2'), false);
+
+      const response = await requestApp('/azure-api.codex/images/generations', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${apiKey.key}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-image-2', prompt: 'an orange circle', quality: 'low' }),
+      });
+      assertEquals(response.status, 200);
+      assertEquals(await response.json(), { created: 1, data: [{ b64_json: 'aGk=' }], background: 'opaque', quality: 'low', size: '1254x1254' });
+    },
+  );
+
+  assertEquals(observedBody, { model: 'gpt-image-2', prompt: 'an orange circle', quality: 'low' });
 });
 
 test('Codex provider-relative image edits reuse the public JSON handler', async () => {

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -154,6 +154,35 @@ describe('putCodexAccessToken', () => {
     expect(storedState().accounts[0].accessToken).toEqual(effective);
   });
 
+  test('includes a captured retry plan in LWW ordering after token invalidation', async () => {
+    current = makeRecord({
+      accounts: [{
+        ...baseAccount,
+        accessToken: {
+          token: 'at_stale',
+          expiresAt: farFutureMs,
+          refreshedAt: '2026-08-10T00:00:01.000Z',
+          planType: 'free',
+          planObservedAt: '2026-08-10T00:00:01.000Z',
+        },
+      }],
+    });
+    const incoming: CodexAccessTokenEntry = {
+      token: 'at_new',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:03.000Z',
+    };
+    const effective = await putCodexAccessToken(upstreamId, accountId, incoming, {
+      planType: 'plus',
+      observedAt: '2026-08-10T00:00:02.000Z',
+    });
+    expect(effective).toEqual({
+      ...incoming,
+      planType: 'plus',
+      planObservedAt: '2026-08-10T00:00:02.000Z',
+    });
+  });
+
   test('propagates storage failures so the request path surfaces them', async () => {
     repo.saveState.mockRejectedValueOnce(new Error('D1 boom'));
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'now' };

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -105,6 +105,24 @@ describe('putCodexAccessToken', () => {
     expect(storedState().accounts[0].accessToken).toEqual(newer);
   });
 
+  test.each(['free', 'team'])('keeps the newer token while merging an older explicit %s plan', async olderPlan => {
+    const newer: CodexAccessTokenEntry = {
+      token: 'at_newer',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:02.000Z',
+    };
+    current = makeRecord({ accounts: [{ ...baseAccount, accessToken: newer }] });
+    const older: CodexAccessTokenEntry = {
+      token: 'at_older',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:01.000Z',
+      planType: olderPlan,
+    };
+    const effective = await putCodexAccessToken(upstreamId, accountId, older);
+    expect(effective).toEqual({ ...newer, planType: olderPlan });
+    expect(storedState().accounts[0].accessToken).toEqual({ ...newer, planType: olderPlan });
+  });
+
   test('propagates storage failures so the request path surfaces them', async () => {
     repo.saveState.mockRejectedValueOnce(new Error('D1 boom'));
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'now' };

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -71,14 +71,38 @@ describe('putCodexAccessToken', () => {
   });
 
   test('prefers the current CAS plan over an older fallback when the new token omits it', async () => {
-    current = makeRecord({ accounts: [{
-      ...baseAccount,
-      accessToken: { token: 'at_current', expiresAt: farFutureMs, refreshedAt: 'current', planType: 'free' },
-    }] });
+    current = makeRecord({
+      accounts: [{
+        ...baseAccount,
+        accessToken: { token: 'at_current', expiresAt: farFutureMs, refreshedAt: 'current', planType: 'free' },
+      }],
+    });
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'new' };
     const effective = await putCodexAccessToken(upstreamId, accountId, entry, 'team');
     expect(effective.planType).toBe('free');
     expect(storedState().accounts[0].accessToken?.planType).toBe('free');
+  });
+
+  test.each([
+    ['team', 'free'],
+    ['free', 'team'],
+  ])('an older explicit %s observation cannot replace newer %s', async (olderPlan, newerPlan) => {
+    const newer: CodexAccessTokenEntry = {
+      token: 'at_newer',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:02.000Z',
+      planType: newerPlan,
+    };
+    current = makeRecord({ accounts: [{ ...baseAccount, accessToken: newer }] });
+    const older: CodexAccessTokenEntry = {
+      token: 'at_older',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:01.000Z',
+      planType: olderPlan,
+    };
+    const effective = await putCodexAccessToken(upstreamId, accountId, older);
+    expect(effective).toEqual(newer);
+    expect(storedState().accounts[0].accessToken).toEqual(newer);
   });
 
   test('propagates storage failures so the request path surfaces them', async () => {

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -219,6 +219,21 @@ describe('invalidateCodexAccessToken', () => {
     await invalidateCodexAccessToken(upstreamId, accountId);
     expect(repo.writes).toEqual([]);
   });
+
+  test('retains a sibling token that replaced the failed token', async () => {
+    const winner: CodexAccessTokenEntry = {
+      token: 'at_winner',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:02.000Z',
+      planType: 'free',
+      planObservedAt: '2026-08-10T00:00:02.000Z',
+    };
+    current = makeRecord({ accounts: [{ ...baseAccount, accessToken: winner }] });
+    const retained = await invalidateCodexAccessToken(upstreamId, accountId, 'at_failed');
+    expect(retained).toEqual(winner);
+    expect(storedState().accounts[0].accessToken).toEqual(winner);
+    expect(repo.writes).toEqual([]);
+  });
 });
 
 describe('ensureCodexAccessToken', () => {

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -78,7 +78,7 @@ describe('putCodexAccessToken', () => {
       }],
     });
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'new' };
-    const effective = await putCodexAccessToken(upstreamId, accountId, entry, 'team');
+    const effective = await putCodexAccessToken(upstreamId, accountId, entry, { planType: 'team' });
     expect(effective.planType).toBe('free');
     expect(storedState().accounts[0].accessToken?.planType).toBe('free');
   });
@@ -101,8 +101,9 @@ describe('putCodexAccessToken', () => {
       planType: olderPlan,
     };
     const effective = await putCodexAccessToken(upstreamId, accountId, older);
-    expect(effective).toEqual(newer);
-    expect(storedState().accounts[0].accessToken).toEqual(newer);
+    const expected = { ...newer, planObservedAt: newer.refreshedAt };
+    expect(effective).toEqual(expected);
+    expect(storedState().accounts[0].accessToken).toEqual(expected);
   });
 
   test.each(['free', 'team'])('keeps the newer token while merging an older explicit %s plan', async olderPlan => {
@@ -119,8 +120,38 @@ describe('putCodexAccessToken', () => {
       planType: olderPlan,
     };
     const effective = await putCodexAccessToken(upstreamId, accountId, older);
-    expect(effective).toEqual({ ...newer, planType: olderPlan });
-    expect(storedState().accounts[0].accessToken).toEqual({ ...newer, planType: olderPlan });
+    const expected = { ...newer, planType: olderPlan, planObservedAt: older.refreshedAt };
+    expect(effective).toEqual(expected);
+    expect(storedState().accounts[0].accessToken).toEqual(expected);
+  });
+
+  test('orders token and explicit plan observations independently', async () => {
+    const tokenOnly: CodexAccessTokenEntry = {
+      token: 'at_t3',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:03.000Z',
+    };
+    await putCodexAccessToken(upstreamId, accountId, tokenOnly);
+    await putCodexAccessToken(upstreamId, accountId, {
+      token: 'at_t1',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:01.000Z',
+      planType: 'free',
+      planObservedAt: '2026-08-10T00:00:01.000Z',
+    });
+    const effective = await putCodexAccessToken(upstreamId, accountId, {
+      token: 'at_t2',
+      expiresAt: farFutureMs,
+      refreshedAt: '2026-08-10T00:00:02.000Z',
+      planType: 'plus',
+      planObservedAt: '2026-08-10T00:00:02.000Z',
+    });
+    expect(effective).toEqual({
+      ...tokenOnly,
+      planType: 'plus',
+      planObservedAt: '2026-08-10T00:00:02.000Z',
+    });
+    expect(storedState().accounts[0].accessToken).toEqual(effective);
   });
 
   test('propagates storage failures so the request path surfaces them', async () => {
@@ -284,6 +315,7 @@ describe('mintCodexAccessToken', () => {
     const persistRotation = vi.fn(async () => {});
     const entry = await mintCodexAccessToken('rt_v1', directFetcher, persistRotation);
     expect(entry.planType).toBe('team');
+    expect(entry.planObservedAt).toBe(entry.refreshedAt);
     expect(persistRotation).toHaveBeenCalledWith('rt_v2');
   });
 

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -4,12 +4,13 @@ import { createUpstreamStateRepoStub, type UpstreamStateRepoStub } from './upstr
 import {
   ensureCodexAccessToken,
   invalidateCodexAccessToken,
+  mintCodexAccessToken,
   putCodexAccessToken,
   type CodexAccessTokenEntry,
 } from '../src/access-token.ts';
 import { CodexOAuthSessionTerminatedError } from '../src/auth/oauth.ts';
 import type { CodexUpstreamState } from '../src/state.ts';
-import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
+import { directFetcher, initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 
 const accountId = 'acc_1';
 const upstreamId = 'up_a';
@@ -193,5 +194,29 @@ describe('ensureCodexAccessToken', () => {
     await expect(ensureCodexAccessToken(upstreamId, accountId, mint)).rejects.toBeInstanceOf(CodexOAuthSessionTerminatedError);
     expect(repo.getById).toHaveBeenCalledTimes(1);
     expect(repo.writes).toEqual([]);
+  });
+});
+
+describe('mintCodexAccessToken', () => {
+  test('stores the current plan from the refreshed id_token', async () => {
+    const idToken = [
+      Buffer.from('{}').toString('base64url'),
+      Buffer.from(JSON.stringify({
+        email: 'a@b.com',
+        'https://api.openai.com/auth': {
+          chatgpt_account_id: accountId,
+          chatgpt_user_id: 'usr',
+          chatgpt_plan_type: 'team',
+        },
+      })).toString('base64url'),
+      Buffer.from('signature').toString('base64url'),
+    ].join('.');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      access_token: 'at', refresh_token: 'rt_v2', id_token: idToken, expires_in: 600,
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const persistRotation = vi.fn(async () => {});
+    const entry = await mintCodexAccessToken('rt_v1', directFetcher, persistRotation);
+    expect(entry.planType).toBe('team');
+    expect(persistRotation).toHaveBeenCalledWith('rt_v2');
   });
 });

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -70,6 +70,17 @@ describe('putCodexAccessToken', () => {
     expect(storedState()).toEqual({ accounts: [{ ...baseAccount, accessToken: entry }] });
   });
 
+  test('prefers the current CAS plan over an older fallback when the new token omits it', async () => {
+    current = makeRecord({ accounts: [{
+      ...baseAccount,
+      accessToken: { token: 'at_current', expiresAt: farFutureMs, refreshedAt: 'current', planType: 'free' },
+    }] });
+    const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'new' };
+    const effective = await putCodexAccessToken(upstreamId, accountId, entry, 'team');
+    expect(effective.planType).toBe('free');
+    expect(storedState().accounts[0].accessToken?.planType).toBe('free');
+  });
+
   test('propagates storage failures so the request path surfaces them', async () => {
     repo.saveState.mockRejectedValueOnce(new Error('D1 boom'));
     const entry: CodexAccessTokenEntry = { token: 'at_new', expiresAt: farFutureMs, refreshedAt: 'now' };

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -137,6 +137,20 @@ describe('ensureCodexAccessToken', () => {
     expect(mint).toHaveBeenCalledWith('rt_v1');
   });
 
+  test('preserves the latest known plan when a refreshed token omits it', async () => {
+    const expiresSoon = Date.now() + 60 * 1000;
+    current = makeRecord({
+      accounts: [{
+        ...baseAccount,
+        accessToken: { token: 'at_old', expiresAt: expiresSoon, refreshedAt: 'old', planType: 'team' },
+      }],
+    });
+    const minted: CodexAccessTokenEntry = { token: 'at_minted', expiresAt: farFutureMs, refreshedAt: 'now' };
+    const out = await ensureCodexAccessToken(upstreamId, accountId, vi.fn().mockResolvedValue(minted));
+    expect(out.planType).toBe('team');
+    expect(storedState().accounts[0].accessToken?.planType).toBe('team');
+  });
+
   test('throws when the upstream row is missing', async () => {
     current = null;
     const mint = vi.fn();

--- a/packages/provider-codex/__tests__/access-token_test.ts
+++ b/packages/provider-codex/__tests__/access-token_test.ts
@@ -219,4 +219,31 @@ describe('mintCodexAccessToken', () => {
     expect(entry.planType).toBe('team');
     expect(persistRotation).toHaveBeenCalledWith('rt_v2');
   });
+
+  test('accepts refreshed id_tokens without import-only identity or plan claims', async () => {
+    const idToken = [
+      Buffer.from('{}').toString('base64url'),
+      Buffer.from(JSON.stringify({ 'https://api.openai.com/auth': {} })).toString('base64url'),
+      Buffer.from('signature').toString('base64url'),
+    ].join('.');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      access_token: 'at', refresh_token: 'rt_v2', id_token: idToken, expires_in: 600,
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const entry = await mintCodexAccessToken('rt_v1', directFetcher, async () => {});
+    expect(entry.planType).toBeUndefined();
+  });
+
+  test('persists a rotated refresh token before surfacing malformed plan metadata', async () => {
+    const idToken = [
+      Buffer.from('{}').toString('base64url'),
+      Buffer.from(JSON.stringify({ 'https://api.openai.com/auth': { chatgpt_plan_type: 42 } })).toString('base64url'),
+      Buffer.from('signature').toString('base64url'),
+    ].join('.');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      access_token: 'at', refresh_token: 'rt_v2', id_token: idToken, expires_in: 600,
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const persistRotation = vi.fn(async () => {});
+    await expect(mintCodexAccessToken('rt_v1', directFetcher, persistRotation)).rejects.toThrow(/chatgpt_plan_type/);
+    expect(persistRotation).toHaveBeenCalledWith('rt_v2');
+  });
 });

--- a/packages/provider-codex/__tests__/auth/import_test.ts
+++ b/packages/provider-codex/__tests__/auth/import_test.ts
@@ -37,6 +37,7 @@ describe('importCodexFromAuthJson', () => {
     expect(result.state.accounts[0].state).toBe('active');
     expect(result.state.accounts[0].accessToken?.token).toBe('at1');
     expect(result.state.accounts[0].accessToken?.planType).toBe('plus');
+    expect(result.state.accounts[0].accessToken?.planObservedAt).toBe(result.state.accounts[0].accessToken?.refreshedAt);
     expect(result.state.accounts[0].accessToken?.expiresAt).toBeGreaterThan(Date.now());
     expect(result.state.accounts[0].openaiDeviceId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
@@ -65,6 +66,7 @@ describe('importCodexFromCallback', () => {
     expect(result.state.accounts[0].refresh_token).toBe('rt');
     expect(result.state.accounts[0].accessToken?.token).toBe('at');
     expect(result.state.accounts[0].accessToken?.planType).toBe('plus');
+    expect(result.state.accounts[0].accessToken?.planObservedAt).toBe(result.state.accounts[0].accessToken?.refreshedAt);
     expect(result.state.accounts[0].openaiDeviceId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
 

--- a/packages/provider-codex/__tests__/auth/import_test.ts
+++ b/packages/provider-codex/__tests__/auth/import_test.ts
@@ -36,6 +36,7 @@ describe('importCodexFromAuthJson', () => {
     expect(result.state.accounts[0].refresh_token).toBe('rt1');
     expect(result.state.accounts[0].state).toBe('active');
     expect(result.state.accounts[0].accessToken?.token).toBe('at1');
+    expect(result.state.accounts[0].accessToken?.planType).toBe('plus');
     expect(result.state.accounts[0].accessToken?.expiresAt).toBeGreaterThan(Date.now());
     expect(result.state.accounts[0].openaiDeviceId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
@@ -63,6 +64,7 @@ describe('importCodexFromCallback', () => {
     expect(result.config.accounts[0].email).toBe('a@b.com');
     expect(result.state.accounts[0].refresh_token).toBe('rt');
     expect(result.state.accounts[0].accessToken?.token).toBe('at');
+    expect(result.state.accounts[0].accessToken?.planType).toBe('plus');
     expect(result.state.accounts[0].openaiDeviceId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
   });
 

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -863,6 +863,8 @@ describe('callCodexImagesGenerations', () => {
     });
     expect(result.response.status).toBe(200);
     expect(fetchSpy.mock.calls.filter(([url]) => String(url).includes('/images/generations'))).toHaveLength(2);
+    await flushMicrotasks();
+    expect((currentRecord.state as CodexUpstreamState).accounts[0].accessToken?.planType).toBe('plus');
   });
 });
 

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -711,6 +711,20 @@ describe('callCodexResponses — upstream classification', () => {
     expect(effects.persistTerminalState).not.toHaveBeenCalled();
     expect(effects.persistRefreshTokenRotation).not.toHaveBeenCalled();
   });
+
+  test('retains a newly observed plan when the 401 refresh omits it', async () => {
+    seedAccountState({ accessToken: null });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(errorJson(200, { access_token: 'at1', refresh_token: 'rt1', id_token: idToken('free'), expires_in: 600 }))
+      .mockResolvedValueOnce(sseResponse(401))
+      .mockResolvedValueOnce(errorJson(200, { access_token: 'at2', refresh_token: 'rt2', id_token: idTokenWithoutPlan(), expires_in: 600 }))
+      .mockResolvedValueOnce(sseResponse());
+    const result = await callCodexResponses({
+      upstreamId, account: activeAccount, model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(), call: noopUpstreamCallOptions(),
+    });
+    expect(result.ok).toBe(true);
+    expect((currentRecord.state as CodexUpstreamState).accounts[0].accessToken?.planType).toBe('free');
+  });
 });
 
 describe('callCodexResponses — background-write registration', () => {
@@ -844,6 +858,34 @@ describe('callCodexImagesGenerations', () => {
     expect(fetchSpy.mock.calls.filter(([url]) => String(url).includes('/images/generations'))).toHaveLength(1);
   });
 
+  test('does not invalidate a sibling token that won before the 401 was handled', async () => {
+    seedFreshAccessToken({ ...farFutureAccessToken, token: 'at_failed', planType: 'plus' });
+    const winner: CodexAccessTokenEntry = {
+      token: 'at_winner',
+      expiresAt: farFutureAccessToken.expiresAt,
+      refreshedAt: '2026-08-10T00:00:02.000Z',
+      planType: 'free',
+      planObservedAt: '2026-08-10T00:00:02.000Z',
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async () => {
+      seedAccountState({ refresh_token: 'rt_winner', accessToken: winner });
+      return errorJson(401, { error: { code: 'expired_token', message: 'expired' } });
+    });
+    const result = await callCodexImagesGenerations({
+      upstreamId,
+      account: { ...activeAccount, accessToken: { ...farFutureAccessToken, token: 'at_failed', planType: 'plus' } },
+      model: imageModel,
+      body: { prompt: 'an orange circle' },
+      fallbackPlanType: 'plus',
+      headers: new Headers(),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    expect(result.response.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((currentRecord.state as CodexUpstreamState).accounts[0].accessToken).toEqual(winner);
+  });
+
   test('keeps the latest known plan when a retry refresh omits the plan claim', async () => {
     seedFreshAccessToken({ ...farFutureAccessToken, planType: 'plus' });
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
@@ -953,6 +995,26 @@ describe('callCodexResponsesCompact', () => {
     expect(new Headers((fetchSpy.mock.calls[2][1] as RequestInit).headers).get('authorization')).toBe('Bearer at2');
   });
 
+  test('retains a newly observed plan when the compact 401 refresh omits it', async () => {
+    seedAccountState({ accessToken: null });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(errorJson(200, { access_token: 'at1', refresh_token: 'rt1', id_token: idToken('free'), expires_in: 600 }))
+      .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
+      .mockResolvedValueOnce(errorJson(200, { access_token: 'at2', refresh_token: 'rt2', id_token: idTokenWithoutPlan(), expires_in: 600 }))
+      .mockResolvedValueOnce(compactJsonResponse());
+    const result = await callCodexResponsesCompact({
+      upstreamId,
+      account: activeAccount,
+      model,
+      body: { input: [], instructions: 'compact' },
+      headers: new Headers(),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    expect(result.ok).toBe(true);
+    expect((currentRecord.state as CodexUpstreamState).accounts[0].accessToken?.planType).toBe('free');
+  });
+
   test('401 token_invalidated → persistTerminalState session_terminated, return synthetic 503', async () => {
     seedFreshAccessToken();
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorJson(401, { error: { code: 'token_invalidated', message: 'session ended' } }));
@@ -1032,6 +1094,26 @@ describe('callCodexAlphaSearch', () => {
       model: 'gpt-5.4',
       commands: { search_query: [{ q: 'Floway' }] },
     });
+  });
+
+  test('retains a newly observed plan when the search 401 refresh omits it', async () => {
+    seedAccountState({ accessToken: null });
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(errorJson(200, { access_token: 'at1', refresh_token: 'rt1', id_token: idToken('free'), expires_in: 600 }))
+      .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
+      .mockResolvedValueOnce(errorJson(200, { access_token: 'at2', refresh_token: 'rt2', id_token: idTokenWithoutPlan(), expires_in: 600 }))
+      .mockResolvedValueOnce(errorJson(200, { encrypted_output: null, output: 'Search result', results: [] }));
+    const result = await callCodexAlphaSearch({
+      upstreamId,
+      account: activeAccount,
+      model,
+      body: { commands: { search_query: [{ q: 'Floway' }] } },
+      headers: new Headers(),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    expect(result.response.status).toBe(200);
+    expect((currentRecord.state as CodexUpstreamState).accounts[0].accessToken?.planType).toBe('free');
   });
 
   test('normalizes a missing request id and omits absent turn metadata', async () => {

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -731,7 +731,7 @@ describe('callCodexResponses — background-write registration', () => {
     expect(waitUntil).toHaveBeenCalledTimes(1);
   });
 
-  test('401-retry registers the freshly-minted access-token put via opts.call.waitUntil', async () => {
+  test('401-retry persists the fresh access token before returning', async () => {
     seedFreshAccessToken();
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
@@ -743,9 +743,10 @@ describe('callCodexResponses — background-write registration', () => {
       model, body: { input: [], stream: true }, headers: new Headers(), effects: makeEffects(),
       call: { ...noopUpstreamCallOptions(), waitUntil },
     });
-    // Two writes get registered: the freshly-minted access token (401 retry
-    // path) and the quota snapshot from the successful second attempt.
-    expect(waitUntil).toHaveBeenCalledTimes(2);
+    // The access-token write is awaited because its CAS result carries the
+    // effective plan; only the successful retry's quota write is backgrounded.
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect((currentRecord.state as CodexUpstreamState).accounts[0].accessToken?.token).toBe('at2');
   });
 });
 

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { createUpstreamStateRepoStub } from './upstream-state-repo.ts';
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from '../src/constants.ts';
-import { callCodexAlphaSearch, callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from '../src/fetch.ts';
+import { callCodexAlphaSearch, callCodexImagesGenerations, callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from '../src/fetch.ts';
 import type { CodexAccessTokenEntry, CodexAccountCredential, CodexQuotaSnapshotEntryMap, CodexUpstreamState } from '../src/state.ts';
 import type { ResponsesResult } from '@floway-dev/protocols/responses';
 import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
@@ -15,6 +15,7 @@ const makeEffects = (): CodexCallEffects => ({
 
 const activeAccount: CodexAccountCredential = { chatgptAccountId: 'acc', refresh_token: 'rt_v1', state: 'active', state_updated_at: '2026-01-01T00:00:00Z', openaiDeviceId: '11111111-2222-4333-8444-555555555555', accessToken: null, quotaSnapshot: null };
 const model = stubProviderModel({ id: 'gpt-5.4', display_name: 'gpt-5.4', endpoints: { responses: {} } });
+const imageModel = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT-Image-2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
 
 const upstreamId = 'up_a';
 const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -96,6 +97,19 @@ const sseResponse = (status = 200): Response => new Response(
 const errorJson = (status: number, body: unknown, extraHeaders: Record<string, string> = {}): Response =>
   new Response(JSON.stringify(body), { status, headers: new Headers({ 'content-type': 'application/json', ...extraHeaders }) });
 
+const idToken = (planType = 'plus'): string => [
+  Buffer.from('{}').toString('base64url'),
+  Buffer.from(JSON.stringify({
+    email: 'a@b.com',
+    'https://api.openai.com/auth': {
+      chatgpt_account_id: 'acc',
+      chatgpt_user_id: 'usr',
+      chatgpt_plan_type: planType,
+    },
+  })).toString('base64url'),
+  Buffer.from('signature').toString('base64url'),
+].join('.');
+
 describe('callCodexResponses — gates', () => {
   test('refuses non-active state with synthetic 503', async () => {
     const result = await callCodexResponses({
@@ -131,7 +145,7 @@ describe('callCodexResponses — gates', () => {
 describe('callCodexResponses — token freshness', () => {
   test('refreshes before call when no cached access token', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at_new', refresh_token: 'rt_v2', id_token: 'it', expires_in: 600 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at_new', refresh_token: 'rt_v2', id_token: idToken(), expires_in: 600 }), { status: 200 }))
       .mockResolvedValueOnce(sseResponse());
     const effects = makeEffects();
     const result = await callCodexResponses({
@@ -648,7 +662,7 @@ describe('callCodexResponses — upstream classification', () => {
     seedFreshAccessToken();
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at2', refresh_token: 'rt_v2', id_token: 'it', expires_in: 600 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at2', refresh_token: 'rt_v2', id_token: idToken(), expires_in: 600 }), { status: 200 }))
       .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'still expired' } }));
     const effects = makeEffects();
     const result = await callCodexResponses({
@@ -715,7 +729,7 @@ describe('callCodexResponses — background-write registration', () => {
     seedFreshAccessToken();
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at2', refresh_token: 'rt_v2', id_token: 'it', expires_in: 600 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at2', refresh_token: 'rt_v2', id_token: idToken(), expires_in: 600 }), { status: 200 }))
       .mockResolvedValueOnce(sseResponse());
     const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
     await callCodexResponses({
@@ -726,6 +740,80 @@ describe('callCodexResponses — background-write registration', () => {
     // Two writes get registered: the freshly-minted access token (401 retry
     // path) and the quota snapshot from the successful second attempt.
     expect(waitUntil).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('callCodexImagesGenerations', () => {
+  test('does not replace a meaningful quota snapshot with a headerless image response', async () => {
+    const quotaSnapshot: CodexQuotaSnapshotEntryMap = {
+      premium: {
+        fetchedAt: 1,
+        data: { observed_at: '2026-01-01T00:00:00Z', active_limit: 'premium', primary_used_percent: 42 },
+      },
+    };
+    seedAccountState({ accessToken: { ...farFutureAccessToken, planType: 'plus' }, quotaSnapshot });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorJson(200, { created: 1, data: [{ b64_json: 'aW1hZ2U=' }] }));
+    const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
+    const result = await callCodexImagesGenerations({
+      upstreamId,
+      account: (currentRecord.state as CodexUpstreamState).accounts[0],
+      model: imageModel,
+      body: { prompt: 'an orange circle' },
+      fallbackPlanType: 'plus',
+      headers: new Headers(),
+      effects: makeEffects(),
+      call: { ...noopUpstreamCallOptions(), waitUntil },
+    });
+    expect(result.response.status).toBe(200);
+    expect(readQuotaEntry()).toEqual(quotaSnapshot);
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  test('keeps image turn identity and originator stable across a 401 refresh retry', async () => {
+    seedFreshAccessToken({ ...farFutureAccessToken, planType: 'plus' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
+      .mockResolvedValueOnce(errorJson(200, { access_token: 'at2', refresh_token: 'rt_v2', id_token: idToken('plus'), expires_in: 600 }))
+      .mockResolvedValueOnce(errorJson(200, { created: 1, data: [{ b64_json: 'aW1hZ2U=' }] }));
+    const result = await callCodexImagesGenerations({
+      upstreamId,
+      account: (currentRecord.state as CodexUpstreamState).accounts[0],
+      model: imageModel,
+      body: { prompt: 'an orange circle' },
+      fallbackPlanType: 'plus',
+      headers: new Headers({ originator: 'chatgpt_cca' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    expect(result.response.status).toBe(200);
+    const imageCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes('/images/generations'));
+    expect(imageCalls).toHaveLength(2);
+    const firstHeaders = new Headers((imageCalls[0][1] as RequestInit).headers);
+    const secondHeaders = new Headers((imageCalls[1][1] as RequestInit).headers);
+    expect(firstHeaders.get('originator')).toBe('chatgpt_cca');
+    expect(secondHeaders.get('originator')).toBe('chatgpt_cca');
+    expect(firstHeaders.get('x-codex-image-turn-id')).toMatch(UUID_V7_RE);
+    expect(secondHeaders.get('x-codex-image-turn-id')).toBe(firstHeaders.get('x-codex-image-turn-id'));
+  });
+
+  test('uses a refreshed Free plan before dispatching the image request', async () => {
+    seedAccountState({ accessToken: null });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(errorJson(200, {
+      access_token: 'at2', refresh_token: 'rt_v2', id_token: idToken('free'), expires_in: 600,
+    }));
+    const result = await callCodexImagesGenerations({
+      upstreamId,
+      account: (currentRecord.state as CodexUpstreamState).accounts[0],
+      model: imageModel,
+      body: { prompt: 'an orange circle' },
+      fallbackPlanType: 'plus',
+      headers: new Headers(),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    expect(result.response.status).toBe(403);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toContain('/oauth/token');
   });
 });
 
@@ -799,7 +887,7 @@ describe('callCodexResponsesCompact', () => {
     seedFreshAccessToken();
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at2', refresh_token: 'rt_v2', id_token: 'it', expires_in: 600 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'at2', refresh_token: 'rt_v2', id_token: idToken(), expires_in: 600 }), { status: 200 }))
       .mockResolvedValueOnce(compactJsonResponse());
     const effects = makeEffects();
     const result = await callCodexResponsesCompact({

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -815,6 +815,27 @@ describe('callCodexImagesGenerations', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(String(fetchSpy.mock.calls[0][0])).toContain('/oauth/token');
   });
+
+  test('stops a 401 retry when the refreshed plan becomes Free', async () => {
+    seedFreshAccessToken({ ...farFutureAccessToken, planType: 'plus' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
+      .mockResolvedValueOnce(errorJson(200, {
+        access_token: 'at2', refresh_token: 'rt_v2', id_token: idToken('free'), expires_in: 600,
+      }));
+    const result = await callCodexImagesGenerations({
+      upstreamId,
+      account: (currentRecord.state as CodexUpstreamState).accounts[0],
+      model: imageModel,
+      body: { prompt: 'an orange circle' },
+      fallbackPlanType: 'plus',
+      headers: new Headers(),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    expect(result.response.status).toBe(403);
+    expect(fetchSpy.mock.calls.filter(([url]) => String(url).includes('/images/generations'))).toHaveLength(1);
+  });
 });
 
 // `callCodexResponsesCompact` shares OAuth + quota + 401-retry plumbing with

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -110,6 +110,12 @@ const idToken = (planType = 'plus'): string => [
   Buffer.from('signature').toString('base64url'),
 ].join('.');
 
+const idTokenWithoutPlan = (): string => [
+  Buffer.from('{}').toString('base64url'),
+  Buffer.from(JSON.stringify({ 'https://api.openai.com/auth': {} })).toString('base64url'),
+  Buffer.from('signature').toString('base64url'),
+].join('.');
+
 describe('callCodexResponses — gates', () => {
   test('refuses non-active state with synthetic 503', async () => {
     const result = await callCodexResponses({
@@ -835,6 +841,28 @@ describe('callCodexImagesGenerations', () => {
     });
     expect(result.response.status).toBe(403);
     expect(fetchSpy.mock.calls.filter(([url]) => String(url).includes('/images/generations'))).toHaveLength(1);
+  });
+
+  test('keeps the latest known plan when a retry refresh omits the plan claim', async () => {
+    seedFreshAccessToken({ ...farFutureAccessToken, planType: 'plus' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(errorJson(401, { error: { code: 'expired_token', message: 'expired' } }))
+      .mockResolvedValueOnce(errorJson(200, {
+        access_token: 'at2', refresh_token: 'rt_v2', id_token: idTokenWithoutPlan(), expires_in: 600,
+      }))
+      .mockResolvedValueOnce(errorJson(200, { created: 1, data: [{ b64_json: 'aW1hZ2U=' }] }));
+    const result = await callCodexImagesGenerations({
+      upstreamId,
+      account: (currentRecord.state as CodexUpstreamState).accounts[0],
+      model: imageModel,
+      body: { prompt: 'an orange circle' },
+      fallbackPlanType: 'free',
+      headers: new Headers(),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+    expect(result.response.status).toBe(200);
+    expect(fetchSpy.mock.calls.filter(([url]) => String(url).includes('/images/generations'))).toHaveLength(2);
   });
 });
 

--- a/packages/provider-codex/__tests__/models_test.ts
+++ b/packages/provider-codex/__tests__/models_test.ts
@@ -271,6 +271,14 @@ describe('Codex image capability', () => {
       limits: {},
       endpoints: { imagesGenerations: {}, imagesEdits: {} },
       enabledFlags: flags,
+      pricing: {
+        entries: [{ rates: {
+          input_tokens: '0.000005',
+          input_cache_read_tokens: '0.00000125',
+          input_image_tokens: '0.000008',
+          output_image_tokens: '0.00003',
+        } }],
+      },
     });
   });
 });

--- a/packages/provider-codex/__tests__/models_test.ts
+++ b/packages/provider-codex/__tests__/models_test.ts
@@ -265,7 +265,7 @@ describe('Codex image capability', () => {
     const flags: ReadonlySet<FlagId> = new Set();
     expect(codexImageProviderModel(flags)).toEqual({
       id: 'gpt-image-2',
-      display_name: 'GPT Image 2',
+      display_name: 'GPT-Image-2',
       owned_by: 'openai',
       kind: 'image',
       limits: {},

--- a/packages/provider-codex/__tests__/models_test.ts
+++ b/packages/provider-codex/__tests__/models_test.ts
@@ -257,6 +257,7 @@ describe('Codex image capability', () => {
     ['plus', true],
     ['team', true],
     ['unknown', true],
+    [undefined, true],
   ])('plan %j image eligibility is %s', (planType, expected) => {
     expect(codexPlanSupportsImages(planType)).toBe(expected);
   });
@@ -272,12 +273,14 @@ describe('Codex image capability', () => {
       endpoints: { imagesGenerations: {}, imagesEdits: {} },
       enabledFlags: flags,
       pricing: {
-        entries: [{ rates: {
-          input_tokens: '0.000005',
-          input_cache_read_tokens: '0.00000125',
-          input_image_tokens: '0.000008',
-          output_image_tokens: '0.00003',
-        } }],
+        entries: [{
+          rates: {
+            input_tokens: '0.000005',
+            input_cache_read_tokens: '0.00000125',
+            input_image_tokens: '0.000008',
+            output_image_tokens: '0.00003',
+          },
+        }],
       },
     });
   });

--- a/packages/provider-codex/__tests__/models_test.ts
+++ b/packages/provider-codex/__tests__/models_test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { CODEX_CLI_VERSION, CODEX_ORIGINATOR, CODEX_USER_AGENT } from '../src/constants.ts';
-import { codexRawToProviderModel, fetchCodexCatalog } from '../src/models.ts';
+import { codexImageProviderModel, codexPlanSupportsImages, codexRawToProviderModel, fetchCodexCatalog } from '../src/models.ts';
 import { priceRequest } from '@floway-dev/protocols/common';
 import { directFetcher, type FlagId } from '@floway-dev/provider';
 
@@ -247,5 +247,30 @@ describe('codexRawToProviderModel', () => {
       reasoning_efforts: ['low', 'medium'],
       default_reasoning_effort: 'high',
     }, noFlags)).toThrow(/default_reasoning_level not in supported_reasoning_levels/);
+  });
+});
+
+describe('Codex image capability', () => {
+  test.each([
+    ['free', false],
+    [' FREE ', false],
+    ['plus', true],
+    ['team', true],
+    ['unknown', true],
+  ])('plan %j image eligibility is %s', (planType, expected) => {
+    expect(codexPlanSupportsImages(planType)).toBe(expected);
+  });
+
+  test('projects gpt-image-2 as a separate image model', () => {
+    const flags: ReadonlySet<FlagId> = new Set();
+    expect(codexImageProviderModel(flags)).toEqual({
+      id: 'gpt-image-2',
+      display_name: 'GPT Image 2',
+      owned_by: 'openai',
+      kind: 'image',
+      limits: {},
+      endpoints: { imagesGenerations: {}, imagesEdits: {} },
+      enabledFlags: flags,
+    });
   });
 });

--- a/packages/provider-codex/__tests__/provider_test.ts
+++ b/packages/provider-codex/__tests__/provider_test.ts
@@ -80,6 +80,7 @@ describe('createCodexProvider', () => {
       'session_id',
       'thread-id',
       'x-client-request-id',
+      'x-codex-image-turn-id',
       'x-codex-turn-metadata',
       'x-codex-window-id',
     ]);
@@ -98,8 +99,9 @@ describe('createCodexProvider', () => {
     const models = await instance.instance.getProvidedModels(directFetcher);
     // Provider surfaces both visible and hidden upstream models — operators
     // can dispatch to `codex-auto-review` even though ChatGPT's UI hides it.
-    expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review']);
+    expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review', 'gpt-image-2']);
     expect(models[0].endpoints).toEqual({ responses: {} });
+    expect(models[2]).toMatchObject({ kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toMatch(/\/codex\/models/);
   });
@@ -114,7 +116,7 @@ describe('createCodexProvider', () => {
     });
     const instance = createCodexProvider(baseRecord);
     const models = await instance.instance.getProvidedModels(directFetcher);
-    expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review']);
+    expect(models.map(m => m.id)).toEqual(['gpt-5.4', 'codex-auto-review', 'gpt-image-2']);
     const urls = fetchSpy.mock.calls.map(c => typeof c[0] === 'string' ? c[0] : (c[0] as URL | Request).toString());
     expect(urls.some(u => u.includes('/oauth/token'))).toBe(true);
     expect(urls.some(u => u.includes('/codex/models'))).toBe(true);
@@ -132,6 +134,26 @@ describe('createCodexProvider', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('upstream down', { status: 502 }));
     const instance = createCodexProvider(baseRecord);
     await expect(instance.instance.getProvidedModels(directFetcher)).rejects.toThrow(/Codex \/models fetch failed/);
+  });
+
+  test('getProvidedModels omits image models only for an explicit Free plan', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(modelsResponse());
+    const freeRecord: UpstreamRecord = {
+      ...baseRecord,
+      config: { accounts: [{ email: 'a@b.com', chatgptAccountId: 'acc', chatgptUserId: 'usr', planType: 'free' }] },
+    };
+    const models = await createCodexProvider(freeRecord).instance.getProvidedModels(directFetcher);
+    expect(models.map(model => model.id)).toEqual(['gpt-5.4', 'codex-auto-review']);
+  });
+
+  test('getProvidedModels fails open for an unknown future plan', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(modelsResponse());
+    const futureRecord: UpstreamRecord = {
+      ...baseRecord,
+      config: { accounts: [{ email: 'a@b.com', chatgptAccountId: 'acc', chatgptUserId: 'usr', planType: 'future-plan' }] },
+    };
+    const models = await createCodexProvider(futureRecord).instance.getProvidedModels(directFetcher);
+    expect(models.map(model => model.id)).toContain('gpt-image-2');
   });
 
   test('getProvidedModels propagates OAuth refresh failures', async () => {
@@ -207,10 +229,63 @@ describe('createCodexProvider', () => {
     if (!result.ok) expect(result.response.status).toBe(503);
   });
 
+  test('callImagesGenerations posts gpt-image-2 through the ChatGPT Codex endpoint', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      created: 1,
+      data: [{ b64_json: 'aW1hZ2U=' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const instance = createCodexProvider(baseRecord);
+    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT Image 2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const options = noopUpstreamCallOptions();
+    options.headers.set('x-codex-image-turn-id', 'turn-image');
+    const result = await instance.instance.callImagesGenerations(model, { prompt: 'an orange circle', quality: 'low' }, undefined, options);
+    expect(result.response.status).toBe(200);
+    expect(result.modelKey).toBe('gpt-image-2');
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://chatgpt.com/backend-api/codex/images/generations');
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get('authorization')).toBe('Bearer at');
+    expect(headers.get('chatgpt-account-id')).toBe('acc');
+    expect(headers.get('x-codex-image-turn-id')).toBe('turn-image');
+    expect(await readJsonRequest(init as RequestInit)).toEqual({ prompt: 'an orange circle', quality: 'low', model: 'gpt-image-2' });
+  });
+
+  test('callImagesGenerations rejects an explicit Free plan without touching upstream', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const freeRecord: UpstreamRecord = {
+      ...baseRecord,
+      config: { accounts: [{ email: 'a@b.com', chatgptAccountId: 'acc', chatgptUserId: 'usr', planType: 'free' }] },
+    };
+    const instance = createCodexProvider(freeRecord);
+    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT Image 2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const result = await instance.instance.callImagesGenerations(model, { prompt: 'an orange circle' }, undefined, noopUpstreamCallOptions());
+    expect(result.response.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('callImagesEdits sends uploads as JSON data URLs to the ChatGPT Codex endpoint', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      created: 1,
+      data: [{ b64_json: 'ZWRpdA==' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const instance = createCodexProvider(baseRecord);
+    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT Image 2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const result = await instance.instance.callImagesEdits(model, {
+      images: [{ type: 'upload', file: new File(['image'], 'image.png', { type: 'image/png' }) }],
+      parameters: { prompt: 'make it blue' },
+    }, undefined, noopUpstreamCallOptions());
+    expect(result.response.status).toBe(200);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://chatgpt.com/backend-api/codex/images/edits');
+    expect(await readJsonRequest(init as RequestInit)).toEqual({
+      prompt: 'make it blue',
+      images: [{ image_url: 'data:image/png;base64,aW1hZ2U=' }],
+      model: 'gpt-image-2',
+    });
+  });
+
   test.each([
     'callEmbeddings',
-    'callImagesGenerations',
-    'callImagesEdits',
     'callAudioTranscriptions',
     'callChatCompletions',
     'callMessagesCountTokens',

--- a/packages/provider-codex/__tests__/provider_test.ts
+++ b/packages/provider-codex/__tests__/provider_test.ts
@@ -64,10 +64,23 @@ const modelsResponse = (): Response => new Response(JSON.stringify({
   ],
 }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
 
+const idToken = (planType = 'plus'): string => [
+  Buffer.from('{}').toString('base64url'),
+  Buffer.from(JSON.stringify({
+    email: 'a@b.com',
+    'https://api.openai.com/auth': {
+      chatgpt_account_id: 'acc',
+      chatgpt_user_id: 'usr',
+      chatgpt_plan_type: planType,
+    },
+  })).toString('base64url'),
+  Buffer.from('signature').toString('base64url'),
+].join('.');
+
 const oauthTokenResponse = (overrides: Partial<{ access_token: string; refresh_token: string; expires_in: number }> = {}): Response => new Response(JSON.stringify({
   access_token: overrides.access_token ?? 'at_minted',
   refresh_token: overrides.refresh_token ?? 'rt_v2',
-  id_token: 'id_token_v2',
+  id_token: idToken(),
   expires_in: overrides.expires_in ?? 3600,
 }), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
 
@@ -76,6 +89,7 @@ describe('createCodexProvider', () => {
     const provider = createCodexProvider(baseRecord);
 
     expect(provider.inboundHeaderAllowlist).toEqual([
+      'originator',
       'session-id',
       'session_id',
       'thread-id',
@@ -154,6 +168,21 @@ describe('createCodexProvider', () => {
     };
     const models = await createCodexProvider(futureRecord).instance.getProvidedModels(directFetcher);
     expect(models.map(model => model.id)).toContain('gpt-image-2');
+  });
+
+  test('getProvidedModels uses the refreshed access-token plan over import-time config', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => modelsResponse());
+    current = recordWithAccessToken({ ...freshAccessToken, planType: 'free' });
+    const downgraded = await createCodexProvider(baseRecord).instance.getProvidedModels(directFetcher);
+    expect(downgraded.map(model => model.id)).not.toContain('gpt-image-2');
+
+    const importedFree: UpstreamRecord = {
+      ...baseRecord,
+      config: { accounts: [{ email: 'a@b.com', chatgptAccountId: 'acc', chatgptUserId: 'usr', planType: 'free' }] },
+    };
+    current = recordWithAccessToken({ ...freshAccessToken, planType: 'plus' });
+    const upgraded = await createCodexProvider(importedFree).instance.getProvidedModels(directFetcher);
+    expect(upgraded.map(model => model.id)).toContain('gpt-image-2');
   });
 
   test('getProvidedModels propagates OAuth refresh failures', async () => {
@@ -263,6 +292,23 @@ describe('createCodexProvider', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  test('callImagesEdits returns an operation-neutral error for an explicit Free plan', async () => {
+    const freeRecord: UpstreamRecord = {
+      ...baseRecord,
+      config: { accounts: [{ email: 'a@b.com', chatgptAccountId: 'acc', chatgptUserId: 'usr', planType: 'free' }] },
+    };
+    const instance = createCodexProvider(freeRecord);
+    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT-Image-2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const result = await instance.instance.callImagesEdits(model, {
+      images: [{ type: 'reference', reference: { image_url: 'https://example.test/image.png' } }],
+      parameters: { prompt: 'edit' },
+    }, undefined, noopUpstreamCallOptions());
+    expect(result.response.status).toBe(403);
+    expect(await result.response.json()).toEqual({
+      error: { type: 'image_tools_unavailable', message: 'ChatGPT Free accounts do not provide Codex image tools.' },
+    });
+  });
+
   test('callImagesEdits sends uploads as JSON data URLs to the ChatGPT Codex endpoint', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
       created: 1,
@@ -270,13 +316,16 @@ describe('createCodexProvider', () => {
     }), { status: 200, headers: { 'content-type': 'application/json' } }));
     const instance = createCodexProvider(baseRecord);
     const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT-Image-2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const options = noopUpstreamCallOptions();
+    options.headers.set('originator', 'chatgpt_cca');
     const result = await instance.instance.callImagesEdits(model, {
       images: [{ type: 'upload', file: new File(['image'], 'image.png', { type: 'image/png' }) }],
       parameters: { prompt: 'make it blue' },
-    }, undefined, noopUpstreamCallOptions());
+    }, undefined, options);
     expect(result.response.status).toBe(200);
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe('https://chatgpt.com/backend-api/codex/images/edits');
+    expect(new Headers((init as RequestInit).headers).get('originator')).toBe('chatgpt_cca');
     expect(await readJsonRequest(init as RequestInit)).toEqual({
       prompt: 'make it blue',
       images: [{ image_url: 'data:image/png;base64,aW1hZ2U=' }],

--- a/packages/provider-codex/__tests__/provider_test.ts
+++ b/packages/provider-codex/__tests__/provider_test.ts
@@ -235,7 +235,7 @@ describe('createCodexProvider', () => {
       data: [{ b64_json: 'aW1hZ2U=' }],
     }), { status: 200, headers: { 'content-type': 'application/json' } }));
     const instance = createCodexProvider(baseRecord);
-    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT Image 2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT-Image-2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
     const options = noopUpstreamCallOptions();
     options.headers.set('x-codex-image-turn-id', 'turn-image');
     const result = await instance.instance.callImagesGenerations(model, { prompt: 'an orange circle', quality: 'low' }, undefined, options);
@@ -257,7 +257,7 @@ describe('createCodexProvider', () => {
       config: { accounts: [{ email: 'a@b.com', chatgptAccountId: 'acc', chatgptUserId: 'usr', planType: 'free' }] },
     };
     const instance = createCodexProvider(freeRecord);
-    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT Image 2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT-Image-2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
     const result = await instance.instance.callImagesGenerations(model, { prompt: 'an orange circle' }, undefined, noopUpstreamCallOptions());
     expect(result.response.status).toBe(403);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -269,7 +269,7 @@ describe('createCodexProvider', () => {
       data: [{ b64_json: 'ZWRpdA==' }],
     }), { status: 200, headers: { 'content-type': 'application/json' } }));
     const instance = createCodexProvider(baseRecord);
-    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT Image 2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
+    const model = stubProviderModel({ id: 'gpt-image-2', display_name: 'GPT-Image-2', kind: 'image', endpoints: { imagesGenerations: {}, imagesEdits: {} } });
     const result = await instance.instance.callImagesEdits(model, {
       images: [{ type: 'upload', file: new File(['image'], 'image.png', { type: 'image/png' }) }],
       parameters: { prompt: 'make it blue' },

--- a/packages/provider-codex/__tests__/quota_test.ts
+++ b/packages/provider-codex/__tests__/quota_test.ts
@@ -5,6 +5,7 @@ import {
   CODEX_QUOTA_UNKNOWN_ACTIVE_LIMIT,
   codexQuotaActiveLimitKey,
   getCodexQuota,
+  hasCodexQuotaReading,
   parseCodexQuotaHeaders,
   putCodexQuota,
   type CodexQuotaSnapshot,
@@ -14,6 +15,11 @@ import { initProviderRepo, type UpstreamRecord } from '@floway-dev/provider';
 
 const accountId = 'acc_1';
 const upstreamId = 'up_a';
+
+test('hasCodexQuotaReading ignores an observation timestamp without quota data', () => {
+  expect(hasCodexQuotaReading({ observed_at: '2026-01-01T00:00:00Z' })).toBe(false);
+  expect(hasCodexQuotaReading({ observed_at: '2026-01-01T00:00:00Z', plan_type: 'plus' })).toBe(true);
+});
 
 const makeRecord = (state: CodexUpstreamState): UpstreamRecord => ({
   id: upstreamId,

--- a/packages/provider-codex/__tests__/state_test.ts
+++ b/packages/provider-codex/__tests__/state_test.ts
@@ -93,6 +93,9 @@ describe('assertCodexUpstreamState', () => {
     expect(() => assertCodexUpstreamState({
       accounts: [{ ...goodAccount, accessToken: { token: 'at', expiresAt: 1, refreshedAt: 'x', planType: '' } }],
     })).toThrow(/planType/);
+    expect(() => assertCodexUpstreamState({
+      accounts: [{ ...goodAccount, accessToken: { token: 'at', expiresAt: 1, refreshedAt: 'x', planObservedAt: 'x' } }],
+    })).toThrow(/requires planType/);
   });
 
   test('accepts quotaSnapshot absent / null / populated', () => {

--- a/packages/provider-codex/__tests__/state_test.ts
+++ b/packages/provider-codex/__tests__/state_test.ts
@@ -77,7 +77,7 @@ describe('assertCodexUpstreamState', () => {
     expect(() => assertCodexUpstreamState({ accounts: [{ ...goodAccount }] })).not.toThrow();
     expect(() => assertCodexUpstreamState({ accounts: [{ ...goodAccount, accessToken: null }] })).not.toThrow();
     expect(() => assertCodexUpstreamState({
-      accounts: [{ ...goodAccount, accessToken: { token: 'at', expiresAt: 1_700_000_000_000, refreshedAt: '2026-06-05T00:00:00Z' } }],
+      accounts: [{ ...goodAccount, accessToken: { token: 'at', expiresAt: 1_700_000_000_000, refreshedAt: '2026-06-05T00:00:00Z', planType: 'plus' } }],
     })).not.toThrow();
   });
   test('rejects malformed accessToken', () => {
@@ -90,6 +90,9 @@ describe('assertCodexUpstreamState', () => {
     expect(() => assertCodexUpstreamState({
       accounts: [{ ...goodAccount, accessToken: { token: 'at', expiresAt: 1, refreshedAt: 'x', extra: 1 } }],
     })).toThrow(/extra/);
+    expect(() => assertCodexUpstreamState({
+      accounts: [{ ...goodAccount, accessToken: { token: 'at', expiresAt: 1, refreshedAt: 'x', planType: '' } }],
+    })).toThrow(/planType/);
   });
 
   test('accepts quotaSnapshot absent / null / populated', () => {

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -13,13 +13,52 @@ const REFRESH_SKEW_MS = 5 * 60 * 1000;
 const isAccessTokenFresh = (entry: CodexAccessTokenEntry): boolean =>
   entry.expiresAt > Date.now() + REFRESH_SKEW_MS;
 
-const preserveCodexAccessTokenPlan = (
-  entry: CodexAccessTokenEntry,
-  previousPlanType: string | undefined,
-): CodexAccessTokenEntry =>
-  entry.planType === undefined && previousPlanType !== undefined
-    ? { ...entry, planType: previousPlanType }
-    : entry;
+export interface CodexPlanObservation {
+  planType: string;
+  observedAt?: string;
+}
+
+const planObservation = (entry: CodexAccessTokenEntry | null | undefined): CodexPlanObservation | null =>
+  entry?.planType === undefined
+    ? null
+    : { planType: entry.planType, observedAt: entry.planObservedAt ?? entry.refreshedAt };
+
+const observationTime = (observation: CodexPlanObservation): number => {
+  const parsed = observation.observedAt === undefined ? Number.NaN : Date.parse(observation.observedAt);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+};
+
+const latestPlanObservation = (
+  first: CodexPlanObservation | null,
+  second: CodexPlanObservation | null,
+  fallback: CodexPlanObservation | undefined,
+): CodexPlanObservation | null => {
+  const observations = [first, second].filter((value): value is CodexPlanObservation => value !== null);
+  if (observations.length === 0) return fallback ?? null;
+  return observations.reduce((latest, candidate) =>
+    observationTime(candidate) > observationTime(latest) ? candidate : latest);
+};
+
+const mergeCodexAccessTokenEntry = (
+  incoming: CodexAccessTokenEntry,
+  current: CodexAccessTokenEntry | null | undefined,
+  fallbackPlan: CodexPlanObservation | undefined,
+): CodexAccessTokenEntry => {
+  const incomingTime = Date.parse(incoming.refreshedAt);
+  const currentTime = current === null || current === undefined ? Number.NEGATIVE_INFINITY : Date.parse(current.refreshedAt);
+  const token = Number.isFinite(currentTime) && (!Number.isFinite(incomingTime) || currentTime >= incomingTime)
+    ? current!
+    : incoming;
+  const plan = latestPlanObservation(planObservation(incoming), planObservation(current), fallbackPlan);
+  const { planType: _planType, planObservedAt: _planObservedAt, ...tokenFields } = token;
+  return plan === null
+    ? tokenFields
+    : {
+        ...tokenFields,
+        planType: plan.planType,
+        ...(plan.observedAt === undefined ? {} : { planObservedAt: plan.observedAt }),
+      };
+};
 
 // The whole change is expressed against the state the repo hands us, so a
 // write that loses its race is simply replayed against the winner's document
@@ -30,7 +69,7 @@ const persistAccessToken = async (
   accountId: string,
   entry: CodexAccessTokenEntry | null,
   where: string,
-  fallbackPlanType?: string,
+  fallbackPlan?: CodexPlanObservation,
 ): Promise<CodexAccessTokenEntry | null> => {
   // The mutator is replayed on a lost race, so the diagnostic is recorded and
   // emitted once afterwards rather than logged from inside it.
@@ -48,23 +87,10 @@ const persistAccessToken = async (
       // Invalidating an already-null slot has nothing to write — the case where
       // a 401 retry races a concurrent refresh that already cleared the token.
       if (entry === null && state.accounts[idx].accessToken === null) return current;
-      const currentEntry = state.accounts[idx].accessToken;
-      if (entry !== null && currentEntry !== null && currentEntry !== undefined) {
-        const incomingObservedAt = Date.parse(entry.refreshedAt);
-        const currentObservedAt = Date.parse(currentEntry.refreshedAt);
-        // OAuth refreshes may finish their access-token writes out of order.
-        // Keep the later observation (and return it to the caller) so an older
-        // explicit plan/token pair cannot overwrite a newer one during replay.
-        if (Number.isFinite(incomingObservedAt) && Number.isFinite(currentObservedAt) && currentObservedAt >= incomingObservedAt) {
-          effectiveEntry = preserveCodexAccessTokenPlan(currentEntry, entry.planType);
-          return effectiveEntry === currentEntry
-            ? current
-            : replaceCodexAccount(state, idx, account => ({ ...account, accessToken: effectiveEntry }));
-        }
-      }
       effectiveEntry = entry === null
         ? null
-        : preserveCodexAccessTokenPlan(entry, state.accounts[idx].accessToken?.planType ?? fallbackPlanType);
+        : mergeCodexAccessTokenEntry(entry, state.accounts[idx].accessToken, fallbackPlan);
+      if (JSON.stringify(effectiveEntry) === JSON.stringify(state.accounts[idx].accessToken)) return current;
       return replaceCodexAccount(state, idx, account => ({ ...account, accessToken: effectiveEntry }));
     });
   } catch (err) {
@@ -85,9 +111,9 @@ export const putCodexAccessToken = async (
   upstreamId: string,
   accountId: string,
   entry: CodexAccessTokenEntry,
-  fallbackPlanType?: string,
+  fallbackPlan?: CodexPlanObservation,
 ): Promise<CodexAccessTokenEntry> =>
-  (await persistAccessToken(upstreamId, accountId, entry, 'putCodexAccessToken', fallbackPlanType)) ?? entry;
+  (await persistAccessToken(upstreamId, accountId, entry, 'putCodexAccessToken', fallbackPlan)) ?? entry;
 
 export const invalidateCodexAccessToken = async (
   upstreamId: string,
@@ -177,7 +203,7 @@ const ensureCodexAccessTokenInner = async (
     accountId,
     minted,
     'ensureCodexAccessToken',
-    account.accessToken?.planType,
+    planObservation(account.accessToken) ?? undefined,
   )) ?? minted;
 };
 
@@ -232,10 +258,11 @@ export const mintCodexAccessToken = async (
   const tokens = await refreshCodexAccessToken(refreshToken, fetcher);
   await persistRefreshTokenRotation(tokens.refresh_token);
   const planType = parseCodexIdTokenPlanType(tokens.id_token);
+  const refreshedAt = new Date().toISOString();
   return {
     token: tokens.access_token,
     expiresAt: Date.now() + tokens.expires_in * 1000,
-    refreshedAt: new Date().toISOString(),
-    ...(planType === undefined ? {} : { planType }),
+    refreshedAt,
+    ...(planType === undefined ? {} : { planType, planObservedAt: refreshedAt }),
   };
 };

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -33,8 +33,9 @@ const latestPlanObservation = (
   second: CodexPlanObservation | null,
   fallback: CodexPlanObservation | undefined,
 ): CodexPlanObservation | null => {
-  const observations = [first, second].filter((value): value is CodexPlanObservation => value !== null);
-  if (observations.length === 0) return fallback ?? null;
+  const observations = [first, second, fallback ?? null]
+    .filter((value): value is CodexPlanObservation => value !== null);
+  if (observations.length === 0) return null;
   return observations.reduce((latest, candidate) =>
     observationTime(candidate) > observationTime(latest) ? candidate : latest);
 };

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -119,7 +119,26 @@ export const putCodexAccessToken = async (
 export const invalidateCodexAccessToken = async (
   upstreamId: string,
   accountId: string,
-): Promise<void> => { await persistAccessToken(upstreamId, accountId, null, 'invalidateCodexAccessToken'); };
+  expectedToken?: string,
+): Promise<CodexAccessTokenEntry | null> => {
+  if (expectedToken === undefined) {
+    return await persistAccessToken(upstreamId, accountId, null, 'invalidateCodexAccessToken');
+  }
+  let retained: CodexAccessTokenEntry | null = null;
+  await getProviderRepo().upstreams.saveState(upstreamId, current => {
+    const state = readCodexUpstreamState(current);
+    const idx = findCodexAccountIndex(state, accountId);
+    if (idx < 0) throw new Error(`invalidateCodexAccessToken: Codex account ${accountId} not found in upstream ${upstreamId}`);
+    const entry = state.accounts[idx].accessToken;
+    if (entry !== null && entry.token !== expectedToken) {
+      retained = entry;
+      return current;
+    }
+    if (entry === null) return current;
+    return replaceCodexAccount(state, idx, account => ({ ...account, accessToken: null }));
+  });
+  return retained;
+};
 
 // Reads, mints, and persists. The mint callback is responsible for routing
 // the rotated refresh_token through the upstream's persistence hook;

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -56,8 +56,10 @@ const persistAccessToken = async (
         // Keep the later observation (and return it to the caller) so an older
         // explicit plan/token pair cannot overwrite a newer one during replay.
         if (Number.isFinite(incomingObservedAt) && Number.isFinite(currentObservedAt) && currentObservedAt >= incomingObservedAt) {
-          effectiveEntry = currentEntry;
-          return current;
+          effectiveEntry = preserveCodexAccessTokenPlan(currentEntry, entry.planType);
+          return effectiveEntry === currentEntry
+            ? current
+            : replaceCodexAccount(state, idx, account => ({ ...account, accessToken: effectiveEntry }));
         }
       }
       effectiveEntry = entry === null

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -13,6 +13,14 @@ const REFRESH_SKEW_MS = 5 * 60 * 1000;
 const isAccessTokenFresh = (entry: CodexAccessTokenEntry): boolean =>
   entry.expiresAt > Date.now() + REFRESH_SKEW_MS;
 
+export const preserveCodexAccessTokenPlan = (
+  entry: CodexAccessTokenEntry,
+  previousPlanType: string | undefined,
+): CodexAccessTokenEntry =>
+  entry.planType === undefined && previousPlanType !== undefined
+    ? { ...entry, planType: previousPlanType }
+    : entry;
+
 // The whole change is expressed against the state the repo hands us, so a
 // write that loses its race is simply replayed against the winner's document
 // and both changes survive. Storage failures propagate so the request path
@@ -142,8 +150,9 @@ const ensureCodexAccessTokenInner = async (
     }
     throw err;
   }
-  await persistAccessToken(upstreamId, accountId, minted, 'ensureCodexAccessToken');
-  return minted;
+  const effective = preserveCodexAccessTokenPlan(minted, account.accessToken?.planType);
+  await persistAccessToken(upstreamId, accountId, effective, 'ensureCodexAccessToken');
+  return effective;
 };
 
 // `invalid_grant` ambiguity: dead refresh token, or a sibling worker raced

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -1,4 +1,4 @@
-import { parseCodexIdTokenClaims } from './auth/jwt.ts';
+import { parseCodexIdTokenPlanType } from './auth/jwt.ts';
 import { CodexOAuthSessionTerminatedError, refreshCodexAccessToken } from './auth/oauth.ts';
 import { findCodexAccountIndex, readCodexUpstreamState, replaceCodexAccount, type CodexAccessTokenEntry } from './state.ts';
 import { getProviderRepo, UpstreamGoneError, type Fetcher } from '@floway-dev/provider';
@@ -195,12 +195,12 @@ export const mintCodexAccessToken = async (
   persistRefreshTokenRotation: (newRefreshToken: string) => Promise<void>,
 ): Promise<CodexAccessTokenEntry> => {
   const tokens = await refreshCodexAccessToken(refreshToken, fetcher);
-  const identity = parseCodexIdTokenClaims(tokens.id_token);
   await persistRefreshTokenRotation(tokens.refresh_token);
+  const planType = parseCodexIdTokenPlanType(tokens.id_token);
   return {
     token: tokens.access_token,
     expiresAt: Date.now() + tokens.expires_in * 1000,
     refreshedAt: new Date().toISOString(),
-    planType: identity.planType,
+    ...(planType === undefined ? {} : { planType }),
   };
 };

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -30,10 +30,12 @@ const persistAccessToken = async (
   accountId: string,
   entry: CodexAccessTokenEntry | null,
   where: string,
-): Promise<void> => {
+  fallbackPlanType?: string,
+): Promise<CodexAccessTokenEntry | null> => {
   // The mutator is replayed on a lost race, so the diagnostic is recorded and
   // emitted once afterwards rather than logged from inside it.
   let accountMissing = false;
+  let effectiveEntry = entry;
   try {
     await getProviderRepo().upstreams.saveState(upstreamId, current => {
       const state = readCodexUpstreamState(current);
@@ -46,7 +48,10 @@ const persistAccessToken = async (
       // Invalidating an already-null slot has nothing to write — the case where
       // a 401 retry races a concurrent refresh that already cleared the token.
       if (entry === null && state.accounts[idx].accessToken === null) return current;
-      return replaceCodexAccount(state, idx, account => ({ ...account, accessToken: entry }));
+      effectiveEntry = entry === null
+        ? null
+        : preserveCodexAccessTokenPlan(entry, state.accounts[idx].accessToken?.planType ?? fallbackPlanType);
+      return replaceCodexAccount(state, idx, account => ({ ...account, accessToken: effectiveEntry }));
     });
   } catch (err) {
     // A minted access token is bookkeeping the next request re-derives, so an
@@ -54,18 +59,21 @@ const persistAccessToken = async (
     // request over. Every other storage failure still propagates.
     if (!(err instanceof UpstreamGoneError)) throw err;
     console.warn(`${where}: Codex upstream ${upstreamId} disappeared mid-request`);
-    return;
+    return effectiveEntry;
   }
   if (accountMissing) {
     console.warn(`${where}: Codex account ${accountId} not found in upstream ${upstreamId}`);
   }
+  return effectiveEntry;
 };
 
 export const putCodexAccessToken = async (
   upstreamId: string,
   accountId: string,
   entry: CodexAccessTokenEntry,
-): Promise<void> => { await persistAccessToken(upstreamId, accountId, entry, 'putCodexAccessToken'); };
+  fallbackPlanType?: string,
+): Promise<CodexAccessTokenEntry> =>
+  (await persistAccessToken(upstreamId, accountId, entry, 'putCodexAccessToken', fallbackPlanType)) ?? entry;
 
 export const invalidateCodexAccessToken = async (
   upstreamId: string,
@@ -150,9 +158,13 @@ const ensureCodexAccessTokenInner = async (
     }
     throw err;
   }
-  const effective = preserveCodexAccessTokenPlan(minted, account.accessToken?.planType);
-  await persistAccessToken(upstreamId, accountId, effective, 'ensureCodexAccessToken');
-  return effective;
+  return (await persistAccessToken(
+    upstreamId,
+    accountId,
+    minted,
+    'ensureCodexAccessToken',
+    account.accessToken?.planType,
+  )) ?? minted;
 };
 
 // `invalid_grant` ambiguity: dead refresh token, or a sibling worker raced

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -1,3 +1,4 @@
+import { parseCodexIdTokenClaims } from './auth/jwt.ts';
 import { CodexOAuthSessionTerminatedError, refreshCodexAccessToken } from './auth/oauth.ts';
 import { findCodexAccountIndex, readCodexUpstreamState, replaceCodexAccount, type CodexAccessTokenEntry } from './state.ts';
 import { getProviderRepo, UpstreamGoneError, type Fetcher } from '@floway-dev/provider';
@@ -194,10 +195,12 @@ export const mintCodexAccessToken = async (
   persistRefreshTokenRotation: (newRefreshToken: string) => Promise<void>,
 ): Promise<CodexAccessTokenEntry> => {
   const tokens = await refreshCodexAccessToken(refreshToken, fetcher);
+  const identity = parseCodexIdTokenClaims(tokens.id_token);
   await persistRefreshTokenRotation(tokens.refresh_token);
   return {
     token: tokens.access_token,
     expiresAt: Date.now() + tokens.expires_in * 1000,
     refreshedAt: new Date().toISOString(),
+    planType: identity.planType,
   };
 };

--- a/packages/provider-codex/src/access-token.ts
+++ b/packages/provider-codex/src/access-token.ts
@@ -13,7 +13,7 @@ const REFRESH_SKEW_MS = 5 * 60 * 1000;
 const isAccessTokenFresh = (entry: CodexAccessTokenEntry): boolean =>
   entry.expiresAt > Date.now() + REFRESH_SKEW_MS;
 
-export const preserveCodexAccessTokenPlan = (
+const preserveCodexAccessTokenPlan = (
   entry: CodexAccessTokenEntry,
   previousPlanType: string | undefined,
 ): CodexAccessTokenEntry =>
@@ -48,6 +48,18 @@ const persistAccessToken = async (
       // Invalidating an already-null slot has nothing to write — the case where
       // a 401 retry races a concurrent refresh that already cleared the token.
       if (entry === null && state.accounts[idx].accessToken === null) return current;
+      const currentEntry = state.accounts[idx].accessToken;
+      if (entry !== null && currentEntry !== null && currentEntry !== undefined) {
+        const incomingObservedAt = Date.parse(entry.refreshedAt);
+        const currentObservedAt = Date.parse(currentEntry.refreshedAt);
+        // OAuth refreshes may finish their access-token writes out of order.
+        // Keep the later observation (and return it to the caller) so an older
+        // explicit plan/token pair cannot overwrite a newer one during replay.
+        if (Number.isFinite(incomingObservedAt) && Number.isFinite(currentObservedAt) && currentObservedAt >= incomingObservedAt) {
+          effectiveEntry = currentEntry;
+          return current;
+        }
+      }
       effectiveEntry = entry === null
         ? null
         : preserveCodexAccessTokenPlan(entry, state.accounts[idx].accessToken?.planType ?? fallbackPlanType);

--- a/packages/provider-codex/src/auth/import.ts
+++ b/packages/provider-codex/src/auth/import.ts
@@ -41,6 +41,7 @@ const buildCodexImportResult = (params: {
         token: params.accessToken,
         expiresAt: params.expiresAt,
         refreshedAt: params.now,
+        planType: params.identity.planType,
       },
       quotaSnapshot: null,
     }],

--- a/packages/provider-codex/src/auth/import.ts
+++ b/packages/provider-codex/src/auth/import.ts
@@ -42,6 +42,7 @@ const buildCodexImportResult = (params: {
         expiresAt: params.expiresAt,
         refreshedAt: params.now,
         planType: params.identity.planType,
+        planObservedAt: params.now,
       },
       quotaSnapshot: null,
     }],

--- a/packages/provider-codex/src/auth/jwt.ts
+++ b/packages/provider-codex/src/auth/jwt.ts
@@ -35,8 +35,9 @@ export const parseCodexIdTokenClaims = (idToken: string): CodexIdTokenIdentity =
 
 // Refresh responses need only update the capability-relevant plan claim. The
 // account identity was validated at import, and OpenAI may omit unrelated
-// profile claims from a later id_token. Missing plan remains the intentional
-// fail-open `unknown` state; malformed present claims still surface.
+// profile claims from a later id_token. Missing plan returns `undefined` so
+// callers can preserve the latest observation or use the import-time identity;
+// malformed present claims still surface.
 export const parseCodexIdTokenPlanType = (idToken: string): string | undefined => {
   const payload = parseCodexIdTokenPayload(idToken);
   const auth = payload['https://api.openai.com/auth'];

--- a/packages/provider-codex/src/auth/jwt.ts
+++ b/packages/provider-codex/src/auth/jwt.ts
@@ -12,17 +12,7 @@ export interface CodexIdTokenIdentity {
 }
 
 export const parseCodexIdTokenClaims = (idToken: string): CodexIdTokenIdentity => {
-  const segments = idToken.split('.');
-  if (segments.length !== 3) throw new Error(`id_token must have 3 segments, got ${segments.length}`);
-
-  let payload: unknown;
-  try {
-    payload = JSON.parse(decodeBase64UrlToUtf8(segments[1]));
-  } catch (cause) {
-    throw new Error('id_token payload is not base64url-encoded JSON', { cause: cause as Error });
-  }
-
-  if (!isObject(payload)) throw new Error('id_token payload is not an object');
+  const payload = parseCodexIdTokenPayload(idToken);
 
   const auth = payload['https://api.openai.com/auth'];
   if (!isObject(auth)) throw new Error('id_token missing https://api.openai.com/auth claim');
@@ -41,6 +31,36 @@ export const parseCodexIdTokenClaims = (idToken: string): CodexIdTokenIdentity =
     chatgptUserId: pickString(auth, 'chatgpt_user_id'),
     planType: pickString(auth, 'chatgpt_plan_type'),
   };
+};
+
+// Refresh responses need only update the capability-relevant plan claim. The
+// account identity was validated at import, and OpenAI may omit unrelated
+// profile claims from a later id_token. Missing plan remains the intentional
+// fail-open `unknown` state; malformed present claims still surface.
+export const parseCodexIdTokenPlanType = (idToken: string): string | undefined => {
+  const payload = parseCodexIdTokenPayload(idToken);
+  const auth = payload['https://api.openai.com/auth'];
+  if (auth === undefined) return undefined;
+  if (!isObject(auth)) throw new Error('id_token https://api.openai.com/auth claim is not an object');
+  const planType = auth.chatgpt_plan_type;
+  if (planType === undefined) return undefined;
+  if (typeof planType !== 'string' || planType === '') throw new Error('id_token has malformed chatgpt_plan_type claim');
+  return planType;
+};
+
+const parseCodexIdTokenPayload = (idToken: string): Record<string, unknown> => {
+  const segments = idToken.split('.');
+  if (segments.length !== 3) throw new Error(`id_token must have 3 segments, got ${segments.length}`);
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(decodeBase64UrlToUtf8(segments[1]));
+  } catch (cause) {
+    throw new Error('id_token payload is not base64url-encoded JSON', { cause: cause as Error });
+  }
+
+  if (!isObject(payload)) throw new Error('id_token payload is not an object');
+  return payload;
 };
 
 const decodeBase64UrlToUtf8 = (value: string): string => {

--- a/packages/provider-codex/src/constants.ts
+++ b/packages/provider-codex/src/constants.ts
@@ -47,6 +47,15 @@ export const CODEX_ALPHA_SEARCH_PATH = '/codex/alpha/search';
 export const CODEX_RESPONSES_COMPACT_PATH = '/codex/responses/compact';
 export const CODEX_MODELS_PATH = '/codex/models';
 
+// Codex's image extension does not discover this model through /codex/models.
+// It owns the capability and sends the fixed model id to these provider-
+// relative endpoints instead.
+// https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/ext/image-generation/src/tool.rs#L51-L59
+// https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/codex-api/src/endpoint/images.rs#L33-L70
+export const CODEX_IMAGE_MODEL_ID = 'gpt-image-2';
+export const CODEX_IMAGES_GENERATIONS_PATH = '/codex/images/generations';
+export const CODEX_IMAGES_EDITS_PATH = '/codex/images/edits';
+
 // codex_cli_rs version we impersonate on the data plane. Bumped against the
 // latest stable release at https://github.com/openai/codex/releases — newer entries in
 // /codex/models gate themselves behind a `minimal_client_version` (e.g.

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -579,7 +579,7 @@ const performImageCall = async (
   path: string,
   body: Record<string, unknown>,
   turnId: string,
-  effectivePlanType: string | undefined,
+  effectivePlanType: string,
   alreadyRetried: boolean,
 ): Promise<ProviderCallResult> => {
   const response = await dispatchCodexImageCall(opts, accessToken, path, body, turnId);

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -1,4 +1,4 @@
-import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, preserveCodexAccessTokenPlan, putCodexAccessToken } from './access-token.ts';
+import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, putCodexAccessToken } from './access-token.ts';
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import {
   CODEX_BACKEND_BASE,
@@ -444,24 +444,29 @@ const dispatchCodexImageCall = async (
   return await classifyCodexHttpResponse(opts, response, 'when-present');
 };
 
-// Force-mint a fresh access token after a 401, persisting it best-effort.
+// Force-mint a fresh access token after a 401 and persist it before retrying.
 // `ensureCodexAccessToken`'s read-then-maybe-mint is bypassed because a
 // re-read can still observe the token we just invalidated: a sibling that
 // minted before our 401 lands its `putCodexAccessToken` after our
 // invalidation, restoring the broken token, and Codex tokens carry multi-day
 // expiresAt so the freshness gate hands it straight back — sending us into an
 // immediate second 401 with `alreadyRetried` already flipped. Minting
-// unconditionally sidesteps that window, and persisting best-effort is enough
-// because the next request re-mints if its read still sees the dead token.
-const refreshAccessTokenForRetry = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
+// unconditionally sidesteps that window. The write is awaited because its CAS
+// result also resolves the latest plan metadata used to authorize the retry.
+const refreshAccessTokenForRetry = async (
+  opts: CodexBackendCallBase,
+  fallbackPlanType?: string,
+): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
   await invalidateCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId);
   try {
-    const minted = preserveCodexAccessTokenPlan(
-      await mintAccessToken(opts, opts.account.refresh_token),
-      opts.account.accessToken?.planType,
+    const minted = await mintAccessToken(opts, opts.account.refresh_token);
+    const effective = await putCodexAccessToken(
+      opts.upstreamId,
+      opts.account.chatgptAccountId,
+      minted,
+      fallbackPlanType ?? opts.account.accessToken?.planType,
     );
-    registerBackgroundWrite(opts, putCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId, minted));
-    return { ok: true, accessToken: minted };
+    return { ok: true, accessToken: effective };
   } catch (err) {
     if (err instanceof CodexOAuthSessionTerminatedError) {
       await opts.effects.persistTerminalState('refresh_failed', err.upstreamMessage);
@@ -579,7 +584,7 @@ const performImageCall = async (
 ): Promise<ProviderCallResult> => {
   const response = await dispatchCodexImageCall(opts, accessToken, path, body, turnId);
   if (response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts);
+    const fresh = await refreshAccessTokenForRetry(opts, effectivePlanType);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
     const refreshedPlanType = fresh.accessToken.planType ?? effectivePlanType;
     if (!codexPlanSupportsImages(refreshedPlanType)) return imageUnavailableResult(opts.model.id);

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -1,4 +1,4 @@
-import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, putCodexAccessToken } from './access-token.ts';
+import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, putCodexAccessToken, type CodexPlanObservation } from './access-token.ts';
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import {
   CODEX_BACKEND_BASE,
@@ -97,21 +97,26 @@ export const callCodexAlphaSearch = async (opts: CallCodexAlphaSearchOptions): P
 export const callCodexImagesGenerations = async (opts: CallCodexImagesGenerationsOptions): Promise<ProviderCallResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
-  const effectivePlanType = ready.accessToken.planType ?? opts.fallbackPlanType;
-  if (!codexPlanSupportsImages(effectivePlanType)) return imageUnavailableResult(opts.model.id);
+  const effectivePlan = accessTokenPlan(ready.accessToken) ?? { planType: opts.fallbackPlanType };
+  if (!codexPlanSupportsImages(effectivePlan.planType)) return imageUnavailableResult(opts.model.id);
   const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
-  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, turnId, effectivePlanType, false);
+  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, turnId, effectivePlan, false);
 };
 
 export const callCodexImagesEdits = async (opts: CallCodexImagesEditsOptions): Promise<ProviderCallResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
-  const effectivePlanType = ready.accessToken.planType ?? opts.fallbackPlanType;
-  if (!codexPlanSupportsImages(effectivePlanType)) return imageUnavailableResult(opts.model.id);
+  const effectivePlan = accessTokenPlan(ready.accessToken) ?? { planType: opts.fallbackPlanType };
+  if (!codexPlanSupportsImages(effectivePlan.planType)) return imageUnavailableResult(opts.model.id);
   const body = await serializeOpenAIImagesEditsJsonPayload(opts.request, opts.model.id);
   const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
-  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_EDITS_PATH, body, turnId, effectivePlanType, false);
+  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_EDITS_PATH, body, turnId, effectivePlan, false);
 };
+
+const accessTokenPlan = (entry: CodexAccessTokenEntry): CodexPlanObservation | null =>
+  entry.planType === undefined
+    ? null
+    : { planType: entry.planType, observedAt: entry.planObservedAt ?? entry.refreshedAt };
 
 // Pre-fetch gates + initial access-token mint.
 const prepareCodexCall = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
@@ -455,7 +460,7 @@ const dispatchCodexImageCall = async (
 // result also resolves the latest plan metadata used to authorize the retry.
 const refreshAccessTokenForRetry = async (
   opts: CodexBackendCallBase,
-  fallbackPlanType?: string,
+  fallbackPlan?: CodexPlanObservation,
 ): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
   await invalidateCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId);
   try {
@@ -464,7 +469,9 @@ const refreshAccessTokenForRetry = async (
       opts.upstreamId,
       opts.account.chatgptAccountId,
       minted,
-      fallbackPlanType ?? opts.account.accessToken?.planType,
+      fallbackPlan ?? (opts.account.accessToken === null || opts.account.accessToken === undefined
+        ? undefined
+        : accessTokenPlan(opts.account.accessToken) ?? undefined),
     );
     return { ok: true, accessToken: effective };
   } catch (err) {
@@ -579,16 +586,16 @@ const performImageCall = async (
   path: string,
   body: Record<string, unknown>,
   turnId: string,
-  effectivePlanType: string,
+  effectivePlan: CodexPlanObservation,
   alreadyRetried: boolean,
 ): Promise<ProviderCallResult> => {
   const response = await dispatchCodexImageCall(opts, accessToken, path, body, turnId);
   if (response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts, effectivePlanType);
+    const fresh = await refreshAccessTokenForRetry(opts, effectivePlan);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
-    const refreshedPlanType = fresh.accessToken.planType ?? effectivePlanType;
-    if (!codexPlanSupportsImages(refreshedPlanType)) return imageUnavailableResult(opts.model.id);
-    return await performImageCall(opts, fresh.accessToken.token, path, body, turnId, refreshedPlanType, true);
+    const refreshedPlan = accessTokenPlan(fresh.accessToken) ?? effectivePlan;
+    if (!codexPlanSupportsImages(refreshedPlan.planType)) return imageUnavailableResult(opts.model.id);
+    return await performImageCall(opts, fresh.accessToken.token, path, body, turnId, refreshedPlan, true);
   }
   return { modelKey: opts.model.id, response };
 };

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -1,4 +1,4 @@
-import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, putCodexAccessToken } from './access-token.ts';
+import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, preserveCodexAccessTokenPlan, putCodexAccessToken } from './access-token.ts';
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import {
   CODEX_BACKEND_BASE,
@@ -456,7 +456,10 @@ const dispatchCodexImageCall = async (
 const refreshAccessTokenForRetry = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
   await invalidateCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId);
   try {
-    const minted = await mintAccessToken(opts, opts.account.refresh_token);
+    const minted = preserveCodexAccessTokenPlan(
+      await mintAccessToken(opts, opts.account.refresh_token),
+      opts.account.accessToken?.planType,
+    );
     registerBackgroundWrite(opts, putCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId, minted));
     return { ok: true, accessToken: minted };
   } catch (err) {

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -13,6 +13,7 @@ import {
 import { sha256JsonUuid, uuidV7 } from './ids.ts';
 import { codexPlanSupportsImages } from './models.ts';
 import {
+  hasCodexQuotaReading,
   parseCodexQuotaHeaders,
   putCodexQuota,
 } from './quota.ts';
@@ -380,23 +381,15 @@ const dispatchCodexHttpCall = async (
 const classifyCodexHttpResponse = async (
   opts: CodexBackendCallBase,
   response: Response,
-  persistEmptyQuota = true,
+  quotaPolicy: 'always' | 'when-present' = 'always',
 ): Promise<Response> => {
   if (response.ok) {
-    const responseNow = new Date();
-    const snapshot = parseCodexQuotaHeaders(response.headers, { now: responseNow, isRateLimited: false });
-    if (persistEmptyQuota || Object.keys(snapshot).length > 1) {
-      registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
-    }
+    persistCodexQuotaObservation(opts, response, false, quotaPolicy);
     return response;
   }
 
   if (response.status === 429) {
-    const responseNow = new Date();
-    const snapshot = parseCodexQuotaHeaders(response.headers, { now: responseNow, isRateLimited: true });
-    if (persistEmptyQuota || Object.keys(snapshot).length > 1) {
-      registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
-    }
+    persistCodexQuotaObservation(opts, response, true, quotaPolicy);
     return response;
   }
 
@@ -411,6 +404,17 @@ const classifyCodexHttpResponse = async (
   }
 
   return response;
+};
+
+const persistCodexQuotaObservation = (
+  opts: CodexBackendCallBase,
+  response: Response,
+  isRateLimited: boolean,
+  policy: 'always' | 'when-present',
+): void => {
+  const snapshot = parseCodexQuotaHeaders(response.headers, { now: new Date(), isRateLimited });
+  if (policy === 'when-present' && !hasCodexQuotaReading(snapshot)) return;
+  registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
 };
 
 const dispatchCodexImageCall = async (
@@ -435,7 +439,7 @@ const dispatchCodexImageCall = async (
     body: jsonRequestBody(body),
     signal: opts.signal,
   }));
-  return await classifyCodexHttpResponse(opts, response, false);
+  return await classifyCodexHttpResponse(opts, response, 'when-present');
 };
 
 // Force-mint a fresh access token after a 401, persisting it best-effort.
@@ -447,12 +451,12 @@ const dispatchCodexImageCall = async (
 // immediate second 401 with `alreadyRetried` already flipped. Minting
 // unconditionally sidesteps that window, and persisting best-effort is enough
 // because the next request re-mints if its read still sees the dead token.
-const refreshAccessTokenForRetry = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: string } | { ok: false; response: Response }> => {
+const refreshAccessTokenForRetry = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
   await invalidateCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId);
   try {
     const minted = await mintAccessToken(opts, opts.account.refresh_token);
     registerBackgroundWrite(opts, putCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId, minted));
-    return { ok: true, accessToken: minted.token };
+    return { ok: true, accessToken: minted };
   } catch (err) {
     if (err instanceof CodexOAuthSessionTerminatedError) {
       await opts.effects.persistTerminalState('refresh_failed', err.upstreamMessage);
@@ -487,7 +491,7 @@ const performStreamingResponsesCall = async (
   if (!result.ok && result.response.status === 401 && !alreadyRetried) {
     const fresh = await refreshAccessTokenForRetry(opts);
     if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
-    return await performStreamingResponsesCall(opts, fresh.accessToken, true);
+    return await performStreamingResponsesCall(opts, fresh.accessToken.token, true);
   }
 
   return result;
@@ -516,7 +520,7 @@ const performUnaryCompactCall = async (
   if (response.status === 401 && !alreadyRetried) {
     const fresh = await refreshAccessTokenForRetry(opts);
     if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
-    return await performUnaryCompactCall(opts, fresh.accessToken, true);
+    return await performUnaryCompactCall(opts, fresh.accessToken.token, true);
   }
 
   if (!response.ok) return { ok: false, modelKey: opts.model.id, response };
@@ -554,13 +558,13 @@ const performAlphaSearchCall = async (
   if (response.status === 401 && !alreadyRetried) {
     const fresh = await refreshAccessTokenForRetry(opts);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
-    return await performAlphaSearchCall(opts, fresh.accessToken, true);
+    return await performAlphaSearchCall(opts, fresh.accessToken.token, true);
   }
   return { modelKey: opts.model.id, response };
 };
 
 const performImageCall = async (
-  opts: CodexBackendCallBase,
+  opts: CodexBackendCallBase & { fallbackPlanType: string },
   accessToken: string,
   path: string,
   body: Record<string, unknown>,
@@ -571,7 +575,8 @@ const performImageCall = async (
   if (response.status === 401 && !alreadyRetried) {
     const fresh = await refreshAccessTokenForRetry(opts);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
-    return await performImageCall(opts, fresh.accessToken, path, body, turnId, true);
+    if (!codexPlanSupportsImages(fresh.accessToken.planType ?? opts.fallbackPlanType)) return imageUnavailableResult(opts.model.id);
+    return await performImageCall(opts, fresh.accessToken.token, path, body, turnId, true);
   }
   return { modelKey: opts.model.id, response };
 };

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -1,4 +1,4 @@
-import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, putCodexAccessToken, type CodexPlanObservation } from './access-token.ts';
+import { ensureCodexAccessToken, invalidateCodexAccessToken, mintCodexAccessToken, type CodexPlanObservation } from './access-token.ts';
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import {
   CODEX_BACKEND_BASE,
@@ -77,13 +77,13 @@ type CodexResponsesBody = CallCodexResponsesOptions['body'] | CallCodexResponses
 export const callCodexResponses = async (opts: CallCodexResponsesOptions): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { ok: false, modelKey: opts.model.id, response: ready.response };
-  return await performStreamingResponsesCall(opts, ready.accessToken.token, false);
+  return await performStreamingResponsesCall(opts, ready.accessToken, false);
 };
 
 export const callCodexResponsesCompact = async (opts: CallCodexResponsesCompactOptions): Promise<ProviderCompactionResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { ok: false, modelKey: opts.model.id, response: ready.response };
-  return await performUnaryCompactCall(opts, ready.accessToken.token, false);
+  return await performUnaryCompactCall(opts, ready.accessToken, false);
 };
 
 export const callCodexAlphaSearch = async (opts: CallCodexAlphaSearchOptions): Promise<ProviderCallResult> => {
@@ -91,7 +91,7 @@ export const callCodexAlphaSearch = async (opts: CallCodexAlphaSearchOptions): P
   const normalized = { ...opts, body: { ...opts.body, id: requestId } };
   const ready = await prepareCodexCall(normalized);
   if (!ready.ok) return { modelKey: normalized.model.id, response: ready.response };
-  return await performAlphaSearchCall(normalized, ready.accessToken.token, false);
+  return await performAlphaSearchCall(normalized, ready.accessToken, false);
 };
 
 export const callCodexImagesGenerations = async (opts: CallCodexImagesGenerationsOptions): Promise<ProviderCallResult> => {
@@ -100,7 +100,7 @@ export const callCodexImagesGenerations = async (opts: CallCodexImagesGeneration
   const effectivePlan = accessTokenPlan(ready.accessToken) ?? { planType: opts.fallbackPlanType };
   if (!codexPlanSupportsImages(effectivePlan.planType)) return imageUnavailableResult(opts.model.id);
   const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
-  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, turnId, effectivePlan, false);
+  return await performImageCall(opts, ready.accessToken, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, turnId, effectivePlan, false);
 };
 
 export const callCodexImagesEdits = async (opts: CallCodexImagesEditsOptions): Promise<ProviderCallResult> => {
@@ -110,7 +110,7 @@ export const callCodexImagesEdits = async (opts: CallCodexImagesEditsOptions): P
   if (!codexPlanSupportsImages(effectivePlan.planType)) return imageUnavailableResult(opts.model.id);
   const body = await serializeOpenAIImagesEditsJsonPayload(opts.request, opts.model.id);
   const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
-  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_EDITS_PATH, body, turnId, effectivePlan, false);
+  return await performImageCall(opts, ready.accessToken, CODEX_IMAGES_EDITS_PATH, body, turnId, effectivePlan, false);
 };
 
 const accessTokenPlan = (entry: CodexAccessTokenEntry): CodexPlanObservation | null =>
@@ -460,18 +460,23 @@ const dispatchCodexImageCall = async (
 // result also resolves the latest plan metadata used to authorize the retry.
 const refreshAccessTokenForRetry = async (
   opts: CodexBackendCallBase,
+  failedEntry: CodexAccessTokenEntry,
   fallbackPlan?: CodexPlanObservation,
 ): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
-  await invalidateCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId);
   try {
-    const minted = await mintAccessToken(opts, opts.account.refresh_token);
-    const effective = await putCodexAccessToken(
+    const retained = await invalidateCodexAccessToken(
       opts.upstreamId,
       opts.account.chatgptAccountId,
-      minted,
-      fallbackPlan ?? (opts.account.accessToken === null || opts.account.accessToken === undefined
-        ? undefined
-        : accessTokenPlan(opts.account.accessToken) ?? undefined),
+      failedEntry.token,
+    );
+    if (retained !== null) return { ok: true, accessToken: retained };
+    const effective = await ensureCodexAccessToken(
+      opts.upstreamId,
+      opts.account.chatgptAccountId,
+      async refreshToken => {
+        const minted = await mintAccessToken(opts, refreshToken);
+        return mergeRetryPlan(minted, fallbackPlan ?? accessTokenPlan(failedEntry) ?? undefined);
+      },
     );
     return { ok: true, accessToken: effective };
   } catch (err) {
@@ -483,9 +488,21 @@ const refreshAccessTokenForRetry = async (
   }
 };
 
+const mergeRetryPlan = (
+  entry: CodexAccessTokenEntry,
+  fallback: CodexPlanObservation | undefined,
+): CodexAccessTokenEntry => {
+  if (entry.planType !== undefined || fallback === undefined) return entry;
+  return {
+    ...entry,
+    planType: fallback.planType,
+    ...(fallback.observedAt === undefined ? {} : { planObservedAt: fallback.observedAt }),
+  };
+};
+
 const performStreamingResponsesCall = async (
   opts: CallCodexResponsesOptions,
-  accessToken: string,
+  accessToken: CodexAccessTokenEntry,
   alreadyRetried: boolean,
 ): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
   const clientTurnMetadata = parseClientTurnMetadataJson(trimHeader(opts.headers, 'x-codex-turn-metadata'));
@@ -495,7 +512,7 @@ const performStreamingResponsesCall = async (
   const turnMetadataJson = buildCodexTurnMetadataJson(identity, metadata, clientTurnMetadata);
   const upstreamFetch = dispatchCodexHttpCall(
     opts,
-    accessToken,
+    accessToken.token,
     CODEX_RESPONSES_PATH,
     'text/event-stream',
     buildCodexResponsesBody(opts, identity, turnMetadataJson),
@@ -506,9 +523,9 @@ const performStreamingResponsesCall = async (
   const result = await streamingProviderCall(upstreamFetch, parseResponsesStream, opts.model.id, opts.signal);
 
   if (!result.ok && result.response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts);
+    const fresh = await refreshAccessTokenForRetry(opts, accessToken, accessTokenPlan(accessToken) ?? undefined);
     if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
-    return await performStreamingResponsesCall(opts, fresh.accessToken.token, true);
+    return await performStreamingResponsesCall(opts, fresh.accessToken, true);
   }
 
   return result;
@@ -516,7 +533,7 @@ const performStreamingResponsesCall = async (
 
 const performUnaryCompactCall = async (
   opts: CallCodexResponsesCompactOptions,
-  accessToken: string,
+  accessToken: CodexAccessTokenEntry,
   alreadyRetried: boolean,
 ): Promise<ProviderCompactionResult> => {
   const clientTurnMetadata = parseClientTurnMetadataJson(trimHeader(opts.headers, 'x-codex-turn-metadata'));
@@ -526,7 +543,7 @@ const performUnaryCompactCall = async (
   const turnMetadataJson = buildCodexTurnMetadataJson(identity, metadata, clientTurnMetadata);
   const response = await dispatchCodexHttpCall(
     opts,
-    accessToken,
+    accessToken.token,
     CODEX_RESPONSES_COMPACT_PATH,
     'application/json',
     { ...opts.body, model: opts.model.id },
@@ -535,9 +552,9 @@ const performUnaryCompactCall = async (
   );
 
   if (response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts);
+    const fresh = await refreshAccessTokenForRetry(opts, accessToken, accessTokenPlan(accessToken) ?? undefined);
     if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
-    return await performUnaryCompactCall(opts, fresh.accessToken.token, true);
+    return await performUnaryCompactCall(opts, fresh.accessToken, true);
   }
 
   if (!response.ok) return { ok: false, modelKey: opts.model.id, response };
@@ -548,7 +565,7 @@ const performUnaryCompactCall = async (
 
 const performAlphaSearchCall = async (
   opts: CallCodexAlphaSearchOptions,
-  accessToken: string,
+  accessToken: CodexAccessTokenEntry,
   alreadyRetried: boolean,
 ): Promise<ProviderCallResult> => {
   const requestId = stringField(opts.body, 'id');
@@ -564,7 +581,7 @@ const performAlphaSearchCall = async (
   const turnMetadataJson = trimHeader(opts.headers, 'x-codex-turn-metadata');
   const response = await dispatchCodexHttpCall(
     opts,
-    accessToken,
+    accessToken.token,
     CODEX_ALPHA_SEARCH_PATH,
     'application/json',
     { ...opts.body, model: opts.model.id },
@@ -573,29 +590,29 @@ const performAlphaSearchCall = async (
   );
 
   if (response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts);
+    const fresh = await refreshAccessTokenForRetry(opts, accessToken, accessTokenPlan(accessToken) ?? undefined);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
-    return await performAlphaSearchCall(opts, fresh.accessToken.token, true);
+    return await performAlphaSearchCall(opts, fresh.accessToken, true);
   }
   return { modelKey: opts.model.id, response };
 };
 
 const performImageCall = async (
   opts: CodexBackendCallBase & { fallbackPlanType: string },
-  accessToken: string,
+  accessToken: CodexAccessTokenEntry,
   path: string,
   body: Record<string, unknown>,
   turnId: string,
   effectivePlan: CodexPlanObservation,
   alreadyRetried: boolean,
 ): Promise<ProviderCallResult> => {
-  const response = await dispatchCodexImageCall(opts, accessToken, path, body, turnId);
+  const response = await dispatchCodexImageCall(opts, accessToken.token, path, body, turnId);
   if (response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts, effectivePlan);
+    const fresh = await refreshAccessTokenForRetry(opts, accessToken, effectivePlan);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
     const refreshedPlan = accessTokenPlan(fresh.accessToken) ?? effectivePlan;
     if (!codexPlanSupportsImages(refreshedPlan.planType)) return imageUnavailableResult(opts.model.id);
-    return await performImageCall(opts, fresh.accessToken.token, path, body, turnId, refreshedPlan, true);
+    return await performImageCall(opts, fresh.accessToken, path, body, turnId, refreshedPlan, true);
   }
   return { modelKey: opts.model.id, response };
 };

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -449,15 +449,10 @@ const dispatchCodexImageCall = async (
   return await classifyCodexHttpResponse(opts, response, 'when-present');
 };
 
-// Force-mint a fresh access token after a 401 and persist it before retrying.
-// `ensureCodexAccessToken`'s read-then-maybe-mint is bypassed because a
-// re-read can still observe the token we just invalidated: a sibling that
-// minted before our 401 lands its `putCodexAccessToken` after our
-// invalidation, restoring the broken token, and Codex tokens carry multi-day
-// expiresAt so the freshness gate hands it straight back — sending us into an
-// immediate second 401 with `alreadyRetried` already flipped. Minting
-// unconditionally sidesteps that window. The write is awaited because its CAS
-// result also resolves the latest plan metadata used to authorize the retry.
+// Recover from a 401 without deleting a sibling's newer credential: invalidate
+// only the exact token that failed, reuse a winner already stored by another
+// request, otherwise force a fresh coalesced mint. The resulting CAS write is
+// awaited because it also resolves the latest plan observation for the retry.
 const refreshAccessTokenForRetry = async (
   opts: CodexBackendCallBase,
   failedEntry: CodexAccessTokenEntry,
@@ -477,6 +472,7 @@ const refreshAccessTokenForRetry = async (
         const minted = await mintAccessToken(opts, refreshToken);
         return mergeRetryPlan(minted, fallbackPlan ?? accessTokenPlan(failedEntry) ?? undefined);
       },
+      true,
     );
     return { ok: true, accessToken: effective };
   } catch (err) {
@@ -523,7 +519,7 @@ const performStreamingResponsesCall = async (
   const result = await streamingProviderCall(upstreamFetch, parseResponsesStream, opts.model.id, opts.signal);
 
   if (!result.ok && result.response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts, accessToken, accessTokenPlan(accessToken) ?? undefined);
+    const fresh = await refreshAccessTokenForRetry(opts, accessToken);
     if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
     return await performStreamingResponsesCall(opts, fresh.accessToken, true);
   }
@@ -552,7 +548,7 @@ const performUnaryCompactCall = async (
   );
 
   if (response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts, accessToken, accessTokenPlan(accessToken) ?? undefined);
+    const fresh = await refreshAccessTokenForRetry(opts, accessToken);
     if (!fresh.ok) return { ok: false, modelKey: opts.model.id, response: fresh.response };
     return await performUnaryCompactCall(opts, fresh.accessToken, true);
   }
@@ -590,7 +586,7 @@ const performAlphaSearchCall = async (
   );
 
   if (response.status === 401 && !alreadyRetried) {
-    const fresh = await refreshAccessTokenForRetry(opts, accessToken, accessTokenPlan(accessToken) ?? undefined);
+    const fresh = await refreshAccessTokenForRetry(opts, accessToken);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
     return await performAlphaSearchCall(opts, fresh.accessToken, true);
   }

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -97,18 +97,20 @@ export const callCodexAlphaSearch = async (opts: CallCodexAlphaSearchOptions): P
 export const callCodexImagesGenerations = async (opts: CallCodexImagesGenerationsOptions): Promise<ProviderCallResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
-  if (!codexPlanSupportsImages(ready.accessToken.planType ?? opts.fallbackPlanType)) return imageUnavailableResult(opts.model.id);
+  const effectivePlanType = ready.accessToken.planType ?? opts.fallbackPlanType;
+  if (!codexPlanSupportsImages(effectivePlanType)) return imageUnavailableResult(opts.model.id);
   const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
-  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, turnId, false);
+  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, turnId, effectivePlanType, false);
 };
 
 export const callCodexImagesEdits = async (opts: CallCodexImagesEditsOptions): Promise<ProviderCallResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
-  if (!codexPlanSupportsImages(ready.accessToken.planType ?? opts.fallbackPlanType)) return imageUnavailableResult(opts.model.id);
+  const effectivePlanType = ready.accessToken.planType ?? opts.fallbackPlanType;
+  if (!codexPlanSupportsImages(effectivePlanType)) return imageUnavailableResult(opts.model.id);
   const body = await serializeOpenAIImagesEditsJsonPayload(opts.request, opts.model.id);
   const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
-  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_EDITS_PATH, body, turnId, false);
+  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_EDITS_PATH, body, turnId, effectivePlanType, false);
 };
 
 // Pre-fetch gates + initial access-token mint.
@@ -569,14 +571,16 @@ const performImageCall = async (
   path: string,
   body: Record<string, unknown>,
   turnId: string,
+  effectivePlanType: string | undefined,
   alreadyRetried: boolean,
 ): Promise<ProviderCallResult> => {
   const response = await dispatchCodexImageCall(opts, accessToken, path, body, turnId);
   if (response.status === 401 && !alreadyRetried) {
     const fresh = await refreshAccessTokenForRetry(opts);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
-    if (!codexPlanSupportsImages(fresh.accessToken.planType ?? opts.fallbackPlanType)) return imageUnavailableResult(opts.model.id);
-    return await performImageCall(opts, fresh.accessToken.token, path, body, turnId, true);
+    const refreshedPlanType = fresh.accessToken.planType ?? effectivePlanType;
+    if (!codexPlanSupportsImages(refreshedPlanType)) return imageUnavailableResult(opts.model.id);
+    return await performImageCall(opts, fresh.accessToken.token, path, body, turnId, refreshedPlanType, true);
   }
   return { modelKey: opts.model.id, response };
 };

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -3,6 +3,8 @@ import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import {
   CODEX_BACKEND_BASE,
   CODEX_ALPHA_SEARCH_PATH,
+  CODEX_IMAGES_EDITS_PATH,
+  CODEX_IMAGES_GENERATIONS_PATH,
   CODEX_ORIGINATOR,
   CODEX_RESPONSES_COMPACT_PATH,
   CODEX_RESPONSES_PATH,
@@ -15,9 +17,10 @@ import {
 } from './quota.ts';
 import type { CodexAccountCredential } from './state.ts';
 import { isEventStreamMediaType } from '@floway-dev/protocols/common';
+import type { ImagesGenerationsPayload } from '@floway-dev/protocols/images';
 import type { CanonicalResponsesCompactPayload, CanonicalResponsesPayload, ResponsesCompactionResult, ResponsesInputItem, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
 import { parseResponsesStream } from '@floway-dev/protocols/responses';
-import { jsonRequestBody, type ProviderCallResult, type ProviderModel, type ProviderStreamResult, streamingProviderCall, type UpstreamCallOptions } from '@floway-dev/provider';
+import { jsonRequestBody, serializeOpenAIImagesEditsJsonPayload, type ImagesEditsRequest, type ProviderCallResult, type ProviderModel, type ProviderStreamResult, streamingProviderCall, type UpstreamCallOptions } from '@floway-dev/provider';
 
 export type ProviderCompactionResult =
   | { ok: true; result: ResponsesCompactionResult; modelKey: string }
@@ -57,6 +60,14 @@ export interface CallCodexAlphaSearchOptions extends CodexBackendCallBase {
   body: Record<string, unknown>;
 }
 
+export interface CallCodexImagesGenerationsOptions extends CodexBackendCallBase {
+  body: Omit<ImagesGenerationsPayload, 'model'>;
+}
+
+export interface CallCodexImagesEditsOptions extends CodexBackendCallBase {
+  request: ImagesEditsRequest;
+}
+
 type CodexResponsesBody = CallCodexResponsesOptions['body'] | CallCodexResponsesCompactOptions['body'];
 
 export const callCodexResponses = async (opts: CallCodexResponsesOptions): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
@@ -77,6 +88,19 @@ export const callCodexAlphaSearch = async (opts: CallCodexAlphaSearchOptions): P
   const ready = await prepareCodexCall(normalized);
   if (!ready.ok) return { modelKey: normalized.model.id, response: ready.response };
   return await performAlphaSearchCall(normalized, ready.accessToken, false);
+};
+
+export const callCodexImagesGenerations = async (opts: CallCodexImagesGenerationsOptions): Promise<ProviderCallResult> => {
+  const ready = await prepareCodexCall(opts);
+  if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
+  return await performImageCall(opts, ready.accessToken, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, false);
+};
+
+export const callCodexImagesEdits = async (opts: CallCodexImagesEditsOptions): Promise<ProviderCallResult> => {
+  const ready = await prepareCodexCall(opts);
+  if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
+  const body = await serializeOpenAIImagesEditsJsonPayload(opts.request, opts.model.id);
+  return await performImageCall(opts, ready.accessToken, CODEX_IMAGES_EDITS_PATH, body, false);
 };
 
 // Pre-fetch gates + initial access-token mint.
@@ -343,6 +367,13 @@ const dispatchCodexHttpCall = async (
     signal: opts.signal,
   }));
 
+  return await classifyCodexHttpResponse(opts, response);
+};
+
+const classifyCodexHttpResponse = async (
+  opts: CodexBackendCallBase,
+  response: Response,
+): Promise<Response> => {
   if (response.ok) {
     const responseNow = new Date();
     const snapshot = parseCodexQuotaHeaders(response.headers, { now: responseNow, isRateLimited: false });
@@ -368,6 +399,30 @@ const dispatchCodexHttpCall = async (
   }
 
   return response;
+};
+
+const dispatchCodexImageCall = async (
+  opts: CodexBackendCallBase,
+  accessToken: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<Response> => {
+  const headers = new Headers({
+    authorization: `Bearer ${accessToken}`,
+    'chatgpt-account-id': opts.account.chatgptAccountId,
+    originator: CODEX_ORIGINATOR,
+    'user-agent': CODEX_USER_AGENT,
+    accept: 'application/json',
+    'content-type': 'application/json',
+    'x-codex-image-turn-id': trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7(),
+  });
+  const response = await opts.call.wrapUpstreamCall(() => opts.call.fetcher(`${CODEX_BACKEND_BASE}${path}`, {
+    method: 'POST',
+    headers,
+    body: jsonRequestBody(body),
+    signal: opts.signal,
+  }));
+  return await classifyCodexHttpResponse(opts, response);
 };
 
 // Force-mint a fresh access token after a 401, persisting it best-effort.
@@ -487,6 +542,22 @@ const performAlphaSearchCall = async (
     const fresh = await refreshAccessTokenForRetry(opts);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
     return await performAlphaSearchCall(opts, fresh.accessToken, true);
+  }
+  return { modelKey: opts.model.id, response };
+};
+
+const performImageCall = async (
+  opts: CodexBackendCallBase,
+  accessToken: string,
+  path: string,
+  body: Record<string, unknown>,
+  alreadyRetried: boolean,
+): Promise<ProviderCallResult> => {
+  const response = await dispatchCodexImageCall(opts, accessToken, path, body);
+  if (response.status === 401 && !alreadyRetried) {
+    const fresh = await refreshAccessTokenForRetry(opts);
+    if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
+    return await performImageCall(opts, fresh.accessToken, path, body, true);
   }
   return { modelKey: opts.model.id, response };
 };

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -11,11 +11,12 @@ import {
   CODEX_USER_AGENT,
 } from './constants.ts';
 import { sha256JsonUuid, uuidV7 } from './ids.ts';
+import { codexPlanSupportsImages } from './models.ts';
 import {
   parseCodexQuotaHeaders,
   putCodexQuota,
 } from './quota.ts';
-import type { CodexAccountCredential } from './state.ts';
+import type { CodexAccessTokenEntry, CodexAccountCredential } from './state.ts';
 import { isEventStreamMediaType } from '@floway-dev/protocols/common';
 import type { ImagesGenerationsPayload } from '@floway-dev/protocols/images';
 import type { CanonicalResponsesCompactPayload, CanonicalResponsesPayload, ResponsesCompactionResult, ResponsesInputItem, ResponsesStreamEvent } from '@floway-dev/protocols/responses';
@@ -35,9 +36,9 @@ export interface CodexCallEffects {
   persistTerminalState(state: 'session_terminated' | 'refresh_failed', message: string): Promise<void>;
 }
 
-// Account selection for one Codex call. Both Codex endpoints share the same
-// OAuth credential, the same quota row, and the same retry contract; only the
-// wire body and the response decoding differ.
+// Account selection shared by Codex backend calls. Every surface uses the same
+// OAuth credential, quota state, terminal-session classification, and refresh
+// retry contract; each operation owns its wire body and response decoding.
 interface CodexBackendCallBase {
   upstreamId: string;
   account: CodexAccountCredential;
@@ -62,10 +63,12 @@ export interface CallCodexAlphaSearchOptions extends CodexBackendCallBase {
 
 export interface CallCodexImagesGenerationsOptions extends CodexBackendCallBase {
   body: Omit<ImagesGenerationsPayload, 'model'>;
+  fallbackPlanType: string;
 }
 
 export interface CallCodexImagesEditsOptions extends CodexBackendCallBase {
   request: ImagesEditsRequest;
+  fallbackPlanType: string;
 }
 
 type CodexResponsesBody = CallCodexResponsesOptions['body'] | CallCodexResponsesCompactOptions['body'];
@@ -73,13 +76,13 @@ type CodexResponsesBody = CallCodexResponsesOptions['body'] | CallCodexResponses
 export const callCodexResponses = async (opts: CallCodexResponsesOptions): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { ok: false, modelKey: opts.model.id, response: ready.response };
-  return await performStreamingResponsesCall(opts, ready.accessToken, false);
+  return await performStreamingResponsesCall(opts, ready.accessToken.token, false);
 };
 
 export const callCodexResponsesCompact = async (opts: CallCodexResponsesCompactOptions): Promise<ProviderCompactionResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { ok: false, modelKey: opts.model.id, response: ready.response };
-  return await performUnaryCompactCall(opts, ready.accessToken, false);
+  return await performUnaryCompactCall(opts, ready.accessToken.token, false);
 };
 
 export const callCodexAlphaSearch = async (opts: CallCodexAlphaSearchOptions): Promise<ProviderCallResult> => {
@@ -87,31 +90,35 @@ export const callCodexAlphaSearch = async (opts: CallCodexAlphaSearchOptions): P
   const normalized = { ...opts, body: { ...opts.body, id: requestId } };
   const ready = await prepareCodexCall(normalized);
   if (!ready.ok) return { modelKey: normalized.model.id, response: ready.response };
-  return await performAlphaSearchCall(normalized, ready.accessToken, false);
+  return await performAlphaSearchCall(normalized, ready.accessToken.token, false);
 };
 
 export const callCodexImagesGenerations = async (opts: CallCodexImagesGenerationsOptions): Promise<ProviderCallResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
-  return await performImageCall(opts, ready.accessToken, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, false);
+  if (!codexPlanSupportsImages(ready.accessToken.planType ?? opts.fallbackPlanType)) return imageUnavailableResult(opts.model.id);
+  const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
+  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_GENERATIONS_PATH, { ...opts.body, model: opts.model.id }, turnId, false);
 };
 
 export const callCodexImagesEdits = async (opts: CallCodexImagesEditsOptions): Promise<ProviderCallResult> => {
   const ready = await prepareCodexCall(opts);
   if (!ready.ok) return { modelKey: opts.model.id, response: ready.response };
+  if (!codexPlanSupportsImages(ready.accessToken.planType ?? opts.fallbackPlanType)) return imageUnavailableResult(opts.model.id);
   const body = await serializeOpenAIImagesEditsJsonPayload(opts.request, opts.model.id);
-  return await performImageCall(opts, ready.accessToken, CODEX_IMAGES_EDITS_PATH, body, false);
+  const turnId = trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7();
+  return await performImageCall(opts, ready.accessToken.token, CODEX_IMAGES_EDITS_PATH, body, turnId, false);
 };
 
 // Pre-fetch gates + initial access-token mint.
-const prepareCodexCall = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: string } | { ok: false; response: Response }> => {
+const prepareCodexCall = async (opts: CodexBackendCallBase): Promise<{ ok: true; accessToken: CodexAccessTokenEntry } | { ok: false; response: Response }> => {
   if (opts.account.state !== 'active') {
     return { ok: false, response: synthetic503(`Codex upstream is ${opts.account.state}`) };
   }
 
   try {
     const entry = await ensureCodexAccessToken(opts.upstreamId, opts.account.chatgptAccountId, refresh => mintAccessToken(opts, refresh));
-    return { ok: true, accessToken: entry.token };
+    return { ok: true, accessToken: entry };
   } catch (err) {
     if (err instanceof CodexOAuthSessionTerminatedError) {
       await opts.effects.persistTerminalState('refresh_failed', err.upstreamMessage);
@@ -373,18 +380,23 @@ const dispatchCodexHttpCall = async (
 const classifyCodexHttpResponse = async (
   opts: CodexBackendCallBase,
   response: Response,
+  persistEmptyQuota = true,
 ): Promise<Response> => {
   if (response.ok) {
     const responseNow = new Date();
     const snapshot = parseCodexQuotaHeaders(response.headers, { now: responseNow, isRateLimited: false });
-    registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
+    if (persistEmptyQuota || Object.keys(snapshot).length > 1) {
+      registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
+    }
     return response;
   }
 
   if (response.status === 429) {
     const responseNow = new Date();
     const snapshot = parseCodexQuotaHeaders(response.headers, { now: responseNow, isRateLimited: true });
-    registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
+    if (persistEmptyQuota || Object.keys(snapshot).length > 1) {
+      registerBackgroundWrite(opts, putCodexQuota(opts.upstreamId, opts.account.chatgptAccountId, snapshot));
+    }
     return response;
   }
 
@@ -406,15 +418,16 @@ const dispatchCodexImageCall = async (
   accessToken: string,
   path: string,
   body: Record<string, unknown>,
+  turnId: string,
 ): Promise<Response> => {
   const headers = new Headers({
     authorization: `Bearer ${accessToken}`,
     'chatgpt-account-id': opts.account.chatgptAccountId,
-    originator: CODEX_ORIGINATOR,
+    originator: trimHeader(opts.headers, 'originator') ?? CODEX_ORIGINATOR,
     'user-agent': CODEX_USER_AGENT,
     accept: 'application/json',
     'content-type': 'application/json',
-    'x-codex-image-turn-id': trimHeader(opts.headers, 'x-codex-image-turn-id') ?? uuidV7(),
+    'x-codex-image-turn-id': turnId,
   });
   const response = await opts.call.wrapUpstreamCall(() => opts.call.fetcher(`${CODEX_BACKEND_BASE}${path}`, {
     method: 'POST',
@@ -422,7 +435,7 @@ const dispatchCodexImageCall = async (
     body: jsonRequestBody(body),
     signal: opts.signal,
   }));
-  return await classifyCodexHttpResponse(opts, response);
+  return await classifyCodexHttpResponse(opts, response, false);
 };
 
 // Force-mint a fresh access token after a 401, persisting it best-effort.
@@ -551,13 +564,14 @@ const performImageCall = async (
   accessToken: string,
   path: string,
   body: Record<string, unknown>,
+  turnId: string,
   alreadyRetried: boolean,
 ): Promise<ProviderCallResult> => {
-  const response = await dispatchCodexImageCall(opts, accessToken, path, body);
+  const response = await dispatchCodexImageCall(opts, accessToken, path, body, turnId);
   if (response.status === 401 && !alreadyRetried) {
     const fresh = await refreshAccessTokenForRetry(opts);
     if (!fresh.ok) return { modelKey: opts.model.id, response: fresh.response };
-    return await performImageCall(opts, fresh.accessToken, path, body, true);
+    return await performImageCall(opts, fresh.accessToken, path, body, turnId, true);
   }
   return { modelKey: opts.model.id, response };
 };
@@ -574,6 +588,16 @@ const parseUpstreamError = (rawText: string): { code: string | null; message: st
     return { code: null, message: rawText.slice(0, 256) };
   }
 };
+
+const imageUnavailableResult = (modelKey: string): ProviderCallResult => ({
+  modelKey,
+  response: new Response(JSON.stringify({
+    error: {
+      type: 'image_tools_unavailable',
+      message: 'ChatGPT Free accounts do not provide Codex image tools.',
+    },
+  }), { status: 403, headers: { 'content-type': 'application/json' } }),
+});
 
 const synthetic503 = (message: string): Response => new Response(JSON.stringify({ error: { type: 'codex_upstream_unavailable', message } }), {
   status: 503,

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -148,7 +148,7 @@ export const codexPlanSupportsImages = (planType: string): boolean =>
 
 export const codexImageProviderModel = (enabledFlags: ReadonlySet<FlagId>): ProviderModel => ({
   id: CODEX_IMAGE_MODEL_ID,
-  display_name: 'GPT Image 2',
+  display_name: 'GPT-Image-2',
   owned_by: 'openai',
   kind: 'image',
   limits: {},

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -6,7 +6,7 @@ import {
   CODEX_ORIGINATOR,
   CODEX_USER_AGENT,
 } from './constants.ts';
-import { pricingForCodexModelKey } from './pricing.ts';
+import { GPT_IMAGE_2_PRICING, pricingForCodexModelKey } from './pricing.ts';
 import { type Fetcher, type FlagId, type ProviderModel, type UpstreamChatModelConfig } from '@floway-dev/provider';
 
 export interface CodexRawModel {
@@ -154,4 +154,5 @@ export const codexImageProviderModel = (enabledFlags: ReadonlySet<FlagId>): Prov
   limits: {},
   endpoints: { imagesGenerations: {}, imagesEdits: {} },
   enabledFlags,
+  pricing: GPT_IMAGE_2_PRICING,
 });

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -143,8 +143,8 @@ export const codexRawToProviderModel = (raw: CodexRawModel, enabledFlags: Readon
 // while keeping the image model outside the remote chat-model catalog.
 // https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/internal/runtime/executor/codex_executor_request.go#L381-L449
 // https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/sdk/cliproxy/auth/conductor_execution.go#L1036-L1066
-export const codexPlanSupportsImages = (planType: string): boolean =>
-  planType.trim().toLowerCase() !== 'free';
+export const codexPlanSupportsImages = (planType: string | undefined): boolean =>
+  planType?.trim().toLowerCase() !== 'free';
 
 export const codexImageProviderModel = (enabledFlags: ReadonlySet<FlagId>): ProviderModel => ({
   id: CODEX_IMAGE_MODEL_ID,

--- a/packages/provider-codex/src/models.ts
+++ b/packages/provider-codex/src/models.ts
@@ -1,6 +1,7 @@
 import {
   CODEX_BACKEND_BASE,
   CODEX_CLI_VERSION,
+  CODEX_IMAGE_MODEL_ID,
   CODEX_MODELS_PATH,
   CODEX_ORIGINATOR,
   CODEX_USER_AGENT,
@@ -94,9 +95,11 @@ const assertRawModel = (value: unknown): CodexRawModel => {
   return raw;
 };
 
-// Codex exposes only the Responses endpoint. Pricing is looked up from the
-// per-slug table in pricing.ts so the dashboard can report a notional
-// API-rate pricing even though Codex itself bills as a flat-fee subscription.
+// Every entry returned by the remote Codex catalog is a Responses chat model.
+// Pricing is looked up from the per-slug table in pricing.ts so the dashboard
+// can report a notional API-rate price even though Codex itself bills as a
+// flat-fee subscription. Provider-owned models such as gpt-image-2 are added
+// separately and never pass through this mapper.
 //
 // `enabledFlags` is the upstream-resolved flag set (provider defaults
 // merged with the row's `flagOverrides`); it propagates per-model so
@@ -133,3 +136,22 @@ export const codexRawToProviderModel = (raw: CodexRawModel, enabledFlags: Readon
     ...(Object.keys(chat).length > 0 ? { chat } : {}),
   };
 };
+
+// CLIProxyAPI exposes Codex's built-in image models for every plan, then
+// rejects image dispatch only when the JWT plan is explicitly `free`; missing
+// and future plan values fail open. Mirror that account-eligibility rule here
+// while keeping the image model outside the remote chat-model catalog.
+// https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/internal/runtime/executor/codex_executor_request.go#L381-L449
+// https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/sdk/cliproxy/auth/conductor_execution.go#L1036-L1066
+export const codexPlanSupportsImages = (planType: string): boolean =>
+  planType.trim().toLowerCase() !== 'free';
+
+export const codexImageProviderModel = (enabledFlags: ReadonlySet<FlagId>): ProviderModel => ({
+  id: CODEX_IMAGE_MODEL_ID,
+  display_name: 'GPT Image 2',
+  owned_by: 'openai',
+  kind: 'image',
+  limits: {},
+  endpoints: { imagesGenerations: {}, imagesEdits: {} },
+  enabledFlags,
+});

--- a/packages/provider-codex/src/pricing.ts
+++ b/packages/provider-codex/src/pricing.ts
@@ -19,7 +19,22 @@ const GPT_5_4_PRICING = modelPricing(
   tokenPricingEntry({ input_tokens: '5', input_cache_read_tokens: '0.5', output_tokens: '22.5' }, { inputTokens: { operator: 'gt', value: 272000 } }),
 );
 
+// GPT Image 2 bills text input, image input, and image output as distinct token
+// modalities. Cached input uses the published text-cache rate here; image
+// responses currently report modality splits for input/output tokens but do
+// not expose a modality split for cached tokens.
+// https://developers.openai.com/api/docs/pricing#image-generation
+export const GPT_IMAGE_2_PRICING = modelPricing(
+  tokenPricingEntry({
+    input_tokens: '5',
+    input_cache_read_tokens: '1.25',
+    input_image_tokens: '8',
+    output_image_tokens: '30',
+  }),
+);
+
 const CODEX_MODEL_PRICING: readonly (readonly [key: string | RegExp, pricing: ModelPricing])[] = [
+  ['gpt-image-2', GPT_IMAGE_2_PRICING],
   // GPT-5.6 publishes standard short/long and priority-short entries. OpenAI-
   // direct does not publish priority-long rates, so that exact combination is
   // deliberately absent and resolves to the whole Base vector.

--- a/packages/provider-codex/src/pricing.ts
+++ b/packages/provider-codex/src/pricing.ts
@@ -34,7 +34,6 @@ export const GPT_IMAGE_2_PRICING = modelPricing(
 );
 
 const CODEX_MODEL_PRICING: readonly (readonly [key: string | RegExp, pricing: ModelPricing])[] = [
-  ['gpt-image-2', GPT_IMAGE_2_PRICING],
   // GPT-5.6 publishes standard short/long and priority-short entries. OpenAI-
   // direct does not publish priority-long rates, so that exact combination is
   // deliberately absent and resolves to the whole Base vector.

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -15,7 +15,9 @@ import { getProviderRepo, resolveEffectiveFlags, type ProviderInstance, type Pro
 // https://github.com/openai/codex/blob/c607da9f371bb66a41cc772c6ddf1989d28137d3/codex-rs/codex-api/src/endpoint/responses.rs#L87-L96
 // https://github.com/openai/codex/blob/c607da9f371bb66a41cc772c6ddf1989d28137d3/codex-rs/core/src/responses_metadata.rs#L255-L270
 // https://github.com/openai/codex/blob/bd8fc9adb93fa5bc0a69b396bd5ac78a5ec14487/codex-rs/codex-api/src/requests/headers.rs#L5-L16
+// https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/ext/image-generation/src/backend.rs#L81-L89
 const INBOUND_HEADER_ALLOWLIST = [
+  'originator',
   'session-id',
   'session_id',
   'thread-id',
@@ -109,7 +111,7 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
       // models even though the ChatGPT UI hides them — and the dashboard
       // toggles them per-upstream when needed.
       const models = raw.map(r => codexRawToProviderModel(r, enabledFlags));
-      if (codexPlanSupportsImages(accountIdentity.planType)) models.push(codexImageProviderModel(enabledFlags));
+      if (codexPlanSupportsImages(access.planType ?? accountIdentity.planType)) models.push(codexImageProviderModel(enabledFlags));
       return models;
     },
 
@@ -165,14 +167,12 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
     callChatCompletions: () => unsupportedStreamResult(),
     callEmbeddings: () => unsupportedCallResult(),
     callImagesGenerations: async (model, body, signal, opts) => {
-      if (!codexPlanSupportsImages(accountIdentity.planType)) return imageUnavailableResult(model.id);
       const { account } = await readActiveAccount();
-      return await callCodexImagesGenerations({ upstreamId: record.id, account, model, headers: opts.headers, signal, effects, call: opts, body });
+      return await callCodexImagesGenerations({ upstreamId: record.id, account, model, headers: opts.headers, signal, effects, call: opts, body, fallbackPlanType: accountIdentity.planType });
     },
     callImagesEdits: async (model, request, signal, opts) => {
-      if (!codexPlanSupportsImages(accountIdentity.planType)) return imageUnavailableResult(model.id);
       const { account } = await readActiveAccount();
-      return await callCodexImagesEdits({ upstreamId: record.id, account, model, headers: opts.headers, signal, effects, call: opts, request });
+      return await callCodexImagesEdits({ upstreamId: record.id, account, model, headers: opts.headers, signal, effects, call: opts, request, fallbackPlanType: accountIdentity.planType });
     },
     callAudioTranscriptions: () => unsupportedCallResult(),
     callRerank: () => Promise.reject(new Error('Codex provider does not support callRerank')),
@@ -200,13 +200,3 @@ const unsupportedStreamResult = <TEvent>(): Promise<ProviderStreamResult<TEvent>
 
 const unsupportedCallResult = (): Promise<ProviderCallResult> =>
   Promise.resolve({ modelKey: '', response: synthetic405() });
-
-const imageUnavailableResult = (modelKey: string): ProviderCallResult => ({
-  modelKey,
-  response: new Response(JSON.stringify({
-    error: {
-      type: 'image_generation_unavailable',
-      message: 'ChatGPT Free accounts do not provide Codex image generation.',
-    },
-  }), { status: 403, headers: { 'content-type': 'application/json' } }),
-});

--- a/packages/provider-codex/src/provider.ts
+++ b/packages/provider-codex/src/provider.ts
@@ -2,10 +2,10 @@ import { ensureCodexAccessToken, mintCodexAccessToken } from './access-token.ts'
 import { CodexOAuthSessionTerminatedError } from './auth/oauth.ts';
 import { assertCodexUpstreamRecord, type CodexUpstreamConfig } from './config.ts';
 import { CODEX_DEFAULT_FLAGS } from './defaults.ts';
-import { callCodexAlphaSearch, callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from './fetch.ts';
+import { callCodexAlphaSearch, callCodexImagesEdits, callCodexImagesGenerations, callCodexResponses, callCodexResponsesCompact, type CodexCallEffects } from './fetch.ts';
 import { CODEX_RESPONSES_BOUNDARY } from './interceptors/responses/index.ts';
 import type { ResponsesBoundaryCtx } from './interceptors/responses/types.ts';
-import { codexRawToProviderModel, fetchCodexCatalog } from './models.ts';
+import { codexImageProviderModel, codexPlanSupportsImages, codexRawToProviderModel, fetchCodexCatalog } from './models.ts';
 import { assertCodexUpstreamState, findCodexAccountIndex, replaceCodexAccount } from './state.ts';
 import { runInterceptors } from '@floway-dev/interceptor';
 import { toCompactPayloadShape } from '@floway-dev/protocols/responses';
@@ -20,6 +20,7 @@ const INBOUND_HEADER_ALLOWLIST = [
   'session_id',
   'thread-id',
   'x-client-request-id',
+  'x-codex-image-turn-id',
   'x-codex-turn-metadata',
   'x-codex-window-id',
 ] as const;
@@ -107,7 +108,9 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
       // operator's gateway is its own surface — they can dispatch to those
       // models even though the ChatGPT UI hides them — and the dashboard
       // toggles them per-upstream when needed.
-      return raw.map(r => codexRawToProviderModel(r, enabledFlags));
+      const models = raw.map(r => codexRawToProviderModel(r, enabledFlags));
+      if (codexPlanSupportsImages(accountIdentity.planType)) models.push(codexImageProviderModel(enabledFlags));
+      return models;
     },
 
     callAlphaSearch: async (model, body, signal, opts) => {
@@ -153,18 +156,24 @@ export const createCodexProvider = (record: UpstreamRecord): Provider => {
       );
     },
 
-    // Codex upstream only exposes /responses; getProvidedModels advertises
-    // that single endpoint and no other entry point is reachable. The data
-    // plane never routes these surfaces here in practice, but a stray
-    // dispatch must surface as a 405 carrying a proper JSON error rather
-    // than letting a raw stack trace bubble up the boundary.
+    // Codex exposes Responses and its provider-owned image endpoints. The
+    // remaining surfaces are unreachable through the advertised catalog, but
+    // a stray dispatch must still surface as a structured 405.
     callMessages: () => unsupportedStreamResult(),
     callMessagesCountTokens: () => unsupportedCallResult(),
     callCompletions: () => unsupportedCallResult(),
     callChatCompletions: () => unsupportedStreamResult(),
     callEmbeddings: () => unsupportedCallResult(),
-    callImagesGenerations: () => unsupportedCallResult(),
-    callImagesEdits: () => unsupportedCallResult(),
+    callImagesGenerations: async (model, body, signal, opts) => {
+      if (!codexPlanSupportsImages(accountIdentity.planType)) return imageUnavailableResult(model.id);
+      const { account } = await readActiveAccount();
+      return await callCodexImagesGenerations({ upstreamId: record.id, account, model, headers: opts.headers, signal, effects, call: opts, body });
+    },
+    callImagesEdits: async (model, request, signal, opts) => {
+      if (!codexPlanSupportsImages(accountIdentity.planType)) return imageUnavailableResult(model.id);
+      const { account } = await readActiveAccount();
+      return await callCodexImagesEdits({ upstreamId: record.id, account, model, headers: opts.headers, signal, effects, call: opts, request });
+    },
     callAudioTranscriptions: () => unsupportedCallResult(),
     callRerank: () => Promise.reject(new Error('Codex provider does not support callRerank')),
   };
@@ -191,3 +200,13 @@ const unsupportedStreamResult = <TEvent>(): Promise<ProviderStreamResult<TEvent>
 
 const unsupportedCallResult = (): Promise<ProviderCallResult> =>
   Promise.resolve({ modelKey: '', response: synthetic405() });
+
+const imageUnavailableResult = (modelKey: string): ProviderCallResult => ({
+  modelKey,
+  response: new Response(JSON.stringify({
+    error: {
+      type: 'image_generation_unavailable',
+      message: 'ChatGPT Free accounts do not provide Codex image generation.',
+    },
+  }), { status: 403, headers: { 'content-type': 'application/json' } }),
+});

--- a/packages/provider-codex/src/quota.ts
+++ b/packages/provider-codex/src/quota.ts
@@ -123,6 +123,11 @@ export const parseCodexQuotaHeaders = (headers: Headers, options: ParseCodexQuot
   return snapshot;
 };
 
+export const hasCodexQuotaReading = (snapshot: CodexQuotaSnapshot): boolean => {
+  const { observed_at: _observationTime, ...reading } = snapshot;
+  return Object.keys(reading).length > 0;
+};
+
 // Every quota snapshot this account has observed, keyed by active limit.
 //
 // No TTL, which is the rule the other three providers state at their own slots:

--- a/packages/provider-codex/src/state.ts
+++ b/packages/provider-codex/src/state.ts
@@ -6,10 +6,10 @@ import type { CodexQuotaSnapshot } from './quota.ts';
 
 export type CodexAccountCredentialHealth = 'active' | 'session_terminated' | 'refresh_failed';
 
-// Short-lived OAuth access token minted by exchanging the stored refresh_token
+// Short-lived OAuth access state minted by exchanging the stored refresh_token
 // against /oauth/token. The refresh_token itself stays on CodexAccountCredential
-// so a KV/cache wipe never forces operator re-import; only the minted token
-// (and its expiry) belong in state alongside it.
+// so a cache loss never forces operator re-import; this entry keeps the minted
+// token, its lifetime, and capability metadata observed at the same refresh.
 export interface CodexAccessTokenEntry {
   token: string;
   expiresAt: number;       // unix ms

--- a/packages/provider-codex/src/state.ts
+++ b/packages/provider-codex/src/state.ts
@@ -14,6 +14,9 @@ export interface CodexAccessTokenEntry {
   token: string;
   expiresAt: number;       // unix ms
   refreshedAt: string;     // ISO 8601
+  // Parsed from the id_token returned alongside this access token. Absent on
+  // legacy rows; callers fall back to the import-time identity in config.
+  planType?: string;
 }
 
 // Most recent quota observation derived from upstream response headers.
@@ -90,6 +93,7 @@ const ALLOWED_ACCESS_TOKEN_KEYS_MAP: Record<keyof CodexAccessTokenEntry, true> =
   token: true,
   expiresAt: true,
   refreshedAt: true,
+  planType: true,
 };
 
 const ALLOWED_QUOTA_SNAPSHOT_KEYS_MAP: Record<keyof CodexQuotaSnapshotEntry, true> = {
@@ -115,6 +119,9 @@ const assertCodexAccessTokenEntry = (value: unknown, where: string): void => {
   }
   if (typeof obj.refreshedAt !== 'string' || obj.refreshedAt === '') {
     throw new TypeError(`${where}.refreshedAt must be a non-empty string`);
+  }
+  if (obj.planType !== undefined && (typeof obj.planType !== 'string' || obj.planType === '')) {
+    throw new TypeError(`${where}.planType must be a non-empty string when present`);
   }
 };
 

--- a/packages/provider-codex/src/state.ts
+++ b/packages/provider-codex/src/state.ts
@@ -18,6 +18,9 @@ export interface CodexAccessTokenEntry {
   // the claim. It is absent only when no refresh has supplied it and legacy
   // state has none, in which case callers use the import-time identity.
   planType?: string;
+  // Observation time for planType, independent from the token's refreshedAt
+  // so out-of-order token writes cannot promote an older plan observation.
+  planObservedAt?: string;
 }
 
 // Most recent quota observation derived from upstream response headers.
@@ -95,6 +98,7 @@ const ALLOWED_ACCESS_TOKEN_KEYS_MAP: Record<keyof CodexAccessTokenEntry, true> =
   expiresAt: true,
   refreshedAt: true,
   planType: true,
+  planObservedAt: true,
 };
 
 const ALLOWED_QUOTA_SNAPSHOT_KEYS_MAP: Record<keyof CodexQuotaSnapshotEntry, true> = {
@@ -123,6 +127,12 @@ const assertCodexAccessTokenEntry = (value: unknown, where: string): void => {
   }
   if (obj.planType !== undefined && (typeof obj.planType !== 'string' || obj.planType === '')) {
     throw new TypeError(`${where}.planType must be a non-empty string when present`);
+  }
+  if (obj.planObservedAt !== undefined && (typeof obj.planObservedAt !== 'string' || obj.planObservedAt === '')) {
+    throw new TypeError(`${where}.planObservedAt must be a non-empty string when present`);
+  }
+  if (obj.planObservedAt !== undefined && obj.planType === undefined) {
+    throw new TypeError(`${where}.planObservedAt requires planType`);
   }
 };
 

--- a/packages/provider-codex/src/state.ts
+++ b/packages/provider-codex/src/state.ts
@@ -9,14 +9,14 @@ export type CodexAccountCredentialHealth = 'active' | 'session_terminated' | 're
 // Short-lived OAuth access state minted by exchanging the stored refresh_token
 // against /oauth/token. The refresh_token itself stays on CodexAccountCredential
 // so a cache loss never forces operator re-import; this entry keeps the minted
-// token, its lifetime, and capability metadata observed at the same refresh.
+// token, its lifetime, and the account's latest observed capability metadata.
 export interface CodexAccessTokenEntry {
   token: string;
   expiresAt: number;       // unix ms
   refreshedAt: string;     // ISO 8601
-  // Parsed from the id_token returned alongside this access token. It may be
-  // absent on legacy state or when the token omits the claim; callers preserve
-  // the latest observation or fall back to the import-time identity.
+  // Observed from refresh id_tokens and retained across later tokens that omit
+  // the claim. It is absent only when no refresh has supplied it and legacy
+  // state has none, in which case callers use the import-time identity.
   planType?: string;
 }
 

--- a/packages/provider-codex/src/state.ts
+++ b/packages/provider-codex/src/state.ts
@@ -14,8 +14,9 @@ export interface CodexAccessTokenEntry {
   token: string;
   expiresAt: number;       // unix ms
   refreshedAt: string;     // ISO 8601
-  // Parsed from the id_token returned alongside this access token. Absent on
-  // legacy rows; callers fall back to the import-time identity in config.
+  // Parsed from the id_token returned alongside this access token. It may be
+  // absent on legacy state or when the token omits the claim; callers preserve
+  // the latest observation or fall back to the import-time identity.
   planType?: string;
 }
 

--- a/packages/provider/__tests__/images_test.ts
+++ b/packages/provider/__tests__/images_test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 
-import { serializeOpenAIImagesEditsRequest } from '../src/images.ts';
+import { serializeOpenAIImagesEditsJsonPayload, serializeOpenAIImagesEditsRequest } from '../src/images.ts';
 import { assertEquals } from '@floway-dev/test-utils';
 
 const parseJsonBody = async (body: Awaited<ReturnType<typeof serializeOpenAIImagesEditsRequest>>): Promise<unknown> => {
@@ -27,6 +27,18 @@ test('serializeOpenAIImagesEditsRequest preserves reference fields and encodes m
     ],
     mask: { file_id: 'file-mask' },
     model: 'gpt-image',
+  });
+});
+
+test('serializeOpenAIImagesEditsJsonPayload forces upload sources into data URLs', async () => {
+  const body = await serializeOpenAIImagesEditsJsonPayload({
+    images: [{ type: 'upload', file: new File(['image'], 'image.png', { type: 'image/png' }) }],
+    parameters: { prompt: 'edit' },
+  }, 'gpt-image-2');
+  assertEquals(body, {
+    prompt: 'edit',
+    images: [{ image_url: 'data:image/png;base64,aW1hZ2U=' }],
+    model: 'gpt-image-2',
   });
 });
 

--- a/packages/provider/src/images.ts
+++ b/packages/provider/src/images.ts
@@ -59,6 +59,11 @@ const jsonBody = async (request: ImagesEditsRequest): Promise<Record<string, unk
   };
 };
 
+export const serializeOpenAIImagesEditsJsonPayload = async (
+  request: ImagesEditsRequest,
+  model: string,
+): Promise<Record<string, unknown>> => ({ ...await jsonBody(request), model });
+
 const multipartBody = (request: ImagesEditsRequest, model: string): FormData | null => {
   const sources = [...request.images, ...(request.mask === undefined ? [] : [request.mask])];
   const compatibleSources = sources.every(source =>
@@ -89,5 +94,5 @@ const multipartBody = (request: ImagesEditsRequest, model: string): FormData | n
 export const serializeOpenAIImagesEditsRequest = async (request: ImagesEditsRequest, model: string): Promise<FormData | ReplayableBody> => {
   const multipart = multipartBody(request, model);
   if (multipart !== null) return multipart;
-  return jsonRequestBody({ ...await jsonBody(request), model });
+  return jsonRequestBody(await serializeOpenAIImagesEditsJsonPayload(request, model));
 };

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -60,7 +60,7 @@ export type {
 } from './provider.ts';
 export { headersForMessagesCall } from './messages.ts';
 export type { ImagesEditsRequest, ImagesEditsSource } from './images.ts';
-export { serializeOpenAIImagesEditsRequest } from './images.ts';
+export { serializeOpenAIImagesEditsJsonPayload, serializeOpenAIImagesEditsRequest } from './images.ts';
 export type { AudioTranscriptionFormEntry, AudioTranscriptionRequest } from './audio.ts';
 export { serializeModelPathAudioTranscriptionRequest, serializeOpenAIAudioTranscriptionRequest } from './audio.ts';
 export type { ProviderStreamParser } from './streaming.ts';


### PR DESCRIPTION
## Summary

- expose ChatGPT's implicit `gpt-image-2` capability as a Floway image model for every Codex account whose JWT plan is not explicitly `free`, matching CLIProxyAPI's fail-open eligibility rule
- forward image generations and edits to ChatGPT's provider-relative Codex image endpoints with OAuth refresh, account identity propagation, quota observation, and upstream response passthrough
- retain the latest explicit plan independently from access-token refresh order so missing claims and concurrent refreshes cannot stale the image capability decision
- publish the image model as `GPT-Image-2` with generation/edit endpoints and OpenAI's standard image-token pricing while keeping it out of the Codex chat-model picker
- document the fixed ChatGPT image capability alongside the live Codex chat catalog

## Evidence

- Codex hard-codes `gpt-image-2` outside `/codex/models`: https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/ext/image-generation/src/tool.rs#L51-L59
- Codex posts to provider-relative image endpoints: https://github.com/openai/codex/blob/646f7c0a91b8e327d263335da68ae8ef212895ce/codex-rs/codex-api/src/endpoint/images.rs#L33-L70
- CLIProxyAPI rejects only explicit Free plans and otherwise fails open: https://github.com/router-for-me/CLIProxyAPI/blob/2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e/internal/runtime/executor/codex_executor_request.go#L381-L449
- OpenAI standard image-token pricing: https://developers.openai.com/api/docs/pricing#image-generation

## Test Plan

- [x] Run `pnpm run verify` (540 test files, 5629 tests; 106 installer tests passed and 4 skipped)
- [x] Confirm all GitHub Verify jobs pass on the final head
- [x] Import a ChatGPT Team credential into a local Floway instance through the control plane and verify `GPT-Image-2` appears in `/v1/models`
- [x] Configure Codex 0.147.0 through Floway Agent Setup in an isolated `CODEX_HOME`
- [x] Generate a real image end to end through `gpt-5.6-sol` and `POST /azure-api.codex/images/generations`, receiving a 1254×1254 PNG and recorded `gpt-image-2` usage/pricing
