### PR TITLE
feat(web): add an in-page language selector

### DIFF
--- a/apps/web/__tests__/components/language-selector_test.tsx
+++ b/apps/web/__tests__/components/language-selector_test.tsx
@@ -14,14 +14,12 @@ describe('LanguageSelector', () => {
     await setLanguage('en');
 
     renderInApp(<LanguageSelector />);
-    const button = screen.getByRole('combobox', { name: 'Language' });
-    expect(button.textContent).toContain('English');
+    const button = screen.getByRole('button', { name: 'Language' });
 
     fireEvent.click(button);
-    fireEvent.click(await screen.findByRole('option', { name: '简体中文' }));
+    fireEvent.click(await screen.findByRole('menuitemradio', { name: '简体中文' }));
 
     await waitFor(() => expect(i18n.language).toBe('zh-Hans'));
-    expect(button.textContent).toContain('简体中文');
     await waitFor(() => expect(storage.get(flowayLanguageStorageKey)).toBe('zh-Hans'));
   });
 });

--- a/apps/web/__tests__/components/language-selector_test.tsx
+++ b/apps/web/__tests__/components/language-selector_test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LanguageSelector } from '../../src/components/language-selector';
+import { i18n, setLanguage } from '../../src/i18n';
+import { stubLocalStorage } from '../local-storage-stub';
+import { renderInApp } from '../render';
+
+describe('LanguageSelector', () => {
+  const storage = stubLocalStorage();
+
+  it('switches the dashboard language and remembers the choice', async () => {
+    await setLanguage('en');
+
+    renderInApp(<LanguageSelector />);
+    const button = screen.getByRole('combobox', { name: 'Language' });
+    expect(button.textContent).toContain('English');
+
+    fireEvent.click(button);
+    fireEvent.click(await screen.findByRole('option', { name: '简体中文' }));
+
+    await waitFor(() => expect(i18n.language).toBe('zh-Hans'));
+    expect(button.textContent).toContain('简体中文');
+    await waitFor(() => expect(storage.get('floway-language')).toBe('zh-Hans'));
+  });
+});

--- a/apps/web/__tests__/components/language-selector_test.tsx
+++ b/apps/web/__tests__/components/language-selector_test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { LanguageSelector } from '../../src/components/language-selector';
 import { i18n, setLanguage } from '../../src/i18n';
+import { flowayLanguageStorageKey } from '../../src/i18n/language-preference';
 import { stubLocalStorage } from '../local-storage-stub';
 import { renderInApp } from '../render';
 
@@ -21,6 +22,6 @@ describe('LanguageSelector', () => {
 
     await waitFor(() => expect(i18n.language).toBe('zh-Hans'));
     expect(button.textContent).toContain('简体中文');
-    await waitFor(() => expect(storage.get('floway-language')).toBe('zh-Hans'));
+    await waitFor(() => expect(storage.get(flowayLanguageStorageKey)).toBe('zh-Hans'));
   });
 });

--- a/apps/web/__tests__/components/requests/dump-subscription-language-change_test.tsx
+++ b/apps/web/__tests__/components/requests/dump-subscription-language-change_test.tsx
@@ -45,7 +45,7 @@ describe('dump subscription language change', () => {
     expect(stream.liveSource()).toBe(live);
   });
 
