### PR TITLE
fix(tools): keep the stored catalog out of an unguarded backfill statement

### DIFF
--- a/tools/__tests__/backfill-usage-pricing/plan_test.ts
+++ b/tools/__tests__/backfill-usage-pricing/plan_test.ts
@@ -5,6 +5,8 @@ import { DatabaseSync } from 'node:sqlite';
 
 import { test } from 'vitest';
 
+import { renderD1Statement } from '../../src/backfill-usage-pricing/d1-database.ts';
+import type { ToolDatabase } from '../../src/backfill-usage-pricing/database.ts';
 import { openNodeDatabase } from '../../src/backfill-usage-pricing/node-database.ts';
 import { applyPlan, buildPlan, parsePlan } from '../../src/backfill-usage-pricing/plan.ts';
 import { assertEquals, assertRejects } from '@floway-dev/test-utils';
@@ -122,4 +124,69 @@ test('obsolete selectors do not block coordinates that the selected mode would n
   assertEquals(fill.plan.operations, []);
   assertEquals(overwrite.plan.blockers, []);
   assertEquals(overwrite.plan.operations, []);
+});
+
+test('an unguarded plan keeps the stored catalog out of its apply statement', async () => {
+  // `models_cache_json` is 73 KB on a live Copilot upstream and doubles under
+  // the hex encoding that renders a parameter into SQL. Every provider except
+  // a cache-priced custom one resolves its rates without the catalog and
+  // short-circuits the comparison, so carrying it into the statement bought
+  // nothing and cost a 6-row backfill, which failed with SQLITE_TOOBIG before
+  // writing a row.
+  const directory = await mkdtemp(join(tmpdir(), 'floway-tools-unguarded-'));
+  const path = join(directory, 'floway.db');
+  const catalog = JSON.stringify({ revision: 1, fetchedAt: Date.now(), models: [{ id: 'public', providerData: 'wire', filler: 'q'.repeat(120_000) }] });
+  const db = new DatabaseSync(path);
+  db.exec(`
+    CREATE TABLE upstreams (
+      id TEXT PRIMARY KEY, provider TEXT NOT NULL, name TEXT NOT NULL, enabled INTEGER NOT NULL,
+      sort_order INTEGER NOT NULL, created_at TEXT NOT NULL, config_json TEXT NOT NULL,
+      models_cache_json TEXT
+    );
+    CREATE TABLE usage (
+      key_id TEXT NOT NULL, model TEXT NOT NULL, upstream TEXT, model_key TEXT NOT NULL,
+      hour TEXT NOT NULL, pricing_selector TEXT NOT NULL, metric TEXT NOT NULL,
+      quantity TEXT NOT NULL, unit_price TEXT
+    );
+    CREATE UNIQUE INDEX idx_usage_metric_identity
+      ON usage (key_id, model, COALESCE(upstream, ''), model_key, hour, pricing_selector, metric);
+  `);
+  const pricing = { entries: [{ rates: { input_tokens: '0.01' } }] };
+  const config = { models: [{ kind: 'chat', endpoints: { openaiResponses: {} }, upstreamModelId: 'wire', pricing }] };
+  db.prepare('INSERT INTO upstreams VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
+    .run('azure-1', 'azure', 'Azure', 1, 0, '2026-01-01T00:00:00.000Z', JSON.stringify(config), catalog);
+  db.prepare('INSERT INTO usage VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
+    .run('key-1', 'public', 'azure-1', 'wire', '2026-01-01T00', '{}', 'input_tokens', '10', null);
+  db.close();
+
+  const read = await openNodeDatabase(path, 'read');
+  const built = await buildPlan(read, {
+    upstream: 'azure-1', model: 'public', modelKey: 'wire',
+    startHour: '2026-01-01T00', endHour: '2026-01-02T00', timezone: 'UTC',
+    mode: 'fill', metrics: ['input_tokens'],
+  }, { createdAt: '2026-01-02T00:00:00.000Z' });
+  await read.close();
+
+  // Azure prices from its own config, so the catalog guard is off.
+  assertEquals(built.guards.guardModelsCache, false);
+
+  const write = await openNodeDatabase(path, 'write');
+  const executed: string[] = [];
+  // Node runs the statement; rendering it the way the D1 connector would is
+  // what puts its size under assertion, since that is the path with a limit.
+  const recording: ToolDatabase = {
+    ...write,
+    execute: async statement => {
+      executed.push(renderD1Statement(statement));
+      return await write.execute(statement);
+    },
+  };
+  const result = await applyPlan(recording, built.plan);
+  await write.close();
+
+  assertEquals(result.rowsUpdated, 1);
+  const applyStatement = executed.find(sql => sql.includes('UPDATE usage'))!;
+  // The catalog never reaches the statement, so its size cannot bound a backfill.
+  assertEquals(applyStatement.includes(Buffer.from(catalog, 'utf8').toString('hex')), false);
+  assertEquals(applyStatement.length < catalog.length, true);
 });

--- a/tools/src/backfill-usage-pricing/plan.ts
+++ b/tools/src/backfill-usage-pricing/plan.ts
@@ -451,7 +451,13 @@ const applyStatement = (plan: BackfillPlan, guards: PlanGuards): SqlStatement =>
       plan.intent.upstream,
       guards.upstreamConfigJson,
       guards.guardModelsCache ? 1 : 0,
-      guards.upstreamModelsCacheJson,
+      // Only a guarded plan carries the catalog into the statement. The column
+      // is 73 KB on a live Copilot upstream and doubles under hex encoding, and
+      // every provider except a cache-priced custom one short-circuits the
+      // comparison on the flag above — so inlining it unguarded pushed the
+      // statement past what `--command` can carry and failed a 6-row backfill
+      // with SQLITE_TOOBIG before any row was written.
+      guards.guardModelsCache ? guards.upstreamModelsCacheJson : null,
       guards.pricedSiblingExists ? 1 : 0,
     ],
   };


