### PR TITLE
fix(gateway): keep the Responses WebSocket session alive through an interrupted turn

### DIFF
--- a/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/responses/websocket_test.ts
@@ -7,9 +7,11 @@ import { responsesServe } from '../../../../src/data-plane/chat/responses/serve.
 import { KEEP_ALIVE_EVENT_TYPE } from '../../../../src/data-plane/chat/responses/websocket.ts';
 import { DOWNSTREAM_KEEP_ALIVE_INTERVAL_MS } from '../../../../src/data-plane/shared/sse.ts';
 import { initDumpBroker, initDumpStore } from '../../../../src/dump/registry.ts';
+import { initBackgroundSchedulerResolver } from '../../../../src/runtime/background.ts';
 import { installDumpStubs } from '../../../dump/test-fixtures.ts';
 import { FakeTime } from '../../../test-time.ts';
 import { buildCodexUpstreamRecord, codexModels, copilotModels, flushAsyncWork, setupAppTest, sseResponse, sseResponsesResponse } from '../../../test-utils/app.ts';
+import { trackBackground } from '../../../test-utils/background-tracker.ts';
 import { installWorkerWebSocketRuntime, type TestWorkerWebSocket } from '../../../test-utils/worker-websocket.ts';
 import { assert, assertEquals, assertExists, assertStringIncludes, jsonResponse, withMockedFetch } from '@floway-dev/test-utils';
 
@@ -85,6 +87,30 @@ const connectResponsesWebSocket = async (apiKey: string, upgradeHeaders: Record<
   const pair = runtime.pairs.at(-1);
   assertExists(pair);
   return pair.client;
+};
+
+// The upgrade registers exactly one runtime background task: the session
+// lifetime promise, which resolves once the socket is closed and every
+// session-scoped write has drained. Capturing it lets a test observe the
+// instant the runtime would be free to evict the isolate — on Cloudflare
+// that is the deadline every session-scoped write has to beat.
+const connectResponsesWebSocketCapturingSessionLifetime = async (
+  apiKey: string,
+): Promise<{ client: TestWorkerWebSocket; sessionLifetime: Promise<unknown> }> => {
+  const registered: Promise<unknown>[] = [];
+  initBackgroundSchedulerResolver(_c => promise => {
+    registered.push(Promise.resolve(promise));
+    trackBackground(promise);
+  });
+  try {
+    const client = await connectResponsesWebSocket(apiKey);
+    assertEquals(registered.length, 1, 'expected the upgrade to register exactly one background task');
+    const sessionLifetime = registered[0];
+    assertExists(sessionLifetime);
+    return { client, sessionLifetime };
+  } finally {
+    initBackgroundSchedulerResolver(_c => trackBackground);
+  }
 };
 
 let currentRuntime: ReturnType<typeof installWorkerWebSocketRuntime> | undefined;
@@ -1362,6 +1388,88 @@ test('Responses WebSocket aborts the in-flight Responses request when the client
       await responsesStarted;
       client.close();
       await upstreamAborted;
+    }),
+  );
+});
+
+// A turn schedules its dump and usage writes from its terminal `finally`, so
+// nothing of its own sits in the session's pending set while it streams. The
+// session lifetime therefore has to hold the in-flight message chain itself:
+// a client that closes mid-turn otherwise finds that set empty at the exact
+// moment the close resolves `sessionClosed`, and the lifetime would resolve —
+// freeing Cloudflare to evict the isolate — before the interrupted turn had
+// recorded anything.
+test('Responses WebSocket holds the session lifetime open until a turn the client interrupted has recorded its dump', async () => {
+  const { apiKey, repo } = await setupAppTest();
+  await repo.apiKeys.save({ ...apiKey, dumpRetentionSeconds: 3600 });
+  const dumps = installDumpStubs(initDumpStore, initDumpBroker);
+  const encoder = new TextEncoder();
+  let resolveUpstreamReadStarted!: () => void;
+  const upstreamReadStarted = new Promise<void>(resolve => {
+    resolveUpstreamReadStarted = resolve;
+  });
+
+  await withMockedFetch(
+    async request => {
+      const url = new URL(request.url);
+      if (url.hostname === 'update.code.visualstudio.com') return jsonResponse(['1.110.1']);
+      if (url.pathname === '/copilot_internal/v2/token') {
+        return jsonResponse({ token: 'copilot-access-token', expires_at: 4102444800, refresh_in: 3600, endpoints: { api: 'https://api.individual.githubcopilot.com' } });
+      }
+      if (url.pathname === '/models') {
+        return jsonResponse(copilotModels([{ id: 'gpt-direct-responses', supported_endpoints: ['/responses'] }]));
+      }
+      if (url.pathname === '/responses') {
+        return new Response(new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(`event: response.created\ndata: ${JSON.stringify({
+              type: 'response.created',
+              response: {
+                id: 'resp_ws_lifetime',
+                object: 'response',
+                model: 'gpt-direct-responses',
+                status: 'in_progress',
+                output: [],
+                output_text: '',
+              },
+              sequence_number: 0,
+            })}\n\n`));
+            // The turn never reaches a terminal event. The client's close
+            // reaches this body through the request signal, which is how a
+            // real streaming upstream is torn down mid-flight.
+            request.signal.addEventListener('abort', () => {
+              controller.error(request.signal.reason);
+            }, { once: true });
+          },
+          pull() {
+            resolveUpstreamReadStarted();
+          },
+        }), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }
+      throw new Error(`Unhandled fetch ${request.url}`);
+    },
+    async () => await withWorkerWebSocketRuntime(async () => {
+      const { client, sessionLifetime } = await connectResponsesWebSocketCapturingSessionLifetime(apiKey.key);
+      client.send(JSON.stringify({
+        type: 'response.create',
+        event_id: 'evt_ws_lifetime',
+        response: {
+          model: 'gpt-direct-responses',
+          input: 'hello',
+        },
+      }));
+
+      await waitForMessages(client, messages => messages.length >= 1);
+      await upstreamReadStarted;
+      client.close();
+
+      await sessionLifetime;
+      // Sampled at the instant the runtime would be free to drop the isolate,
+      // deliberately without flushing background work first: the interrupted
+      // turn's dump has to be stored by then, not merely scheduled.
+      assertEquals(dumps.stored.length, 1);
     }),
   );
 });