-  // BrowserLanguageSync applies the visitor's language once the tree is
+  // LanguageSync applies the visitor's language once the tree is
   // mounted, and i18next announces the change whether or not the language it
   // lands on differs from the one it booted in.
   it('keeps the stream open when boot re-applies the language it already has', async () => {

--- a/apps/web/__tests__/i18n/language_preference_test.ts
+++ b/apps/web/__tests__/i18n/language_preference_test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clearStoredLanguage,
+  flowayLanguageStorageKey,
+  storeLanguage,
+  storedLanguage,
+} from '../../src/i18n/language-preference';
+import { stubLocalStorage } from '../local-storage-stub';
+
+describe('language preference', () => {
+  const storage = stubLocalStorage();
+
+  it('has no preference by default', () => {
+    expect(storedLanguage()).toBeNull();
+  });
+
+  it('round-trips a supported language', () => {
+    storeLanguage('zh-Hans');
+
+    expect(storage.get(flowayLanguageStorageKey)).toBe('zh-Hans');
+    expect(storedLanguage()).toBe('zh-Hans');
+  });
+
+  it('ignores an unsupported stored language', () => {
+    storage.set(flowayLanguageStorageKey, 'ko-KR');
+
+    expect(storedLanguage()).toBeNull();
+  });
+
+  it('clears a stored language', () => {
+    storeLanguage('en');
+    clearStoredLanguage();
+
+    expect(storedLanguage()).toBeNull();
+  });
+});

--- a/apps/web/src/components/language-selector.tsx
+++ b/apps/web/src/components/language-selector.tsx
@@ -19,10 +19,13 @@ export function LanguageSelector({ className }: { className?: string }) {
   const { i18n, t } = useTranslation();
   const currentLanguage = normalizeLanguage(i18n.language) ?? defaultLanguage;
 
-  const selectLanguage = (next: SupportedLanguage) => {
-    void setLanguage(next)
-      .then(() => storeLanguage(next))
-      .catch(() => undefined);
+  const selectLanguage = async (next: SupportedLanguage) => {
+    try {
+      await setLanguage(next);
+      storeLanguage(next);
+    } catch {
+      // The locale chunk could not be fetched; keep the current language.
+    }
   };
 
   return (
@@ -31,7 +34,7 @@ export function LanguageSelector({ className }: { className?: string }) {
       className={className}
       onOptionSelect={(_, data) => {
         const next = normalizeLanguage(data.optionValue);
-        if (next) selectLanguage(next);
+        if (next) void selectLanguage(next);
       }}
       selectedOptions={[currentLanguage]}
       value={languageNames[currentLanguage]}

--- a/apps/web/src/components/language-selector.tsx
+++ b/apps/web/src/components/language-selector.tsx
@@ -1,11 +1,20 @@
+import type { MenuCheckedValueChangeData } from '@fluentui/react-components';
+import { GlobeRegular } from '@fluentui/react-icons';
+
 import { fluentComponents } from '../fluent';
 import { setLanguage } from '../i18n';
 import { storeLanguage } from '../i18n/language-preference';
 import { defaultLanguage, normalizeLanguage, supportedLanguages, type SupportedLanguage } from '../i18n/languages';
 import { useTranslation } from '../i18n/translation';
-import { Dropdown } from './ui/fluent-form-controls';
 
-const { Option } = fluentComponents;
+const {
+  Button,
+  Menu,
+  MenuItemRadio,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+} = fluentComponents;
 
 // The languages are named in themselves, the way a native reader knows them; a
 // translated label would tell a reader about their own language in someone
@@ -28,22 +37,33 @@ export function LanguageSelector({ className }: { className?: string }) {
     }
   };
 
+  const onCheckedValueChange = (
+    _e: unknown,
+    data: Pick<MenuCheckedValueChangeData, 'checkedItems'>,
+  ) => {
+    const next = normalizeLanguage(data.checkedItems?.[0]);
+    if (next) void selectLanguage(next);
+  };
+
   return (
-    <Dropdown
-      aria-label={t('common.language')}
-      className={className}
-      onOptionSelect={(_, data) => {
-        const next = normalizeLanguage(data.optionValue);
-        if (next) void selectLanguage(next);
-      }}
-      selectedOptions={[currentLanguage]}
-      value={languageNames[currentLanguage]}
-    >
-      {supportedLanguages.map(language => (
-        <Option key={language} value={language}>
-          {languageNames[language]}
-        </Option>
-      ))}
-    </Dropdown>
+    <Menu checkedValues={{ language: [currentLanguage] }} onCheckedValueChange={onCheckedValueChange}>
+      <MenuTrigger disableButtonEnhancement>
+        <Button
+          appearance="subtle"
+          aria-label={t('common.language')}
+          className={className}
+          icon={<GlobeRegular />}
+        />
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          {supportedLanguages.map(language => (
+            <MenuItemRadio key={language} name="language" value={language}>
+              {languageNames[language]}
+            </MenuItemRadio>
+          ))}
+        </MenuList>
+      </MenuPopover>
+    </Menu>
   );
 }

--- a/apps/web/src/components/language-selector.tsx
+++ b/apps/web/src/components/language-selector.tsx
@@ -1,0 +1,46 @@
+import { fluentComponents } from '../fluent';
+import { setLanguage } from '../i18n';
+import { storeLanguage } from '../i18n/language-preference';
+import { defaultLanguage, normalizeLanguage, supportedLanguages, type SupportedLanguage } from '../i18n/languages';
+import { useTranslation } from '../i18n/translation';
+import { Dropdown } from './ui/fluent-form-controls';
+
+const { Option } = fluentComponents;
+
+// The languages are named in themselves, the way a native reader knows them; a
+// translated label would tell a reader about their own language in someone
+// else's. The control's accessible name is the one translated string here.
+const languageNames: Record<SupportedLanguage, string> = {
+  'en': 'English',
+  'zh-Hans': '简体中文',
+};
+
+export function LanguageSelector({ className }: { className?: string }) {
+  const { i18n, t } = useTranslation();
+  const currentLanguage = normalizeLanguage(i18n.language) ?? defaultLanguage;
+
+  const selectLanguage = (next: SupportedLanguage) => {
+    void setLanguage(next)
+      .then(() => storeLanguage(next))
+      .catch(() => undefined);
+  };
+
+  return (
+    <Dropdown
+      aria-label={t('common.language')}
+      className={className}
+      onOptionSelect={(_, data) => {
+        const next = normalizeLanguage(data.optionValue);
+        if (next) selectLanguage(next);
+      }}
+      selectedOptions={[currentLanguage]}
+      value={languageNames[currentLanguage]}
+    >
+      {supportedLanguages.map(language => (
+        <Option key={language} value={language}>
+          {languageNames[language]}
+        </Option>
+      ))}
+    </Dropdown>
+  );
+}

--- a/apps/web/src/components/language-sync.tsx
+++ b/apps/web/src/components/language-sync.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 
 import { setLanguage } from '../i18n';
+import { storedLanguage } from '../i18n/language-preference';
 import { browserLanguage } from '../i18n/languages';
 
-export function BrowserLanguageSync() {
+export function LanguageSync() {
   useEffect(() => {
-    void setLanguage(browserLanguage());
+    void setLanguage(storedLanguage() ?? browserLanguage());
   }, []);
 
   return null;

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -91,7 +91,9 @@ export function LoginForm() {
     <Panel className="relative w-[min(440px,100%)]">
       <header className="flex items-center">
         <FlowayLogo />
-        <LanguageSelector className="ml-auto" />
+        <div className="ml-auto flex items-center gap-2">
+          <LanguageSelector />
+        </div>
       </header>
 
       {/* The first Field carries 12px of its own above its label, so no gap is

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -5,6 +5,7 @@ import { useFetcher } from 'react-router';
 import { z } from 'zod';
 
 import { fluentComponents } from '../fluent';
+import { LanguageSelector } from './language-selector';
 import { FlowayLogo } from './logo';
 import { Trans, useTranslation } from '../i18n/translation';
 import { Input } from './ui/fluent-form-controls';
@@ -87,7 +88,10 @@ export function LoginForm() {
   const passwordMessage = errors.password?.message ?? credentialError ?? null;
 
   return (
-    <Panel className="w-[min(440px,100%)]">
+    <Panel className="relative w-[min(440px,100%)]">
+      <div className="absolute right-[var(--floway-panel-inset)] top-[var(--floway-panel-inset)]">
+        <LanguageSelector />
+      </div>
       <header className="grid justify-items-center">
         <FlowayLogo />
       </header>

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -89,11 +89,9 @@ export function LoginForm() {
 
   return (
     <Panel className="relative w-[min(440px,100%)]">
-      <div className="absolute right-[var(--floway-panel-inset)] top-[var(--floway-panel-inset)]">
-        <LanguageSelector />
-      </div>
-      <header className="grid justify-items-center">
+      <header className="flex items-center">
         <FlowayLogo />
+        <LanguageSelector className="ml-auto" />
       </header>
 
       {/* The first Field carries 12px of its own above its label, so no gap is

--- a/apps/web/src/components/requests/use-dump-subscription.ts
+++ b/apps/web/src/components/requests/use-dump-subscription.ts
@@ -42,7 +42,7 @@ export const useDumpSubscription = (keyId: string | null, initialRecords: DumpMe
   initialRecordsRef.current = initialRecords;
 
   // react-i18next hands back a new `t` on every language change, and
-  // BrowserLanguageSync announces one at boot whether or not the language it
+  // LanguageSync announces one at boot whether or not the language it
   // lands on is the one i18next booted in, so the disconnect message reaches
   // the effect the same way the seed does.
   const disconnectedRef = useRef('');

--- a/apps/web/src/components/sidebar/nav.tsx
+++ b/apps/web/src/components/sidebar/nav.tsx
@@ -12,6 +12,7 @@ import { NavSelectionIndicator } from './nav-selection-indicator';
 import { accountPage, dashboardPages, navGroups } from './pages';
 import { useTranslation } from '../../i18n/translation';
 import { useAuthStore } from '../../stores/auth-store';
+import { LanguageSelector } from '../language-selector';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { ScrollArea } from '../ui/scroll-area';
 import { useDialogInvocation } from '../ui/use-dialog-invocation';
@@ -165,6 +166,7 @@ export function Sidebar({ onNavigate, user }: { onNavigate?: () => void; user: A
           https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/NavigationView/NavigationView.xaml#L375
           https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/NavigationView/NavigationView.cpp#L1585-L1626 */}
       <NavDrawerFooter className="!bg-transparent !gap-y-1 !px-[10px] !py-3">
+        <LanguageSelector className="w-full [&_button]:w-full" />
         <div className="grid gap-y-1 relative w-full" ref={footerRef}>
           <NavSelectionIndicator containerRef={footerRef} inset={NAV_INDICATOR_INSET} otherListIs="above" selectedValue={selectedValue} />
           <SidebarLink

--- a/apps/web/src/components/sidebar/nav.tsx
+++ b/apps/web/src/components/sidebar/nav.tsx
@@ -129,6 +129,7 @@ export function Sidebar({ onNavigate, user }: { onNavigate?: () => void; user: A
       <NavDrawerHeader className="!bg-transparent !px-5 !py-4">
         <div className="flex items-center min-h-10">
           <FlowayLogo />
+          <LanguageSelector className="ml-auto" />
           {onNavigate && <Button appearance="subtle" aria-label={t('dashboard.nav.close')} className="!ml-auto" icon={<DismissRegular />} onClick={onNavigate} />}
         </div>
       </NavDrawerHeader>
@@ -166,7 +167,6 @@ export function Sidebar({ onNavigate, user }: { onNavigate?: () => void; user: A
           https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/NavigationView/NavigationView.xaml#L375
           https://github.com/microsoft/microsoft-ui-xaml/blob/188f602b27cdb47572b28c380e9c087b02e1ccee/controls/dev/NavigationView/NavigationView.cpp#L1585-L1626 */}
       <NavDrawerFooter className="!bg-transparent !gap-y-1 !px-[10px] !py-3">
-        <LanguageSelector className="w-full [&_button]:w-full" />
         <div className="grid gap-y-1 relative w-full" ref={footerRef}>
           <NavSelectionIndicator containerRef={footerRef} inset={NAV_INDICATOR_INSET} otherListIs="above" selectedValue={selectedValue} />
           <SidebarLink

--- a/apps/web/src/components/sidebar/nav.tsx
+++ b/apps/web/src/components/sidebar/nav.tsx
@@ -129,7 +129,9 @@ export function Sidebar({ onNavigate, user }: { onNavigate?: () => void; user: A
       <NavDrawerHeader className="!bg-transparent !px-5 !py-4">
         <div className="flex items-center min-h-10">
           <FlowayLogo />
-          <LanguageSelector className="ml-auto" />
+          {!onNavigate && <div className="ml-auto flex items-center gap-2">
+            <LanguageSelector />
+          </div>}
           {onNavigate && <Button appearance="subtle" aria-label={t('dashboard.nav.close')} className="!ml-auto" icon={<DismissRegular />} onClick={onNavigate} />}
         </div>
       </NavDrawerHeader>

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+import { storedLanguage } from './language-preference';
 import {
   browserLanguage,
   defaultLanguage,
@@ -23,11 +24,12 @@ import { shellResources } from './shell';
 // Hydration is the one render that cannot be in the visitor's language: it has
 // to reproduce index.html, which was prerendered in the default language. So
 // the active language starts as the default with only ./shell's strings behind
-// it, while `fallbackLng` names the visitor's language and carries the bundle
-// loaded here. Every key outside the shell resolves through that fallback,
-// which puts whatever renders between hydration and BrowserLanguageSync in the
-// visitor's language rather than briefly in English.
-const language = browserLanguage();
+// it, while `fallbackLng` names the language the visitor will read -- an
+// explicit in-page choice, or the browser language before one has been made --
+// and carries the bundle loaded here. Every key outside the shell resolves
+// through that fallback, which puts whatever renders between hydration and
+// LanguageSync in the visitor's language rather than briefly in English.
+const language = storedLanguage() ?? browserLanguage();
 const loaded = new Set<SupportedLanguage>([language]);
 
 void i18n.use(numberFormatter).use(initReactI18next).init({
@@ -49,7 +51,9 @@ i18n.on('languageChanged', language => {
 
 // The way the app changes language. A bare `changeLanguage` would reach a
 // language whose bundle was never fetched, and the default language is present
-// from boot carrying the shell's strings alone.
+// from boot carrying the shell's strings alone. Persisting the choice is the
+// caller's job: boot sync and tests also call this, and neither is an explicit
+// in-page choice.
 export const setLanguage = async (next: SupportedLanguage): Promise<void> => {
   if (!loaded.has(next)) {
     i18n.addResourceBundle(next, 'translation', (await loadLocale(next)).translation);

--- a/apps/web/src/i18n/language-preference.ts
+++ b/apps/web/src/i18n/language-preference.ts
@@ -1,0 +1,39 @@
+import { normalizeLanguage, type SupportedLanguage } from './languages';
+
+export const flowayLanguageStorageKey = 'floway-language';
+
+// An explicit choice made in the page outranks the browser language, and has to
+// survive reloads; localStorage is the same place the session and dashboard
+// prefs already live. Storage can be denied (Safari private browsing, a
+// partitioned third-party context) and happy-dom ships none, so every access is
+// guarded and the app just carries on unpersisted.
+export const storedLanguage = (): SupportedLanguage | null => {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return normalizeLanguage(window.localStorage.getItem(flowayLanguageStorageKey));
+  } catch {
+    return null;
+  }
+};
+
+export const storeLanguage = (language: SupportedLanguage): void => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(flowayLanguageStorageKey, language);
+  } catch {
+    // A denied or unavailable storage still allows the choice for this session;
+    // it just does not survive the next reload.
+  }
+};
+
+export const clearStoredLanguage = (): void => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.removeItem(flowayLanguageStorageKey);
+  } catch {
+    // As above.
+  }
+};

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -7,6 +7,7 @@ const en = {
       documentTitle: '{{title}} | Floway',
     },
     common: {
+      language: 'Language',
       loading: shellLoadingLabel,
       on: 'On',
       off: 'Off',

--- a/apps/web/src/i18n/locales/zh-Hans.ts
+++ b/apps/web/src/i18n/locales/zh-Hans.ts
@@ -5,6 +5,7 @@ const zhHansCN = {
       documentTitle: '{{title}} | Floway',
     },
     common: {
+      language: '语言',
       loading: '加载中…',
       on: '开',
       off: '关',

--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -9,9 +9,9 @@ import criticalCss from 'virtual:floway-critical.css?inline';
 import winuiStylesheet from 'virtual:floway-winui.css?url';
 
 import type { Route } from './+types/root';
-import { BrowserLanguageSync } from './components/browser-language-sync';
 import { DocumentTitleSync } from './components/document-title-sync';
 import { GradientBackground } from './components/gradient-background';
+import { LanguageSync } from './components/language-sync';
 import { markPickerScript } from './components/logo-mark';
 import { NavigationProgress } from './components/navigation-progress';
 import { ErrorShell, ErrorStack } from './components/ui/error-shell';
@@ -73,7 +73,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </head>
       <body className="text-[14px]">
         <FluentProvider theme={theme}>
-          <BrowserLanguageSync />
+          <LanguageSync />
           <GradientBackground>{children}</GradientBackground>
         </FluentProvider>
         <Scripts />

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from '../i18n/translation';
 import type { Route } from './+types/dashboard';
 import { requireDashboardSession } from './guards';
 import type { AuthUser } from '../api/auth';
+import { LanguageSelector } from '../components/language-selector';
 import { FlowayLogo } from '../components/logo';
 import { usePageFrames } from '../components/page-frames';
 import { Sidebar } from '../components/sidebar/nav';
@@ -111,6 +112,7 @@ function DashboardShell({ user }: { user: AuthUser }) {
             onClick={() => setNavigationOpen(true)}
           />
           <FlowayLogo />
+          <LanguageSelector className="ml-auto" />
         </header>
         <div className="grid grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)] min-h-0">
           {frames.map(frame => <div

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -112,7 +112,9 @@ function DashboardShell({ user }: { user: AuthUser }) {
             onClick={() => setNavigationOpen(true)}
           />
           <FlowayLogo />
-          <LanguageSelector className="ml-auto" />
+          <div className="ml-auto flex items-center gap-2">
+            <LanguageSelector />
+          </div>
         </header>
         <div className="grid grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)] min-h-0">
           {frames.map(frame => <div


### PR DESCRIPTION
## Summary

The dashboard rendered in whatever language the browser asked for, with no way to change it from the page. A globe-icon menu now sits beside the Floway logo in the sidebar header, at the top-right of the mobile header bar, and on the login card — a subtle `Button` in a `MenuTrigger` + `MenuPopover` + `MenuList`, with a `MenuItemRadio` per supported language.

A new `language-preference` module persists the choice as `floway-language` in `localStorage`, the same place the session and dashboard prefs live. Every access is guarded — storage can be denied and is absent in happy-dom — so a denied write still serves the choice for the session and an unsupported stored value is ignored. Boot reads `storedLanguage() ?? browserLanguage()`, so an explicit choice outranks the browser language and survives reloads; `setLanguage` stays free of persistence because the boot sync and the tests call it too. The boot-time sync component is renamed `BrowserLanguageSync` → `LanguageSync` since it now reconciles a stored preference as well.

## Test Plan

- [x] web typecheck and lint
- [x] `language_preference_test`, `language-selector_test`