### PR TITLE
fix(codex): treat the request body as the canonical turn-metadata surface

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -9,7 +9,7 @@ import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS } from '../../../../src/data-plane/sh
 import { initDumpBroker, initDumpStore } from '../../../../src/dump/registry.ts';
 import { installDumpStubs } from '../../../dump/test-fixtures.ts';
 import { FakeTime } from '../../../test-time.ts';
-import { copilotModels, flushAsyncWork, setupAppTest, sseResponse, sseResponsesResponse } from '../../../test-utils/app.ts';
+import { buildCodexUpstreamRecord, codexModels, copilotModels, flushAsyncWork, setupAppTest, sseResponse, sseResponsesResponse } from '../../../test-utils/app.ts';
 import { installWorkerWebSocketRuntime, type TestWorkerWebSocket } from '../../../test-utils/worker-websocket.ts';
 import { assert, assertEquals, assertExists, assertStringIncludes, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
@@ -65,7 +65,7 @@ const terminalResponseId = (messages: readonly Record<string, unknown>[]): strin
   return id;
 };
 
-const connectResponsesWebSocket = async (apiKey: string): Promise<TestWorkerWebSocket> => {
+const connectResponsesWebSocket = async (apiKey: string, upgradeHeaders: Record<string, string> = {}): Promise<TestWorkerWebSocket> => {
   const executionCtx = {
     waitUntil: () => {},
     passThroughOnException: () => {},
@@ -76,6 +76,7 @@ const connectResponsesWebSocket = async (apiKey: string): Promise<TestWorkerWebS
     headers: {
       upgrade: 'websocket',
       'x-api-key': apiKey,
+      ...upgradeHeaders,
     },
   }), {}, executionCtx);
   assertEquals(response.status, 101);
@@ -1467,4 +1468,124 @@ test('Responses WebSocket outer catch records a failed perf sample attributed to
   } finally {
     generateSpy.mockRestore();
   }
