### PR TITLE
fix(protocols): bound opaque replay string memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,20 @@ pnpm run dev
 pnpm run verify
 ```
 
-`verify` chains every check `.github/workflows/verify.yaml` runs, so a green run
-locally is a green run on a pull request. Each link is also a script of its own,
-in the order the chain runs them: `typegen`, `lint`, `typecheck`, `test`,
-`test:installers`, `check:agents-md`, `check:generated-assets`,
-`check:verify-parity`, and `build:web`, which carries the assertions about the
-emitted bundle. `typegen` comes first because the generated route types are not
-checked in and the lint configuration is type-aware, so a fresh clone has to
-produce them before anything else can read the dashboard's sources.
+`verify` chains every check in `.github/workflows/verify.yaml`: `typegen`,
+`lint`, `typecheck`, `test`, `test:installers`, `check:agents-md`,
+`check:generated-assets`, `check:verify-parity`, and `build:web`. Each check is
+also available as a root script. Route type generation runs first because the
+web app's generated types are not checked in and its lint configuration is
+type-aware. The web build includes assertions on the emitted bundle.
+
+The protocol tests cover opaque-value wire compatibility, lossless UTF-16
+code-unit recovery, and retained-memory growth during history replay. The
+memory regression runs a bounded fixture in a separate Node.js process with
+explicit garbage collection, samples the retained heap before content checks
+can flatten strings, and then verifies every decoded value. It runs through
+`pnpm run test` and `pnpm run verify` without additional setup; this local
+regression is not a measurement of a production Worker's peak memory.
 
 [AGENTS.md](./AGENTS.md) defines the repository-wide agent requirements and
 indexes its CI workflows, skills, workspace packages, and their responsibilities.

--- a/packages/protocols/__tests__/common/fixtures/opaque-value-retained-heap.ts
+++ b/packages/protocols/__tests__/common/fixtures/opaque-value-retained-heap.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+
+import { encodeOpaqueValue } from '../../../src/common/opaque-value.ts';
+
+if (globalThis.gc === undefined) throw new Error('The retained-heap fixture requires --expose-gc');
+
+const expected = Array.from({ length: 64 }, (_, index) => `${index}:`.padEnd(6144, 'a'));
+const inputs = expected.map(value => Buffer.from(value, 'utf16le').swap16());
+for (const input of inputs) encodeOpaqueValue(input, 'raw');
+
+globalThis.gc();
+const baseline = process.memoryUsage().heapUsed;
+const retained = inputs.map(input => encodeOpaqueValue(input, 'raw'));
+globalThis.gc();
+const retainedHeapBytes = process.memoryUsage().heapUsed - baseline;
+
+// Comparing or serializing the strings before sampling can flatten V8 ropes,
+// hiding the representation retained while later affinity blocks are decoded.
+assert.deepEqual(retained, expected);
+process.stdout.write(JSON.stringify({
+  count: retained.length,
+  codeUnits: retained.reduce((sum, value) => sum + value.length, 0),
+  retainedHeapBytes,
+}));

--- a/packages/protocols/__tests__/common/opaque-value_test.ts
+++ b/packages/protocols/__tests__/common/opaque-value_test.ts
@@ -1,7 +1,10 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
 import { test } from 'vitest';
 
 import { appendOpaqueTrailer, decodeOpaqueValue, encodeOpaqueValue, splitOpaqueTrailer } from '../../src/common/opaque-value.ts';
-import { assertEquals } from '@floway-dev/test-utils';
+import { assert, assertEquals, assertThrows } from '@floway-dev/test-utils';
 
 test('opaque values preserve canonical Base64 alphabets byte-for-byte', () => {
   assertEquals(decodeOpaqueValue('AP+A'), { bytes: new Uint8Array([0x00, 0xff, 0x80]), origin: 'base64' });
@@ -25,6 +28,53 @@ test('raw opaque values freeze UTF-16 code units including lone surrogates', () 
   });
   assertEquals(encodeOpaqueValue(decoded.bytes, decoded.origin), raw);
 });
+
+test('raw opaque values preserve every UTF-16 code unit', () => {
+  const littleEndian = Buffer.alloc(0x10000 * 2);
+  for (let codeUnit = 0; codeUnit <= 0xffff; codeUnit += 1) {
+    littleEndian.writeUInt16LE(codeUnit, codeUnit * 2);
+  }
+  const expected = littleEndian.toString('utf16le');
+  assertEquals(encodeOpaqueValue(littleEndian.swap16(), 'raw'), expected);
+});
+
+test.each([0, 8190, 8191, 8192, 8193, 16383, 16384, 16385, 131073])(
+  'raw opaque values preserve BOMs and surrogate code units after %i characters',
+  prefixLength => {
+    const markers = String.fromCharCode(0xfeff, 0xd83d, 0xde00, 0xd800, 0x0000, 0xdfff, 0xfeff);
+    const expected = markers[0] + 'a'.repeat(prefixLength) + markers.slice(1);
+    const bytes = Buffer.from(expected, 'utf16le').swap16();
+    const backing = Buffer.concat([Buffer.from([0xff]), bytes, Buffer.from([0xff])]);
+    assertEquals(encodeOpaqueValue(backing.subarray(1, -1), 'raw'), expected);
+  },
+);
+
+test('raw opaque values preserve empty input and reject incomplete code units', () => {
+  assertEquals(encodeOpaqueValue(new Uint8Array(), 'raw'), '');
+  assertThrows(() => encodeOpaqueValue(new Uint8Array([0x00]), 'raw'), TypeError);
+  assertThrows(() => encodeOpaqueValue(new Uint8Array([0x00, 0x61, 0x00]), 'raw'), TypeError);
+});
+
+test('retained raw opaque values use heap proportional to decoded text', () => {
+  const output = execFileSync(process.execPath, [
+    '--expose-gc',
+    '--max-old-space-size=256',
+    '--import', 'jiti/register',
+    fileURLToPath(new URL('./fixtures/opaque-value-retained-heap.ts', import.meta.url)),
+  ], {
+    encoding: 'utf8',
+    env: { ...process.env, NODE_OPTIONS: '', JITI_FS_CACHE: 'false' },
+    timeout: 60_000,
+  });
+  const result = JSON.parse(output) as { count: number; codeUnits: number; retainedHeapBytes: number };
+  assertEquals(result.count, 64);
+  assertEquals(result.codeUnits, 64 * 6144);
+  assert(Number.isFinite(result.retainedHeapBytes));
+  assert(
+    result.retainedHeapBytes < result.codeUnits * 8 + 1024 * 1024,
+    `Retained ${result.retainedHeapBytes} heap bytes for ${result.codeUnits} code units`,
+  );
+}, 60_000);
 
 test('opaque trailers freeze original-trailer-length framing and alphabet selection', () => {
   const base64 = appendOpaqueTrailer(

--- a/packages/protocols/src/common/opaque-value.ts
+++ b/packages/protocols/src/common/opaque-value.ts
@@ -86,9 +86,18 @@ const rawStringToBytes = (value: string): Uint8Array => {
 
 const rawStringFromBytes = (bytes: Uint8Array): string => {
   if (bytes.length % 2 !== 0) throw new TypeError('Raw opaque value has an odd byte length');
-  let value = '';
-  for (let offset = 0; offset < bytes.length; offset += 2) {
-    value += String.fromCharCode((bytes[offset] << 8) | bytes[offset + 1]);
+
+  // Retained opaque histories amplify per-character V8 ropes. Bounded
+  // fromCharCode calls build compact strings and preserve lone surrogates.
+  const codeUnits = new Uint16Array(Math.min(bytes.length / 2, 8192));
+  const chunks: string[] = [];
+  for (let offset = 0; offset < bytes.length; offset += codeUnits.length * 2) {
+    const length = Math.min(codeUnits.length, (bytes.length - offset) / 2);
+    for (let index = 0; index < length; index += 1) {
+      const byteOffset = offset + index * 2;
+      codeUnits[index] = (bytes[byteOffset] << 8) | bytes[byteOffset + 1];
+    }
+    chunks.push(String.fromCharCode(...codeUnits.subarray(0, length)));
   }
-  return value;
+  return chunks.join('');
 };


### PR DESCRIPTION
## Summary

Recover raw opaque UTF-16 strings in bounded, compact chunks so long reasoning-replay histories do not retain a V8 rope node for every code unit. Preserve the existing carrier bytes, every UTF-16 code unit, BOMs, and lone surrogates.

The regression coverage exercises the full code-unit range, chunk boundaries, large values, nonzero-offset views, empty input, and incomplete code units. A separate retained-heap fixture protects the memory behavior, and the development documentation explains how it runs through standard verification.

## Memory behavior

Affinity analysis retains decoded opaque values while subsequent history blocks are processed. Per-character concatenation retained approximately **12 MiB** for a bounded fixture of 64 strings containing 393,216 ASCII code units; chunked recovery retains approximately **0.35 MiB** for the same output.

The fixture launches an isolated Node.js process with explicit GC, warms the production helper, and measures heap usage while all decoded strings remain reachable. It compares their contents after sampling because comparisons can flatten ropes and hide the defect. These figures measure retained Node.js heap, not peak production Worker memory. The wire format and persisted data remain unchanged.

## Test Plan

- [x] Preserve the raw carrier contract across all UTF-16 code units, BOMs, lone surrogates, chunk boundaries, offset views, empty input, and odd-length rejection.
- [x] Verify that the retained-heap regression fails for per-character recovery and passes for chunked recovery, with identical decoded output.
- [x] Run the complete `pnpm run verify` chain: 548 test files and 5,733 tests passed; local installer verification passed 106 cases with four environment-dependent skips; lint, typecheck, repository checks, and web-build assertions passed.
- [x] Pass all eight PR CI checks. CI installer verification passed 109 cases and covered the three absent-CLI scenarios skipped locally.
- [x] Review the recorded production trial: the affected session resumed real tool-use cycles at approximately 861k–874k input/cache tokens without a new compaction, and live logs captured repeated successful requests around 15 MiB without observed resource-limit outcomes.
- [ ] Run the real pinned Codex 0.144.5 app-server smoke test. That exact CLI version is absent from both local and CI environments; this is the sole remaining CI installer skip.

The client version also changed during the production trial, so recovery is not a single-variable experiment. The isolated before/after heap regression independently establishes the implementation's memory improvement.