### PR DESCRIPTION
A usage-pricing backfill against production D1 failed with `SQLITE_TOOBIG` before writing a row — and the slice was **six rows**.

The size came from the statement, not the data. Parameters render into the SQL as literals (`sqlLiteral` hex-encodes strings), and the apply path passed `upstreams.models_cache_json` unconditionally. That column is 73 KB on a live Copilot upstream and doubles to ~146 KB under the hex encoding, so the rendered statement ran past what a `--command` argv entry can carry regardless of slice size. The 7670-row plan and the 6-row plan failed identically.

## Why the catalog was there, and why it usually isn't needed

The guard pins the rates a plan resolved from a stored model catalog against the ones apply would read. Only a cache-priced **custom** upstream resolves that way:

```
pricing.ts:105   copilot → staticResolution(pricingForCopilotPublicModelId(…), 'provider:copilot')
pricing.ts:52-53 staticResolution → { guardsModelsCache: false }
```

Every other provider prices from a static table and reports `guardsModelsCache: false`, which makes the SQL short-circuit on `(? = 0 OR models_cache_json IS ?)` and never compare the column. The catalog was being paid for in statement size and not used.

## The change

```ts
guards.guardModelsCache ? guards.upstreamModelsCacheJson : null,
```

A guarded plan is unchanged byte for byte. An unguarded one no longer carries a payload its statement cannot afford and its comparison would skip.

## Approaches rejected

- **`wrangler d1 execute --file`** — carries longer statements, but it is a bulk-ingest channel: it returns `Total queries executed / Rows read / Rows written` instead of result rows, and prints progress lines before the JSON. `plan` reads real rows, so the semantics do not match.
- **Digest guard** (length + boundary fragments instead of full equality) — would shrink the statement, but it is strictly weaker than the equality it replaces and can be constructed around. Not acceptable for the guard protecting production billing data.

## Test Plan

- [x] `pnpm run verify`
- [x] New test asserts an unguarded plan's apply statement is smaller than the catalog in its upstream row; confirmed failing without the change and passing with it
- [x] Confirmed against production D1: the same six-row plan that had failed applies cleanly