+});
+
+test('Responses WebSocket dispatches each Codex turn with the metadata blob that turn carried', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  await repo.upstreams.save(buildCodexUpstreamRecord());
+  const upstreamBodies: Record<string, unknown>[] = [];
+
+  // The handshake carries the connection's first turn, exactly as the Codex
+  // client sends it. Every later turn arrives on the frame body alone, so a
+  // dispatch that re-reads these headers announces turn 1 forever.
+  const handshakeTurnMetadata = {
+    session_id: 'codex-session',
+    thread_id: 'codex-thread',
+    window_id: 'codex-thread:0',
+    turn_id: 'handshake-turn',
+    request_kind: 'turn',
+    turn_started_at_unix_ms: 1700000000000,
+  };
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') return jsonResponse(copilotModels([]));
+      if (url.pathname === '/backend-api/codex/models') return jsonResponse(codexModels([{ slug: 'gpt-5.4' }]));
+      if (url.pathname === '/backend-api/codex/responses') {
+        upstreamBodies.push(JSON.parse(await request.text()) as Record<string, unknown>);
+        const turn = upstreamBodies.length;
+        return sseResponsesResponse({
+          id: `resp_codex_ws_${turn}`,
+          object: 'response',
+          model: 'gpt-5.4',
+          status: 'completed',
+          output_text: `answer ${turn}`,
+          output: [{
+            id: `assistant_codex_ws_${turn}`,
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: `answer ${turn}`, annotations: [] }],
+          }],
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const socket = await connectResponsesWebSocket(apiKey.key, {
+        'session-id': 'codex-session',
+        'thread-id': 'codex-thread',
+        'x-codex-window-id': 'codex-thread:0',
+        'x-codex-turn-metadata': JSON.stringify(handshakeTurnMetadata),
+      });
+
+      const firstTerminal = waitForMessages(socket, messages => messages.some(isTerminalResponseEvent));
+      socket.send(JSON.stringify({
+        type: 'response.create',
+        response: {
+          model: 'gpt-5.4',
+          input: 'turn one input',
+          client_metadata: {
+            session_id: 'codex-session',
+            thread_id: 'codex-thread',
+            'x-codex-window-id': 'codex-thread:0',
+            turn_id: 'turn-1',
+            'x-codex-turn-metadata': JSON.stringify(handshakeTurnMetadata),
+          },
+        },
+      }));
+      await firstTerminal;
+
+      const secondTerminal = waitForMessages(socket, messages => messages.some(isTerminalResponseEvent));
+      socket.send(JSON.stringify({
+        type: 'response.create',
+        response: {
+          model: 'gpt-5.4',
+          input: [
+            { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'turn two input' }] },
+            { type: 'compaction_trigger' },
+          ],
+          client_metadata: {
+            session_id: 'codex-session',
+            thread_id: 'codex-thread',
+            // Codex advances the window on auto-compaction and the advanced
+            // value never reaches the handshake.
+            'x-codex-window-id': 'codex-thread:1',
+            turn_id: 'turn-2',
+            'x-codex-turn-metadata': JSON.stringify({
+              session_id: 'codex-session',
+              thread_id: 'codex-thread',
+              window_id: 'codex-thread:1',
+              turn_id: 'turn-2',
+              request_kind: 'compaction',
+              compaction: { trigger: 'auto', reason: 'context_limit', implementation: 'responses_compaction_v2', phase: 'standalone_turn', strategy: 'memento' },
+              turn_started_at_unix_ms: 1700000000002,
+            }),
+          },
+        },
+      }));
+      await secondTerminal;
+
+      assertEquals(upstreamBodies.length, 2);
+      const turnMetadataOf = (body: Record<string, unknown>): Record<string, unknown> =>
+        JSON.parse((body.client_metadata as Record<string, string>)['x-codex-turn-metadata']) as Record<string, unknown>;
+
+      const first = turnMetadataOf(upstreamBodies[0]);
+      assertEquals(first.request_kind, 'turn');
+      assertEquals(first.window_id, 'codex-thread:0');
+      assertEquals(first.turn_started_at_unix_ms, 1700000000000);
+
+      const second = turnMetadataOf(upstreamBodies[1]);
+      assertEquals(second.request_kind, 'compaction');
+      assertEquals(second.window_id, 'codex-thread:1');
+      assertEquals(second.turn_id, 'turn-2');
+      assertEquals(second.turn_started_at_unix_ms, 1700000000002);
+      assertEquals((upstreamBodies[1].client_metadata as Record<string, string>)['x-codex-window-id'], 'codex-thread:1');
+    }),
+  );
 });

--- a/packages/gateway/__tests__/test-utils/app.ts
+++ b/packages/gateway/__tests__/test-utils/app.ts
@@ -83,6 +83,55 @@ export const buildCopilotUpstreamRecord = (githubAccount: CopilotAccountFixture,
   };
 };
 
