### PR TITLE
fix(gateway): bill from the usage the chain normalized, not the wire it received

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/chat-completions/attempt_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/chat-completions/attempt_test.ts
@@ -316,3 +316,58 @@ test('generate propagates upstream response headers onto the EventResult so resp
   assertEquals(result.headers?.get('cf-ray'), 'cf_ray_cc');
   await collectEvents(result.events);
 });
+
+const makeUsageChunk = (usage: Record<string, unknown>): ChatCompletionsStreamEvent => ({
+  id: 'chatcmpl_test', object: 'chat.completion.chunk', created: 0, model: 'test-model',
+  choices: [],
+  usage: usage as unknown as ChatCompletionsStreamEvent['usage'],
+});
+
+const generateWithUsage = async (usage: Record<string, unknown>, enabledFlags: readonly FlagId[]) => {
+  installRepo();
+  const callChatCompletions = vi.fn(async (): Promise<ProviderStreamResult<ChatCompletionsStreamEvent>> => ({
+    ok: true,
+    events: makeProtocolFrames([...makeChatCompletionsEvents(), makeUsageChunk(usage)]),
+    modelKey: 'k',
+    headers: new Headers(),
+  }));
+  const result = await chatCompletionsAttempt.generate({
+    payload: makePayload(),
+    ctx: makeGatewayCtx(),
+    candidate: makeCandidate({ callChatCompletions, endpoints: { chatCompletions: {} }, enabledFlags: new Set(enabledFlags) }),
+    headers: new Headers(),
+  });
+  if (result.type !== 'events') throw new Error('unreachable');
+  await collectEvents(result.events);
+  return await result.finalMetadata;
+};
+
+test('generate bills a declared exclusive-cache upstream from its folded usage', async () => {
+  const metadata = await generateWithUsage({
+    prompt_tokens: 50,
+    completion_tokens: 7,
+    prompt_tokens_details: { cached_tokens: 5450 },
+  }, ['usage-exclusive-cached-tokens']);
+  assertEquals(metadata?.billableUsage, { input: 50, cacheRead: 5450, cacheWrite: 0, cacheWrite1h: 0, output: 7 });
+});
+
+test('generate bills from the folded usage when total_tokens witnesses the exclusive convention', async () => {
+  const metadata = await generateWithUsage({
+    prompt_tokens: 479,
+    completion_tokens: 373,
+    total_tokens: 14164,
+    prompt_tokens_details: { cached_tokens: 13312 },
+  }, []);
+  assertEquals(metadata?.billableUsage, { input: 479, cacheRead: 13312, cacheWrite: 0, cacheWrite1h: 0, output: 373 });
+});
+
+test('generate bills a vendor cache-hit count as a cache read rather than as input', async () => {
+  const metadata = await generateWithUsage({
+    prompt_tokens: 100,
+    completion_tokens: 5,
+    total_tokens: 105,
+    prompt_cache_hit_tokens: 60,
+    prompt_cache_miss_tokens: 40,
+  }, ['vendor-deepseek']);
+  assertEquals(metadata?.billableUsage, { input: 40, cacheRead: 60, cacheWrite: 0, cacheWrite1h: 0, output: 5 });
+});

--- a/packages/gateway/__tests__/data-plane/chat/responses/attempt_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/attempt_test.ts
@@ -662,3 +662,44 @@ test('generate propagates upstream response headers onto the EventResult so resp
   assertEquals(result.headers?.get('request-id'), 'req_resp_xyz');
   await collectEvents(result.events);
 });
+
+// An upstream that reports the cache buckets alongside `input_tokens` rather
+// than inside it is repaired on the inbound path; billing reads that repaired
+// figure rather than the wire the upstream sent. The total below sums neither
+// convention, which is exactly the case where the flag is what settles it.
+test('generate bills a declared exclusive-cache upstream from its folded usage', async () => {
+  installRepo();
+  const callResponses = vi.fn(async (): Promise<ProviderResponsesResult> => ({
+    action: 'generate',
+    ok: true,
+    events: makeProviderEvents([{
+      type: 'response.completed',
+      sequence_number: 0,
+      response: {
+        ...makeResponsesResult(),
+        usage: {
+          input_tokens: 50,
+          output_tokens: 7,
+          total_tokens: 5500,
+          input_tokens_details: { cached_tokens: 5450 },
+        },
+      },
+    }]),
+    modelKey: 'test-model-key',
+    headers: new Headers(),
+  }));
+
+  const result = await responsesAttempt.generate({
+    payload: makePayload(),
+    ctx: makeGatewayCtx(),
+    candidate: makeCandidate(callResponses, new Set<FlagId>(['usage-exclusive-cached-tokens'])),
+    headers: new Headers(),
+  });
+
+  assertEquals(result.type, 'events');
+  if (result.type !== 'events') throw new Error('unreachable');
+  await collectEvents(result.events);
+  assertEquals((await result.finalMetadata)?.billableUsage, {
+    input: 50, cacheRead: 5450, cacheWrite: 0, cacheWrite1h: 0, output: 7,
+  });
+});

