### PR TITLE
perf(web): cache hashed client assets for a year

### DIFF
--- a/apps/web/__tests__/static-asset-caching_test.ts
+++ b/apps/web/__tests__/static-asset-caching_test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// Two hosting topologies serve the client build's hashed assets themselves --
+// Workers Static Assets on Cloudflare, nginx in docker-compose -- and each one
+// states the cache policy for them in its own syntax, with no way to consult
+// the other. Both default to revalidating every asset on every page load, so a
+// topology that silently loses this policy looks correct and is merely slow.
+// Reading the policy back out of both files is what turns that into a failing
+// suite.
+const repoRoot = resolve(import.meta.dirname, '../../..');
+const readRepoFile = (path: string) => readFileSync(resolve(repoRoot, path), 'utf8');
+
+const CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+// A `_headers` rule block opens with an unindented URL pattern and continues
+// with indented `Name: value` lines:
+// https://developers.cloudflare.com/workers/static-assets/headers/
+const parseHeadersFile = (source: string) => {
+  const rules = new Map<string, Map<string, string>>();
+  let current: Map<string, string> | undefined;
+  for (const line of source.split('\n')) {
+    if (line.trim() === '' || line.trimStart().startsWith('#')) continue;
+    if (!/^\s/.test(line)) {
+      current = new Map();
+      rules.set(line.trim(), current);
+      continue;
+    }
+    const [, name, value] = /^\s*([^:]+):\s*(.*)$/.exec(line)!;
+    current!.set(name!.toLowerCase(), value!.trim());
+  }
+  return rules;
+};
+
+// nginx blocks nest, so the block is taken by matching braces rather than by a
+// regex that would stop at the inner `location ~ \.map$`.
+const nginxBlock = (source: string, header: string) => {
+  const start = source.indexOf(header);
+  expect(start, `${header} is missing from docker/nginx.conf`).not.toBe(-1);
+  let depth = 0;
+  for (let index = start + header.length - 1; index < source.length; index++) {
+    if (source[index] === '{') depth++;
+    else if (source[index] === '}' && --depth === 0) return source.slice(start, index + 1);
+  }
+  throw new Error(`${header} is not closed in docker/nginx.conf`);
+};
+
+const headersRules = parseHeadersFile(readRepoFile('apps/web/public/_headers'));
+const nginxAssets = nginxBlock(readRepoFile('docker/nginx.conf'), 'location /assets/ {');
+
+describe('static asset caching', () => {
+  it('caches the hashed asset directory for a year in every topology', () => {
+    const [, nginxCacheControl] = /add_header\s+Cache-Control\s+"([^"]+)"/.exec(nginxAssets) ?? [];
+    expect({
+      wrangler: headersRules.get('/assets/*')?.get('cache-control'),
+      nginx: nginxCacheControl,
+    }).toEqual({ wrangler: CACHE_CONTROL, nginx: CACHE_CONTROL });
+  });
+
+  // index.html names the current hashes, so it is the one file whose URL
+  // answers with different bytes after a deploy. Both topologies leave it on
+  // their revalidating default, and a rule reaching beyond /assets/ would be
+  // how that is lost.
+  it('leaves the unhashed document out of the cached scope', () => {
+    expect([...headersRules.keys()]).toEqual(['/assets/*']);
+  });
+
+  // The sourcemap content type is settled inside the cached block, where nginx
+  // resolves the more specific regex location first; moving it back out would
+  // take the cache header off every map with it.
+  it('settles the sourcemap content type inside the cached block', () => {
+    expect(nginxAssets).toMatch(/location\s+~\s+\\\.map\$\s*\{\s*default_type\s+application\/json;/);
+  });
+});

--- a/apps/web/__tests__/static-asset-caching_test.ts
+++ b/apps/web/__tests__/static-asset-caching_test.ts
@@ -59,10 +59,9 @@ describe('static asset caching', () => {
     }).toEqual({ wrangler: CACHE_CONTROL, nginx: CACHE_CONTROL });
   });
 
-  // index.html names the current hashes, so it is the one file whose URL
-  // answers with different bytes after a deploy. Both topologies leave it on
-  // their revalidating default, and a rule reaching beyond /assets/ would be
-  // how that is lost.
+  // index.html names the current hashes, so it is the document every deploy
+  // rewrites. Both topologies leave it on their revalidating default, and a
+  // rule reaching beyond /assets/ would be how that is lost.
   it('leaves the unhashed document out of the cached scope', () => {
     expect([...headersRules.keys()]).toEqual(['/assets/*']);
   });

