### PR TITLE
feat(copilot): price GPT-6 Astra from its live catalog

### DIFF
--- a/packages/gateway/src/repo/models-cache-contract.ts
+++ b/packages/gateway/src/repo/models-cache-contract.ts
@@ -1,4 +1,4 @@
 // Persisted ProviderModel rows contain code-derived metadata as well as the
 // upstream response. Increment this whenever that derived catalog contract or
 // its serialization changes so older rows become cold across deployments.
-export const MODEL_CATALOG_REVISION = 9;
+export const MODEL_CATALOG_REVISION = 10;

--- a/packages/provider-copilot/__tests__/pricing_test.ts
+++ b/packages/provider-copilot/__tests__/pricing_test.ts
@@ -105,3 +105,21 @@ test('Copilot prices the models added to the live catalog since the last refresh
   // The 1-Flash prefix rule must not swallow the dotted 1.1 id.
   assertEquals(rates('mai-code-1-flash-picker'), published({ input_tokens: '0.75', input_cache_read_tokens: '0.075', output_tokens: '4.5' }));
 });
+
+test('Copilot GPT-6 Astra prices the standard short and long bands its catalog serves', () => {
+  const pricing = pricingForCopilotPublicModelId('gpt-6-astra');
+  assertEquals(
+    priceRequest(pricing, { inputTokens: 272000 }).rates,
+    published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }),
+  );
+  assertEquals(
+    priceRequest(pricing, { inputTokens: 272001 }).rates,
+    published({ input_tokens: '20', input_cache_read_tokens: '2', input_cache_write_tokens: '25', output_tokens: '75' }),
+  );
+  // Copilot publishes no accelerated Astra sibling and reports `default`, so
+  // an unserved tier falls back to Base rather than gaining an invented rate.
+  assertEquals(
+    priceRequest(pricing, { serviceTier: 'priority', inputTokens: 0 }).rates,
+    published({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }),
+  );
+});

--- a/packages/provider-copilot/src/pricing.ts
+++ b/packages/provider-copilot/src/pricing.ts
@@ -32,6 +32,18 @@ const COPILOT_MODEL_PRICING: readonly PricingRule[] = [
   ['claude-sonnet-5', tokenBasePricing({ input_tokens: '2', input_cache_read_tokens: '0.2', input_cache_write_tokens: '2.5', output_tokens: '10' })],
   [/^claude-sonnet-4(-[56])?$/, tokenBasePricing({ input_tokens: '3', input_cache_read_tokens: '0.3', input_cache_write_tokens: '3.75', output_tokens: '15' })],
   ['claude-haiku-4-5', tokenBasePricing({ input_tokens: '1', input_cache_read_tokens: '0.1', input_cache_write_tokens: '1.25', output_tokens: '5' })],
+  // Two Copilot accounts began returning GPT-6 Astra on 2026-09-05 and served
+  // a real `/responses` request as `model: "gpt-6-astra"` with
+  // `service_tier: "default"`. Their catalogs quote exactly OpenAI's standard
+  // short/long rates and publish no sibling raw variant, so Copilot gets those
+  // two bands only — adding the priority or flex lanes here would claim a
+  // GitHub path neither catalog exposes. models.dev has no Astra row yet.
+  // https://developers.openai.com/api/docs/models/gpt-6-astra
+  // https://openai.com/index/gpt-6-astra/
+  ['gpt-6-astra', modelPricing(
+    tokenPricingEntry({ input_tokens: '10', input_cache_read_tokens: '1', input_cache_write_tokens: '12.5', output_tokens: '50' }),
+    tokenPricingEntry({ input_tokens: '20', input_cache_read_tokens: '2', input_cache_write_tokens: '25', output_tokens: '75' }, { inputTokens: { operator: 'gt', value: 272000 } }),
+  )],
   // GPT-5.6 Sol, and the lane Copilot publishes as the separate raw variant
   // `gpt-5.6-sol-fast` and this table reaches through the merged public id.
   // Rates are OpenAI's published ones for the tier each lane is served at, in


### PR DESCRIPTION
GPT-6 Astra has now entered Copilot's live catalog. This adds its actual GitHub-served rate card to the Copilot pricing table; #503 already added OpenAI's complete six-coordinate grid to Codex while the model was still absent from both catalogs.

## Live evidence

Two enabled Copilot accounts returned identical metadata:

- `id`, family, version: `gpt-6-astra`
- `supported_endpoints`: `/responses`, `ws:/responses`
- context 1,000,000 / prompt 872,000 / output 128,000
- reasoning effort: `low`, `medium`, `high`, `xhigh`, `max`
- streaming, structured outputs, tools, parallel tools, vision
- enabled, non-preview, powerful / very-high price category
- restricted to Pro+, Business, Enterprise and Max

Both accounts completed a real `/responses` request:

```text
HTTP 200
status = completed
model = gpt-6-astra
service_tier = default
```

Two other enabled accounts currently fail GitHub token exchange with `Bad credentials`; no inference is drawn from them.

## Pricing

The live catalog quotes exactly OpenAI's Standard card:

| Context | Input | Cached input | Cache write | Output |
|---|---:|---:|---:|---:|
| ≤272k | $10 | $1 | $12.50 | $50 |
| >272k | $20 | $2 | $25 | $75 |

Copilot exposes no accelerated Astra sibling and the real response reports `default`, so only the short and long Standard bands are added. The `priority` and `flex` coordinates from Codex are deliberately absent: adding either would claim a GitHub path neither live account exposes. A pricing request carrying an unserved tier therefore falls back to Base rather than acquiring an invented rate.

models.dev still has no OpenAI or GitHub Copilot Astra row, so the cross-check is the agreement between two Copilot accounts and OpenAI's first-party model card.

Sources:

- [GPT-6 Astra model card](https://developers.openai.com/api/docs/models/gpt-6-astra)
- [OpenAI announcement](https://openai.com/index/gpt-6-astra/)

## Catalog cache

`MODEL_CATALOG_REVISION` moves from 9 to 10 because the static pricing serializes into persisted `ProviderModel` rows.

## Test Plan

- [x] Direct Copilot `/models` probe on two enabled accounts, with identical Astra metadata
- [x] Real `/responses` completion on both accounts, each reporting `model: gpt-6-astra` and `service_tier: default`
- [x] Pricing test pins Standard rates at 272000 and long-context rates at 272001
- [x] Pricing test verifies an unserved priority tier falls back to Base
- [ ] `pnpm run verify`