--- a/packages/gateway/__tests__/data-plane/chat/shared/billable-usage-meter_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/shared/billable-usage-meter_test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from 'vitest';
+
+import { meteringBillableUsage } from '../../../../src/data-plane/chat/shared/billable-usage-meter.ts';
+import type { BillableUsage, ProtocolFrame } from '@floway-dev/protocols/common';
+import { eventResult, type ChatTargetApi, type EventResultMetadata, type ExecuteResult } from '@floway-dev/provider';
+import { testTelemetryModelIdentity } from '@floway-dev/test-utils';
+
+interface UsageEvent {
+  readonly type: string;
+  readonly usage?: BillableUsage;
+}
+
+const usage = (input: number, output: number): BillableUsage => ({ input, cacheRead: 0, cacheWrite: 0, cacheWrite1h: 0, output });
+
+const meter = meteringBillableUsage<{ targetApi: ChatTargetApi }, unknown, UsageEvent>(
+  'responses',
+  () => event => event.usage ?? null,
+);
+
+const meterOver = async (
+  events: AsyncIterable<ProtocolFrame<UsageEvent>>,
+  options: { targetApi?: ChatTargetApi; finalMetadata?: Promise<EventResultMetadata> } = {},
+): Promise<Extract<ExecuteResult<ProtocolFrame<UsageEvent>>, { type: 'events' }>> => {
+  const result = await meter({ targetApi: options.targetApi ?? 'responses' }, {}, () =>
+    Promise.resolve(eventResult(events, testTelemetryModelIdentity, {
+      ...(options.finalMetadata ? { finalMetadata: options.finalMetadata } : {}),
+    })));
+  if (result.type !== 'events') throw new Error(`expected events result, got ${result.type}`);
+  return result;
+};
+
+const framesOf = (...events: readonly UsageEvent[]): AsyncIterable<ProtocolFrame<UsageEvent>> => (async function* () {
+  for (const event of events) yield { type: 'event', event } as const;
+})();
+
+test('bills the last report carrying real counts', async () => {
+  const result = await meterOver(framesOf(
+    { type: 'response.created' },
+    { type: 'response.in_progress', usage: usage(7, 1) },
+    { type: 'response.completed', usage: usage(7, 3) },
+  ));
+  for await (const _ of result.events) { /* drain */ }
+  expect((await result.finalMetadata!).billableUsage).toEqual(usage(7, 3));
+});
+
+test('stands down when the chain translated into another protocol', async () => {
+  const result = await meterOver(framesOf({ type: 'response.completed', usage: usage(7, 3) }), { targetApi: 'chat-completions' });
+  for await (const _ of result.events) { /* drain */ }
+  expect(result.finalMetadata).toBe(undefined);
+});
+
+// A native compaction states its counts in the body rather than in a stream,
+// and a probe answered without dialing states that it has none. Neither is a
+// figure the meter may overwrite from synthesized frames.
+test('leaves an inner figure alone when the stream reports none', async () => {
+  const inner: EventResultMetadata = { modelIdentity: testTelemetryModelIdentity, billableUsage: usage(11, 5) };
+  const result = await meterOver(framesOf({ type: 'response.completed' }), { finalMetadata: Promise.resolve(inner) });
+  for await (const _ of result.events) { /* drain */ }
+  expect((await result.finalMetadata!).billableUsage).toEqual(usage(11, 5));
+});
+
+test('settles on cancellation, because a cancelled turn is billed like any other', async () => {
+  const result = await meterOver(framesOf(
+    { type: 'response.in_progress', usage: usage(7, 1) },
+    { type: 'response.completed', usage: usage(7, 3) },
+  ));
+  const iterator = result.events[Symbol.asyncIterator]();
+  await iterator.next();
+  await iterator.return!();
+  expect((await result.finalMetadata!).billableUsage).toEqual(usage(7, 1));
+});
+
+test('does not settle before the terminal usage frame is drained', async () => {
+  let releaseTerminal!: (frame: ProtocolFrame<UsageEvent>) => void;
+  const terminal = new Promise<ProtocolFrame<UsageEvent>>(resolve => { releaseTerminal = resolve; });
+  const result = await meterOver((async function* () {
+    yield { type: 'event', event: { type: 'response.created' } } as const;
+    yield await terminal;
+  })());
+
+  const iterator = result.events[Symbol.asyncIterator]();
+  await iterator.next();
+  let settled = false;
+  void result.finalMetadata!.then(() => { settled = true; });
+  await Promise.resolve();
+  expect(settled).toBe(false);
+
+  releaseTerminal({ type: 'event', event: { type: 'response.completed', usage: usage(7, 3) } });
+  await iterator.next();
+  await iterator.next();
+  expect((await result.finalMetadata!).billableUsage).toEqual(usage(7, 3));
+});

