### PR TITLE
fix(protocols): read a null Messages usage counter as an absent counter

### DIFF
--- a/apps/web/src/components/playground/request.ts
+++ b/apps/web/src/components/playground/request.ts
@@ -70,10 +70,11 @@ const normalizeMessagesSseLine = (line: string): string => {
       message?: { usage?: Record<string, unknown> };
     };
     if (event.type !== 'message_start' || !event.message) return line;
-    event.message.usage = {
-      input_tokens: 0,
-      ...event.message.usage,
-    };
+    const usage = event.message.usage ?? {};
+    // An upstream that never counted the prompt states it as an absent or null
+    // counter; the playground's reader needs the number the panel renders.
+    if (typeof usage.input_tokens !== 'number') usage.input_tokens = 0;
+    event.message.usage = usage;
     return `data: ${JSON.stringify(event)}`;
   } catch {
     return line;

--- a/apps/web/src/components/playground/request.ts
+++ b/apps/web/src/components/playground/request.ts
@@ -71,8 +71,6 @@ const normalizeMessagesSseLine = (line: string): string => {
     };
     if (event.type !== 'message_start' || !event.message) return line;
     const usage = event.message.usage ?? {};
-    // An upstream that never counted the prompt states it as an absent or null
-    // counter; the playground's reader needs the number the panel renders.
     if (typeof usage.input_tokens !== 'number') usage.input_tokens = 0;
     event.message.usage = usage;
     return `data: ${JSON.stringify(event)}`;

--- a/packages/gateway/__tests__/data-plane/chat/messages/usage_test.ts
+++ b/packages/gateway/__tests__/data-plane/chat/messages/usage_test.ts
@@ -37,3 +37,14 @@ test('Messages billable usage keeps the per-TTL cache-creation split the protoco
 test('Messages billable usage reports the served speed as the tier', () => {
   expect(read([start({ input_tokens: 1, output_tokens: 1, speed: 'fast' })])?.tier).toBe('fast');
 });
+
+// Anthropic states a bucket that does not apply to the request as `null` on
+// either usage carrier, and a `message_delta` that nulls the input-side
+// counters is not a correction of what `message_start` already billed.
+// https://github.com/anthropics/anthropic-sdk-python/issues/994
+test('Messages billable usage bills a turn whose upstream nulls its cache counters', () => {
+  expect(read([
+    start({ input_tokens: 10, output_tokens: 0, cache_read_input_tokens: 30, cache_creation_input_tokens: 9, cache_creation: null }),
+    delta({ input_tokens: null, output_tokens: 7, cache_read_input_tokens: null, cache_creation_input_tokens: null }),
+  ])).toEqual({ input: 10, cacheRead: 30, cacheWrite: 9, cacheWrite1h: 0, output: 7 });
+});

--- a/packages/gateway/src/data-plane/chat/messages/usage.ts
+++ b/packages/gateway/src/data-plane/chat/messages/usage.ts
@@ -26,7 +26,7 @@ export const createMessagesBillableUsageReader = (): (event: MessagesStreamEvent
       : event.type === 'message_delta' ? event.usage
         : undefined;
     if (usage === undefined) return null;
-    merged = mergeMessagesUsageSnapshot(merged, messagesUsageSnapshot(usage));
+    merged = mergeMessagesUsageSnapshot(merged, usage);
     return billableUsageFromMessagesUsage(merged);
   };
 };

--- a/packages/protocols/__tests__/messages/reassemble_test.ts
+++ b/packages/protocols/__tests__/messages/reassemble_test.ts
@@ -103,6 +103,43 @@ test('reassembleMessagesEvents reassembles text response', async () => {
   assertEquals(result.usage.output_tokens, 5);
 });
 
+test('reassembleMessagesEvents keeps counters a later null does not restate', async () => {
+  const body = makeEvents([
+    {
+      event: 'message_start',
+      data: {
+        type: 'message_start',
+        message: {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-test',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 0, cache_read_input_tokens: 4, cache_creation_input_tokens: 9 },
+        },
+      },
+    },
+    {
+      event: 'message_delta',
+      data: {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn', stop_sequence: null },
+        usage: { input_tokens: null, output_tokens: 5, cache_read_input_tokens: null, cache_creation_input_tokens: null },
+      },
+    },
+    { event: 'message_stop', data: { type: 'message_stop' } },
+  ]);
+
+  const result: MessagesResult = await reassembleMessagesEvents(body);
+
+  assertEquals(result.usage.input_tokens, 10);
+  assertEquals(result.usage.output_tokens, 5);
+  assertEquals(result.usage.cache_read_input_tokens, 4);
+  assertEquals(result.usage.cache_creation_input_tokens, 9);
+});
+
 test('MessagesTool supports both client and native web search shapes', () => {
   const clientTool: MessagesTool = {
     name: 'get_weather',

--- a/packages/protocols/__tests__/messages/usage_test.ts
+++ b/packages/protocols/__tests__/messages/usage_test.ts
@@ -45,6 +45,58 @@ test('Messages usage snapshots merge late counters and atomically replace the ti
   });
 });
 
+test('Messages usage snapshots read an upstream null counter as an absent counter', () => {
+  expect(messagesUsageSnapshot({
+    input_tokens: null,
+    output_tokens: 2,
+    cache_creation_input_tokens: null,
+    cache_read_input_tokens: null,
+    cache_creation: null,
+    output_tokens_details: null,
+    service_tier: null,
+    speed: null,
+  })).toEqual({ output_tokens: 2 });
+});
+
+test('Messages cache creation splits usage whose upstream reported no cache buckets', () => {
+  expect(splitMessagesCacheCreationTokens(messagesUsageSnapshot({
+    output_tokens: 2,
+    cache_creation_input_tokens: null,
+    cache_creation: null,
+  }))).toEqual({ cacheWrite: 0, cacheWrite1h: 0 });
+});
+
+test('Messages usage snapshots keep counters a later null does not restate', () => {
+  const start = messagesUsageSnapshot({
+    input_tokens: 11,
+    output_tokens: 0,
+    cache_creation_input_tokens: 9,
+    cache_read_input_tokens: 4,
+    output_tokens_details: { thinking_tokens: 3 },
+  });
+  expect(mergeMessagesUsageSnapshot(start, {
+    input_tokens: null,
+    output_tokens: 2,
+    cache_creation_input_tokens: null,
+    cache_read_input_tokens: null,
+    output_tokens_details: null,
+  })).toEqual({
+    input_tokens: 11,
+    output_tokens: 2,
+    cache_creation_input_tokens: 9,
+    cache_read_input_tokens: 4,
+    output_tokens_details: { thinking_tokens: 3 },
+  });
+});
+
+test('Messages usage snapshots keep the served tier a later null does not restate', () => {
+  const start = messagesUsageSnapshot({ output_tokens: 0, speed: 'fast' });
+  expect(mergeMessagesUsageSnapshot(start, { output_tokens: 2, speed: null, service_tier: null }))
+    .toEqual({ output_tokens: 2, speed: 'fast' });
+  expect(mergeMessagesUsageSnapshot(start, { output_tokens: 2, speed: null, service_tier: 'standard' }))
+    .toEqual({ output_tokens: 2, speed: undefined, service_tier: 'standard' });
+});
+
 test('Messages usage snapshots preserve nullable iterations and isolate all nested iteration data', () => {
   expect(messagesUsageSnapshot({ output_tokens: 0, iterations: null })).toEqual({ output_tokens: 0, iterations: null });
 

--- a/packages/protocols/src/messages/index.ts
+++ b/packages/protocols/src/messages/index.ts
@@ -1,4 +1,4 @@
-import type { MessagesUsage, MessagesUsageIteration, MessagesUsageServerToolUse } from './usage.ts';
+import type { MessagesUsage, MessagesUsageDelta } from './usage.ts';
 
 /**
  * Messages requires `max_tokens`, but the Chat Completions, Responses, and
@@ -287,8 +287,7 @@ export {
   splitMessagesCacheCreationTokens,
   type MessagesCacheCreationUsage,
   type MessagesUsage,
-  type MessagesUsageIteration,
-  type MessagesUsageServerToolUse,
+  type MessagesUsageDelta,
   type MessagesUsageSnapshot,
 } from './usage.ts';
 
@@ -361,21 +360,7 @@ export interface MessagesMessageDeltaEvent {
     stop_details?: MessagesRefusalStopDetails | null;
     stop_sequence?: string | null;
   };
-  usage?: {
-    input_tokens?: number;
-    output_tokens: number;
-    cache_creation_input_tokens?: number;
-    cache_read_input_tokens?: number;
-    cache_creation?: {
-      ephemeral_5m_input_tokens?: number;
-      ephemeral_1h_input_tokens?: number;
-    };
-    output_tokens_details?: { thinking_tokens: number };
-    service_tier?: 'standard' | 'priority' | 'batch' | (string & {});
-    speed?: 'standard' | 'fast' | (string & {});
-    server_tool_use?: MessagesUsageServerToolUse;
-    iterations?: MessagesUsageIteration[] | null;
-  };
+  usage?: MessagesUsageDelta;
 }
 
 interface MessagesMessageStopEvent {

--- a/packages/protocols/src/messages/reassemble.ts
+++ b/packages/protocols/src/messages/reassemble.ts
@@ -10,6 +10,7 @@ import type {
   MessagesThinkingBlock,
   MessagesToolUseBlock,
   MessagesUsage,
+  MessagesUsageDelta,
   MessagesWebSearchToolResultBlock,
 } from './index.ts';
 import { cloneMessagesUsageIterations } from './usage.ts';
@@ -93,7 +94,11 @@ const KNOWN_BLOCK_KEYS_BY_TYPE: Record<string, ReadonlySet<string>> = {
 };
 const FALLBACK_BLOCK_KNOWN = new Set(['type']);
 
-const applyMessagesUsage = (usage: MessagesUsage, update: Partial<MessagesUsage> | undefined): void => {
+// Both usage carriers repeat cumulative whole-message counters, so a counter
+// the upstream reports as absent or `null` leaves the running total alone
+// rather than erasing what an earlier event already stated.
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/lib/MessageStream.ts#L592-L616
+const applyMessagesUsage = (usage: MessagesUsage, update: MessagesUsageDelta | undefined): void => {
   if (!update) return;
 
   if (update.input_tokens != null) usage.input_tokens = update.input_tokens;

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -111,13 +111,10 @@ export const mergeMessagesUsageSnapshot = (
   const update = messagesUsageSnapshot(delta);
   return {
     ...current,
-    output_tokens: update.output_tokens,
-    ...(update.input_tokens === undefined ? {} : { input_tokens: update.input_tokens }),
-    ...(update.cache_read_input_tokens === undefined ? {} : { cache_read_input_tokens: update.cache_read_input_tokens }),
-    ...(update.cache_creation_input_tokens === undefined ? {} : { cache_creation_input_tokens: update.cache_creation_input_tokens }),
-    ...(update.cache_creation === undefined ? {} : { cache_creation: update.cache_creation }),
-    ...(update.output_tokens_details === undefined ? {} : { output_tokens_details: update.output_tokens_details }),
-    ...(update.iterations === undefined ? {} : { iterations: update.iterations }),
+    ...update,
+    // The served tier is one fact spelled by two fields, so an update that
+    // states either one restates both and neither may survive from an earlier
+    // event on its own.
     ...(update.speed === undefined && update.service_tier === undefined
       ? {}
       : { speed: update.speed, service_tier: update.service_tier }),

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -23,41 +23,60 @@ export interface MessagesUsageIteration {
 export const cloneMessagesUsageIterations = (iterations: MessagesUsageIteration[] | null): MessagesUsageIteration[] | null =>
   iterations === null ? null : structuredClone(iterations);
 
-export interface MessagesUsage {
-  input_tokens: number;
+export interface MessagesCacheCreationTtlTokens {
+  ephemeral_5m_input_tokens?: number;
+  ephemeral_1h_input_tokens?: number;
+}
+
+// Cumulative whole-message counters. Every one of them but `output_tokens` is
+// declared nullable upstream and carries `null` when the bucket does not apply
+// to the request, while upstreams that never opted into the owning feature
+// omit the field instead — the SDK's own accumulator reads both spellings as
+// "no value" and overwrites only when the counter is present.
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/resources/messages/messages.ts#L1169-L1204
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/lib/MessageStream.ts#L592-L616
+export interface MessagesUsageDelta {
+  input_tokens?: number | null;
   output_tokens: number;
-  cache_creation_input_tokens?: number;
-  cache_read_input_tokens?: number;
+  cache_read_input_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
   // Per-TTL split for cache writes introduced by extended-cache-ttl-2025-04-11.
   // Each `ephemeral_*` field is a disjoint subset of `cache_creation_input_tokens`
   // (the legacy flat field is the sum of both); upstreams that have not opted
   // into the beta omit `cache_creation` entirely and emit only the flat field.
-  cache_creation?: {
-    ephemeral_5m_input_tokens?: number;
-    ephemeral_1h_input_tokens?: number;
-  };
+  cache_creation?: MessagesCacheCreationTtlTokens | null;
   // `thinking_tokens` is the reasoning subset of the inclusive `output_tokens`
   // total, re-tokenized from the raw reasoning rather than from the possibly
   // summarized thinking text that reaches the response body, so it can differ
   // from the model's own generation count by a few tokens.
   // https://github.com/anthropics/anthropic-sdk-typescript/blob/3b45cd3b69c956ac63384fdb09ce1d8109f3fa80/src/resources/messages/messages.ts#L1292-L1304
-  output_tokens_details?: { thinking_tokens: number };
+  output_tokens_details?: { thinking_tokens: number } | null;
   // https://docs.claude.com/en/api/service-tiers
-  service_tier?: 'standard' | 'priority' | 'batch' | (string & {});
+  service_tier?: 'standard' | 'priority' | 'batch' | (string & {}) | null;
   // https://docs.claude.com/en/build-with-claude/fast-mode
-  speed?: 'standard' | 'fast' | (string & {});
-  server_tool_use?: MessagesUsageServerToolUse;
+  speed?: 'standard' | 'fast' | (string & {}) | null;
+  server_tool_use?: MessagesUsageServerToolUse | null;
   iterations?: MessagesUsageIteration[] | null;
+}
+
+// The `message_start` totals are the one carrier upstream declares
+// `input_tokens` non-null on. Upstream's own delta carrier declares a narrower
+// field set than the type above, which stays widened because real upstreams do
+// repeat the tier and per-TTL fields on `message_delta`.
+// https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/resources/messages/messages.ts#L2362-L2412
+export interface MessagesUsage extends Omit<MessagesUsageDelta, 'input_tokens'> {
+  input_tokens: number;
 }
 
 export interface MessagesCacheCreationUsage {
   cache_creation_input_tokens?: number;
-  cache_creation?: {
-    ephemeral_5m_input_tokens?: number;
-    ephemeral_1h_input_tokens?: number;
-  };
+  cache_creation?: MessagesCacheCreationTtlTokens;
 }
 
+// Usage as Floway accounts for it: the upstream counters with every `null`
+// already collapsed to absence, so consumers test presence rather than repeat
+// the wire's two spellings of "no value". `iterations` keeps its explicit
+// `null`, which upstream uses to state that a turn ran no iterations at all.
 export interface MessagesUsageSnapshot extends MessagesCacheCreationUsage {
   input_tokens?: number;
   output_tokens: number;
@@ -68,31 +87,41 @@ export interface MessagesUsageSnapshot extends MessagesCacheCreationUsage {
   iterations?: MessagesUsageIteration[] | null;
 }
 
-export const messagesUsageSnapshot = (usage?: MessagesUsageSnapshot): MessagesUsageSnapshot => usage === undefined
+const present = <T>(value: T | null | undefined): value is T => value !== null && value !== undefined;
+
+export const messagesUsageSnapshot = (usage?: MessagesUsageDelta): MessagesUsageSnapshot => usage === undefined
   ? { output_tokens: 0 }
   : {
-      ...usage,
-      ...(usage.cache_creation === undefined ? {} : { cache_creation: { ...usage.cache_creation } }),
-      ...(usage.output_tokens_details === undefined ? {} : { output_tokens_details: { ...usage.output_tokens_details } }),
+      output_tokens: usage.output_tokens,
+      ...(present(usage.input_tokens) ? { input_tokens: usage.input_tokens } : {}),
+      ...(present(usage.cache_read_input_tokens) ? { cache_read_input_tokens: usage.cache_read_input_tokens } : {}),
+      ...(present(usage.cache_creation_input_tokens) ? { cache_creation_input_tokens: usage.cache_creation_input_tokens } : {}),
+      ...(present(usage.cache_creation) ? { cache_creation: { ...usage.cache_creation } } : {}),
+      ...(present(usage.output_tokens_details) ? { output_tokens_details: { ...usage.output_tokens_details } } : {}),
+      ...(present(usage.service_tier) ? { service_tier: usage.service_tier } : {}),
+      ...(present(usage.speed) ? { speed: usage.speed } : {}),
       ...(usage.iterations === undefined ? {} : { iterations: cloneMessagesUsageIterations(usage.iterations) }),
     };
 
 export const mergeMessagesUsageSnapshot = (
   current: MessagesUsageSnapshot,
-  delta: MessagesUsageSnapshot,
-): MessagesUsageSnapshot => ({
-  ...current,
-  output_tokens: delta.output_tokens,
-  ...(delta.input_tokens === undefined ? {} : { input_tokens: delta.input_tokens }),
-  ...(delta.cache_read_input_tokens === undefined ? {} : { cache_read_input_tokens: delta.cache_read_input_tokens }),
-  ...(delta.cache_creation_input_tokens === undefined ? {} : { cache_creation_input_tokens: delta.cache_creation_input_tokens }),
-  ...(delta.cache_creation === undefined ? {} : { cache_creation: { ...delta.cache_creation } }),
-  ...(delta.output_tokens_details === undefined ? {} : { output_tokens_details: { ...delta.output_tokens_details } }),
-  ...(delta.iterations === undefined ? {} : { iterations: cloneMessagesUsageIterations(delta.iterations) }),
-  ...(delta.speed === undefined && delta.service_tier === undefined
-    ? {}
-    : { speed: delta.speed, service_tier: delta.service_tier }),
-});
+  delta: MessagesUsageDelta,
+): MessagesUsageSnapshot => {
+  const update = messagesUsageSnapshot(delta);
+  return {
+    ...current,
+    output_tokens: update.output_tokens,
+    ...(update.input_tokens === undefined ? {} : { input_tokens: update.input_tokens }),
+    ...(update.cache_read_input_tokens === undefined ? {} : { cache_read_input_tokens: update.cache_read_input_tokens }),
+    ...(update.cache_creation_input_tokens === undefined ? {} : { cache_creation_input_tokens: update.cache_creation_input_tokens }),
+    ...(update.cache_creation === undefined ? {} : { cache_creation: update.cache_creation }),
+    ...(update.output_tokens_details === undefined ? {} : { output_tokens_details: update.output_tokens_details }),
+    ...(update.iterations === undefined ? {} : { iterations: update.iterations }),
+    ...(update.speed === undefined && update.service_tier === undefined
+      ? {}
+      : { speed: update.speed, service_tier: update.service_tier }),
+  };
+};
 
 export const splitMessagesCacheCreationTokens = (
   usage: MessagesCacheCreationUsage,

--- a/packages/protocols/src/messages/usage.ts
+++ b/packages/protocols/src/messages/usage.ts
@@ -59,10 +59,11 @@ export interface MessagesUsageDelta {
   iterations?: MessagesUsageIteration[] | null;
 }
 
-// The `message_start` totals are the one carrier upstream declares
-// `input_tokens` non-null on. Upstream's own delta carrier declares a narrower
-// field set than the type above, which stays widened because real upstreams do
-// repeat the tier and per-TTL fields on `message_delta`.
+// The whole-message totals, carried by the non-streaming response body and by
+// the `message_start` snapshot that reuses it — the two places upstream
+// declares `input_tokens` non-null. Upstream's own delta carrier declares a
+// narrower field set than the type above, which stays widened because real
+// upstreams do repeat the tier and per-TTL fields on `message_delta`.
 // https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/resources/messages/messages.ts#L2362-L2412
 export interface MessagesUsage extends Omit<MessagesUsageDelta, 'input_tokens'> {
   input_tokens: number;

--- a/packages/translate/__tests__/chat-completions-via-messages/events_test.ts
+++ b/packages/translate/__tests__/chat-completions-via-messages/events_test.ts
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { createMessagesToChatCompletionsStreamState, translateMessagesEventToChatCompletionsChunks } from '../../src/chat-completions-via-messages/events.ts';
 import type { ChatCompletionsStreamEvent, ChatCompletionsDelta } from '@floway-dev/protocols/chat-completions';
 import type { MessagesStreamEvent } from '@floway-dev/protocols/messages';
-import { assertEquals } from '@floway-dev/test-utils';
+import { assertEquals, assertFalse } from '@floway-dev/test-utils';
 
 // ── Helpers ──
 
@@ -513,6 +513,45 @@ test('message_delta usage includes cache_read_input_tokens from message_start', 
   assertEquals(chunk.usage!.completion_tokens, 50);
   assertEquals(chunk.usage!.total_tokens, 150);
   assertEquals(chunk.usage!.prompt_tokens_details!.cached_tokens, 20);
+});
+
+// A null counter states that the bucket did not apply, so nothing about it
+// reaches the client: no cache detail, and no tier the upstream never served.
+test('null Messages usage counters translate to absent Chat Completions usage detail', () => {
+  const state = createMessagesToChatCompletionsStreamState();
+  translateMessagesEventToChatCompletionsChunks(
+    {
+      type: 'message_start',
+      message: {
+        ...(MSG_START as { type: 'message_start'; message: Record<string, unknown> }).message,
+        usage: {
+          input_tokens: 80,
+          output_tokens: 0,
+          cache_read_input_tokens: null,
+          cache_creation_input_tokens: null,
+          cache_creation: null,
+          service_tier: null,
+          speed: null,
+        },
+      },
+    } as MessagesStreamEvent,
+    state,
+  );
+
+  const result = translateMessagesEventToChatCompletionsChunks(
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn' },
+      usage: { input_tokens: null, output_tokens: 50, cache_read_input_tokens: null, cache_creation_input_tokens: null },
+    },
+    state,
+  );
+  const chunk = (result as ChatCompletionsStreamEvent[])[1];
+  assertEquals(chunk.usage!.prompt_tokens, 80);
+  assertEquals(chunk.usage!.completion_tokens, 50);
+  assertEquals(chunk.usage!.total_tokens, 130);
+  assertEquals(chunk.usage!.prompt_tokens_details, undefined);
+  assertFalse('service_tier' in chunk);
 });
 
 // ── message_stop ──

--- a/packages/translate/__tests__/gemini-via-messages/events_test.ts
+++ b/packages/translate/__tests__/gemini-via-messages/events_test.ts
@@ -358,6 +358,30 @@ test('translateToSourceEvents folds Anthropic cache fields into Gemini promptTok
   ]);
 });
 
+test('translateToSourceEvents counts null Anthropic cache fields as no cache activity', async () => {
+  const frames = await collect([
+    eventFrame(messageStart({
+      input_tokens: 10,
+      output_tokens: 0,
+      cache_read_input_tokens: null,
+      cache_creation_input_tokens: null,
+      cache_creation: null,
+    })),
+    eventFrame({
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn' },
+      usage: { input_tokens: null, output_tokens: 7, cache_read_input_tokens: null, cache_creation_input_tokens: null },
+    }),
+    eventFrame({ type: 'message_stop' }),
+  ]);
+  const usage = frames[0]?.type === 'event' && !('error' in frames[0].event) ? frames[0].event.usageMetadata : undefined;
+  assertEquals(usage, {
+    promptTokenCount: 10,
+    candidatesTokenCount: 7,
+    totalTokenCount: 17,
+  });
+});
+
 test('translateToSourceEvents accepts late input accounting from message_delta', async () => {
   const frames = await collect([
     eventFrame(messageStart()),

--- a/packages/translate/__tests__/messages-via-chat-completions/events_test.ts
+++ b/packages/translate/__tests__/messages-via-chat-completions/events_test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest';
 
 import { createChatCompletionsToMessagesStreamState, flushChatCompletionsToMessagesEvents, mapChatCompletionsUsageToMessagesUsage, translateChatCompletionsChunkToMessagesEvents } from '../../src/messages-via-chat-completions/events.ts';
 import type { ChatCompletionsStreamEvent } from '@floway-dev/protocols/chat-completions';
-import { assertEquals, assertFalse } from '@floway-dev/test-utils';
+import { assertEquals, assertExists, assertFalse } from '@floway-dev/test-utils';
 
 const chunk = (delta: ChatCompletionsStreamEvent['choices'][0]['delta'], finishReason: ChatCompletionsStreamEvent['choices'][0]['finish_reason'] = null): ChatCompletionsStreamEvent => ({
   id: 'chatcmpl_test',
@@ -600,7 +600,8 @@ test('translateChatCompletionsChunkToMessagesEvents omits usage.speed when servi
   ];
 
   const messageDelta = events.find(event => event.type === 'message_delta');
-  const usage = (messageDelta as { usage: Record<string, unknown> }).usage;
+  const usage = messageDelta?.usage;
+  assertExists(usage);
   assertFalse('speed' in usage);
   assertEquals(usage.service_tier, 'default');
 });
@@ -614,5 +615,7 @@ test('translateChatCompletionsChunkToMessagesEvents omits usage.speed when servi
   ];
 
   const messageDelta = events.find(event => event.type === 'message_delta');
-  assertFalse('speed' in (messageDelta as { usage: Record<string, unknown> }).usage);
+  const usage = messageDelta?.usage;
+  assertExists(usage);
+  assertFalse('speed' in usage);
 });

--- a/packages/translate/__tests__/responses-via-messages/events_test.ts
+++ b/packages/translate/__tests__/responses-via-messages/events_test.ts
@@ -15,17 +15,17 @@ const runToCompletion = (
   usage: {
     input_tokens: number;
     output_tokens: number;
-    cache_read_input_tokens?: number;
-    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number | null;
+    cache_creation_input_tokens?: number | null;
     speed?: string;
     service_tier?: string;
   },
   deltaUsageExtras?: {
-    input_tokens?: number;
-    cache_read_input_tokens?: number;
-    cache_creation_input_tokens?: number;
-    cache_creation?: { ephemeral_5m_input_tokens?: number; ephemeral_1h_input_tokens?: number };
-    output_tokens_details?: { thinking_tokens: number };
+    input_tokens?: number | null;
+    cache_read_input_tokens?: number | null;
+    cache_creation_input_tokens?: number | null;
+    cache_creation?: { ephemeral_5m_input_tokens?: number; ephemeral_1h_input_tokens?: number } | null;
+    output_tokens_details?: { thinking_tokens: number } | null;
     speed?: string;
     service_tier?: string;
   },
@@ -129,6 +129,21 @@ test('handles no cache fields (backward compat)', () => {
     input_tokens: 100,
     output_tokens: 50,
   });
+
+  assertEquals(result.usage!.input_tokens, 100);
+  assertEquals(result.usage!.total_tokens, 150);
+  assertEquals(result.usage!.input_tokens_details, undefined);
+  assertEquals(result.usage!.output_tokens_details, undefined);
+});
+
+// An upstream that states an inapplicable cache bucket as `null` reported no
+// cache activity, so the translation carries absence rather than a zero the
+// upstream never billed.
+test('translates null cache counters to absent Responses cache details', () => {
+  const result = runToCompletion(
+    { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: null, cache_creation_input_tokens: null },
+    { cache_creation: null, output_tokens_details: null },
+  );
 
   assertEquals(result.usage!.input_tokens, 100);
   assertEquals(result.usage!.total_tokens, 150);


### PR DESCRIPTION
## Problem

Anthropic declares every cumulative Messages `usage` counter except `output_tokens` as nullable, and sends `null` for a bucket that does not apply to the request — while upstreams that never opted into the owning feature omit the same field instead. Both spellings mean "no value":

- [`Usage`](https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/resources/messages/messages.ts#L2362-L2412) — `cache_creation_input_tokens: number | null`, `cache_read_input_tokens: number | null`, `cache_creation: CacheCreation | null`, plus `output_tokens_details`, `service_tier`, `speed`, `server_tool_use`, `iterations`; `input_tokens` and `output_tokens` are not nullable.
- [`MessageDeltaUsage`](https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/resources/messages/messages.ts#L1169-L1204) — the same, and `input_tokens` itself is nullable on that carrier.
- The SDK's own accumulator [treats absent and `null` identically](https://github.com/anthropics/anthropic-sdk-typescript/blob/18ea26d324911c3236f2ce762dd0c87f04d038d3/src/lib/MessageStream.ts#L592-L616): *"cumulative whole-message totals that are omitted when they don't apply, so overwrite when present and never add."*
- Reported in the wild for streaming turns: [anthropic-sdk-python#994](https://github.com/anthropics/anthropic-sdk-python/issues/994) shows `"cache_creation_input_tokens": null, "cache_read_input_tokens": null`.

Floway typed the counters as optional-only and guarded them with `!== undefined`, which a `null` walks straight past. Three consequences, all on genuine upstream traffic:

1. **The turn dies.** `splitMessagesCacheCreationTokens` fails its non-negative-integer check with `RangeError: cache_creation_input_tokens must be a non-negative safe integer: null`. It is thrown inside the usage-stamping generator, so the client's whole turn is replaced with an `error` SSE frame and no usage row is recorded.
2. **Silent under-billing.** A `message_delta` that nulls the input-side counters overwrote what `message_start` had already reported, so the request billed `0` input tokens.
3. **Leaked nulls.** Presence tests on `cache_read_input_tokens` and friends passed for `null`, emitting a synthesized `cached_tokens: 0` / `cache_write_tokens: 0` to Responses and Chat Completions clients, and `service_tier: null` for a tier the upstream never served.

For comparison, every other gateway accepts the null: LiteLLM guards `is not None` per field, claude-code-router coerces through `asNumber()`, opencode schema-types the cache fields as `optional(NullOr(Number))`, and `@ai-sdk/anthropic` types them `number | null`. None of them throws.

## Fix

Model the wire shape as upstream declares it, then normalize once:

- `MessagesUsageDelta` carries the nullable cumulative counters and types `message_delta`; `MessagesUsage` is that shape with `input_tokens` non-null, for the non-streaming response body and the `message_start` snapshot that reuses it. The delta type stays widened with `cache_creation` / `service_tier` / `speed`, which upstream declares only on the whole-message carrier but real upstreams do repeat on deltas.
- `messagesUsageSnapshot` collapses `null` to absence and is the only way to produce a `MessagesUsageSnapshot`; `mergeMessagesUsageSnapshot` normalizes its delta and then spreads it, so the absence test exists in exactly one place and the three `*-via-messages` call sites that pass a raw usage carrier are correct by construction.
- `splitMessagesCacheCreationTokens` still rejects a counter that is neither absent nor a non-negative integer — its parameter type now admits only an already normalized snapshot, so no wire value can reach it.
- `iterations` keeps its explicit-`null` contract, which upstream uses to state that a turn ran no iterations at all, and the served tier keeps moving as one atomic `speed`/`service_tier` pair.
- The dashboard playground's `input_tokens` shim placed its default ahead of the spread, which let the same null through; it now fills from a presence test.

## Test Plan

- [x] Eight new cases across the protocol normalization, the billing reader, and the Responses / Chat Completions / Gemini translations, each confirmed to fail without the fix with the `RangeError` or the clobbered total, and a ninth guarding the reassembly path that already read absence correctly
- [x] `pnpm run verify` — typecheck, lint, 545 test files / 5696 tests, installers, and the web build
- [ ] Observed end to end against an upstream actually emitting `null` — not reachable on demand, since which buckets an upstream nulls is its own choice; the wire evidence is anthropic-sdk-python#994 and the SDK declarations linked above