--- a/apps/web/__tests__/static-asset-caching_test.ts
+++ b/apps/web/__tests__/static-asset-caching_test.ts
@@ -48,7 +48,10 @@ const nginxBlock = (source: string, header: string) => {
 };
 
 const headersRules = parseHeadersFile(readRepoFile('apps/web/public/_headers'));
-const nginxAssets = nginxBlock(readRepoFile('docker/nginx.conf'), 'location /assets/ {');
+// The block header carries `^~`, which is what keeps a regex location added to
+// docker/nginx.conf later from taking these paths away from it; naming it here
+// means dropping it fails this suite rather than only the next deploy.
+const nginxAssets = nginxBlock(readRepoFile('docker/nginx.conf'), 'location ^~ /assets/ {');
 
 describe('static asset caching', () => {
   it('caches the hashed asset directory for a year in every topology', () => {
@@ -70,6 +73,6 @@ describe('static asset caching', () => {
   // resolves the more specific regex location first; moving it back out would
   // take the cache header off every map with it.
   it('settles the sourcemap content type inside the cached block', () => {
-    expect(nginxAssets).toMatch(/location\s+~\s+\\\.map\$\s*\{\s*default_type\s+application\/json;/);
+    expect(nginxAssets).toMatch(/location\s+~\s+\\\.map\$\s*\{[^}]*default_type\s+application\/json;/);
   });
 });

--- a/apps/web/__tests__/static-asset-caching_test.ts
+++ b/apps/web/__tests__/static-asset-caching_test.ts
@@ -69,9 +69,10 @@ describe('static asset caching', () => {
     expect([...headersRules.keys()]).toEqual(['/assets/*']);
   });
 
-  // The sourcemap content type is settled inside the cached block, where nginx
-  // resolves the more specific regex location first; moving it back out would
-  // take the cache header off every map with it.
+  // The sourcemap content type is settled inside the cached block because `^~`
+  // on that block stops the server-level regex locations being tested at all:
+  // a `\.map$` location moved back out would never match under /assets/, and
+  // every map there would fall back to `application/octet-stream`.
   it('settles the sourcemap content type inside the cached block', () => {
     expect(nginxAssets).toMatch(/location\s+~\s+\\\.map\$\s*\{[^}]*default_type\s+application\/json;/);
   });

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -21,14 +21,20 @@
 # here is matched against the request URL, with no knowledge of what was served
 # -- so a browser can end up holding HTML, permanently, at a chunk's URL. What
 # bounds it is that the blast radius is that one browser: the asset worker
-# writes to no shared HTTP cache, and the one cache it does use is keyed by
-# content hash rather than by URL. (Cloudflare Pages, where the two public
-# reports of this come from, kept a URL-keyed CDN cache and so poisoned every
-# visitor at a PoP.) Under the deployment that poisons it the URL is already
-# dead, since a deploy only drops the assets whose hash changed; it comes back
-# to life only through a rollback, or through a gradual deployment serving one
-# version's document beside another version's assets. We deploy all at once and
-# roll back rarely, which is the trade we are making here.
+# writes to no shared HTTP cache, and the one cache it does use is KV's, keyed
+# by the asset's content hash rather than by URL, so a fallback response is
+# stored under index.html's own hash.
+# https://github.com/cloudflare/workers-sdk/blob/4b52975aac295c8483d6b4001d0b50945293265a/packages/workers-shared/asset-worker/src/utils/kv.ts#L18-L24
+# Cloudflare Pages, where both public reports of this come from, kept a
+# URL-keyed CDN cache instead and so poisoned every visitor at a PoP.
+# https://developers.cloudflare.com/pages/configuration/serving-pages/
+# https://community.cloudflare.com/t/pages-how-to-prevent-caching-404s-when-using-headers/516765
+# https://community.cloudflare.com/t/disable-spa-fallback-for-some-paths-file-extensions/649908
+# Under the deployment that poisons it the URL is already dead, since a deploy
+# only drops the assets whose hash changed; it comes back to life only through
+# a rollback, or through a gradual deployment serving one version's document
+# beside another version's assets. We deploy all at once and roll back rarely,
+# which is the trade we are making here.
 # https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/
 #
 # docker/nginx.conf states the same policy for the docker-compose topology, and

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -4,11 +4,15 @@
 # per page load:
 # https://developers.cloudflare.com/workers/static-assets/headers/
 #
-# Everything the client build emits under /assets/ carries a content hash in its
-# filename, sourcemaps included -- a map is named after the chunk it belongs to,
-# so it rehashes with it. A URL there therefore always answers with the same
-# bytes and never needs revalidating. index.html is deliberately left out: it is
-# the unhashed document that names the current hashes.
+# Every chunk the client build emits under /assets/ is content-addressed, so a
+# URL there answers with the same bytes for as long as it exists and never needs
+# revalidating. A sourcemap carries the hash of the chunk it belongs to rather
+# than one of its own, so an edit that moves source positions without changing
+# the emitted chunk -- a comment-only edit is the plain case -- leaves the URL
+# fixed while the map behind it changes. Maps are declared immutable regardless:
+# the whole cost of holding a stale one is a stack trace restored against
+# out-of-date positions. index.html is deliberately left out: it is the unhashed
+# document that names the current hashes.
 #
 # The lifetime also lands on a response we did not intend it for, and we accept
 # that. `not_found_handling: single-page-application` answers a request for a

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,32 @@
+# Workers Static Assets answers every asset with
+# `Cache-Control: public, max-age=0, must-revalidate` unless a rule here says
+# otherwise, so each already-downloaded chunk still costs a conditional request
+# per page load:
+# https://developers.cloudflare.com/workers/static-assets/headers/
+#
+# Everything the client build emits under /assets/ carries a content hash in its
+# filename, sourcemaps included -- a map is named after the chunk it belongs to,
+# so it rehashes with it. A URL there therefore always answers with the same
+# bytes and never needs revalidating. index.html is deliberately left out: it is
+# the unhashed document that names the current hashes.
+#
+# The lifetime also lands on a response we did not intend it for, and we accept
+# that. `not_found_handling: single-page-application` answers a request for a
+# file this deployment no longer holds with index.html and a 200, and a rule
+# here is matched against the request URL, with no knowledge of what was served
+# -- so a browser can end up holding HTML, permanently, at a chunk's URL. What
+# bounds it is that the blast radius is that one browser: the asset worker
+# writes to no shared HTTP cache, and the one cache it does use is keyed by
+# content hash rather than by URL. (Cloudflare Pages, where the two public
+# reports of this come from, kept a URL-keyed CDN cache and so poisoned every
+# visitor at a PoP.) Under the deployment that poisons it the URL is already
+# dead, since a deploy only drops the assets whose hash changed; it comes back
+# to life only through a rollback, or through a gradual deployment serving one
+# version's document beside another version's assets. We deploy all at once and
+# roll back rarely, which is the trade we are making here.
+# https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/
+#
+# docker/nginx.conf states the same policy for the docker-compose topology, and
+# apps/web/__tests__/static-asset-caching_test.ts fails when the two drift.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -4,15 +4,16 @@
 # per page load:
 # https://developers.cloudflare.com/workers/static-assets/headers/
 #
-# Every chunk the client build emits under /assets/ is content-addressed, so a
-# URL there answers with the same bytes for as long as it exists and never needs
-# revalidating. A sourcemap carries the hash of the chunk it belongs to rather
-# than one of its own, so an edit that moves source positions without changing
-# the emitted chunk -- a comment-only edit is the plain case -- leaves the URL
-# fixed while the map behind it changes. Maps are declared immutable regardless:
-# the whole cost of holding a stale one is a stack trace restored against
-# out-of-date positions. index.html is deliberately left out: it is the unhashed
-# document that names the current hashes.
+# Everything the client build emits under /assets/ -- chunks, stylesheets,
+# fonts, images -- carries a content hash in its filename, so those URLs never
+# need revalidating. A sourcemap is the one member of that set whose bytes are
+# not what its name derives from: it is named after the chunk it belongs to, so
+# an edit that moves source positions without changing the emitted chunk -- a
+# comment-only edit is the plain case -- leaves the URL fixed while the map
+# behind it changes. Maps are cached on the same rule anyway, since a stale one
+# can only degrade the dashboard's stack restore, never the running app.
+# index.html is deliberately left out: it is the unhashed document that names
+# the current hashes.
 #
 # The lifetime also lands on a response we did not intend it for, and we accept
 # that. `not_found_handling: single-page-application` answers a request for a

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,11 +46,15 @@ server {
     proxy_pass http://server:8788;
   }
 
-  # Everything the client build emits under /assets/ carries a content hash in
-  # its filename, sourcemaps included -- a map is named after the chunk it
-  # belongs to, so it rehashes with it. A URL there therefore always answers
-  # with the same bytes and never needs revalidating. index.html is deliberately
-  # left out: it is the unhashed document that names the current hashes.
+  # Every chunk the client build emits under /assets/ is content-addressed, so
+  # a URL there answers with the same bytes for as long as it exists and never
+  # needs revalidating. A sourcemap carries the hash of the chunk it belongs to
+  # rather than one of its own, so an edit that moves source positions without
+  # changing the emitted chunk -- a comment-only edit is the plain case --
+  # leaves the URL fixed while the map behind it changes. Maps are declared
+  # immutable regardless: the whole cost of holding a stale one is a stack trace
+  # restored against out-of-date positions. index.html is deliberately left out:
+  # it is the unhashed document that names the current hashes.
   #
   # apps/web/public/_headers states the same policy for Workers Static Assets,
   # and apps/web/__tests__/static-asset-caching_test.ts fails when the two

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -52,8 +52,8 @@ server {
   # not what its name derives from: it is named after the chunk it belongs to,
   # so an edit that moves source positions without changing the emitted chunk --
   # a comment-only edit is the plain case -- leaves the URL fixed while the map
-  # behind it changes. Maps are cached on the same rule anyway, since a stale one
-  # can only degrade the dashboard's stack restore, never the running app.
+  # behind it changes. Maps are cached on the same rule anyway, since a stale
+  # one can only degrade the dashboard's stack restore, never the running app.
   # index.html is deliberately left out: it is the unhashed document that names
   # the current hashes.
   #
@@ -62,9 +62,10 @@ server {
   # drift.
   #
   # `^~` stops nginx testing the server-level regex locations once this prefix
-  # is the longest match. Without it any regex location added to this file later
-  # would take these paths away from this block and silently drop the header,
-  # which is the whole reason the `.map` rule below had to move in here.
+  # is the longest match, so no regex location added to this file later can take
+  # these paths away from this block. It is also what makes nesting the `.map`
+  # rule below mandatory rather than merely tidy: at server level that location
+  # would no longer be reached for anything under /assets/ at all.
   # https://nginx.org/en/docs/http/ngx_http_core_module.html#location
   location ^~ /assets/ {
     add_header Cache-Control "public, max-age=31536000, immutable";

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,20 +46,27 @@ server {
     proxy_pass http://server:8788;
   }
 
-  # Every chunk the client build emits under /assets/ is content-addressed, so
-  # a URL there answers with the same bytes for as long as it exists and never
-  # needs revalidating. A sourcemap carries the hash of the chunk it belongs to
-  # rather than one of its own, so an edit that moves source positions without
-  # changing the emitted chunk -- a comment-only edit is the plain case --
-  # leaves the URL fixed while the map behind it changes. Maps are declared
-  # immutable regardless: the whole cost of holding a stale one is a stack trace
-  # restored against out-of-date positions. index.html is deliberately left out:
-  # it is the unhashed document that names the current hashes.
+  # Everything the client build emits under /assets/ -- chunks, stylesheets,
+  # fonts, images -- carries a content hash in its filename, so those URLs never
+  # need revalidating. A sourcemap is the one member of that set whose bytes are
+  # not what its name derives from: it is named after the chunk it belongs to,
+  # so an edit that moves source positions without changing the emitted chunk --
+  # a comment-only edit is the plain case -- leaves the URL fixed while the map
+  # behind it changes. Maps are cached on the same rule anyway, since a stale one
+  # can only degrade the dashboard's stack restore, never the running app.
+  # index.html is deliberately left out: it is the unhashed document that names
+  # the current hashes.
   #
   # apps/web/public/_headers states the same policy for Workers Static Assets,
   # and apps/web/__tests__/static-asset-caching_test.ts fails when the two
   # drift.
-  location /assets/ {
+  #
+  # `^~` stops nginx testing the server-level regex locations once this prefix
+  # is the longest match. Without it any regex location added to this file later
+  # would take these paths away from this block and silently drop the header,
+  # which is the whole reason the `.map` rule below had to move in here.
+  # https://nginx.org/en/docs/http/ngx_http_core_module.html#location
+  location ^~ /assets/ {
     add_header Cache-Control "public, max-age=31536000, immutable";
     # Keeps the SPA fallback `location /` would otherwise have given these
     # paths. It arrives there by internal redirect, which re-runs location

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,16 +46,38 @@ server {
     proxy_pass http://server:8788;
   }
 
-  # nginx 1.27.4's bundled mime.types has no entry for `.map`, while its base
-  # config defaults unknown files to `application/octet-stream`; the dashboard's
-  # stack restore would refuse that as something other than a map.
-  # https://github.com/nginx/nginx/blob/ecb809305e54ed15be9f620d56b19ff4e4be7db5/conf/mime.types
-  # https://github.com/nginx/nginx/blob/ecb809305e54ed15be9f620d56b19ff4e4be7db5/conf/nginx.conf#L18-L19
-  # Use `default_type` because defining `types` here would replace the inherited
-  # table rather than extend it.
-  # https://nginx.org/en/docs/http/ngx_http_core_module.html#types
-  location ~ \.map$ {
-    default_type application/json;
+  # Everything the client build emits under /assets/ carries a content hash in
+  # its filename, sourcemaps included -- a map is named after the chunk it
+  # belongs to, so it rehashes with it. A URL there therefore always answers
+  # with the same bytes and never needs revalidating. index.html is deliberately
+  # left out: it is the unhashed document that names the current hashes.
+  #
+  # apps/web/public/_headers states the same policy for Workers Static Assets,
+  # and apps/web/__tests__/static-asset-caching_test.ts fails when the two
+  # drift.
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    # Keeps the SPA fallback `location /` would otherwise have given these
+    # paths. It arrives there by internal redirect, which re-runs location
+    # matching, so the document is served under that block's headers rather
+    # than under the lifetime set here.
+    try_files $uri /index.html;
+
+    # nginx 1.27.4's bundled mime.types has no entry for `.map`, while its base
+    # config defaults unknown files to `application/octet-stream`; the
+    # dashboard's stack restore would refuse that as something other than a map.
+    # https://github.com/nginx/nginx/blob/ecb809305e54ed15be9f620d56b19ff4e4be7db5/conf/mime.types
+    # https://github.com/nginx/nginx/blob/ecb809305e54ed15be9f620d56b19ff4e4be7db5/conf/nginx.conf#L18-L19
+    # Use `default_type` because defining `types` here would replace the
+    # inherited table rather than extend it.
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#types
+    #
+    # A nested block defines no add_header of its own, so it inherits the one
+    # above rather than clearing it.
+    # https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+    location ~ \.map$ {
+      default_type application/json;
+    }
   }
 
   location / {


### PR DESCRIPTION
## Problem

Both topologies that serve the client build answer every asset with a revalidating default:

- Workers Static Assets sends `Cache-Control: public, max-age=0, must-revalidate` unless a `_headers` rule says otherwise ([docs](https://developers.cloudflare.com/workers/static-assets/headers/)).
- `docker/nginx.conf` sets no `Cache-Control` at all, and in a freshly built image the `Last-Modified` heuristic window is effectively zero.

So an already-downloaded chunk still costs a conditional request, on every page load.

## Change

Everything the client build emits under `/assets/` — chunks, stylesheets, fonts, images — carries a content hash in its filename, so those URLs are declared `public, max-age=31536000, immutable` in both topologies. `index.html`, the unhashed document that names the current hashes, keeps the revalidating default.

A sourcemap is the one member of that set whose bytes are not what its name derives from: it is named after the chunk it belongs to, so an edit that moves source positions without changing the emitted chunk leaves the URL fixed while the map behind it changes. Maps are cached on the same rule anyway, since a stale one can only degrade the dashboard's stack restore, never the running app.

The nginx block is `location ^~ /assets/`. The modifier is load-bearing: nginx tests every server-level regex location before falling back to the longest prefix match, so without it any regex location added to that file later would take these paths away from the block and silently drop the header. It is also what makes nesting the `.map` content-type rule inside the block mandatory rather than merely tidy — at server level that location would no longer be reached for anything under `/assets/` at all.

The two topologies restate one policy in two syntaxes and cannot consult each other, so `apps/web/__tests__/static-asset-caching_test.ts` parses it back out of both and fails when they drift — the same shape as the existing `gateway-paths_test.ts`.

## Accepted trade-off on Cloudflare

Unlike nginx, Workers Static Assets attaches the lifetime to the SPA fallback: `_headers` is matched against the request URL with no knowledge of what was served, and `not_found_handling: single-page-application` answers a missing file with `index.html` and a **200**. A browser can therefore end up holding HTML, permanently, at a chunk's URL.

- It is structural, not a misconfiguration. `attachCustomHeaders` runs on every response with no status or resolver guard. Cloudflare fixed the neighbouring 5xx case in [workers-sdk#5750](https://github.com/cloudflare/workers-sdk/pull/5750) and deliberately excluded 404, adding a test named `404 doesn't skip headers`.
- No configuration avoids it. `_headers` has no path negation and allows one wildcard per rule; `not_found_handling` is a single global enum whose other values either keep the header or break deep links; the whole `assets` surface is five keys with `additionalProperties: false`.
- **The blast radius is one browser.** The asset worker writes to no shared HTTP cache, and the one cache it does use is [KV's, keyed by the asset's content hash](https://github.com/cloudflare/workers-sdk/blob/4b52975aac295c8483d6b4001d0b50945293265a/packages/workers-shared/asset-worker/src/utils/kv.ts#L18-L24) rather than by URL, so a fallback response is stored under `index.html`'s own hash. [Cloudflare Pages](https://developers.cloudflare.com/pages/configuration/serving-pages/), where both [public](https://community.cloudflare.com/t/pages-how-to-prevent-caching-404s-when-using-headers/516765) [reports](https://community.cloudflare.com/t/disable-spa-fallback-for-some-paths-file-extensions/649908) of this come from, kept a URL-keyed CDN cache instead and so poisoned every visitor at a PoP.
- Under the deployment that poisons it the URL is already dead, since a deploy only drops the assets whose hash changed. It returns to life only through a rollback, or through a [gradual deployment](https://developers.cloudflare.com/workers/versions-and-deployments/gradual-deployments/version-affinity/) serving one version's document beside another version's assets.

We deploy all at once and roll back rarely, so this is accepted rather than paid for. The one alternative that fixes it — adding `/assets/*` to `run_worker_first` and rewriting the fallback to a real 404 — works, but removes every JS/CSS/font/sourcemap request from the "static assets are free and unlimited" exemption and turns each into a billable Worker invocation, answering 429 rather than degrading once a free tier is exhausted.

## Test Plan

- [x] `pnpm run verify`
- [x] **nginx topology.** `nginx:1.27-alpine` with this config and a fake `dist/client`, with a `location ~ \.(js|css)$ { add_header X-Preempted "yes"; }` injected ahead of the fallback to prove `^~` holds:

  | Path | Status | Content-Type | Cache-Control | X-Preempted |
  |---|---|---|---|---|
  | `/assets/app-abcdef12.js` | 200 | `application/javascript` | `public, max-age=31536000, immutable` | *(absent)* |
  | `/assets/app-abcdef12.js.map` | 200 | `application/json` | `public, max-age=31536000, immutable` | *(absent)* |
  | `/assets/root-abcdef12.css` | 200 | `text/css` | `public, max-age=31536000, immutable` | *(absent)* |
  | `/assets/missing-00000000.js` | 200 | `text/html` | *(none)* | *(absent)* |
  | `/dashboard` | 200 | `text/html` | *(none)* | *(absent)* |

  `nginx -t` passes, the injected regex location never sees an `/assets/` request, the sourcemap content type survives the nesting, and the SPA fallback reaches `location /` by internal redirect so it never carries the immutable lifetime.

- [x] **Cloudflare topology.** `wrangler dev` against an assets-only Worker reading this exact `_headers`:

  ```
  [wrangler:info] ✨ Parsed 1 valid header rule.
  /assets/app-abcdef12.js       200  Cache-Control: public, max-age=31536000, immutable
  /assets/root-abcdef12.css     200  Cache-Control: public, max-age=31536000, immutable
  /                             200  Cache-Control: public, max-age=0, must-revalidate
  /assets/missing-00000000.js   200  text/html  Cache-Control: public, max-age=31536000, immutable
  ```

  The last row is the accepted trade-off above, reproduced rather than assumed.