--- a/packages/gateway/src/data-plane/chat/responses/websocket.ts
+++ b/packages/gateway/src/data-plane/chat/responses/websocket.ts
@@ -140,6 +140,15 @@ const createResponsesWebSocketEvents = (c: AuthedContext): ResponsesWebSocketHan
   // `sessionClosed` resolves. The loop keeps going until the Set is
   // genuinely empty, which is bounded because `closed = true` short-
   // circuits future message handlers at the top of `handleClientMessage`.
+  //
+  // That loop only ever runs while the Set is non-empty, which is why the
+  // message chain itself is tracked as session work in `onMessage`. A turn
+  // schedules nothing until its terminal `finally` — dump.finalize and
+  // settle are the only background work it produces, and both come after an
+  // `await` there — so a client closing mid-turn finds the Set empty at the
+  // exact moment `sessionClosed` resolves, and the drain would fall through
+  // before the turn recorded anything. Holding the chain keeps the lifetime
+  // open until the handler has unwound and its records are in the Set.
   const pendingWork = new Set<Promise<unknown>>();
   let sessionClosedResolve: (() => void) | undefined;
   const sessionClosed = new Promise<void>(resolve => { sessionClosedResolve = resolve; });
@@ -183,6 +192,7 @@ const createResponsesWebSocketEvents = (c: AuthedContext): ResponsesWebSocketHan
         .catch(error => {
           if (!closed) sendError(socket, 500, serverErrorEnvelope(error));
         });
+      sessionScheduler(queue);
     },
   };
 };


### PR DESCRIPTION
The session lifetime promise registered at upgrade is what keeps a Cloudflare isolate alive for a socket whose per-message work can no longer reach `executionCtx.waitUntil`. It resolves once the socket is closed and `pendingWork` has drained, and the drain only ever runs while that set is non-empty.

A turn puts nothing of its own in the set while it streams: `dump.finalize` and `settle` are the only background work it produces, and both are issued from its terminal `finally`, behind an `await`. So a client that closes mid-turn leaves the set empty at the exact moment the close resolves `sessionClosed`, the drain falls straight through, and the interrupted turn's dump and usage records are written into an isolate the runtime is already free to evict.

Tracking the message chain itself as session work holds the lifetime until the handler has unwound and its records are in the set, where the existing loop drains them. This stays bounded: `closed = true` short-circuits every later handler at the top of `handleClientMessage`.

Node is unaffected either way — its scheduler does not depend on `waitUntil`, and the event loop runs the writes to completion.

This restores one line that #409 introduced and #473 reverted along with the client-disconnect retention it shipped in. The defect is independent of that retention: it is about when the session lifetime is allowed to resolve, not about how long an upstream is read.

## Test Plan

- [x] `pnpm run verify` — 542 test files, 5645 tests, all passing
- [x] The new test fails without the fix: with the one line removed it reports `dumps.stored.length` as `0` at the instant the lifetime promise resolves, and passes with it restored