+export const buildCodexUpstreamRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => {
+  const config = {
+    accounts: [{ email: 'codex@example.com', chatgptAccountId: 'acc', chatgptUserId: 'usr', planType: 'plus' }],
+  };
+  const { config: overrideConfig, ...rest } = overrides;
+
+  return {
+    id: 'up_codex',
+    kind: 'codex',
+    name: 'Codex',
+    enabled: true,
+    sortOrder: 200,
+    createdAt: TEST_UPSTREAM_TIMESTAMP,
+    updatedAt: TEST_UPSTREAM_TIMESTAMP,
+    // A seeded access token keeps the OAuth refresh off the fetch mock's path.
+    state: {
+      accounts: [{
+        chatgptAccountId: 'acc',
+        refresh_token: 'rt_v1',
+        state: 'active',
+        state_updated_at: TEST_UPSTREAM_TIMESTAMP,
+        openaiDeviceId: '11111111-2222-4333-8444-555555555555',
+        accessToken: { token: 'codex-access-token', expiresAt: Date.parse('2100-01-01T00:00:00.000Z'), refreshedAt: TEST_UPSTREAM_TIMESTAMP },
+        quotaSnapshot: null,
+      }],
+    },
+    flagOverrides: {},
+    disabledPublicModelIds: [],
+    proxyFallbackList: MOCKED_FETCH_EGRESS,
+    modelPrefix: null,
+    modelsCache: null,
+    hue: 210,
+    ...rest,
+    config: overrideConfig ?? config,
+  };
+};
+
+export function codexModels(models: Array<{ slug: string; display_name?: string }>) {
+  return {
+    models: models.map(model => ({
+      slug: model.slug,
+      display_name: model.display_name ?? model.slug,
+      visibility: 'list',
+      context_window: 272000,
+      max_context_window: 1000000,
+    })),
+  };
+}
+
 export const buildCustomUpstreamRecord = (overrides: Partial<UpstreamRecord> = {}): UpstreamRecord => {
   const config = {
     baseUrl: 'https://custom.example.com',

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -615,6 +615,7 @@ describe('callCodexResponses — upstream classification', () => {
       body: {
         input: [], stream: true,
         client_metadata: {
+          session_id: 'body-session',
           'x-codex-window-id': 'thread-1:2',
           'x-codex-turn-metadata': JSON.stringify({
             window_id: 'thread-1:2',
@@ -627,7 +628,7 @@ describe('callCodexResponses — upstream classification', () => {
       // A WebSocket upgrade's headers are frozen for the life of the socket,
       // so they carry the connection's first turn, not this one.
       headers: new Headers({
-        'session-id': 'sess',
+        'session-id': 'header-session',
         'x-codex-window-id': 'thread-1:0',
         'x-codex-turn-metadata': JSON.stringify({
           window_id: 'thread-1:0',
@@ -644,6 +645,7 @@ describe('callCodexResponses — upstream classification', () => {
     expect(turnMetadata.request_kind).toBe('compaction');
     expect(turnMetadata.compaction).toEqual({ trigger: 'auto', reason: 'context_limit' });
     expect(turnMetadata.turn_started_at_unix_ms).toBe(1700000000002);
+    expect(turnMetadata.session_id).toBe('body-session');
     // The window advances on every auto-compaction and the advanced value
     // reaches us in the body alone.
     expect(turnMetadata.window_id).toBe('thread-1:2');
@@ -687,7 +689,7 @@ describe('callCodexResponses — upstream classification', () => {
       upstreamId, account: activeAccount, model,
       body: {
         input: [], stream: true,
-        client_metadata: { 'x-extra-key': 'caller-supplied', session_id: 'body-session' },
+        client_metadata: { 'x-extra-key': 'caller-supplied', session_id: '   ' },
       } as unknown as Parameters<typeof callCodexResponses>[0]['body'],
       headers: new Headers({ 'session-id': 'header-session' }),
       effects: makeEffects(),
@@ -698,13 +700,13 @@ describe('callCodexResponses — upstream classification', () => {
     const clientMetadata = body.client_metadata as Record<string, unknown>;
     // Non-identity extras pass through verbatim.
     expect(clientMetadata['x-extra-key']).toBe('caller-supplied');
-    // Identity-mirror keys come from identity, and identity reads the body
-    // before the header, so the three surfaces never disagree and a frozen
-    // handshake header never outranks the current turn.
-    expect(clientMetadata.session_id).toBe('body-session');
-    expect(clientMetadata.thread_id).toBe('body-session');
+    // A mirrored key identity could not absorb — a blank `session_id` resolves
+    // to nothing, so identity falls back to the header — still comes from
+    // identity instead of being spread over it.
+    expect(clientMetadata.session_id).toBe('header-session');
+    expect(clientMetadata.thread_id).toBe('header-session');
     const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
-    expect(headers.get('session-id')).toBe('body-session');
+    expect(headers.get('session-id')).toBe('header-session');
   });
 
   test('401 token_invalidated → persistTerminalState session_terminated, return 503', async () => {

--- a/packages/provider-codex/__tests__/fetch_test.ts
+++ b/packages/provider-codex/__tests__/fetch_test.ts
@@ -607,6 +607,79 @@ describe('callCodexResponses — upstream classification', () => {
     expect((body.client_metadata as Record<string, unknown>).turn_id).toBe('caller-turn');
   });
 
+  test('reads the turn-metadata blob from the body before the header', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    await callCodexResponses({
+      upstreamId, account: activeAccount, model,
+      body: {
+        input: [], stream: true,
+        client_metadata: {
+          'x-codex-window-id': 'thread-1:2',
+          'x-codex-turn-metadata': JSON.stringify({
+            window_id: 'thread-1:2',
+            request_kind: 'compaction',
+            compaction: { trigger: 'auto', reason: 'context_limit' },
+            turn_started_at_unix_ms: 1700000000002,
+          }),
+        },
+      } as unknown as Parameters<typeof callCodexResponses>[0]['body'],
+      // A WebSocket upgrade's headers are frozen for the life of the socket,
+      // so they carry the connection's first turn, not this one.
+      headers: new Headers({
+        'session-id': 'sess',
+        'x-codex-window-id': 'thread-1:0',
+        'x-codex-turn-metadata': JSON.stringify({
+          window_id: 'thread-1:0',
+          request_kind: 'turn',
+          turn_started_at_unix_ms: 1700000000000,
+        }),
+      }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    const turnMetadata = JSON.parse(headers.get('x-codex-turn-metadata') ?? 'null') as Record<string, unknown>;
+    expect(turnMetadata.request_kind).toBe('compaction');
+    expect(turnMetadata.compaction).toEqual({ trigger: 'auto', reason: 'context_limit' });
+    expect(turnMetadata.turn_started_at_unix_ms).toBe(1700000000002);
+    // The window advances on every auto-compaction and the advanced value
+    // reaches us in the body alone.
+    expect(turnMetadata.window_id).toBe('thread-1:2');
+    expect(headers.get('x-codex-window-id')).toBe('thread-1:2');
+  });
+
+  test('keeps the unbounded tool inventory in the body blob and out of the header blob', async () => {
+    seedFreshAccessToken();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
+    const toolNamespacesInfo = { namespaces: [{ name: 'shell', tools: ['exec'] }] };
+    await callCodexResponses({
+      upstreamId, account: activeAccount, model,
+      body: {
+        input: [], stream: true,
+        client_metadata: {
+          'x-codex-turn-metadata': JSON.stringify({ tool_namespaces_info: toolNamespacesInfo, thread_source: 'user' }),
+        },
+      } as unknown as Parameters<typeof callCodexResponses>[0]['body'],
+      headers: new Headers({ 'session-id': 'sess' }),
+      effects: makeEffects(),
+      call: noopUpstreamCallOptions(),
+    });
+
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    const headerMetadata = JSON.parse(headers.get('x-codex-turn-metadata') ?? 'null') as Record<string, unknown>;
+    expect(headerMetadata.tool_namespaces_info).toBeUndefined();
+    expect(headerMetadata.thread_source).toBe('user');
+
+    const body = await readJsonRequest(fetchSpy.mock.calls[0][1] as RequestInit) as Record<string, unknown>;
+    const bodyMetadata = JSON.parse(
+      (body.client_metadata as Record<string, string>)['x-codex-turn-metadata'],
+    ) as Record<string, unknown>;
+    expect(bodyMetadata.tool_namespaces_info).toEqual(toolNamespacesInfo);
+    expect(bodyMetadata.thread_source).toBe('user');
+  });
+
   test('preserves caller client_metadata extras while keeping identity-mirror keys gateway-owned', async () => {
     seedFreshAccessToken();
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(sseResponse());
@@ -614,9 +687,9 @@ describe('callCodexResponses — upstream classification', () => {
       upstreamId, account: activeAccount, model,
       body: {
         input: [], stream: true,
-        client_metadata: { 'x-extra-key': 'caller-supplied', session_id: 'caller-override' },
+        client_metadata: { 'x-extra-key': 'caller-supplied', session_id: 'body-session' },
       } as unknown as Parameters<typeof callCodexResponses>[0]['body'],
-      headers: new Headers({ 'session-id': 'sess' }),
+      headers: new Headers({ 'session-id': 'header-session' }),
       effects: makeEffects(),
       call: noopUpstreamCallOptions(),
     });
@@ -625,10 +698,13 @@ describe('callCodexResponses — upstream classification', () => {
     const clientMetadata = body.client_metadata as Record<string, unknown>;
     // Non-identity extras pass through verbatim.
     expect(clientMetadata['x-extra-key']).toBe('caller-supplied');
-    // Identity-mirror keys come from identity (header beats body), so the
-    // three surfaces never disagree.
-    expect(clientMetadata.session_id).toBe('sess');
-    expect(clientMetadata.thread_id).toBe('sess');
+    // Identity-mirror keys come from identity, and identity reads the body
+    // before the header, so the three surfaces never disagree and a frozen
+    // handshake header never outranks the current turn.
+    expect(clientMetadata.session_id).toBe('body-session');
+    expect(clientMetadata.thread_id).toBe('body-session');
+    const headers = new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get('session-id')).toBe('body-session');
   });
 
   test('401 token_invalidated → persistTerminalState session_terminated, return 503', async () => {

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -172,12 +172,13 @@ const parseClientTurnMetadataJson = (raw: string | null): Record<string, unknown
 // this snapshot, not separate sources of truth":
 // https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/responses_metadata.rs#L184-L189
 //
-// Only the body surfaces are rebuilt per turn. The WebSocket transport writes
-// its headers once, during the upgrade, and then carries many turns of
-// differing `request_kind` and `window_id` over that one socket without
-// reconnecting, so reading a header there yields the handshake's value for the
-// life of the connection. Resolve the body first and keep the header as the
-// fallback for callers that only speak the header projection.
+// Only the body surfaces are rebuilt per turn on every transport. The
+// WebSocket transport writes its headers once, during the upgrade, and then
+// carries many turns of differing `request_kind` and `window_id` over that one
+// socket without reconnecting, so reading a header there yields the
+// handshake's value for the life of the connection. Resolve the body first and
+// keep the header as the fallback for callers that only speak the header
+// projection.
 const callerTurnMetadata = (opts: CodexBackendCallBase, clientMetadata: Record<string, unknown>): Record<string, unknown> | null =>
   parseClientTurnMetadataJson(stringField(clientMetadata, 'x-codex-turn-metadata'))
     ?? parseClientTurnMetadataJson(trimHeader(opts.headers, 'x-codex-turn-metadata'));
@@ -221,6 +222,7 @@ const buildCodexRequestIdentity = (
   // send it as a header carrying the thread id, which is immutable for the
   // life of a connection anyway:
   // https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/codex-api/src/endpoint/responses.rs#L87-L91
+  // https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/client.rs#L1134-L1136
   const clientRequestId = trimHeader(opts.headers, 'x-client-request-id') ?? threadId;
   const installationId = stringField(clientMetadata, 'x-codex-installation-id')
     ?? stringField(clientTurnMetadata, 'installation_id')

--- a/packages/provider-codex/src/fetch.ts
+++ b/packages/provider-codex/src/fetch.ts
@@ -165,6 +165,23 @@ const parseClientTurnMetadataJson = (raw: string | null): Record<string, unknown
   }
 };
 
+// Codex owns one metadata snapshot per turn and projects it onto three
+// surfaces — the request headers, the body's flat `client_metadata` keys, and
+// the body's `client_metadata["x-codex-turn-metadata"]` blob — with the blob
+// declared canonical and the other two declared "compatibility projections of
+// this snapshot, not separate sources of truth":
+// https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/responses_metadata.rs#L184-L189
+//
+// Only the body surfaces are rebuilt per turn. The WebSocket transport writes
+// its headers once, during the upgrade, and then carries many turns of
+// differing `request_kind` and `window_id` over that one socket without
+// reconnecting, so reading a header there yields the handshake's value for the
+// life of the connection. Resolve the body first and keep the header as the
+// fallback for callers that only speak the header projection.
+const callerTurnMetadata = (opts: CodexBackendCallBase, clientMetadata: Record<string, unknown>): Record<string, unknown> | null =>
+  parseClientTurnMetadataJson(stringField(clientMetadata, 'x-codex-turn-metadata'))
+    ?? parseClientTurnMetadataJson(trimHeader(opts.headers, 'x-codex-turn-metadata'));
+
 // Identity-mirror keys live on `identity` and are projected onto every
 // surface (headers, body's `client_metadata`, body's `x-codex-turn-metadata`
 // blob). Drop them from caller spreads so a caller that supplies the same
@@ -184,27 +201,37 @@ const buildCodexRequestIdentity = (
   clientMetadata: Record<string, unknown>,
   clientTurnMetadata: Record<string, unknown> | null,
 ): CodexRequestIdentity => {
-  // Identity priority for every mirrored id: caller-supplied header → caller
-  // body `client_metadata` key → parsed `x-codex-turn-metadata` key → gateway
-  // default. So a caller can split its identity across surfaces and we still
-  // emit consistent values everywhere.
-  const sessionId = trimHeader(opts.headers, 'session-id')
-    ?? trimHeader(opts.headers, 'session_id')
-    ?? stringField(clientMetadata, 'session_id')
+  // Identity priority for every mirrored id follows the same per-turn rule as
+  // `callerTurnMetadata`: caller body `client_metadata` key → parsed
+  // `x-codex-turn-metadata` key → caller-supplied header → gateway default. So
+  // a caller can split its identity across surfaces and we still emit
+  // consistent values everywhere, and a long-lived socket's frozen handshake
+  // headers never outrank the current turn's body.
+  const sessionId = stringField(clientMetadata, 'session_id')
     ?? stringField(clientTurnMetadata, 'session_id')
+    ?? trimHeader(opts.headers, 'session-id')
+    ?? trimHeader(opts.headers, 'session_id')
     ?? deriveSessionIdFromInput(body)
     ?? uuidV7();
-  const threadId = trimHeader(opts.headers, 'thread-id')
-    ?? stringField(clientMetadata, 'thread_id')
+  const threadId = stringField(clientMetadata, 'thread_id')
     ?? stringField(clientTurnMetadata, 'thread_id')
+    ?? trimHeader(opts.headers, 'thread-id')
     ?? sessionId;
+  // Codex has no `client_metadata` counterpart for this one — both transports
+  // send it as a header carrying the thread id, which is immutable for the
+  // life of a connection anyway:
+  // https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/codex-api/src/endpoint/responses.rs#L87-L91
   const clientRequestId = trimHeader(opts.headers, 'x-client-request-id') ?? threadId;
   const installationId = stringField(clientMetadata, 'x-codex-installation-id')
     ?? stringField(clientTurnMetadata, 'installation_id')
     ?? opts.account.openaiDeviceId;
-  const windowId = trimHeader(opts.headers, 'x-codex-window-id')
-    ?? stringField(clientMetadata, 'x-codex-window-id')
+  // Codex advances the window on every auto-compaction — the id is
+  // `{thread_id}:{auto_compact_window_number}` — and a reused socket carries
+  // the advanced value in the frame body alone:
+  // https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/session/mod.rs#L3684-L3689
+  const windowId = stringField(clientMetadata, 'x-codex-window-id')
     ?? stringField(clientTurnMetadata, 'window_id')
+    ?? trimHeader(opts.headers, 'x-codex-window-id')
     ?? `${sessionId}:0`;
   const turnId = stringField(clientMetadata, 'turn_id')
     ?? stringField(clientTurnMetadata, 'turn_id')
@@ -267,12 +294,30 @@ const buildCodexTurnMetadata = (
   return base;
 };
 
+// The blob rides both the body and a header. Codex keeps the unbounded tool
+// inventory in the body copy only, "so HTTP and WebSocket compatibility
+// headers remain bounded":
+// https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/responses_metadata.rs#L291-L300
+const HEADER_OMITTED_TURN_METADATA_KEYS = new Set<string>(['tool_namespaces_info']);
+
+interface CodexTurnMetadataJson {
+  body: string;
+  header: string;
+}
+
 const buildCodexTurnMetadataJson = (
   identity: CodexRequestIdentity,
   options: CodexTurnMetadataOptions,
   clientOverrides: Record<string, unknown> | null,
-): string =>
-  JSON.stringify(buildCodexTurnMetadata(identity, options, clientOverrides));
+): CodexTurnMetadataJson => {
+  const turnMetadata = buildCodexTurnMetadata(identity, options, clientOverrides);
+  return {
+    body: JSON.stringify(turnMetadata),
+    header: JSON.stringify(Object.fromEntries(
+      Object.entries(turnMetadata).filter(([key]) => !HEADER_OMITTED_TURN_METADATA_KEYS.has(key)),
+    )),
+  };
+};
 
 const buildCodexClientMetadata = (identity: CodexRequestIdentity, turnMetadataJson: string): Record<string, string> => ({
   'x-codex-installation-id': identity.installationId,
@@ -399,8 +444,8 @@ const performStreamingResponsesCall = async (
   accessToken: string,
   alreadyRetried: boolean,
 ): Promise<ProviderStreamResult<ResponsesStreamEvent>> => {
-  const clientTurnMetadata = parseClientTurnMetadataJson(trimHeader(opts.headers, 'x-codex-turn-metadata'));
   const clientMetadata = clientCodexClientMetadata(opts.body);
+  const clientTurnMetadata = callerTurnMetadata(opts, clientMetadata);
   const identity = buildCodexRequestIdentity(opts, opts.body, clientMetadata, clientTurnMetadata);
   const metadata: CodexTurnMetadataOptions = opts.body.input.some(item => item.type === 'compaction_trigger') ? CODEX_RESPONSES_COMPACTION_V2_TURN_METADATA : { requestKind: 'turn' };
   const turnMetadataJson = buildCodexTurnMetadataJson(identity, metadata, clientTurnMetadata);
@@ -409,9 +454,9 @@ const performStreamingResponsesCall = async (
     accessToken,
     CODEX_RESPONSES_PATH,
     'text/event-stream',
-    buildCodexResponsesBody(opts, identity, turnMetadataJson),
+    buildCodexResponsesBody(opts, identity, turnMetadataJson.body),
     identity,
-    turnMetadataJson,
+    turnMetadataJson.header,
   ).then(ensureSseContentType);
 
   const result = await streamingProviderCall(upstreamFetch, parseResponsesStream, opts.model.id, opts.signal);
@@ -430,8 +475,8 @@ const performUnaryCompactCall = async (
   accessToken: string,
   alreadyRetried: boolean,
 ): Promise<ProviderCompactionResult> => {
-  const clientTurnMetadata = parseClientTurnMetadataJson(trimHeader(opts.headers, 'x-codex-turn-metadata'));
   const clientMetadata = clientCodexClientMetadata(opts.body);
+  const clientTurnMetadata = callerTurnMetadata(opts, clientMetadata);
   const identity = buildCodexRequestIdentity(opts, opts.body, clientMetadata, clientTurnMetadata);
   const metadata: CodexTurnMetadataOptions = { requestKind: 'compaction' };
   const turnMetadataJson = buildCodexTurnMetadataJson(identity, metadata, clientTurnMetadata);
@@ -442,7 +487,7 @@ const performUnaryCompactCall = async (
     'application/json',
     { ...opts.body, model: opts.model.id },
     identity,
-    turnMetadataJson,
+    turnMetadataJson.header,
   );
 
   if (response.status === 401 && !alreadyRetried) {


### PR DESCRIPTION
Fixes #455.

## Problem

The Responses WebSocket entry builds its event handlers once, during the upgrade, and they close over that one Hono `Context`. Every `response.create` frame afterwards re-derives its inbound headers from that frozen context, and the Codex provider read both `x-codex-turn-metadata` and `x-codex-window-id` from there. Codex reuses one socket across many turns, so every turn after the first was dispatched with the handshake's values.

It was not only a stale read. The blob's non-identity keys are merged **over** the values the gateway computes fresh for the current turn, so `request_kind` and `compaction` — derived from this turn's `compaction_trigger` input — were discarded in favour of the handshake's. A compaction turn was announced upstream as an ordinary turn, with `turn_started_at_unix_ms`, `sandbox`, `workspaces` and `parent_thread_id` replayed from connection time.

## Why the body is the canonical surface

Codex builds every metadata surface by projecting one per-turn snapshot, and says so:

> The full Codex turn metadata blob is transported canonically as `client_metadata["x-codex-turn-metadata"]`. Flat `client_metadata` keys and direct HTTP/ws headers are generated compatibility projections of this snapshot, not separate sources of truth.
>
> — [`responses_metadata.rs#L186-L189`](https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/responses_metadata.rs#L186-L189)

Only the body surfaces are rebuilt per turn on every transport:

- `client_metadata` is reassembled for every `response.create` frame ([`client.rs#L1702-L1711`](https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/client.rs#L1702-L1711)), including on the incremental-delta path — websocket reuse deliberately ignores metadata when deciding whether a frame can be a delta ([`client.rs#L305-L307`](https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/client.rs#L305-L307)).
- The handshake is written once and never revisited while the socket stays open ([`build_websocket_headers`](https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/client.rs#L1125-L1158)), yet `request_kind` varies frame to frame — upstream's own test asserts one handshake carrying a `prewarm` frame followed by a `turn` frame ([`agent_websocket.rs#L174-L206`](https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/tests/suite/agent_websocket.rs#L174-L206)).
- The window id is `{thread_id}:{auto_compact_window_number}` ([`session/mod.rs#L3684-L3689`](https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/session/mod.rs#L3684-L3689)) and every auto-compaction advances it without reconnecting, so the advanced value reaches us in the frame body alone.

## Change

`buildCodexRequestIdentity` and the blob parse resolve **body `client_metadata` → parsed blob → header → gateway default**, uniformly, instead of putting the header first for the blob and the window id. `x-client-request-id` keeps its header-only resolution because Codex has no body counterpart for it on either transport.

The outgoing blob is projected the way Codex projects it: full in the body, bounded in the header. Codex keeps the unbounded tool inventory out of the header copy on purpose — *"so HTTP and WebSocket compatibility headers remain bounded"* ([`responses_metadata.rs#L291-L300`](https://github.com/openai/codex/blob/a16863f8704831d13e041ed7dba2c4a57a2a940b/codex-rs/core/src/responses_metadata.rs#L291-L300)) — so parsing the header had been dropping `tool_namespaces_info` on every request, WebSocket or not.

The gateway's frozen `Context` is left alone deliberately: headers *are* connection-scoped on a WebSocket, so capturing them at the upgrade is accurate. The defect was reading a connection-scoped surface for turn-scoped truth.

## Test Plan

- [x] `pnpm run verify` on the branch synchronized with `main` — 540 test files, 5632 tests, all green
- [x] The WebSocket end-to-end test reproduces the report: reverting the provider to header-first resolution fails it with `expected 'turn' to deeply equal 'compaction'`
- [x] The identity-mirror assertion is load-bearing: removing the `IDENTITY_MIRRORED_CLIENT_METADATA_KEYS` filter fails it with `expected '   ' to be 'header-session'`
- [x] Every upstream claim in the new comments checked against `openai/codex` at `a16863f870`, with permalinks at the owning code