--- a/packages/gateway/__tests__/data-plane/chat/shared/provider-stream-result_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/shared/provider-stream-result_test.ts
@@ -32,7 +32,7 @@ describe('providerStreamResultToExecuteResult (first-output-token stamping)', ()
       { type: 'event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } } },
       { type: 'event', event: { type: 'content_block_delta', delta: { type: 'text_delta', text: ' there' } } },
     ];
-    const result = await providerStreamResultToExecuteResult(okStreamResult(iter(frames)), stubModelCandidate(), 'messages', ctx, () => null);
+    const result = await providerStreamResultToExecuteResult(okStreamResult(iter(frames)), stubModelCandidate(), 'messages', ctx);
     const collected = await drainEvents(result);
     expect(collected).toEqual(frames);
     expect(ctx.attempt.firstOutputTokenAt).not.toBe(null);
@@ -44,7 +44,7 @@ describe('providerStreamResultToExecuteResult (first-output-token stamping)', ()
       { type: 'event', event: { type: 'response.created' } },
       { type: 'event', event: { type: 'response.output_item.added' } },
     ];
-    const result = await providerStreamResultToExecuteResult(okStreamResult(iter(frames)), stubModelCandidate(), 'responses', ctx, () => null);
+    const result = await providerStreamResultToExecuteResult(okStreamResult(iter(frames)), stubModelCandidate(), 'responses', ctx);
     await drainEvents(result);
     expect(ctx.attempt.firstOutputTokenAt).toBe(null);
   });
@@ -56,7 +56,7 @@ describe('providerStreamResultToExecuteResult (first-output-token stamping)', ()
       { type: 'event', event: { choices: [{ delta: { content: 'b' } }] } },
       { type: 'event', event: { choices: [{ delta: { content: 'c' } }] } },
     ];
-    const result = await providerStreamResultToExecuteResult(okStreamResult(iter(frames)), stubModelCandidate(), 'chat-completions', ctx, () => null);
+    const result = await providerStreamResultToExecuteResult(okStreamResult(iter(frames)), stubModelCandidate(), 'chat-completions', ctx);
     if (result.type !== 'events') throw new Error(`expected events result, got ${result.type}`);
     const stampsAfterEachFrame: (number | null)[] = [];
     for await (const _ of result.events) stampsAfterEachFrame.push(ctx.attempt.firstOutputTokenAt);
@@ -66,38 +66,4 @@ describe('providerStreamResultToExecuteResult (first-output-token stamping)', ()
     expect(stampsAfterEachFrame[1]).toBe(stampsAfterEachFrame[0]);
     expect(stampsAfterEachFrame[2]).toBe(stampsAfterEachFrame[0]);
   });
-});
-
-test('client disconnect does not settle metadata before terminal usage is drained', async () => {
-  const terminalUsage = { input: 7, cacheRead: 0, cacheWrite: 0, cacheWrite1h: 0, output: 3 };
-  let releaseTerminal!: (frame: ProtocolFrame<{ type: string; usage?: typeof terminalUsage }>) => void;
-  const terminal = new Promise<ProtocolFrame<{ type: string; usage?: typeof terminalUsage }>>(resolve => { releaseTerminal = resolve; });
-  const events = (async function* () {
-    yield { type: 'event', event: { type: 'response.created' } } as const;
-    yield await terminal;
-  })();
-  const controller = new AbortController();
-  const ctx = mockGatewayCtx({ clientDisconnectSignal: controller.signal, clientDisconnectController: controller });
-  const result = await providerStreamResultToExecuteResult(
-    okStreamResult(events),
-    stubModelCandidate(),
-    'responses',
-    ctx,
-    event => event.usage ?? null,
-  );
-  expect(result.type).toBe('events');
-  if (result.type !== 'events') return;
-
-  const iterator = result.events[Symbol.asyncIterator]();
-  await iterator.next();
-  controller.abort();
-  let metadataSettled = false;
-  void result.finalMetadata!.then(() => { metadataSettled = true; });
-  await Promise.resolve();
-  expect(metadataSettled).toBe(false);
-
-  releaseTerminal({ type: 'event', event: { type: 'response.completed', usage: terminalUsage } });
-  await iterator.next();
-  await iterator.next();
-  expect((await result.finalMetadata!).billableUsage).toEqual(terminalUsage);
 });

