### PR TITLE
feat(providers): price Gemini 3.8 Flash and GPT-6 Astra

### DIFF
--- a/packages/gateway/src/repo/models-cache-contract.ts
+++ b/packages/gateway/src/repo/models-cache-contract.ts
@@ -1,4 +1,4 @@
 // Persisted ProviderModel rows contain code-derived metadata as well as the
 // upstream response. Increment this whenever that derived catalog contract or
 // its serialization changes so older rows become cold across deployments.
-export const MODEL_CATALOG_REVISION = 8;
+export const MODEL_CATALOG_REVISION = 9;

--- a/packages/provider-codex/__tests__/pricing_test.ts
+++ b/packages/provider-codex/__tests__/pricing_test.ts
@@ -90,3 +90,19 @@ test('Codex gpt-5.4 and gpt-5.4-mini keep their explicit flex and priority entri
 test('pricingForCodexModelKey returns null for an unknown slug', () => {
   assertEquals(pricingForCodexModelKey('totally-made-up-model'), null);
 });
+
+test('Codex GPT-6 Astra resolves the announced standard, priority and flex rate grid', () => {
+  const pricing = pricingForCodexModelKey('gpt-6-astra');
+  const cases = [
+    [{ inputTokens: 272000 }, { input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }],
+    [{ inputTokens: 272001 }, { input_tokens: '20', input_cache_read_tokens: '2', input_cache_write_tokens: '25', output_tokens: '75' }],
+    [{ serviceTier: 'priority', inputTokens: 272000 }, { input_tokens: '20', input_cache_read_tokens: '2', input_cache_write_tokens: '25', output_tokens: '100' }],
+    [{ serviceTier: 'priority', inputTokens: 272001 }, { input_tokens: '40', input_cache_read_tokens: '4', input_cache_write_tokens: '50', output_tokens: '150' }],
+    [{ serviceTier: 'flex', inputTokens: 272000 }, { input_tokens: '5', input_cache_read_tokens: '0.5', input_cache_write_tokens: '6.25', output_tokens: '25' }],
+    [{ serviceTier: 'flex', inputTokens: 272001 }, { input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '37.5' }],
+  ] as const;
+
+  for (const [facts, rates] of cases) {
+    assertEquals(priceRequest(pricing, facts).rates, published(rates));
+  }
+});

--- a/packages/provider-codex/src/pricing.ts
+++ b/packages/provider-codex/src/pricing.ts
@@ -34,6 +34,24 @@ export const GPT_IMAGE_2_PRICING = modelPricing(
 );
 
 const CODEX_MODEL_PRICING: readonly (readonly [key: string | RegExp, pricing: ModelPricing])[] = [
+  // Announced on 2026-09-03 and rolling out first to enterprises in OpenAI's
+  // Trusted Access Program; broader API and subscription access is coming in
+  // the following days. The public model card already fixes the id, limits and
+  // all six rate coordinates, so the notional table can price it before this
+  // account's `/codex/models` catalog starts returning it. There is no
+  // models.dev row to cross-check yet; OpenAI's Python SDK independently
+  // recognizes the exact `gpt-6-astra` id.
+  // https://developers.openai.com/api/docs/models/gpt-6-astra
+  // https://openai.com/index/gpt-6-astra/
+  // https://github.com/openai/openai-python/blob/3cc8d784ad05f75a265012ee86638adaf93d8bf2/src/openai/types/shared/chat_model.py
+  ['gpt-6-astra', modelPricing(
+    tokenPricingEntry({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }),
+    tokenPricingEntry({ input_tokens: '20', input_cache_read_tokens: '2', input_cache_write_tokens: '25', output_tokens: '75' }, { inputTokens: { operator: 'gt', value: 272000 } }),
+    tokenPricingEntry({ input_tokens: '20', input_cache_read_tokens: '2', input_cache_write_tokens: '25', output_tokens: '100' }, { serviceTier: 'priority' }),
+    tokenPricingEntry({ input_tokens: '40', input_cache_read_tokens: '4', input_cache_write_tokens: '50', output_tokens: '150' }, { serviceTier: 'priority', inputTokens: { operator: 'gt', value: 272000 } }),
+    tokenPricingEntry({ input_tokens: '5', input_cache_read_tokens: '0.5', input_cache_write_tokens: '6.25', output_tokens: '25' }, { serviceTier: 'flex' }),
+    tokenPricingEntry({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '37.5' }, { serviceTier: 'flex', inputTokens: { operator: 'gt', value: 272000 } }),
+  )],
   // The GPT-5.6 family, refreshed from OpenAI's current card — the values
   // these replace were the launch rates, since cut across the board and by a
   // factor of five on Luna. OpenAI now publishes all four columns (standard,

--- a/packages/provider-copilot/__tests__/pricing_test.ts
+++ b/packages/provider-copilot/__tests__/pricing_test.ts
@@ -72,9 +72,9 @@ test('Copilot Grok 4.5 long-context band starts at the 200k prompt itself', () =
   assertEquals(priceRequest(pricing, { inputTokens: 200000 }).rates, published({ input_tokens: '4', input_cache_read_tokens: '0.6', output_tokens: '12' }));
 });
 
-test('Copilot Gemini 3.6 and 3.7 Flash share one rate across every prompt length', () => {
+test('Copilot Gemini 3.6, 3.7 and 3.8 Flash share one rate across every prompt length', () => {
   const base = published({ input_tokens: '0.75', input_cache_read_tokens: '0.075', output_tokens: '3.75' });
-  for (const id of ['gemini-3.6-flash', 'gemini-3.7-flash']) {
+  for (const id of ['gemini-3.6-flash', 'gemini-3.7-flash', 'gemini-3.8-flash']) {
     const pricing = pricingForCopilotPublicModelId(id);
     assertEquals(priceRequest(pricing, { inputTokens: 0 }).rates, base);
     assertEquals(priceRequest(pricing, { inputTokens: 936000 }).rates, base);

--- a/packages/provider-copilot/src/pricing.ts
+++ b/packages/provider-copilot/src/pricing.ts
@@ -107,15 +107,19 @@ const COPILOT_MODEL_PRICING: readonly PricingRule[] = [
     tokenPricingEntry({ input_tokens: '4', input_cache_read_tokens: '0.4', output_tokens: '18' }, { inputTokens: { operator: 'gt', value: 200000 } }),
   )],
   ['gemini-3.5-flash', tokenBasePricing({ input_tokens: '1.5', input_cache_read_tokens: '0.15', output_tokens: '9' })],
-  // Gemini 3.6 and 3.7 Flash share one promotional rate card, halved from the
-  // standard $1.50/$0.15/$7.50 through 2026-12-31 and reverting on
-  // 2027-01-01 — recheck these two after that date. Both are among the
+  // Gemini 3.6, 3.7 and 3.8 Flash share one promotional rate card, halved
+  // from the standard $1.50/$0.15/$7.50 through 2026-12-31 and reverting on
+  // 2027-01-01 — recheck the trio after that date. All three are among the
   // Gemini 3 models Google excludes from the >200k tier: the Vertex table
   // lists identical rates in both columns, and Copilot's catalog quotes one
-  // band whose `long_context` repeats the default.
-  // https://ai.google.dev/gemini-api/docs/pricing
+  // band whose `long_context` repeats the default. Gemini 3.8 Flash reached
+  // GA on 2026-09-02 with this stable id; two Copilot accounts returned the
+  // same 1,048,576-token capability and rate metadata.
+  // https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash
+  // https://ai.google.dev/gemini-api/docs/pricing#gemini-3.8-flash
+  // https://github.com/github/docs/blob/f067ad0f9840f1b4afb5a801a77f74ef70951189/data/tables/copilot/model-release-status.yml
   // https://cloud.google.com/vertex-ai/generative-ai/pricing
-  [/^gemini-3\.[67]-flash$/, tokenBasePricing({ input_tokens: '0.75', input_cache_read_tokens: '0.075', output_tokens: '3.75' })],
+  [/^gemini-3\.[678]-flash$/, tokenBasePricing({ input_tokens: '0.75', input_cache_read_tokens: '0.075', output_tokens: '3.75' })],
   // xAI reprices the whole request at 2× once the prompt reaches 200k tokens.
   // Cached-read is xAI's own published $0.30/$0.60; Copilot's catalog and
   // LiteLLM both carry $0.50/$1.00 for that metric, which the vendor contradicts.


### PR DESCRIPTION
Adds notional pricing for two newly announced models at different release stages: Gemini 3.8 Flash is GA and already live on Copilot; GPT-6 Astra has an official OpenAI model card and rate grid but remains in staged rollout and does not yet appear in this account's Codex or Copilot catalogs.

## Gemini 3.8 Flash

Google announced GA on 2026-09-02 under the stable `gemini-3.8-flash` id. It publishes the same promotional card as Gemini 3.6 and 3.7 Flash through 2026-12-31:

| Input | Cached input | Output |
|---:|---:|---:|
| $0.75 / MTok | $0.075 / MTok | $3.75 / MTok |

Two enabled Copilot accounts returned identical live metadata:

- `id` / family / version: `gemini-3.8-flash`
- 1,048,576-token context, 983,040-token prompt, 65,536-token output
- `reasoning_effort`: `low`, `medium`, `high`
- `/chat/completions`, streaming, tools, parallel tools, vision
- one price band whose `long_context` entry repeats the default
- available to Pro, Pro+, Business, Enterprise and Max

The shared Copilot regex moves from 3.6/3.7 to 3.6/3.7/3.8, and the existing every-prompt-length test covers the new id. models.dev's `google` and `github-copilot` records independently agree with the three published rates.

Sources:

- [Google model page](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash)
- [Google pricing](https://ai.google.dev/gemini-api/docs/pricing#gemini-3.8-flash)
- [GitHub Copilot release-status data](https://github.com/github/docs/blob/f067ad0f9840f1b4afb5a801a77f74ef70951189/data/tables/copilot/model-release-status.yml)

## GPT-6 Astra

OpenAI announced `gpt-6-astra` on 2026-09-03 and is rolling it out first to enterprises in the Trusted Access Program, with broader API and Plus/Pro/Business/Enterprise access promised in the following days. It is therefore intentionally priced before the authenticated `/codex/models` catalog starts returning it.

The official model card fixes the id, 1,050,000-token context, 128,000-token output limit, and the complete six-coordinate rate grid:

| Tier | Context | Input | Cached input | Cache write | Output |
|---|---|---:|---:|---:|---:|
| Standard | ≤272k | $10 | $1 | $12.50 | $50 |
| Standard | >272k | $20 | $2 | $25 | $75 |
| Priority / Fast | ≤272k | $20 | $2 | $25 | $100 |
| Priority / Fast | >272k | $40 | $4 | $50 | $150 |
| Flex | ≤272k | $5 | $0.50 | $6.25 | $25 |
| Flex | >272k | $10 | $1 | $12.50 | $37.50 |

The exact 272,000-token boundary stays on the short-context card; 272,001 selects the long-context rate in every tier. The test pins both sides for all three tiers.

models.dev has no Astra row yet, and two live Copilot catalogs do not contain the id or name. It is added only to Codex pricing: pre-adding it to Copilot would invent which lane GitHub serves and therefore which vendor rate applies. OpenAI's Python SDK independently recognizes the exact id.

Sources:

- [OpenAI announcement](https://openai.com/index/gpt-6-astra/)
- [OpenAI model card and pricing](https://developers.openai.com/api/docs/models/gpt-6-astra)
- [OpenAI Python SDK model id](https://github.com/openai/openai-python/blob/3cc8d784ad05f75a265012ee86638adaf93d8bf2/src/openai/types/shared/chat_model.py)

## Catalog cache

`MODEL_CATALOG_REVISION` moves from 8 to 9 because both static pricing changes serialize into persisted `ProviderModel` rows.

## Test Plan

- [x] Copilot `/models` probe on two enabled accounts; Gemini metadata identical, Astra absent from both
- [x] Cross-check Gemini against Google pricing, GitHub Copilot docs and models.dev
- [x] Cross-check Astra against OpenAI's announcement, model card and Python SDK; confirm models.dev and Copilot have no row yet
- [x] Provider pricing tests, including all six Astra coordinates and exact 272k threshold edges
- [ ] `pnpm run verify`