--- a/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/attempt.ts
@@ -1,6 +1,5 @@
 import { chatCompletionsInterceptors } from './interceptors/index.ts';
 import type { ChatCompletionsInvocation } from './interceptors/types.ts';
-import { billableUsageFromChatCompletionsEvent } from './usage.ts';
 import { buildUpstreamCallOptions } from '../../shared/upstream-call-options.ts';
 import { messagesAttempt } from '../messages/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
@@ -49,7 +48,7 @@ export const chatCompletionsAttempt = {
           undefined,
           buildUpstreamCallOptions(candidate, ctx, invocation.headers),
         );
-        return await providerStreamResultToExecuteResult(providerResult, candidate, 'chat-completions', ctx, billableUsageFromChatCompletionsEvent);
+        return await providerStreamResultToExecuteResult(providerResult, candidate, 'chat-completions', ctx);
       }
       if (targetApi === 'messages') {
         return await traverseTranslation(

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/index.ts
@@ -1,6 +1,7 @@
 import { withRoleCompatibilityApplied } from './apply-role-compatibility.ts';
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
 import { withUsageStreamOptionsIncluded } from './include-usage-stream-options.ts';
+import { withBillableUsageMetered } from './meter-billable-usage.ts';
 import { withExclusiveCachedTokensNormalized } from './normalize-exclusive-cached-tokens.ts';
 import { withUsageNormalized } from './normalize-usage.ts';
 import { withPromptCacheKeyStripped } from './strip-prompt-cache-key.ts';
@@ -17,9 +18,13 @@ import { withVendorQwenChatCompletionsNormalize } from './vendor-qwen-normalize.
 // compatibility entry therefore acts only when Chat Completions is the final
 // target, after pairwise translation has finished.
 //
-//   - withUsageStreamOptionsIncluded, withUsageNormalized: unconditional.
-//     Both gate the gateway's usage-tracking pipeline. Turning either off
-//     would silently break per-key telemetry, so neither is surfaced as a flag.
+//   - withUsageStreamOptionsIncluded, withUsageNormalized, withBillableUsageMetered:
+//     unconditional. All three gate the gateway's usage-tracking pipeline.
+//     Turning any off would silently break per-key telemetry, so none is
+//     surfaced as a flag. The meter is registered FIRST so that on the inbound
+//     path it runs last, reading usage that every entry below it has already
+//     normalized; see `shared/billable-usage-meter.ts` for why that position
+//     is the billing figure's correctness condition rather than a preference.
 //   - withReasoningDisabledOnForcedToolChoice: gated by
 //     `disable-reasoning-on-forced-tool-choice`. Emits the gateway's canonical
 //     "no reasoning" sentinel only; vendor wire form is the vendor's job.
@@ -47,6 +52,7 @@ import { withVendorQwenChatCompletionsNormalize } from './vendor-qwen-normalize.
 //     are independent and run in declared order if more than one is somehow
 //     enabled.
 export const chatCompletionsInterceptors: readonly ChatCompletionsInterceptor[] = [
+  withBillableUsageMetered,
   withUsageStreamOptionsIncluded,
   withUsageNormalized,
   withReasoningDisabledOnForcedToolChoice,

--- a/packages/gateway/src/data-plane/chat/chat-completions/interceptors/meter-billable-usage.ts
+++ b/packages/gateway/src/data-plane/chat/chat-completions/interceptors/meter-billable-usage.ts
@@ -1,0 +1,8 @@
+import type { ChatCompletionsInterceptor } from './types.ts';
+import { meteringBillableUsage } from '../../shared/billable-usage-meter.ts';
+import { billableUsageFromChatCompletionsEvent } from '../usage.ts';
+
+export const withBillableUsageMetered: ChatCompletionsInterceptor = meteringBillableUsage(
+  'chat-completions',
+  () => billableUsageFromChatCompletionsEvent,
+);

--- a/packages/gateway/src/data-plane/chat/messages/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/messages/attempt.ts
@@ -1,6 +1,5 @@
 import { messagesInterceptors, messagesCountTokensInterceptors } from './interceptors/index.ts';
 import type { MessagesInvocation } from './interceptors/types.ts';
-import { createMessagesBillableUsageReader } from './usage.ts';
 import { buildUpstreamCallOptions } from '../../shared/upstream-call-options.ts';
 import { chatCompletionsAttempt } from '../chat-completions/attempt.ts';
 import { responsesAttempt } from '../responses/attempt.ts';
@@ -66,7 +65,7 @@ export const messagesAttempt = {
           undefined,
           buildMessagesUpstreamCallOptions(candidate, ctx, invocation.headers, anthropicBeta),
         );
-        return await providerStreamResultToExecuteResult(providerResult, candidate, targetApi, ctx, createMessagesBillableUsageReader());
+        return await providerStreamResultToExecuteResult(providerResult, candidate, targetApi, ctx);
       }
       if (targetApi === 'responses') {
         return await traverseTranslation(

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/index.ts
@@ -1,6 +1,7 @@
 import { answerClaudeCodeProbe } from './answer-claude-code-probe.ts';
 import { withRoleCompatibilityApplied } from './apply-role-compatibility.ts';
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
+import { withBillableUsageMetered } from './meter-billable-usage.ts';
 import { stripBillingAttribution } from './strip-billing-attribution.ts';
 import type { MessagesCountTokensInterceptor, MessagesInterceptor, MessagesPayloadInterceptor } from './types.ts';
 import { withMessagesWebSearchRequestPrepared, withMessagesWebSearchShim } from './web-search-shim.ts';
@@ -24,6 +25,11 @@ import { withMessagesWebSearchRequestPrepared, withMessagesWebSearchShim } from 
 //     carry Anthropic server tools); gated by `messages-web-search-shim` for
 //     native Messages targets. count_tokens runs the same request preparation
 //     without the stream-response wrapper.
+//   - withBillableUsageMetered: unconditional on a Messages target. Reads what
+//     each turn cost, below the probe so a turn that never dialed stays
+//     unbilled and below the web-search shim so each of its turns is metered
+//     separately — which is also what keeps the reader's cross-event merge
+//     scoped to one turn; see `shared/billable-usage-meter.ts`.
 //   - stripBillingAttribution: gated by `strip-billing-attribution` (default
 //     on for copilot/azure/custom, off for claude-code). On candidates
 //     where it runs, it scrubs Claude Code's `x-anthropic-billing-header` /
@@ -50,6 +56,7 @@ const messagesPayloadInterceptors: readonly MessagesPayloadInterceptor[] = [
 export const messagesInterceptors: readonly MessagesInterceptor[] = [
   answerClaudeCodeProbe,
   withMessagesWebSearchShim,
+  withBillableUsageMetered,
   ...messagesPayloadInterceptors,
 ];
 

--- a/packages/gateway/src/data-plane/chat/messages/interceptors/meter-billable-usage.ts
+++ b/packages/gateway/src/data-plane/chat/messages/interceptors/meter-billable-usage.ts
@@ -1,0 +1,8 @@
+import type { MessagesInterceptor } from './types.ts';
+import { meteringBillableUsage } from '../../shared/billable-usage-meter.ts';
+import { createMessagesBillableUsageReader } from '../usage.ts';
+
+export const withBillableUsageMetered: MessagesInterceptor = meteringBillableUsage(
+  'messages',
+  createMessagesBillableUsageReader,
+);

--- a/packages/gateway/src/data-plane/chat/responses/attempt.ts
+++ b/packages/gateway/src/data-plane/chat/responses/attempt.ts
@@ -4,7 +4,7 @@ import { responsesInterceptors } from './interceptors/index.ts';
 import type { ResponsesAttemptResult, ResponsesInvocation } from './interceptors/types.ts';
 import { normalizeAssistantInputText } from './items/normalize-assistant-content.ts';
 import { syntheticEventsFromCompaction } from './items/output.ts';
-import { billableUsageFromResponsesEvent, billableUsageFromResponsesResult } from './usage.ts';
+import { billableUsageFromResponsesResult } from './usage.ts';
 import { telemetryModelIdentity, upstreamPerformanceContext } from '../../shared/telemetry/attribution.ts';
 import { tokenUsageFromBillableUsage } from '../../shared/telemetry/usage.ts';
 import { buildUpstreamCallOptions } from '../../shared/upstream-call-options.ts';
@@ -225,7 +225,6 @@ const providerResponsesResultToExecuteResult = async (
       candidate,
       targetApi,
       ctx,
-      billableUsageFromResponsesEvent,
     );
   }
   const context = upstreamPerformanceContext(ctx, candidate, 'chat');

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/index.ts
@@ -1,6 +1,7 @@
 import { withRoleCompatibilityApplied } from './apply-role-compatibility.ts';
 import { withResponsesCompactShim } from './compact-shim.ts';
 import { withReasoningDisabledOnForcedToolChoice } from './disable-reasoning-on-forced-tool-choice.ts';
+import { withBillableUsageMetered } from './meter-billable-usage.ts';
 import { withExclusiveCachedTokensNormalized } from './normalize-exclusive-cached-tokens.ts';
 import { withResponsesServerToolShim } from './server-tool-shim.ts';
 import { imageGenerationServerTool } from './server-tools/image-generation.ts';
@@ -26,6 +27,11 @@ import { withVendorQwenResponsesNormalize } from './vendor-qwen-normalize.ts';
 //     items so the upstream sees the summarized history.
 //   - withResponsesServerToolShim: wraps the multi-turn ReAct loop around
 //     the rest of the chain.
+//   - withBillableUsageMetered: unconditional on a Responses target. Reads
+//     what each turn cost, below the two shims so every turn they compose is
+//     metered separately and above every entry that rewrites usage; see
+//     `shared/billable-usage-meter.ts` for why that position is the billing
+//     figure's correctness condition rather than a preference.
 //   - withReasoningDisabledOnForcedToolChoice: gated by
 //     `disable-reasoning-on-forced-tool-choice`.
 //   - withRoleCompatibilityApplied: applies role flags in the fixed order
@@ -51,6 +57,7 @@ export const responsesInterceptors: readonly ResponsesInterceptor[] = [
     webSearchServerTool,
     imageGenerationServerTool,
   ]),
+  withBillableUsageMetered,
   withReasoningDisabledOnForcedToolChoice,
   withRoleCompatibilityApplied,
   withPromptCacheKeyStripped,

--- a/packages/gateway/src/data-plane/chat/responses/interceptors/meter-billable-usage.ts
+++ b/packages/gateway/src/data-plane/chat/responses/interceptors/meter-billable-usage.ts
@@ -1,0 +1,8 @@
+import type { ResponsesInterceptor } from './types.ts';
+import { meteringBillableUsage } from '../../shared/billable-usage-meter.ts';
+import { billableUsageFromResponsesEvent } from '../usage.ts';
+
+export const withBillableUsageMetered: ResponsesInterceptor = meteringBillableUsage(
+  'responses',
+  () => billableUsageFromResponsesEvent,
+);

--- a/packages/gateway/src/data-plane/chat/shared/billable-usage-meter.ts
+++ b/packages/gateway/src/data-plane/chat/shared/billable-usage-meter.ts
@@ -1,0 +1,82 @@
+// Reads what an upstream turn cost off that turn's own event stream, as an
+// interceptor rather than at the terminal that calls the provider.
+//
+// The position is the whole point. An upstream's usage reaches us in the
+// dialect it happens to speak: DeepSeek states its cached prefix as
+// `prompt_cache_hit_tokens`, Kimi as a flat `cached_tokens`, and a gateway
+// fronting an Anthropic-shaped model reports the cache buckets alongside the
+// input total instead of inside it. The interceptors that repair all of this
+// — `vendor-<X>-normalize`, `normalize-exclusive-cached-tokens` — rewrite the
+// inbound stream, so a figure read below them is read from a dialect no
+// reader is written against: at best it under-counts the cache buckets and
+// bills them at the full input rate, at worst the split underflows and tears
+// the response down mid-stream.
+//
+// So the meter runs above every entry that rewrites usage, and below every
+// entry that owns turn composition or answers without an upstream:
+//
+//   - Below a multi-turn shim, so each of that shim's `run()` turns is
+//     metered on its own and the shim sums the turns it stitched. A meter
+//     above it would instead read the stitched stream, whose synthesized
+//     usage carries only what that shim chose to re-emit.
+//   - Below a short-circuiting entry, so a turn that never dialed an upstream
+//     keeps its absent metadata rather than being billed for zero tokens.
+//   - Per `run()`, which is also what makes a stateful reader correct: the
+//     Messages reader merges `message_start` and `message_delta` into one
+//     running figure and is scoped to a single turn.
+//
+// The contribution is merge-shaped: only `billableUsage` is written, so a
+// shim's latest-turn `modelIdentity` and `performance` survive, and a turn
+// that already stated its cost outside any stream — a native Responses
+// compaction, whose body carries the counts — keeps the figure it published.
+
+import { eventResultMetadata } from './respond.ts';
+import type { Interceptor } from '@floway-dev/interceptor';
+import type { BillableUsage, ProtocolFrame } from '@floway-dev/protocols/common';
+import type { ChatTargetApi, EventResultMetadata, ExecuteResult } from '@floway-dev/provider';
+
+export const meteringBillableUsage = <TInvocation extends { readonly targetApi: ChatTargetApi }, TEnv, TEvent>(
+  // The protocol this chain speaks natively. A translated request re-enters
+  // its target's chain, where that chain's own meter reads the upstream's own
+  // usage and `traverseTranslation` carries the figure back out; metering the
+  // translation here as well would double-count it.
+  nativeApi: ChatTargetApi,
+  createReader: () => (event: TEvent) => BillableUsage | null,
+): Interceptor<TInvocation, TEnv, ExecuteResult<ProtocolFrame<TEvent>>> => async (ctx, _env, run) => {
+  if (ctx.targetApi !== nativeApi) return await run();
+
+  const result = await run();
+  if (result.type !== 'events') return result;
+
+  const read = createReader();
+  // Only a report carrying real counts replaces the running figure, so a
+  // trailing empty usage frame cannot wipe a good one.
+  let billableUsage: BillableUsage | undefined;
+  let resolveFinal!: (metadata: EventResultMetadata) => void;
+  const finalMetadata = new Promise<EventResultMetadata>(resolve => { resolveFinal = resolve; });
+
+  return {
+    ...result,
+    finalMetadata,
+    events: (async function* () {
+      try {
+        for await (const frame of result.events) {
+          if (frame.type === 'event') {
+            const reported = read(frame.event);
+            if (reported !== null) billableUsage = reported;
+          }
+          yield frame;
+        }
+      } finally {
+        // Settles on cancellation too: `respond` returns at the terminal frame
+        // and closes the iterator rather than draining it, and that turn is
+        // billed like any other. The inner metadata has already settled by
+        // then — closing this generator closes the one it reads from first.
+        resolveFinal({
+          ...(await eventResultMetadata(result)),
+          ...(billableUsage !== undefined ? { billableUsage } : {}),
+        });
+      }
+    })(),
+  };
+};

--- a/packages/gateway/src/data-plane/chat/shared/provider-stream-result.ts
+++ b/packages/gateway/src/data-plane/chat/shared/provider-stream-result.ts
@@ -1,54 +1,35 @@
 import { isFirstOutputTokenFrame } from './first-output-token.ts';
 import type { GatewayCtx } from '../../shared/gateway-ctx.ts';
 import { telemetryModelIdentity, upstreamPerformanceContext } from '../../shared/telemetry/attribution.ts';
-import type { BillableUsage, ProtocolFrame } from '@floway-dev/protocols/common';
-import { eventResult, readUpstreamApiError, type ChatTargetApi, type EventResultMetadata, type ExecuteResult, type ModelCandidate, type ProviderStreamResult } from '@floway-dev/provider';
+import type { ProtocolFrame } from '@floway-dev/protocols/common';
+import { eventResult, readUpstreamApiError, type ChatTargetApi, type ExecuteResult, type ModelCandidate, type ProviderStreamResult } from '@floway-dev/provider';
 
+// Lowers a provider's stream into the chain's currency and stamps the
+// attribution that belongs to the call itself: which upstream model answered,
+// and when its first output token arrived. What the turn cost is not read
+// here — the usage on these frames is still in the upstream's own dialect,
+// and `meteringBillableUsage` reads it above the interceptors that normalize
+// it.
 export const providerStreamResultToExecuteResult = async <TEvent>(
   providerResult: ProviderStreamResult<TEvent>,
   candidate: ModelCandidate,
   targetApi: ChatTargetApi,
   ctx: GatewayCtx,
-  // Reads the upstream's own usage off one of its events, in the upstream's
-  // own protocol. This is the only place pricing figures are produced; nothing
-  // downstream re-derives them from the translated result the client receives.
-  readBillableUsage: (event: TEvent) => BillableUsage | null,
 ): Promise<ExecuteResult<ProtocolFrame<TEvent>>> => {
   const context = upstreamPerformanceContext(ctx, candidate, 'chat');
   if (!providerResult.ok) {
     return { ...(await readUpstreamApiError(providerResult.response, candidate.provider.upstreamId)), performance: context };
   }
-  const identity = telemetryModelIdentity(candidate, providerResult.modelKey);
-  let resolveFinal!: (metadata: EventResultMetadata) => void;
-  const finalMetadata = new Promise<EventResultMetadata>(resolve => { resolveFinal = resolve; });
-  // Only a report carrying real counts replaces the running figure, so a
-  // trailing empty usage frame cannot wipe a good one. Held outside the
-  // generator so final metadata can resolve after the transport drains the
-  // complete upstream stream.
-  let billableUsage: BillableUsage | undefined;
-  const settleMetadata = (): void => resolveFinal({
-    modelIdentity: identity,
-    ...(context !== undefined ? { performance: context } : {}),
-    ...(billableUsage !== undefined ? { billableUsage } : {}),
-  });
   const stampedEvents = (async function* () {
-    try {
-      for await (const frame of providerResult.events) {
-        if (ctx.attempt.firstOutputTokenAt === null && isFirstOutputTokenFrame(frame, targetApi)) {
-          ctx.attempt.firstOutputTokenAt = performance.now();
-        }
-        if (frame.type === 'event') {
-          const reported = readBillableUsage(frame.event);
-          if (reported !== null) billableUsage = reported;
-        }
-        yield frame;
+    for await (const frame of providerResult.events) {
+      if (ctx.attempt.firstOutputTokenAt === null && isFirstOutputTokenFrame(frame, targetApi)) {
+        ctx.attempt.firstOutputTokenAt = performance.now();
       }
-    } finally {
-      settleMetadata();
+      yield frame;
     }
   })();
-  return {
-    ...eventResult(stampedEvents, identity, { performance: context, headers: providerResult.headers }),
-    finalMetadata,
-  };
+  return eventResult(stampedEvents, telemetryModelIdentity(candidate, providerResult.modelKey), {
+    performance: context,
+    headers: providerResult.headers,
+  });
 };


### PR DESCRIPTION
## The report

A Chat Completions upstream that reports its cache buckets alongside `prompt_tokens` instead of inside it tears the stream down mid-response:

```
RangeError: cache token counts exceed inclusive input tokens: 50 - 5450 - 0
    at splitInclusiveInputTokens (packages/protocols/src/common/usage.ts:99)
    at billableUsageFromChatCompletionsUsage (…/chat-completions/usage.ts:13)
    at …/shared/provider-stream-result.ts:41
    at async …/interceptors/normalize-exclusive-cached-tokens.ts:87
```

`usage-exclusive-cached-tokens` was enabled for that upstream, and made no difference.

## Root cause

The flag was doing its job; nothing was reading the result.

Billable usage was read at the terminal that calls the provider — the innermost point of the interceptor chain. Every inbound rewrite sits *above* that point, so no rewrite could ever reach the figure. `withExclusiveCachedTokensNormalized` folded the cache buckets back into `prompt_tokens` for the wire the client sees, while the billing read went on looking at the upstream's raw counts, where the split underflows. The stack above shows exactly this: the frame at `normalize-exclusive-cached-tokens.ts:87` is that interceptor *pulling from* the inner generator that throws.

The interceptor's own test passed throughout — its fake `run()` returns a stream with no billing read in it.

The same blindness hid a second defect, silent rather than fatal: the vendor normalizers remap DeepSeek's `prompt_cache_hit_tokens` and Kimi's flat `cached_tokens` into OpenAI's names on that same inbound path, so **every vendor-dialect cache hit was billed as uncached input at the full input rate** (`cacheRead: 0`).

## The fix

Metering becomes an interceptor, `meteringBillableUsage`, positioned above every entry that rewrites usage and below every entry that composes turns or answers without dialing an upstream:

- **chat-completions** — outermost.
- **responses** — below the compact and server-tool shims, so each turn the ReAct loop composes is metered on its own. Metering above the shim would instead read its stitched stream, whose synthesized usage drops `cache_write_tokens` and carries turn 1's `service_tier` on a multi-turn sum.
- **messages** — below the Claude Code probe, so a turn that never dialed stays unbilled instead of recording a zero-token row, and below the web-search shim, which also keeps the reader's `message_start` / `message_delta` merge scoped to one turn (that merge is last-write-wins, not additive).

The contribution is merge-shaped — only `billableUsage` is written — so a shim's latest-turn `modelIdentity` / `performance` survive, and a native Responses compaction keeps the figure its body stated.

`providerStreamResultToExecuteResult` loses its reader parameter and now stamps only model identity and first-output-token timing. That is what keeps the class from recurring: the seam below the normalizers no longer has the means to produce a billing figure at all.

## Tests

`billable-usage-meter_test.ts` covers the meter itself: last real reading wins, stand-down on a translated target, no clobbering of an inner figure, settlement on cancellation, and no settlement before the terminal usage frame (that last one moved over from `provider-stream-result_test.ts`, where it had been asserting the old seam).

Three end-to-end regressions run through the real chains — flag-declared exclusive counts, `total_tokens` witnessing the exclusive convention on its own, and a DeepSeek cache-hit count. Before this change the first two crashed and the third silently reported `input: 100, cacheRead: 0` where `input: 40, cacheRead: 60` was owed.

## Note for operators

Historical `usage` rows for vendor-dialect upstreams undercount cache reads and overcount input. Repricing cannot correct them — the recorded quantities, not the rates, are what is wrong.
